### PR TITLE
Do not select disabled items when select-all checkbox in List is clicked

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Header.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Header.js
@@ -96,7 +96,7 @@ export default class Header extends React.PureComponent<Props> {
                     <Checkbox
                         checked={allSelected}
                         onChange={this.handleAllSelectionChange}
-                        skin={skin}
+                        skin={skin === 'dark' ? 'light' : 'dark'}
                     />
                 </span>
                 {children}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Table.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Table.js
@@ -90,7 +90,7 @@ class Table<T: string | number> extends React.Component<Props<T>> {
             return false;
         }
 
-        const rowSelections = React.Children.map(rows, (row) => row.props.selected);
+        const rowSelections = React.Children.map(rows, (row) => row.props.selected || row.props.disabled);
 
         return !rowSelections.includes(false);
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/Table.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/Table.test.js
@@ -332,6 +332,25 @@ test('Render the Table component in multiple selection mode', () => {
     )).toMatchSnapshot();
 });
 
+test('Render the Table component in multiple selection mode with select inside first cell', () => {
+    expect(render(
+        <Table onAllSelectionChange={jest.fn()} selectInFirstCell={true} selectMode="multiple">
+            <Header>
+                <HeaderCell>Column Title</HeaderCell>
+                <HeaderCell>Column Title</HeaderCell>
+                <HeaderCell>Column Title</HeaderCell>
+            </Header>
+            <Body>
+                <Row>
+                    <Cell>Column Text</Cell>
+                    <Cell>Column Text</Cell>
+                    <Cell>Column Text</Cell>
+                </Row>
+            </Body>
+        </Table>
+    )).toMatchSnapshot();
+});
+
 test('Clicking a checkbox should call onRowSelectionChange with the selection state and row-id', () => {
     const onChangeSpy = jest.fn();
     const props = {
@@ -369,6 +388,59 @@ test('Clicking a checkbox should call onRowSelectionChange with the selection st
 
     checkboxOne.simulate('change');
     expect(onChangeSpy).toHaveBeenCalledWith(rowIdOne, true);
+});
+
+test('Select-all checkbox should be checked if every non-disabled line is selected', () => {
+    const allRowsSelectedTable = mount(
+        <Table selectMode="multiple">
+            <Header>
+                <HeaderCell>Column Title</HeaderCell>
+            </Header>
+            <Body>
+                <Row selected={true}>
+                    <Cell>Column Text</Cell>
+                </Row>
+                <Row selected={true}>
+                    <Cell>Column Text</Cell>
+                </Row>
+            </Body>
+        </Table>
+    );
+    expect(allRowsSelectedTable.find('Header').find('Checkbox input').props().checked).toEqual(true);
+
+    const someRowsSelectedTable = mount(
+        <Table selectMode="multiple">
+            <Header>
+                <HeaderCell>Column Title</HeaderCell>
+            </Header>
+            <Body>
+                <Row selected={true}>
+                    <Cell>Column Text</Cell>
+                </Row>
+                <Row selected={false}>
+                    <Cell>Column Text</Cell>
+                </Row>
+            </Body>
+        </Table>
+    );
+    expect(someRowsSelectedTable.find('Header').find('Checkbox input').props().checked).toEqual(false);
+
+    const allEnabledRowsSelectedTable = mount(
+        <Table selectMode="multiple">
+            <Header>
+                <HeaderCell>Column Title</HeaderCell>
+            </Header>
+            <Body>
+                <Row selected={true}>
+                    <Cell>Column Text</Cell>
+                </Row>
+                <Row disabled={true}>
+                    <Cell>Column Text</Cell>
+                </Row>
+            </Body>
+        </Table>
+    );
+    expect(allEnabledRowsSelectedTable.find('Header').find('Checkbox input').props().checked).toEqual(true);
 });
 
 test('Clicking the select-all checkbox should call the onAllSelectionChange callback', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/Table.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/Table.test.js
@@ -390,7 +390,7 @@ test('Clicking a checkbox should call onRowSelectionChange with the selection st
     expect(onChangeSpy).toHaveBeenCalledWith(rowIdOne, true);
 });
 
-test('Select-all checkbox should be checked if every non-disabled line is selected', () => {
+test('Select-all checkbox should be checked if every line is selected', () => {
     const allRowsSelectedTable = mount(
         <Table selectMode="multiple">
             <Header>
@@ -406,8 +406,11 @@ test('Select-all checkbox should be checked if every non-disabled line is select
             </Body>
         </Table>
     );
-    expect(allRowsSelectedTable.find('Header').find('Checkbox input').props().checked).toEqual(true);
 
+    expect(allRowsSelectedTable.find('Header').find('Checkbox input').props().checked).toEqual(true);
+});
+
+test('Select-all checkbox should not be checked if at least one non-disabled line is not selected', () => {
     const someRowsSelectedTable = mount(
         <Table selectMode="multiple">
             <Header>
@@ -423,8 +426,11 @@ test('Select-all checkbox should be checked if every non-disabled line is select
             </Body>
         </Table>
     );
-    expect(someRowsSelectedTable.find('Header').find('Checkbox input').props().checked).toEqual(false);
 
+    expect(someRowsSelectedTable.find('Header').find('Checkbox input').props().checked).toEqual(false);
+});
+
+test('Select-all checkbox should be checked if every non-disabled line is selected', () => {
     const allEnabledRowsSelectedTable = mount(
         <Table selectMode="multiple">
             <Header>
@@ -440,6 +446,7 @@ test('Select-all checkbox should be checked if every non-disabled line is select
             </Body>
         </Table>
     );
+
     expect(allEnabledRowsSelectedTable.find('Header').find('Checkbox input').props().checked).toEqual(true);
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/__snapshots__/Table.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/__snapshots__/Table.test.js.snap
@@ -665,6 +665,93 @@ exports[`Render the Table component in multiple selection mode 1`] = `
 </div>
 `;
 
+exports[`Render the Table component in multiple selection mode with select inside first cell 1`] = `
+<div
+  class="tableContainer dark"
+>
+  <table
+    class="table"
+  >
+    <thead
+      class="header"
+    >
+      <tr>
+        <th
+          class="headerCell"
+        >
+          <span>
+            <span
+              class="cellSelect"
+            >
+              <label
+                class="label"
+              >
+                <span
+                  class="switch checkbox light"
+                >
+                  <input
+                    type="checkbox"
+                  />
+                  <span />
+                </span>
+              </label>
+            </span>
+            Column Title
+          </span>
+        </th>
+        <th
+          class="headerCell"
+        >
+          <span>
+            Column Title
+          </span>
+        </th>
+        <th
+          class="headerCell"
+        >
+          <span>
+            Column Title
+          </span>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        class="row"
+      >
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            Column Text
+          </div>
+        </td>
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            Column Text
+          </div>
+        </td>
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            Column Text
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
 exports[`Render the Table component in single selection mode 1`] = `
 <div
   class="tableContainer dark"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
@@ -413,7 +413,13 @@ class List extends React.Component<Props> {
 
     handleAllSelectionChange = (selected?: boolean) => {
         const {store} = this.props;
-        selected ? store.selectVisibleItems() : store.deselectVisibleItems();
+
+        store.visibleItems.forEach((item) => {
+            // TODO do not hardcode "id", but use some kind of metadata instead
+            if (!this.disabledIds.includes(item.id)) {
+                selected ? store.select(item) : store.deselect(item);
+            }
+        });
     };
 
     handleAdapterChange = (adapter: string) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
@@ -605,7 +605,16 @@ export default class ListStore {
         this.selections.push(row);
     }
 
+    /**
+     * @deprecated
+     */
     @action selectVisibleItems() {
+        log.warn(
+            'The "selectVisibleItems" method will select disabled rows. ' +
+            'Therefore the method is deprecated since version 2.0. ' +
+            'Use the "visibleItems" property and the "select" method instead.'
+        );
+
         this.visibleItems.forEach((item) => {
             this.select(item);
         });
@@ -626,7 +635,16 @@ export default class ListStore {
         this.selections.splice(index, 1);
     }
 
+    /**
+     * @deprecated
+     */
     @action deselectVisibleItems() {
+        log.warn(
+            'The "deselectVisibleItems" method will deselect disabled rows. ' +
+            'Therefore the method is deprecated since version 2.0. ' +
+            'Use the "visibleItems" property and the "deselect" method instead.'
+        );
+
         this.visibleItems.forEach((item) => {
             this.deselect(item);
         });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
@@ -1,10 +1,16 @@
 // @flow
 import 'url-search-params-polyfill';
 import {autorun, observable, toJS, when} from 'mobx';
+import log from 'loglevel';
 import ResourceRequester from '../../../../services/ResourceRequester';
 import ListStore from '../../stores/ListStore';
 import metadataStore from '../../stores/metadataStore';
 import {userStore} from '../../../../stores';
+
+jest.mock('loglevel', () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+}));
 
 jest.mock('../../stores/metadataStore', () => ({
     getSchema: jest.fn(() => Promise.resolve()),
@@ -956,7 +962,10 @@ test('Select all visible items', () => {
         {id: 7},
     ];
     listStore.selectVisibleItems();
+
     expect(toJS(listStore.selectionIds)).toEqual([1, 7, 2, 3]);
+    expect(log.warn).toBeCalledWith(expect.stringContaining('The "selectVisibleItems" method'));
+
     listStore.destroy();
 });
 
@@ -975,7 +984,10 @@ test('Deselect all visible items', () => {
         {id: 7},
     ];
     listStore.deselectVisibleItems();
+
     expect(toJS(listStore.selectionIds)).toEqual([7]);
+    expect(log.warn).toBeCalledWith(expect.stringContaining('The "deselectVisibleItems" method'));
+
     listStore.destroy();
 });
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | Builds upon #4992
| License | MIT

#### What's in this PR?

This PR adjusts the behaviour of the `List` container to only select **non-disabled** items if the`onAllSelectionChange` callback is fired by a `ListAdapter` (for example when the select-all checkbox of the `TableAdapter` is clicked). 

Furthermore, this PR fixes a bug that rendered the select-all checkbox of the `TableAdapter` with the wrong skin. Also, the select-all checkbox of the `TableAdapter` is now rendered as checked if all non-disabled rows are selected.

#### Why?

Because the goal of disabling items is that they cannot get selected.. 😉 
