### PR TITLE
Display add button in category list only if user has sufficient permissions

### DIFF
--- a/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
+++ b/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
@@ -105,8 +105,7 @@ class CategoryAdmin extends Admin
                 ->enableSearching()
                 ->addToolbarActions($listToolbarActions);
 
-            // set add view of list-view only if user has add permission
-            // this will hide the add button of the tree_table adapter if the user has no add permission
+            // hide add button of the tree_table adapter by not setting an add view if the user has no add permission
             if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::ADD)) {
                 $listViewBuilder->setAddView(static::ADD_FORM_VIEW);
             }

--- a/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
+++ b/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
@@ -93,20 +93,25 @@ class CategoryAdmin extends Admin
         }
 
         if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
-            $viewCollection->add(
-                $this->viewBuilderFactory
-                    ->createListViewBuilder(static::LIST_VIEW, '/categories/:locale')
-                    ->setResourceKey('categories')
-                    ->setListKey('categories')
-                    ->setTitle('sulu_category.categories')
-                    ->addListAdapters(['tree_table'])
-                    ->addLocales($locales)
-                    ->setDefaultLocale($locales[0])
-                    ->setAddView(static::ADD_FORM_VIEW)
-                    ->setEditView(static::EDIT_FORM_VIEW)
-                    ->enableSearching()
-                    ->addToolbarActions($listToolbarActions)
-            );
+            $listViewBuilder = $this->viewBuilderFactory
+                ->createListViewBuilder(static::LIST_VIEW, '/categories/:locale')
+                ->setResourceKey('categories')
+                ->setListKey('categories')
+                ->setTitle('sulu_category.categories')
+                ->addListAdapters(['tree_table'])
+                ->addLocales($locales)
+                ->setDefaultLocale($locales[0])
+                ->setEditView(static::EDIT_FORM_VIEW)
+                ->enableSearching()
+                ->addToolbarActions($listToolbarActions);
+
+            // set add view of list-view only if user has add permission
+            // this will hide the add button of the tree_table adapter if the user has no add permission
+            if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::ADD)) {
+                $listViewBuilder->setAddView(static::ADD_FORM_VIEW);
+            }
+            $viewCollection->add($listViewBuilder);
+
             $viewCollection->add(
                 $this->viewBuilderFactory
                     ->createResourceTabViewBuilder(static::ADD_FORM_VIEW, '/categories/:locale/add')


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR hides the add button inside the tree-table list-adapter of the category list if the current user does not have the respective permission.

#### Why?

Because Sulu usually hides control elements for which the current user does not have sufficient permissions. Eg. toolbar actions are only displayed if the current user has the permissions to execute the action.
