### PR TITLE
Extract teaser attributes to getAttribute method

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Teaser/PageTeaserProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Teaser/PageTeaserProvider.php
@@ -96,9 +96,7 @@ class PageTeaserProvider implements TeaserProviderInterface
                 $document->getField('excerptMore')->getValue(),
                 $document->getField('__url')->getValue(),
                 (null !== $excerptMedia ? $excerptMedia : $teaserMedia),
-                [
-                    'structureType' => $document->getField(StructureProvider::FIELD_STRUCTURE_TYPE)->getValue(),
-                ]
+                $this->getAttributes($document)
             );
         }
 
@@ -152,5 +150,19 @@ class PageTeaserProvider implements TeaserProviderInterface
                 return preg_match('/page_(.*)_published/', $index) > 0;
             }
         );
+    }
+
+    /**
+     * Returns attributes for teaser.
+     *
+     * @param Document $document
+     *
+     * @return array
+     */
+    protected function getAttributes(Document $document)
+    {
+        return [
+            'structureType' => $document->getField(StructureProvider::FIELD_STRUCTURE_TYPE)->getValue(),
+        ];
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Extracts the teaser attributes to the `getAttributes` method. The same structure is already used in the `ArticleTeaserProvider`.

#### Why?

For custom attributes it is easier to override only the `getAttributes` method instead of the `find` method.