### PR TITLE
Add getter for type property of ToolbarAction class

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ToolbarAction.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ToolbarAction.php
@@ -33,6 +33,11 @@ class ToolbarAction
         $this->options = $options;
     }
 
+    public function getType()
+    {
+        return $this->type;
+    }
+
     public function getOptions()
     {
         return $this->options;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### Why?

To allow for determining the type of an existing toolbar action.
