### PR TITLE
Adjust style of disabled items in SingleSelection and MultiSelection component

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/Item.js
@@ -83,20 +83,6 @@ export default class Item<T> extends React.PureComponent<Props<T>> {
             }
         );
 
-        const editButtonClass = classNames(
-            itemStyles.button,
-            {
-                [itemStyles.hidden]: disabled,
-            }
-        );
-
-        const removeButtonClass = classNames(
-            itemStyles.button,
-            {
-                [itemStyles.hidden]: disabled && !allowRemoveWhileDisabled,
-            }
-        );
-
         return (
             <div className={itemClass}>
                 <DragHandle className={dragHandleClass}>
@@ -107,13 +93,13 @@ export default class Item<T> extends React.PureComponent<Props<T>> {
                     {children}
                 </div>
                 <div className={itemStyles.buttons}>
-                    {onEdit &&
-                        <button className={editButtonClass} onClick={this.handleEdit} type="button">
+                    {onEdit && !disabled &&
+                        <button className={itemStyles.button} onClick={this.handleEdit} type="button">
                             <Icon name="su-pen" />
                         </button>
                     }
-                    {onRemove &&
-                        <button className={removeButtonClass} onClick={this.handleRemove} type="button">
+                    {onRemove && (!disabled || allowRemoveWhileDisabled) &&
+                        <button className={itemStyles.button} onClick={this.handleRemove} type="button">
                             <Icon name="su-trash-alt" />
                         </button>
                     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/Item.js
@@ -9,6 +9,7 @@ import itemStyles from './item.scss';
 const DRAG_ICON = 'su-more';
 
 type Props<T> = {
+    allowRemoveWhileDisabled: boolean,
     children: Node,
     disabled: boolean,
     id: T,
@@ -20,6 +21,7 @@ type Props<T> = {
 
 export default class Item<T> extends React.PureComponent<Props<T>> {
     static defaultProps = {
+        allowRemoveWhileDisabled: false,
         disabled: false,
         sortable: true,
     };
@@ -56,6 +58,7 @@ export default class Item<T> extends React.PureComponent<Props<T>> {
 
     render() {
         const {
+            allowRemoveWhileDisabled,
             children,
             disabled,
             index,
@@ -80,6 +83,20 @@ export default class Item<T> extends React.PureComponent<Props<T>> {
             }
         );
 
+        const editButtonClass = classNames(
+            itemStyles.button,
+            {
+                [itemStyles.hidden]: disabled,
+            }
+        );
+
+        const removeButtonClass = classNames(
+            itemStyles.button,
+            {
+                [itemStyles.hidden]: disabled && !allowRemoveWhileDisabled,
+            }
+        );
+
         return (
             <div className={itemClass}>
                 <DragHandle className={dragHandleClass}>
@@ -91,12 +108,12 @@ export default class Item<T> extends React.PureComponent<Props<T>> {
                 </div>
                 <div className={itemStyles.buttons}>
                     {onEdit &&
-                        <button className={itemStyles.button} onClick={this.handleEdit} type="button">
+                        <button className={editButtonClass} onClick={this.handleEdit} type="button">
                             <Icon name="su-pen" />
                         </button>
                     }
                     {onRemove &&
-                        <button className={itemStyles.button} onClick={this.handleRemove} type="button">
+                        <button className={removeButtonClass} onClick={this.handleRemove} type="button">
                             <Icon name="su-trash-alt" />
                         </button>
                     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/Item.js
@@ -10,6 +10,7 @@ const DRAG_ICON = 'su-more';
 
 type Props<T> = {
     children: Node,
+    disabled: boolean,
     id: T,
     index: number,
     onEdit?: (id: T) => void,
@@ -19,6 +20,7 @@ type Props<T> = {
 
 export default class Item<T> extends React.PureComponent<Props<T>> {
     static defaultProps = {
+        disabled: false,
         sortable: true,
     };
 
@@ -55,6 +57,7 @@ export default class Item<T> extends React.PureComponent<Props<T>> {
     render() {
         const {
             children,
+            disabled,
             index,
             onEdit,
             onRemove,
@@ -62,6 +65,13 @@ export default class Item<T> extends React.PureComponent<Props<T>> {
         } = this.props;
 
         const DragHandle = this.createDragHandle();
+
+        const itemClass = classNames(
+            itemStyles.item,
+            {
+                [itemStyles.disabled]: disabled,
+            }
+        );
 
         const dragHandleClass = classNames(
             itemStyles.dragHandle,
@@ -71,7 +81,7 @@ export default class Item<T> extends React.PureComponent<Props<T>> {
         );
 
         return (
-            <div className={itemStyles.item}>
+            <div className={itemClass}>
                 <DragHandle className={dragHandleClass}>
                     {sortable && <Icon name={DRAG_ICON} />}
                     <span className={itemStyles.index}>{index}</span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/item.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/item.scss
@@ -1,18 +1,24 @@
 @import '../../containers/Application/colors.scss';
 
 $itemBackgroundColor: $white;
+$disabledItemBackgroundColor: $wildSand;
+
+$itemColor: $black;
+$disabledItemColor: $gray;
 
 .item {
     display: flex;
     justify-content: space-between;
+    color: $itemColor;
     background-color: $itemBackgroundColor;
 
     &.disabled {
-        opacity: .5;
-        pointer-events: none;
+        color: $disabledItemColor;
+        background-color: $disabledItemBackgroundColor;
 
-        .buttons {
-            display: none;
+        .drag-handle,
+        .content {
+            pointer-events: none;
         }
     }
 }
@@ -37,6 +43,10 @@ $itemBackgroundColor: $white;
     padding: 13px 10px 0 0;
     cursor: pointer;
     background-color: transparent;
+
+    &.hidden {
+        display: none;
+    }
 }
 
 .drag-handle {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/item.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/item.scss
@@ -43,10 +43,6 @@ $disabledItemColor: $gray;
     padding: 13px 10px 0 0;
     cursor: pointer;
     background-color: transparent;
-
-    &.hidden {
-        display: none;
-    }
 }
 
 .drag-handle {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/item.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/item.scss
@@ -6,6 +6,15 @@ $itemBackgroundColor: $white;
     display: flex;
     justify-content: space-between;
     background-color: $itemBackgroundColor;
+
+    &.disabled {
+        opacity: .5;
+        pointer-events: none;
+
+        .buttons {
+            display: none;
+        }
+    }
 }
 
 .content {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/tests/MultiItemSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/tests/MultiItemSelection.test.js
@@ -23,10 +23,11 @@ test('Render an MultiItemSelection with children', () => {
                 Child 2
             </MultiItemSelection.Item>
             <MultiItemSelection.Item
+                disabled={true}
                 id="3"
                 index={3}
             >
-                Child 3
+                Child 3 (disabled)
             </MultiItemSelection.Item>
         </MultiItemSelection>
     )).toMatchSnapshot();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/tests/MultiItemSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/tests/MultiItemSelection.test.js
@@ -19,6 +19,8 @@ test('Render an MultiItemSelection with children', () => {
             <MultiItemSelection.Item
                 id="2"
                 index={2}
+                onEdit={jest.fn()}
+                onRemove={jest.fn()}
             >
                 Child 2
             </MultiItemSelection.Item>
@@ -26,8 +28,20 @@ test('Render an MultiItemSelection with children', () => {
                 disabled={true}
                 id="3"
                 index={3}
+                onEdit={jest.fn()}
+                onRemove={jest.fn()}
             >
                 Child 3 (disabled)
+            </MultiItemSelection.Item>
+            <MultiItemSelection.Item
+                allowRemoveWhileDisabled={true}
+                disabled={true}
+                id="4"
+                index={4}
+                onEdit={jest.fn()}
+                onRemove={jest.fn()}
+            >
+                Child 4 (disabled with remove button)
             </MultiItemSelection.Item>
         </MultiItemSelection>
     )).toMatchSnapshot();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/tests/__snapshots__/MultiItemSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/tests/__snapshots__/MultiItemSelection.test.js.snap
@@ -677,7 +677,7 @@ exports[`Render an MultiItemSelection with children 1`] = `
       class="listElement"
     >
       <div
-        class="item"
+        class="item disabled"
       >
         <span
           class="dragHandle sortable"
@@ -695,7 +695,7 @@ exports[`Render an MultiItemSelection with children 1`] = `
         <div
           class="content"
         >
-          Child 3
+          Child 3 (disabled)
         </div>
         <div
           class="buttons"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/tests/__snapshots__/MultiItemSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/tests/__snapshots__/MultiItemSelection.test.js.snap
@@ -670,7 +670,26 @@ exports[`Render an MultiItemSelection with children 1`] = `
         </div>
         <div
           class="buttons"
-        />
+        >
+          <button
+            class="button"
+            type="button"
+          >
+            <span
+              aria-label="su-pen"
+              class="su-pen"
+            />
+          </button>
+          <button
+            class="button"
+            type="button"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt"
+            />
+          </button>
+        </div>
       </div>
     </li>
     <li
@@ -699,7 +718,74 @@ exports[`Render an MultiItemSelection with children 1`] = `
         </div>
         <div
           class="buttons"
-        />
+        >
+          <button
+            class="button hidden"
+            type="button"
+          >
+            <span
+              aria-label="su-pen"
+              class="su-pen"
+            />
+          </button>
+          <button
+            class="button hidden"
+            type="button"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt"
+            />
+          </button>
+        </div>
+      </div>
+    </li>
+    <li
+      class="listElement"
+    >
+      <div
+        class="item disabled"
+      >
+        <span
+          class="dragHandle sortable"
+        >
+          <span
+            aria-label="su-more"
+            class="su-more"
+          />
+          <span
+            class="index"
+          >
+            4
+          </span>
+        </span>
+        <div
+          class="content"
+        >
+          Child 4 (disabled with remove button)
+        </div>
+        <div
+          class="buttons"
+        >
+          <button
+            class="button hidden"
+            type="button"
+          >
+            <span
+              aria-label="su-pen"
+              class="su-pen"
+            />
+          </button>
+          <button
+            class="button"
+            type="button"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt"
+            />
+          </button>
+        </div>
       </div>
     </li>
   </ul>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/tests/__snapshots__/MultiItemSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/tests/__snapshots__/MultiItemSelection.test.js.snap
@@ -718,26 +718,7 @@ exports[`Render an MultiItemSelection with children 1`] = `
         </div>
         <div
           class="buttons"
-        >
-          <button
-            class="button hidden"
-            type="button"
-          >
-            <span
-              aria-label="su-pen"
-              class="su-pen"
-            />
-          </button>
-          <button
-            class="button hidden"
-            type="button"
-          >
-            <span
-              aria-label="su-trash-alt"
-              class="su-trash-alt"
-            />
-          </button>
-        </div>
+        />
       </div>
     </li>
     <li
@@ -767,15 +748,6 @@ exports[`Render an MultiItemSelection with children 1`] = `
         <div
           class="buttons"
         >
-          <button
-            class="button hidden"
-            type="button"
-          >
-            <span
-              aria-label="su-pen"
-              class="su-pen"
-            />
-          </button>
           <button
             class="button"
             type="button"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/SingleItemSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/SingleItemSelection.js
@@ -9,10 +9,11 @@ import Button from './Button';
 import type {Button as ButtonConfig} from './types';
 
 type Props = {|
-    allowRemoveWhileDisabled: boolean,
+    allowRemoveWhileItemDisabled: boolean,
     children?: Node,
     disabled: boolean,
     emptyText?: string,
+    itemDisabled: boolean,
     leftButton: ButtonConfig<*>,
     loading: boolean,
     onRemove?: () => void,
@@ -22,17 +23,19 @@ type Props = {|
 
 export default class SingleItemSelection extends React.Component<Props> {
     static defaultProps = {
-        allowRemoveWhileDisabled: false,
+        allowRemoveWhileItemDisabled: false,
         disabled: false,
+        itemDisabled: false,
         loading: false,
         valid: true,
     };
 
     render() {
         const {
-            allowRemoveWhileDisabled,
+            allowRemoveWhileItemDisabled,
             children,
             disabled,
+            itemDisabled,
             emptyText,
             leftButton,
             loading,
@@ -45,7 +48,7 @@ export default class SingleItemSelection extends React.Component<Props> {
             singleItemSelectionStyles.singleItemSelection,
             {
                 [singleItemSelectionStyles.error]: !valid,
-                [singleItemSelectionStyles.disabled]: disabled,
+                [singleItemSelectionStyles.disabled]: disabled || itemDisabled,
             }
         );
 
@@ -56,18 +59,11 @@ export default class SingleItemSelection extends React.Component<Props> {
             }
         );
 
-        const removeButtonClass = classNames(
-            singleItemSelectionStyles.removeButton,
-            {
-                [singleItemSelectionStyles.hidden]: disabled && !allowRemoveWhileDisabled,
-            }
-        );
-
         return (
             <div className={singleItemSelectionClass}>
                 <Button
                     {...leftButton}
-                    disabled={disabled}
+                    disabled={disabled || itemDisabled}
                     location="left"
                 />
                 <div className={itemContainerClass}>
@@ -79,9 +75,9 @@ export default class SingleItemSelection extends React.Component<Props> {
                             </div>
                         }
                     </div>
-                    {onRemove && !loading &&
+                    {onRemove && !loading && !disabled && (!itemDisabled || allowRemoveWhileItemDisabled) &&
                         <button
-                            className={removeButtonClass}
+                            className={singleItemSelectionStyles.removeButton}
                             onClick={onRemove}
                             type="button"
                         >
@@ -95,7 +91,7 @@ export default class SingleItemSelection extends React.Component<Props> {
                 {rightButton &&
                     <Button
                         {...rightButton}
-                        disabled={disabled}
+                        disabled={disabled || itemDisabled}
                         location="right"
                     />
                 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/SingleItemSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/SingleItemSelection.js
@@ -9,6 +9,7 @@ import Button from './Button';
 import type {Button as ButtonConfig} from './types';
 
 type Props = {|
+    allowRemoveWhileDisabled: boolean,
     children?: Node,
     disabled: boolean,
     emptyText?: string,
@@ -21,13 +22,32 @@ type Props = {|
 
 export default class SingleItemSelection extends React.Component<Props> {
     static defaultProps = {
+        allowRemoveWhileDisabled: false,
         disabled: false,
         loading: false,
         valid: true,
     };
 
     render() {
-        const {children, disabled, emptyText, leftButton, loading, onRemove, rightButton, valid} = this.props;
+        const {
+            allowRemoveWhileDisabled,
+            children,
+            disabled,
+            emptyText,
+            leftButton,
+            loading,
+            onRemove,
+            rightButton,
+            valid,
+        } = this.props;
+
+        const singleItemSelectionClass = classNames(
+            singleItemSelectionStyles.singleItemSelection,
+            {
+                [singleItemSelectionStyles.error]: !valid,
+                [singleItemSelectionStyles.disabled]: disabled,
+            }
+        );
 
         const itemContainerClass = classNames(
             singleItemSelectionStyles.itemContainer,
@@ -36,11 +56,10 @@ export default class SingleItemSelection extends React.Component<Props> {
             }
         );
 
-        const singleItemSelectionClass = classNames(
-            singleItemSelectionStyles.singleItemSelection,
+        const removeButtonClass = classNames(
+            singleItemSelectionStyles.removeButton,
             {
-                [singleItemSelectionStyles.error]: !valid,
-                [singleItemSelectionStyles.disabled]: disabled,
+                [singleItemSelectionStyles.hidden]: disabled && !allowRemoveWhileDisabled,
             }
         );
 
@@ -62,8 +81,7 @@ export default class SingleItemSelection extends React.Component<Props> {
                     </div>
                     {onRemove && !loading &&
                         <button
-                            className={singleItemSelectionStyles.removeButton}
-                            disabled={disabled}
+                            className={removeButtonClass}
                             onClick={onRemove}
                             type="button"
                         >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/singleItemSelection.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/singleItemSelection.scss
@@ -44,10 +44,6 @@ $singleItemSelectionDisabledColor: $gray;
         margin: 0 10px;
         cursor: pointer;
         background-color: transparent;
-
-        &.hidden {
-            display: none;
-        }
     }
 
     .loader {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/singleItemSelection.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/singleItemSelection.scss
@@ -44,6 +44,10 @@ $singleItemSelectionDisabledColor: $gray;
         margin: 0 10px;
         cursor: pointer;
         background-color: transparent;
+
+        &.hidden {
+            display: none;
+        }
     }
 
     .loader {
@@ -64,9 +68,5 @@ $singleItemSelectionDisabledColor: $gray;
     &.disabled {
         background-color: $singleItemSelectionDisabledBackgroundColor;
         color: $singleItemSelectionDisabledColor;
-
-        .remove-button {
-            display: none;
-        }
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/SingleItemSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/SingleItemSelection.test.js
@@ -47,14 +47,38 @@ test('Render with right button with options', () => {
     )).toMatchSnapshot();
 });
 
-test('Render in disabled state', () => {
+test('Render in disabled state without remove button', () => {
     const leftButton = {
         icon: 'su-document',
         onClick: jest.fn(),
     };
 
     expect(render(
-        <SingleItemSelection disabled={true} leftButton={leftButton}>Test Item</SingleItemSelection>
+        <SingleItemSelection
+            disabled={true}
+            leftButton={leftButton}
+            onRemove={jest.fn()}
+        >
+            Test Item
+        </SingleItemSelection>
+    )).toMatchSnapshot();
+});
+
+test('Render in disabled state with remove button', () => {
+    const leftButton = {
+        icon: 'su-document',
+        onClick: jest.fn(),
+    };
+
+    expect(render(
+        <SingleItemSelection
+            allowRemoveWhileDisabled={true}
+            disabled={true}
+            leftButton={leftButton}
+            onRemove={jest.fn()}
+        >
+            Test Item
+        </SingleItemSelection>
     )).toMatchSnapshot();
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/SingleItemSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/SingleItemSelection.test.js
@@ -47,7 +47,7 @@ test('Render with right button with options', () => {
     )).toMatchSnapshot();
 });
 
-test('Render in disabled state without remove button', () => {
+test('Render in disabled state', () => {
     const leftButton = {
         icon: 'su-document',
         onClick: jest.fn(),
@@ -64,7 +64,7 @@ test('Render in disabled state without remove button', () => {
     )).toMatchSnapshot();
 });
 
-test('Render in disabled state with remove button', () => {
+test('Render in item-disabled state without remove button', () => {
     const leftButton = {
         icon: 'su-document',
         onClick: jest.fn(),
@@ -72,8 +72,26 @@ test('Render in disabled state with remove button', () => {
 
     expect(render(
         <SingleItemSelection
-            allowRemoveWhileDisabled={true}
-            disabled={true}
+            allowRemoveWhileItemDisabled={false}
+            itemDisabled={true}
+            leftButton={leftButton}
+            onRemove={jest.fn()}
+        >
+            Test Item
+        </SingleItemSelection>
+    )).toMatchSnapshot();
+});
+
+test('Render in item-disabled state with remove button', () => {
+    const leftButton = {
+        icon: 'su-document',
+        onClick: jest.fn(),
+    };
+
+    expect(render(
+        <SingleItemSelection
+            allowRemoveWhileItemDisabled={true}
+            itemDisabled={true}
             leftButton={leftButton}
             onRemove={jest.fn()}
         >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/__snapshots__/SingleItemSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/__snapshots__/SingleItemSelection.test.js.snap
@@ -1,6 +1,57 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Render in disabled state with remove button 1`] = `
+exports[`Render in disabled state 1`] = `
+<div
+  class="singleItemSelection disabled"
+>
+  <button
+    class="button left"
+    disabled=""
+    type="button"
+  >
+    <span
+      aria-label="su-document"
+      class="su-document icon"
+    />
+  </button>
+  <div
+    class="itemContainer"
+  >
+    <div
+      class="item"
+    >
+      Test Item
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Render in invalid state 1`] = `
+<div
+  class="singleItemSelection error"
+>
+  <button
+    class="button left"
+    type="button"
+  >
+    <span
+      aria-label="su-document"
+      class="su-document icon"
+    />
+  </button>
+  <div
+    class="itemContainer"
+  >
+    <div
+      class="item"
+    >
+      Test Item
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Render in item-disabled state with remove button 1`] = `
 <div
   class="singleItemSelection disabled"
 >
@@ -35,47 +86,13 @@ exports[`Render in disabled state with remove button 1`] = `
 </div>
 `;
 
-exports[`Render in disabled state without remove button 1`] = `
+exports[`Render in item-disabled state without remove button 1`] = `
 <div
   class="singleItemSelection disabled"
 >
   <button
     class="button left"
     disabled=""
-    type="button"
-  >
-    <span
-      aria-label="su-document"
-      class="su-document icon"
-    />
-  </button>
-  <div
-    class="itemContainer"
-  >
-    <div
-      class="item"
-    >
-      Test Item
-    </div>
-    <button
-      class="removeButton hidden"
-      type="button"
-    >
-      <span
-        aria-label="su-trash-alt"
-        class="su-trash-alt"
-      />
-    </button>
-  </div>
-</div>
-`;
-
-exports[`Render in invalid state 1`] = `
-<div
-  class="singleItemSelection error"
->
-  <button
-    class="button left"
     type="button"
   >
     <span

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/__snapshots__/SingleItemSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/__snapshots__/SingleItemSelection.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Render in disabled state 1`] = `
+exports[`Render in disabled state with remove button 1`] = `
 <div
   class="singleItemSelection disabled"
 >
@@ -22,6 +22,50 @@ exports[`Render in disabled state 1`] = `
     >
       Test Item
     </div>
+    <button
+      class="removeButton"
+      type="button"
+    >
+      <span
+        aria-label="su-trash-alt"
+        class="su-trash-alt"
+      />
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Render in disabled state without remove button 1`] = `
+<div
+  class="singleItemSelection disabled"
+>
+  <button
+    class="button left"
+    disabled=""
+    type="button"
+  >
+    <span
+      aria-label="su-document"
+      class="su-document icon"
+    />
+  </button>
+  <div
+    class="itemContainer"
+  >
+    <div
+      class="item"
+    >
+      Test Item
+    </div>
+    <button
+      class="removeButton hidden"
+      type="button"
+    >
+      <span
+        aria-label="su-trash-alt"
+        class="su-trash-alt"
+      />
+    </button>
   </div>
 </div>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Checkbox.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Checkbox.js
@@ -21,7 +21,7 @@ export default class Checkbox extends React.Component<FieldTypeProps<boolean>> {
         }
 
         if (typeof defaultValue !== 'boolean') {
-            throw new Error('The "default_value" schema option must be a string or a number!');
+            throw new Error('The "default_value" schema option must be a boolean if given!');
         }
 
         if (value === undefined) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -160,7 +160,7 @@ export default class Selection extends React.Component<Props> {
                     value: itemDisabledCondition,
                 } = {},
                 allow_deselect_for_disabled_items: {
-                    value: allowDeselectForDisabledItems,
+                    value: allowDeselectForDisabledItems = true,
                 } = {},
             },
             value,
@@ -172,6 +172,10 @@ export default class Selection extends React.Component<Props> {
 
         if (itemDisabledCondition !== undefined && typeof itemDisabledCondition !== 'string') {
             throw new Error('The "item_disabled_condition" schema option must be a string if given!');
+        }
+
+        if (allowDeselectForDisabledItems !== undefined && typeof allowDeselectForDisabledItems !== 'boolean') {
+            throw new Error('The "allow_deselect_for_disabled_items" schema option must be a boolean if given!');
         }
 
         const options = {};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -159,6 +159,9 @@ export default class Selection extends React.Component<Props> {
                 item_disabled_condition: {
                     value: itemDisabledCondition,
                 } = {},
+                allow_deselect_for_disabled_items: {
+                    value: allowDeselectForDisabledItems,
+                } = {},
             },
             value,
         } = this.props;
@@ -183,6 +186,7 @@ export default class Selection extends React.Component<Props> {
         return (
             <MultiSelectionComponent
                 adapter={adapter}
+                allowDeselectForDisabledItems={!!allowDeselectForDisabledItems}
                 disabled={!!disabled}
                 disabledIds={resourceKey === formInspector.resourceKey && formInspector.id ? [formInspector.id] : []}
                 displayProperties={displayProperties}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
@@ -100,7 +100,7 @@ export default class SingleSelection extends React.Component<Props>
                     value: itemDisabledCondition,
                 } = {},
                 allow_deselect_for_disabled_items: {
-                    value: allowDeselectForDisabledItems,
+                    value: allowDeselectForDisabledItems = true,
                 } = {},
                 types: {
                     value: types,
@@ -122,6 +122,10 @@ export default class SingleSelection extends React.Component<Props>
 
         if (itemDisabledCondition !== undefined && typeof itemDisabledCondition !== 'string') {
             throw new Error('The "item_disabled_condition" schema option must be a string if given!');
+        }
+
+        if (allowDeselectForDisabledItems !== undefined && typeof allowDeselectForDisabledItems !== 'boolean') {
+            throw new Error('The "allow_deselect_for_disabled_items" schema option must be a boolean if given!');
         }
 
         if (formOptionsToListOptions && !Array.isArray(formOptionsToListOptions)) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
@@ -99,6 +99,9 @@ export default class SingleSelection extends React.Component<Props>
                 item_disabled_condition: {
                     value: itemDisabledCondition,
                 } = {},
+                allow_deselect_for_disabled_items: {
+                    value: allowDeselectForDisabledItems,
+                } = {},
                 types: {
                     value: types,
                 } = {},
@@ -152,6 +155,7 @@ export default class SingleSelection extends React.Component<Props>
         return (
             <SingleSelectionComponent
                 adapter={adapter}
+                allowDeselectForDisabledItems={!!allowDeselectForDisabledItems}
                 detailOptions={detailOptions}
                 disabled={!!disabled}
                 disabledIds={resourceKey === formInspector.resourceKey && formInspector.id ? [formInspector.id] : []}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -111,6 +111,7 @@ test('Should pass props correctly to MultiSelection component', () => {
 
     expect(selection.find('MultiSelection').props()).toEqual(expect.objectContaining({
         adapter: 'table',
+        allowDeselectForDisabledItems: false,
         listKey: 'snippets_list',
         disabled: true,
         displayProperties: ['id', 'title'],
@@ -206,7 +207,7 @@ test('Should pass locale from userStore to MultiSelection component if form has 
     expect(toJS(selection.find('MultiSelection').prop('locale'))).toEqual('de');
 });
 
-test('Should pass props with schema-options type correctly to MultiSelection component', () => {
+test('Should pass props with schema-options correctly to MultiSelection component', () => {
     const value = [1, 6, 8];
 
     const fieldTypeOptions = {
@@ -231,11 +232,12 @@ test('Should pass props with schema-options type correctly to MultiSelection com
 
     const schemaOptions = {
         type: {
-            name: 'type',
             value: 'list_overlay',
         },
+        allow_deselect_for_disabled_items: {
+            value: 'true',
+        },
         item_disabled_condition: {
-            name: 'item_disabled_condition',
             value: 'status == "inactive"',
         },
     };
@@ -265,6 +267,7 @@ test('Should pass props with schema-options type correctly to MultiSelection com
 
     expect(selection.find('MultiSelection').props()).toEqual(expect.objectContaining({
         adapter: 'table',
+        allowDeselectForDisabledItems: true,
         disabled: true,
         displayProperties: ['id', 'title'],
         itemDisabledCondition: 'status == "inactive"',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -111,7 +111,7 @@ test('Should pass props correctly to MultiSelection component', () => {
 
     expect(selection.find('MultiSelection').props()).toEqual(expect.objectContaining({
         adapter: 'table',
-        allowDeselectForDisabledItems: false,
+        allowDeselectForDisabledItems: true,
         listKey: 'snippets_list',
         disabled: true,
         displayProperties: ['id', 'title'],
@@ -235,7 +235,7 @@ test('Should pass props with schema-options correctly to MultiSelection componen
             value: 'list_overlay',
         },
         allow_deselect_for_disabled_items: {
-            value: 'true',
+            value: false,
         },
         item_disabled_condition: {
             value: 'status == "inactive"',
@@ -267,7 +267,7 @@ test('Should pass props with schema-options correctly to MultiSelection componen
 
     expect(selection.find('MultiSelection').props()).toEqual(expect.objectContaining({
         adapter: 'table',
-        allowDeselectForDisabledItems: true,
+        allowDeselectForDisabledItems: false,
         disabled: true,
         displayProperties: ['id', 'title'],
         itemDisabledCondition: 'status == "inactive"',
@@ -402,6 +402,26 @@ test('Should throw an error if "item_disabled_condition" schema option is not a 
             fieldTypeOptions={fieldTypeOptions}
             formInspector={formInspector}
             schemaOptions={{item_disabled_condition: {value: []}}}
+        />
+    )).toThrowError(/"item_disabled_condition"/);
+});
+
+test('Should throw an error if "allow_deselect_for_disabled_items" schema option is not a boolean', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('snippets'), 'pages'));
+    const fieldTypeOptions = {
+        default_type: 'list_overlay',
+        resource_key: 'test',
+        types: {
+            list_overlay: {},
+        },
+    };
+
+    expect(() => shallow(
+        <Selection
+            {...fieldTypeDefaultProps}
+            fieldTypeOptions={fieldTypeOptions}
+            formInspector={formInspector}
+            schemaOptions={{allow_deselect_for_disabled_items: {value: 'not-boolean'}}}
         />
     )).toThrowError(/"item_disabled_condition"/);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -423,7 +423,7 @@ test('Should throw an error if "allow_deselect_for_disabled_items" schema option
             formInspector={formInspector}
             schemaOptions={{allow_deselect_for_disabled_items: {value: 'not-boolean'}}}
         />
-    )).toThrowError(/"item_disabled_condition"/);
+    )).toThrowError(/"allow_deselect_for_disabled_items"/);
 });
 
 test('Should throw an error if no "resource_key" option is passed in fieldOptions', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
@@ -402,7 +402,7 @@ test('Pass correct props to SingleItemSelection', () => {
 
     expect(singleSelection.find(SingleSelectionComponent).props()).toEqual(expect.objectContaining({
         adapter: 'table',
-        allowDeselectForDisabledItems: false,
+        allowDeselectForDisabledItems: true,
         listKey: 'accounts_list',
         detailOptions: undefined,
         disabled: true,
@@ -449,7 +449,7 @@ test('Pass resourceKey as listKey to SingleItemSelection if no listKey is given'
     expect(singleSelection.find(SingleSelectionComponent).prop('listKey')).toEqual('accounts');
 });
 
-test('Throw an error if form_options_to_list_options has wrong value', () => {
+test('Throw an error if form_options_to_list_options schema option is not an array', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
 
     const value = 3;
@@ -486,7 +486,7 @@ test('Throw an error if form_options_to_list_options has wrong value', () => {
     )).toThrow('"form_options_to_list_options"');
 });
 
-test('Throw an error if item_disabled_condition has wrong value', () => {
+test('Throw an error if item_disabled_condition schema option is not a string', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
 
     const value = 3;
@@ -521,6 +521,43 @@ test('Throw an error if item_disabled_condition has wrong value', () => {
             value={value}
         />
     )).toThrow('"item_disabled_condition"');
+});
+
+test('Throw an error if allow_deselect_for_disabled_items schema option is not a boolean', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+
+    const value = 3;
+
+    const fieldTypeOptions = {
+        default_type: 'list_overlay',
+        resource_key: 'accounts',
+        types: {
+            list_overlay: {
+                adapter: 'table',
+                display_properties: ['name'],
+                empty_text: 'sulu_contact.nothing',
+                icon: 'su-account',
+                overlay_title: 'sulu_contact.overlay_title',
+            },
+        },
+    };
+
+    const schemaOptions = {
+        allow_deselect_for_disabled_items: {
+            name: 'allow_deselect_for_disabled_items',
+            value: 'not-boolean',
+        },
+    };
+
+    expect(() => shallow(
+        <SingleSelection
+            {...fieldTypeDefaultProps}
+            fieldTypeOptions={fieldTypeOptions}
+            formInspector={formInspector}
+            schemaOptions={schemaOptions}
+            value={value}
+        />
+    )).toThrow('"allow_deselect_for_disabled_items"');
 });
 
 test('Throw an error if detail_options has wrong value', () => {
@@ -582,7 +619,7 @@ test('Pass correct props with schema-options type to SingleItemSelection', () =>
 
     const schemaOptions = {
         allow_deselect_for_disabled_items: {
-            value: 'true',
+            value: false,
         },
         form_options_to_list_options: {
             name: 'formOptionsToApi',
@@ -615,7 +652,7 @@ test('Pass correct props with schema-options type to SingleItemSelection', () =>
 
     expect(singleSelection.find(SingleSelectionComponent).props()).toEqual(expect.objectContaining({
         adapter: 'table',
-        allowDeselectForDisabledItems: true,
+        allowDeselectForDisabledItems: false,
         detailOptions: {
             'ghost-content': true,
         },

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
@@ -402,6 +402,7 @@ test('Pass correct props to SingleItemSelection', () => {
 
     expect(singleSelection.find(SingleSelectionComponent).props()).toEqual(expect.objectContaining({
         adapter: 'table',
+        allowDeselectForDisabledItems: false,
         listKey: 'accounts_list',
         detailOptions: undefined,
         disabled: true,
@@ -580,6 +581,9 @@ test('Pass correct props with schema-options type to SingleItemSelection', () =>
     };
 
     const schemaOptions = {
+        allow_deselect_for_disabled_items: {
+            value: 'true',
+        },
         form_options_to_list_options: {
             name: 'formOptionsToApi',
             value: [
@@ -588,11 +592,9 @@ test('Pass correct props with schema-options type to SingleItemSelection', () =>
             ],
         },
         type: {
-            name: 'type',
             value: 'list_overlay',
         },
         item_disabled_condition: {
-            name: 'item_disabled_condition',
             value: 'status == "inactive"',
         },
         types: {
@@ -613,6 +615,7 @@ test('Pass correct props with schema-options type to SingleItemSelection', () =>
 
     expect(singleSelection.find(SingleSelectionComponent).props()).toEqual(expect.objectContaining({
         adapter: 'table',
+        allowDeselectForDisabledItems: true,
         detailOptions: {
             'ghost-content': true,
         },

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
@@ -4,6 +4,7 @@ import {action, observable, reaction, toJS} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import equals from 'fast-deep-equal';
+import jexl from 'jexl';
 import CroppedText from '../../components/CroppedText';
 import MultiItemSelection from '../../components/MultiItemSelection';
 import MultiSelectionStore from '../../stores/MultiSelectionStore';
@@ -137,21 +138,31 @@ class MultiSelection extends React.Component<Props> {
                     onItemRemove={this.handleRemove}
                     onItemsSorted={this.handleSorted}
                 >
-                    {items.map((item, index) => (
-                        <MultiItemSelection.Item id={item.id} index={index + 1} key={item.id}>
-                            <div>
-                                {displayProperties.map((displayProperty) => (
-                                    <span
-                                        className={multiSelectionStyles.itemColumn}
-                                        key={displayProperty}
-                                        style={{width: 100 / columns + '%'}}
-                                    >
-                                        <CroppedText>{item[displayProperty]}</CroppedText>
-                                    </span>
-                                ))}
-                            </div>
-                        </MultiItemSelection.Item>
-                    ))}
+                    {items.map((item, index) => {
+                        const itemDisabled = disabledIds.includes(item.id) ||
+                            (!!itemDisabledCondition && jexl.evalSync(itemDisabledCondition, item));
+
+                        return (
+                            <MultiItemSelection.Item
+                                disabled={itemDisabled}
+                                id={item.id}
+                                index={index + 1}
+                                key={item.id}
+                            >
+                                <div>
+                                    {displayProperties.map((displayProperty) => (
+                                        <span
+                                            className={multiSelectionStyles.itemColumn}
+                                            key={displayProperty}
+                                            style={{width: 100 / columns + '%'}}
+                                        >
+                                            <CroppedText>{item[displayProperty]}</CroppedText>
+                                        </span>
+                                    ))}
+                                </div>
+                            </MultiItemSelection.Item>
+                        );
+                    })}
                 </MultiItemSelection>
                 <MultiListOverlay
                     adapter={adapter}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
@@ -5,6 +5,7 @@ import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import equals from 'fast-deep-equal';
 import jexl from 'jexl';
+import classNames from 'classnames';
 import CroppedText from '../../components/CroppedText';
 import MultiItemSelection from '../../components/MultiItemSelection';
 import MultiSelectionStore from '../../stores/MultiSelectionStore';
@@ -13,6 +14,7 @@ import multiSelectionStyles from './multiSelection.scss';
 
 type Props = {|
     adapter: string,
+    allowDeselectForDisabledItems: boolean,
     disabled: boolean,
     disabledIds: Array<string | number>,
     displayProperties: Array<string>,
@@ -31,6 +33,7 @@ type Props = {|
 @observer
 class MultiSelection extends React.Component<Props> {
     static defaultProps = {
+        allowDeselectForDisabledItems: false,
         disabled: false,
         disabledIds: [],
         displayProperties: [],
@@ -109,6 +112,7 @@ class MultiSelection extends React.Component<Props> {
     render() {
         const {
             adapter,
+            allowDeselectForDisabledItems,
             listKey,
             disabled,
             disabledIds,
@@ -142,8 +146,16 @@ class MultiSelection extends React.Component<Props> {
                         const itemDisabled = disabledIds.includes(item.id) ||
                             (!!itemDisabledCondition && jexl.evalSync(itemDisabledCondition, item));
 
+                        const itemColumnClass = classNames(
+                            multiSelectionStyles.itemColumn,
+                            {
+                                [multiSelectionStyles.disabled]: itemDisabled,
+                            }
+                        );
+
                         return (
                             <MultiItemSelection.Item
+                                allowRemoveWhileDisabled={allowDeselectForDisabledItems}
                                 disabled={itemDisabled}
                                 id={item.id}
                                 index={index + 1}
@@ -152,7 +164,7 @@ class MultiSelection extends React.Component<Props> {
                                 <div>
                                     {displayProperties.map((displayProperty) => (
                                         <span
-                                            className={multiSelectionStyles.itemColumn}
+                                            className={itemColumnClass}
                                             key={displayProperty}
                                             style={{width: 100 / columns + '%'}}
                                         >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/multiSelection.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/multiSelection.scss
@@ -2,6 +2,7 @@
 
 $multiSelectionMainColumnColor: $black;
 $multiSelectionColumnColor: $scorpion;
+$multiSelectionDisabledColumnColor: $gray;
 
 .item-column {
     color: $multiSelectionColumnColor;
@@ -15,5 +16,9 @@ $multiSelectionColumnColor: $scorpion;
     &:first-child {
         color: $multiSelectionMainColumnColor;
         padding-left: 0;
+    }
+
+    &.disabled {
+        color: $multiSelectionDisabledColumnColor;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/MultiSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/MultiSelection.test.js
@@ -5,6 +5,7 @@ import {extendObservable as mockExtendObservable, observable} from 'mobx';
 import pretty from 'pretty';
 import MultiSelection from '../MultiSelection';
 import MultiSelectionStore from '../../../stores/MultiSelectionStore';
+import MultiItemSelection from '../../../components/MultiItemSelection';
 
 jest.mock('../../../utils', () => ({
     translate: jest.fn((key) => key),
@@ -564,4 +565,54 @@ test('Should not call onChange callback if an unrelated observable that is acces
     // change callback should not be called when the unrelated observable changes
     unrelatedObservable.set(55);
     expect(changeSpy).toHaveBeenCalledTimes(1);
+});
+
+test('Should render selected item in disabled state if it fulfills passed itemDisabledCondition', () => {
+    // $FlowFixMe
+    MultiSelectionStore.mockImplementationOnce(function() {
+        this.items = [
+            {id: 1, status: 'active'},
+            {id: 2, status: 'inactive'},
+        ];
+    });
+
+    const selection = mount(
+        <MultiSelection
+            adapter="table"
+            itemDisabledCondition={'status == "inactive"'}
+            listKey="snippets"
+            onChange={jest.fn()}
+            overlayTitle="Selection"
+            resourceKey="pages"
+            value={[1, 5, 8]}
+        />
+    );
+
+    expect(selection.find(MultiItemSelection.Item).at(0).prop('disabled')).toEqual(false);
+    expect(selection.find(MultiItemSelection.Item).at(1).prop('disabled')).toEqual(true);
+});
+
+test('Should render selected item in disabled state if passed disabledIds contain id of item', () => {
+    // $FlowFixMe
+    MultiSelectionStore.mockImplementationOnce(function() {
+        this.items = [
+            {id: 1},
+            {id: 2},
+        ];
+    });
+
+    const selection = mount(
+        <MultiSelection
+            adapter="table"
+            disabledIds={[2, 4]}
+            listKey="snippets"
+            onChange={jest.fn()}
+            overlayTitle="Selection"
+            resourceKey="pages"
+            value={[1, 5, 8]}
+        />
+    );
+
+    expect(selection.find(MultiItemSelection.Item).at(0).prop('disabled')).toEqual(false);
+    expect(selection.find(MultiItemSelection.Item).at(1).prop('disabled')).toEqual(true);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/MultiSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/MultiSelection.test.js
@@ -76,6 +76,28 @@ test('Render in disabled state', () => {
     )).toMatchSnapshot();
 });
 
+test('Render with disabled item', () => {
+    // $FlowFixMe
+    MultiSelectionStore.mockImplementationOnce(function() {
+        this.items = [
+            {id: 1},
+            {id: 2},
+        ];
+    });
+
+    expect(render(
+        <MultiSelection
+            adapter="table"
+            disabledIds={[2, 4]}
+            listKey="snippets"
+            onChange={jest.fn()}
+            overlayTitle="Selection"
+            resourceKey="pages"
+            value={[1, 5, 8]}
+        />
+    )).toMatchSnapshot();
+});
+
 test('Show with passed label', () => {
     expect(render(
         <MultiSelection
@@ -615,4 +637,27 @@ test('Should render selected item in disabled state if passed disabledIds contai
 
     expect(selection.find(MultiItemSelection.Item).at(0).prop('disabled')).toEqual(false);
     expect(selection.find(MultiItemSelection.Item).at(1).prop('disabled')).toEqual(true);
+});
+
+test('Pass correct allowRemoveWhileDisabled prop to Item of MultiItemSelection', () => {
+    // $FlowFixMe
+    MultiSelectionStore.mockImplementationOnce(function() {
+        this.items = [
+            {id: 1},
+        ];
+    });
+
+    const selection = mount(
+        <MultiSelection
+            adapter="table"
+            allowDeselectForDisabledItems={true}
+            listKey="snippets"
+            onChange={jest.fn()}
+            overlayTitle="Selection"
+            resourceKey="pages"
+            value={[1, 5, 8]}
+        />
+    );
+
+    expect(selection.find(MultiItemSelection.Item).at(0).prop('allowRemoveWhileDisabled')).toEqual(true);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/__snapshots__/MultiSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/__snapshots__/MultiSelection.test.js.snap
@@ -27,6 +27,111 @@ exports[`Render in disabled state 1`] = `
 </div>
 `;
 
+exports[`Render with disabled item 1`] = `
+<div
+  class="multiItemSelectionClass"
+>
+  <div
+    class="header"
+  >
+    <button
+      class="button left"
+      type="button"
+    >
+      <span
+        aria-label="su-plus"
+        class="su-plus icon"
+      />
+    </button>
+    <div
+      class="label"
+    />
+  </div>
+  <ul
+    class="list"
+  >
+    <li
+      class="listElement"
+    >
+      <div
+        class="item"
+      >
+        <span
+          class="dragHandle sortable"
+        >
+          <span
+            aria-label="su-more"
+            class="su-more"
+          />
+          <span
+            class="index"
+          >
+            1
+          </span>
+        </span>
+        <div
+          class="content"
+        >
+          <div />
+        </div>
+        <div
+          class="buttons"
+        >
+          <button
+            class="button"
+            type="button"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt"
+            />
+          </button>
+        </div>
+      </div>
+    </li>
+    <li
+      class="listElement"
+    >
+      <div
+        class="item disabled"
+      >
+        <span
+          class="dragHandle sortable"
+        >
+          <span
+            aria-label="su-more"
+            class="su-more"
+          />
+          <span
+            class="index"
+          >
+            2
+          </span>
+        </span>
+        <div
+          class="content"
+        >
+          <div />
+        </div>
+        <div
+          class="buttons"
+        >
+          <button
+            class="button hidden"
+            type="button"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt"
+            />
+          </button>
+        </div>
+      </div>
+    </li>
+  </ul>
+</div>
+`;
+
 exports[`Should open an overlay 1`] = `
 "<div>
   <div class=\\"backdrop visible fixed\\" role=\\"button\\"></div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/__snapshots__/MultiSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/__snapshots__/MultiSelection.test.js.snap
@@ -115,17 +115,7 @@ exports[`Render with disabled item 1`] = `
         </div>
         <div
           class="buttons"
-        >
-          <button
-            class="button hidden"
-            type="button"
-          >
-            <span
-              aria-label="su-trash-alt"
-              class="su-trash-alt"
-            />
-          </button>
-        </div>
+        />
       </div>
     </li>
   </ul>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
@@ -11,6 +11,7 @@ import singleSelectionStyles from './singleSelection.scss';
 
 type Props = {|
     adapter: string,
+    allowDeselectForDisabledItems: boolean,
     detailOptions?: Object,
     disabled: boolean,
     disabledIds: Array<string | number>,
@@ -30,6 +31,7 @@ type Props = {|
 @observer
 class SingleSelection extends React.Component<Props> {
     static defaultProps = {
+        allowDeselectForDisabledItems: false,
         disabled: false,
         disabledIds: [],
         icon: 'su-plus',
@@ -104,6 +106,7 @@ class SingleSelection extends React.Component<Props> {
     render() {
         const {
             adapter,
+            allowDeselectForDisabledItems,
             listKey,
             disabled,
             disabledIds,
@@ -125,6 +128,7 @@ class SingleSelection extends React.Component<Props> {
         return (
             <Fragment>
                 <SingleItemSelection
+                    allowRemoveWhileDisabled={!disabled && allowDeselectForDisabledItems}
                     disabled={disabled || itemDisabled}
                     emptyText={emptyText}
                     leftButton={{

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
@@ -119,8 +119,8 @@ class SingleSelection extends React.Component<Props> {
         const {item, loading} = this.singleSelectionStore;
         const columns = displayProperties.length;
 
-        const itemDisabled = (item && disabledIds.includes(item.id)) ||
-            (item && itemDisabledCondition && jexl.evalSync(itemDisabledCondition, item));
+        const itemDisabled = (!!item && disabledIds.includes(item.id)) ||
+            (!!item && !!itemDisabledCondition && jexl.evalSync(itemDisabledCondition, item));
 
         return (
             <Fragment>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
@@ -128,9 +128,10 @@ class SingleSelection extends React.Component<Props> {
         return (
             <Fragment>
                 <SingleItemSelection
-                    allowRemoveWhileDisabled={!disabled && allowDeselectForDisabledItems}
-                    disabled={disabled || itemDisabled}
+                    allowRemoveWhileItemDisabled={allowDeselectForDisabledItems}
+                    disabled={disabled}
                     emptyText={emptyText}
+                    itemDisabled={itemDisabled}
                     leftButton={{
                         icon,
                         onClick: this.handleOverlayOpen,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
@@ -3,6 +3,7 @@ import React, {Fragment} from 'react';
 import {action, reaction, observable, toJS} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
+import jexl from 'jexl';
 import SingleItemSelection from '../../components/SingleItemSelection';
 import SingleSelectionStore from '../../stores/SingleSelectionStore';
 import SingleListOverlay from '../SingleListOverlay';
@@ -118,10 +119,13 @@ class SingleSelection extends React.Component<Props> {
         const {item, loading} = this.singleSelectionStore;
         const columns = displayProperties.length;
 
+        const itemDisabled = (item && disabledIds.includes(item.id)) ||
+            (item && itemDisabledCondition && jexl.evalSync(itemDisabledCondition, item));
+
         return (
             <Fragment>
                 <SingleItemSelection
-                    disabled={disabled}
+                    disabled={disabled || itemDisabled}
                     emptyText={emptyText}
                     leftButton={{
                         icon,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/SingleSelection.test.js
@@ -456,6 +456,56 @@ test('Correct props should be passed to SingleItemSelection component', () => {
     expect(singleSelection.find(SingleItemSelection).prop('emptyText')).toEqual('nothing');
 });
 
+test('Pass correct disabled prop to SingleItemSelection component when item fulfills itemDisabledCondition', () => {
+    const singleSelection = shallow(
+        <SingleSelection
+            adapter="table"
+            displayProperties={[]}
+            emptyText="nothing"
+            itemDisabledCondition={'status == "inactive"'}
+            listKey="snippets"
+            onChange={jest.fn()}
+            overlayTitle="Selection"
+            resourceKey="snippets"
+            value={1}
+        />
+    );
+
+    expect(singleSelection.find(SingleItemSelection).prop('disabled')).toEqual(false);
+
+    singleSelection.instance().singleSelectionStore.item = {
+        id: 3,
+        status: 'inactive',
+    };
+
+    expect(singleSelection.find(SingleItemSelection).prop('disabled')).toEqual(true);
+});
+
+test('Pass correct disabled prop to SingleItemSelection component when disabledIds contains id of item', () => {
+    const singleSelection = shallow(
+        <SingleSelection
+            adapter="table"
+            disabledIds={[1, 3, 5]}
+            displayProperties={[]}
+            emptyText="nothing"
+            listKey="snippets"
+            onChange={jest.fn()}
+            overlayTitle="Selection"
+            resourceKey="snippets"
+            value={1}
+        />
+    );
+
+    expect(singleSelection.find(SingleItemSelection).prop('disabled')).toEqual(false);
+
+    singleSelection.instance().singleSelectionStore.item = {
+        id: 3,
+        status: 'inactive',
+    };
+
+    expect(singleSelection.find(SingleItemSelection).prop('disabled')).toEqual(true);
+});
+
 test('Set loading prop of SingleItemSelection component if SingleSelectionStore is loading', () => {
     const singleSelection = shallow(
         <SingleSelection

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/SingleSelection.test.js
@@ -456,7 +456,7 @@ test('Correct props should be passed to SingleItemSelection component', () => {
     expect(singleSelection.find(SingleItemSelection).prop('emptyText')).toEqual('nothing');
 });
 
-test('Pass correct disabled prop to SingleItemSelection component when item fulfills itemDisabledCondition', () => {
+test('Pass correct itemDisabled prop to SingleItemSelection component when item fulfills itemDisabledCondition', () => {
     const singleSelection = shallow(
         <SingleSelection
             adapter="table"
@@ -471,17 +471,17 @@ test('Pass correct disabled prop to SingleItemSelection component when item fulf
         />
     );
 
-    expect(singleSelection.find(SingleItemSelection).prop('disabled')).toEqual(false);
+    expect(singleSelection.find(SingleItemSelection).prop('itemDisabled')).toEqual(false);
 
     singleSelection.instance().singleSelectionStore.item = {
         id: 3,
         status: 'inactive',
     };
 
-    expect(singleSelection.find(SingleItemSelection).prop('disabled')).toEqual(true);
+    expect(singleSelection.find(SingleItemSelection).prop('itemDisabled')).toEqual(true);
 });
 
-test('Pass correct disabled prop to SingleItemSelection component when disabledIds contains id of item', () => {
+test('Pass correct itemDisabled prop to SingleItemSelection component when disabledIds contains id of item', () => {
     const singleSelection = shallow(
         <SingleSelection
             adapter="table"
@@ -496,14 +496,14 @@ test('Pass correct disabled prop to SingleItemSelection component when disabledI
         />
     );
 
-    expect(singleSelection.find(SingleItemSelection).prop('disabled')).toEqual(false);
+    expect(singleSelection.find(SingleItemSelection).prop('itemDisabled')).toEqual(false);
 
     singleSelection.instance().singleSelectionStore.item = {
         id: 3,
         status: 'inactive',
     };
 
-    expect(singleSelection.find(SingleItemSelection).prop('disabled')).toEqual(true);
+    expect(singleSelection.find(SingleItemSelection).prop('itemDisabled')).toEqual(true);
 });
 
 test('Set loading prop of SingleItemSelection component if SingleSelectionStore is loading', () => {
@@ -527,7 +527,7 @@ test('Set loading prop of SingleItemSelection component if SingleSelectionStore 
     expect(singleSelection.find(SingleListOverlay)).toHaveLength(0);
 });
 
-test('Pass correct allowRemoveWhileDisabled prop to SingleItemSelection component', () => {
+test('Pass correct allowRemoveWhileItemDisabled prop to SingleItemSelection component', () => {
     const singleSelection = shallow(
         <SingleSelection
             adapter="table"
@@ -543,24 +543,5 @@ test('Pass correct allowRemoveWhileDisabled prop to SingleItemSelection componen
         />
     );
 
-    expect(singleSelection.find(SingleItemSelection).prop('allowRemoveWhileDisabled')).toEqual(true);
-});
-
-test('Pass correct allowRemoveWhileDisabled prop to SingleItemSelection when component is disabled', () => {
-    const singleSelection = shallow(
-        <SingleSelection
-            adapter="table"
-            allowDeselectForDisabledItems={true}
-            disabled={true}
-            displayProperties={[]}
-            emptyText="nothing"
-            listKey="snippets"
-            onChange={jest.fn()}
-            overlayTitle="Selection"
-            resourceKey="snippets"
-            value={1}
-        />
-    );
-
-    expect(singleSelection.find(SingleItemSelection).prop('allowRemoveWhileDisabled')).toEqual(false);
+    expect(singleSelection.find(SingleItemSelection).prop('allowRemoveWhileItemDisabled')).toEqual(true);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/SingleSelection.test.js
@@ -526,3 +526,41 @@ test('Set loading prop of SingleItemSelection component if SingleSelectionStore 
     expect(singleSelection.find(SingleItemSelection).prop('loading')).toEqual(true);
     expect(singleSelection.find(SingleListOverlay)).toHaveLength(0);
 });
+
+test('Pass correct allowRemoveWhileDisabled prop to SingleItemSelection component', () => {
+    const singleSelection = shallow(
+        <SingleSelection
+            adapter="table"
+            allowDeselectForDisabledItems={true}
+            disabledIds={[1, 3, 5]}
+            displayProperties={[]}
+            emptyText="nothing"
+            listKey="snippets"
+            onChange={jest.fn()}
+            overlayTitle="Selection"
+            resourceKey="snippets"
+            value={1}
+        />
+    );
+
+    expect(singleSelection.find(SingleItemSelection).prop('allowRemoveWhileDisabled')).toEqual(true);
+});
+
+test('Pass correct allowRemoveWhileDisabled prop to SingleItemSelection when component is disabled', () => {
+    const singleSelection = shallow(
+        <SingleSelection
+            adapter="table"
+            allowDeselectForDisabledItems={true}
+            disabled={true}
+            displayProperties={[]}
+            emptyText="nothing"
+            listKey="snippets"
+            onChange={jest.fn()}
+            overlayTitle="Selection"
+            resourceKey="snippets"
+            value={1}
+        />
+    );
+
+    expect(singleSelection.find(SingleItemSelection).prop('allowRemoveWhileDisabled')).toEqual(false);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/__snapshots__/SingleSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/__snapshots__/SingleSelection.test.js.snap
@@ -82,15 +82,6 @@ exports[`Render with selected item in disabled state 1`] = `
         </span>
       </div>
     </div>
-    <button
-      class="removeButton hidden"
-      type="button"
-    >
-      <span
-        aria-label="su-trash-alt"
-        class="su-trash-alt"
-      />
-    </button>
   </div>
 </div>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/__snapshots__/SingleSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/__snapshots__/SingleSelection.test.js.snap
@@ -83,8 +83,7 @@ exports[`Render with selected item in disabled state 1`] = `
       </div>
     </div>
     <button
-      class="removeButton"
-      disabled=""
+      class="removeButton hidden"
       type="button"
     >
       <span


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | Builds upon #4992
| License | MIT

#### What's in this PR?

This PR adjusts the `SingleSelection` component and the `MultiSelection` component to render items in a disabled state if they fulfill the given `itemDisabledCondition` or their id is contained in the given `disabledIds`. Furthermore it adds a `allow_deselect_for_disabled_items` option that allows to configure if the user should be able to deselect/remove disabled items from a selection.

#### Why?

Because the user should see if a selected item is disabled without opening the `ListOverlay`.