### PR TITLE
Show MimeTypeIndicator instead of infinite loader if image cannot be loaded for a reason

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
@@ -41,10 +41,9 @@ class MediaCard extends React.Component<Props> {
     image: Image;
 
     @observable downloadButtonRef: ?ElementRef<'button'>;
-
     @observable downloadListOpen: boolean = false;
-
     @observable imageLoading: boolean = true;
+    @observable imageError: boolean = false;
 
     constructor(props: Props) {
         super(props);
@@ -54,6 +53,7 @@ class MediaCard extends React.Component<Props> {
         if (src) {
             this.image = new Image();
             this.image.onload = this.handleImageLoad;
+            this.image.onerror = this.handleImageError;
             this.image.src = src;
         } else {
             this.handleImageLoad();
@@ -115,6 +115,10 @@ class MediaCard extends React.Component<Props> {
 
     @action handleImageLoad = () => {
         this.imageLoading = false;
+    };
+
+    @action handleImageError = () => {
+        this.imageError = true;
     };
 
     render() {
@@ -208,7 +212,7 @@ class MediaCard extends React.Component<Props> {
                     onClick={this.handleClick}
                     role="button"
                 >
-                    {image
+                    {image && !this.imageError
                         ? (
                             <Fragment>
                                 <img alt={title} src={this.image.src} />

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/MediaCard.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/MediaCard.test.js
@@ -37,6 +37,24 @@ test('Render a MediaCard component with loader if image has not been loaded yet'
     expect(mediaCard.render()).toMatchSnapshot();
 });
 
+test('Render a MediaCard component with MimeTypeIndicator if an error appeared while loading the image', () => {
+    const mediaCard = mount(
+        <MediaCard
+            downloadText=""
+            downloadUrl=""
+            id="test"
+            image="http://lorempixel.com/300/200"
+            meta="Test/Test"
+            mimeType="image/jpeg"
+            title="Test"
+        />
+    );
+
+    mediaCard.instance().image.onerror();
+
+    expect(mediaCard.render()).toMatchSnapshot();
+});
+
 test('Render a MediaCard component with a checkbox for selection', () => {
     const mediaCard = mount(
         <MediaCard

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/__snapshots__/MediaCard.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/__snapshots__/MediaCard.test.js.snap
@@ -90,6 +90,101 @@ exports[`Render a MediaCard component 1`] = `
 </div>
 `;
 
+exports[`Render a MediaCard component with MimeTypeIndicator if an error appeared while loading the image 1`] = `
+<div
+  class="mediaCard noDownloadList"
+>
+  <div
+    class="header"
+  >
+    <div
+      class="description"
+      role="button"
+    >
+      <div
+        class="title"
+      >
+        <div
+          class="titleText"
+        >
+          <div
+            aria-label="Test"
+            class="croppedText"
+            title="Test"
+          >
+            <div
+              aria-hidden="true"
+              class="front"
+            >
+              Te
+            </div>
+            <div
+              aria-hidden="true"
+              class="back"
+            >
+              <span>
+                st
+              </span>
+            </div>
+            <div
+              class="whole"
+            >
+              Test
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="meta"
+      >
+        <div
+          aria-label="Test/Test"
+          class="croppedText"
+          title="Test/Test"
+        >
+          <div
+            aria-hidden="true"
+            class="front"
+          >
+            Test/
+          </div>
+          <div
+            aria-hidden="true"
+            class="back"
+          >
+            <span>
+              Test
+            </span>
+          </div>
+          <div
+            class="whole"
+          >
+            Test/Test
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="media"
+    role="button"
+  >
+    <div
+      class="mimeTypeIndicator"
+      style="color: rgb(255, 255, 255); font-size: 52px; background-color: rgb(246, 126, 0); height: 200px;"
+    >
+      <span
+        aria-label="fa-file-image-o"
+        class="fa fa-file-image-o"
+      />
+    </div>
+    <div
+      class="cover"
+    />
+  </div>
+</div>
+`;
+
 exports[`Render a MediaCard component with a checkbox for selection 1`] = `
 <div
   class="mediaCard noDownloadList"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/SingleMediaDropzone.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/SingleMediaDropzone.js
@@ -37,6 +37,7 @@ class SingleMediaDropzone extends React.Component<Props> {
 
     @observable uploadIndicatorVisibility: boolean;
     @observable imageLoading: boolean = false;
+    @observable imageError: boolean = false;
 
     componentDidMount() {
         this.preloadImage();
@@ -55,6 +56,7 @@ class SingleMediaDropzone extends React.Component<Props> {
             this.imageLoading = true;
 
             this.image = new Image();
+            this.image.onerror = this.handleImageError;
             this.image.onload = this.handleImageLoad;
             this.image.src = src;
         } else {
@@ -83,6 +85,10 @@ class SingleMediaDropzone extends React.Component<Props> {
 
     handleDragLeave = () => {
         this.setUploadIndicatorVisibility(false);
+    };
+
+    @action handleImageError = () => {
+        this.imageError = true;
     };
 
     render() {
@@ -116,13 +122,13 @@ class SingleMediaDropzone extends React.Component<Props> {
                 onDragLeave={this.handleDragLeave}
                 onDrop={this.handleDrop}
             >
-                {image &&
+                {image && !this.imageError &&
                     <Fragment>
                         <img className={singleMediaDropzoneStyles.thumbnail} key={image} src={image} />
                         {this.imageLoading && <Loader />}
                     </Fragment>
                 }
-                {!image && mimeType &&
+                {(!image || this.imageError) && mimeType &&
                     <div className={singleMediaDropzoneStyles.mimeTypeIndicator}>
                         <MimeTypeIndicator iconSize={100} mimeType={mimeType} />
                     </div>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/tests/SingleMediaDropzone.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/tests/SingleMediaDropzone.test.js
@@ -35,6 +35,17 @@ test('Render a SingleMediaDropzone without a loader if image has been loaded yet
     expect(singleMediaDropzone.render()).toMatchSnapshot();
 });
 
+test('Render a SingleMediaDropzone with a MimeTypeIndicator if an error appeared during image loading', () => {
+    const singleMediaDropzone = mount(
+        <SingleMediaDropzone emptyIcon="su-user" image="test.jpg" mimeType="video/x-m4v" onDrop={jest.fn()} />
+    );
+
+    singleMediaDropzone.instance().image.onerror();
+    singleMediaDropzone.update();
+
+    expect(singleMediaDropzone.render()).toMatchSnapshot();
+});
+
 test('Render a SingleMediaDropzone in disabled state', () => {
     expect(render(
         <SingleMediaDropzone

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/tests/__snapshots__/SingleMediaDropzone.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/tests/__snapshots__/SingleMediaDropzone.test.js.snap
@@ -129,6 +129,47 @@ exports[`Render a SingleMediaDropzone while uploading 1`] = `
 </div>
 `;
 
+exports[`Render a SingleMediaDropzone with a MimeTypeIndicator if an error appeared during image loading 1`] = `
+<div
+  aria-disabled="false"
+  class="mediaContainer default"
+  style="position: relative;"
+>
+  <div
+    class="mimeTypeIndicator"
+  >
+    <div
+      class="mimeTypeIndicator"
+      style="color: rgb(255, 255, 255); font-size: 100px; background-color: rgb(246, 126, 0);"
+    >
+      <span
+        aria-label="fa-file-video-o"
+        class="fa fa-file-video-o"
+      />
+    </div>
+  </div>
+  <div
+    class="uploadIndicatorContainer"
+  >
+    <div
+      class="uploadIndicator"
+    >
+      <div>
+        <span
+          aria-label="fa-cloud-upload"
+          class="fa fa-cloud-upload uploadIcon"
+        />
+      </div>
+    </div>
+  </div>
+  <input
+    autocomplete="off"
+    style="position: absolute; top: 0px; right: 0px; bottom: 0px; left: 0px; opacity: 0.00001; pointer-events: none;"
+    type="file"
+  />
+</div>
+`;
+
 exports[`Render a SingleMediaDropzone with a loader if image has not been loaded yet 1`] = `
 <div
   aria-disabled="false"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR displays the `MimeTypeIndicator` in the media overview and the upload in the media form if loading the image throws an error.

#### Why?

Because seeing an infinite loader then is not the solution either. This e.g. happens when uploading a video without `ffmpeg` being installed.