### PR TITLE
Fix types in CollectionManagerInterface and StructureInterface

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
@@ -387,7 +387,7 @@ class CollectionManager implements CollectionManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function save(array $data, ?int $userId, bool $breadcrumb = false)
+    public function save(array $data, ?int $userId = null, bool $breadcrumb = false)
     {
         if (isset($data['id'])) {
             $collection = $this->modifyCollection($data, $this->getUser($userId), $breadcrumb);

--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManagerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManagerInterface.php
@@ -97,7 +97,7 @@ interface CollectionManagerInterface
      *
      * @return Collection
      */
-    public function save(array $data, int $userId, bool $breadcrumb = false);
+    public function save(array $data, ?int $userId = null, bool $breadcrumb = false);
 
     /**
      * Deletes a collection with a given id.

--- a/src/Sulu/Component/Content/Compat/StructureInterface.php
+++ b/src/Sulu/Component/Content/Compat/StructureInterface.php
@@ -50,7 +50,7 @@ interface StructureInterface extends \JsonSerializable
     /**
      * id of node.
      *
-     * @return int
+     * @return string
      */
     public function getUuid();
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | possible
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix phpdoc types in CollectionManagerInterface and StructureInterface.

#### Why?

Because they are wrong, to improve static code analyzers.
