### PR TITLE
Add itemDisabledCondition schemaOption to Selection and SingleSelection field-type

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/table.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/table.scss
@@ -137,6 +137,14 @@ $borderRadius: 3px;
     &.disabled {
         pointer-events: none;
         opacity: .5;
+
+        .cell {
+            border: $cellBorderColor;
+        }
+
+        .toggle-icon {
+            pointer-events: auto;
+        }
     }
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -156,12 +156,19 @@ export default class Selection extends React.Component<Props> {
                 types: {
                     value: types,
                 } = {},
+                itemDisabledCondition: {
+                    value: itemDisabledCondition,
+                } = {},
             },
             value,
         } = this.props;
 
         if (types !== undefined && typeof types !== 'string') {
             throw new Error('The "types" schema option must be a string if given!');
+        }
+
+        if (itemDisabledCondition !== undefined && typeof itemDisabledCondition !== 'string') {
+            throw new Error('The "itemDisabledCondition" schema option must be a string if given!');
         }
 
         const options = {};
@@ -180,6 +187,7 @@ export default class Selection extends React.Component<Props> {
                 disabledIds={resourceKey === formInspector.resourceKey && formInspector.id ? [formInspector.id] : []}
                 displayProperties={displayProperties}
                 icon={icon}
+                itemDisabledCondition={itemDisabledCondition}
                 label={translate(label, {count: value ? value.length : 0})}
                 listKey={listKey || resourceKey}
                 locale={this.locale}
@@ -263,15 +271,30 @@ export default class Selection extends React.Component<Props> {
                     },
                 },
             },
+            schemaOptions: {
+                itemDisabledCondition: {
+                    value: itemDisabledCondition,
+                } = {},
+            },
         } = this.props;
 
         if (!adapter) {
             throw new Error('The selection field needs a "adapter" option for the list type to work properly');
         }
 
+        if (itemDisabledCondition !== undefined && typeof itemDisabledCondition !== 'string') {
+            throw new Error('The "itemDisabledCondition" schema option must be a string if given!');
+        }
+
         return (
             <div className={selectionStyles.list}>
-                <List adapters={[adapter]} disabled={!!disabled} searchable={false} store={this.listStore} />
+                <List
+                    adapters={[adapter]}
+                    disabled={!!disabled}
+                    itemDisabledCondition={itemDisabledCondition}
+                    searchable={false}
+                    store={this.listStore}
+                />
             </div>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -156,7 +156,7 @@ export default class Selection extends React.Component<Props> {
                 types: {
                     value: types,
                 } = {},
-                itemDisabledCondition: {
+                item_disabled_condition: {
                     value: itemDisabledCondition,
                 } = {},
             },
@@ -168,7 +168,7 @@ export default class Selection extends React.Component<Props> {
         }
 
         if (itemDisabledCondition !== undefined && typeof itemDisabledCondition !== 'string') {
-            throw new Error('The "itemDisabledCondition" schema option must be a string if given!');
+            throw new Error('The "item_disabled_condition" schema option must be a string if given!');
         }
 
         const options = {};
@@ -272,7 +272,7 @@ export default class Selection extends React.Component<Props> {
                 },
             },
             schemaOptions: {
-                itemDisabledCondition: {
+                item_disabled_condition: {
                     value: itemDisabledCondition,
                 } = {},
             },
@@ -283,7 +283,7 @@ export default class Selection extends React.Component<Props> {
         }
 
         if (itemDisabledCondition !== undefined && typeof itemDisabledCondition !== 'string') {
-            throw new Error('The "itemDisabledCondition" schema option must be a string if given!');
+            throw new Error('The "item_disabled_condition" schema option must be a string if given!');
         }
 
         return (

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
@@ -96,6 +96,9 @@ export default class SingleSelection extends React.Component<Props>
                 form_options_to_list_options: {
                     value: formOptionsToListOptions,
                 } = {},
+                itemDisabledCondition: {
+                    value: itemDisabledCondition,
+                } = {},
                 types: {
                     value: types,
                 } = {},
@@ -112,6 +115,10 @@ export default class SingleSelection extends React.Component<Props>
 
         if (types !== undefined && typeof types !== 'string') {
             throw new Error('The "types" schema option must be a string if given!');
+        }
+
+        if (itemDisabledCondition !== undefined && typeof itemDisabledCondition !== 'string') {
+            throw new Error('The "itemDisabledCondition" schema option must be a string if given!');
         }
 
         if (formOptionsToListOptions && !Array.isArray(formOptionsToListOptions)) {
@@ -151,6 +158,7 @@ export default class SingleSelection extends React.Component<Props>
                 displayProperties={displayProperties}
                 emptyText={translate(emptyText)}
                 icon={icon}
+                itemDisabledCondition={itemDisabledCondition}
                 listKey={listKey || resourceKey}
                 listOptions={listOptions}
                 locale={this.locale}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
@@ -96,7 +96,7 @@ export default class SingleSelection extends React.Component<Props>
                 form_options_to_list_options: {
                     value: formOptionsToListOptions,
                 } = {},
-                itemDisabledCondition: {
+                item_disabled_condition: {
                     value: itemDisabledCondition,
                 } = {},
                 types: {
@@ -118,7 +118,7 @@ export default class SingleSelection extends React.Component<Props>
         }
 
         if (itemDisabledCondition !== undefined && typeof itemDisabledCondition !== 'string') {
-            throw new Error('The "itemDisabledCondition" schema option must be a string if given!');
+            throw new Error('The "item_disabled_condition" schema option must be a string if given!');
         }
 
         if (formOptionsToListOptions && !Array.isArray(formOptionsToListOptions)) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -62,7 +62,7 @@ jest.mock('../../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 
-test('Should pass props correctly to selection component', () => {
+test('Should pass props correctly to MultiSelection component', () => {
     const value = [1, 6, 8];
 
     const fieldTypeOptions = {
@@ -114,6 +114,7 @@ test('Should pass props correctly to selection component', () => {
         listKey: 'snippets_list',
         disabled: true,
         displayProperties: ['id', 'title'],
+        itemDisabledCondition: undefined,
         label: 'sulu_snippet.selection_label',
         locale,
         resourceKey: 'snippets',
@@ -163,7 +164,7 @@ test('Should pass resourceKey as listKey to selection component if no listKey is
     expect(selection.find('MultiSelection').prop('listKey')).toEqual('snippets');
 });
 
-test('Should pass locale from userStore to selection component if form has no locale', () => {
+test('Should pass locale from userStore to MultiSelection component if form has no locale', () => {
     const value = [1, 6, 8];
 
     const fieldTypeOptions = {
@@ -205,7 +206,7 @@ test('Should pass locale from userStore to selection component if form has no lo
     expect(toJS(selection.find('MultiSelection').prop('locale'))).toEqual('de');
 });
 
-test('Should pass props with schema-options type correctly to selection component', () => {
+test('Should pass props with schema-options type correctly to MultiSelection component', () => {
     const value = [1, 6, 8];
 
     const fieldTypeOptions = {
@@ -232,6 +233,10 @@ test('Should pass props with schema-options type correctly to selection componen
         type: {
             name: 'type',
             value: 'list_overlay',
+        },
+        item_disabled_condition: {
+            name: 'item_disabled_condition',
+            value: 'status == "inactive"',
         },
     };
 
@@ -262,6 +267,7 @@ test('Should pass props with schema-options type correctly to selection componen
         adapter: 'table',
         disabled: true,
         displayProperties: ['id', 'title'],
+        itemDisabledCondition: 'status == "inactive"',
         label: 'sulu_snippet.selection_label',
         locale,
         resourceKey: 'snippets',
@@ -270,7 +276,7 @@ test('Should pass props with schema-options type correctly to selection componen
     }));
 });
 
-test('Should pass id of form as disabledId to overlay type to avoid assigning something to itself', () => {
+test('Should pass id of form as disabledId to MultiSelection component to avoid assigning something to itself', () => {
     const fieldTypeOptions = {
         default_type: 'list_overlay',
         resource_key: 'pages',
@@ -294,7 +300,7 @@ test('Should pass id of form as disabledId to overlay type to avoid assigning so
     expect(selection.find('MultiSelection').prop('disabledIds')).toEqual([4]);
 });
 
-test('Should pass empty array if value is not given to overlay type', () => {
+test('Should pass empty array to MultiSelection component if value is not given', () => {
     const changeSpy = jest.fn();
     const fieldOptions = {
         default_type: 'list_overlay',
@@ -325,7 +331,7 @@ test('Should pass empty array if value is not given to overlay type', () => {
     }));
 });
 
-test('Should call onChange and onFinish callback when selection overlay is confirmed', () => {
+test('Should call onChange and onFinish callback when MultiSelection component fires onChange callback', () => {
     const changeSpy = jest.fn();
     const finishSpy = jest.fn();
 
@@ -375,6 +381,26 @@ test('Should throw an error if "types" schema option is not a string', () => {
             schemaOptions={{types: {value: []}}}
         />
     )).toThrowError(/"types"/);
+});
+
+test('Should throw an error if "item_disabled_condition" schema option is not a string', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('snippets'), 'pages'));
+    const fieldTypeOptions = {
+        default_type: 'list_overlay',
+        resource_key: 'test',
+        types: {
+            list_overlay: {},
+        },
+    };
+
+    expect(() => shallow(
+        <Selection
+            {...fieldTypeDefaultProps}
+            fieldTypeOptions={fieldTypeOptions}
+            formInspector={formInspector}
+            schemaOptions={{item_disabled_condition: {value: []}}}
+        />
+    )).toThrowError(/"item_disabled_condition"/);
 });
 
 test('Should throw an error if no "resource_key" option is passed in fieldOptions', () => {
@@ -493,6 +519,13 @@ test('Should pass props correctly to list component', () => {
         },
     };
 
+    const schemaOptions = {
+        item_disabled_condition: {
+            name: 'item_disabled_condition',
+            value: 'status == "inactive"',
+        },
+    };
+
     const locale = observable.box('en');
 
     const formInspector = new FormInspector(
@@ -508,6 +541,7 @@ test('Should pass props correctly to list component', () => {
             disabled={true}
             fieldTypeOptions={fieldTypeOptions}
             formInspector={formInspector}
+            schemaOptions={schemaOptions}
             value={value}
         />
     );
@@ -518,6 +552,7 @@ test('Should pass props correctly to list component', () => {
     expect(selection.find(List).props()).toEqual(expect.objectContaining({
         adapters: ['table'],
         disabled: true,
+        itemDisabledCondition: 'status == "inactive"',
         searchable: false,
     }));
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
@@ -258,7 +258,7 @@ test('Throw an error if the auto_complete configuration was omitted', () => {
     ).toThrow(/"auto_complete"/);
 });
 
-test('Pass correct props to SingleItemSelection', () => {
+test('Pass correct props to SingleSelect', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
     const value = 3;
 
@@ -409,6 +409,7 @@ test('Pass correct props to SingleItemSelection', () => {
         displayProperties: ['name'],
         emptyText: 'sulu_contact.nothing',
         icon: 'su-account',
+        itemDisabledCondition: undefined,
         listOptions: undefined,
         overlayTitle: 'sulu_contact.overlay_title',
         resourceKey: 'accounts',
@@ -484,6 +485,43 @@ test('Throw an error if form_options_to_list_options has wrong value', () => {
     )).toThrow('"form_options_to_list_options"');
 });
 
+test('Throw an error if item_disabled_condition has wrong value', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+
+    const value = 3;
+
+    const fieldTypeOptions = {
+        default_type: 'list_overlay',
+        resource_key: 'accounts',
+        types: {
+            list_overlay: {
+                adapter: 'table',
+                display_properties: ['name'],
+                empty_text: 'sulu_contact.nothing',
+                icon: 'su-account',
+                overlay_title: 'sulu_contact.overlay_title',
+            },
+        },
+    };
+
+    const schemaOptions = {
+        item_disabled_condition: {
+            name: 'item_disabled_condition',
+            value: [],
+        },
+    };
+
+    expect(() => shallow(
+        <SingleSelection
+            {...fieldTypeDefaultProps}
+            fieldTypeOptions={fieldTypeOptions}
+            formInspector={formInspector}
+            schemaOptions={schemaOptions}
+            value={value}
+        />
+    )).toThrow('"item_disabled_condition"');
+});
+
 test('Throw an error if detail_options has wrong value', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
 
@@ -553,6 +591,10 @@ test('Pass correct props with schema-options type to SingleItemSelection', () =>
             name: 'type',
             value: 'list_overlay',
         },
+        item_disabled_condition: {
+            name: 'item_disabled_condition',
+            value: 'status == "inactive"',
+        },
         types: {
             value: 'test',
         },
@@ -579,6 +621,7 @@ test('Pass correct props with schema-options type to SingleItemSelection', () =>
         displayProperties: ['name'],
         emptyText: 'sulu_contact.nothing',
         icon: 'su-account',
+        itemDisabledCondition: 'status == "inactive"',
         listOptions: {
             segment: 'developer',
             webspace: 'sulu',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
@@ -115,7 +115,7 @@ class List extends React.Component<Props> {
         } = this.props;
 
         const disabledItems = itemDisabledCondition
-            ? store.data.filter((item) => jexl.evalSync(itemDisabledCondition, item))
+            ? store.visibleItems.filter((item) => jexl.evalSync(itemDisabledCondition, item))
             : [];
 
         // TODO do not hardcode "id", but use some kind of metadata instead

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
@@ -15,6 +15,7 @@ import FolderAdapter from '../adapters/FolderAdapter';
 import StringFieldTransformer from '../fieldTransformers/StringFieldTransformer';
 
 let mockStructureStrategyData;
+let mockStructureStrategyVisibleItems;
 
 jest.mock('../../../stores/userStore', () => ({
     setPersistentSetting: jest.fn(),
@@ -89,8 +90,10 @@ jest.mock('../stores/ListStore', () => {
         this.updateLoadingStrategy = jest.fn();
         this.structureStrategy = {
             data: mockStructureStrategyData,
+            visibleItems: mockStructureStrategyVisibleItems,
         };
         this.data = this.structureStrategy.data;
+        this.visibleItems = this.structureStrategy.visibleItems;
         this.search = jest.fn();
         this.move = jest.fn();
         this.copy = jest.fn();
@@ -342,7 +345,7 @@ test('Pass the given disabledIds to the adapter', () => {
 });
 
 test('Pass given disabledIds and ids of items that fulfill given itemDisabledCondition to the adapter', () => {
-    mockStructureStrategyData = [
+    mockStructureStrategyVisibleItems = [
         {
             id: 1,
             status: 'active',
@@ -413,7 +416,7 @@ test('Do not call activate if item is activated but disabled and allowActivateFo
 });
 
 test('Do not call activate if item fulfills itemDisabledCondition and allowActivateForDisabledItems is false', () => {
-    mockStructureStrategyData = [
+    mockStructureStrategyVisibleItems = [
         {
             id: 1,
             status: 'active',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ListOverlay/ListOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ListOverlay/ListOverlay.js
@@ -18,6 +18,7 @@ type Props = {|
     clearSelectionOnClose: boolean,
     confirmLoading?: boolean,
     disabledIds: Array<string | number>,
+    itemDisabledCondition?: ?string,
     listStore: ListStore,
     onClose: () => void,
     onConfirm: () => void,
@@ -89,6 +90,7 @@ class ListOverlay extends React.Component<Props> {
             allowActivateForDisabledItems,
             confirmLoading,
             disabledIds,
+            itemDisabledCondition,
             onClose,
             open,
             overlayType,
@@ -117,6 +119,7 @@ class ListOverlay extends React.Component<Props> {
                         copyable={false}
                         deletable={false}
                         disabledIds={disabledIds}
+                        itemDisabledCondition={itemDisabledCondition}
                         movable={false}
                         orderable={false}
                         searchable={true}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ListOverlay/tests/ListOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ListOverlay/tests/ListOverlay.test.js
@@ -112,6 +112,24 @@ test('Should pass allowActivateForDisabledItems to the List', () => {
     expect(listOverlay.find(List).prop('allowActivateForDisabledItems')).toEqual(false);
 });
 
+test('Should pass itemDisabledCondition to the List', () => {
+    const listStore = new ListStore('snippets', 'snippets', 'list_overlay_test', {page: observable.box(1)});
+
+    const listOverlay = shallow(
+        <ListOverlay
+            adapter="table"
+            itemDisabledCondition={'status == "inactive"'}
+            listStore={listStore}
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+            open={false}
+            title="Selection"
+        />
+    );
+
+    expect(listOverlay.find(List).prop('itemDisabledCondition')).toBe('status == "inactive"');
+});
+
 test('Should pass correct flags to the List', () => {
     const listStore = new ListStore('snippets', 'snippets', 'list_overlay_test', {page: observable.box(1)});
     const disabledIds = [1, 2, 5];

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/MultiListOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/MultiListOverlay.js
@@ -16,6 +16,7 @@ type Props = {|
     confirmLoading?: boolean,
     disabledIds: Array<string | number>,
     excludedIds: Array<string | number>,
+    itemDisabledCondition?: ?string,
     listKey: string,
     locale?: ?IObservableValue<string>,
     onClose: () => void,
@@ -86,6 +87,7 @@ class MultiListOverlay extends React.Component<Props> {
             clearSelectionOnClose,
             confirmLoading,
             disabledIds,
+            itemDisabledCondition,
             onClose,
             open,
             overlayType,
@@ -101,6 +103,7 @@ class MultiListOverlay extends React.Component<Props> {
                 clearSelectionOnClose={clearSelectionOnClose}
                 confirmLoading={confirmLoading}
                 disabledIds={disabledIds}
+                itemDisabledCondition={itemDisabledCondition}
                 listStore={this.listStore}
                 onClose={onClose}
                 onConfirm={this.handleConfirm}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/tests/MultiListOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/tests/MultiListOverlay.test.js
@@ -126,7 +126,7 @@ test('Should pass disabledIds to the ListOverlay', () => {
     expect(multiListOverlay.find(ListOverlay).prop('allowActivateForDisabledItems')).toEqual(true);
 });
 
-test('Should pass reloadOnOpen to the List', () => {
+test('Should pass reloadOnOpen to the ListOverlay', () => {
     const multiListOverlay = shallow(
         <MultiListOverlay
             adapter="table"
@@ -144,7 +144,7 @@ test('Should pass reloadOnOpen to the List', () => {
     expect(multiListOverlay.find(ListOverlay).prop('reloadOnOpen')).toEqual(true);
 });
 
-test('Should pass clearSelectionOnClose to the List', () => {
+test('Should pass clearSelectionOnClose to the ListOverlay', () => {
     const multiListOverlay = shallow(
         <MultiListOverlay
             adapter="table"
@@ -162,7 +162,7 @@ test('Should pass clearSelectionOnClose to the List', () => {
     expect(multiListOverlay.find(ListOverlay).prop('clearSelectionOnClose')).toEqual(true);
 });
 
-test('Should pass allowActivateForDisabledItems to the List', () => {
+test('Should pass allowActivateForDisabledItems to the ListOverlay', () => {
     const disabledIds = [1, 2, 5];
 
     const multiListOverlay = shallow(
@@ -183,7 +183,24 @@ test('Should pass allowActivateForDisabledItems to the List', () => {
     expect(multiListOverlay.find(ListOverlay).prop('allowActivateForDisabledItems')).toEqual(false);
 });
 
-test('Should pass confirmLoading flag to the Overlay', () => {
+test('Should pass itemDisabledCondition to the ListOverlay', () => {
+    const multiListOverlay = shallow(
+        <MultiListOverlay
+            adapter="table"
+            itemDisabledCondition={'status == "inactive"'}
+            listKey="snippets"
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+            open={false}
+            resourceKey="snippets"
+            title="Selection"
+        />
+    );
+
+    expect(multiListOverlay.find(ListOverlay).prop('itemDisabledCondition')).toBe('status == "inactive"');
+});
+
+test('Should pass confirmLoading flag to the ListOverlay', () => {
     const multiListOverlay = shallow(
         <MultiListOverlay
             adapter="table"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
@@ -16,6 +16,7 @@ type Props = {|
     disabledIds: Array<string | number>,
     displayProperties: Array<string>,
     icon: string,
+    itemDisabledCondition?: ?string,
     label?: string,
     listKey: string,
     locale?: ?IObservableValue<string>,
@@ -112,6 +113,7 @@ class MultiSelection extends React.Component<Props> {
             disabledIds,
             displayProperties,
             icon,
+            itemDisabledCondition,
             label,
             locale,
             resourceKey,
@@ -154,6 +156,7 @@ class MultiSelection extends React.Component<Props> {
                 <MultiListOverlay
                     adapter={adapter}
                     disabledIds={disabledIds}
+                    itemDisabledCondition={itemDisabledCondition}
                     listKey={listKey}
                     locale={locale}
                     onClose={this.handleOverlayClose}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/MultiSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/MultiSelection.test.js
@@ -150,6 +150,21 @@ test('Pass disabledIds to MultiListOverlay', () => {
     expect(selection.find('MultiListOverlay').prop('disabledIds')).toEqual(disabledIds);
 });
 
+test('Pass itemDisabledCondition to MultiListOverlay', () => {
+    const selection = mount(
+        <MultiSelection
+            adapter="table"
+            itemDisabledCondition={'status == "inactive"'}
+            listKey="snippets"
+            onChange={jest.fn()}
+            overlayTitle="Selection"
+            resourceKey="snippets"
+        />
+    );
+
+    expect(selection.find('MultiListOverlay').prop('itemDisabledCondition')).toEqual('status == "inactive"');
+});
+
 test('Show with passed values as items in right locale', () => {
     const locale = observable.box('en');
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/SingleListOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/SingleListOverlay.js
@@ -16,6 +16,7 @@ type Props = {|
     confirmLoading?: boolean,
     disabledIds: Array<string | number>,
     excludedIds: Array<string | number>,
+    itemDisabledCondition?: ?string,
     listKey: string,
     locale?: ?IObservableValue<string>,
     metadataOptions?: ?Object,
@@ -115,6 +116,7 @@ class SingleListOverlay extends React.Component<Props> {
             clearSelectionOnClose,
             confirmLoading,
             disabledIds,
+            itemDisabledCondition,
             onClose,
             open,
             overlayType,
@@ -130,6 +132,7 @@ class SingleListOverlay extends React.Component<Props> {
                 clearSelectionOnClose={clearSelectionOnClose}
                 confirmLoading={confirmLoading}
                 disabledIds={disabledIds}
+                itemDisabledCondition={itemDisabledCondition}
                 listStore={this.listStore}
                 onClose={onClose}
                 onConfirm={this.handleConfirm}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/tests/SingleListOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/tests/SingleListOverlay.test.js
@@ -174,7 +174,7 @@ test('Should pass clearSelectionOnClose to the ListOverlay', () => {
     expect(singleListOverlay.find(ListOverlay).prop('clearSelectionOnClose')).toEqual(true);
 });
 
-test('Should pass allowActivateForDisabledItems to the List', () => {
+test('Should pass allowActivateForDisabledItems to the ListOverlay', () => {
     const disabledIds = [1, 2, 5];
 
     const singleListOverlay = shallow(
@@ -193,6 +193,23 @@ test('Should pass allowActivateForDisabledItems to the List', () => {
 
     expect(singleListOverlay.find(ListOverlay).prop('disabledIds')).toBe(disabledIds);
     expect(singleListOverlay.find(ListOverlay).prop('allowActivateForDisabledItems')).toEqual(false);
+});
+
+test('Should pass itemDisabledCondition to the ListOverlay', () => {
+    const singleListOverlay = shallow(
+        <SingleListOverlay
+            adapter="table"
+            itemDisabledCondition={'status == "inactive"'}
+            listKey="snippets"
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+            open={false}
+            resourceKey="snippets"
+            title="Selection"
+        />
+    );
+
+    expect(singleListOverlay.find(ListOverlay).prop('itemDisabledCondition')).toBe('status == "inactive"');
 });
 
 test('Should pass confirmLoading flag to the Overlay', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
@@ -16,6 +16,7 @@ type Props = {|
     displayProperties: Array<string>,
     emptyText: string,
     icon: string,
+    itemDisabledCondition?: ?string,
     listKey: string,
     listOptions?: Object,
     locale?: ?IObservableValue<string>,
@@ -108,6 +109,7 @@ class SingleSelection extends React.Component<Props> {
             displayProperties,
             emptyText,
             icon,
+            itemDisabledCondition,
             locale,
             listOptions,
             overlayTitle,
@@ -146,6 +148,7 @@ class SingleSelection extends React.Component<Props> {
                     <SingleListOverlay
                         adapter={adapter}
                         disabledIds={disabledIds}
+                        itemDisabledCondition={itemDisabledCondition}
                         listKey={listKey}
                         locale={locale}
                         onClose={this.handleOverlayClose}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/SingleSelection.test.js
@@ -177,6 +177,25 @@ test('Pass disabledIds to SingleListOverlay', () => {
     expect(singleSelection.find(SingleListOverlay).prop('disabledIds')).toEqual([1, 2, 3]);
 });
 
+test('Pass itemDisabledCondition to SingleListOverlay', () => {
+    const singleSelection = shallow(
+        <SingleSelection
+            adapter="table"
+            displayProperties={['name', 'value']}
+            emptyText="Nothing"
+            icon="su-test"
+            itemDisabledCondition={'status == "inactive"'}
+            listKey="test"
+            onChange={jest.fn()}
+            overlayTitle="Test"
+            resourceKey="test"
+            value={3}
+        />
+    );
+
+    expect(singleSelection.find(SingleListOverlay).prop('itemDisabledCondition')).toEqual('status == "inactive"');
+});
+
 test('Should open and close an overlay', () => {
     const singleSelection = mount(
         <SingleSelection


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adds a `itemDisabledCondition` option to the `Selection` and `SingleSelection` field type that allows to pass a `jexl` expression. If the expression evalues to true for an item, the item is rendered in a disabled state and cannot be selected in the selection.

With this PR, the following selection types support the `itemDisabledCondition` option:
* Selection / list_overlay
* Selection / list
* SingleSelection / list_overlay

#### Why?

One usecase is to disable items for which the current user does not have sufficient permissions. When using the TreeTableAdapter, it is not possible to hide those rows because the user might have sufficient permissions for a child row.

#### Example Usage

~~~xml
<property name="events" type="event_selection">
    <meta>
        <title>Events</title>
    </meta>
    <params>
        <param name="itemDisabledCondition" value="(_permissions && !_permissions.view)'"/>
    </params>
</property>
~~~
