### PR TITLE
Fix http cache directory for symfony cache

### DIFF
--- a/src/Sulu/Bundle/HttpCacheBundle/Cache/SuluHttpCache.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Cache/SuluHttpCache.php
@@ -42,7 +42,7 @@ class SuluHttpCache extends HttpCache implements CacheInvalidation
     public function __construct(HttpKernelInterface $kernel, $cacheDir = null)
     {
         if (!$cacheDir && $kernel instanceof SuluKernel) {
-            $cacheDir = $kernel->getCommonCacheDir();
+            $cacheDir = $kernel->getCommonCacheDir() . DIRECTORY_SEPARATOR . 'http_cache';
         }
 
         parent::__construct($kernel, $cacheDir);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Change the http_cache folder to the http_cache subdirectory of the common cache dir.

#### Why?

Only the http_cache subdirectory is cleared see:

https://github.com/sulu/sulu/blob/8b8c674c5f9254ceab0014095387c11ee004a603/src/Sulu/Bundle/WebsiteBundle/Cache/CacheClearer.php#L96-L106

#### Example Usage

1. Create new page
2. Add it to navigation context
3. Publish it
4. Click Cache Clear Website

The new page does not appear on the homepage navigation as the http cache was written into the false directory.
