### PR TITLE
Rename display_condition option of toolbar actions of Form view to visible_condition

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/CopyLocaleToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/CopyLocaleToolbarAction.test.js
@@ -1,12 +1,12 @@
 // @flow
 import {mount} from 'enzyme';
+import log from 'loglevel';
 import {ResourceFormStore} from '../../../../containers/Form';
 import ResourceRequester from '../../../../services/ResourceRequester';
 import ResourceStore from '../../../../stores/ResourceStore';
 import Router from '../../../../services/Router';
 import Form from '../../../../views/Form';
 import CopyLocaleToolbarAction from '../../toolbarActions/CopyLocaleToolbarAction';
-import log from 'loglevel';
 
 jest.mock('loglevel', () => ({
     warn: jest.fn(),

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/CopyLocaleToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/CopyLocaleToolbarAction.test.js
@@ -6,6 +6,11 @@ import ResourceStore from '../../../../stores/ResourceStore';
 import Router from '../../../../services/Router';
 import Form from '../../../../views/Form';
 import CopyLocaleToolbarAction from '../../toolbarActions/CopyLocaleToolbarAction';
+import log from 'loglevel';
+
+jest.mock('loglevel', () => ({
+    warn: jest.fn(),
+}));
 
 jest.mock('../../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
@@ -85,7 +90,7 @@ test('Return enabled item config', () => {
     }));
 });
 
-test('Return no item config if condition is not met', () => {
+test('Return no item config if deprecated display_condition is not met', () => {
     const copyLocaleToolbarAction = createCopyLocaleToolbarAction(
         ['en', 'de'],
         {display_condition: '_permission.edit'}
@@ -93,12 +98,24 @@ test('Return no item config if condition is not met', () => {
 
     const toolbarItemConfig = copyLocaleToolbarAction.getToolbarItemConfig();
     expect(toolbarItemConfig).toEqual(undefined);
+    expect(log.warn).toBeCalledWith(expect.stringContaining('The "display_condition" option is deprecated'));
 });
 
-test('Return item config if condition is met', () => {
+test('Return no item config if passed visible_condition is not met', () => {
     const copyLocaleToolbarAction = createCopyLocaleToolbarAction(
         ['en', 'de'],
-        {display_condition: '_permission.edit'}
+        {visible_condition: '_permission.edit'}
+    );
+
+    const toolbarItemConfig = copyLocaleToolbarAction.getToolbarItemConfig();
+    expect(toolbarItemConfig).toEqual(undefined);
+    expect(log.warn).not.toBeCalled();
+});
+
+test('Return item config if passed visible_condition is met', () => {
+    const copyLocaleToolbarAction = createCopyLocaleToolbarAction(
+        ['en', 'de'],
+        {visible_condition: '_permission.edit'}
     );
 
     copyLocaleToolbarAction.resourceFormStore.resourceStore.data._permission = {edit: true};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteDraftToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteDraftToolbarAction.test.js
@@ -1,12 +1,12 @@
 // @flow
 import {mount} from 'enzyme';
+import log from 'loglevel';
 import {ResourceFormStore} from '../../../../containers/Form';
 import ResourceRequester from '../../../../services/ResourceRequester';
 import ResourceStore from '../../../../stores/ResourceStore';
 import Router from '../../../../services/Router';
 import Form from '../../../../views/Form';
 import DeleteDraftToolbarAction from '../../toolbarActions/DeleteDraftToolbarAction';
-import log from 'loglevel';
 
 jest.mock('loglevel', () => ({
     warn: jest.fn(),

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteDraftToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteDraftToolbarAction.test.js
@@ -6,6 +6,11 @@ import ResourceStore from '../../../../stores/ResourceStore';
 import Router from '../../../../services/Router';
 import Form from '../../../../views/Form';
 import DeleteDraftToolbarAction from '../../toolbarActions/DeleteDraftToolbarAction';
+import log from 'loglevel';
+
+jest.mock('loglevel', () => ({
+    warn: jest.fn(),
+}));
 
 jest.mock('../../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
@@ -89,15 +94,24 @@ test('Return enabled item config', () => {
     }));
 });
 
-test('Return no item config if condition is not met', () => {
+test('Return no item config if deprecated display_condition is not met', () => {
     const deleteDraftToolbarAction = createDeleteDraftToolbarAction({display_condition: '_permission.live'});
 
     const toolbarItemConfig = deleteDraftToolbarAction.getToolbarItemConfig();
     expect(toolbarItemConfig).toEqual(undefined);
+    expect(log.warn).toBeCalledWith(expect.stringContaining('The "display_condition" option is deprecated'));
 });
 
-test('Return item config if condition is met', () => {
-    const deleteDraftToolbarAction = createDeleteDraftToolbarAction({display_condition: '_permission.edit'});
+test('Return no item config if passed visible_condition is not met', () => {
+    const deleteDraftToolbarAction = createDeleteDraftToolbarAction({visible_condition: '_permission.live'});
+
+    const toolbarItemConfig = deleteDraftToolbarAction.getToolbarItemConfig();
+    expect(toolbarItemConfig).toEqual(undefined);
+    expect(log.warn).not.toBeCalled();
+});
+
+test('Return item config if passed visible_condition is met', () => {
+    const deleteDraftToolbarAction = createDeleteDraftToolbarAction({visible_condition: '_permission.edit'});
     deleteDraftToolbarAction.resourceFormStore.resourceStore.data._permission = {edit: true};
 
     const toolbarItemConfig = deleteDraftToolbarAction.getToolbarItemConfig();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteToolbarAction.test.js
@@ -6,6 +6,11 @@ import {ResourceFormStore} from '../../../../containers/Form';
 import ResourceStore from '../../../../stores/ResourceStore';
 import Router from '../../../../services/Router';
 import Form from '../../../../views/Form';
+import log from 'loglevel';
+
+jest.mock('loglevel', () => ({
+    warn: jest.fn(),
+}));
 
 jest.mock('../../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
@@ -98,14 +103,22 @@ test('Return item config with disabled button if an add form is opened', () => {
     }));
 });
 
-test('Return empty item config when passed condition is not met', () => {
+test('Return empty item config when deprecated display_condition is not met', () => {
     const deleteToolbarAction = createDeleteToolbarAction({display_condition: 'url == "/"'});
 
     expect(deleteToolbarAction.getToolbarItemConfig()).toEqual(undefined);
+    expect(log.warn).toBeCalledWith(expect.stringContaining('The "display_condition" option is deprecated'));
 });
 
-test('Return item config when passed condition is met', () => {
-    const deleteToolbarAction = createDeleteToolbarAction({display_condition: 'url == "/"'});
+test('Return empty item config when passed visible_condition is not met', () => {
+    const deleteToolbarAction = createDeleteToolbarAction({visible_condition: 'url == "/"'});
+
+    expect(deleteToolbarAction.getToolbarItemConfig()).toEqual(undefined);
+    expect(log.warn).not.toBeCalled();
+});
+
+test('Return item config when passed visible_condition is met', () => {
+    const deleteToolbarAction = createDeleteToolbarAction({visible_condition: 'url == "/"'});
     deleteToolbarAction.resourceFormStore.data.url = '/';
 
     expect(deleteToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({label: 'sulu_admin.delete'}));

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteToolbarAction.test.js
@@ -1,12 +1,12 @@
 // @flow
 import {mount} from 'enzyme';
 import {observable} from 'mobx';
+import log from 'loglevel';
 import DeleteToolbarAction from '../../toolbarActions/DeleteToolbarAction';
 import {ResourceFormStore} from '../../../../containers/Form';
 import ResourceStore from '../../../../stores/ResourceStore';
 import Router from '../../../../services/Router';
 import Form from '../../../../views/Form';
-import log from 'loglevel';
 
 jest.mock('loglevel', () => ({
     warn: jest.fn(),

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithPublishingToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithPublishingToolbarAction.test.js
@@ -1,10 +1,10 @@
 // @flow
+import log from 'loglevel';
 import SaveWithPublishingToolbarAction from '../../toolbarActions/SaveWithPublishingToolbarAction';
 import {ResourceFormStore} from '../../../../containers/Form';
 import ResourceStore from '../../../../stores/ResourceStore';
 import Router from '../../../../services/Router';
 import Form from '../../../../views/Form';
-import log from 'loglevel';
 
 jest.mock('loglevel', () => ({
     warn: jest.fn(),

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithPublishingToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithPublishingToolbarAction.test.js
@@ -4,6 +4,11 @@ import {ResourceFormStore} from '../../../../containers/Form';
 import ResourceStore from '../../../../stores/ResourceStore';
 import Router from '../../../../services/Router';
 import Form from '../../../../views/Form';
+import log from 'loglevel';
+
+jest.mock('loglevel', () => ({
+    warn: jest.fn(),
+}));
 
 jest.mock('../../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
@@ -150,7 +155,7 @@ test('Return item config with all options disabled when not dirty and data was n
     }));
 });
 
-test('Return item config without publish specific options if condition is not met', () => {
+test('Return item config without publish specific options if deprecated publish_display_condition is not met', () => {
     const editToolbarAction = createSaveWithPublishingToolbarAction({publish_display_condition: '_permission.live'});
 
     const toolbarItemConfig = editToolbarAction.getToolbarItemConfig();
@@ -163,9 +168,26 @@ test('Return item config without publish specific options if condition is not me
             label: 'sulu_admin.save_draft',
         }),
     ]);
+    expect(log.warn).toBeCalledWith(expect.stringContaining('The "publish_display_condition" option is deprecated'));
 });
 
-test('Return item config without saving specific options if condition is not met', () => {
+test('Return item config without publish specific options if passed publish_visible_condition is not met', () => {
+    const editToolbarAction = createSaveWithPublishingToolbarAction({publish_visible_condition: '_permission.live'});
+
+    const toolbarItemConfig = editToolbarAction.getToolbarItemConfig();
+    if (!toolbarItemConfig) {
+        throw new Error('The toolbarItemConfig should be a value!');
+    }
+
+    expect(toolbarItemConfig.options).toEqual([
+        expect.objectContaining({
+            label: 'sulu_admin.save_draft',
+        }),
+    ]);
+    expect(log.warn).not.toBeCalled();
+});
+
+test('Return item config without saving specific options if deprecated save_display_condition is not met', () => {
     const editToolbarAction = createSaveWithPublishingToolbarAction({save_display_condition: '_permission.live'});
 
     const toolbarItemConfig = editToolbarAction.getToolbarItemConfig();
@@ -178,10 +200,27 @@ test('Return item config without saving specific options if condition is not met
             label: 'sulu_admin.publish',
         }),
     ]);
+    expect(log.warn).toBeCalledWith(expect.stringContaining('The "save_display_condition" option is deprecated'));
 });
 
-test('Return item config with publish specific options if condition is met', () => {
-    const editToolbarAction = createSaveWithPublishingToolbarAction({publish_display_condition: '_permission.live'});
+test('Return item config without saving specific options if passed save_visible_condition is not met', () => {
+    const editToolbarAction = createSaveWithPublishingToolbarAction({save_visible_condition: '_permission.live'});
+
+    const toolbarItemConfig = editToolbarAction.getToolbarItemConfig();
+    if (!toolbarItemConfig) {
+        throw new Error('The toolbarItemConfig should be a value!');
+    }
+
+    expect(toolbarItemConfig.options).toEqual([
+        expect.objectContaining({
+            label: 'sulu_admin.publish',
+        }),
+    ]);
+    expect(log.warn).not.toBeCalled();
+});
+
+test('Return item config with publish specific options if passed publish_visible_condition is met', () => {
+    const editToolbarAction = createSaveWithPublishingToolbarAction({publish_visible_condition: '_permission.live'});
     editToolbarAction.resourceFormStore.resourceStore.data._permission = {live: true};
 
     const toolbarItemConfig = editToolbarAction.getToolbarItemConfig();
@@ -202,8 +241,8 @@ test('Return item config with publish specific options if condition is met', () 
     ]);
 });
 
-test('Return item config with saving specific options if condition is met', () => {
-    const editToolbarAction = createSaveWithPublishingToolbarAction({save_display_condition: '_permission.edit'});
+test('Return item config with saving specific options if passed save_visible_condition is met', () => {
+    const editToolbarAction = createSaveWithPublishingToolbarAction({save_visible_condition: '_permission.edit'});
     editToolbarAction.resourceFormStore.resourceStore.data._permission = {edit: true};
 
     const toolbarItemConfig = editToolbarAction.getToolbarItemConfig();
@@ -226,12 +265,13 @@ test('Return item config with saving specific options if condition is met', () =
 
 test('Return empty item config if no options are returned', () => {
     const editToolbarAction = createSaveWithPublishingToolbarAction({
-        publish_display_condition: '_permisison.live',
-        save_display_condition: '_permission.edit',
+        publish_visible_condition: '_permisison.live',
+        save_visible_condition: '_permission.edit',
     });
 
     const toolbarItemConfig = editToolbarAction.getToolbarItemConfig();
     expect(toolbarItemConfig).toEqual(undefined);
+    expect(log.warn).not.toBeCalled();
 });
 
 test('Return item config with loading button when saving flag is set', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SetUnpublishedToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SetUnpublishedToolbarAction.test.js
@@ -6,6 +6,11 @@ import ResourceStore from '../../../../stores/ResourceStore';
 import Router from '../../../../services/Router';
 import Form from '../../../../views/Form';
 import SetUnpublishedToolbarAction from '../../toolbarActions/SetUnpublishedToolbarAction';
+import log from 'loglevel';
+
+jest.mock('loglevel', () => ({
+    warn: jest.fn(),
+}));
 
 jest.mock('../../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
@@ -88,8 +93,8 @@ test('Return enabled item config', () => {
     }));
 });
 
-test('Return item config if condition is met', () => {
-    const setUnpublishedToolbarAction = createSetUnpublishedToolbarAction({display_condition: '_permission.edit'});
+test('Return item config if passed visible_condition is met', () => {
+    const setUnpublishedToolbarAction = createSetUnpublishedToolbarAction({visible_condition: '_permission.edit'});
     setUnpublishedToolbarAction.resourceFormStore.resourceStore.data._permission = {edit: true};
 
     const toolbarItemConfig = setUnpublishedToolbarAction.getToolbarItemConfig();
@@ -102,12 +107,22 @@ test('Return item config if condition is met', () => {
     }));
 });
 
-test('Return empty item config if conditions are not met', () => {
+test('Return empty item config if deprecated display_condition is not met', () => {
     const setUnpublishedToolbarAction = createSetUnpublishedToolbarAction({display_condition: '_permission.live'});
 
     const toolbarItemConfig = setUnpublishedToolbarAction.getToolbarItemConfig();
 
     expect(toolbarItemConfig).toEqual(undefined);
+    expect(log.warn).toBeCalledWith(expect.stringContaining('The "display_condition" option is deprecated'));
+});
+
+test('Return empty item config if passed visible_condition is not met', () => {
+    const setUnpublishedToolbarAction = createSetUnpublishedToolbarAction({visible_condition: '_permission.live'});
+
+    const toolbarItemConfig = setUnpublishedToolbarAction.getToolbarItemConfig();
+
+    expect(toolbarItemConfig).toEqual(undefined);
+    expect(log.warn).not.toBeCalled();
 });
 
 test('Return disabled delete draft and unpublish items when page is not published', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SetUnpublishedToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SetUnpublishedToolbarAction.test.js
@@ -1,12 +1,12 @@
 // @flow
 import {mount} from 'enzyme';
+import log from 'loglevel';
 import {ResourceFormStore} from '../../../../containers/Form';
 import ResourceRequester from '../../../../services/ResourceRequester';
 import ResourceStore from '../../../../stores/ResourceStore';
 import Router from '../../../../services/Router';
 import Form from '../../../../views/Form';
 import SetUnpublishedToolbarAction from '../../toolbarActions/SetUnpublishedToolbarAction';
-import log from 'loglevel';
 
 jest.mock('loglevel', () => ({
     warn: jest.fn(),

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/CopyLocaleToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/CopyLocaleToolbarAction.js
@@ -31,6 +31,7 @@ export default class CopyLocaleToolbarAction extends AbstractFormToolbarAction {
         } = options;
 
         if (displayCondition) {
+            // @deprecated
             log.warn(
                 'The "display_condition" option is deprecated since version 2.0 and will be removed. ' +
                 'Use the "visible_condition" option instead.'

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/CopyLocaleToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/CopyLocaleToolbarAction.js
@@ -2,17 +2,47 @@
 import React from 'react';
 import {action, observable} from 'mobx';
 import jexl from 'jexl';
+import log from 'loglevel';
 import Checkbox from '../../../components/Checkbox';
 import Dialog from '../../../components/Dialog';
 import ResourceRequester from '../../../services/ResourceRequester';
 import {translate} from '../../../utils/Translator';
-import AbstractFormToolbarAction from './AbstractFormToolbarAction';
+import {ResourceFormStore} from '../../../containers/Form';
+import Form from '../Form';
+import Router from '../../../services/Router';
 import copyLocaleActionStyles from './copyLocaleAction.scss';
+import AbstractFormToolbarAction from './AbstractFormToolbarAction';
 
 export default class CopyLocaleToolbarAction extends AbstractFormToolbarAction {
     @observable showCopyLocaleDialog = false;
     @observable selectedLocales: Array<string> = [];
     @observable copying: boolean = false;
+
+    constructor(
+        resourceFormStore: ResourceFormStore,
+        form: Form,
+        router: Router,
+        locales: ?Array<string>,
+        options: {[key: string]: mixed}
+    ) {
+        const {
+            display_condition: displayCondition,
+            visible_condition: visibleCondition,
+        } = options;
+
+        if (displayCondition) {
+            log.warn(
+                'The "display_condition" option is deprecated since version 2.0 and will be removed. ' +
+                'Use the "visible_condition" option instead.'
+            );
+
+            if (!visibleCondition) {
+                options.visible_condition = displayCondition;
+            }
+        }
+
+        super(resourceFormStore, form, router, locales, options);
+    }
 
     getNode() {
         const {
@@ -66,14 +96,14 @@ export default class CopyLocaleToolbarAction extends AbstractFormToolbarAction {
 
     getToolbarItemConfig() {
         const {
-            display_condition: displayCondition,
+            visible_condition: visibleCondition,
         } = this.options;
 
         const {id, data} = this.resourceFormStore;
 
-        const copyLocaleAllowed = !displayCondition || jexl.evalSync(displayCondition, data);
+        const visibleConditionFulfilled = !visibleCondition || jexl.evalSync(visibleCondition, data);
 
-        if (copyLocaleAllowed) {
+        if (visibleConditionFulfilled) {
             return {
                 disabled: !id,
                 label: translate('sulu_admin.copy_locale'),

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteDraftToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteDraftToolbarAction.js
@@ -2,14 +2,44 @@
 import React from 'react';
 import {action, observable} from 'mobx';
 import jexl from 'jexl';
+import log from 'loglevel';
 import Dialog from '../../../components/Dialog';
 import ResourceRequester from '../../../services/ResourceRequester';
 import {translate} from '../../../utils/Translator';
+import {ResourceFormStore} from '../../../containers/Form';
+import Form from '../Form';
+import Router from '../../../services/Router';
 import AbstractFormToolbarAction from './AbstractFormToolbarAction';
 
 export default class DeleteDraftToolbarAction extends AbstractFormToolbarAction {
     @observable showDeleteDraftDialog = false;
     @observable deletingDraft = false;
+
+    constructor(
+        resourceFormStore: ResourceFormStore,
+        form: Form,
+        router: Router,
+        locales: ?Array<string>,
+        options: {[key: string]: mixed}
+    ) {
+        const {
+            display_condition: displayCondition,
+            visible_condition: visibleCondition,
+        } = options;
+
+        if (displayCondition) {
+            log.warn(
+                'The "display_condition" option is deprecated since version 2.0 and will be removed. ' +
+                'Use the "visible_condition" option instead.'
+            );
+
+            if (!visibleCondition) {
+                options.visible_condition = displayCondition;
+            }
+        }
+
+        super(resourceFormStore, form, router, locales, options);
+    }
 
     getNode() {
         const {
@@ -40,17 +70,16 @@ export default class DeleteDraftToolbarAction extends AbstractFormToolbarAction 
 
     getToolbarItemConfig() {
         const {
-            display_condition: displayCondition,
+            visible_condition: visibleCondition,
         } = this.options;
 
         const {id, data} = this.resourceFormStore;
 
         const {published, publishedState} = data;
 
-        const publishAllowed = !displayCondition
-            || jexl.evalSync(displayCondition, this.resourceFormStore.data);
+        const visibleConditionFulfilled = !visibleCondition || jexl.evalSync(visibleCondition, data);
 
-        if (publishAllowed) {
+        if (visibleConditionFulfilled) {
             return {
                 disabled: !id || !published || publishedState,
                 label: translate('sulu_page.delete_draft'),

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteDraftToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteDraftToolbarAction.js
@@ -28,6 +28,7 @@ export default class DeleteDraftToolbarAction extends AbstractFormToolbarAction 
         } = options;
 
         if (displayCondition) {
+            // @deprecated
             log.warn(
                 'The "display_condition" option is deprecated since version 2.0 and will be removed. ' +
                 'Use the "visible_condition" option instead.'

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteToolbarAction.js
@@ -34,6 +34,7 @@ export default class DeleteToolbarAction extends AbstractFormToolbarAction {
         } = options;
 
         if (displayCondition) {
+            // @deprecated
             log.warn(
                 'The "display_condition" option is deprecated since version 2.0 and will be removed. ' +
                 'Use the "visible_condition" option instead.'

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveWithPublishingToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveWithPublishingToolbarAction.js
@@ -1,26 +1,69 @@
 // @flow
 import jexl from 'jexl';
+import log from 'loglevel';
 import {translate} from '../../../utils/Translator';
+import {ResourceFormStore} from '../../../containers/Form';
+import Form from '../Form';
+import Router from '../../../services/Router';
 import AbstractFormToolbarAction from './AbstractFormToolbarAction';
 
 export default class SaveWithPublishingToolbarAction extends AbstractFormToolbarAction {
-    getToolbarItemConfig() {
+    constructor(
+        resourceFormStore: ResourceFormStore,
+        form: Form,
+        router: Router,
+        locales: ?Array<string>,
+        options: {[key: string]: mixed}
+    ) {
         const {
             publish_display_condition: publishDisplayCondition,
             save_display_condition: saveDisplayCondition,
+            publish_visible_condition: publishVisibleCondition,
+            save_visible_condition: saveVisibleCondition,
+        } = options;
+
+        if (publishDisplayCondition) {
+            log.warn(
+                'The "publish_display_condition" option is deprecated since version 2.0 and will be removed. ' +
+                'Use the "publish_visible_condition" option instead.'
+            );
+
+            if (!publishVisibleCondition) {
+                options.publish_visible_condition = publishDisplayCondition;
+            }
+        }
+
+        if (saveDisplayCondition) {
+            log.warn(
+                'The "save_display_condition" option is deprecated since version 2.0 and will be removed. ' +
+                'Use the "save_visible_condition" option instead.'
+            );
+
+            if (!saveVisibleCondition) {
+                options.save_visible_condition = saveDisplayCondition;
+            }
+        }
+
+        super(resourceFormStore, form, router, locales, options);
+    }
+
+    getToolbarItemConfig() {
+        const {
+            publish_visible_condition: publishVisibleCondition,
+            save_visible_condition: saveVisibleCondition,
         } = this.options;
 
         const {dirty, data, saving} = this.resourceFormStore;
 
-        const publishAllowed = !publishDisplayCondition
-            || jexl.evalSync(publishDisplayCondition, this.resourceFormStore.data);
+        const publishVisibleConditionFulfilled = !publishVisibleCondition
+            || jexl.evalSync(publishVisibleCondition, data);
 
-        const saveAllowed = !saveDisplayCondition
-            || jexl.evalSync(saveDisplayCondition, this.resourceFormStore.data);
+        const saveVisibleConditionFulfilled = !saveVisibleCondition
+            || jexl.evalSync(saveVisibleCondition, data);
 
         const options = [];
 
-        if (saveAllowed) {
+        if (saveVisibleConditionFulfilled) {
             options.push({
                 label: translate('sulu_admin.save_draft'),
                 disabled: !dirty,
@@ -30,7 +73,7 @@ export default class SaveWithPublishingToolbarAction extends AbstractFormToolbar
             });
         }
 
-        if (saveAllowed && publishAllowed) {
+        if (saveVisibleConditionFulfilled && publishVisibleConditionFulfilled) {
             options.push({
                 label: translate('sulu_admin.save_publish'),
                 disabled: !dirty,
@@ -40,7 +83,7 @@ export default class SaveWithPublishingToolbarAction extends AbstractFormToolbar
             });
         }
 
-        if (publishAllowed) {
+        if (publishVisibleConditionFulfilled) {
             options.push({
                 label: translate('sulu_admin.publish'),
                 // TODO do not hardcode "publishedState" but use metadata instead

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveWithPublishingToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveWithPublishingToolbarAction.js
@@ -23,6 +23,7 @@ export default class SaveWithPublishingToolbarAction extends AbstractFormToolbar
         } = options;
 
         if (publishDisplayCondition) {
+            // @deprecated
             log.warn(
                 'The "publish_display_condition" option is deprecated since version 2.0 and will be removed. ' +
                 'Use the "publish_visible_condition" option instead.'
@@ -34,6 +35,7 @@ export default class SaveWithPublishingToolbarAction extends AbstractFormToolbar
         }
 
         if (saveDisplayCondition) {
+            // @deprecated
             log.warn(
                 'The "save_display_condition" option is deprecated since version 2.0 and will be removed. ' +
                 'Use the "save_visible_condition" option instead.'

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SetUnpublishedToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SetUnpublishedToolbarAction.js
@@ -28,6 +28,7 @@ export default class SetUnpublishedToolbarAction extends AbstractFormToolbarActi
         } = options;
 
         if (displayCondition) {
+            // @deprecated
             log.warn(
                 'The "display_condition" option is deprecated since version 2.0 and will be removed. ' +
                 'Use the "visible_condition" option instead.'

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SetUnpublishedToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SetUnpublishedToolbarAction.js
@@ -2,14 +2,44 @@
 import React from 'react';
 import {action, observable} from 'mobx';
 import jexl from 'jexl';
+import log from 'loglevel';
 import Dialog from '../../../components/Dialog';
 import ResourceRequester from '../../../services/ResourceRequester';
 import {translate} from '../../../utils/Translator';
+import {ResourceFormStore} from '../../../containers/Form';
+import Form from '../Form';
+import Router from '../../../services/Router';
 import AbstractFormToolbarAction from './AbstractFormToolbarAction';
 
 export default class SetUnpublishedToolbarAction extends AbstractFormToolbarAction {
     @observable showUnpublishDialog = false;
     @observable unpublishing = false;
+
+    constructor(
+        resourceFormStore: ResourceFormStore,
+        form: Form,
+        router: Router,
+        locales: ?Array<string>,
+        options: {[key: string]: mixed}
+    ) {
+        const {
+            display_condition: displayCondition,
+            visible_condition: visibleCondition,
+        } = options;
+
+        if (displayCondition) {
+            log.warn(
+                'The "display_condition" option is deprecated since version 2.0 and will be removed. ' +
+                'Use the "visible_condition" option instead.'
+            );
+
+            if (!visibleCondition) {
+                options.visible_condition = displayCondition;
+            }
+        }
+
+        super(resourceFormStore, form, router, locales, options);
+    }
 
     getNode() {
         const {
@@ -45,17 +75,16 @@ export default class SetUnpublishedToolbarAction extends AbstractFormToolbarActi
 
     getToolbarItemConfig() {
         const {
-            display_condition: displayCondition,
+            visible_condition: visibleCondition,
         } = this.options;
 
         const {id, data} = this.resourceFormStore;
 
         const {published} = data;
 
-        const publishAllowed = !displayCondition
-            || jexl.evalSync(displayCondition, this.resourceFormStore.data);
+        const visibleConditionFulfilled = !visibleCondition || jexl.evalSync(visibleCondition, data);
 
-        if (publishAllowed) {
+        if (visibleConditionFulfilled) {
             return {
                 disabled: !id || !published,
                 label: translate('sulu_page.unpublish'),

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -114,15 +114,15 @@ class PageAdmin extends Admin
             new ToolbarAction(
                 'sulu_admin.save_with_publishing',
                 [
-                    'publish_display_condition' => '(!_permissions || _permissions.live)',
-                    'save_display_condition' => '(!_permissions || _permissions.edit)',
+                    'publish_visible_condition' => '(!_permissions || _permissions.live)',
+                    'save_visible_condition' => '(!_permissions || _permissions.edit)',
                 ]
             ),
             new ToolbarAction('sulu_page.templates'),
             new ToolbarAction(
                 'sulu_admin.delete',
                 [
-                    'display_condition' => '(!_permissions || _permissions.delete) && url != "/"',
+                    'visible_condition' => '(!_permissions || _permissions.delete) && url != "/"',
                     'router_attributes_to_back_view' => ['webspace'],
                 ]
             ),
@@ -133,19 +133,19 @@ class PageAdmin extends Admin
                     new ToolbarAction(
                         'sulu_admin.copy_locale',
                         [
-                            'display_condition' => '(!_permissions || _permissions.edit)',
+                            'visible_condition' => '(!_permissions || _permissions.edit)',
                         ]
                     ),
                     new ToolbarAction(
                         'sulu_admin.delete_draft',
                         [
-                            'display_condition' => $publishDisplayCondition,
+                            'visible_condition' => $publishDisplayCondition,
                         ]
                     ),
                     new ToolbarAction(
                         'sulu_admin.set_unpublished',
                         [
-                            'display_condition' => $publishDisplayCondition,
+                            'visible_condition' => $publishDisplayCondition,
                         ]
                     ),
                 ]


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR renames the `display_condition` option of various toolbar actions of the Form view to `visible_condition`. The old `display_condition` was deprecated and will log a deprecation warning if it is used.

#### Why?

Because we already support a `visibleCondition` attribute in our Form XML files that allows to hide specific field-types and i would like to provide a consistent naming. 

#### Example Usage

~~~php
new ToolbarAction(
    'sulu_admin.copy_locale',
    [
         'visible_condition' => '(!_permissions || _permissions.edit)',
    ]
),
~~~

#### BC Breaks/Deprecations

The `display_condition` option of the following toolbar actions was deprecated:
* CopyLocaleToolbarAction
* DeleteDraftToolbarAction
* DeleteToolbarAction
* SetUnpublishedToolbarAction

The `publish_display_condition` and `save_display_condition` of the following toolbar action was deprecated:
* SaveWithPublishingToolbarAction