### PR TITLE
Add itemDisabledCondition option to List view

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilder.php
@@ -127,6 +127,13 @@ class FormOverlayListViewBuilder implements FormOverlayListViewBuilderInterface
         return $this;
     }
 
+    public function setItemDisabledCondition(string $itemDisabledCondition): FormOverlayListViewBuilderInterface
+    {
+        $this->setItemDisabledConditionToView($this->view, $itemDisabledCondition);
+
+        return $this;
+    }
+
     public function addToolbarActions(array $toolbarActions): FormOverlayListViewBuilderInterface
     {
         $this->addToolbarActionsToView($this->view, $toolbarActions);

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilderInterface.php
@@ -48,6 +48,8 @@ interface FormOverlayListViewBuilderInterface extends ViewBuilderInterface
 
     public function setDefaultLocale(string $locale): self;
 
+    public function setItemDisabledCondition(string $itemDisabledCondition): self;
+
     public function setBackView(string $editView): self;
 
     public function enableSearching(): self;

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilder.php
@@ -94,6 +94,13 @@ class ListViewBuilder implements ListViewBuilderInterface
         return $this;
     }
 
+    public function setItemDisabledCondition(string $itemDisabledCondition): ListViewBuilderInterface
+    {
+        $this->setItemDisabledConditionToView($this->view, $itemDisabledCondition);
+
+        return $this;
+    }
+
     public function addToolbarActions(array $toolbarActions): ListViewBuilderInterface
     {
         $this->addToolbarActionsToView($this->view, $toolbarActions);

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilderInterface.php
@@ -44,6 +44,8 @@ interface ListViewBuilderInterface extends ViewBuilderInterface
 
     public function setDefaultLocale(string $locale): self;
 
+    public function setItemDisabledCondition(string $itemDisabledCondition): self;
+
     public function setAddView(string $addView): self;
 
     public function setEditView(string $editView): self;

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilderTrait.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilderTrait.php
@@ -94,6 +94,11 @@ trait ListViewBuilderTrait
         $route->setAttributeDefault('locale', $locale);
     }
 
+    private function setItemDisabledConditionToView(View $route, string $itemDisabledCondition): void
+    {
+        $route->setOption('itemDisabledCondition', $itemDisabledCondition);
+    }
+
     private function addResourceStorePropertiesToListRequestToView(View $route, array $resourceStorePropertiesToListRequest): void
     {
         $oldResourceStorePropertiesToListRequest = $route->getOption('resourceStorePropertiesToListRequest');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Row.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Row.js
@@ -1,6 +1,7 @@
 // @flow
 import React, {Fragment} from 'react';
 import type {ChildrenArray, Element} from 'react';
+import classNames from 'classnames';
 import Checkbox from '../Checkbox';
 import {Radio} from '../Radio';
 import Icon from '../Icon/Icon';
@@ -15,6 +16,7 @@ type Props = {
     buttons?: Array<ButtonConfig>,
     children: ChildrenArray<Element<typeof Cell>>,
     depth?: number,
+    disabled: boolean,
     expanded: boolean,
     hasChildren: boolean,
     id?: string | number,
@@ -35,6 +37,7 @@ type Props = {
 export default class Row extends React.PureComponent<Props> {
     static defaultProps = {
         depth: 0,
+        disabled: false,
         expanded: false,
         hasChildren: false,
         isLoading: false,
@@ -240,11 +243,20 @@ export default class Row extends React.PureComponent<Props> {
     render() {
         const {
             children,
+            disabled,
         } = this.props;
+
+        const listClass = classNames(
+            tableStyles.row,
+            {
+                [tableStyles.disabled]: disabled,
+            }
+        );
+
         const cells = this.createCells(children);
 
         return (
-            <tr className={tableStyles.row}>
+            <tr className={listClass}>
                 {cells}
             </tr>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/table.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/table.scss
@@ -133,6 +133,11 @@ $borderRadius: 3px;
             }
         }
     }
+
+    &.disabled {
+        pointer-events: none;
+        opacity: .5;
+    }
 }
 
 .button-cell,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/Table.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/Table.test.js
@@ -166,6 +166,32 @@ test('Render a table with different buttons for each row', () => {
     )).toMatchSnapshot();
 });
 
+test('Render a table with disabled rows', () => {
+    const buttons = [{
+        icon: 'fa-pencil',
+        onClick: jest.fn(),
+    }];
+
+    expect(render(
+        <Table buttons={buttons}>
+            <Header>
+                <HeaderCell>Column Title</HeaderCell>
+                <HeaderCell>Column Title</HeaderCell>
+            </Header>
+            <Body>
+                <Row>
+                    <Cell>Boring Row</Cell>
+                    <Cell>Column 2</Cell>
+                </Row>
+                <Row disabled={true}>
+                    <Cell>Disabled Row</Cell>
+                    <Cell>Column 2</Cell>
+                </Row>
+            </Body>
+        </Table>
+    )).toMatchSnapshot();
+});
+
 test('Table buttons should implement an onClick handler', () => {
     const clickSpy = jest.fn();
     const buttons = [{

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/__snapshots__/Table.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/__snapshots__/Table.test.js.snap
@@ -307,6 +307,121 @@ exports[`Render a table with different buttons for each row 1`] = `
 </div>
 `;
 
+exports[`Render a table with disabled rows 1`] = `
+<div
+  class="tableContainer dark"
+>
+  <table
+    class="table"
+  >
+    <thead
+      class="header"
+    >
+      <tr>
+        <th
+          class="headerButtonCell headerCell"
+        >
+          <span>
+            <span
+              aria-label="fa-pencil"
+              class="fa fa-pencil"
+            />
+          </span>
+        </th>
+        <th
+          class="headerCell"
+        >
+          <span>
+            Column Title
+          </span>
+        </th>
+        <th
+          class="headerCell"
+        >
+          <span>
+            Column Title
+          </span>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        class="row"
+      >
+        <td
+          class="buttonCell cell"
+        >
+          <div
+            class="cellContent"
+          >
+            <button>
+              <span
+                aria-label="fa-pencil"
+                class="fa fa-pencil"
+              />
+            </button>
+          </div>
+        </td>
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            Boring Row
+          </div>
+        </td>
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            Column 2
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="row disabled"
+      >
+        <td
+          class="buttonCell cell"
+        >
+          <div
+            class="cellContent"
+          >
+            <button>
+              <span
+                aria-label="fa-pencil"
+                class="fa fa-pencil"
+              />
+            </button>
+          </div>
+        </td>
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            Disabled Row
+          </div>
+        </td>
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            Column 2
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
 exports[`Render an empty table 1`] = `
 <div
   class="tableContainer dark"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TableAdapter.js
@@ -47,12 +47,13 @@ class TableAdapter extends AbstractTableAdapter {
     };
 
     renderRows(): Array<Element<typeof Table.Row>> {
-        const {data, selections} = this.props;
+        const {data, selections, disabledIds} = this.props;
 
         return data.map((item) => {
             return (
                 <Table.Row
                     buttons={this.getButtons(item)}
+                    disabled={disabledIds.includes(item.id)}
                     id={item.id}
                     key={item.id}
                     selected={selections.includes(item.id)}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TableAdapter.js
@@ -47,7 +47,7 @@ class TableAdapter extends AbstractTableAdapter {
     };
 
     renderRows(): Array<Element<typeof Table.Row>> {
-        const {data, selections, disabledIds} = this.props;
+        const {data, disabledIds, selections} = this.props;
 
         return data.map((item) => {
             return (

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TreeTableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TreeTableAdapter.js
@@ -64,6 +64,7 @@ class TreeTableAdapter extends AbstractTableAdapter {
     renderRows(items: Array<*>, depth: number = 0) {
         const rows = [];
         const {
+            disabledIds,
             selections,
         } = this.props;
 
@@ -74,6 +75,7 @@ class TreeTableAdapter extends AbstractTableAdapter {
                 <Table.Row
                     buttons={this.getButtons(item)}
                     depth={depth}
+                    disabled={disabledIds.includes(data.id)}
                     expanded={item.children.length > 0}
                     hasChildren={hasChildren}
                     id={data.id}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
@@ -362,7 +362,14 @@ test('Pass given disabledIds and ids of items that fulfill given itemDisabledCon
     ];
 
     const listStore = new ListStore('test', 'test', 'list_test', {page: observable.box(1)});
-    const list = shallow(<List adapters={['test']} disabledIds={[1, 3]} itemDisabledCondition={'status == "inactive"'} store={listStore} />);
+    const list = shallow(
+        <List
+            adapters={['test']}
+            disabledIds={[1, 3]}
+            itemDisabledCondition={'status == "inactive"'}
+            store={listStore}
+        />
+    );
 
     expect(list.find('TestAdapter').prop('disabledIds')).toEqual([1, 3, 4]);
 });
@@ -405,7 +412,7 @@ test('Do not call activate if item is activated but disabled and allowActivateFo
     expect(listStore.activate).toBeCalledWith(7);
 });
 
-test('Do not call activate if item is activated but fulfills itemDisabledCondition and allowActivateForDisabledItems is false', () => {
+test('Do not call activate if item fulfills itemDisabledCondition and allowActivateForDisabledItems is false', () => {
     mockStructureStrategyData = [
         {
             id: 1,
@@ -419,7 +426,12 @@ test('Do not call activate if item is activated but fulfills itemDisabledConditi
 
     const listStore = new ListStore('test', 'test', 'list_test', {page: observable.box(1)});
     const list = shallow(
-        <List adapters={['test']} allowActivateForDisabledItems={false} itemDisabledCondition={'status == "inactive"'}  store={listStore} />
+        <List
+            adapters={['test']}
+            allowActivateForDisabledItems={false}
+            itemDisabledCondition={'status == "inactive"'}
+            store={listStore}
+        />
     );
 
     list.find('TestAdapter').prop('onItemActivate')(1);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
@@ -397,6 +397,46 @@ test('Render correct button based on permissions when item permissions are provi
     expect(tableAdapter.find('Row').at(2).find('ButtonCell').props().disabled).toEqual(false);
 });
 
+test('Render disabled rows based on given disabledIds prop', () => {
+    const data = [
+        {
+            id: 1,
+            title: 'First item',
+        },
+        {
+            id: 2,
+            title: 'Second item',
+        },
+        {
+            id: 3,
+            title: 'third item',
+        },
+    ];
+    const schema = {
+        title: {
+            label: 'Title',
+            sortable: true,
+            type: 'string',
+            visibility: 'no',
+        },
+    };
+    const tableAdapter = mount(
+        <TableAdapter
+            {...listAdapterDefaultProps}
+            data={data}
+            disabledIds={[1, 3]}
+            onItemClick={jest.fn()}
+            page={1}
+            pageCount={3}
+            schema={schema}
+        />
+    );
+
+    expect(tableAdapter.find('Row').at(0).props().disabled).toEqual(true);
+    expect(tableAdapter.find('Row').at(1).props().disabled).toEqual(false);
+    expect(tableAdapter.find('Row').at(2).props().disabled).toEqual(true);
+});
+
 test('Render data with pencil button and given actions when onItemEdit callback is passed', () => {
     const rowEditClickSpy = jest.fn();
     const data = [

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
@@ -506,7 +506,7 @@ test('Render correct buttons based on permissions when item permissions are prov
                     },
                     children: [],
                     hasChildren: false,
-                }
+                },
             ],
             hasChildren: true,
         },

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
@@ -483,7 +483,7 @@ test('Render correct buttons based on permissions when item permissions are prov
     expect(treeListAdapter.find('Row').at(3).find('ButtonCell').at(1).props().disabled).toEqual(false);
 });
 
-test('Render correct buttons based on permissions when item permissions are provided', () => {
+test('Render disabled rows based on given disabledIds prop', () => {
     const data = [
         {
             data: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
@@ -100,7 +100,16 @@ test('Render data without header', () => {
             id: 6,
             title: 'Test3',
         },
-        children: [],
+        children: [
+            {
+                data: {
+                    id: 7,
+                    title: 'Test4',
+                },
+                children: [],
+                hasChildren: false,
+            },
+        ],
         hasChildren: true,
     };
 
@@ -472,6 +481,58 @@ test('Render correct buttons based on permissions when item permissions are prov
     expect(treeListAdapter.find('Row').at(3).find('ButtonCell').at(0).props().disabled).toEqual(false);
     expect(treeListAdapter.find('Row').at(3).find('ButtonCell').at(1).props().icon).toEqual('su-plus-circle');
     expect(treeListAdapter.find('Row').at(3).find('ButtonCell').at(1).props().disabled).toEqual(false);
+});
+
+test('Render correct buttons based on permissions when item permissions are provided', () => {
+    const data = [
+        {
+            data: {
+                id: 1,
+                title: 'First item',
+            },
+            children: [],
+            hasChildren: false,
+        },
+        {
+            data: {
+                id: 2,
+                title: 'Second item',
+            },
+            children: [
+                {
+                    data: {
+                        id: 3,
+                        title: 'Child item',
+                    },
+                    children: [],
+                    hasChildren: false,
+                }
+            ],
+            hasChildren: true,
+        },
+    ];
+    const schema = {
+        title: {
+            label: 'Title',
+            sortable: true,
+            type: 'string',
+            visibility: 'no',
+        },
+    };
+    const treeListAdapter = mount(
+        <TreeTableAdapter
+            {...listAdapterDefaultProps}
+            data={data}
+            disabledIds={[1, 3]}
+            onItemAdd={jest.fn()}
+            onItemClick={jest.fn()}
+            schema={schema}
+        />
+    );
+
+    expect(treeListAdapter.find('Row').at(0).props().disabled).toEqual(true);
+    expect(treeListAdapter.find('Row').at(1).props().disabled).toEqual(false);
+    expect(treeListAdapter.find('Row').at(2).props().disabled).toEqual(true);
 });
 
 test('Render data with plus button when onItemAdd callback is passed', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TreeTableAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TreeTableAdapter.test.js.snap
@@ -473,13 +473,27 @@ exports[`Render data without header 1`] = `
               class="toggleIcon"
             >
               <span
-                aria-label="su-angle-right"
-                class="su-angle-right clickable"
+                aria-label="su-angle-down"
+                class="su-angle-down clickable"
                 role="button"
                 tabindex="0"
               />
             </span>
             Test3
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+            style="padding-left:25px"
+          >
+            Test4
           </div>
         </td>
       </tr>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -334,6 +334,7 @@ class List extends React.Component<Props> {
                         adapters,
                         addView,
                         editView,
+                        itemDisabledCondition,
                         searchable,
                         title: routeTitle,
                     },
@@ -349,6 +350,7 @@ class List extends React.Component<Props> {
                 <ListContainer
                     adapters={adapters}
                     header={title && <h1 className={listStyles.header}>{title}</h1>}
+                    itemDisabledCondition={itemDisabledCondition}
                     onItemAdd={onItemAdd || addView ? this.addItem : undefined}
                     onItemClick={onItemClick || editView ? this.handleItemClick : undefined}
                     ref={this.setListRef}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
@@ -509,7 +509,7 @@ test('Should render the list with the passed itemDisabledCondition option', () =
                 adapters: ['tree_table'],
                 listKey: 'snippets',
                 resourceKey: 'snippets',
-                itemDisabledCondition: '(_permissions && !_permissions.view)'
+                itemDisabledCondition: '(_permissions && !_permissions.view)',
             },
         },
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
@@ -500,6 +500,24 @@ test('Should render the list non-searchable if the searchable option has been pa
     expect(list.find('List').prop('searchable')).toEqual(false);
 });
 
+test('Should render the list with the passed itemDisabledCondition option', () => {
+    const List = require('../List').default;
+    const router = {
+        bind: jest.fn(),
+        route: {
+            options: {
+                adapters: ['tree_table'],
+                listKey: 'snippets',
+                resourceKey: 'snippets',
+                itemDisabledCondition: '(_permissions && !_permissions.view)'
+            },
+        },
+    };
+
+    const list = shallow(<List router={router} />);
+    expect(list.find('List').prop('itemDisabledCondition')).toEqual('(_permissions && !_permissions.view)');
+});
+
 test('Should throw an error when no resourceKey is defined in the route options', () => {
     const List = require('../List').default;
     const router = {

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormOverlayListViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormOverlayListViewBuilderTest.php
@@ -379,6 +379,19 @@ class FormOverlayListViewBuilderTest extends TestCase
         $this->assertEquals('sulu_category.edit_form', $route->getOption('backView'));
     }
 
+    public function testBuildListSetItemDisabledCondition()
+    {
+        $route = (new FormOverlayListViewBuilder('sulu_role.list', '/roles'))
+            ->setResourceKey('roles')
+            ->setListKey('roles')
+            ->setFormKey('role_details')
+            ->addListAdapters(['tree'])
+            ->setItemDisabledCondition('(_permissions && !_permissions.delete)')
+            ->getView();
+
+        $this->assertSame('(_permissions && !_permissions.delete)', $route->getOption('itemDisabledCondition'));
+    }
+
     public function testBuildAddToolbarActions()
     {
         $saveToolbarAction = new ToolbarAction('sulu_admin.save');

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ListViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ListViewBuilderTest.php
@@ -366,6 +366,18 @@ class ListViewBuilderTest extends TestCase
         $this->assertSame('sulu_category.edit_form', $view->getOption('backView'));
     }
 
+    public function testBuildListSetItemDisabledCondition()
+    {
+        $view = (new ListViewBuilder('sulu_role.list', '/roles'))
+            ->setResourceKey('roles')
+            ->setListKey('roles')
+            ->addListAdapters(['tree'])
+            ->setItemDisabledCondition('(_permissions && !_permissions.delete)')
+            ->getView();
+
+        $this->assertSame('(_permissions && !_permissions.delete)', $view->getOption('itemDisabledCondition'));
+    }
+
     public function testBuildAddToolbarActions()
     {
         $saveToolbarAction = new ToolbarAction('sulu_admin.save');

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -128,7 +128,6 @@ class ContactAdmin extends Admin
                     ->setListKey('contacts')
                     ->setTitle('sulu_contact.people')
                     ->addListAdapters(['table'])
-                    ->setItemDisabledCondition('lastName == "Test"')
                     ->setAddView(static::CONTACT_ADD_FORM_VIEW)
                     ->setEditView(static::CONTACT_EDIT_FORM_VIEW)
                     ->addToolbarActions($contactListToolbarActions)

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -128,6 +128,7 @@ class ContactAdmin extends Admin
                     ->setListKey('contacts')
                     ->setTitle('sulu_contact.people')
                     ->addListAdapters(['table'])
+                    ->setItemDisabledCondition('lastName == "Test"')
                     ->setAddView(static::CONTACT_ADD_FORM_VIEW)
                     ->setEditView(static::CONTACT_EDIT_FORM_VIEW)
                     ->addToolbarActions($contactListToolbarActions)


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adds a `itemDisabledCondition` to the `List` view that allows to pass a `jexl` expression. This `jexl` expression is evaluated on each item of the list. If the expression evaluates to true for an item, the item is rendered in a disabled state.

Additionally, this PR adds a `setItemDisabledCondition` method to the `FormOverlayListViewBuilderInterface` and the `ListViewBuilderInterface` that allows to set the `itemDisabledCondition` via a view-builder instance.

The PR builds upon the existing `disabledIds` prop of the `ListAdapterProps` type. With this PR, the following list adapters mind the given `disabledIds`:
* ColumnListAdapter
* TableAdapter
* TreeTableAdapter

#### Why?

One usecase that is enabled by this feature is to disable rows for which the current user does not have sufficient permissions. When using the `TreeTableAdapter`, it is not possible to hide those rows because the user might have sufficient permissions for a child row.

#### Example Usage

~~~php
$this->viewBuilderFactory->createListViewBuilder('xyz-view', '/xyz')
     ->setItemDisabledCondition('(_permissions && !_permissions.view)')
~~~
