### PR TITLE
Fix Update of List Selection Value from outside

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -78,6 +78,24 @@ export default class Selection extends React.Component<Props> {
         }
     }
 
+    componentDidUpdate(prevProps: Props) {
+        this.updateListStoreSelection(prevProps);
+    }
+
+    updateListStoreSelection(prevProps: Props) {
+        if (prevProps.value === this.props.value) {
+            return;
+        }
+
+        const listStore = this.listStore;
+
+        if (!listStore) {
+            return;
+        }
+
+        listStore.updateSelectionIds(toJS(this.props.value) || []);
+    }
+
     componentWillUnmount() {
         if (this.changeListDisposer) {
             this.changeListDisposer();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
@@ -526,6 +526,66 @@ export default class ListStore {
         });
     };
 
+    updateSelectionIds(newSelectionIds: Array<string | number>) {
+        const oldSelectionIds = this.selectionIds;
+
+        if (oldSelectionIds === newSelectionIds) {
+            return;
+        }
+
+        const removedValues = oldSelectionIds.filter((x) => !newSelectionIds.includes(x));
+        const addedValues = newSelectionIds.filter((x) => !oldSelectionIds.includes(x));
+        const notLoadedIds = [];
+
+        removedValues.forEach((oldId: string | number) => {
+            this.deselectById(oldId);
+        });
+
+        addedValues.forEach((newId: string | number) => {
+            const row = this.findById(newId);
+
+            if (!row) {
+                notLoadedIds.push(newId);
+
+                return;
+            }
+
+            this.select(row);
+        });
+
+        if (!notLoadedIds.length) {
+            return;
+        }
+
+        const observableOptions = {};
+
+        for (const key in this.observableOptions) {
+            observableOptions[key] = this.observableOptions[key].get();
+        }
+
+        this.setDataLoading(true);
+        const options = {...observableOptions, ...this.options};
+
+        options.selectedIds = newSelectionIds.join(',');
+
+        this.loadingStrategy.load(
+            this.resourceKey,
+            options
+        ).then(action(() => {
+            this.setDataLoading(false);
+
+            newSelectionIds
+                .map((selectionId) => this.findById(selectionId))
+                .forEach((selectionRow) => {
+                    if (!selectionRow) {
+                        return;
+                    }
+
+                    this.select(selectionRow);
+                });
+        }));
+    }
+
     @action setDataLoading(dataLoading: boolean) {
         this.dataLoading = dataLoading;
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix Update of List Selection Value from outside.

#### Why?

If you manipulate the selection value from outside e.g.: setting it directly on the resourceStore or in my case over a custom form the selection is not updated.

Also the selection is not updated if the response from the server would add because of businessLogic new selections.

#### Example Usage

Easiest way to test it is using the following inside a page template:

```xml
        <section name="hello-1">
            <properties>
                <property name="categories" type="category_selection"/>
            </properties>
        </section>

        <section name="hello-2">
            <properties>
                <property name="categories" type="category_selection"/>
            </properties>
        </section>
```

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
