### PR TITLE
Fix fast pagination of List view

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/loadingStrategies/AbstractLoadingStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/loadingStrategies/AbstractLoadingStrategy.js
@@ -1,4 +1,5 @@
 // @flow
+import {RequestPromise} from '../../../services/Requester';
 import type {LoadingStrategyInterface, LoadOptions, StructureStrategyInterface} from '../types';
 
 export default class AbstractLoadingStrategy implements LoadingStrategyInterface {
@@ -9,7 +10,7 @@ export default class AbstractLoadingStrategy implements LoadingStrategyInterface
     }
 
     // eslint-disable-next-line no-unused-vars
-    load(resourceKey: string, options: LoadOptions): Promise<Object> {
+    load(resourceKey: string, options: LoadOptions): RequestPromise<Object> {
         throw new Error('Not implemented');
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
@@ -491,7 +491,7 @@ export default class ListStore {
 
         log.info('List loads "' + this.resourceKey + '" data with the following options:', options);
 
-        if (this.pendingRequest instanceof RequestPromise) {
+        if (this.pendingRequest) {
             this.pendingRequest.abort();
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
@@ -2,7 +2,7 @@
 import {action, autorun, computed, intercept, observable, untracked} from 'mobx';
 import type {IObservableValue, IValueWillChange} from 'mobx';
 import log from 'loglevel';
-import ResourceRequester from '../../../services/ResourceRequester';
+import ResourceRequester, {RequestPromise} from '../../../services/ResourceRequester';
 import type {
     LoadingStrategyInterface,
     ObservableOptions,
@@ -55,6 +55,7 @@ export default class ListStore {
     activeSettingDisposer: () => void;
     sendRequestDisposer: () => void;
     initialSelectionIds: ?Array<string | number>;
+    pendingRequest: ?RequestPromise<*>;
     metadataOptions: ?Object;
 
     static getActiveSetting(listKey: string, userSettingsKey: string): string {
@@ -490,11 +491,16 @@ export default class ListStore {
 
         log.info('List loads "' + this.resourceKey + '" data with the following options:', options);
 
-        this.loadingStrategy.load(
+        if (this.pendingRequest instanceof RequestPromise) {
+            this.pendingRequest.abort();
+        }
+
+        this.pendingRequest = this.loadingStrategy.load(
             this.resourceKey,
             options,
             options.expandedIds ? undefined : active
         ).then(action((response) => {
+            this.pendingRequest = undefined;
             this.pageCount = response.pages;
             this.setDataLoading(false);
 
@@ -511,6 +517,11 @@ export default class ListStore {
                 this.initialSelectionIds = undefined;
             }
         })).catch((response) => {
+            if (response.name === 'AbortError') {
+                return;
+            }
+
+            this.pendingRequest = undefined;
             if (this.active.get() && response.status === 404) {
                 // need to set the user setting to null manually, because the autorun runs too late
                 ListStore.setActiveSetting(this.listKey, this.userSettingsKey, undefined);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/structureStrategies/ColumnStructureStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/structureStrategies/ColumnStructureStrategy.js
@@ -100,7 +100,13 @@ export default class ColumnStructureStrategy implements StructureStrategyInterfa
             this.rawData.set(parentId, []);
         }
 
-        removeColumnsAfterIndex(this.activeItems, this.activeItems.indexOf(parentId), this.rawData);
+        const parentIndex = this.activeItems.indexOf(parentId);
+
+        if (parentIndex === -1) {
+            return;
+        }
+
+        removeColumnsAfterIndex(this.activeItems, parentIndex, this.rawData);
         const column = this.rawData.get(parentId);
         if (column && column.length > 0) {
             column.splice(0, column.length);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/structureStrategies/ColumnStructureStrategy.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/structureStrategies/ColumnStructureStrategy.test.js
@@ -159,6 +159,19 @@ test('Should be empty after clear without a parent was called', () => {
     expect(columnStructureStrategy.data[0]).toEqual([]);
 });
 
+test('Should not be empty if called with a non-existing parent', () => {
+    const columnStructureStrategy = new ColumnStructureStrategy();
+    columnStructureStrategy.rawData = new Map();
+    columnStructureStrategy.rawData.set(0, []);
+    columnStructureStrategy.rawData.set(1, []);
+
+    expect(columnStructureStrategy.data).toHaveLength(2);
+    columnStructureStrategy.clear(5);
+    expect(columnStructureStrategy.data).toHaveLength(2);
+    expect(columnStructureStrategy.data[0]).toEqual([]);
+    expect(columnStructureStrategy.data[1]).toEqual([]);
+});
+
 test('Should add the items in a recursive way', () => {
     const columnStructureStrategy = new ColumnStructureStrategy();
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/types.js
@@ -1,6 +1,7 @@
 // @flow
 import type {Node} from 'react';
 import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
+import {RequestPromise} from '../../services/Requester';
 
 export type DataItem = {
     id: string | number,
@@ -75,7 +76,7 @@ export type LoadOptions = {
 
 export interface LoadingStrategyInterface {
     constructor(): void,
-    load(resourceKey: string, options: LoadOptions, parentId: ?string | number): Promise<Object>,
+    load(resourceKey: string, options: LoadOptions, parentId: ?string | number): RequestPromise<Object>,
     setStructureStrategy(structureStrategy: StructureStrategyInterface): void,
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/RequestPromise.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/RequestPromise.js
@@ -1,0 +1,28 @@
+//@flow
+
+export default class RequestPromise<T> extends Promise<T> {
+    abortController: ?AbortController;
+
+    setAbortController(abortController: ?AbortController) {
+        this.abortController = abortController;
+    }
+
+    abort() {
+        if (!this.abortController) {
+            throw new Error('A request can only be aborted if the setAbortController function was called.');
+        }
+        this.abortController.abort();
+    }
+
+    then(onFulfilled: ?(*) => Promise<*> | *, onRejected: ?(*) => Promise<*> | *): RequestPromise<*> {
+        const requestPromise: RequestPromise<*> = ((super.then(onFulfilled, onRejected): any): RequestPromise<*>);
+        requestPromise.setAbortController(this.abortController);
+
+        return requestPromise;
+    }
+
+    catch(onReject: ?(*) => Promise<*> | *): RequestPromise<*> {
+        // $FlowFixMe
+        return super.catch(onReject);
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/RequestPromise.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/RequestPromise.js
@@ -22,7 +22,9 @@ export default class RequestPromise<T> extends Promise<T> {
     }
 
     catch(onReject: ?(*) => Promise<*> | *): RequestPromise<*> {
-        // $FlowFixMe
-        return super.catch(onReject);
+        const requestPromise = ((super.catch(onReject): any): RequestPromise<*>);
+        requestPromise.setAbortController(this.abortController);
+
+        return requestPromise;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/index.js
@@ -1,4 +1,6 @@
 // @flow
 import Requester from './Requester';
+import RequestPromise from './RequestPromise';
 
 export default Requester;
+export {RequestPromise};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/tests/RequestPromise.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/tests/RequestPromise.test.js
@@ -1,0 +1,37 @@
+// @flow
+import RequestPromise from '../RequestPromise';
+
+test('Cancel request when abort is called', () => {
+    const requestPromise = new RequestPromise(function() {});
+    const abortController = {
+        abort: jest.fn(),
+    };
+
+    // $FlowFixMe
+    requestPromise.setAbortController(abortController);
+    requestPromise.abort();
+
+    expect(abortController.abort).toBeCalledWith();
+});
+
+test('Passing promises via then should also have the AbortController set', () => {
+    const requestPromise = new RequestPromise(function(resolve) {
+        resolve();
+    });
+    const abortController = {
+        abort: jest.fn(),
+    };
+
+    // $FlowFixMe
+    requestPromise.setAbortController(abortController);
+    requestPromise.abort();
+
+    const thenPromise = requestPromise.then(function() {});
+
+    expect(thenPromise.abortController).toEqual(abortController);
+});
+
+test('Throw error if abort is called without AbortController', () => {
+    const requestPromise = new RequestPromise(function() {});
+    expect(() => requestPromise.abort()).toThrow('setAbortController');
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/tests/RequestPromise.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/tests/RequestPromise.test.js
@@ -31,6 +31,23 @@ test('Passing promises via then should also have the AbortController set', () =>
     expect(thenPromise.abortController).toEqual(abortController);
 });
 
+test('Passing promises via catch should also have the AbortController set', () => {
+    const requestPromise = new RequestPromise(function(resolve, reject) {
+        reject();
+    });
+    const abortController = {
+        abort: jest.fn(),
+    };
+
+    // $FlowFixMe
+    requestPromise.setAbortController(abortController);
+    requestPromise.abort();
+
+    const catchPromise = requestPromise.catch(function() {});
+
+    expect(catchPromise.abortController).toEqual(abortController);
+});
+
 test('Throw error if abort is called without AbortController', () => {
     const requestPromise = new RequestPromise(function() {});
     expect(() => requestPromise.abort()).toThrow('setAbortController');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/tests/Requester.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/tests/Requester.test.js
@@ -17,6 +17,7 @@ test('Should execute GET request and reject with response when the response cont
     expect(window.fetch).toBeCalledWith('/some-url', {
         credentials: 'same-origin',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
+        signal: expect.any(AbortSignal),
     });
 });
 
@@ -88,6 +89,7 @@ test('Should execute GET request and replace null with undefined', () => {
     expect(window.fetch).toBeCalledWith('/some-url', {
         credentials: 'same-origin',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
+        signal: expect.any(AbortSignal),
     });
 
     return requestPromise;
@@ -151,6 +153,7 @@ test('Should execute POST request and return JSON', () => {
         }),
         credentials: 'same-origin',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
+        signal: expect.any(AbortSignal),
     });
 
     return requestPromise;
@@ -180,6 +183,7 @@ test('Should execute POST request and return JSON when value is observable', () 
         }),
         credentials: 'same-origin',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
+        signal: expect.any(AbortSignal),
     });
 
     return requestPromise;
@@ -214,6 +218,7 @@ test('Should execute PUT request and return JSON', () => {
         }),
         credentials: 'same-origin',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
+        signal: expect.any(AbortSignal),
     });
 
     return requestPromise;
@@ -238,6 +243,7 @@ test('Should execute PUT request without data and return JSON', () => {
         method: 'PUT',
         credentials: 'same-origin',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
+        signal: expect.any(AbortSignal),
     });
 
     return requestPromise;
@@ -271,6 +277,7 @@ test('Should execute PATCH request and return JSON', () => {
         body: JSON.stringify([{title: 'Titel', description: 'Description', test: null}]),
         credentials: 'same-origin',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
+        signal: expect.any(AbortSignal),
     });
 
     return requestPromise;
@@ -295,6 +302,7 @@ test('Should execute DELETE request and return JSON', () => {
         method: 'DELETE',
         credentials: 'same-origin',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
+        signal: expect.any(AbortSignal),
     });
 
     return requestPromise;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/index.js
@@ -1,6 +1,7 @@
 // @flow
+import {RequestPromise} from '../Requester';
 import ResourceRequester from './ResourceRequester';
 import resourceRouteRegistry from './registries/resourceRouteRegistry';
 
 export default ResourceRequester;
-export {resourceRouteRegistry};
+export {resourceRouteRegistry, RequestPromise};

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
@@ -2,8 +2,9 @@
 import React from 'react';
 import {mount, render} from 'enzyme';
 import {extendObservable as mockExtendObservable, observable} from 'mobx';
-import MediaCollection from '../MediaCollection';
+import {RequestPromise} from 'sulu-admin-bundle/services/ResourceRequester';
 import MediaCardOverviewAdapter from '../../List/adapters/MediaCardOverviewAdapter';
+import MediaCollection from '../MediaCollection';
 
 const MEDIA_RESOURCE_KEY = 'media';
 const COLLECTIONS_RESOURCE_KEY = 'collections';
@@ -999,7 +1000,9 @@ test('Confirming the delete dialog should delete the item and navigate to its pa
 });
 
 test('Confirming the move dialog should move the item', () => {
-    const promise = Promise.resolve({});
+    const promise = new RequestPromise(function(resolve) {
+        resolve({});
+    });
     const page = observable.box();
     const locale = observable.box();
     const SingleListOverlay = require('sulu-admin-bundle/containers').SingleListOverlay;
@@ -1066,7 +1069,9 @@ test('Confirming the move dialog should move the item', () => {
 });
 
 test('Confirming the permission overlay should save the permissions', () => {
-    const promise = Promise.resolve({});
+    const promise = new RequestPromise(function(resolve) {
+        resolve({});
+    });
     const page = observable.box();
     const locale = observable.box();
     const ListStore = require('sulu-admin-bundle/containers').ListStore;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4912 
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR cancels the request from a list when a new request for the same list has been sent.

#### Why?

Because otherwise it can happen that sooner requests finish later than the ones starting later, causing the wrong page to display. E.g. if you navigate from page 1 to page 10 by clicking the next icon without waiting for the requests to finish, you could e.g. to be shown page 9, although the list shows page 10.