### PR TITLE
Provide a default user provider for the firewall

### DIFF
--- a/config/packages/security_admin.yaml
+++ b/config/packages/security_admin.yaml
@@ -24,6 +24,7 @@ security:
         admin:
             pattern: ^/
             anonymous: ~
+            provider: sulu
             entry_point: sulu_security.authentication_entry_point
             json_login:
                 check_path: sulu_admin.login_check

--- a/config/packages/test/security_admin.yaml
+++ b/config/packages/test/security_admin.yaml
@@ -7,8 +7,6 @@ security:
         admin:
             http_basic:
                 provider: testprovider
-            json_login:
-                provider: sulu
 
 sulu_test:
     enable_test_user_provider: true


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | https://github.com/sulu/skeleton/pull/26, symfony/symfony#34596
| License | MIT
| Documentation PR | -

#### What's in this PR?

Provide a default user provider for the firewall

#### Why?

Avoid following error message in test environment when using Symfony 4.4.

> Not configuring explicitly the provider for the "anonymous" listener on "admin" firewall is ambiguous as there is more than one registered provider.   
