### PR TITLE
Improve performance for one layered images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-release/1.6
+    * ENHANCEMENT #4968  [MediaBundle]             Improve performance for one layered images
+
 * 1.6.29 (2019-10-24)
     * BUGFIX      #4644  [LocationBundle]          Fix location content type default map provider option
     * ENHANCEMENT #4812  [MediaBundle]             Optimize gif image output

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImagineImageConverter.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImagineImageConverter.php
@@ -342,7 +342,7 @@ class ImagineImageConverter implements ImageConverterInterface
      */
     private function modifyAllLayers(ImageInterface $image, callable $modifier)
     {
-        if (count($image->layers())) {
+        if (count($image->layers()) > 1) {
             $countLayer = 0;
             $image->layers()->coalesce();
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Interate over layers only when there exist more then 1 layer.

#### Why?

As I did analysed the changes we did for the [vips adapter](https://github.com/sulu/sulu/pull/4862) I did see that we always got into the multi layer part.

Tests did give that the memory usage was reduced from my test images 40mb -> 8mb (- ~80%) and another test image from 435mb -> 162mb memory usage (- ~62%).

#### Example Usage

To test the memory usage I used in ImagineImageConverter:

```php
// var_dump($this->humanFileSize($image->getImagick()->getResource(\Imagick::RESOURCETYPE_MEMORY)));
// var_dump($this->humanFileSize(memory_get_usage()));
```

#### BC Breaks/Deprecations

No BC Break

#### To Do

- [ ] ~~Create a documentation PR~~
- [ ] ~~Add breaking changes to UPGRADE.md~~
