### PR TITLE
Avoid sorting of pages in tree view because it does not work

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Resources/config/lists/pages.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/lists/pages.xml
@@ -5,20 +5,22 @@
     <properties>
         <property
             name="id"
-            visibility="no"
             sortable="false"
             translation="sulu_admin.id"
+            visibility="no"
         />
         <property
             name="title"
-            visibility="always"
+            sortable="false"
             translation="sulu_admin.title"
+            visibility="always"
         />
         <property
             name="published"
+            sortable="false"
+            translation="sulu_admin.published"
             type="datetime"
             visibility="yes"
-            translation="sulu_admin.published"
         />
     </properties>
 </list>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes(?) #4875
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR removes the sorting functionality in page lists.

#### Why?

Because the API does not support sorting. Apart from that we have to think if this is a good idea at all, because the pages have a fixed place in the tree (also the position between its siblings) and being able to change it might make things look "wrong".