### PR TITLE
Fix TestUserProvider supportsClass call

### DIFF
--- a/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\TestBundle\Testing;
 
 use Doctrine\ORM\EntityManager;
 use Sulu\Bundle\ContactBundle\Entity\ContactRepositoryInterface;
+use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Component\Security\Authentication\UserRepositoryInterface;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
@@ -159,7 +160,7 @@ class TestUserProvider implements UserProviderInterface
      */
     public function supportsClass($class)
     {
-        return $class instanceof UserInterface;
+        return $this->userProvider->supportsClass($class);
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | https://github.com/symfony/symfony/pull/35065 #4998
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix TestUserProvider supportsClass call.

#### Why?

The TestUserProvider should call the other user provider for supportsClass. This did work before as symfony before 3.4.37 didn't call supportsClass. Related PR: https://github.com/symfony/symfony/pull/35065

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
