### PR TITLE
Add nullable to UserBlameInterface getCreator and getChanger functions

### DIFF
--- a/src/Sulu/Component/Persistence/Model/UserBlameInterface.php
+++ b/src/Sulu/Component/Persistence/Model/UserBlameInterface.php
@@ -21,7 +21,7 @@ interface UserBlameInterface
     /**
      * Return the user that created this object.
      *
-     * @return UserInterface
+     * @return UserInterface|null
      */
     public function getCreator();
 
@@ -29,7 +29,7 @@ interface UserBlameInterface
      * Return the user that change this object the last time.
      * this object.
      *
-     * @return UserInterface
+     * @return UserInterface|null
      */
     public function getChanger();
 }

--- a/src/Sulu/Component/Persistence/Model/UserBlameTrait.php
+++ b/src/Sulu/Component/Persistence/Model/UserBlameTrait.php
@@ -19,12 +19,12 @@ use Sulu\Component\Security\Authentication\UserInterface;
 trait UserBlameTrait
 {
     /**
-     * @var UserInterface
+     * @var UserInterface|null
      */
     protected $creator;
 
     /**
-     * @var UserInterface
+     * @var UserInterface|null
      */
     protected $changer;
 
@@ -39,7 +39,7 @@ trait UserBlameTrait
     /**
      * Set creator.
      *
-     * @param UserInterface $creator
+     * @param UserInterface|null $creator
      *
      * @return $this
      */
@@ -61,7 +61,7 @@ trait UserBlameTrait
     /**
      * Set changer.
      *
-     * @param UserInterface $changer
+     * @param UserInterface|null $changer
      *
      * @return $this
      */


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Add nullable to UserBlameInterface getCreator and getChanger functions.

#### Why?

The creator and changer can be null if the user was deleted or the entity was created over an cli script. This phpdocs should improve static code analyzes and so avoid errors. 

#### Example usage

Should throw an error in static code analyzes as getCreator could return null and would end up in calling getId on null.

```php
$creatorId = $entity->getCreator()->getId();
```

instead it should be:

```php
$creatorId = null;
$creator = $entity->getCreator();

if ($creator) {
     $creatorId = $creator->getId();
}
```