### PR TITLE
Add method to add resource-store-properties to metadata-request

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,6 +5,16 @@
 When upgrading also have a look at the changes in the
 [sulu skeleton](https://github.com/sulu/skeleton/compare/2.0.2...2.0.3).
 
+### New methods in ViewBuilderInterfaces
+
+Following methods has been added:
+
+* `ListViewBuilderInterface::addResourceStorePropertiesToListMetadata`
+* `ListViewBuilderInterface::addRequestParameters`
+* `FormViewBuilderInterface::addRequestParameters`
+* `FormOverlayListViewBuilderInterface::addRequestParameters`
+* `PreviewFormViewBuilderInterface::addRequestParameters`
+
 ### Symfony/templating requirement removed
 
 Sulu does not longer need the `symfony/templating` package which is deprecated.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
     DATABASE_CHARSET: utf8mb4
     DATABASE_COLLATE: utf8mb4_unicode_ci
     SYMFONY_DEPRECATIONS_HELPER: weak
-    MYSQL_VERSION: 8.0.17
+    MYSQL_VERSION: 8.0.18
     NODEJS_VERSION: "12"
     matrix:
         - PHP_VERSION: 7.2.4

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
     DATABASE_CHARSET: utf8mb4
     DATABASE_COLLATE: utf8mb4_unicode_ci
     SYMFONY_DEPRECATIONS_HELPER: weak
-    MYSQL_VERSION: 8.0
+    MYSQL_VERSION: 8.0.17
     NODEJS_VERSION: "12"
     matrix:
         - PHP_VERSION: 7.2.4

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
     DATABASE_CHARSET: utf8mb4
     DATABASE_COLLATE: utf8mb4_unicode_ci
     SYMFONY_DEPRECATIONS_HELPER: weak
-    MYSQL_VERSION: 8.0.18
+    MYSQL_VERSION: 8.0
     NODEJS_VERSION: "12"
     matrix:
         - PHP_VERSION: 7.2.4

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilder.php
@@ -20,6 +20,7 @@ class FormOverlayListViewBuilder implements FormOverlayListViewBuilderInterface
         ListViewBuilderTrait::setEditViewToView insteadof FormViewBuilderTrait;
         ListViewBuilderTrait::addLocalesToView insteadof FormViewBuilderTrait;
         ListViewBuilderTrait::addToolbarActionsToView insteadof FormViewBuilderTrait;
+        ListViewBuilderTrait::addRequestParametersToView insteadof FormViewBuilderTrait;
     }
     use TabViewBuilderTrait;
 
@@ -51,8 +52,13 @@ class FormOverlayListViewBuilder implements FormOverlayListViewBuilderInterface
         return $this;
     }
 
+    /**
+     * @deprecated The usage of the "setRequestParameters" method in the FormOverlayListViewBuilder is deprecated. Please use "addRequestParameters" instead.
+     */
     public function setRequestParameters(array $requestParameters): FormOverlayListViewBuilderInterface
     {
+        @trigger_error('The usage of the "setRequestParameters" method in the FormOverlayListViewBuilder is deprecated. Please use "addRequestParameters" instead.', E_USER_DEPRECATED);
+
         $this->setRequestParametersToView($this->view, $requestParameters);
 
         return $this;
@@ -175,6 +181,13 @@ class FormOverlayListViewBuilder implements FormOverlayListViewBuilderInterface
         $oldResourceStorePropertiesToFormRequest = $this->view->getOption('resourceStorePropertiesToFormRequest');
         $newResourceStorePropertiesToFormRequest = $oldResourceStorePropertiesToFormRequest ? array_merge($oldResourceStorePropertiesToFormRequest, $resourceStorePropertiesToFormRequest) : $resourceStorePropertiesToFormRequest;
         $this->view->setOption('resourceStorePropertiesToFormRequest', $newResourceStorePropertiesToFormRequest);
+
+        return $this;
+    }
+
+    public function addRequestParameters(array $requestParameters): FormOverlayListViewBuilderInterface
+    {
+        $this->addRequestParametersToView($this->view, $requestParameters);
 
         return $this;
     }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilderInterface.php
@@ -74,6 +74,8 @@ interface FormOverlayListViewBuilderInterface extends ViewBuilderInterface
      */
     public function addResourceStorePropertiesToFormRequest(array $resourceStorePropertiesToFormRequest): self;
 
+    public function addRequestParameters(array $requestParameters): self;
+
     public function setOverlaySize(string $overlaySize): self;
 
     public function addMetadataRequestParameters(array $metadataRequestParameters): self;

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilder.php
@@ -38,8 +38,13 @@ class FormViewBuilder implements FormViewBuilderInterface
         return $this;
     }
 
+    /**
+     * @deprecated The usage of the "setRequestParameters" method in the FormViewBuilder is deprecated. Please use "addRequestParameters" instead.
+     */
     public function setRequestParameters(array $requestParameters): FormViewBuilderInterface
     {
+        @trigger_error('The usage of the "setRequestParameters" method in the FormViewBuilder is deprecated. Please use "addRequestParameters" instead.', E_USER_DEPRECATED);
+
         $this->setRequestParametersToView($this->view, $requestParameters);
 
         return $this;
@@ -133,6 +138,13 @@ class FormViewBuilder implements FormViewBuilderInterface
     public function addMetadataRequestParameters(array $metadataRequestParameters): FormViewBuilderInterface
     {
         $this->addMetadataRequestParametersToView($this->view, $metadataRequestParameters);
+
+        return $this;
+    }
+
+    public function addRequestParameters(array $requestParameters): FormViewBuilderInterface
+    {
+        $this->addRequestParametersToView($this->view, $requestParameters);
 
         return $this;
     }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilderInterface.php
@@ -53,6 +53,8 @@ interface FormViewBuilderInterface extends ViewBuilderInterface
 
     public function addMetadataRequestParameters(array $metadataRequestParameters): self;
 
+    public function addRequestParameters(array $requestParameters): self;
+
     public function setIdQueryParameter(string $idQueryParameter): self;
 
     public function setTitleVisible(bool $titleVisible): self;

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilderTrait.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilderTrait.php
@@ -25,11 +25,6 @@ trait FormViewBuilderTrait
         $view->setOption('formKey', $formKey);
     }
 
-    private function setRequestParametersToView(View $view, array $requestParameters): void
-    {
-        $view->setOption('requestParameters', $requestParameters);
-    }
-
     private function setBackViewToView(View $view, string $backView): void
     {
         $view->setOption('backView', $backView);
@@ -103,5 +98,18 @@ trait FormViewBuilderTrait
         $newMetadataRequestParameters = $oldMetadataRequestParameters ? array_merge($oldMetadataRequestParameters, $metadataRequestParameters) : $metadataRequestParameters;
 
         $route->setOption('metadataRequestParameters', $newMetadataRequestParameters);
+    }
+
+    private function addRequestParametersToView(View $route, array $requestParameters): void
+    {
+        $oldRequestParameters = $route->getOption('requestParameters');
+        $newRequestParameters = $oldRequestParameters ? array_merge($oldRequestParameters, $requestParameters) : $requestParameters;
+
+        $route->setOption('requestParameters', $newRequestParameters);
+    }
+
+    private function setRequestParametersToView(View $view, array $requestParameters): void
+    {
+        $view->setOption('requestParameters', $requestParameters);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilder.php
@@ -157,6 +157,20 @@ class ListViewBuilder implements ListViewBuilderInterface
         return $this;
     }
 
+    public function addResourceStorePropertiesToListMetadata(array $resourceStorePropertiesToListMetadata): ListViewBuilderInterface
+    {
+        $this->addResourceStorePropertiesToListMetadataToView($this->view, $resourceStorePropertiesToListMetadata);
+
+        return $this;
+    }
+
+    public function addRequestParameters(array $requestParameters): ListViewBuilderInterface
+    {
+        $this->addRequestParametersToView($this->view, $requestParameters);
+
+        return $this;
+    }
+
     public function getView(): View
     {
         if (!$this->view->getOption('resourceKey')) {

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilderInterface.php
@@ -68,4 +68,11 @@ interface ListViewBuilderInterface extends ViewBuilderInterface
      * @param string[] $resourceStorePropertiesToListRequest
      */
     public function addResourceStorePropertiesToListRequest(array $resourceStorePropertiesToListRequest): self;
+
+    /**
+     * @param string[] $resourceStorePropertiesToListMetadata
+     */
+    public function addResourceStorePropertiesToListMetadata(array $resourceStorePropertiesToListMetadata): self;
+
+    public function addRequestParameters(array $requestParameters): self;
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilderTrait.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilderTrait.php
@@ -103,4 +103,22 @@ trait ListViewBuilderTrait
 
         $route->setOption('resourceStorePropertiesToListRequest', $newResourceStorePropertiesToListRequest);
     }
+
+    private function addResourceStorePropertiesToListMetadataToView(View $route, array $resourceStorePropertiesToListMetadata): void
+    {
+        $oldResourceStorePropertiesToListMetadata = $route->getOption('resourceStorePropertiesToListMetadata');
+        $newResourceStorePropertiesToListMetadata = $oldResourceStorePropertiesToListMetadata
+            ? array_merge($oldResourceStorePropertiesToListMetadata, $resourceStorePropertiesToListMetadata)
+            : $resourceStorePropertiesToListMetadata;
+
+        $route->setOption('resourceStorePropertiesToListMetadata', $newResourceStorePropertiesToListMetadata);
+    }
+
+    private function addRequestParametersToView(View $route, array $requestParameters): void
+    {
+        $oldRequestParameters = $route->getOption('requestParameters');
+        $newRequestParameters = $oldRequestParameters ? array_merge($oldRequestParameters, $requestParameters) : $requestParameters;
+
+        $route->setOption('requestParameters', $newRequestParameters);
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/PreviewFormViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/PreviewFormViewBuilder.php
@@ -46,7 +46,7 @@ class PreviewFormViewBuilder implements PreviewFormViewBuilderInterface
     }
 
     /**
-     * @deprecated The usage of the "setRequestParameters" method in the FormOverlayListViewBuilder is deprecated. Please use "addRequestParameters" instead.
+     * @deprecated The usage of the "setRequestParameters" method in the PreviewFormViewBuilder is deprecated. Please use "addRequestParameters" instead.
      */
     public function setRequestParameters(array $requestParameters): PreviewFormViewBuilderInterface
     {

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/PreviewFormViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/PreviewFormViewBuilder.php
@@ -45,8 +45,13 @@ class PreviewFormViewBuilder implements PreviewFormViewBuilderInterface
         return $this;
     }
 
+    /**
+     * @deprecated The usage of the "setRequestParameters" method in the FormOverlayListViewBuilder is deprecated. Please use "addRequestParameters" instead.
+     */
     public function setRequestParameters(array $requestParameters): PreviewFormViewBuilderInterface
     {
+        @trigger_error('The usage of the "setRequestParameters" method in the PreviewFormViewBuilder is deprecated. Please use "addRequestParameters" instead.', E_USER_DEPRECATED);
+
         $this->setRequestParametersToView($this->view, $requestParameters);
 
         return $this;
@@ -112,6 +117,13 @@ class PreviewFormViewBuilder implements PreviewFormViewBuilderInterface
         array $routerAttributesToFormMetadata
     ): PreviewFormViewBuilderInterface {
         $this->addRouterAttributesToFormMetadataToView($this->view, $routerAttributesToFormMetadata);
+
+        return $this;
+    }
+
+    public function addRequestParameters(array $requestParameters): PreviewFormViewBuilderInterface
+    {
+        $this->addRequestParametersToView($this->view, $requestParameters);
 
         return $this;
     }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/PreviewFormViewBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/PreviewFormViewBuilderInterface.php
@@ -47,6 +47,10 @@ interface PreviewFormViewBuilderInterface extends ViewBuilderInterface
 
     public function addRouterAttributesToFormMetadata(array $routerAttributesToFormMetadata): self;
 
+    public function addRequestParameters(array $requestParameters): self;
+
+    public function addMetadataRequestParameters(array $metadataRequestParameters): self;
+
     public function setEditView(string $editView): self;
 
     public function setBackView(string $editView): self;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -86,6 +86,7 @@ class List extends React.Component<Props> {
                     resourceStorePropertiesToListRequest = {},
                     userSettingsKey = DEFAULT_USER_SETTINGS_KEY,
                     routerAttributesToListMetadata = {},
+                    resourceStorePropertiesToListMetadata = {},
                 },
             },
         } = router;
@@ -124,7 +125,9 @@ class List extends React.Component<Props> {
 
         const metadataOptions = this.buildMetadataOptions(
             attributes,
-            routerAttributesToListMetadata
+            routerAttributesToListMetadata,
+            resourceStorePropertiesToListMetadata,
+            props.resourceStore
         );
 
         this.listStore = new ListStore(
@@ -145,7 +148,9 @@ class List extends React.Component<Props> {
 
     buildMetadataOptions(
         attributes: Object,
-        routerAttributesToListMetadata: {[string | number]: string}
+        routerAttributesToListMetadata: {[string | number]: string},
+        resourceStorePropertiesToListMetadata: {[string | number]: string},
+        resourceStore: ?ResourceStore
     ) {
         const metadataOptions = {};
         routerAttributesToListMetadata = toJS(routerAttributesToListMetadata);
@@ -155,6 +160,18 @@ class List extends React.Component<Props> {
             const attributeName = isNaN(key) ? key : routerAttributesToListMetadata[key];
 
             metadataOptions[listOptionKey] = attributes[attributeName];
+        });
+
+        resourceStorePropertiesToListMetadata = toJS(resourceStorePropertiesToListMetadata);
+        Object.keys(resourceStorePropertiesToListMetadata).forEach((key) => {
+            const listMetadataKey = resourceStorePropertiesToListMetadata[key];
+            const attributeName = isNaN(key) ? key : resourceStorePropertiesToListMetadata[key];
+
+            if (!resourceStore || !resourceStore.data) {
+                return;
+            }
+
+            metadataOptions[listMetadataKey] = resourceStore.data[attributeName];
         });
 
         return metadataOptions;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
@@ -1193,6 +1193,36 @@ test('Should pass router attributes array from router to the ListStore metadataO
     expect(listStore.metadataOptions.title).toBeUndefined();
 });
 
+test('Should pass resource-store properties array from router to the ListStore metadataOptions', () => {
+    const List = require('../List').default;
+    const router = {
+        bind: jest.fn(),
+        attributes: {
+            id: '123-123-123',
+            locale: 'en',
+            title: 'Sulu is awesome',
+        },
+        route: {
+            options: {
+                adapters: ['table'],
+                requestParameters: {},
+                listKey: 'test',
+                locales: ['en', 'de'],
+                resourceKey: 'test',
+                resourceStorePropertiesToListMetadata: {0: 'locale', 'id': 'pageId'},
+            },
+        },
+    };
+    const resourceStore = new ResourceStore('tests', '123-123-123');
+
+    const list = mount(<List resourceStore={resourceStore} router={router} />);
+    const listStore = list.instance().listStore;
+
+    expect(listStore.metadataOptions.locale).toEqual('de');
+    expect(listStore.metadataOptions.pageId).toEqual('123-123-123');
+    expect(listStore.metadataOptions.title).toBeUndefined();
+});
+
 test('Should pass locale and page observables to the ListStore', () => {
     const List = require('../List').default;
     const router = {

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormOverlayListViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormOverlayListViewBuilderTest.php
@@ -106,7 +106,7 @@ class FormOverlayListViewBuilderTest extends TestCase
             ->setAddOverlayTitle($addOverlayTitle)
             ->setEditOverlayTitle($editOverlayTitle)
             ->setOverlaySize($overlaySize)
-            ->setRequestParameters($requestParameters)
+            ->addRequestParameters($requestParameters)
             ->getView();
 
         $this->assertEquals($name, $route->getName());

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormViewBuilderTest.php
@@ -165,7 +165,7 @@ class FormViewBuilderTest extends TestCase
         }
 
         if ($requestParameters) {
-            $viewBuilder->setRequestParameters($requestParameters);
+            $viewBuilder->addRequestParameters($requestParameters);
         }
 
         $view = $viewBuilder->getView();

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ListViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ListViewBuilderTest.php
@@ -262,6 +262,38 @@ class ListViewBuilderTest extends TestCase
         );
     }
 
+    public function testBuildListWithResourceStorePropertiesToMetadataRequest()
+    {
+        $view = (new ListViewBuilder('sulu_role.datagrid', '/roles'))
+            ->setResourceKey('roles')
+            ->setListKey('roles')
+            ->addListAdapters(['tree'])
+            ->addResourceStorePropertiesToListMetadata(['id' => 'dimensionId', 'parent' => 'parentId'])
+            ->addResourceStorePropertiesToListMetadata(['locale'])
+            ->getView();
+
+        $this->assertSame(
+            ['id' => 'dimensionId', 'parent' => 'parentId', 'locale'],
+            $view->getOption('resourceStorePropertiesToListMetadata')
+        );
+    }
+
+    public function testBuildListWithRequestParameters()
+    {
+        $view = (new ListViewBuilder('sulu_role.datagrid', '/roles'))
+            ->setResourceKey('roles')
+            ->setListKey('roles')
+            ->addListAdapters(['tree'])
+            ->addRequestParameters(['resourceKey' => 'pages', 'flat' => true])
+            ->addRequestParameters(['locale' => 'de'])
+            ->getView();
+
+        $this->assertSame(
+            ['resourceKey' => 'pages', 'flat' => true, 'locale' => 'de'],
+            $view->getOption('requestParameters')
+        );
+    }
+
     public function testBuildListSetParent()
     {
         $view = (new ListViewBuilder('sulu_role.list', '/roles'))

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/PreviewFormViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/PreviewFormViewBuilderTest.php
@@ -125,7 +125,7 @@ class PreviewFormViewBuilderTest extends TestCase
         }
 
         if ($requestParameters) {
-            $viewBuilder->setRequestParameters($requestParameters);
+            $viewBuilder->addRequestParameters($requestParameters);
         }
 
         if ($disablePreviewWebspaceChooser) {

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -279,7 +279,7 @@ class PageAdmin extends Admin
                     ->createFormViewBuilder('sulu_page.page_edit_form.permissions', '/permissions')
                     ->setResourceKey('permissions')
                     ->setFormKey('permission_details')
-                    ->setRequestParameters(['resourceKey' => 'pages'])
+                    ->addRequestParameters(['resourceKey' => 'pages'])
                     ->setTabCondition('_permissions.security')
                     ->setTabTitle('sulu_security.permissions')
                     ->addToolbarActions([new ToolbarAction('sulu_admin.save')])


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | none
| Related issues/PRs | sulu/SuluFormBundle#211
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add following methods:

* `ListViewBuilderInterface::addResourceStorePropertiesToListMetadata`
* `ListViewBuilderInterface::addRequestParameters`
* `FormViewBuilderInterface::addRequestParameters`
* `FormOverlayListViewBuilderInterface::addRequestParameters`
* `PreviewFormViewBuilderInterface::addRequestParameters`

#### Why?

See PR in sulu-form-bundle.

#### BC Breaks/Deprecations

New methods in interfaces.

#### To Do

- [x] Add breaking changes to UPGRADE.md
- [x] JS tests
- [x] PHPUnit tests
