### PR TITLE
Add getPriority function to admin pool compiler pass

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Admin/Admin.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Admin.php
@@ -23,6 +23,11 @@ abstract class Admin implements ViewProviderInterface, NavigationProviderInterfa
 {
     const SETTINGS_NAVIGATION_ITEM = 'sulu_admin.settings';
 
+    public static function getPriority(): int
+    {
+        return 0;
+    }
+
     public function configureViews(ViewCollection $viewCollection): void
     {
     }

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/AddAdminPass.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/AddAdminPass.php
@@ -19,6 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class AddAdminPass implements CompilerPassInterface
 {
+    const ADMIN_POOL_DEFINITION_ID = 'sulu_admin.admin_pool';
     const ADMIN_TAG = 'sulu.admin';
 
     /**
@@ -26,7 +27,7 @@ class AddAdminPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $pool = $container->getDefinition('sulu_admin.admin_pool');
+        $pool = $container->getDefinition(self::ADMIN_POOL_DEFINITION_ID);
 
         $adminServiceDefinitions = [];
         foreach ($container->findTaggedServiceIds(self::ADMIN_TAG) as $id => $tags) {

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/DependencyInjection/Compiler/AddAdminPassTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/DependencyInjection/Compiler/AddAdminPassTest.php
@@ -54,13 +54,13 @@ class AddAdminPassTest extends TestCase
         $admins = [];
 
         $poolDefinition->addMethodCall('addAdmin', [$adminDefinition1->reveal()])->will(
-            function () use (&$admins, $adminDefinition1) {
+            function() use (&$admins, $adminDefinition1) {
                 $admins[] = $adminDefinition1;
             }
         )->shouldBeCalled();
 
         $poolDefinition->addMethodCall('addAdmin', [$adminDefinition2->reveal()])->will(
-            function () use (&$admins, $adminDefinition2) {
+            function() use (&$admins, $adminDefinition2) {
                 $admins[] = $adminDefinition2;
             }
         )->shouldBeCalled();

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/DependencyInjection/Compiler/AddAdminPassTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/DependencyInjection/Compiler/AddAdminPassTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Admin\Admin;
+use Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\AddAdminPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+class AddAdminPassTest extends TestCase
+{
+    public function testProcess(): void
+    {
+        $adminPass = new AddAdminPass();
+
+        $poolDefinition = $this->prophesize(Definition::class);
+
+        $container = $this->prophesize(ContainerBuilder::class);
+        $container->getDefinition(AddAdminPass::ADMIN_POOL_DEFINITION_ID)->willReturn($poolDefinition->reveal());
+
+        $adminDefinition1 = $this->prophesize(Definition::class);
+        $adminDefinition1->getClass()->willReturn(TestAdmin1::class);
+
+        $adminDefinition2 = $this->prophesize(Definition::class);
+        $adminDefinition2->getClass()->willReturn('%class2%');
+
+        $container->findTaggedServiceIds(AddAdminPass::ADMIN_TAG)->willReturn(
+            [
+                'test_admin1' => [],
+                'test_admin2' => [],
+            ]
+        );
+
+        $container->getDefinition('test_admin1')->willReturn($adminDefinition1->reveal());
+        $container->getDefinition('test_admin2')->willReturn($adminDefinition2->reveal());
+
+        $parameterBag = $this->prophesize(ParameterBag::class);
+        $container->getParameterBag()->willReturn($parameterBag->reveal());
+
+        $parameterBag->resolveValue(TestAdmin1::class)->willReturn(TestAdmin1::class);
+        $parameterBag->resolveValue('%class2%')->willReturn(TestAdmin2::class);
+
+        $admins = [];
+
+        $poolDefinition->addMethodCall('addAdmin', [$adminDefinition1->reveal()])->will(
+            function () use (&$admins, $adminDefinition1) {
+                $admins[] = $adminDefinition1;
+            }
+        )->shouldBeCalled();
+
+        $poolDefinition->addMethodCall('addAdmin', [$adminDefinition2->reveal()])->will(
+            function () use (&$admins, $adminDefinition2) {
+                $admins[] = $adminDefinition2;
+            }
+        )->shouldBeCalled();
+
+        $adminPass->process($container->reveal());
+
+        $this->assertEquals([$adminDefinition1, $adminDefinition2], $admins);
+    }
+}
+
+class TestAdmin1 extends Admin
+{
+    public static function getPriority(): int
+    {
+        return 1;
+    }
+}
+
+class TestAdmin2 extends Admin
+{
+    public static function getPriority(): int
+    {
+        return -1;
+    }
+}

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -92,12 +92,6 @@ class ContactAdmin extends Admin
 
     public function configureViews(ViewCollection $viewCollection): void
     {
-        $contactEditFormView = $this->viewBuilderFactory
-            ->createResourceTabViewBuilder(static::CONTACT_EDIT_FORM_VIEW, '/contacts/:id')
-            ->setResourceKey('contacts')
-            ->setBackView(static::CONTACT_LIST_VIEW)
-            ->setTitleProperty('fullName');
-
         if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::EDIT)) {
             $contactFormToolbarActions = [];
             $contactListToolbarActions = [];
@@ -138,7 +132,13 @@ class ContactAdmin extends Admin
                     ->setResourceKey('contacts')
                     ->setBackView(static::CONTACT_LIST_VIEW)
             );
-            $viewCollection->add($contactEditFormView);
+            $viewCollection->add(
+                $this->viewBuilderFactory
+                    ->createResourceTabViewBuilder(static::CONTACT_EDIT_FORM_VIEW, '/contacts/:id')
+                    ->setResourceKey('contacts')
+                    ->setBackView(static::CONTACT_LIST_VIEW)
+                    ->setTitleProperty('fullName')
+            );
             $viewCollection->add(
                 $this->viewBuilderFactory
                     ->createFormViewBuilder('sulu_contact.contact_add_form.details', '/details')
@@ -172,10 +172,6 @@ class ContactAdmin extends Admin
                     ->setTabOrder(2048)
                     ->setParent(static::CONTACT_EDIT_FORM_VIEW)
             );
-        } else {
-            // This view has to be registered even if permissions for contacts are missing
-            // Otherwise the application breaks when other bundles try to add child views to this one
-            $viewCollection->add($contactEditFormView);
         }
 
         if ($this->securityChecker->hasPermission(static::ACCOUNT_SECURITY_CONTEXT, PermissionTypes::EDIT)) {

--- a/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
+++ b/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
@@ -43,7 +43,7 @@ class SecurityAdmin extends Admin
      */
     public static function getPriority(): int
     {
-        return -10;
+        return -1024;
     }
 
     /**

--- a/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
+++ b/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
@@ -39,6 +39,14 @@ class SecurityAdmin extends Admin
     const EDIT_FORM_VIEW = 'sulu_security.role_edit_form';
 
     /**
+     * Should be called after ContactAdmin.
+     */
+    public static function getPriority(): int
+    {
+        return -10;
+    }
+
+    /**
      * @var ViewBuilderFactoryInterface
      */
     private $viewBuilderFactory;
@@ -180,7 +188,9 @@ class SecurityAdmin extends Admin
             );
         }
 
-        if ($this->securityChecker->hasPermission(static::USER_SECURITY_CONTEXT, PermissionTypes::EDIT)) {
+        if ($viewCollection->has(ContactAdmin::CONTACT_EDIT_FORM_VIEW)
+            && $this->securityChecker->hasPermission(static::USER_SECURITY_CONTEXT, PermissionTypes::EDIT)
+        ) {
             $viewCollection->add(
                 $this->viewBuilderFactory
                     ->createFormViewBuilder('sulu_security.form.permissions', '/permissions')


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | used in sulu/SuluFormBundle#225
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR introduces a `getPriority` function in the admin.

#### Why?

This allow to put the concrete admin at a specific place inside the admin chain.

It will be used in the form bundle to ensure that the check if a view is available will be called as the last admin.

#### Example Usage

~~~php
class AppAdmin extends Admin
{
    public static function getPriority(): int
    {
        return -1024;
    }
    ...
}
~~~

#### BC Breaks/Deprecations

No BC break all the admins existing admin automatically get the priority `0`.
