### PR TITLE
Consider the webspace when creating navigation links

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -28,7 +28,7 @@
 
                     {% for item in sulu_navigation_root_tree('main') %}
                         <li>
-                            <a href="{{ sulu_content_path(item.url) }}"
+                            <a href="{{ sulu_content_path(item.url, item.webspaceKey) }}"
                                title="{{ item.title }}">{{ item.title }}</a>
                         </li>
                     {% endfor %}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4864
| Related issues/PRs | sulu/skeleton#20
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds the webspace key when generating a url for the navigation.