### PR TITLE
Added positionName to ContactAccountSelection

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Api/Contact.php
+++ b/src/Sulu/Bundle/ContactBundle/Api/Contact.php
@@ -246,6 +246,26 @@ class Contact extends ApiWrapper
     }
 
     /**
+     * Get position.
+     *
+     * @return string
+     *
+     * @VirtualProperty
+     * @SerializedName("positionName")
+     * @Groups({"contactPosition"})
+     */
+    public function getPositionName()
+    {
+        $position = $this->entity->getPosition();
+
+        if (!$position) {
+            return null;
+        }
+
+        return $position->getPosition();
+    }
+
+    /**
      * Set birthday.
      *
      * @param \DateTime $birthday

--- a/src/Sulu/Bundle/ContactBundle/Content/Types/ContactAccountSelection.php
+++ b/src/Sulu/Bundle/ContactBundle/Content/Types/ContactAccountSelection.php
@@ -170,7 +170,7 @@ class ContactAccountSelection extends ComplexContentType implements ContentTypeE
 
         return array_map(
             function($entity) {
-                $groups = ['fullContact', 'partialAccount'];
+                $groups = ['fullContact', 'partialAccount', 'contactPosition'];
                 if ($entity instanceof Account) {
                     $groups = ['fullAccount', 'partialContact'];
                 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5358
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Added getPositionName function to Contact API.

#### Why?

To get the Contact position name, so you don't have to resolve it by the id.
