### PR TITLE
Show GhostIndicator for Categories and Media

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,6 +5,12 @@
 When upgrading also have a look at the changes in the
 [sulu skeleton](https://github.com/sulu/skeleton/compare/2.0.2...2.0.3).
 
+### Ghost- and Shadow-Locale in ListAdapters
+
+Our `ListAdapter`s, namely `table`, `table_light`, `tree_table`, `column_list`, `media_card_overview` and
+`media_card_selection` are now always using the `ghostLocale` and `shadowLocale` properties from the resource instead of
+the `type` property.
+
 ### Symfony/templating requirement removed
 
 Sulu does not longer need the `symfony/templating` package which is deprecated.

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/GhostIndicator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/GhostIndicator.js
@@ -1,13 +1,22 @@
 // @flow
 import React from 'react';
+import classNames from 'classnames';
 import ghostIndicatorStyles from './ghostIndicator.scss';
 
-type Props = {
+type Props = {|
+    className?: string,
     locale: string,
-};
+|};
 
 export default class GhostIndicator extends React.Component<Props> {
     render() {
-        return <span className={ghostIndicatorStyles.ghostIndicator}>{this.props.locale}</span>;
+        const {className} = this.props;
+
+        const ghostIndicatorClass = classNames(
+            ghostIndicatorStyles.ghostIndicator,
+            className
+        );
+
+        return <span className={ghostIndicatorClass}>{this.props.locale}</span>;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/ghostIndicator.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/ghostIndicator.scss
@@ -9,6 +9,7 @@ $ghostIndicatorColor: $shakespeare;
     border-radius: 3px;
     font-size: 8px;
     font-weight: 600;
+    line-height: 9px;
     text-transform: uppercase;
     padding: 5px;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/tests/GhostIndicator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/tests/GhostIndicator.test.js
@@ -6,3 +6,7 @@ import GhostIndicator from '../GhostIndicator';
 test('Should render with given locale', () => {
     expect(render(<GhostIndicator locale="de-at" />)).toMatchSnapshot();
 });
+
+test('Should render with given locale and className', () => {
+    expect(render(<GhostIndicator className="test" locale="de-at" />)).toMatchSnapshot();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/tests/__snapshots__/GhostIndicator.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/tests/__snapshots__/GhostIndicator.test.js.snap
@@ -7,3 +7,11 @@ exports[`Should render with given locale 1`] = `
   de-at
 </span>
 `;
+
+exports[`Should render with given locale and className 1`] = `
+<span
+  class="ghostIndicator test"
+>
+  de-at
+</span>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/index.js
@@ -14,6 +14,7 @@ import DropdownButton from './DropdownButton';
 import Email from './Email';
 import FileUploadButton from './FileUploadButton';
 import Form from './Form';
+import GhostIndicator from './GhostIndicator';
 import Grid from './Grid';
 import Icon from './Icon';
 import ImageRectangleSelection from './ImageRectangleSelection';
@@ -53,6 +54,7 @@ export {
     Email,
     FileUploadButton,
     Form,
+    GhostIndicator,
     Grid,
     Icon,
     ImageRectangleSelection,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/AbstractTableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/AbstractTableAdapter.js
@@ -1,10 +1,12 @@
 // @flow
 import {computed} from 'mobx';
 import React from 'react';
+import GhostIndicator from '../../../components/GhostIndicator';
 import Table from '../../../components/Table';
 import listFieldTransformerRegistry from '../registries/listFieldTransformerRegistry';
 import type {Schema} from '../types';
 import AbstractAdapter from './AbstractAdapter';
+import abstractTableAdapterStyles from './abstractTableAdapter.scss';
 
 export default class AbstractTableAdapter extends AbstractAdapter {
     static hasColumnOptions: boolean = true;
@@ -32,12 +34,20 @@ export default class AbstractTableAdapter extends AbstractAdapter {
     renderCells(item: Object): Array<*> {
         const schemaKeys = Object.keys(this.schema);
 
-        return schemaKeys.map((schemaKey) => {
+        return schemaKeys.map((schemaKey, index) => {
             const transformer = listFieldTransformerRegistry.get(this.schema[schemaKey].type);
             const value = transformer.transform(item[schemaKey]);
 
             return (
-                <Table.Cell key={item.id + schemaKey}>{value}</Table.Cell>
+                <Table.Cell key={item.id + schemaKey}>
+                    {index === 0 && item.ghostLocale &&
+                        <GhostIndicator
+                            className={abstractTableAdapterStyles.ghostIndicator}
+                            locale={item.ghostLocale}
+                        />
+                    }
+                    {value}
+                </Table.Cell>
             );
         });
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
@@ -80,8 +80,8 @@ class ColumnListAdapter extends AbstractAdapter {
     };
 
     getIndicators = (item: Object) => {
-        if (item.type && item.type.name === 'ghost') {
-            return [<GhostIndicator key="ghost" locale={item.type.value} />];
+        if (item.ghostLocale) {
+            return [<GhostIndicator key="ghost" locale={item.ghostLocale} />];
         }
 
         const indicators = [];
@@ -90,7 +90,7 @@ class ColumnListAdapter extends AbstractAdapter {
             indicators.push(<Icon key="internal" name="su-link2" />);
         } else if (item.linked === 'external') {
             indicators.push(<Icon key="external" name="su-link" />);
-        } else if (item.type && item.type.name === 'shadow') {
+        } else if (item.shadowLocale) {
             indicators.push(<Icon key="shadow" name="su-shadow-page" />);
         }
 
@@ -106,7 +106,7 @@ class ColumnListAdapter extends AbstractAdapter {
 
     getButtons = (item: Object) => {
         const {onItemClick, onItemSelectionChange} = this.props;
-        const isGhost = item.type && item.type.name === 'ghost';
+        const isGhost = !!item.ghostLocale;
 
         const buttons = [];
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/abstractTableAdapter.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/abstractTableAdapter.scss
@@ -1,0 +1,3 @@
+.ghost-indicator {
+    margin-right: 5px;
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/ColumnListAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/ColumnListAdapter.test.js
@@ -46,10 +46,7 @@ test('Render different kind of data with edit button', () => {
                 id: 4,
                 title: 'Page 2.1',
                 hasChildren: true,
-                type: {
-                    name: 'ghost',
-                    value: 'nl',
-                },
+                ghostLocale: 'nl',
             },
             {
                 id: 5,
@@ -57,10 +54,7 @@ test('Render different kind of data with edit button', () => {
                 hasChildren: true,
                 publishedState: false,
                 published: '2017-07-02',
-                type: {
-                    name: 'ghost',
-                    value: 'nl',
-                },
+                ghostLocale: 'nl',
             },
             {
                 id: 8,
@@ -86,9 +80,7 @@ test('Render different kind of data with edit button', () => {
                 hasChildren: false,
                 publishedState: false,
                 published: null,
-                type: {
-                    name: 'shadow',
-                },
+                shadowLocale: 'en',
             },
             {
                 id: 11,
@@ -96,9 +88,7 @@ test('Render different kind of data with edit button', () => {
                 hasChildren: false,
                 publishedState: true,
                 published: '2018-10-16',
-                type: {
-                    name: 'shadow',
-                },
+                shadowLocale: 'en',
                 _permissions: {
                     view: false,
                 },

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
@@ -38,6 +38,7 @@ test('Render data with schema', () => {
             id: 2,
             title: 'Title 2',
             description: 'Description 2',
+            ghostLocale: 'en',
         },
     ];
     const schema = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
@@ -38,6 +38,7 @@ test('Render data with schema', () => {
     };
     const test2 = {
         data: {
+            ghostLocale: 'en',
             id: 3,
             title: 'Test2',
         },

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TableAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TableAdapter.test.js.snap
@@ -980,6 +980,11 @@ exports[`Render data with schema 1`] = `
             <div
               class="cellContent"
             >
+              <span
+                class="ghostIndicator ghostIndicator"
+              >
+                en
+              </span>
               Description 2
             </div>
           </td>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TreeTableAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TreeTableAdapter.test.js.snap
@@ -175,6 +175,11 @@ exports[`Render data with schema 1`] = `
                 tabindex="0"
               />
             </span>
+            <span
+              class="ghostIndicator ghostIndicator"
+            >
+              en
+            </span>
             Test2
           </div>
         </td>

--- a/src/Sulu/Bundle/CategoryBundle/Api/Category.php
+++ b/src/Sulu/Bundle/CategoryBundle/Api/Category.php
@@ -168,6 +168,24 @@ class Category extends ApiEntityWrapper
     }
 
     /**
+     * Returns the locale of the Category dependent on the existing translations and default locale.
+     *
+     * @VirtualProperty
+     * @SerializedName("ghostLocale")
+     * @Groups({"fullCategory","partialCategory"})
+     *
+     * @return string
+     */
+    public function getGhostLocale()
+    {
+        if (null === ($translation = $this->getTranslation(true))) {
+            return;
+        }
+
+        return $translation->getLocale();
+    }
+
+    /**
      * Returns the name of the Category dependent on the locale.
      *
      * @VirtualProperty

--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -281,6 +281,10 @@ class CategoryController extends AbstractRestController implements ClassResource
 
         foreach ($categories as &$category) {
             $category['hasChildren'] = ($category['lft'] + 1) !== $category['rgt'];
+
+            if ($category['locale'] !== $locale) {
+                $category['ghostLocale'] = $category['locale'];
+            }
         }
 
         if (!empty($expandedIds)) {

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
@@ -174,6 +174,8 @@ class CategoryControllerTest extends SuluTestCase
         $this->createCategoryTranslation($category3, 'en', 'Third Category');
         $category4 = $this->createCategory(null, 'en', $category3);
         $this->createCategoryTranslation($category4, 'en', 'Fourth Category');
+        $category5 = $this->createCategory(null, 'de');
+        $this->createCategoryTranslation($category5, 'de', 'Fünfte Kategorie');
 
         $this->em->flush();
 
@@ -195,7 +197,7 @@ class CategoryControllerTest extends SuluTestCase
             }
         );
 
-        $this->assertCount(2, $categories);
+        $this->assertCount(3, $categories);
         $this->assertCount(1, $categories[0]->children);
         $this->assertCount(1, $categories[0]->children[0]->children);
 
@@ -208,6 +210,9 @@ class CategoryControllerTest extends SuluTestCase
         $this->assertEquals('en', $categories[1]->defaultLocale);
         $this->assertEquals('Third Category', $categories[0]->children[0]->name);
         $this->assertEquals('Fourth Category', $categories[0]->children[0]->children[0]->name);
+        $this->assertEquals('Fünfte Kategorie', $categories[2]->name);
+        $this->assertEquals('de', $categories[2]->locale);
+        $this->assertEquals('de', $categories[2]->ghostLocale);
     }
 
     public function testCGetByIds()
@@ -251,6 +256,8 @@ class CategoryControllerTest extends SuluTestCase
         $this->createCategoryTranslation($category2, 'de', 'Zweite Kategorie');
         $category3 = $this->createCategory(null, 'en', $category1);
         $this->createCategoryTranslation($category3, 'en', 'Third Category');
+        $category4 = $this->createCategory(null, 'de');
+        $this->createCategoryTranslation($category4, 'de', 'Vierte Kategorie');
 
         $this->em->flush();
 
@@ -272,18 +279,24 @@ class CategoryControllerTest extends SuluTestCase
             }
         );
 
-        $this->assertCount(2, $categories);
-        $this->assertEquals(2, $response->total);
+        $this->assertCount(3, $categories);
+        $this->assertEquals(3, $response->total);
 
         $this->assertEquals('First Category', $categories[0]->name);
         $this->assertEquals('en', $categories[0]->defaultLocale);
         $this->assertEquals('en', $categories[0]->locale);
         $this->assertEquals('first-category-key', $categories[0]->key);
         $this->assertTrue($categories[0]->hasChildren);
+        $this->assertObjectNotHasAttribute('ghostLocale', $categories[0]);
 
         $this->assertEquals('second-category-key', $categories[1]->key);
         $this->assertEquals('en', $categories[1]->defaultLocale);
         $this->assertFalse($categories[1]->hasChildren);
+        $this->assertObjectNotHasAttribute('ghostLocale', $categories[1]);
+
+        $this->assertEquals('Vierte Kategorie', $categories[2]->name);
+        $this->assertEquals('de', $categories[2]->locale);
+        $this->assertEquals('de', $categories[2]->ghostLocale);
     }
 
     public function testCGetFlatWithSelectedIds()

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
@@ -226,6 +226,10 @@ class MediaController extends AbstractMediaController implements
                 $listResponse[$i]['name'],
                 $listResponse[$i]['version']
             );
+
+            if ($locale !== $listResponse[$i]['locale']) {
+                $listResponse[$i]['ghostLocale'] = $listResponse[$i]['locale'];
+            }
         }
 
         $ids = $listBuilder->getIds();

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
@@ -4,17 +4,18 @@ import type {ElementRef} from 'react';
 import classNames from 'classnames';
 import {observer} from 'mobx-react';
 import {action, observable} from 'mobx';
-import {Loader, Icon, Checkbox, CroppedText} from 'sulu-admin-bundle/components';
+import {Checkbox, CroppedText, GhostIndicator, Icon, Loader} from 'sulu-admin-bundle/components';
 import MimeTypeIndicator from '../MimeTypeIndicator';
 import DownloadList from './DownloadList';
 import mediaCardStyles from './mediaCard.scss';
 
 const DOWNLOAD_ICON = 'fa-cloud-download';
 
-type Props = {
+type Props = {|
     downloadCopyText: string,
     downloadText: string,
     downloadUrl: string,
+    ghostLocale?: string,
     icon?: string,
     id: string | number,
     image: ?string,
@@ -27,7 +28,7 @@ type Props = {
     selected: boolean,
     showCover: boolean,
     title: string,
-};
+|};
 
 @observer
 class MediaCard extends React.Component<Props> {
@@ -126,6 +127,7 @@ class MediaCard extends React.Component<Props> {
             downloadCopyText,
             downloadText,
             downloadUrl,
+            ghostLocale,
             icon,
             id,
             image,
@@ -155,6 +157,7 @@ class MediaCard extends React.Component<Props> {
 
         const mediaTitle = (
             <div className={mediaCardStyles.titleText}>
+                {ghostLocale && <GhostIndicator className={mediaCardStyles.ghostIndicator} locale={ghostLocale} />}
                 <CroppedText>{title}</CroppedText>
             </div>
         );

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/mediaCard.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/mediaCard.scss
@@ -77,17 +77,23 @@ $downloadButtonBorderColorActive: $shakespeare;
     transition: margin-left .15s linear;
 }
 
+.ghost-indicator {
+    margin-right: 5px;
+}
+
 .title {
     pointer-events: none; /* We don't want the label/title to trigger an "onClick" event */
     position: relative;
     font-size: 12px;
     font-weight: bold;
+    height: 21px;
     margin-bottom: 10px;
     overflow: hidden;
 }
 
 .meta,
 .title-text {
+    display: flex;
     width: 140px;
 }
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/MediaCard.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/MediaCard.test.js
@@ -21,6 +21,25 @@ test('Render a MediaCard component', () => {
     expect(mediaCard.render()).toMatchSnapshot();
 });
 
+test('Render a MediaCard component with ghostLocale', () => {
+    const mediaCard = mount(
+        <MediaCard
+            downloadText=""
+            downloadUrl=""
+            ghostLocale="en"
+            id="test"
+            image="http://lorempixel.com/300/200"
+            meta="Test/Test"
+            mimeType="image/jpeg"
+            title="Test"
+        />
+    );
+
+    mediaCard.instance().image.onload();
+
+    expect(mediaCard.render()).toMatchSnapshot();
+});
+
 test('Render a MediaCard component with loader if image has not been loaded yet', () => {
     const mediaCard = mount(
         <MediaCard

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/__snapshots__/MediaCard.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/__snapshots__/MediaCard.test.js.snap
@@ -290,6 +290,101 @@ exports[`Render a MediaCard component with a checkbox for selection 1`] = `
 </div>
 `;
 
+exports[`Render a MediaCard component with ghostLocale 1`] = `
+<div
+  class="mediaCard noDownloadList"
+>
+  <div
+    class="header"
+  >
+    <div
+      class="description"
+      role="button"
+    >
+      <div
+        class="title"
+      >
+        <div
+          class="titleText"
+        >
+          <span
+            class="ghostIndicator ghostIndicator"
+          >
+            en
+          </span>
+          <div
+            aria-label="Test"
+            class="croppedText"
+            title="Test"
+          >
+            <div
+              aria-hidden="true"
+              class="front"
+            >
+              Te
+            </div>
+            <div
+              aria-hidden="true"
+              class="back"
+            >
+              <span>
+                st
+              </span>
+            </div>
+            <div
+              class="whole"
+            >
+              Test
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="meta"
+      >
+        <div
+          aria-label="Test/Test"
+          class="croppedText"
+          title="Test/Test"
+        >
+          <div
+            aria-hidden="true"
+            class="front"
+          >
+            Test/
+          </div>
+          <div
+            aria-hidden="true"
+            class="back"
+          >
+            <span>
+              Test
+            </span>
+          </div>
+          <div
+            class="whole"
+          >
+            Test/Test
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="media"
+    role="button"
+  >
+    <img
+      alt="Test"
+      src="http://lorempixel.com/300/200"
+    />
+    <div
+      class="cover"
+    />
+  </div>
+</div>
+`;
+
 exports[`Render a MediaCard component with loader if image has not been loaded yet 1`] = `
 <div
   class="mediaCard noDownloadList"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/adapters/MediaCardAdapter.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/adapters/MediaCardAdapter.js
@@ -88,9 +88,10 @@ class MediaCardAdapter extends React.Component<Props> {
                         const thumbnail = item.thumbnails ? item.thumbnails[THUMBNAIL_SIZE] : null;
 
                         return (
-                            // TODO: Don't access properties like "title" directly.
+                            // TODO: Don't access properties like "title" or "ghostLocale" directly.
                             <MediaCard
                                 {...downloadDropdownProps}
+                                ghostLocale={item.ghostLocale}
                                 icon={icon}
                                 id={item.id}
                                 image={thumbnail}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/MediaCardAdapter.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/MediaCardAdapter.test.js
@@ -30,6 +30,7 @@ test('Render a basic Masonry view with MediaCards', () => {
             thumbnails: thumbnails,
         },
         {
+            ghostLocale: 'en',
             id: 2,
             title: 'Title 1',
             mimeType: 'image/jpeg',

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/__snapshots__/MediaCardAdapter.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/__snapshots__/MediaCardAdapter.test.js.snap
@@ -170,6 +170,11 @@ exports[`Render a basic Masonry view with MediaCards 1`] = `
                     <div
                       class="titleText"
                     >
+                      <span
+                        class="ghostIndicator ghostIndicator"
+                      >
+                        en
+                      </span>
                       <div
                         aria-label="Title 1"
                         class="croppedText"

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
@@ -670,7 +670,13 @@ class MediaControllerTest extends SuluTestCase
 
         $medias = array_map(
             function($item) {
-                return ['id' => $item->id, 'name' => $item->name, 'title' => $item->title, 'locale' => $item->locale];
+                return [
+                    'id' => $item->id,
+                    'name' => $item->name,
+                    'title' => $item->title,
+                    'locale' => $item->locale,
+                    'ghostLocale' => $item->ghostLocale ?? null,
+                ];
             },
             $response->_embedded->media
         );
@@ -678,11 +684,23 @@ class MediaControllerTest extends SuluTestCase
         $this->assertEquals(2, $response->total);
         $this->assertCount(2, $medias);
         $this->assertContains(
-            ['id' => $mediaEN->getId(), 'name' => 'test-en.jpeg', 'title' => 'test-en', 'locale' => 'en'],
+            [
+                'id' => $mediaEN->getId(),
+                'name' => 'test-en.jpeg',
+                'title' => 'test-en',
+                'locale' => 'en',
+                'ghostLocale' => 'en',
+            ],
             $medias
         );
         $this->assertContains(
-            ['id' => $mediaDE->getId(), 'name' => 'test-de.jpeg', 'title' => 'test-de', 'locale' => 'de'],
+            [
+                'id' => $mediaDE->getId(),
+                'name' => 'test-de.jpeg',
+                'title' => 'test-de',
+                'locale' => 'de',
+                'ghostLocale' => null,
+            ],
             $medias
         );
     }

--- a/src/Sulu/Bundle/PageBundle/Serializer/Subscriber/LocaleSubscriber.php
+++ b/src/Sulu/Bundle/PageBundle/Serializer/Subscriber/LocaleSubscriber.php
@@ -89,14 +89,25 @@ class LocaleSubscriber implements EventSubscriberInterface
         $type = null;
 
         if (LocalizationState::GHOST === $localizationState) {
-            $type = ['name' => 'ghost', 'value' => $document->getLocale()];
+            $ghostLocale = $document->getLocale();
+            $type = ['name' => 'ghost', 'value' => $ghostLocale];
+            $visitor->visitProperty(
+                new StaticPropertyMetadata('', 'ghostLocale', $ghostLocale),
+                $ghostLocale
+            );
         }
 
         if (LocalizationState::SHADOW === $localizationState) {
-            $type = ['name' => 'shadow', 'value' => $document->getLocale()];
+            $shadowLocale = $document->getLocale();
+            $type = ['name' => 'shadow', 'value' => $shadowLocale];
+            $visitor->visitProperty(
+                new StaticPropertyMetadata('', 'shadowLocale', $shadowLocale),
+                $shadowLocale
+            );
         }
 
         if ($type) {
+            // TODO should be removed at some point, and the ghostLocale resp. shadowLocale properties should be used
             $visitor->visitProperty(
                 new StaticPropertyMetadata('', 'type', $type),
                 $type

--- a/src/Sulu/Component/Content/Repository/Serializer/SerializerEventListener.php
+++ b/src/Sulu/Component/Content/Repository/Serializer/SerializerEventListener.php
@@ -17,6 +17,7 @@ use JMS\Serializer\EventDispatcher\ObjectEvent;
 use JMS\Serializer\Metadata\StaticPropertyMetadata;
 use JMS\Serializer\Visitor\SerializationVisitorInterface;
 use Sulu\Bundle\PageBundle\Admin\PageAdmin;
+use Sulu\Component\Content\Document\LocalizationState;
 use Sulu\Component\Content\Document\RedirectType;
 use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\Content\Repository\Content;
@@ -105,11 +106,27 @@ class SerializerEventListener implements EventSubscriberInterface
         }
 
         if (null !== $content->getLocalizationType()) {
-            $type = $content->getLocalizationType()->toArray();
+            $localizationType = $content->getLocalizationType();
             $visitor->visitProperty(
-                new StaticPropertyMetadata('', 'type', $type),
-                $type
+                new StaticPropertyMetadata('', 'type', $localizationType),
+                $localizationType->toArray()
             );
+
+            if (LocalizationState::GHOST === $localizationType->getName()) {
+                $ghostLocale = $localizationType->getValue();
+                $visitor->visitProperty(
+                    new StaticPropertyMetadata('', 'ghostLocale', $ghostLocale),
+                    $ghostLocale
+                );
+            }
+
+            if (LocalizationState::SHADOW === $localizationType->getName()) {
+                $shadowLocale = $localizationType->getValue();
+                $visitor->visitProperty(
+                    new StaticPropertyMetadata('', 'shadowLocale', $shadowLocale),
+                    $shadowLocale
+                );
+            }
         }
 
         if (!$this->tokenStorage) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds the ghost indicator to snippets and categories.

#### Why?

Because this is a useful information and was already shown in Sulu 1.x.