### PR TITLE
Default template based on the template of the parent page

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Resources/js/stores/webspaceStore/types.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/stores/webspaceStore/types.js
@@ -4,7 +4,7 @@ import type {Localization} from 'sulu-admin-bundle/stores';
 export type Webspace = {
     allLocalizations: Array<LocalizationItem>,
     customUrls: Array<CustomUrl>,
-    defaultTemplates: {[type: string]: string},
+    defaultTemplates: {[type: string]: Array<DefaultTemplate>},
     key: string,
     localizations: Array<Localization>,
     name: string,
@@ -17,6 +17,12 @@ export type Webspace = {
 export type ResourceLocatorStrategy = {
     inputType: string,
 };
+
+export type DefaultTemplate = {
+    type: string,
+    template: string,
+    parentTemplate: string | null
+}
 
 export type Navigation = {
     key: string,

--- a/src/Sulu/Bundle/PageBundle/Resources/js/stores/webspaceStore/types.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/stores/webspaceStore/types.js
@@ -19,9 +19,9 @@ export type ResourceLocatorStrategy = {
 };
 
 export type DefaultTemplate = {
-    type: string,
+    parentTemplate: string | null,
     template: string,
-    parentTemplate: string | null
+    type: string,
 }
 
 export type Navigation = {

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/TemplateToolbarAction.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/TemplateToolbarAction.js
@@ -31,7 +31,7 @@ export default class TemplateToolbarAction extends AbstractFormToolbarAction {
         if (parentPageId && this.webspace && !this.parentPage) {
             ResourceRequester.get('pages', {
                 id: parentPageId,
-                language: this.router.attributes.locale
+                language: this.router.attributes.locale,
             }).then((response) => {
                 this.parentPage = response;
                 const parentTemplate = response.template;
@@ -41,13 +41,12 @@ export default class TemplateToolbarAction extends AbstractFormToolbarAction {
                         break;
                     }
                 }
-            })
+            });
         }
 
         if (!this.resourceFormStore.typesLoading && Object.keys(formTypes).length === 0) {
             throw new Error('The ToolbarAction for types only works with entities actually supporting types!');
         }
-
 
         return {
             type: 'select',

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/TemplateToolbarAction.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/TemplateToolbarAction.js
@@ -8,7 +8,7 @@ import type {Webspace} from '../../../stores/webspaceStore/types';
 
 export default class TemplateToolbarAction extends AbstractFormToolbarAction {
     @observable webspace: ?Webspace = undefined;
-    parentPage;
+    parentPage: any;
 
     @computed get defaultTemplate(): ?string {
         if (!this.webspace) {

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/TemplateToolbarAction.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/TemplateToolbarAction.js
@@ -4,6 +4,7 @@ import {AbstractFormToolbarAction} from 'sulu-admin-bundle/views';
 import type {ToolbarItemConfig} from 'sulu-admin-bundle/types';
 import webspaceStore from '../../../stores/webspaceStore';
 import type {Webspace} from '../../../stores/webspaceStore/types';
+import {ResourceRequester} from 'sulu-admin-bundle/services';
 
 export default class TemplateToolbarAction extends AbstractFormToolbarAction {
     @observable webspace: ?Webspace = undefined;
@@ -29,17 +30,17 @@ export default class TemplateToolbarAction extends AbstractFormToolbarAction {
         if (this.router.attributes.parentId && this.webspace) {
             ResourceRequester.get('pages', {
                 id: this.router.attributes.parentId,
-                language: this.router.attributes.locale
-            }).then(response => {
+                language: this.router.attributes.locale,
+            }).then((response) => {
                 const parentTemplate = response.template;
-                for (let key in this.webspace.defaultTemplates) {
-                    let defaultTemplate = this.webspace.defaultTemplates[key];
+                for (const key in this.webspace.defaultTemplates) {
+                    const defaultTemplate = this.webspace.defaultTemplates[key];
                     if (defaultTemplate.parentTemplate === parentTemplate) {
                         this.resourceFormStore.setType(key);
                         break;
                     }
                 }
-            })
+            });
         }
 
         if (!this.resourceFormStore.typesLoading && Object.keys(formTypes).length === 0) {

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/TemplateToolbarAction.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/TemplateToolbarAction.js
@@ -2,9 +2,9 @@
 import {action, computed, observable} from 'mobx';
 import {AbstractFormToolbarAction} from 'sulu-admin-bundle/views';
 import type {ToolbarItemConfig} from 'sulu-admin-bundle/types';
+import {ResourceRequester} from 'sulu-admin-bundle/services';
 import webspaceStore from '../../../stores/webspaceStore';
 import type {Webspace} from '../../../stores/webspaceStore/types';
-import {ResourceRequester} from 'sulu-admin-bundle/services';
 
 export default class TemplateToolbarAction extends AbstractFormToolbarAction {
     @observable webspace: ?Webspace = undefined;

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/TemplateToolbarAction.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/TemplateToolbarAction.js
@@ -35,11 +35,11 @@ export default class TemplateToolbarAction extends AbstractFormToolbarAction {
             }).then((response) => {
                 this.parentPage = response;
                 const parentTemplate = response.template;
-                for (const defaultTemplate of this.webspace.defaultTemplates['page']) {
-                    if (defaultTemplate.parentTemplate === parentTemplate) {
-                        this.resourceFormStore.setType(defaultTemplate.template);
-                        break;
-                    }
+                const defaultTemplate = this.webspace.defaultTemplates['page'].find((defaultTemplate) => {
+                    return defaultTemplate.parentTemplate === parentTemplate;
+                });
+                if (defaultTemplate) {
+                    this.resourceFormStore.setType(defaultTemplate.template);
                 }
             });
         }

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/TemplateToolbarAction.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/TemplateToolbarAction.js
@@ -8,6 +8,7 @@ import type {Webspace} from '../../../stores/webspaceStore/types';
 
 export default class TemplateToolbarAction extends AbstractFormToolbarAction {
     @observable webspace: ?Webspace = undefined;
+    parentPage;
 
     @computed get defaultTemplate(): ?string {
         if (!this.webspace) {

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/TemplateToolbarAction.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/TemplateToolbarAction.js
@@ -26,6 +26,22 @@ export default class TemplateToolbarAction extends AbstractFormToolbarAction {
             this.resourceFormStore.setType(this.defaultTemplate);
         }
 
+        if (this.router.attributes.parentId && this.webspace) {
+            ResourceRequester.get('pages', {
+                id: this.router.attributes.parentId,
+                language: this.router.attributes.locale
+            }).then(response => {
+                const parentTemplate = response.template;
+                for (let key in this.webspace.defaultTemplates) {
+                    let defaultTemplate = this.webspace.defaultTemplates[key];
+                    if (defaultTemplate.parentTemplate === parentTemplate) {
+                        this.resourceFormStore.setType(key);
+                        break;
+                    }
+                }
+            })
+        }
+
         if (!this.resourceFormStore.typesLoading && Object.keys(formTypes).length === 0) {
             throw new Error('The ToolbarAction for types only works with entities actually supporting types!');
         }

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/TemplateToolbarAction.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/TemplateToolbarAction.js
@@ -27,25 +27,27 @@ export default class TemplateToolbarAction extends AbstractFormToolbarAction {
             this.resourceFormStore.setType(this.defaultTemplate);
         }
 
-        if (this.router.attributes.parentId && this.webspace) {
+        const parentPageId = this.router.attributes.parentId;
+        if (parentPageId && this.webspace && !this.parentPage) {
             ResourceRequester.get('pages', {
-                id: this.router.attributes.parentId,
-                language: this.router.attributes.locale,
+                id: parentPageId,
+                language: this.router.attributes.locale
             }).then((response) => {
+                this.parentPage = response;
                 const parentTemplate = response.template;
-                for (const key in this.webspace.defaultTemplates) {
-                    const defaultTemplate = this.webspace.defaultTemplates[key];
+                for (const defaultTemplate of this.webspace.defaultTemplates['page']) {
                     if (defaultTemplate.parentTemplate === parentTemplate) {
-                        this.resourceFormStore.setType(key);
+                        this.resourceFormStore.setType(defaultTemplate.template);
                         break;
                     }
                 }
-            });
+            })
         }
 
         if (!this.resourceFormStore.typesLoading && Object.keys(formTypes).length === 0) {
             throw new Error('The ToolbarAction for types only works with entities actually supporting types!');
         }
+
 
         return {
             type: 'select',

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/TemplateToolbarAction.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/TemplateToolbarAction.js
@@ -29,7 +29,7 @@ export default class TemplateToolbarAction extends AbstractFormToolbarAction {
         }
 
         const parentPageId = this.router.attributes.parentId;
-        if (parentPageId && this.webspace && !this.parentPage) {
+        if (parentPageId && this.webspace && this.webspace.defaultTemplates && !this.parentPage) {
             ResourceRequester.get('pages', {
                 id: parentPageId,
                 language: this.router.attributes.locale,

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/TemplateToolbarAction.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/TemplateToolbarAction.js
@@ -35,9 +35,10 @@ export default class TemplateToolbarAction extends AbstractFormToolbarAction {
             }).then((response) => {
                 this.parentPage = response;
                 const parentTemplate = response.template;
-                const defaultTemplate = this.webspace.defaultTemplates['page'].find((defaultTemplate) => {
+                const defaultTemplate = this.webspace.defaultTemplates.page.find((defaultTemplate) => {
                     return defaultTemplate.parentTemplate === parentTemplate;
                 });
+
                 if (defaultTemplate) {
                     this.resourceFormStore.setType(defaultTemplate.template);
                 }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapGeneratorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapGeneratorTest.php
@@ -30,6 +30,7 @@ use Sulu\Component\Content\Query\ContentQueryExecutor;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
+use Sulu\Component\Webspace\DefaultTemplate;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Navigation;
 use Sulu\Component\Webspace\NavigationContext;
@@ -144,7 +145,7 @@ class SitemapGeneratorTest extends SuluTestCase
         $this->webspace->setLocalizations([$local1, $local2]);
         $this->webspace->setName('Default');
 
-        $this->webspace->addDefaultTemplate('page', 'default');
+        $this->webspace->addDefaultTemplate(new DefaultTemplate('page', 'default'));
         $this->webspace->setTheme('test');
 
         $this->webspace->setNavigation(

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/StructureSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/StructureSubscriberTest.php
@@ -27,6 +27,7 @@ use Sulu\Component\Content\Mapper\Translation\TranslatedProperty;
 use Sulu\Component\Content\Metadata\PropertyMetadata;
 use Sulu\Component\Content\Metadata\StructureMetadata;
 use Sulu\Component\DocumentManager\Metadata;
+use Sulu\Component\Webspace\DefaultTemplate;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Webspace;
 
@@ -426,7 +427,7 @@ class StructureSubscriberTest extends SubscriberTestCase
         $this->inspector->getMetadata($this->document->reveal())->willReturn($metadata->reveal());
 
         $webspace = new Webspace();
-        $webspace->addDefaultTemplate('page', 'default');
+        $webspace->addDefaultTemplate(new DefaultTemplate('page', 'default'));
 
         $this->webspaceManager->findWebspaceByKey('sulu_io')->willReturn($webspace);
 

--- a/src/Sulu/Component/Webspace/DefaultTemplate.php
+++ b/src/Sulu/Component/Webspace/DefaultTemplate.php
@@ -31,13 +31,6 @@ class DefaultTemplate
      */
     private $parentTemplate;
 
-    /**
-     * DefaultTemplate constructor.
-     *
-     * @param string $type
-     * @param string $template
-     * @param string|null $parentTemplate
-     */
     public function __construct(string $type, string $template, ?string $parentTemplate = null)
     {
         $this->type = $type;

--- a/src/Sulu/Component/Webspace/DefaultTemplate.php
+++ b/src/Sulu/Component/Webspace/DefaultTemplate.php
@@ -1,0 +1,89 @@
+<?php
+
+
+namespace Sulu\Component\Webspace;
+
+
+class DefaultTemplate
+{
+    /**
+     * @var string $type
+     */
+    private $type;
+
+    /**
+     * @var string $template
+     */
+    private $template;
+
+    /**
+     * @var string|null $parentTemplate
+     */
+    private $parentTemplate;
+
+    /**
+     * DefaultTemplate constructor.
+     * @param string $type
+     * @param string $template
+     * @param string|null $parentTemplate
+     */
+    public function __construct(string $type, string $template, ?string $parentTemplate = null)
+    {
+        $this->type = $type;
+        $this->template = $template;
+        $this->parentTemplate = $parentTemplate;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param string $type
+     */
+    public function setType(string $type): void
+    {
+        $this->type = $type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTemplate(): string
+    {
+        return $this->template;
+    }
+
+    /**
+     * @param string $template
+     */
+    public function setTemplate(string $template): void
+    {
+        $this->template = $template;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getParentTemplate(): ?string
+    {
+        return $this->parentTemplate;
+    }
+
+    /**
+     * @param string|null $parentTemplate
+     */
+    public function setParentTemplate(?string $parentTemplate): void
+    {
+        $this->parentTemplate = $parentTemplate;
+    }
+
+    public function isValid()
+    {
+        return !empty($this->type) && !empty($this->template);
+    }
+}

--- a/src/Sulu/Component/Webspace/DefaultTemplate.php
+++ b/src/Sulu/Component/Webspace/DefaultTemplate.php
@@ -1,28 +1,39 @@
 <?php
 
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
 
 namespace Sulu\Component\Webspace;
 
-
+/**
+ * Container for a default template definition.
+ */
 class DefaultTemplate
 {
     /**
-     * @var string $type
+     * @var string
      */
     private $type;
 
     /**
-     * @var string $template
+     * @var string
      */
     private $template;
 
     /**
-     * @var string|null $parentTemplate
+     * @var string|null
      */
     private $parentTemplate;
 
     /**
      * DefaultTemplate constructor.
+     *
      * @param string $type
      * @param string $template
      * @param string|null $parentTemplate

--- a/src/Sulu/Component/Webspace/DefaultTemplate.php
+++ b/src/Sulu/Component/Webspace/DefaultTemplate.php
@@ -54,14 +54,6 @@ class DefaultTemplate
     }
 
     /**
-     * @param string $type
-     */
-    public function setType(string $type): void
-    {
-        $this->type = $type;
-    }
-
-    /**
      * @return string
      */
     public function getTemplate(): string
@@ -70,31 +62,10 @@ class DefaultTemplate
     }
 
     /**
-     * @param string $template
-     */
-    public function setTemplate(string $template): void
-    {
-        $this->template = $template;
-    }
-
-    /**
      * @return string|null
      */
     public function getParentTemplate(): ?string
     {
         return $this->parentTemplate;
-    }
-
-    /**
-     * @param string|null $parentTemplate
-     */
-    public function setParentTemplate(?string $parentTemplate): void
-    {
-        $this->parentTemplate = $parentTemplate;
-    }
-
-    public function isValid()
-    {
-        return !empty($this->type) && !empty($this->template);
     }
 }

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
@@ -426,11 +426,14 @@ class XmlFileLoader10 extends BaseXmlFileLoader
             /* @var \DOMNode $node */
             $template = $node->nodeValue;
             $type = $node->attributes->getNamedItem('type')->nodeValue;
-            $parentTemplate = $node->attributes->getNamedItem('parent-template')->nodeValue;
+            $parentTemplateNode = $node->attributes->getNamedItem('parent-template');
+            if ($parentTemplateNode) {
+                $parentTemplate = $parentTemplateNode->nodeValue;
+            }
 
-            $webspace->addDefaultTemplate($type, $template, $parentTemplate);
+            $webspace->addDefaultTemplate($type, $template, isset($parentTemplate) ? $parentTemplate : null);
             if ('homepage' === $type) {
-                $webspace->addDefaultTemplate('home', $template, $parentTemplate);
+                $webspace->addDefaultTemplate('home', $template, isset($parentTemplate) ? $parentTemplate : null);
             }
         }
 

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\Webspace\Loader;
 
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\CustomUrl;
+use Sulu\Component\Webspace\DefaultTemplate;
 use Sulu\Component\Webspace\Environment;
 use Sulu\Component\Webspace\Exception\InvalidWebspaceException;
 use Sulu\Component\Webspace\Loader\Exception\ExpectedDefaultTemplatesNotFound;
@@ -426,14 +427,10 @@ class XmlFileLoader10 extends BaseXmlFileLoader
             /* @var \DOMNode $node */
             $template = $node->nodeValue;
             $type = $node->attributes->getNamedItem('type')->nodeValue;
-            $parentTemplateNode = $node->attributes->getNamedItem('parent-template');
-            if ($parentTemplateNode) {
-                $parentTemplate = $parentTemplateNode->nodeValue;
-            }
 
-            $webspace->addDefaultTemplate($type, $template, isset($parentTemplate) ? $parentTemplate : null);
+            $webspace->addDefaultTemplate(new DefaultTemplate($type, $template));
             if ('homepage' === $type) {
-                $webspace->addDefaultTemplate('home', $template, isset($parentTemplate) ? $parentTemplate : null);
+                $webspace->addDefaultTemplate(new DefaultTemplate('home', $template));
             }
         }
 

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
@@ -426,10 +426,11 @@ class XmlFileLoader10 extends BaseXmlFileLoader
             /* @var \DOMNode $node */
             $template = $node->nodeValue;
             $type = $node->attributes->getNamedItem('type')->nodeValue;
+            $parentTemplate = $node->attributes->getNamedItem('parent-template')->nodeValue;
 
-            $webspace->addDefaultTemplate($type, $template);
+            $webspace->addDefaultTemplate($type, $template, $parentTemplate);
             if ('homepage' === $type) {
-                $webspace->addDefaultTemplate('home', $template);
+                $webspace->addDefaultTemplate('home', $template, $parentTemplate);
             }
         }
 

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader11.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader11.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Component\Webspace\Loader;
 
+use Sulu\Component\Webspace\DefaultTemplate;
 use Sulu\Component\Webspace\Loader\Exception\ExpectedDefaultTemplatesNotFound;
 use Sulu\Component\Webspace\Webspace;
 
@@ -59,9 +60,9 @@ class XmlFileLoader11 extends XmlFileLoader10
                 $parentTemplate = $parentTemplateNode->nodeValue;
             }
 
-            $webspace->addDefaultTemplate($type, $template, isset($parentTemplate) ? $parentTemplate : null);
+            $webspace->addDefaultTemplate(new DefaultTemplate($type, $template, isset($parentTemplate) ? $parentTemplate : null));
             if ('homepage' === $type) {
-                $webspace->addDefaultTemplate('home', $template, isset($parentTemplate) ? $parentTemplate : null);
+                $webspace->addDefaultTemplate(new DefaultTemplate('home', $template, isset($parentTemplate) ? $parentTemplate : null));
             }
         }
 

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader11.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader11.php
@@ -54,10 +54,14 @@ class XmlFileLoader11 extends XmlFileLoader10
             /* @var \DOMNode $node */
             $template = $node->nodeValue;
             $type = $node->attributes->getNamedItem('type')->nodeValue;
+            $parentTemplateNode = $node->attributes->getNamedItem('parent-template');
+            if ($parentTemplateNode) {
+                $parentTemplate = $parentTemplateNode->nodeValue;
+            }
 
-            $webspace->addDefaultTemplate($type, $template);
+            $webspace->addDefaultTemplate($type, $template, isset($parentTemplate) ? $parentTemplate : null);
             if ('homepage' === $type) {
-                $webspace->addDefaultTemplate('home', $template);
+                $webspace->addDefaultTemplate('home', $template, isset($parentTemplate) ? $parentTemplate : null);
             }
         }
 

--- a/src/Sulu/Component/Webspace/Loader/schema/webspace/webspace-1.0.xsd
+++ b/src/Sulu/Component/Webspace/Loader/schema/webspace/webspace-1.0.xsd
@@ -130,6 +130,7 @@
         <xs:simpleContent>
             <xs:extension base="xs:string">
                 <xs:attribute name="type" type="xs:string" use="required"/>
+                <xs:attribute name="parent-template" type="xs:string" use="optional"/>
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>

--- a/src/Sulu/Component/Webspace/Loader/schema/webspace/webspace-1.0.xsd
+++ b/src/Sulu/Component/Webspace/Loader/schema/webspace/webspace-1.0.xsd
@@ -130,7 +130,6 @@
         <xs:simpleContent>
             <xs:extension base="xs:string">
                 <xs:attribute name="type" type="xs:string" use="required"/>
-                <xs:attribute name="parent-template" type="xs:string" use="optional"/>
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>

--- a/src/Sulu/Component/Webspace/Loader/schema/webspace/webspace-1.1.xsd
+++ b/src/Sulu/Component/Webspace/Loader/schema/webspace/webspace-1.1.xsd
@@ -128,6 +128,7 @@
         <xs:simpleContent>
             <xs:extension base="xs:string">
                 <xs:attribute name="type" type="xs:string" use="required"/>
+                <xs:attribute name="parent-template" type="xs:string" use="optional"/>
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>

--- a/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
+++ b/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
@@ -69,7 +69,7 @@ class {{ cache_class }} extends {{ base_class }}
 
 {% for type,template in webspace.templates %}        $webspace->addTemplate('{{ type|raw }}', '{{ template }}');
 {% endfor %}
-{% for type,template in webspace.defaultTemplates %}        $webspace->addDefaultTemplate('{{ type }}', '{{ template }}');
+{% for type,defaultTemplate in webspace.defaultTemplates %}        $webspace->addDefaultTemplate('{{ type }}', '{{ defaultTemplate.template }}', '{{ defaultTemplate.parentTemplate }}');
 {% endfor %}
 {% for template in webspace.excludedTemplates %}        $webspace->addExcludedTemplate('{{ template }}');
 {% endfor %}

--- a/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
+++ b/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
@@ -71,8 +71,7 @@ $webspace->setName('{{ webspace.name }}');
 {% endfor %}
 
 {% for type, templates in webspace.defaultTemplates %}
-    {% for defaultTemplate in templates %}
-        $webspace->addDefaultTemplate('{{ type }}', '{{ defaultTemplate.template }}', '{{ defaultTemplate.parentTemplate }}');
+    {% for defaultTemplate in templates %}        $webspace->addDefaultTemplate('{{ type }}', '{{ defaultTemplate.template }}', '{{ defaultTemplate.parentTemplate }}');
     {% endfor %}
 {% endfor %}
 {% for template in webspace.excludedTemplates %}        $webspace->addExcludedTemplate('{{ template }}');

--- a/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
+++ b/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
@@ -32,62 +32,66 @@ class {{ cache_class }} extends {{ base_class }}
         // new webspace
         $webspace = new Webspace();
         $webspace->setKey('{{ webspace.key }}');
-        $webspace->setName('{{ webspace.name }}');
+$webspace->setName('{{ webspace.name }}');
 {% if webspace.security != null %}
-        $security = new Security();
-        $security->setSystem('{{ webspace.security.system }}');
-        $webspace->setSecurity($security);
+    $security = new Security();
+    $security->setSystem('{{ webspace.security.system }}');
+    $webspace->setSecurity($security);
 {% endif %}
 {% for localization in webspace.localizations %}
-        // add localization to webspace
-        $localization0 = new Localization();
-        $localization0->setLanguage('{{ localization.language }}');
-        $localization0->setCountry('{{ localization.country }}');
-        $localization0->setShadow('{{ (localization.shadow) }}');
-        $localization0->setDefault('{{ localization.default }}');
-        $localization0->setXDefault('{{ localization.xDefault }}');
-{% for childLocalization in localization.children %}
-{{ self.create_localizations(childLocalization, 1, 0, webspace) }}
-{% endfor %}
-        $localizationRefs['{{ webspace.key }}_{{ localization.localization }}'] = $localization0;
-        $webspace->addLocalization($localization0);
+    // add localization to webspace
+    $localization0 = new Localization();
+    $localization0->setLanguage('{{ localization.language }}');
+    $localization0->setCountry('{{ localization.country }}');
+    $localization0->setShadow('{{ (localization.shadow) }}');
+    $localization0->setDefault('{{ localization.default }}');
+    $localization0->setXDefault('{{ localization.xDefault }}');
+    {% for childLocalization in localization.children %}
+        {{ self.create_localizations(childLocalization, 1, 0, webspace) }}
+    {% endfor %}
+    $localizationRefs['{{ webspace.key }}_{{ localization.localization }}'] = $localization0;
+    $webspace->addLocalization($localization0);
 {% endfor %}
 {% for segment in webspace.segments %}
-        // add segment to webspace
-        $segment = new Segment();
-        $segment->setName('{{ segment.name }}');
-        $segment->setKey('{{ segment.key }}');
-        $webspace->addSegment($segment);
-        $segmentRefs['{{ webspace.key }}_{{ segment.key }}'] = $segment;
+    // add segment to webspace
+    $segment = new Segment();
+    $segment->setName('{{ segment.name }}');
+    $segment->setKey('{{ segment.key }}');
+    $webspace->addSegment($segment);
+    $segmentRefs['{{ webspace.key }}_{{ segment.key }}'] = $segment;
 
 {% endfor %}
-        // add theme
+// add theme
 {% if webspace.theme != null %}
-        $webspace->setTheme('{{ webspace.theme }}');
+    $webspace->setTheme('{{ webspace.theme }}');
 {% endif %}
 
 
 {% for type,template in webspace.templates %}        $webspace->addTemplate('{{ type|raw }}', '{{ template }}');
 {% endfor %}
-{% for type,defaultTemplate in webspace.defaultTemplates %}        $webspace->addDefaultTemplate('{{ type }}', '{{ defaultTemplate.template }}', '{{ defaultTemplate.parentTemplate }}');
+
+{% for type, templates in webspace.defaultTemplates %}
+    {% for defaultTemplate in templates %}
+        $webspace->addDefaultTemplate('{{ type }}', '{{ defaultTemplate.template }}', '{{ defaultTemplate.parentTemplate }}');
+    {% endfor %}
 {% endfor %}
 {% for template in webspace.excludedTemplates %}        $webspace->addExcludedTemplate('{{ template }}');
 {% endfor %}
 
-        // add navigation
-        $navigation = new Navigation();
+// add navigation
+$navigation = new Navigation();
 {% for context in webspace.navigation.contexts %}        $navigation->addContext(new NavigationContext('{{ context.key }}', {{ self.renderArray(context.metadata) }}));
 {% endfor %}        $webspace->setNavigation($navigation);
-        $webspace->setResourceLocatorStrategy('{{ webspace.resourceLocator.strategy }}');
+$webspace->setResourceLocatorStrategy('{{ webspace.resourceLocator.strategy }}');
 
 {% for portal in webspace.portals %}
 
-        // new portal
-        $portal = new Portal();
-        $portal->setName('{{ portal.name }}');
-        $portal->setKey('{{ portal.key }}');
-        $portal->setWebspace($webspace);
-{% for localization in portal.localizations %}
+    // new portal
+    $portal = new Portal();
+    $portal->setName('{{ portal.name }}');
+    $portal->setKey('{{ portal.key }}');
+    $portal->setWebspace($webspace);
+    {% for localization in portal.localizations %}
 
         // add localization
         $localization = new Localization();
@@ -96,86 +100,86 @@ class {{ cache_class }} extends {{ base_class }}
         $localization->setDefault('{{ localization.default }}');
         $localization->setXDefault('{{ localization.xDefault }}');
         $portal->addLocalization($localization);
-{% endfor %}
+    {% endfor %}
 
-{% for environment in portal.environments %}
+    {% for environment in portal.environments %}
 
         // add environment
         $environment = new Environment();
         $environment->setType('{{ environment.type }}');
-{% for url in environment.urls %}
+        {% for url in environment.urls %}
 
-        // add environment url
-        $url = new Url();
-        $url->setUrl('{{ url.url }}');
-        $url->setLanguage('{{ url.language }}');
-        $url->setCountry('{{ url.country }}');
-        $url->setSegment('{{ url.segment }}');
-        $url->setRedirect('{{ url.redirect }}');
-        $url->setMain({{ url.main?'true':'false' }});
-        $environment->addUrl($url);
-{% endfor %}
-{% for customUrl in environment.customUrls %}
-        $environment->addCustomUrl(new CustomUrl('{{ customUrl.url }}'));
-{% endfor %}
+            // add environment url
+            $url = new Url();
+            $url->setUrl('{{ url.url }}');
+            $url->setLanguage('{{ url.language }}');
+            $url->setCountry('{{ url.country }}');
+            $url->setSegment('{{ url.segment }}');
+            $url->setRedirect('{{ url.redirect }}');
+            $url->setMain({{ url.main?'true':'false' }});
+            $environment->addUrl($url);
+        {% endfor %}
+        {% for customUrl in environment.customUrls %}
+            $environment->addCustomUrl(new CustomUrl('{{ customUrl.url }}'));
+        {% endfor %}
 
         $portal->addEnvironment($environment);
-{% endfor %}
-        $portalRefs['{{ portal.key }}'] = $portal;
-        $webspace->addPortal($portal);
+    {% endfor %}
+    $portalRefs['{{ portal.key }}'] = $portal;
+    $webspace->addPortal($portal);
 
 {% endfor %}
-        $webspaceRefs['{{ webspace.key }}'] = $webspace;
+$webspaceRefs['{{ webspace.key }}'] = $webspace;
 
 
 {% endfor %}
 
 {% for environmentKey, environment in collection.portalInformations %}
-{% for portalInformation in environment %}
+    {% for portalInformation in environment %}
         $portalInformationRefs['{{ environmentKey }}']['{{ portalInformation.url }}'] = new PortalInformation(
-            {{ portalInformation.type }},
-            $webspaceRefs['{{ portalInformation.webspace }}'],
-{% if portalInformation.portal %}
+        {{ portalInformation.type }},
+        $webspaceRefs['{{ portalInformation.webspace }}'],
+        {% if portalInformation.portal %}
             $portalRefs['{{ portalInformation.portal }}'],
-{% else %}
+        {% else %}
             null,
-{% endif %}
-{% if portalInformation.localization %}
+        {% endif %}
+        {% if portalInformation.localization %}
             $localizationRefs['{{ portalInformation.webspace }}_{{ portalInformation.localization.localization }}'],
-{% else %}
+        {% else %}
             null,
-{% endif %}
-            '{{ portalInformation.url }}',
-{% if portalInformation.segment %}
+        {% endif %}
+        '{{ portalInformation.url }}',
+        {% if portalInformation.segment %}
             $segmentRefs['{{ portalInformation.webspace }}_{{ portalInformation.segment }}'],
-{% else %}
+        {% else %}
             null,
-{% endif %}
-{% if portalInformation.redirect %}
+        {% endif %}
+        {% if portalInformation.redirect %}
             '{{ portalInformation.redirect }}',
-{% else %}
+        {% else %}
             null,
-{% endif %}
-{% if portalInformation.main %}
+        {% endif %}
+        {% if portalInformation.main %}
             true,
-{% else %}
+        {% else %}
             false,
-{% endif %}
-{% if portalInformation.urlExpression %}
+        {% endif %}
+        {% if portalInformation.urlExpression %}
             '{{ portalInformation.urlExpression }}',
-{% else %}
+        {% else %}
             null,
-{% endif %}
-            {{ portalInformation.priority }}
+        {% endif %}
+        {{ portalInformation.priority }}
         );
 
-{% endfor %}
+    {% endfor %}
 {% endfor %}
 
-        $this->setWebspaces($webspaceRefs);
-        $this->setPortals($portalRefs);
-        $this->setPortalInformations($portalInformationRefs);
-    }
+$this->setWebspaces($webspaceRefs);
+$this->setPortals($portalRefs);
+$this->setPortalInformations($portalInformationRefs);
+}
 }
 
 {% macro renderArray(array) %}{% import _self as self %}

--- a/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
+++ b/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
@@ -11,6 +11,7 @@ use Sulu\Component\Webspace\CustomUrl;
 use Sulu\Component\Webspace\Webspace;
 use Sulu\Component\Webspace\Navigation;
 use Sulu\Component\Webspace\NavigationContext;
+use Sulu\Component\Webspace\DefaultTemplate;
 
 /**
  * {{ cache_class }}
@@ -70,8 +71,8 @@ $webspace->setName('{{ webspace.name }}');
 {% for type,template in webspace.templates %}        $webspace->addTemplate('{{ type|raw }}', '{{ template }}');
 {% endfor %}
 
-{% for type, templates in webspace.defaultTemplates %}
-    {% for defaultTemplate in templates %}        $webspace->addDefaultTemplate('{{ type }}', '{{ defaultTemplate.template }}', '{{ defaultTemplate.parentTemplate }}');
+{% for templates in webspace.defaultTemplates %}
+    {% for defaultTemplate in templates %}        $webspace->addDefaultTemplate(new DefaultTemplate('{{ defaultTemplate.type }}', '{{ defaultTemplate.template }}', '{{ defaultTemplate.parentTemplate }}'));
     {% endfor %}
 {% endfor %}
 {% for template in webspace.excludedTemplates %}        $webspace->addExcludedTemplate('{{ template }}');

--- a/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\Webspace\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\DefaultTemplate;
 use Sulu\Component\Webspace\Environment;
 use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\Security;
@@ -270,8 +271,8 @@ class WebspaceTest extends TestCase
         $defaultTemplates = ['page' => 'default', 'homepage' => 'overview'];
 
         $webspace = new Webspace();
-        $webspace->addDefaultTemplate('page', 'default');
-        $webspace->addDefaultTemplate('homepage', 'overview');
+        $webspace->addDefaultTemplate(new DefaultTemplate('page', 'default'));
+        $webspace->addDefaultTemplate(new DefaultTemplate('homepage', 'overview'));
         $this->assertEquals($defaultTemplates, $webspace->getDefaultTemplates());
         $this->assertEquals($defaultTemplates['page'], $webspace->getDefaultTemplate('page'));
         $this->assertEquals($defaultTemplates['homepage'], $webspace->getDefaultTemplate('homepage'));

--- a/src/Sulu/Component/Webspace/Webspace.php
+++ b/src/Sulu/Component/Webspace/Webspace.php
@@ -495,10 +495,14 @@ class Webspace implements ArrayableInterface
      *
      * @param string $type
      * @param string $template
+     * @param string $parentTemplate
      */
-    public function addDefaultTemplate($type, $template)
+    public function addDefaultTemplate($type, $template, $parentTemplate)
     {
-        $this->defaultTemplates[$type] = $template;
+        $this->defaultTemplates[$template] = [
+            'type' => $type,
+            'parentTemplate' => $parentTemplate
+        ];
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Webspace.php
+++ b/src/Sulu/Component/Webspace/Webspace.php
@@ -497,7 +497,7 @@ class Webspace implements ArrayableInterface
      */
     public function addDefaultTemplate(DefaultTemplate $defaultTemplate)
     {
-        $this->defaultTemplates[$defaultTemplate->getType()][] = $defaultTemplate;;
+        $this->defaultTemplates[$defaultTemplate->getType()][] = $defaultTemplate;
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Webspace.php
+++ b/src/Sulu/Component/Webspace/Webspace.php
@@ -493,16 +493,11 @@ class Webspace implements ArrayableInterface
     /**
      * Add a new default template for given type.
      *
-     * @param string $type
-     * @param string $template
-     * @param string|null $parentTemplate
+     * @param DefaultTemplate $defaultTemplate
      */
-    public function addDefaultTemplate($type, $template, $parentTemplate = null)
+    public function addDefaultTemplate(DefaultTemplate $defaultTemplate)
     {
-        $defaultTemplate = new DefaultTemplate($type, $template, $parentTemplate);
-        if ($defaultTemplate->isValid()) {
-            $this->defaultTemplates[$type][] = $defaultTemplate;
-        }
+        $this->defaultTemplates[$defaultTemplate->getType()][] = $defaultTemplate;;
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Webspace.php
+++ b/src/Sulu/Component/Webspace/Webspace.php
@@ -495,14 +495,14 @@ class Webspace implements ArrayableInterface
      *
      * @param string $type
      * @param string $template
-     * @param string $parentTemplate
+     * @param string|null $parentTemplate
      */
-    public function addDefaultTemplate($type, $template, $parentTemplate)
+    public function addDefaultTemplate($type, $template, $parentTemplate = null)
     {
-        $this->defaultTemplates[$template] = [
-            'type' => $type,
-            'parentTemplate' => $parentTemplate,
-        ];
+        $defaultTemplate = new DefaultTemplate($type, $template, $parentTemplate);
+        if ($defaultTemplate->isValid()) {
+            $this->defaultTemplates[$type][] = $defaultTemplate;
+        }
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Webspace.php
+++ b/src/Sulu/Component/Webspace/Webspace.php
@@ -501,7 +501,7 @@ class Webspace implements ArrayableInterface
     {
         $this->defaultTemplates[$template] = [
             'type' => $type,
-            'parentTemplate' => $parentTemplate
+            'parentTemplate' => $parentTemplate,
         ];
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4922
| Related issues/PRs | #4922
| License | MIT
| Documentation PR | sulu/sulu-docs#479

#### What's in this PR?

It allows the user to define the child template being used on a given parent template.

#### Why?

When we have a list of artist we'd have a Artist overview page and an artist detail page. Underneath an artist overview you would (most of the time) have a artist detail page. Having the option to set that as default is now made available.

#### Example Usage

**In your webspace:**
~~~xml
<default-templates>
        <default-template type="page">default</default-template>
        <default-template type="home">homepage</default-template>
        <default-template type="page" parent-template="artists">artist</default-template>
</default-templates>
~~~

Add a page with the Artists template, now add a child page of that page and the Artist template will be automatically selected.

#### To Do

- [x] Create a documentation PR
