### PR TITLE
Render buttons of TableAdapter and TreeTableAdapter based on item-specific permissions

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TableAdapter.js
@@ -16,12 +16,47 @@ class TableAdapter extends AbstractTableAdapter {
 
     static icon = 'su-align-justify';
 
+    getButtons = (item: ?Object) => {
+        const {
+            actions,
+            onItemClick,
+        } = this.props;
+
+        const {
+            _permissions: {
+                edit: editPermission = true,
+                view: viewPermission = true,
+            } = {},
+        } = item || {};
+
+        const buttons = [];
+
+        if (onItemClick) {
+            buttons.push({
+                disabled: !viewPermission,
+                icon: editPermission ? 'su-pen' : 'su-eye',
+                onClick: onItemClick,
+            });
+        }
+
+        if (actions) {
+            buttons.push(...actions);
+        }
+
+        return buttons;
+    };
+
     renderRows(): Array<Element<typeof Table.Row>> {
         const {data, selections} = this.props;
 
         return data.map((item) => {
             return (
-                <Table.Row id={item.id} key={item.id} selected={selections.includes(item.id)}>
+                <Table.Row
+                    buttons={this.getButtons(item)}
+                    id={item.id}
+                    key={item.id}
+                    selected={selections.includes(item.id)}
+                >
                     {this.renderCells(item)}
                 </Table.Row>
             );
@@ -30,12 +65,10 @@ class TableAdapter extends AbstractTableAdapter {
 
     render() {
         const {
-            actions,
             data,
             limit,
             loading,
             onAllSelectionChange,
-            onItemClick,
             onItemSelectionChange,
             onLimitChange,
             onPageChange,
@@ -45,22 +78,10 @@ class TableAdapter extends AbstractTableAdapter {
             page,
             pageCount,
         } = this.props;
-        const buttons = [];
-
-        if (onItemClick) {
-            buttons.push({
-                icon: 'su-pen',
-                onClick: (rowId) => onItemClick(rowId),
-            });
-        }
-
-        if (actions) {
-            buttons.push(...actions);
-        }
 
         const table = (
             <Table
-                buttons={buttons}
+                buttons={this.getButtons()}
                 onAllSelectionChange={onAllSelectionChange}
                 onRowSelectionChange={onItemSelectionChange}
                 selectMode={onItemSelectionChange ? 'multiple' : undefined}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TreeTableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TreeTableAdapter.js
@@ -1,5 +1,5 @@
 // @flow
-import {action} from 'mobx';
+import {action, toJS} from 'mobx';
 import {observer} from 'mobx-react';
 import React from 'react';
 import Table from '../../../components/Table';
@@ -24,6 +24,43 @@ class TreeTableAdapter extends AbstractTableAdapter {
         this.props.onItemActivate(rowId);
     };
 
+    getButtons = (item: ?Object) => {
+        const {
+            onItemClick,
+            onItemAdd,
+        } = this.props;
+
+        const {
+            data: {
+                _permissions: {
+                    add: addPermission = true,
+                    edit: editPermission = true,
+                    view: viewPermission = true,
+                } = {},
+            } = {},
+        } = item || {};
+
+        const buttons = [];
+
+        if (onItemClick) {
+            buttons.push({
+                disabled: !viewPermission,
+                icon: editPermission ? 'su-pen' : 'su-eye',
+                onClick: onItemClick,
+            });
+        }
+
+        if (onItemAdd) {
+            buttons.push({
+                disabled: !addPermission,
+                icon: 'su-plus-circle',
+                onClick: onItemAdd,
+            });
+        }
+
+        return buttons;
+    };
+
     renderRows(items: Array<*>, depth: number = 0) {
         const rows = [];
         const {
@@ -35,6 +72,7 @@ class TreeTableAdapter extends AbstractTableAdapter {
 
             rows.push(
                 <Table.Row
+                    buttons={this.getButtons(item)}
                     depth={depth}
                     expanded={item.children.length > 0}
                     hasChildren={hasChildren}
@@ -58,37 +96,20 @@ class TreeTableAdapter extends AbstractTableAdapter {
             active,
             data,
             loading,
-            onItemClick,
-            onItemAdd,
             onAllSelectionChange,
             onItemSelectionChange,
             options: {
                 showHeader = true,
             },
         } = this.props;
-        const buttons = [];
 
         if (!active && loading) {
             return <Loader />;
         }
 
-        if (onItemClick) {
-            buttons.push({
-                icon: 'su-pen',
-                onClick: onItemClick,
-            });
-        }
-
-        if (onItemAdd) {
-            buttons.push({
-                icon: 'su-plus-circle',
-                onClick: onItemAdd,
-            });
-        }
-
         return (
             <Table
-                buttons={buttons}
+                buttons={this.getButtons()}
                 onAllSelectionChange={onAllSelectionChange}
                 onRowCollapse={this.handleRowCollapse}
                 onRowExpand={this.handleRowExpand}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TreeTableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TreeTableAdapter.js
@@ -1,5 +1,5 @@
 // @flow
-import {action, toJS} from 'mobx';
+import {action} from 'mobx';
 import {observer} from 'mobx-react';
 import React from 'react';
 import Table from '../../../components/Table';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {render, shallow} from 'enzyme';
+import {mount, render, shallow} from 'enzyme';
 import listAdapterDefaultProps from '../../../../utils/TestHelper/listAdapterDefaultProps';
 import TableAdapter from '../../adapters/TableAdapter';
 import StringFieldTransformer from '../../fieldTransformers/StringFieldTransformer';
@@ -344,6 +344,57 @@ test('Render data with pencil button when onItemEdit callback is passed', () => 
     );
 
     expect(tableAdapter).toMatchSnapshot();
+});
+
+test('Render correct button based on permissions when item permissions are provided', () => {
+    const rowEditClickSpy = jest.fn();
+    const data = [
+        {
+            id: 1,
+            title: 'Missing view permission',
+            _permissions: {
+                view: false,
+            },
+        },
+        {
+            id: 2,
+            title: 'Missing edit permission',
+            _permissions: {
+                edit: false,
+            },
+        },
+        {
+            id: 3,
+            title: 'No missing permissions',
+        },
+    ];
+    const schema = {
+        title: {
+            label: 'Title',
+            sortable: true,
+            type: 'string',
+            visibility: 'no',
+        },
+    };
+    const tableAdapter = mount(
+        <TableAdapter
+            {...listAdapterDefaultProps}
+            data={data}
+            onItemClick={rowEditClickSpy}
+            page={1}
+            pageCount={3}
+            schema={schema}
+        />
+    );
+
+    expect(tableAdapter.find('Row').at(0).find('ButtonCell').props().icon).toEqual('su-pen');
+    expect(tableAdapter.find('Row').at(0).find('ButtonCell').props().disabled).toEqual(true);
+
+    expect(tableAdapter.find('Row').at(1).find('ButtonCell').props().icon).toEqual('su-eye');
+    expect(tableAdapter.find('Row').at(1).find('ButtonCell').props().disabled).toEqual(false);
+
+    expect(tableAdapter.find('Row').at(2).find('ButtonCell').props().icon).toEqual('su-pen');
+    expect(tableAdapter.find('Row').at(2).find('ButtonCell').props().disabled).toEqual(false);
 });
 
 test('Render data with pencil button and given actions when onItemEdit callback is passed', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
@@ -406,7 +406,7 @@ test('Render correct buttons based on permissions when item permissions are prov
         },
         {
             data: {
-                id: 1,
+                id: 2,
                 title: 'Missing edit permission',
                 _permissions: {
                     edit: false,
@@ -417,11 +417,19 @@ test('Render correct buttons based on permissions when item permissions are prov
         },
         {
             data: {
-                id: 1,
+                id: 3,
                 title: 'Missing add permission',
                 _permissions: {
                     add: false,
                 },
+            },
+            children: [],
+            hasChildren: false,
+        },
+        {
+            data: {
+                id: 4,
+                title: 'No missing permissions',
             },
             children: [],
             hasChildren: false,
@@ -459,6 +467,11 @@ test('Render correct buttons based on permissions when item permissions are prov
     expect(treeListAdapter.find('Row').at(2).find('ButtonCell').at(0).props().disabled).toEqual(false);
     expect(treeListAdapter.find('Row').at(2).find('ButtonCell').at(1).props().icon).toEqual('su-plus-circle');
     expect(treeListAdapter.find('Row').at(2).find('ButtonCell').at(1).props().disabled).toEqual(true);
+
+    expect(treeListAdapter.find('Row').at(3).find('ButtonCell').at(0).props().icon).toEqual('su-pen');
+    expect(treeListAdapter.find('Row').at(3).find('ButtonCell').at(0).props().disabled).toEqual(false);
+    expect(treeListAdapter.find('Row').at(3).find('ButtonCell').at(1).props().icon).toEqual('su-plus-circle');
+    expect(treeListAdapter.find('Row').at(3).find('ButtonCell').at(1).props().disabled).toEqual(false);
 });
 
 test('Render data with plus button when onItemAdd callback is passed', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
@@ -391,6 +391,76 @@ test('Render data with pencil button when onItemEdit callback is passed', () => 
     expect(treeListAdapter).toMatchSnapshot();
 });
 
+test('Render correct buttons based on permissions when item permissions are provided', () => {
+    const data = [
+        {
+            data: {
+                id: 1,
+                title: 'Missing view permission',
+                _permissions: {
+                    view: false,
+                },
+            },
+            children: [],
+            hasChildren: false,
+        },
+        {
+            data: {
+                id: 1,
+                title: 'Missing edit permission',
+                _permissions: {
+                    edit: false,
+                },
+            },
+            children: [],
+            hasChildren: false,
+        },
+        {
+            data: {
+                id: 1,
+                title: 'Missing add permission',
+                _permissions: {
+                    add: false,
+                },
+            },
+            children: [],
+            hasChildren: false,
+        },
+    ];
+    const schema = {
+        title: {
+            label: 'Title',
+            sortable: true,
+            type: 'string',
+            visibility: 'no',
+        },
+    };
+    const treeListAdapter = mount(
+        <TreeTableAdapter
+            {...listAdapterDefaultProps}
+            data={data}
+            onItemAdd={jest.fn()}
+            onItemClick={jest.fn()}
+            schema={schema}
+        />
+    );
+
+    expect(treeListAdapter.find('Row').at(0).find('ButtonCell').at(0).props().icon).toEqual('su-pen');
+    expect(treeListAdapter.find('Row').at(0).find('ButtonCell').at(0).props().disabled).toEqual(true);
+    expect(treeListAdapter.find('Row').at(0).find('ButtonCell').at(1).props().icon).toEqual('su-plus-circle');
+    expect(treeListAdapter.find('Row').at(0).find('ButtonCell').at(1).props().disabled).toEqual(false);
+
+    expect(treeListAdapter.find('Row').at(1).find('ButtonCell').at(0).props().icon).toEqual('su-eye');
+    expect(treeListAdapter.find('Row').at(1).find('ButtonCell').at(0).props().disabled).toEqual(false);
+    expect(treeListAdapter.find('Row').at(1).find('ButtonCell').at(1).props().icon).toEqual('su-plus-circle');
+    expect(treeListAdapter.find('Row').at(1).find('ButtonCell').at(1).props().disabled).toEqual(false);
+
+    expect(treeListAdapter.find('Row').at(2).find('ButtonCell').at(0).props().icon).toEqual('su-pen');
+    expect(treeListAdapter.find('Row').at(2).find('ButtonCell').at(0).props().disabled).toEqual(false);
+    expect(treeListAdapter.find('Row').at(2).find('ButtonCell').at(1).props().icon).toEqual('su-plus-circle');
+    expect(treeListAdapter.find('Row').at(2).find('ButtonCell').at(1).props().disabled).toEqual(true);
+});
+
 test('Render data with plus button when onItemAdd callback is passed', () => {
     const rowAddClickSpy = jest.fn();
     const test1 = {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adjust the TableAdapter and the TreeTableAdapter of the List container to display different icons in their buttons based on item-specific permissions of the current user.

#### Why?

Because it is kind of misleading to display a `pen` icon if the current user is not allowed to edit anything.
