### PR TITLE
Add params to smart-content items request

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
@@ -87,13 +87,14 @@ class SmartContent extends React.Component<Props> {
         const {
             formInspector,
             onChange,
-            schemaOptions: {
-                exclude_duplicates: {
-                    value: excludeDuplicates = false,
-                } = {},
-            } = {},
+            schemaOptions = {},
             value,
         } = this.props;
+        const {
+            exclude_duplicates: {
+                value: excludeDuplicates = false,
+            } = {},
+        } = schemaOptions;
 
         if (typeof excludeDuplicates !== 'boolean') {
             throw new Error('The "exclude_duplicates" schemaOption must be a boolean if set!');
@@ -110,7 +111,8 @@ class SmartContent extends React.Component<Props> {
             this.value,
             formInspector.locale,
             datasourceResourceKey,
-            formInspector.resourceKey === this.provider ? formInspector.id : undefined
+            formInspector.resourceKey === this.provider ? formInspector.id : undefined,
+            schemaOptions
         );
 
         smartContentStorePool.add(this.smartContentStore, excludeDuplicates);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SmartContent.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SmartContent.test.js
@@ -86,7 +86,7 @@ test('Should correctly initialize SmartContentStore', () => {
 
     expect(smartContentStorePool.add).toBeCalledWith(smartContentStore, false);
     expect(smartContentConfigStore.getConfig).toBeCalledWith('media');
-    expect(SmartContentStore).toBeCalledWith('media', value, undefined, 'collections', undefined);
+    expect(SmartContentStore).toBeCalledWith('media', value, undefined, 'collections', undefined, schemaOptions);
 
     smartContent.unmount();
     expect(smartContentStorePool.remove).toBeCalledWith(smartContentStore);
@@ -186,7 +186,7 @@ test('Should pass id to SmartContentStore if resourceKeys match', () => {
     );
 
     expect(smartContentConfigStore.getConfig).toBeCalledWith('pages');
-    expect(SmartContentStore).toBeCalledWith('pages', value, undefined, 'pages', 4);
+    expect(SmartContentStore).toBeCalledWith('pages', value, undefined, 'pages', 4, schemaOptions);
 });
 
 test('Pass correct props to SmartContent component', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/stores/SmartContentStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/stores/SmartContentStore.js
@@ -12,6 +12,7 @@ export default class SmartContentStore {
     provider: string;
     locale: ?IObservableValue<string>;
     dataSourceResourceKey: ?string;
+    params: Object;
     @observable items: Array<Object> = [];
     @observable itemsLoading: boolean = true;
     @observable categoriesLoading: boolean;
@@ -36,12 +37,14 @@ export default class SmartContentStore {
         filterCriteria: ?FilterCriteria,
         locale?: ?IObservableValue<string>,
         dataSourceResourceKey: ?string,
-        id: ?string | number
+        id: ?string | number,
+        params: Object
     ) {
         this.provider = provider;
         this.locale = locale;
         this.dataSourceResourceKey = dataSourceResourceKey;
         this.id = id;
+        this.params = params;
 
         if (filterCriteria) {
             this.audienceTargeting = filterCriteria.audienceTargeting;
@@ -105,6 +108,7 @@ export default class SmartContentStore {
                 provider: this.provider,
                 excluded: [this.id, ...this.excludedIds],
                 locale: this.locale,
+                params: JSON.stringify(this.params),
                 ...this.filterCriteria,
             })
         ).then(action((response) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/stores/SmartContentStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/stores/SmartContentStore.test.js
@@ -103,6 +103,7 @@ test('Load items if FilterCriteria is given with datasource', () => {
 
 test('Load items if FilterCriteria is given with categories', () => {
     const locale = observable.box('en');
+    const params = {provider: {name: 'provider', value: 'content'}};
     const filterCriteria = {
         dataSource: undefined,
         includeSubFolders: undefined,
@@ -124,16 +125,20 @@ test('Load items if FilterCriteria is given with categories', () => {
     });
     ResourceRequester.get.mockReturnValue(categoriesPromise);
 
-    const smartContentStore = new SmartContentStore('content', filterCriteria, locale, 'pages', 4);
+    const smartContentStore = new SmartContentStore('content', filterCriteria, locale, 'pages', 4, params);
     smartContentStore.start();
 
+    const expectedParams = '%7B%22provider%22%3A%7B%22name%22%3A%22provider%22,%22value%22%3A%22content%22%7D%7D';
     return categoriesPromise.then(() => {
-        expect(Requester.get).toBeCalledWith('/api/items?provider=content&excluded=4&locale=en&categories=1,5');
+        expect(Requester.get).toBeCalledWith(
+            '/api/items?provider=content&excluded=4&locale=en&params=' + expectedParams + '&categories=1,5'
+        );
     });
 });
 
 test('Load items if FilterCriteria is given with tags', () => {
     const locale = observable.box('en');
+    const params = {provider: {name: 'provider', value: 'content'}};
     const filterCriteria = {
         dataSource: undefined,
         includeSubFolders: undefined,
@@ -148,10 +153,13 @@ test('Load items if FilterCriteria is given with tags', () => {
         limitResult: undefined,
     };
 
-    const smartContentStore = new SmartContentStore('content', filterCriteria, locale, 'pages', 4);
+    const smartContentStore = new SmartContentStore('content', filterCriteria, locale, 'pages', 4, params);
     smartContentStore.start();
 
-    expect(Requester.get).toBeCalledWith('/api/items?provider=content&excluded=4&locale=en&tags=Tag2');
+    const expectedParams = '%7B%22provider%22%3A%7B%22name%22%3A%22provider%22,%22value%22%3A%22content%22%7D%7D';
+    expect(Requester.get).toBeCalledWith(
+        '/api/items?provider=content&excluded=4&locale=en&params=' + expectedParams + '&tags=Tag2'
+    );
 });
 
 test('Load items excluding given ids', () => {

--- a/src/Sulu/Bundle/PageBundle/Controller/SmartContentItemController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/SmartContentItemController.php
@@ -115,12 +115,13 @@ class SmartContentItemController extends AbstractRestController
     {
         $result = [];
         foreach ($params as $name => $item) {
+            $type = $item['type'] ?? null;
             $value = $item['value'];
-            if ('collection' === $item['type']) {
+            if ('collection' === $type) {
                 $value = $this->getParams($value);
             }
 
-            $result[$name] = new PropertyParameter($name, $value, $item['type']);
+            $result[$name] = new PropertyParameter($name, $value, $type);
         }
 
         return $result;

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/SmartContentItemControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/SmartContentItemControllerTest.php
@@ -422,6 +422,51 @@ class SmartContentItemControllerTest extends SuluTestCase
         );
     }
 
+    public function testGetItemsWithParamsAndNoType()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request(
+            'GET',
+            '/api/items?webspace=sulu_io&locale=en&dataSource=' . $this->team->getUuid() .
+            '&provider=pages&excluded=' . $this->johannes->getUuid() .
+            '&params={"max_per_page":{"value":"5"},' .
+            '"properties":{"value":{"title":{"value":"title","type":"string"}},"type":"collection"}}'
+        );
+
+        $this->assertHttpStatusCode(200, $client->getResponse());
+
+        $result = json_decode($client->getResponse()->getContent(), true);
+        $this->assertEquals(
+            [
+                'id' => $this->team->getUuid(),
+                'title' => 'Team',
+                'path' => '/team',
+                'image' => null,
+            ],
+            $result['datasource']
+        );
+        $this->assertEquals(
+            [
+                [
+                    'id' => $this->daniel->getUuid(),
+                    'title' => 'Daniel',
+                    'publishedState' => false,
+                    'url' => '/team/daniel',
+                    'published' => null,
+                ],
+                [
+                    'id' => $this->thomas->getUuid(),
+                    'title' => 'Thomas',
+                    'publishedState' => false,
+                    'url' => '/team/thomas',
+                    'published' => null,
+                ],
+            ],
+            $result['_embedded']['items']
+        );
+    }
+
     public function testGetItemsLimit()
     {
         $client = $this->createAuthenticatedClient();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes https://github.com/sulu/SuluArticleBundle/issues/413
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add the params parameter to the smart-content items request for the admin form field.

#### Why?

See the linked issue from the ArticleBundle.

The Provider uses the params to filter for types/structureTypes

#### To Do

- [x] Tests
