### PR TITLE
Add disabled_condition option to DeleteToolbarAction of List view

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/toolbarActions/DeleteToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/toolbarActions/DeleteToolbarAction.test.js
@@ -12,6 +12,7 @@ jest.mock('../../../../utils/Translator', () => ({
 
 jest.mock('../../../../containers/List/stores/ListStore', () => jest.fn(function() {
     this.selectionIds = [];
+    this.selections = [];
     this.deletingSelection = false;
 }));
 
@@ -36,6 +37,32 @@ function createDeleteToolbarAction(options = {}) {
 
 test('Return config for toolbar item', () => {
     const deleteToolbarAction = createDeleteToolbarAction();
+
+    expect(deleteToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        disabled: true,
+        icon: 'su-trash-alt',
+        label: 'sulu_admin.delete',
+        loading: false,
+        type: 'button',
+    }));
+});
+
+test('Return disabled config for toolbar item if one selected item fulfills the passed disabled_condition', () => {
+    const deleteToolbarAction = createDeleteToolbarAction({disabled_condition: 'url == "/"'});
+
+    deleteToolbarAction.listStore.selectionIds.push(1);
+    deleteToolbarAction.listStore.selections.push({id: 1, url: '/test1'});
+
+    expect(deleteToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        disabled: false,
+        icon: 'su-trash-alt',
+        label: 'sulu_admin.delete',
+        loading: false,
+        type: 'button',
+    }));
+
+    deleteToolbarAction.listStore.selectionIds.push(2);
+    deleteToolbarAction.listStore.selections.push({id: 2, url: '/'});
 
     expect(deleteToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
         disabled: true,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/DeleteToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/DeleteToolbarAction.js
@@ -1,11 +1,20 @@
 // @flow
+import jexl from 'jexl';
 import {translate} from '../../../utils/Translator';
 import AbstractListToolbarAction from './AbstractListToolbarAction';
 
 export default class DeleteToolbarAction extends AbstractListToolbarAction {
     getToolbarItemConfig() {
+        const {
+            disabled_condition: disabledCondition,
+        } = this.options;
+
+        const disabledConditionFulfilled = !!disabledCondition && this.listStore.selections.some(
+            (item) => jexl.evalSync(disabledCondition, item)
+        );
+
         return {
-            disabled: this.listStore.selectionIds.length === 0,
+            disabled: disabledConditionFulfilled || this.listStore.selectionIds.length === 0,
             icon: 'su-trash-alt',
             label: translate('sulu_admin.delete'),
             loading: this.listStore.deletingSelection,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR add a `disabled_condition` option to the DeleteToolbarAction of the List view. This allows to pass a `jexl` expression that is evaluated on every selected item. If the expression evaluates to true for at least one selected item, the toolbar action is rendered in a disabled state.

#### Why?

One usecase is to disable the toolbar action if the user does not have sufficient permissions to delete one of the selected items.

#### Example Usage

~~~php
new ToolbarAction(
    'sulu_admin.delete',
    ['disabled_condition' => (_permissions && !_permissions.delete)']
);
~~~