### PR TITLE
Remove alt from Thumbnail transformer because alt is not delivered by API

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/ThumbnailFieldTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/ThumbnailFieldTransformer.js
@@ -24,6 +24,6 @@ export default class ThumbnailFieldTransformer implements FieldTransformer {
             return null;
         }
 
-        return <img alt={value.alt} src={value[IMAGE_FORMAT]} />;
+        return <img src={value[IMAGE_FORMAT]} />;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldTransformers/ThumbnailFieldTransformer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldTransformers/ThumbnailFieldTransformer.test.js
@@ -33,9 +33,3 @@ test('Test valid object', () => {
         <img alt={undefined} src="/path/to/image.png" />
     );
 });
-
-test('Test valid full object', () => {
-    expect(thumbnailTransformer.transform({'sulu-40x40': '/path/to/image.png', alt: 'Alternative'})).toEqual(
-        <img alt="Alternative" src="/path/to/image.png" />
-    );
-});


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

The `alt` tag is not passed in the list response, therefore we should not render it.

#### Why?

It could even cause problems if an image format named `alt`, because then this content instead of a proper alt text would be used.