### PR TITLE
Avoid SingleContactSelection to trigger save button when contact is loaded

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/SingleContactSelectionTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/SingleContactSelectionTest.php
@@ -86,7 +86,7 @@ class SingleContactSelectionTest extends TestCase
 
     public function testWrite()
     {
-        $this->node->setProperty('contact', 1)->shouldBeCalled();
+        $this->node->setProperty('contact', Argument::is(1))->shouldBeCalled();
         $property = new Property('contact', [], 'single_contact_selection');
         $property->setValue(1);
 

--- a/src/Sulu/Component/Content/SimpleContentType.php
+++ b/src/Sulu/Component/Content/SimpleContentType.php
@@ -205,13 +205,17 @@ abstract class SimpleContentType implements ContentTypeInterface, ContentTypeExp
      * Remove illegal characters from content string, else PHPCR would throw an `PHPCR\ValueFormatException`
      * if an illegal characters is detected.
      *
-     * @param string $content
+     * @param string|int $content
      *
-     * @return string
+     * @return string|int
      */
     protected function removeIllegalCharacters($content)
     {
-        return preg_replace(NodeProcessor::VALIDATE_STRING, '', $content);
+        if (is_string($content)) {
+            return preg_replace(NodeProcessor::VALIDATE_STRING, '', $content);
+        }
+
+        return $content;
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR only executes a `preg_replace` to remove illegal characters if the passed value is actually a string.

#### Why?

Because `preg_replace` also changes the type of the passed value, which means that a number will be converted to a string. This will cause to trigger the save button for e.g. the `SingleContactSelection` immediately, because the type changes and we are doing a type-strict check to realize if something changed.

#### Example Usage

~~~xml
<property name="single_contact" type="single_contact_selection" />
~~~

Assign a value and reload the form, then the save button will be activated.