### PR TITLE
Add rule to avoid that the AdminBundle depends on other bundles

### DIFF
--- a/dependency-cruiser.json
+++ b/dependency-cruiser.json
@@ -65,6 +65,12 @@
             "severity": "error",
             "from": {"path": "Resources/js/stores"},
             "to": {"path": "views"}
+        },
+        {
+            "name": "sulu-admin-bundle-not-to-other-sulu-bundles",
+            "severity": "error",
+            "from": {"path": "src/Sulu/Bundle/AdminBundle/Resources/js"},
+            "to": {"path": "src\\/Sulu\\/Bundle\\/(?!AdminBundle)(.*)Bundle\\/Resources\\/js"}
         }
     ]
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

Add a Rule to avoid the AdminBundle to depend on other bundles.

#### Why?

Because the AdminBundle is the base for all the other bundles, and we would like to avoid bidirectional dependencies.