### PR TITLE
Fix assigning more than 10 teasers when using elasticsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-release/1.6
+    * BUGFIX      #4998  [ContentBundle]           Fix assigning more than 10 teasers when using elasticsearch
+
 * 1.6.30 (2020-01-13)
     * ENHANCEMENT #4968  [MediaBundle]             Improve performance for one layered images
 

--- a/src/Sulu/Bundle/ContentBundle/Teaser/ContentTeaserProvider.php
+++ b/src/Sulu/Bundle/ContentBundle/Teaser/ContentTeaserProvider.php
@@ -61,6 +61,7 @@ class ContentTeaserProvider implements TeaserProviderInterface
             ->createSearch(implode(' OR ', $statements))
             ->indexes($this->getPageIndexes())
             ->locale($locale)
+            ->setLimit(count($ids))
             ->execute();
 
         /** @var QueryHit $item */

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Teaser/ContentTeaserProviderTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Teaser/ContentTeaserProviderTest.php
@@ -83,6 +83,7 @@ class ContentTeaserProviderTest extends \PHPUnit_Framework_TestCase
         )->willReturn($this->search->reveal())->shouldBeCalled();
         $this->search->indexes(['page_sulu_io_published'])->willReturn($this->search->reveal())->shouldBeCalled();
         $this->search->locale('de')->willReturn($this->search->reveal())->shouldBeCalled();
+        $this->search->setLimit(2)->willReturn($this->search->reveal())->shouldBeCalled();
         $this->search->execute()->willReturn(
             [$this->createQueryHit($ids[0], $data[$ids[0]]), $this->createQueryHit($ids[1], $data[$ids[1]])]
         );

--- a/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\TestBundle\Testing;
 
 use Doctrine\ORM\EntityManager;
-use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Component\Contact\Model\ContactRepositoryInterface;
 use Sulu\Component\Security\Authentication\UserRepositoryInterface;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
@@ -141,7 +140,7 @@ class TestUserProvider implements UserProviderInterface
      */
     public function supportsClass($class)
     {
-        return $class instanceof UserInterface;
+        return is_subclass_of($class, UserInterface::class);
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4331 
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes the bug that only 10 teaser items are returned if there are more than 10 assigned.