### PR TITLE
find and findChildren should return either a NavigationItem or null

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItem.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItem.php
@@ -291,7 +291,7 @@ class NavigationItem implements \Iterator
      *
      * @param NavigationItem $navigationItem The NavigationItem to look for
      *
-     * @return NavigationItem The item if it is found, otherwise false
+     * @return NavigationItem|null The item if it is found, otherwise null
      */
     public function find($navigationItem)
     {
@@ -308,7 +308,7 @@ class NavigationItem implements \Iterator
             }
         }
 
-        return;
+        return null;
     }
 
     /**
@@ -327,7 +327,7 @@ class NavigationItem implements \Iterator
             }
         }
 
-        return;
+        return null;
     }
 
     /**

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Navigation/NavigationItemTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Navigation/NavigationItemTest.php
@@ -85,7 +85,7 @@ class NavigationItemTest extends TestCase
         $this->assertEquals($child, $this->navigationItem->getChildren()[0]);
     }
 
-    public function testSearch()
+    public function testFind()
     {
         $this->assertEquals('Globals', $this->item2->find(new NavigationItem('Globals'))->getName());
         $this->assertNull($this->item1->find(new NavigationItem('Nothing')));
@@ -95,6 +95,12 @@ class NavigationItemTest extends TestCase
     {
         $this->assertTrue($this->item1->hasChildren());
         $this->assertFalse($this->navigationItem->hasChildren());
+    }
+
+    public function testFindChildren()
+    {
+        $this->assertEquals('Portals', $this->item1->findChildren(new NavigationItem('Portals'))->getName());
+        $this->assertNull($this->navigationItem->findChildren(new NavigationItem(('Nothing'))));
     }
 
     public function testCopyChildless()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

The NavigationItem features the methods find and findChildren.
This pull requests fixes the phpdoc and behaviour of these methods by returning Navigationitem or null.

#### Why?

In case of  find it is documented that it would return false if no navigation item is found.
However find returns void instead of false if no navigation item is found.

In case of findChildren the phpdoc states that it would return a NavigationItem or null.
However findChildren returns a NavigationItem or void instead.