### PR TITLE
Add the SymfonyTestsListener to all phpunit configuration files

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,4 +23,8 @@
         <env name="APP_ENV" value="test"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/phpunit.xml.dist
@@ -22,4 +22,8 @@
         <env name="KERNEL_CLASS" value="Sulu\Bundle\AudienceTargetingBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/CategoryBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/CategoryBundle/phpunit.xml.dist
@@ -23,4 +23,7 @@
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
 
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/ContactBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/ContactBundle/phpunit.xml.dist
@@ -23,4 +23,7 @@
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
 
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/CoreBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/CoreBundle/phpunit.xml.dist
@@ -22,4 +22,8 @@
         <env name="KERNEL_CLASS" value="Sulu\Bundle\CoreBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/CustomUrlBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/CustomUrlBundle/phpunit.xml.dist
@@ -23,4 +23,7 @@
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
 
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/DocumentManagerBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/DocumentManagerBundle/phpunit.xml.dist
@@ -26,5 +26,9 @@
         <env name="KERNEL_CLASS" value="Sulu\Bundle\DocumentManagerBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>
 

--- a/src/Sulu/Bundle/HttpCacheBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/HttpCacheBundle/phpunit.xml.dist
@@ -21,4 +21,8 @@
         <env name="APP_ENV" value="test"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/LocationBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/LocationBundle/phpunit.xml.dist
@@ -21,4 +21,8 @@
         <env name="APP_ENV" value="test"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/MarkupBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/MarkupBundle/phpunit.xml.dist
@@ -20,4 +20,8 @@
     <php>
         <env name="APP_ENV" value="test"/>
     </php>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/MarkupBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/MarkupBundle/phpunit.xml.dist
@@ -19,6 +19,7 @@
 
     <php>
         <env name="APP_ENV" value="test"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
 
     <listeners>

--- a/src/Sulu/Bundle/MediaBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/MediaBundle/phpunit.xml.dist
@@ -22,4 +22,8 @@
         <env name="KERNEL_CLASS" value="Sulu\Bundle\MediaBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/PageBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/PageBundle/phpunit.xml.dist
@@ -23,4 +23,7 @@
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
 
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/PersistenceBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/PersistenceBundle/phpunit.xml.dist
@@ -22,4 +22,8 @@
         <env name="KERNEL_CLASS" value="Sulu\Bundle\PersistenceBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/PreviewBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/PreviewBundle/phpunit.xml.dist
@@ -22,4 +22,8 @@
         <env name="KERNEL_CLASS" value="Sulu\Bundle\PreviewBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/RouteBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/RouteBundle/phpunit.xml.dist
@@ -22,4 +22,8 @@
         <env name="KERNEL_CLASS" value="Sulu\Bundle\RouteBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/SearchBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/SearchBundle/phpunit.xml.dist
@@ -27,5 +27,9 @@
         <env name="KERNEL_CLASS" value="Sulu\Bundle\SearchBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>
 

--- a/src/Sulu/Bundle/SecurityBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/SecurityBundle/phpunit.xml.dist
@@ -22,4 +22,8 @@
         <env name="KERNEL_CLASS" value="Sulu\Bundle\SecurityBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/SnippetBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/SnippetBundle/phpunit.xml.dist
@@ -26,4 +26,8 @@
         <env name="KERNEL_CLASS" value="Sulu\Bundle\SnippetBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/TagBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/TagBundle/phpunit.xml.dist
@@ -22,4 +22,8 @@
         <env name="KERNEL_CLASS" value="Sulu\Bundle\TagBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/WebsiteBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/WebsiteBundle/phpunit.xml.dist
@@ -22,4 +22,8 @@
         <env name="KERNEL_CLASS" value="Sulu\Bundle\WebsiteBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR makes sure that the deprecations are listened on every phpunit call.

#### Why?

Because this setting was not used on my local machine.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
- [ ] Add settings to show internal deprecations
