### PR TITLE
CustomUrlManagerInterface::findByUrl needs locale parameter

### DIFF
--- a/src/Sulu/Component/CustomUrl/Manager/CustomUrlManagerInterface.php
+++ b/src/Sulu/Component/CustomUrl/Manager/CustomUrlManagerInterface.php
@@ -64,7 +64,7 @@ interface CustomUrlManagerInterface
      *
      * @param string $url
      * @param string $webspaceKey
-     * @param string $locale
+     * @param string|null $locale
      *
      * @return CustomUrlDocument
      */

--- a/src/Sulu/Component/CustomUrl/Manager/CustomUrlManagerInterface.php
+++ b/src/Sulu/Component/CustomUrl/Manager/CustomUrlManagerInterface.php
@@ -64,10 +64,11 @@ interface CustomUrlManagerInterface
      *
      * @param string $url
      * @param string $webspaceKey
+     * @param string $locale
      *
      * @return CustomUrlDocument
      */
-    public function findByUrl($url, $webspaceKey);
+    public function findByUrl($url, $webspaceKey, $locale = null);
 
     /**
      * Returns a list of custom-url documents which targeting the given page.


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

CustomUrlManagerInterface::findByUrl needs to have the locale as 3rd parameter.

#### Why?

The CustomUrlRequestProcessor works with a CustomUrlManagerInterface and calls findByUrl with the locale as 3rd parameter.

As consequence the locale must be added to the CustomUrlManagerInterface. It is not sufficient, that CustomUrlManager::findByUrl has the locale in its signature.