### PR TITLE
Remove unnecessary PHPCR initialization in build script

### DIFF
--- a/bin/runtests
+++ b/bin/runtests
@@ -343,11 +343,6 @@ function init_dbal()
     );
 }
 
-function init_phpcr_dbal()
-{
-    exec_sf_cmd('doctrine:phpcr:init:dbal');
-}
-
 function run_bundle_tests(\SplFileInfo $phpunitFile)
 {
     global $failedTests, $input, $filesystem;
@@ -482,9 +477,6 @@ if ($input->getOption('initialize')) {
     }
     init_dbal();
     write_info('Initializing the content repository');
-    if (getenv('SYMFONY__PHPCR__TRANSPORT') === 'doctrine_dbal') {
-        init_phpcr_dbal();
-    }
     write(PHP_EOL);
 }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR removes the `doctrine:phpcr:dbal:init` step. 

#### Why?

Because this step is failing on travis for Sulu 2.0, and the tests still succeed. Therefore I guess that this step would not be necessary at all.

And because it always feels good to delete something from this script :see_no_evil: 