### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,20 +11,20 @@ assignees: ''
 | Sulu Version | Specific version or SHA of a commit
 | Browser Version | Browser name and version
 
-#### Actual Behavior
+# Actual Behavior
 
 How does Sulu behave at the moment? 
 
-#### Expected Behavior
+# Expected Behavior
 
 What is the behavior you expect?
 
-#### Steps to Reproduce
+# Steps to Reproduce
 
 What are the steps to reproduce this bug? Please add code examples,
 screenshots or links to GitHub repositories that reproduce the problem.
 
-#### Possible Solutions
+# Possible Solutions
 
 If you have already ideas how to solve the issue, add them here.
 (remove this section if not needed)

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,13 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: Bug
+assignees: ''
+---
+
 | Q | A
 | --- | ---
-| Bug? | no
-| New Feature? | no
 | Sulu Version | Specific version or SHA of a commit
 | Browser Version | Browser name and version
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: Feature
+assignees: ''
+---
+
+#### Problem description
+
+A clear description of what the problem is.
+
+#### Proposed solution
+
+A clear description of what you want to be implemented.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,10 +6,10 @@ labels: Feature
 assignees: ''
 ---
 
-#### Problem description
+# Problem description
 
 A clear description of what the problem is.
 
-#### Proposed solution
+# Proposed solution
 
 A clear description of what you want to be implemented.


### PR DESCRIPTION
[Github now allows to have multiple issue templates for one repository.](https://help.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates#issue-templates)

I think we should make use of this feature, in order to allow people create proper feature requests as well. What I especially like about this, is that the correct label is automatically added.