### PR TITLE
add used PHP extensions to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,11 @@
     },
     "require": {
         "php": "^7.2",
+        "ext-SimpleXML": "*",
+        "ext-dom": "*",
+        "ext-fileinfo": "*",
+        "ext-json": "*",
+        "ext-zip": "*",
         "aferrandini/urlizer": "^1.0",
         "dantleech/phpcr-migrations-bundle": "^1.0",
         "doctrine/annotations": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,9 @@
     },
     "require": {
         "php": "^7.2",
-        "ext-SimpleXML": "*",
         "ext-dom": "*",
-        "ext-fileinfo": "*",
         "ext-json": "*",
-        "ext-zip": "*",
+        "ext-simplexml": "*",
         "aferrandini/urlizer": "^1.0",
         "dantleech/phpcr-migrations-bundle": "^1.0",
         "doctrine/annotations": "^1.2",
@@ -154,6 +152,8 @@
         "sulu/translate-bundle": "self.version"
     },
     "suggest": {
+        "ext-fileinfo": "* - Needed to recognize file types of uploaded files",
+        "ext-zip": "* - Needed by the download commands for the admin build and its translations",
         "handcraftedinthealps/zendsearch": "To use the PHP based Zend Search library (based on Lucene)",
         "league/flysystem": "^1.0 - Needed for remote media-storages",
         "league/flysystem-aws-s3-v3": "^1.0.1 - Needed for AWS S3 compatible storages (aws s3 or minio)",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

This pull requests add the used PHP extensions to the composer.json file.

#### Why?

Composer should fail at install time instead of having runtime errors in Sulu.
One can compile a nice list of dependencies when migrating servers.

It's a very good practice to always add the used dependencies.

Citing https://getcomposer.org/doc/04-schema.md
> Note: It is important to list PHP extensions your project requires.

| Extension | Usage
| --- | ---
| ext-json | All over the place
| ext-dom | \Sulu\Bundle\MediaBundle\Media\FormatLoader\BaseXmlFormatLoader, \Sulu\Bundle\AdminBundle\FormMetadata\FormXmlLoader
| ext-fileinfo | \Sulu\Bundle\MediaBundle\Media\FormatManager\FormatManager
| ext-simplexml | \Sulu\Bundle\PageBundle\DependencyInjection\Compiler\WebspacesPass
| ext-zip | \Sulu\Bundle\AdminBundle\Command\DownloadBuildCommand

I added neihter mbstring nor iconv because only one of these extension is required and AFAIK there is no way to specify that only one of those is needed.

Also ext-openssl is optional. I suggest one should have a look at the TokenGenerator as it seems a bit dated.

#### Example Usage

~~~bash
php -d memory_limit=1G composer.phar install
~~~