### PR TITLE
Fix crashing when media_selection contains invalid value

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
@@ -76,7 +76,7 @@ class MediaSelectionContentType extends ComplexContentType implements ContentTyp
     ) {
         $data = json_decode($node->getPropertyValueWithDefault($property->getName(), '{"ids": []}'), true);
 
-        $property->setValue($data);
+        $property->setValue(isset($data['ids']) ? $data : null);
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/MediaSelectionContentTypeTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/MediaSelectionContentTypeTest.php
@@ -209,6 +209,58 @@ class MediaSelectionContentTypeTest extends TestCase
         $this->mediaSelection->read($node, $property, 'test', 'en', 's');
     }
 
+    public function testReadWithInvalidValue()
+    {
+        $config = '[]';
+
+        $node = $this->getMockForAbstractClass(
+            NodeInterface::class,
+            [],
+            '',
+            true,
+            true,
+            true,
+            ['getPropertyValueWithDefault']
+        );
+
+        $property = $this->getMockForAbstractClass(
+            PropertyInterface::class,
+            [],
+            '',
+            true,
+            true,
+            true,
+            ['setValue', 'getParams']
+        );
+
+        $node->expects($this->any())->method('getPropertyValueWithDefault')->will(
+            $this->returnValueMap(
+                [
+                    [
+                        'property',
+                        '{"ids": []}',
+                        $config,
+                    ],
+                ]
+            )
+        );
+
+        $property->expects($this->any())->method('getName')->will($this->returnValue('property'));
+
+        $property->expects($this->once())->method('setValue')->with(null)->will(
+            $this->returnValue(null)
+        );
+
+        $property->expects($this->any())->method('getParams')->will(
+            $this->returnValue(
+                [
+                ]
+            )
+        );
+
+        $this->mediaSelection->read($node, $property, 'test', 'en', 's');
+    }
+
     public function testReadWithType()
     {
         $config = '{"config":{"conf1": 1, "conf2": 2}, "displayOption": "right", "ids": [1,2,3,4]}';


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes parts of #4302
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR checks if the value in PHPCR for a media type is valid. If it is not we return a value of `null` instead.

#### Why?

Sometimes there are invalid values for the `media_selection` content type in PHPCR. These values made the UI crash, because it assumed a different structure. I originally wanted to fix this in the JS code, but then I realized that the `single_media_selection` does not have this problem. After a quick check I realized that the content type already returned `null` when a wrong value was passed, instead of blindly passing the value.

So I decided that it indeed makes more sense to fix this closer to the storage code. This way other potential clients using the API don't have to fix this as well.

#### Example Usage

Set the value of e.g. `i18n:en-excerpt-icon` in a page to `[]` using the PHPCR shell:

~~~bash
node:property:set i18n:en-excerpt-icon []
~~~

Afterwards the excerpt tab of this page will crash. This is not the case anymore with this fix.