### PR TITLE
Fix bug when loading items in admin for smart content with properties param

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/OptionMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/OptionMetadata.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
 
-use JMS\Serializer\Annotation\Exclude;
-
 class OptionMetadata
 {
     const TYPE_STRING = 'string';
@@ -28,7 +26,6 @@ class OptionMetadata
 
     /**
      * @var string
-     * @Exclude
      */
     protected $type;
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -126,6 +126,22 @@ class AdminControllerTest extends SuluTestCase
         $this->assertEquals(5, $blocksType->form->block->maxOccurs);
         $this->assertEquals(2, $blocksType->form->block->types->article->form->lines->minOccurs);
         $this->assertEquals(2, $blocksType->form->block->types->article->form->lines->maxOccurs);
+
+        $smartContentType = $types->smartcontent;
+        $smartContentOptions = $smartContentType->form->smart_content->options;
+        $this->assertEquals('properties', $smartContentOptions->properties->name);
+        $this->assertEquals('collection', $smartContentOptions->properties->type);
+        $this->assertCount(5, $smartContentOptions->properties->value);
+        $this->assertEquals('article', $smartContentOptions->properties->value[0]->name);
+        $this->assertEquals('article', $smartContentOptions->properties->value[0]->value);
+        $this->assertEquals('excerptTitle', $smartContentOptions->properties->value[1]->name);
+        $this->assertEquals('excerpt.title', $smartContentOptions->properties->value[1]->value);
+        $this->assertEquals('excerptTags', $smartContentOptions->properties->value[2]->name);
+        $this->assertEquals('excerpt.tags', $smartContentOptions->properties->value[2]->value);
+        $this->assertEquals('excerptImages', $smartContentOptions->properties->value[3]->name);
+        $this->assertEquals('excerpt.images', $smartContentOptions->properties->value[3]->value);
+        $this->assertEquals('excerptDescription', $smartContentOptions->properties->value[4]->name);
+        $this->assertEquals('excerpt.description', $smartContentOptions->properties->value[4]->value);
     }
 
     public function testPageSeoFormMetadataAction()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds the type information for options to the form metadata serialization.

#### Why?

Because if this information is missing the smart content is not loading the items in the administration interface if something has been selected and the `properties` param has been passed.

#### Example Usage

~~~xml
        <property name="smart_content" type="smart_content">                                                                                                                                                                                                                    
            <params>                                                                                                                                                                                                                                                            
                <param name="properties" type="collection">                                                                                                                                                                                                                     
                    <param name="title" value="title" />                                                                                                                                                                                                                        
                </param>                                                                                                                                                                                                                                                        
            </params>                                                                                                                                                                                                                                                           
        </property>                                                                                                                                                                                                                                                             
~~~

Use this property and select something so that the field type loads something in the administration interface. Then you'll see this request fail.