### PR TITLE
Add possibility to filter for types in single selections

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -152,16 +152,13 @@ export default class Selection extends React.Component<Props> {
                     },
                 },
             },
+            schemaOptions: {
+                types: {
+                    value: types,
+                } = {},
+            },
             value,
         } = this.props;
-
-        const {schemaOptions} = this.props;
-
-        const {
-            types: {
-                value: types,
-            } = {},
-        } = schemaOptions;
 
         if (types !== undefined && typeof types !== 'string') {
             throw new Error('The "types" schema option must be a string if given!');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
@@ -96,6 +96,9 @@ export default class SingleSelection extends React.Component<Props>
                 form_options_to_list_options: {
                     value: formOptionsToListOptions,
                 } = {},
+                types: {
+                    value: types,
+                } = {},
             } = {},
             value,
         } = this.props;
@@ -107,11 +110,15 @@ export default class SingleSelection extends React.Component<Props>
             );
         }
 
+        if (types !== undefined && typeof types !== 'string') {
+            throw new Error('The "types" schema option must be a string if given!');
+        }
+
         if (formOptionsToListOptions && !Array.isArray(formOptionsToListOptions)) {
             throw new Error('The "form_options_to_list_options" option has to be an array if defined!');
         }
 
-        const listOptions = formOptionsToListOptions
+        const formListOptions = formOptionsToListOptions
             ? formOptionsToListOptions.reduce((currentOptions, formOption) => {
                 if (!formOption.name) {
                     throw new Error('All options set in "form_options_to_list_options" must define name!');
@@ -120,6 +127,15 @@ export default class SingleSelection extends React.Component<Props>
 
                 return currentOptions;
             }, {})
+            : undefined;
+
+        const typeOptions = types ? {types} : undefined;
+
+        const listOptions = formListOptions || typeOptions
+            ? {
+                ...formListOptions,
+                ...typeOptions,
+            }
             : undefined;
 
         if (detailOptions && typeof detailOptions !== 'object') {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
@@ -754,3 +754,23 @@ test('Call onChange and onFinish when SingleSelection changes', () => {
     expect(changeSpy).toBeCalledWith(undefined);
     expect(finishSpy).toBeCalledWith();
 });
+
+test('Should throw an error if "types" schema option is not a string', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('snippets'), 'pages'));
+    const fieldTypeOptions = {
+        default_type: 'list_overlay',
+        resource_key: 'test',
+        types: {
+            list_overlay: {},
+        },
+    };
+
+    expect(() => shallow(
+        <SingleSelection
+            {...fieldTypeDefaultProps}
+            fieldTypeOptions={fieldTypeOptions}
+            formInspector={formInspector}
+            schemaOptions={{types: {value: []}}}
+        />
+    )).toThrowError(/"types"/);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
@@ -553,6 +553,9 @@ test('Pass correct props with schema-options type to SingleItemSelection', () =>
             name: 'type',
             value: 'list_overlay',
         },
+        types: {
+            value: 'test',
+        },
     };
 
     const singleSelection = shallow(
@@ -579,6 +582,7 @@ test('Pass correct props with schema-options type to SingleItemSelection', () =>
         listOptions: {
             segment: 'developer',
             webspace: 'sulu',
+            types: 'test',
         },
         overlayTitle: 'sulu_contact.overlay_title',
         resourceKey: 'accounts',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Adds possibility to filter for types in single selections

#### Why?

Because it was only available for `selections`, not `single_selections`.

#### Example Usage

~~~xml
<property name="foo" type="single_article_selection">
    <params>
        <param name="types" value="special"/>
    </params>
</property>
~~~
