### PR TITLE
Add RouteableStructureInterface

### DIFF
--- a/src/Sulu/Bundle/HttpCacheBundle/CacheLifetime/CacheLifetimeEnhancer.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/CacheLifetime/CacheLifetimeEnhancer.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\HttpCacheBundle\CacheLifetime;
 
 use Sulu\Bundle\HttpCacheBundle\Cache\SuluHttpCache;
-use Sulu\Component\Content\Compat\PageInterface;
+use Sulu\Component\Content\Compat\RoutableStructureInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -48,7 +48,7 @@ class CacheLifetimeEnhancer implements CacheLifetimeEnhancerInterface
      */
     public function enhance(Response $response, StructureInterface $structure)
     {
-        if (!$structure instanceof PageInterface) {
+        if (!$structure instanceof RoutableStructureInterface) {
             return;
         }
 

--- a/src/Sulu/Component/Content/Compat/PageInterface.php
+++ b/src/Sulu/Component/Content/Compat/PageInterface.php
@@ -14,29 +14,8 @@ namespace Sulu\Component\Content\Compat;
 /**
  * Structure for template.
  */
-interface PageInterface extends StructureInterface
+interface PageInterface extends StructureInterface, RoutableStructureInterface
 {
-    /**
-     * twig template of template definition.
-     *
-     * @return string
-     */
-    public function getView();
-
-    /**
-     * controller which renders the template definition.
-     *
-     * @return string
-     */
-    public function getController();
-
-    /**
-     * cacheLifeTime of template definition.
-     *
-     * @return array
-     */
-    public function getCacheLifeTime();
-
     /**
      * @return string
      */

--- a/src/Sulu/Component/Content/Compat/RoutableStructureInterface.php
+++ b/src/Sulu/Component/Content/Compat/RoutableStructureInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Compat;
+
+interface RoutableStructureInterface
+{
+    /**
+     * twig template of template definition.
+     *
+     * @return string
+     */
+    public function getView();
+
+    /**
+     * controller which renders the template definition.
+     *
+     * @return string
+     */
+    public function getController();
+
+    /**
+     * cacheLifeTime of template definition.
+     *
+     * @return array
+     */
+    public function getCacheLifeTime();
+}

--- a/src/Sulu/Component/Content/Compat/StructureInterface.php
+++ b/src/Sulu/Component/Content/Compat/StructureInterface.php
@@ -64,28 +64,28 @@ interface StructureInterface extends \JsonSerializable
     /**
      * gets user id of creator.
      *
-     * @return int
+     * @return int|null
      */
     public function getCreator();
 
     /**
      * sets user id of creator.
      *
-     * @param $userId int id of creator
+     * @param int|null $userId id of creator
      */
     public function setCreator($userId);
 
     /**
      * returns user id of changer.
      *
-     * @return int
+     * @return int|null
      */
     public function getChanger();
 
     /**
      * sets user id of changer.
      *
-     * @param $userId int id of changer
+     * @param int|null $userId id of changer
      */
     public function setChanger($userId);
 

--- a/src/Sulu/Component/Content/Compat/StructureInterface.php
+++ b/src/Sulu/Component/Content/Compat/StructureInterface.php
@@ -50,14 +50,14 @@ interface StructureInterface extends \JsonSerializable
     /**
      * id of node.
      *
-     * @return int
+     * @return int|string
      */
     public function getUuid();
 
     /**
      * sets id of node.
      *
-     * @param $uuid
+     * @param int|string $uuid
      */
     public function setUuid($uuid);
 

--- a/src/Sulu/Component/Content/Document/Behavior/StructureBehavior.php
+++ b/src/Sulu/Component/Content/Document/Behavior/StructureBehavior.php
@@ -45,7 +45,7 @@ interface StructureBehavior extends LocaleBehavior
     /**
      * Return the StructureInterface instance.
      *
-     * @return StructureInterface
+     * @return StructureInterface|null
      */
     public function getStructure();
 }

--- a/src/Sulu/Component/Content/Metadata/StructureMetadata.php
+++ b/src/Sulu/Component/Content/Metadata/StructureMetadata.php
@@ -17,6 +17,8 @@ use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
  * Represents metadata for a structure.
  *
  * @deprecated use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata instead
+ *
+ * @method string getName()
  */
 class StructureMetadata extends PropertiesMetadata
 {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3452
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Add RouteableStructureInterface and fixes some phpstan issues.

#### Why?

Currently only a PageInterface set the CacheLifetime. And in ArticleBundle and ContentBundle we also use the Controller and View variables but they are in no interface to generalize this I moved this functions into an own interface.

#### To Do

- [ ] Create a documentation PR
