### PR TITLE
Allow scrolling in toolbar select

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
@@ -105,11 +105,19 @@ class Popover extends React.Component<Props> {
         }
 
         const {
-            offsetWidth,
+            clientHeight,
+            clientWidth,
             offsetHeight,
+            offsetWidth,
+            scrollHeight,
+            scrollWidth,
         } = this.popoverChildRef;
 
-        this.setPopoverSize(offsetWidth, offsetHeight);
+        // calculating real size by considering borders, margins and paddings
+        this.setPopoverSize(
+            scrollWidth + offsetWidth - clientWidth,
+            scrollHeight + offsetHeight - clientHeight
+        );
     };
 
     @action setPopoverSize(width: number, height: number) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
@@ -107,20 +107,9 @@ class Popover extends React.Component<Props> {
         const {
             offsetWidth,
             offsetHeight,
-            scrollWidth,
-            scrollHeight,
-            clientWidth,
-            clientHeight,
         } = this.popoverChildRef;
 
-        // calculating real size by considering borders, margins and paddings
-        const outerWidth = scrollWidth + offsetWidth - clientWidth;
-        const outerHeight = scrollHeight + offsetHeight - clientHeight;
-
-        this.setPopoverSize(
-            outerWidth,
-            outerHeight
-        );
+        this.setPopoverSize(offsetWidth, offsetHeight);
     };
 
     @action setPopoverSize(width: number, height: number) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Dropdown.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Dropdown.js
@@ -97,14 +97,14 @@ class Dropdown extends React.Component<DropdownProps> {
                 >
                     {
                         (setPopoverElementRef, popoverStyle) => (
-                            <OptionList
-                                onClose={this.handleOptionListClose}
-                                onOptionClick={this.handleOptionListClick}
-                                optionListRef={setPopoverElementRef}
-                                options={options}
-                                skin={skin}
-                                style={popoverStyle}
-                            />
+                            <div ref={setPopoverElementRef} style={popoverStyle}>
+                                <OptionList
+                                    onClose={this.handleOptionListClose}
+                                    onOptionClick={this.handleOptionListClick}
+                                    options={options}
+                                    skin={skin}
+                                />
+                            </div>
                         )
                     }
                 </Popover>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/OptionList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/OptionList.js
@@ -19,12 +19,13 @@ type Props = {
 
 export default class OptionList extends React.PureComponent<Props> {
     handleOptionClick = (option: Object) => {
-        if (this.props.onOptionClick) {
-            this.props.onOptionClick(option);
+        const {onClose, onOptionClick} = this.props;
+        if (onOptionClick) {
+            onOptionClick(option);
         }
 
-        if (this.props.onClose) {
-            this.props.onClose();
+        if (onClose) {
+            onClose();
         }
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/OptionList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/OptionList.js
@@ -1,7 +1,6 @@
 // @flow
 import classNames from 'classnames';
 import React from 'react';
-import type {ElementRef} from 'react';
 import Option from './Option';
 import type {Skin} from './types';
 import optionListStyles from './optionList.scss';
@@ -9,11 +8,9 @@ import optionListStyles from './optionList.scss';
 type Props = {
     onClose?: () => void,
     onOptionClick: (option: Object) => void,
-    optionListRef?: (ref: ElementRef<'ul'>) => void,
     options: Array<Object>,
     size?: string,
     skin?: Skin,
-    style?: Object,
     value?: string | number,
 };
 
@@ -29,20 +26,12 @@ export default class OptionList extends React.PureComponent<Props> {
         }
     };
 
-    setRef = (ref: ?ElementRef<'ul'>) => {
-        const {optionListRef} = this.props;
-        if (optionListRef && ref) {
-            optionListRef(ref);
-        }
-    };
-
     render() {
         const {
             size,
             value,
             options,
             skin,
-            style,
         } = this.props;
         const optionListClass = classNames(
             optionListStyles.optionList,
@@ -53,11 +42,7 @@ export default class OptionList extends React.PureComponent<Props> {
         );
 
         return (
-            <ul
-                className={optionListClass}
-                ref={this.setRef}
-                style={style}
-            >
+            <ul className={optionListClass}>
                 {
                     options.map((option, index: number) => {
                         const selected = option.value ? option.value === value : false;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Select.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Select.js
@@ -105,16 +105,16 @@ class Select extends React.Component<SelectProps> {
                 >
                     {
                         (setPopoverElementRef, popoverStyle) => (
-                            <OptionList
-                                onClose={this.handleOptionListClose}
-                                onOptionClick={this.handleOptionClick}
-                                optionListRef={setPopoverElementRef}
-                                options={options}
-                                size={size}
-                                skin={skin}
-                                style={popoverStyle}
-                                value={value}
-                            />
+                            <div ref={setPopoverElementRef} style={popoverStyle}>
+                                <OptionList
+                                    onClose={this.handleOptionListClose}
+                                    onOptionClick={this.handleOptionClick}
+                                    options={options}
+                                    size={size}
+                                    skin={skin}
+                                    value={value}
+                                />
+                            </div>
                         )
                     }
                 </Popover>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/option.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/option.scss
@@ -79,8 +79,7 @@ $optionTextDarkColorActive: $white;
 
     &.small {
         button {
-            padding: 10px 20px;
-            text-align: center;
+            padding: 10px 10px 10px 23px;
         }
 
         .selected-icon {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/optionList.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/optionList.scss
@@ -18,17 +18,18 @@ $optionListShadowColor: $silver;
     list-style: none;
     position: absolute;
     left: 0;
-    top: 100%;
     z-index: 100;
     margin: 0;
     padding: 0;
     white-space: nowrap;
+    max-height: 70vh;
+    overflow: auto;
 
     &.is-open {
         display: block;
     }
 
     &.small {
-        width: $smallSelectWidth;
+        min-width: $smallSelectWidth;
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3061
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR allows to scroll in the Toolbar selects.

#### Why?

Because if many templates or languages exist in a template, then the last ones cannot be clicked, because they stick out of the display.

#### To Do

- [x] Fix if collaboration warning is shown
