### PR TITLE
Change cookie name to SULUSESSID

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -9,6 +9,7 @@ framework:
         handler_id: ~
 #        cookie_secure: auto
 #        cookie_samesite: lax
+        name: SULUSESSID # This avoids conflicts with other applications running on the same domain
 
     #esi: true
     #fragments: true


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | https://github.com/sulu/skeleton/pull/21
| License | MIT
| Documentation PR | -

#### What's in this PR?

Change cookie name to `SULUSESSID` to avoid conflict with `PHPSESSID`.

#### Why?

Avoids conflicts to applications running on the same domain overwriting this cookie session.
