### PR TITLE
Add distinct attribute to group-concat node in xml schema for list

### DIFF
--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/Resources/schema/list-2.0.xsd
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/Resources/schema/list-2.0.xsd
@@ -132,6 +132,7 @@
     <xs:attributeGroup name="groupConcatPropertyAttributeGroup">
         <xs:attributeGroup ref="propertyAttributeGroup"/>
         <xs:attribute name="glue" type="xs:string"/>
+        <xs:attribute name="distinct" type="xs:boolean"/>
     </xs:attributeGroup>
 
     <xs:group name="casePropertyGroup">


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add a missing attribute `distinct` to GroupConcat node in xml schema.

#### Why?

This is used to load and also for the query but not allowed in the XML.
