### PR TITLE
Fix missing reset of URL if multiple external links are set in CKEditor5

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/ExternalLinkPlugin/ExternalLinkOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/ExternalLinkPlugin/ExternalLinkOverlay.js
@@ -45,6 +45,7 @@ class ExternalLinkOverlay extends React.Component<Props> {
         const {url} = this.props;
 
         if (!url) {
+            this.url = undefined;
             return;
         }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

Reset URL in `ExternalLinkOverlay`.

#### Why?

Because otherwise the URL stays there, if multiple external links are added.

Reproducation:

1. Go to a page with a `text_editor`
2. Write some text
3. Add an external link with some URL
4. Select another text and add another External Link
5. The URL from step 3 will still be in the input field