### PR TITLE
Fix conflict message when referenced snippet is being deleted

### DIFF
--- a/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
@@ -269,7 +269,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
         $references = $this->snippetRepository->getReferences($id);
 
         if (count($references) > 0) {
-            $force = $request->headers->get('SuluForceRemove', false);
+            $force = $request->query->get('force', false);
             if ($force) {
                 $this->contentMapper->delete($id, $webspaceKey, true);
             } else {
@@ -417,22 +417,21 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
     private function getReferentialIntegrityResponse($webspace, $references, $id, $locale)
     {
         $data = [
-            'structures' => [],
-            'other' => [],
+            'id' => $id,
+            'items' => [],
             'isDefault' => $this->defaultSnippetManager->isDefault($id),
         ];
 
         foreach ($references as $reference) {
-            if ($reference->getParent()->isNodeType('sulu:page')) {
+            $parentReference = $reference->getParent();
+            if ($parentReference->isNodeType('sulu:page') || $parentReference->isNodeType('sulu:home')) {
                 $content = $this->contentMapper->load(
-                    $reference->getParent()->getIdentifier(),
+                    $parentReference->getIdentifier(),
                     $webspace,
                     $locale,
                     true
                 );
-                $data['structures'][] = $content->toArray();
-            } else {
-                $data['other'][] = $reference->getParent()->getPath();
+                $data['items'][] = ['name' => $content->getPropertyValue('title')];
             }
         }
 

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/snippet.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/snippet.xml
@@ -54,6 +54,7 @@
             <argument type="service" id="sulu_hash.request_hash_checker"/>
             <argument type="service" id="sulu_core.list_rest_helper"/>
             <argument type="service" id="sulu_document_manager.metadata_factory.base"/>
+            <argument type="service" id="translator"/>
 
             <tag name="sulu.context" context="admin"/>
         </service>

--- a/src/Sulu/Bundle/SnippetBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/translations/admin.de.json
@@ -5,5 +5,6 @@
     "sulu_snippet.snippet": "Schnipsel",
     "sulu_snippet.default_snippets": "Standard Schnipsel",
     "sulu_snippet.snippet_area": "Typ oder Bereich",
-    "sulu_snippet.taxonomies": "Taxonomien"
+    "sulu_snippet.taxonomies": "Taxonomien",
+    "sulu_snippet.webspace_default_snippet": "%webspaceKey% Standard Schnipsel"
 }

--- a/src/Sulu/Bundle/SnippetBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/translations/admin.en.json
@@ -5,5 +5,6 @@
     "sulu_snippet.snippet": "Snippet",
     "sulu_snippet.default_snippets": "Default Snippets",
     "sulu_snippet.snippet_area": "Type or area",
-    "sulu_snippet.taxonomies": "Taxonomies"
+    "sulu_snippet.taxonomies": "Taxonomies",
+    "sulu_snippet.webspace_default_snippet": "%webspaceKey% default snippet"
 }

--- a/src/Sulu/Bundle/SnippetBundle/Snippet/DefaultSnippetManager.php
+++ b/src/Sulu/Bundle/SnippetBundle/Snippet/DefaultSnippetManager.php
@@ -62,9 +62,6 @@ class DefaultSnippetManager implements DefaultSnippetManagerInterface
         $this->areas = new FrozenParameterBag($areas);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function save($webspaceKey, $type, $uuid, $locale)
     {
         /** @var SnippetDocument $document */
@@ -87,17 +84,11 @@ class DefaultSnippetManager implements DefaultSnippetManagerInterface
         return $document;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function remove($webspaceKey, $type)
     {
         $this->settingsManager->remove($webspaceKey, 'snippets-' . $type);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function load($webspaceKey, $type, $locale)
     {
         $snippetNode = $this->settingsManager->load($webspaceKey, 'snippets-' . $type);
@@ -117,9 +108,6 @@ class DefaultSnippetManager implements DefaultSnippetManagerInterface
         return $document;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function isDefault($uuid)
     {
         foreach ($this->webspaceManager->getWebspaceCollection() as $webspace) {
@@ -133,15 +121,12 @@ class DefaultSnippetManager implements DefaultSnippetManagerInterface
         return false;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function loadType($uuid)
     {
         foreach ($this->webspaceManager->getWebspaceCollection() as $webspace) {
             $settings = $this->settingsManager->loadStringByWildcard($webspace->getKey(), 'snippets-*');
 
-            if (in_array(!$uuid, $settings)) {
+            if (!in_array($uuid, $settings)) {
                 continue;
             }
 
@@ -153,9 +138,23 @@ class DefaultSnippetManager implements DefaultSnippetManagerInterface
         return null;
     }
 
-    /**
-     * {@inheritdoc}
-     */
+    public function loadWebspaces($uuid)
+    {
+        $webspaces = [];
+        foreach ($this->webspaceManager->getWebspaceCollection() as $webspace) {
+            $webspaceKey = $webspace->getKey();
+            $settings = $this->settingsManager->loadStringByWildcard($webspaceKey, 'snippets-*');
+
+            if (!in_array($uuid, $settings)) {
+                continue;
+            }
+
+            $webspaces[] = $webspace;
+        }
+
+        return $webspaces;
+    }
+
     public function loadIdentifier($webspaceKey, $type)
     {
         $area = $this->areas->get($type);

--- a/src/Sulu/Bundle/SnippetBundle/Snippet/DefaultSnippetManagerInterface.php
+++ b/src/Sulu/Bundle/SnippetBundle/Snippet/DefaultSnippetManagerInterface.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\SnippetBundle\Snippet;
 
 use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
+use Sulu\Component\Webspace\Webspace;
 
 /**
  * Manages default snippets.
@@ -80,4 +81,13 @@ interface DefaultSnippetManagerInterface
      * @return string
      */
     public function loadType($uuid);
+
+    /**
+     * Returns all webspaces for which the snippet with the given ID is assigned as default snippet.
+     *
+     * @param string $uuid
+     *
+     * @return Webspace[]
+     */
+    public function loadWebspaces($uuid);
 }

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
@@ -56,6 +56,7 @@ class SnippetControllerTest extends SuluTestCase
     public function setUp(): void
     {
         parent::setUp();
+        $this->purgeDatabase();
         $this->initPhpcr();
         $this->client = $this->createAuthenticatedClient();
         $this->phpcrSession = $this->getContainer()->get('doctrine_phpcr')->getConnection();

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
@@ -452,26 +452,18 @@ class SnippetControllerTest extends SuluTestCase
         $this->documentManager->persist($page, 'de', ['parent_path' => '/cmf/sulu_io/contents']);
         $this->documentManager->flush();
 
-        $this->client->request('DELETE', '/api/snippets/' . $this->hotel1->getUuid() . '?_format=text');
+        $this->client->request('DELETE', '/api/snippets/' . $this->hotel1->getUuid());
         $response = $this->client->getResponse();
         $content = json_decode($response->getContent(), true);
 
         $this->assertEquals(409, $response->getStatusCode());
-        $this->assertEquals($page->getUuid(), $content['structures'][0]['id']);
-    }
+        $this->assertEquals('Hotels page', $content['items'][0]['name']);
 
-    public function testDeleteReferencedOther()
-    {
-        $node = $this->phpcrSession->getRootNode()->addNode('test-other');
-        $node->setProperty('test', $this->phpcrSession->getNodeByIdentifier($this->hotel1->getUuid()));
-        $this->phpcrSession->save();
-
-        $this->client->request('DELETE', '/api/snippets/' . $this->hotel1->getUuid() . '?_format=text');
+        $this->client->request('DELETE', '/api/snippets/' . $this->hotel1->getUuid() . '?force=true');
         $response = $this->client->getResponse();
         $content = json_decode($response->getContent(), true);
 
-        $this->assertHttpStatusCode(409, $response);
-        $this->assertEquals($node->getPath(), $content['other'][0]);
+        $this->assertEquals(200, $response->getStatusCode());
     }
 
     public function testCopyLocale()

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/DefaultSnippetManagerTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/DefaultSnippetManagerTest.php
@@ -246,13 +246,79 @@ class DefaultSnippetManagerTest extends TestCase
 
         $webspaceManager->getWebspaceCollection()->willReturn(new WebspaceCollection([$webspace1, $webspace2]));
         $settingsManager->loadStringByWildcard('test-1', 'snippets-*')->willReturn(
-            ['test-1' => '123', 'test-2' => '456']
+            ['snippets-test-1' => '123', 'snippets-test-2' => '456']
         );
         $settingsManager->loadStringByWildcard('test-2', 'snippets-*')->willReturn(
-            ['test-1' => '123-123-123', 'test-2' => '456']
+            ['snippets-test-1' => '123-123-123', 'snippets-test-2' => '456']
         );
 
         $this->assertTrue($manager->isDefault('123-123-123'));
         $this->assertFalse($manager->isDefault('321-123-123'));
+    }
+
+    public function testLoadType()
+    {
+        $settingsManager = $this->prophesize(SettingsManagerInterface::class);
+        $documentManager = $this->prophesize(DocumentManagerInterface::class);
+        $webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $registry = $this->prophesize(DocumentRegistry::class);
+
+        $manager = new DefaultSnippetManager(
+            $settingsManager->reveal(),
+            $documentManager->reveal(),
+            $webspaceManager->reveal(),
+            $registry->reveal(),
+            $this->defaultTypes
+        );
+
+        $webspace1 = new Webspace();
+        $webspace1->setKey('test-1');
+        $webspace2 = new Webspace();
+        $webspace2->setKey('test-2');
+
+        $webspaceManager->getWebspaceCollection()->willReturn(new WebspaceCollection([$webspace1, $webspace2]));
+        $settingsManager->loadStringByWildcard('test-1', 'snippets-*')->willReturn(
+            ['snippets-test-1' => '123', 'snippets-test-2' => '456']
+        );
+        $settingsManager->loadStringByWildcard('test-2', 'snippets-*')->willReturn(
+            ['snippets-test-1' => '123-123-123', 'snippets-test-2' => '456']
+        );
+
+        $this->assertEquals('test-1', $manager->loadType('123-123-123'));
+        $this->assertEquals('test-2', $manager->loadType('456'));
+        $this->assertEquals(null, $manager->loadType('321-321-321'));
+    }
+
+    public function testLoadWebspaces()
+    {
+        $settingsManager = $this->prophesize(SettingsManagerInterface::class);
+        $documentManager = $this->prophesize(DocumentManagerInterface::class);
+        $webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $registry = $this->prophesize(DocumentRegistry::class);
+
+        $manager = new DefaultSnippetManager(
+            $settingsManager->reveal(),
+            $documentManager->reveal(),
+            $webspaceManager->reveal(),
+            $registry->reveal(),
+            $this->defaultTypes
+        );
+
+        $webspace1 = new Webspace();
+        $webspace1->setKey('test-1');
+        $webspace2 = new Webspace();
+        $webspace2->setKey('test-2');
+
+        $webspaceManager->getWebspaceCollection()->willReturn(new WebspaceCollection([$webspace1, $webspace2]));
+        $settingsManager->loadStringByWildcard('test-1', 'snippets-*')->willReturn(
+            ['snippets-test-1' => '123-123-123']
+        );
+        $settingsManager->loadStringByWildcard('test-2', 'snippets-*')->willReturn(
+            ['snippets-test-2' => '456']
+        );
+
+        $this->assertEquals([$webspace1], $manager->loadWebspaces('123-123-123'));
+        $this->assertEquals([$webspace2], $manager->loadWebspaces('456'));
+        $this->assertEquals([], $manager->loadWebspaces('321-321-321'));
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes the message when a referenced snippet is tried to be deleted.

#### Why?

Because now a JS error was thrown, which caused all other clicks to have no effect.

#### To Do

- [ ] Check `SnippetController::putAction` with referential integrity message
