### PR TITLE
Fix assertHttpStatusCode for 201 response

### DIFF
--- a/src/Sulu/Bundle/TestBundle/Testing/AssertHttpStatusCodeTrait.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/AssertHttpStatusCodeTrait.php
@@ -34,8 +34,7 @@ trait AssertHttpStatusCodeTrait
 
         $message = '';
         if ($code !== $httpCode) {
-            if ($response->isRedirect()) {
-                /** @var RedirectResponse $response */
+            if ($response instanceof RedirectResponse) {
                 $message = sprintf(
                     'Unexpected "%s" status code with redirect to "%s".',
                     $httpCode,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix assertHttpStatusCode for 201 response

#### Why?

A 201 can be a redirect but the Response instance could be not a RedirectResponse.

#### Example Usage

~~~php
$this-assertHttpStatusCode($response, 200); // But response is 201
~~~

