### PR TITLE
Pass the exception in the logger context

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
@@ -167,7 +167,7 @@ class FormatManager implements FormatManagerInterface
                 );
             }
         } catch (MediaException $e) {
-            $this->logger->error($e->getMessage(), $e->getTrace());
+            $this->logger->error($e->getMessage(), ['exception' => $e]);
             $responseContent = null;
             $status = 404;
             $mimeType = null;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

Pass the exception in the FormatManager to the LoggerInterface.
https://www.php-fig.org/psr/psr-3/#13-context describes how it is done.
https://github.com/symfony/console/blob/master/EventListener/ErrorListener.php#L48 shows that symfony may pass an exception as context.

#### Why?

I want to ignore a MediaNotFoundException on a staging system.
Without passing the exception one has to interpret the error message string instead which is inconvenient and perhaps not reliable.

#### BC Breaks/Deprecations

The stack trace is no longer logged as context. One can get that from the exception instead.

#### To Do

- [ ] Add breaking changes to UPGRADE.md?
