### PR TITLE
Update Documenation link

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -56,7 +56,7 @@ if ('dev' !== $_SERVER['APP_ENV'] && SuluKernel::CONTEXT_WEBSITE === $suluContex
 
 // When using the HttpCache, you need to call the method in your front controller
 // instead of relying on the configuration parameter
-// https://symfony.com/doc/3.4/reference/configuration/framework.html#http-method-override
+// https://symfony.com/doc/4.3/reference/configuration/framework.html#http-method-override
 Request::enableHttpMethodParameterOverride();
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

There's a link for "http-method-override" that points to the Symfony 3.4 documentation but Sulu 2.0 requires Symfony 4.3 or later.

#### Why?

The link should use the newer Symfony documentation version.

#### Example Usage

Open /public/index.php in an editor and open the link in line 59 in a web browser.