### PR TITLE
Fix SmartContent when the data source has been deleted

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/stores/SmartContentStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/stores/SmartContentStore.js
@@ -80,6 +80,8 @@ export default class SmartContentStore {
                 ).then(action((response) => {
                     this.dataSource = response;
                     this.dataSourceLoading = false;
+                })).catch(action(() => {
+                    this.dataSourceLoading = false;
                 }));
             }
         }
@@ -134,7 +136,7 @@ export default class SmartContentStore {
     }
 
     @computed get loading() {
-        return this.dataSourceLoading || this.categoriesLoading;
+        return !!this.dataSourceLoading || !!this.categoriesLoading;
     }
 
     @computed get filterCriteria(): FilterCriteria {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/stores/SmartContentStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/stores/SmartContentStore.test.js
@@ -74,6 +74,43 @@ test('Load categories and datasource when constructed', () => {
     });
 });
 
+test('Reset dataSourceLoading if loading of dataSource fails', (done) => {
+    const locale = observable.box('en');
+
+    const dataSourcePromise = Promise.reject();
+    ResourceRequester.get.mockReturnValue(dataSourcePromise);
+
+    const smartContentStore = new SmartContentStore(
+        'content',
+        {
+            audienceTargeting: undefined,
+            categories: undefined,
+            categoryOperator: undefined,
+            dataSource: 4,
+            includeSubFolders: undefined,
+            limitResult: undefined,
+            sortBy: undefined,
+            sortMethod: undefined,
+            tagOperator: undefined,
+            tags: undefined,
+            presentAs: undefined,
+        },
+        locale,
+        'pages'
+    );
+
+    expect(smartContentStore.loading).toEqual(true);
+    expect(ResourceRequester.get).toBeCalledWith('pages', {id: 4, locale: 'en'});
+
+    setTimeout(() => {
+        expect(smartContentStore.loading).toEqual(false);
+        expect(smartContentStore.dataSource).toEqual(undefined);
+
+        smartContentStore.destroy();
+        done();
+    });
+});
+
 test('Load items if FilterCriteria is given with datasource', () => {
     const locale = observable.box('en');
     const filterCriteria = {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4931
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes the SmartContent, if the datasource that was selected was deleted.

#### Why?

Because previously the smart content showed an infinite loader, and the datasource could not be changed anymore.