### PR TITLE
Fix PHP Fatal error by adding broken doctrine/persistence as conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -127,6 +127,7 @@
     "conflict": {
         "doctrine/dbal": "2.7.0",
         "doctrine/lexer": "1.0.0",
+        "doctrine/persistence": "1.3.2",
         "symfony/doctrine-bridge": "< 3.4.0",
         "symfony/http-foundation": "4.3.4",
         "jackalope/jackalope": "< 1.3.4",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | https://github.com/doctrine/persistence/issues/81, https://github.com/doctrine/persistence/pull/80, https://github.com/doctrine/persistence/pull/82
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add 1.3.2 doctrine/persistence as conflict

#### Why?

Following error currently happens:

```
> Tests/Application/bin/adminconsole doctrine:database:drop --if-exists --force --env test
PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Argument 1 passed to Doctrine\ORM\Configuration::setMetadataDriverImpl() must be an instance of Doctrine\Common\Persistence\Mapping\Driver\MappingDriver, instance of Doctrine\Persistence\Mapping\Driver\MappingDriverChain given, called in /sulu-minimal/vendor/sulu/content-bundle/tests/Application/var/cache/admin/test/ContainerRwSGias/adminAdminTestDebugProjectContainer.php on line 1516 in /sulu-minimal/vendor/sulu/content-bundle/vendor/doctrine/orm/lib/Doctrine/ORM/Configuration.php:149
Stack trace:
#0 /sulu-minimal/vendor/sulu/content-bundle/tests/Application/var/cache/admin/test/ContainerRwSGias/adminAdminTestDebugProjectContainer.php(1516): Doctrine\ORM\Configuration->setMetadataDriverImpl(Object(Doctrine\Persistence\Mapping\Driver\MappingDriverChain))
#1 /sulu-minimal/vendor/sul in /sulu-minimal/vendor/sulu/content-bundle/vendor/doctrine/orm/lib/Doctrine/ORM/Configuration.php on line 149

Fatal error: Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Argument 1 passed to Doctrine\ORM\Configuration::setMetadataDriverImpl() must be an instance of Doctrine\Common\Persistence\Mapping\Driver\MappingDriver, instance of Doctrine\Persistence\Mapping\Driver\MappingDriverChain given, called in /sulu-minimal/vendor/sulu/content-bundle/tests/Application/var/cache/admin/test/ContainerRwSGias/adminAdminTestDebugProjectContainer.php on line 1516 in /sulu-minimal/vendor/sulu/content-bundle/vendor/doctrine/orm/lib/Doctrine/ORM/Configuration.php:149
Stack trace:
#0 /sulu-minimal/vendor/sulu/content-bundle/tests/Application/var/cache/admin/test/ContainerRwSGias/adminAdminTestDebugProjectContainer.php(1516): Doctrine\ORM\Configuration->setMetadataDriverImpl(Object(Doctrine\Persistence\Mapping\Driver\MappingDriverChain))
#1 /sulu-minimal/vendor/sul in /sulu-minimal/vendor/sulu/content-bundle/vendor/doctrine/orm/lib/Doctrine/ORM/Configuration.php on line 149
```

#### Example Usage

Add it as conflict and run:

~~~php
composer update
~~~

