### PR TITLE
Swap render index arguments

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/XmlSitemapDumper.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/XmlSitemapDumper.php
@@ -90,7 +90,7 @@ class XmlSitemapDumper implements XmlSitemapDumperInterface
     public function dumpHost($scheme, $host)
     {
         $dumpPath = $this->getIndexDumpPath($scheme, $host);
-        $sitemap = $this->sitemapRenderer->renderIndex($host, $scheme);
+        $sitemap = $this->sitemapRenderer->renderIndex($scheme, $host);
         if (!$sitemap) {
             $aliases = array_keys($this->sitemapProviderPool->getProviders());
             $this->dumpFile(

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/XmlSitemapDumperTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/XmlSitemapDumperTest.php
@@ -77,7 +77,7 @@ class XmlSitemapDumperTest extends TestCase
 
     public function testDumpHost()
     {
-        $this->renderer->renderIndex('sulu.io', 'http')->willReturn('<sitemapindex/>');
+        $this->renderer->renderIndex('http', 'sulu.io')->willReturn('<sitemapindex/>');
 
         $this->filesystem->dumpFile(
             $this->dumper->getIndexDumpPath('http', 'sulu.io'),
@@ -116,7 +116,7 @@ class XmlSitemapDumperTest extends TestCase
 
     public function testDumpPortalInformationNoIndex()
     {
-        $this->renderer->renderIndex('sulu.io', 'http')->willReturn(null);
+        $this->renderer->renderIndex('http', 'sulu.io')->willReturn(null);
 
         $provider = $this->prophesize(SitemapProviderInterface::class);
 
@@ -139,7 +139,7 @@ class XmlSitemapDumperTest extends TestCase
 
     public function testDumpHostWildcard()
     {
-        $this->renderer->renderIndex('sulu.io', 'http')->willReturn('<sitemapindex/>');
+        $this->renderer->renderIndex('http', 'sulu.io')->willReturn('<sitemapindex/>');
 
         $this->filesystem->dumpFile(
             $this->dumper->getIndexDumpPath('http', 'sulu.io'),
@@ -178,7 +178,7 @@ class XmlSitemapDumperTest extends TestCase
 
     public function testDumpPortalInformationMultiplePages()
     {
-        $this->renderer->renderIndex('sulu.io', 'http')->willReturn('<sitemapindex/>');
+        $this->renderer->renderIndex('http', 'sulu.io')->willReturn('<sitemapindex/>');
 
         $this->filesystem->dumpFile(
             $this->dumper->getIndexDumpPath('http', 'sulu.io'),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

In https://github.com/sulu/sulu/blob/46ca99928872780a0034854bb1d72d89a4c06c1d/src/Sulu/Bundle/WebsiteBundle/Sitemap/XmlSitemapDumper.php#L93 there was an bug in swapped arguments for sitemap render. Also fixes swapped arguments in tests.