### PR TITLE
Add method to handle routables without the routable interface

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,12 @@
 # Upgrade
 
+## dev-release/2.0
+
+### RouteManagerInterface / RouteRepositoryInterface changed
+
+In the `RouteManagerInterface` a new method was introduced `createOrUpdateByAttributes`.
+In the `RouteRepositoryInterface` a new method was introduced `persist`.
+
 ## 2.0.1
 
 ### mode schemaOption in ResourceLocator

--- a/src/Sulu/Bundle/RouteBundle/Entity/RouteRepository.php
+++ b/src/Sulu/Bundle/RouteBundle/Entity/RouteRepository.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\RouteBundle\Entity;
 
 use Doctrine\ORM\NoResultException;
+use Sulu\Bundle\RouteBundle\Model\RouteInterface;
 use Sulu\Component\Persistence\Repository\ORM\EntityRepository;
 
 /**
@@ -92,5 +93,10 @@ class RouteRepository extends EntityRepository implements RouteRepositoryInterfa
         }
 
         return $queryBuilder->getQuery()->getResult();
+    }
+
+    public function persist(RouteInterface $route)
+    {
+        $this->getEntityManager()->persist($route);
     }
 }

--- a/src/Sulu/Bundle/RouteBundle/Entity/RouteRepositoryInterface.php
+++ b/src/Sulu/Bundle/RouteBundle/Entity/RouteRepositoryInterface.php
@@ -76,4 +76,6 @@ interface RouteRepositoryInterface
      * @return RouteInterface[]
      */
     public function findAllByEntity($entityClass, $entityId, $locale = null);
+
+    public function persist(RouteInterface $route);
 }

--- a/src/Sulu/Bundle/RouteBundle/Manager/RouteManagerInterface.php
+++ b/src/Sulu/Bundle/RouteBundle/Manager/RouteManagerInterface.php
@@ -43,4 +43,9 @@ interface RouteManagerInterface
      * @return RouteInterface|null
      */
     public function update(RoutableInterface $entity, $path = null, $resolveConflict = true);
+
+    /**
+     * Creates a new route and handles the histories if the route has changed.
+     */
+    public function createOrUpdateByAttributes(string $entityClass, string $id, string $locale, string $path): RouteInterface;
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add a method to the `RouteManager` to handle routables without the `RoutableInterface`.

#### Why?

This will be used by the SuluContentBundle.

#### Example Usage

~~~php
        $this->routeManager->createOrUpdateByAttributes(
            $localizedContentDimension->getContentClass(),
            (string)$localizedContentDimension->getContentId(),
            $dimension->getLocale(),
            $routePath
        );
~~~

#### BC Breaks/Deprecations

New method in the `RouteManagerInterface` and `RouteRepositoryInterface`.

#### To Do

- [x] Add breaking changes to UPGRADE.md
