### PR TITLE
Add request_parameters option to Selection field-type

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/Header.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/Header.js
@@ -43,11 +43,13 @@ export default class Header<T: string | number, U: string | number> extends Reac
                     <Button {...leftButton} location="left" />
                 }
                 <div className={headerStyles.label}>
-                    {label}
                     {loading &&
                         <div className={headerStyles.loader}>
                             <Loader size={LOADER_SIZE} />
                         </div>
+                    }
+                    {!loading &&
+                        label
                     }
                 </div>
                 {rightButton &&

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/tests/__snapshots__/MultiItemSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/tests/__snapshots__/MultiItemSelection.test.js.snap
@@ -575,7 +575,6 @@ exports[`Render an MultiItemSelection while loading 1`] = `
     <div
       class="label"
     >
-      I am loading
       <div
         class="loader"
       >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/SelectBlockPreviewTransformer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/SelectBlockPreviewTransformer.test.js
@@ -10,6 +10,7 @@ test('Return JSX for multiple selected items', () => {
             {
                 options: {
                     values: {
+                        name: 'values',
                         value: [
                             {
                                 name: 'value1',
@@ -40,6 +41,7 @@ test('Return null if no array is passed', () => {
             {
                 options: {
                     values: {
+                        name: 'values',
                         value: [
                             {
                                 name: 'value1',
@@ -76,7 +78,10 @@ test('Throw an error if values schema option is not an array', () => {
             ['value1', 'value3'],
             {
                 options: {
-                    values: {},
+                    values: {
+                        name: 'values',
+                        value: 'not-array',
+                    },
                 },
                 type: 'single_select',
             }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/SingleSelectBlockPreviewTransformer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/SingleSelectBlockPreviewTransformer.test.js
@@ -9,6 +9,7 @@ test('Return JSX for selected item', () => {
             {
                 options: {
                     values: {
+                        name: 'values',
                         value: [
                             {
                                 name: 'value1',
@@ -39,6 +40,7 @@ test('Return null if nothing is passed', () => {
             {
                 options: {
                     values: {
+                        name: 'values',
                         value: [
                             {
                                 name: 'value1',
@@ -75,7 +77,10 @@ test('Throw an error if values schema option is not an array', () => {
             'value3',
             {
                 options: {
-                    values: {},
+                    values: {
+                        name: 'values',
+                        value: 'not-array',
+                    },
                 },
                 type: 'single_select',
             }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -174,7 +174,7 @@ class Selection extends React.Component<Props> {
 
         resourceStorePropertiesToRequest.forEach((propertyToRequest) => {
             const {name: parameterName, value: propertyName} = propertyToRequest;
-            const propertyPath = propertyName || parameterName;
+            const propertyPath = typeof propertyName === 'string' ? propertyName : parameterName;
             requestOptions[parameterName] = formInspector.getValueByPath('/' + propertyPath);
         });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -4,7 +4,7 @@ import {computed, observable, intercept, toJS, reaction} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import equal from 'fast-deep-equal';
 import {observer} from 'mobx-react';
-import {FormInspector} from '../../../containers';
+import FormInspector from '../FormInspector';
 import List from '../../../containers/List';
 import ListStore from '../../../containers/List/stores/ListStore';
 import MultiAutoComplete from '../../../containers/MultiAutoComplete';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -169,13 +169,13 @@ class Selection extends React.Component<Props> {
         const requestOptions = {};
 
         requestParameters.forEach((parameter) => {
-            requestOptions[String(parameter.name)] = parameter.value;
+            requestOptions[parameter.name] = parameter.value;
         });
 
         resourceStorePropertiesToRequest.forEach((propertyToRequest) => {
             const {name: parameterName, value: propertyName} = propertyToRequest;
-            const propertyPath = String(propertyName || parameterName);
-            requestOptions[String(parameterName)] = formInspector.getValueByPath('/' + propertyPath);
+            const propertyPath = propertyName || parameterName;
+            requestOptions[parameterName] = formInspector.getValueByPath('/' + propertyPath);
         });
 
         return requestOptions;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -67,14 +67,6 @@ class Selection extends React.Component<Props> {
                 value,
             } = this.props;
 
-            if (!Array.isArray(requestParameters)) {
-                throw new Error('The "request_parameters" schemaOption must be an array!');
-            }
-
-            if (!Array.isArray(resourceStorePropertiesToRequest)) {
-                throw new Error('The "resource_store_properties_to_request" schemaOption must be an array!');
-            }
-
             this.listStore = new ListStore(
                 resourceKey,
                 listKey || resourceKey,
@@ -166,6 +158,14 @@ class Selection extends React.Component<Props> {
         resourceStorePropertiesToRequest: Array<SchemaOption>,
         formInspector: FormInspector
     ) {
+        if (!Array.isArray(requestParameters)) {
+            throw new Error('The "request_parameters" schemaOption must be an array!');
+        }
+
+        if (!Array.isArray(resourceStorePropertiesToRequest)) {
+            throw new Error('The "resource_store_properties_to_request" schemaOption must be an array!');
+        }
+
         const requestOptions = {};
 
         requestParameters.forEach((parameter) => {
@@ -233,14 +233,6 @@ class Selection extends React.Component<Props> {
             },
             value,
         } = this.props;
-
-        if (!Array.isArray(requestParameters)) {
-            throw new Error('The "request_parameters" schemaOption must be an array!');
-        }
-
-        if (!Array.isArray(resourceStorePropertiesToRequest)) {
-            throw new Error('The "resource_store_properties_to_request" schemaOption must be an array!');
-        }
 
         if (types !== undefined && typeof types !== 'string') {
             throw new Error('The "types" schema option must be a string if given!');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -57,6 +57,14 @@ class Selection extends React.Component<Props> {
             throw new Error('The selection field needs a "resource_key" option to work properly');
         }
 
+        if (!Array.isArray(requestParameters)) {
+            throw new Error('The "request_parameters" schemaOption must be an array!');
+        }
+
+        if (!Array.isArray(resourceStorePropertiesToRequest)) {
+            throw new Error('The "resource_store_properties_to_request" schemaOption must be an array!');
+        }
+
         this.requestOptions = this.buildRequestOptions(
             requestParameters,
             resourceStorePropertiesToRequest,
@@ -184,14 +192,6 @@ class Selection extends React.Component<Props> {
         resourceStorePropertiesToRequest: Array<SchemaOption>,
         formInspector: FormInspector
     ) {
-        if (!Array.isArray(requestParameters)) {
-            throw new Error('The "request_parameters" schemaOption must be an array!');
-        }
-
-        if (!Array.isArray(resourceStorePropertiesToRequest)) {
-            throw new Error('The "resource_store_properties_to_request" schemaOption must be an array!');
-        }
-
         const requestOptions = {};
 
         requestParameters.forEach((parameter) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -72,10 +72,11 @@ class Selection extends React.Component<Props> {
         );
 
         // update requestOptions observable if one of the "resource_store_properties_to_request" properties is changed
-        const observedDataPaths = resourceStorePropertiesToRequest.map((property) => {
-            return typeof property.value === 'string' ? '/' + property.value : '/' + property.name;
-        });
         formInspector.addFinishFieldHandler((dataPath) => {
+            const observedDataPaths = resourceStorePropertiesToRequest.map((property) => {
+                return typeof property.value === 'string' ? '/' + property.value : '/' + property.name;
+            });
+
             if (observedDataPaths.includes(dataPath)) {
                 const newRequestOptions = this.buildRequestOptions(
                     requestParameters,
@@ -201,7 +202,7 @@ class Selection extends React.Component<Props> {
         resourceStorePropertiesToRequest.forEach((propertyToRequest) => {
             const {name: parameterName, value: propertyName} = propertyToRequest;
             const propertyPath = typeof propertyName === 'string' ? propertyName : parameterName;
-            requestOptions[parameterName] = formInspector.getValueByPath('/' + propertyPath);
+            requestOptions[parameterName] = toJS(formInspector.getValueByPath('/' + propertyPath));
         });
 
         return requestOptions;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
@@ -332,7 +332,7 @@ test('Merge with options from fieldRegistry before passing props to FieldType', 
         maxOccurs: 4,
         minOccurs: 2,
         options: {
-            anotherOption: {value: 'anotherValue'},
+            anotherOption: {name: 'anotherOption', value: 'anotherValue'},
         },
         type: 'text_line',
         types: {},

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
@@ -361,7 +361,7 @@ test('Merge with options from fieldRegistry before passing props to FieldType', 
         maxOccurs: 4,
         minOccurs: 2,
         schemaOptions: {
-            anotherOption: {value: 'anotherValue'},
+            anotherOption: {name: 'anotherOption', value: 'anotherValue'},
         },
         showAllErrors: true,
         types: {},

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Checkbox.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Checkbox.test.js
@@ -20,7 +20,7 @@ test('Pass the label correctly to Checkbox component', () => {
             {...fieldTypeDefaultProps}
             formInspector={formInspector}
             label="Test"
-            schemaOptions={{label: {title: 'Checkbox Title'}}}
+            schemaOptions={{label: {name: 'label', title: 'Checkbox Title'}}}
         />
     );
     expect(checkbox.find(CheckboxComponent).prop('children')).toEqual('Checkbox Title');
@@ -34,7 +34,7 @@ test('Pass disabled correctly to Checkbox component', () => {
             disabled={true}
             formInspector={formInspector}
             label="Test"
-            schemaOptions={{label: {title: 'Checkbox Title'}}}
+            schemaOptions={{label: {name: 'label', title: 'Checkbox Title'}}}
         />
     );
     expect(checkbox.find(CheckboxComponent).props().disabled).toEqual(true);
@@ -44,7 +44,8 @@ test('Should throw an exception if defaultValue is of wrong type', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
     const schemaOptions = {
         default_value: {
-            value: {},
+            name: 'default_value',
+            value: 'not-boolean',
         },
     };
 
@@ -52,7 +53,7 @@ test('Should throw an exception if defaultValue is of wrong type', () => {
         <Checkbox
             {...fieldTypeDefaultProps}
             formInspector={formInspector}
-            schemaOptions={(schemaOptions: any)}
+            schemaOptions={schemaOptions}
         />
     )).toThrow(/"default_value"/);
 });
@@ -63,6 +64,7 @@ test('Set default value of null should not call onChange', () => {
 
     const schemaOptions = {
         default_value: {
+            name: 'default_value',
             value: null,
         },
     };
@@ -72,7 +74,7 @@ test('Set default value of null should not call onChange', () => {
             {...fieldTypeDefaultProps}
             formInspector={formInspector}
             onChange={changeSpy}
-            schemaOptions={(schemaOptions: any)}
+            schemaOptions={schemaOptions}
         />
     );
 
@@ -85,6 +87,7 @@ test('Set default value if no value is passed', () => {
 
     const schemaOptions = {
         default_value: {
+            name: 'default_value',
             value: false,
         },
     };
@@ -94,7 +97,7 @@ test('Set default value if no value is passed', () => {
             {...fieldTypeDefaultProps}
             formInspector={formInspector}
             onChange={changeSpy}
-            schemaOptions={(schemaOptions: any)}
+            schemaOptions={schemaOptions}
         />
     );
 
@@ -107,6 +110,7 @@ test('Do not set default value if a value is passed', () => {
 
     const schemaOptions = {
         default_value: {
+            name: 'default_value',
             value: false,
         },
     };
@@ -116,7 +120,7 @@ test('Do not set default value if a value is passed', () => {
             {...fieldTypeDefaultProps}
             formInspector={formInspector}
             onChange={changeSpy}
-            schemaOptions={(schemaOptions: any)}
+            schemaOptions={schemaOptions}
             value={false}
         />
     );
@@ -169,12 +173,17 @@ test('Call onChange and onFinish on the changed callback of the Checkbox', () =>
 
 test('Pass the label correctly to Toggler component', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'snippets'));
+    const schemaOptions = {
+        label: {name: 'label', title: 'Toggler Title'},
+        type: {name: 'type', value: 'toggler'},
+    };
+
     const checkbox = shallow(
         <Checkbox
             {...fieldTypeDefaultProps}
             formInspector={formInspector}
             label="Test"
-            schemaOptions={{label: {title: 'Toggler Title'}, type: {value: 'toggler'}}}
+            schemaOptions={schemaOptions}
         />
     );
     expect(checkbox.find(Toggler).prop('children')).toEqual('Toggler Title');
@@ -182,13 +191,18 @@ test('Pass the label correctly to Toggler component', () => {
 
 test('Pass disabled correctly to Toggler component', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'snippets'));
+    const schemaOptions = {
+        label: {name: 'label', title: 'Toggler Title'},
+        type: {name: 'type', value: 'toggler'},
+    };
+
     const checkbox = shallow(
         <Checkbox
             {...fieldTypeDefaultProps}
             disabled={true}
             formInspector={formInspector}
             label="Test"
-            schemaOptions={{label: {title: 'Toggler Title'}, type: {value: 'toggler'}}}
+            schemaOptions={schemaOptions}
         />
     );
     expect(checkbox.find(Toggler).props().disabled).toEqual(true);
@@ -201,7 +215,7 @@ test('Pass the value of true correctly to Toggler component', () => {
             {...fieldTypeDefaultProps}
             formInspector={formInspector}
             label="Test"
-            schemaOptions={{type: {value: 'toggler'}}}
+            schemaOptions={{type: {name: 'type', value: 'toggler'}}}
             value={true}
         />
     );
@@ -214,7 +228,7 @@ test('Pass the value of false correctly to Toggler component', () => {
         <Checkbox
             {...fieldTypeDefaultProps}
             formInspector={formInspector}
-            schemaOptions={{type: {value: 'toggler'}}}
+            schemaOptions={{type: {name: 'type', value: 'toggler'}}}
             value={false}
         />
     );
@@ -232,7 +246,7 @@ test('Call onChange and onFinish on the changed callback of the Toggler', () => 
             formInspector={formInspector}
             onChange={changeSpy}
             onFinish={finishSpy}
-            schemaOptions={{type: {value: 'toggler'}}}
+            schemaOptions={{type: {name: 'type', value: 'toggler'}}}
         />
     );
     checkbox.find(Toggler).simulate('change', true);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Input.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Input.test.js
@@ -46,6 +46,7 @@ test('Pass props correctly to Input component', () => {
 test('Pass headline prop correctly', () => {
     const schemaOptions = {
         headline: {
+            name: 'headline',
             value: true,
         },
     };
@@ -64,12 +65,15 @@ test('Pass headline prop correctly', () => {
 test('Pass props correctly including maxCharacters to Input component', () => {
     const schemaOptions = {
         max_characters: {
+            name: 'max_characters',
             value: '70',
         },
         max_segments: {
+            name: 'max_segments',
             value: '6',
         },
         segment_delimiter: {
+            name: 'segment_delimiter',
             value: ',',
         },
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Number.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Number.test.js
@@ -45,12 +45,15 @@ test('Pass props correctly to component inclusive schemaOptions', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'snippets'));
     const schemaOptions = {
         min: {
+            name: 'min',
             value: 50,
         },
         max: {
+            name: 'max',
             value: 100,
         },
         step: {
+            name: 'step',
             value: 10,
         },
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Select.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Select.test.js
@@ -15,6 +15,7 @@ test('Pass props correctly to Select', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
     const schemaOptions = {
         values: {
+            name: 'values',
             value: [
                 {
                     name: 'mr',
@@ -53,9 +54,11 @@ test('Should throw an exception if defaultValue is of wrong type', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
     const schemaOptions = {
         default_values: {
+            name: 'default_values',
             value: {},
         },
         values: {
+            name: 'values',
             value: [
                 {
                     name: 'mr',
@@ -82,6 +85,7 @@ test('Should throw an exception if value is of wrong type', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
     const schemaOptions = {
         values: {
+            name: 'values',
             value: [
                 {
                     name: [],
@@ -110,6 +114,7 @@ test('Should call onChange with undefined if value is changed to an empty array'
     const finishSpy = jest.fn();
     const schemaOptions = {
         values: {
+            name: 'values',
             value: [
                 {
                     name: 'mr',
@@ -144,6 +149,7 @@ test('Should call onFinish callback on every onChange', () => {
     const finishSpy = jest.fn();
     const schemaOptions = {
         values: {
+            name: 'values',
             value: [
                 {
                     name: 'mr',
@@ -176,9 +182,10 @@ test('Set default value of null should not call onChange', () => {
     const changeSpy = jest.fn();
     const schemaOptions = {
         default_values: {
-            name: null,
+            name: 'default_values',
         },
         values: {
+            name: 'values',
             value: [
                 {
                     name: 'mr',
@@ -208,9 +215,11 @@ test('Set default value if no value is passed', () => {
     const changeSpy = jest.fn();
     const schemaOptions = {
         default_values: {
+            name: 'default_values',
             value: [{name: 'mr'}],
         },
         values: {
+            name: 'values',
             value: [
                 {
                     name: 'mr',
@@ -240,9 +249,11 @@ test('Set default value to a number of 0 should work', () => {
     const changeSpy = jest.fn();
     const schemaOptions = {
         default_values: {
+            name: 'default_values',
             value: [{name: 0}],
         },
         values: {
+            name: 'values',
             value: [
                 {
                     name: 0,
@@ -283,7 +294,7 @@ test('Throw error if value option with wrong is passed', () => {
         <Select
             {...fieldTypeDefaultProps}
             formInspector={formInspector}
-            schemaOptions={{values: {value: true}}}
+            schemaOptions={{values: {name: 'values', value: true}}}
         />)
     ).toThrow(/"values"/);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -245,6 +245,7 @@ test('Should pass props with schema-options correctly to MultiSelection componen
             value: 'image,video',
         },
         allow_deselect_for_disabled_items: {
+            name: 'allow_deselect_for_disabled_items',
             value: false,
         },
         item_disabled_condition: {
@@ -453,13 +454,19 @@ test('Should throw an error if "allow_deselect_for_disabled_items" schema option
             list_overlay: {},
         },
     };
+    const schemaOptions = {
+        allow_deselect_for_disabled_items: {
+            name: 'allow_deselect_for_disabled_items',
+            value: 'not-boolean',
+        },
+    };
 
     expect(() => shallow(
         <Selection
             {...fieldTypeDefaultProps}
             fieldTypeOptions={fieldTypeOptions}
             formInspector={formInspector}
-            schemaOptions={{allow_deselect_for_disabled_items: {value: 'not-boolean'}}}
+            schemaOptions={schemaOptions}
         />
     )).toThrowError(/"allow_deselect_for_disabled_items"/);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -86,6 +86,7 @@ test('Should pass props correctly to MultiSelection component', () => {
 
     const schemaOptions = {
         types: {
+            name: 'types',
             value: 'test',
         },
     };
@@ -240,6 +241,7 @@ test('Should pass props with schema-options correctly to MultiSelection componen
             value: 'list_overlay',
         },
         types: {
+            name: 'types',
             value: 'image,video',
         },
         allow_deselect_for_disabled_items: {
@@ -250,6 +252,7 @@ test('Should pass props with schema-options correctly to MultiSelection componen
             value: 'status == "inactive"',
         },
         request_parameters: {
+            name: 'request_parameters',
             value: [
                 {
                     name: 'staticKey',
@@ -258,6 +261,7 @@ test('Should pass props with schema-options correctly to MultiSelection componen
             ],
         },
         resource_store_properties_to_request: {
+            name: 'resource_store_properties_to_request',
             value: [
                 {
                     name: 'dynamicKey',
@@ -415,7 +419,7 @@ test('Should throw an error if "types" schema option is not a string', () => {
             {...fieldTypeDefaultProps}
             fieldTypeOptions={fieldTypeOptions}
             formInspector={formInspector}
-            schemaOptions={{types: {value: []}}}
+            schemaOptions={{types: {name: 'type', value: []}}}
         />
     )).toThrowError(/"types"/);
 });
@@ -435,7 +439,7 @@ test('Should throw an error if "item_disabled_condition" schema option is not a 
             {...fieldTypeDefaultProps}
             fieldTypeOptions={fieldTypeOptions}
             formInspector={formInspector}
-            schemaOptions={{item_disabled_condition: {value: []}}}
+            schemaOptions={{item_disabled_condition: {name: 'item_disabled_condition', value: []}}}
         />
     )).toThrowError(/"item_disabled_condition"/);
 });
@@ -475,7 +479,7 @@ test('Should throw an error if "request_parameters" schema option is not an arra
             {...fieldTypeDefaultProps}
             fieldTypeOptions={fieldTypeOptions}
             formInspector={formInspector}
-            schemaOptions={{request_parameters: {value: 'not-an-array'}}}
+            schemaOptions={{request_parameters: {name: 'request_parameters', value: 'not-an-array'}}}
         />
     )).toThrowError(/"request_parameters"/);
 });
@@ -489,13 +493,16 @@ test('Should throw an error if "resource_store_properties_to_request" schema opt
             list_overlay: {},
         },
     };
+    const schemaOptions = {
+        resource_store_properties_to_request: {name: 'resource_store_properties_to_request', value: 'not-an-array'},
+    };
 
     expect(() => shallow(
         <Selection
             {...fieldTypeDefaultProps}
             fieldTypeOptions={fieldTypeOptions}
             formInspector={formInspector}
-            schemaOptions={{resource_store_properties_to_request: {value: 'not-an-array'}}}
+            schemaOptions={schemaOptions}
         />
     )).toThrowError(/"resource_store_properties_to_request"/);
 });
@@ -670,6 +677,7 @@ test('Should pass correct parameters to listStore', () => {
 
     const schemaOptions = {
         request_parameters: {
+            name: 'request_parameters',
             value: [
                 {
                     name: 'staticKey',
@@ -678,6 +686,7 @@ test('Should pass correct parameters to listStore', () => {
             ],
         },
         resource_store_properties_to_request: {
+            name: 'resource_store_properties_to_request',
             value: [
                 {
                     name: 'dynamicKey',
@@ -885,6 +894,7 @@ test('Should update listStore when the value of a "resource_store_properties_to_
 
     const schemaOptions = {
         resource_store_properties_to_request: {
+            name: 'resource_store_properties_to_request',
             value: [
                 {
                     name: 'dynamicKey',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -275,7 +275,9 @@ test('Should pass props with schema-options correctly to MultiSelection componen
             'pages'
         )
     );
-    formInspector.getValueByPath.mockReturnValue('value-returned-by-form-inspector');
+
+    const formInspectorValues = {'/otherPropertyName': 'value-returned-by-form-inspector'};
+    formInspector.getValueByPath.mockImplementation((path) => formInspectorValues[path]);
 
     const selection = shallow(
         <Selection
@@ -693,7 +695,9 @@ test('Should pass correct parameters to listStore', () => {
             'pages'
         )
     );
-    formInspector.getValueByPath.mockReturnValue('value-returned-by-form-inspector');
+
+    const formInspectorValues = {'/otherPropertyName': 'value-returned-by-form-inspector'};
+    formInspector.getValueByPath.mockImplementation((path) => formInspectorValues[path]);
 
     const selection = shallow(
         <Selection
@@ -899,8 +903,8 @@ test('Should update listStore when the value of a "resource_store_properties_to_
         )
     );
 
-    const resourceStoreData = observable({'/otherPropertyName': 'first-value'});
-    formInspector.getValueByPath.mockImplementation((path) => resourceStoreData[path]);
+    const formInspectorValues = observable({'/otherPropertyName': 'first-value'});
+    formInspector.getValueByPath.mockImplementation((path) => formInspectorValues[path]);
 
     const selection = shallow(
         <Selection
@@ -918,7 +922,7 @@ test('Should update listStore when the value of a "resource_store_properties_to_
     });
 
     selection.instance().listStore.selectionIds = [12, 14];
-    resourceStoreData['/otherPropertyName'] = 'second-value';
+    formInspectorValues['/otherPropertyName'] = 'second-value';
 
     expect(selection.instance().listStore.options).toEqual({
         dynamicKey: 'second-value',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelect.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelect.test.js
@@ -16,6 +16,7 @@ test('Pass props correctly to SingleSelect', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
     const schemaOptions = observable({
         values: {
+            name: 'values',
             value: [
                 {
                     name: 'mr',
@@ -54,6 +55,7 @@ test('Pass value if no title is given to SingleSelect', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
     const schemaOptions = observable({
         values: {
+            name: 'values',
             value: [
                 {
                     name: 'mr',
@@ -86,9 +88,11 @@ test('Should throw an exception if defaultValue is of wrong type', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
     const schemaOptions = {
         default_value: {
+            name: 'default_value',
             value: [],
         },
         values: {
+            name: 'values',
             value: [
                 {
                     name: 'mr',
@@ -115,6 +119,7 @@ test('Should throw an exception if value is of wrong type', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
     const schemaOptions = {
         values: {
+            name: 'values',
             value: [
                 {
                     name: [],
@@ -142,6 +147,7 @@ test('Should call onFinish callback on every onChange', () => {
     const finishSpy = jest.fn();
     const schemaOptions = {
         values: {
+            name: 'values',
             value: [
                 {
                     name: 'mr',
@@ -174,9 +180,11 @@ test('Set default value of null should not call onChange', () => {
     const changeSpy = jest.fn();
     const schemaOptions = {
         default_value: {
+            name: 'default_value',
             value: null,
         },
         values: {
+            name: 'values',
             value: [
                 {
                     name: 'mr',
@@ -206,9 +214,11 @@ test('Set default value if no value is passed', () => {
     const changeSpy = jest.fn();
     const schemaOptions = {
         default_value: {
+            name: 'default_value',
             value: 'mr',
         },
         values: {
+            name: 'values',
             value: [
                 {
                     name: 'mr',
@@ -238,9 +248,11 @@ test('Set default value to a number of 0 should work', () => {
     const changeSpy = jest.fn();
     const schemaOptions = {
         default_value: {
+            name: 'default_value',
             value: 0,
         },
         values: {
+            name: 'values',
             value: [
                 {
                     name: 0,
@@ -281,7 +293,7 @@ test('Throw error if value option with wrong is passed', () => {
         <SingleSelect
             {...fieldTypeDefaultProps}
             formInspector={formInspector}
-            schemaOptions={{values: {value: true}}}
+            schemaOptions={{values: {name: 'values', value: true}}}
         />)
     ).toThrow(/"values"/);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
@@ -619,19 +619,22 @@ test('Pass correct props with schema-options type to SingleItemSelection', () =>
 
     const schemaOptions = {
         allow_deselect_for_disabled_items: {
+            name: 'allow_deselect_for_disabled_items',
             value: false,
         },
         form_options_to_list_options: {
-            name: 'formOptionsToApi',
+            name: 'form_options_to_list_options',
             value: [
                 {name: 'segment'},
                 {name: 'webspace'},
             ],
         },
         type: {
+            name: 'type',
             value: 'list_overlay',
         },
         item_disabled_condition: {
+            name: 'item_disabled_condition',
             value: 'status == "inactive"',
         },
         types: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
@@ -280,7 +280,7 @@ test('Pass correct props to SingleSelect', () => {
             disabled={true}
             fieldTypeOptions={fieldTypeOptions}
             formInspector={formInspector}
-            schemaOptions={{editable: {value: true}}}
+            schemaOptions={{editable: {name: 'editable', value: true}}}
             value={value}
         />
     );
@@ -635,6 +635,7 @@ test('Pass correct props with schema-options type to SingleItemSelection', () =>
             value: 'status == "inactive"',
         },
         types: {
+            name: 'types',
             value: 'test',
         },
     };
@@ -857,7 +858,7 @@ test('Should throw an error if "types" schema option is not a string', () => {
             {...fieldTypeDefaultProps}
             fieldTypeOptions={fieldTypeOptions}
             formInspector={formInspector}
-            schemaOptions={{types: {value: []}}}
+            schemaOptions={{types: {name: 'types', value: []}}}
         />
     )).toThrowError(/"types"/);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SmartContent.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SmartContent.test.js
@@ -67,6 +67,7 @@ test('Should correctly initialize SmartContentStore', () => {
 
     const schemaOptions = {
         provider: {
+            name: 'provider',
             value: 'media',
         },
     };
@@ -98,6 +99,7 @@ test('Should correctly initialize SmartContentStore with a exclude_duplicates va
 
     const schemaOptions = {
         exclude_duplicates: {
+            name: 'exclude_duplicates',
             value: true,
         },
     };
@@ -126,6 +128,7 @@ test('Defer start of smartContentStore until all previous stores have loaded the
 
     const schemaOptions = {
         exclude_duplicates: {
+            name: 'exclude_duplicates',
             value: true,
         },
     };
@@ -172,6 +175,7 @@ test('Should pass id to SmartContentStore if resourceKeys match', () => {
 
     const schemaOptions = {
         provider: {
+            name: 'provider',
             value: 'pages',
         },
     };
@@ -194,12 +198,15 @@ test('Pass correct props to SmartContent component', () => {
 
     const schemaOptions = {
         category_root: {
+            name: 'category_root',
             value: 'test1',
         },
         provider: {
+            name: 'provider',
             value: 'media',
         },
         present_as: {
+            name: 'present_as',
             value: [
                 {name: 'one', title: 'One column'},
                 {name: 'two', title: 'Two column'},
@@ -233,6 +240,7 @@ test('Should not call the onChange and onFinish callbacks if SmartContentStore i
 
     const schemaOptions = {
         provider: {
+            name: 'provider',
             value: 'media',
         },
     };
@@ -266,6 +274,7 @@ test('Should call the onChange and onFinish callbacks if SmartContentStore chang
 
     const schemaOptions = {
         provider: {
+            name: 'provider',
             value: 'media',
         },
     };
@@ -311,6 +320,7 @@ test('Should not call the onChange and onFinish callbacks if categories only dif
 
     const schemaOptions = {
         provider: {
+            name: 'provider',
             value: 'media',
         },
     };
@@ -360,6 +370,7 @@ test('Should not call the onChange and onFinish callbacks if tags only differ in
 
     const schemaOptions = {
         provider: {
+            name: 'provider',
             value: 'media',
         },
     };
@@ -393,6 +404,7 @@ test('Should call destroy on SmartContentStore when unmounted', () => {
 
     const schemaOptions = {
         provider: {
+            name: 'provider',
             value: 'media',
         },
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/TextArea.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/TextArea.test.js
@@ -46,6 +46,7 @@ test('Pass props correctly to TextArea component', () => {
 test('Pass props correctly including max_characters to TextArea component', () => {
     const schemaOptions = {
         max_characters: {
+            name: 'max_characters',
             value: '70',
         },
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Url.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Url.test.js
@@ -15,6 +15,7 @@ jest.mock('../../FormInspector', () => jest.fn());
 test('Pass error prop correctly to Url component', () => {
     const schemaOptions = {
         schemes: {
+            name: 'schemes',
             value: [
                 {name: 'http://'},
                 {name: 'https://'},
@@ -40,6 +41,7 @@ test('Pass error prop correctly to Url component', () => {
 test('Pass props correctly to Url component', () => {
     const schemaOptions = {
         schemes: {
+            name: 'schemes',
             value: [
                 {name: 'http://'},
                 {name: 'https://'},
@@ -66,6 +68,7 @@ test('Pass props correctly to Url component', () => {
 test('Not call changed when only protocol is given', () => {
     const schemaOptions = {
         defaults: {
+            name: 'defaults',
             value: [
                 {name: 'scheme', value: 'http://'},
             ],
@@ -92,6 +95,7 @@ test('Not call changed when only protocol is given', () => {
 test('Pass correct default props to Url component', () => {
     const schemaOptions = {
         defaults: {
+            name: 'defaults',
             value: [
                 {name: 'scheme', value: 'http://'},
                 {name: 'specific_part', value: 'github.com'},
@@ -117,12 +121,14 @@ test('Pass correct default props to Url component', () => {
 test('Throw error if only specific_part default is set', () => {
     const schemaOptions = {
         schemes: {
+            name: 'schemes',
             value: [
                 {name: 'http://'},
                 {name: 'https://'},
             ],
         },
         defaults: {
+            name: 'defaults',
             value: [
                 {name: 'specific_part', value: 'sulu.io'},
             ],
@@ -144,12 +150,14 @@ test('Do not build URL from defaults if value is already given', () => {
 
     const schemaOptions = {
         schemes: {
+            name: 'schemes',
             value: [
                 {name: 'http://'},
                 {name: 'https://'},
             ],
         },
         defaults: {
+            name: 'defaults',
             value: [
                 {name: 'scheme', value: 'https://'},
                 {name: 'specific_part', value: 'sulu.io'},
@@ -176,12 +184,14 @@ test('Build URL from defaults to pass as value to URL component', () => {
 
     const schemaOptions = {
         schemes: {
+            name: 'schemes',
             value: [
                 {name: 'http://'},
                 {name: 'https://'},
             ],
         },
         defaults: {
+            name: 'defaults',
             value: [
                 {name: 'scheme', value: 'https://'},
                 {name: 'specific_part', value: 'sulu.io'},
@@ -205,6 +215,7 @@ test('Build URL from defaults to pass as value to URL component', () => {
 test('Should not pass any arguments to onFinish callback', () => {
     const schemaOptions = {
         schemes: {
+            name: 'schemes',
             value: [
                 {name: 'http://'},
                 {name: 'https://'},

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -45,7 +45,7 @@ export type ErrorCollection = {[key: string]: Error};
 
 export type SchemaOption = {
     infoText?: string,
-    name?: string | number,
+    name: string | number,
     title?: string,
     value?: ?string | number | boolean | Array<SchemaOption>,
 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
@@ -498,7 +498,7 @@ export default class ListStore {
         this.pendingRequest = this.loadingStrategy.load(
             this.resourceKey,
             options,
-            options.expandedIds ? undefined : active
+            (options.selectedIds || options.expandedIds) ? undefined : active
         ).then(action((response) => {
             this.pendingRequest = undefined;
             this.pageCount = response.pages;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/MultiListOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/MultiListOverlay.js
@@ -45,6 +45,7 @@ class MultiListOverlay extends React.Component<Props> {
     listStore: ListStore;
     page: IObservableValue<number> = observable.box(1);
     excludedIdsDisposer: () => void;
+    changeOptionsDisposer: () => *;
 
     constructor(props: Props) {
         super(props);
@@ -87,6 +88,7 @@ class MultiListOverlay extends React.Component<Props> {
     componentWillUnmount() {
         this.listStore.destroy();
         this.excludedIdsDisposer();
+        this.changeOptionsDisposer();
     }
 
     handleConfirm = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/MultiListOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/MultiListOverlay.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {computed, observable} from 'mobx';
+import {computed, observable, reaction, comparer} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import ListStore from '../../containers/List/stores/ListStore';
@@ -67,7 +67,20 @@ class MultiListOverlay extends React.Component<Props> {
             USER_SETTINGS_KEY,
             observableOptions,
             options,
+            undefined,
             preloadSelectedItems ? preSelectedItems.map((preSelectedItem) => preSelectedItem.id) : undefined
+        );
+
+        this.changeOptionsDisposer = reaction(
+            () => this.props.options,
+            (options) => {
+                // reset liststore to reload whole tree instead of children of current active item
+                this.listStore.reset();
+                // set selected items as initialSelectionIds to expand them in case of a tree
+                this.listStore.initialSelectionIds = this.listStore.selectionIds;
+                this.listStore.options = {...this.listStore.options, ...options};
+            },
+            {equals: comparer.structural}
         );
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/MultiListOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/MultiListOverlay.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {computed, observable, reaction, comparer} from 'mobx';
+import {comparer, computed, observable, reaction} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import ListStore from '../../containers/List/stores/ListStore';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/tests/MultiListOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/tests/MultiListOverlay.test.js
@@ -23,7 +23,9 @@ jest.mock('../../../containers/List/stores/ListStore', () => jest.fn(
         this.observableOptions = observableOptions;
         this.select = jest.fn();
         this.clear = jest.fn();
+        this.reset = jest.fn();
         this.selections = [];
+        this.selectionIds = [];
     }
 ));
 
@@ -51,6 +53,66 @@ test('Should instantiate the ListStore with locale, excluded-ids and options', (
     expect(multiListOverlay.instance().listStore.observableOptions.locale.get()).toEqual('en');
     expect(multiListOverlay.instance().listStore.observableOptions.excludedIds.get()).toEqual(['id-1', 'id-2']);
     expect(multiListOverlay.instance().listStore.options).toBe(options);
+});
+
+test('Should update options of ListStore if the options prop is changed', () => {
+    const oldOptions = {key: 'value-1'};
+
+    const multiListOverlay = shallow(
+        <MultiListOverlay
+            adapter="table"
+            excludedIds={['id-1', 'id-2']}
+            listKey="snippets_list"
+            locale={observable.box('en')}
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+            open={false}
+            options={oldOptions}
+            resourceKey="snippets"
+            title="Selection"
+        />
+    );
+    multiListOverlay.instance().listStore.selectionIds = [12, 14];
+
+    expect(multiListOverlay.instance().listStore.reset).not.toBeCalled();
+    expect(multiListOverlay.instance().listStore.options).toEqual(oldOptions);
+
+    const newOptions = {key: 'value-2'};
+    multiListOverlay.setProps({
+        options: newOptions,
+    });
+
+    expect(multiListOverlay.instance().listStore.reset).toBeCalled();
+    expect(multiListOverlay.instance().listStore.initialSelectionIds).toEqual([12, 14]);
+    expect(multiListOverlay.instance().listStore.options).toEqual(newOptions);
+});
+
+test('Should not update options of ListStore if new value of options prop is equal to old value', () => {
+    const oldOptions = {key: 'value-1'};
+
+    const multiListOverlay = shallow(
+        <MultiListOverlay
+            adapter="table"
+            excludedIds={['id-1', 'id-2']}
+            listKey="snippets_list"
+            locale={observable.box('en')}
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+            open={false}
+            options={oldOptions}
+            resourceKey="snippets"
+            title="Selection"
+        />
+    );
+
+    expect(multiListOverlay.instance().listStore.reset).not.toBeCalled();
+
+    const newOldOptions = {key: 'value-1'};
+    multiListOverlay.setProps({
+        options: newOldOptions,
+    });
+
+    expect(multiListOverlay.instance().listStore.reset).not.toBeCalled();
 });
 
 test('Should instantiate the ListStore without locale, excluded-ids and options', () => {
@@ -262,6 +324,7 @@ test('Should select the preSelectedItems in the ListStore', () => {
         'multi_list_overlay',
         expect.anything(),
         undefined,
+        undefined,
         [1, 2, 3]
     );
 });
@@ -286,6 +349,7 @@ test('Should not add the preSelectedItems to the ListStore if preloadSelectedIte
         'snippets',
         'multi_list_overlay',
         expect.anything(),
+        undefined,
         undefined,
         undefined
     );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
@@ -51,9 +51,9 @@ class MultiSelection extends React.Component<Props> {
     constructor(props: Props) {
         super(props);
 
-        const {locale, resourceKey, value} = this.props;
+        const {locale, options, resourceKey, value} = this.props;
 
-        this.selectionStore = new MultiSelectionStore(resourceKey, value, locale);
+        this.selectionStore = new MultiSelectionStore(resourceKey, value, locale, 'ids', options);
 
         this.changeSelectionDisposer = reaction(
             () => (this.selectionStore.items.map((item) => item.id)),

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
@@ -1,6 +1,6 @@
 // @flow
 import React, {Fragment} from 'react';
-import {action, observable, reaction, toJS} from 'mobx';
+import {action, comparer, observable, reaction, toJS} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import equals from 'fast-deep-equal';
@@ -43,7 +43,8 @@ class MultiSelection extends React.Component<Props> {
     };
 
     selectionStore: MultiSelectionStore<string | number>;
-    changeDisposer: () => *;
+    changeSelectionDisposer: () => *;
+    changeOptionsDisposer: () => *;
 
     @observable overlayOpen: boolean = false;
 
@@ -53,7 +54,8 @@ class MultiSelection extends React.Component<Props> {
         const {locale, resourceKey, value} = this.props;
 
         this.selectionStore = new MultiSelectionStore(resourceKey, value, locale);
-        this.changeDisposer = reaction(
+
+        this.changeSelectionDisposer = reaction(
             () => (this.selectionStore.items.map((item) => item.id)),
             (loadedItemIds: Array<string | number>) => {
                 const {onChange, value} = this.props;
@@ -62,6 +64,15 @@ class MultiSelection extends React.Component<Props> {
                     onChange(loadedItemIds);
                 }
             }
+        );
+
+        this.changeOptionsDisposer = reaction(
+            () => this.props.options,
+            (options) => {
+                this.selectionStore.setRequestParameters(options);
+                this.selectionStore.loadItems(this.props.value);
+            },
+            {equals: comparer.structural}
         );
     }
 
@@ -77,7 +88,8 @@ class MultiSelection extends React.Component<Props> {
     }
 
     componentWillUnmount() {
-        this.changeDisposer();
+        this.changeSelectionDisposer();
+        this.changeOptionsDisposer();
     }
 
     @action closeOverlay() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/MultiSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/MultiSelection.test.js
@@ -164,19 +164,18 @@ test('Pass locale to MultiListOverlay', () => {
 });
 
 test('Pass options to MultiListOverlay', () => {
-    const options = {types: 'test'};
     const selection = mount(
         <MultiSelection
             adapter="table"
             listKey="snippets"
             onChange={jest.fn()}
-            options={options}
+            options={{types: 'test'}}
             overlayTitle="Selection"
             resourceKey="snippets"
         />
     );
 
-    expect(selection.find('MultiListOverlay').prop('options')).toEqual(options);
+    expect(selection.find('MultiListOverlay').prop('options')).toEqual({types: 'test'});
 });
 
 test('Pass disabledIds to MultiListOverlay', () => {
@@ -213,7 +212,6 @@ test('Pass itemDisabledCondition to MultiListOverlay', () => {
 
 test('Construct MultiSelectionStore with correct parameters', () => {
     const locale = observable.box('en');
-    const options = {key: 'value-1'};
 
     shallow(
         <MultiSelection
@@ -222,19 +220,18 @@ test('Construct MultiSelectionStore with correct parameters', () => {
             listKey="snippets"
             locale={locale}
             onChange={jest.fn()}
-            options={options}
+            options={{key: 'value-1'}}
             overlayTitle="Selection"
             resourceKey="snippets"
             value={[1, 2, 5]}
         />
     );
 
-    expect(MultiSelectionStore).toBeCalledWith('snippets', [1, 2, 5], locale, 'ids', options);
+    expect(MultiSelectionStore).toBeCalledWith('snippets', [1, 2, 5], locale, 'ids', {key: 'value-1'});
 });
 
 test('Update requestParameters and reload items of MultiSelectionStore when options prop is changed', () => {
     const locale = observable.box('en');
-    const oldOptions = {key: 'value-1'};
 
     const selection = shallow(
         <MultiSelection
@@ -243,7 +240,7 @@ test('Update requestParameters and reload items of MultiSelectionStore when opti
             listKey="snippets"
             locale={locale}
             onChange={jest.fn()}
-            options={oldOptions}
+            options={{key: 'value-1'}}
             overlayTitle="Selection"
             resourceKey="snippets"
             value={[1, 2, 5]}
@@ -253,18 +250,16 @@ test('Update requestParameters and reload items of MultiSelectionStore when opti
     expect(selection.instance().selectionStore.setRequestParameters).not.toBeCalled();
     expect(selection.instance().selectionStore.loadItems).not.toBeCalled();
 
-    const newOptions = {key: 'value-2'};
     selection.setProps({
-        options: newOptions,
+        options: {key: 'value-2'},
     });
 
-    expect(selection.instance().selectionStore.setRequestParameters).toBeCalledWith(newOptions);
+    expect(selection.instance().selectionStore.setRequestParameters).toBeCalledWith({key: 'value-2'});
     expect(selection.instance().selectionStore.loadItems).toBeCalledWith([1, 2, 5]);
 });
 
 test('Not reload items of MultiSelectionStore when new value of option prop is equal to old value', () => {
     const locale = observable.box('en');
-    const oldOptions = {key: 'value-1'};
 
     const selection = shallow(
         <MultiSelection
@@ -273,7 +268,7 @@ test('Not reload items of MultiSelectionStore when new value of option prop is e
             listKey="snippets"
             locale={locale}
             onChange={jest.fn()}
-            options={oldOptions}
+            options={{key: 'value-1'}}
             overlayTitle="Selection"
             resourceKey="snippets"
             value={[]}
@@ -283,9 +278,8 @@ test('Not reload items of MultiSelectionStore when new value of option prop is e
     expect(selection.instance().selectionStore.setRequestParameters).not.toBeCalled();
     expect(selection.instance().selectionStore.loadItems).not.toBeCalled();
 
-    const newOldOptions = {key: 'value-1'};
     selection.setProps({
-        options: newOldOptions,
+        options: {key: 'value-1'},
     });
 
     expect(selection.instance().selectionStore.setRequestParameters).not.toBeCalled();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/MultiSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/MultiSelection.test.js
@@ -37,6 +37,7 @@ jest.mock('../../../stores/MultiSelectionStore', () => jest.fn(function() {
     this.move = jest.fn();
     this.removeById = jest.fn();
     this.loadItems = jest.fn();
+    this.setRequestParameters = jest.fn();
 
     mockExtendObservable(this, {
         items: [],
@@ -124,6 +125,28 @@ test('Show with passed icon', () => {
     )).toMatchSnapshot();
 });
 
+test('Show with items', () => {
+    const locale = observable.box('en');
+
+    // $FlowFixMe
+    MultiSelectionStore.mockImplementationOnce(function() {
+        this.items = [{id: 1, title: 'Title 1'}, {id: 2, title: 'Title 2'}, {id: 5, title: 'Title 5'}];
+    });
+
+    expect(render(
+        <MultiSelection
+            adapter="table"
+            displayProperties={['id', 'title']}
+            listKey="snippets"
+            locale={locale}
+            onChange={jest.fn()}
+            overlayTitle="Selection"
+            resourceKey="snippets"
+            value={[1, 2, 5]}
+        />
+    )).toMatchSnapshot();
+});
+
 test('Pass locale to MultiListOverlay', () => {
     const locale = observable.box('de');
     const selection = mount(
@@ -188,28 +211,85 @@ test('Pass itemDisabledCondition to MultiListOverlay', () => {
     expect(selection.find('MultiListOverlay').prop('itemDisabledCondition')).toEqual('status == "inactive"');
 });
 
-test('Show with passed values as items in right locale', () => {
+test('Construct MultiSelectionStore with correct parameters', () => {
     const locale = observable.box('en');
+    const options = {key: 'value-1'};
 
-    // $FlowFixMe
-    MultiSelectionStore.mockImplementationOnce(function() {
-        this.items = [{id: 1, title: 'Title 1'}, {id: 2, title: 'Title 2'}, {id: 5, title: 'Title 5'}];
-    });
-
-    expect(render(
+    shallow(
         <MultiSelection
             adapter="table"
             displayProperties={['id', 'title']}
             listKey="snippets"
             locale={locale}
             onChange={jest.fn()}
+            options={options}
             overlayTitle="Selection"
             resourceKey="snippets"
             value={[1, 2, 5]}
         />
-    )).toMatchSnapshot();
+    );
 
-    expect(MultiSelectionStore).toBeCalledWith('snippets', [1, 2, 5], locale);
+    expect(MultiSelectionStore).toBeCalledWith('snippets', [1, 2, 5], locale, 'ids', options);
+});
+
+test('Update requestParameters and reload items of MultiSelectionStore when options prop is changed', () => {
+    const locale = observable.box('en');
+    const oldOptions = {key: 'value-1'};
+
+    const selection = shallow(
+        <MultiSelection
+            adapter="table"
+            displayProperties={['id', 'title']}
+            listKey="snippets"
+            locale={locale}
+            onChange={jest.fn()}
+            options={oldOptions}
+            overlayTitle="Selection"
+            resourceKey="snippets"
+            value={[1, 2, 5]}
+        />
+    );
+
+    expect(selection.instance().selectionStore.setRequestParameters).not.toBeCalled();
+    expect(selection.instance().selectionStore.loadItems).not.toBeCalled();
+
+    const newOptions = {key: 'value-2'};
+    selection.setProps({
+        options: newOptions,
+    });
+
+    expect(selection.instance().selectionStore.setRequestParameters).toBeCalledWith(newOptions);
+    expect(selection.instance().selectionStore.loadItems).toBeCalledWith([1, 2, 5]);
+});
+
+test('Not reload items of MultiSelectionStore when new value of option prop is equal to old value', () => {
+    const locale = observable.box('en');
+    const oldOptions = {key: 'value-1'};
+
+    const selection = shallow(
+        <MultiSelection
+            adapter="table"
+            displayProperties={['id', 'title']}
+            listKey="snippets"
+            locale={locale}
+            onChange={jest.fn()}
+            options={oldOptions}
+            overlayTitle="Selection"
+            resourceKey="snippets"
+            value={[]}
+        />
+    );
+
+    expect(selection.instance().selectionStore.setRequestParameters).not.toBeCalled();
+    expect(selection.instance().selectionStore.loadItems).not.toBeCalled();
+
+    const newOldOptions = {key: 'value-1'};
+    selection.setProps({
+        options: newOldOptions,
+    });
+
+    expect(selection.instance().selectionStore.setRequestParameters).not.toBeCalled();
+    expect(selection.instance().selectionStore.loadItems).not.toBeCalled();
 });
 
 test('Should open an overlay', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/__snapshots__/MultiSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/__snapshots__/MultiSelection.test.js.snap
@@ -173,61 +173,7 @@ exports[`Show with default plus icon 1`] = `
 </div>
 `;
 
-exports[`Show with passed icon 1`] = `
-<div
-  class="multiItemSelectionClass"
->
-  <div
-    class="header emptyList"
-  >
-    <button
-      class="button left"
-      type="button"
-    >
-      <span
-        aria-label="su-document"
-        class="su-document icon"
-      />
-    </button>
-    <div
-      class="label"
-    />
-  </div>
-  <ul
-    class="list"
-  />
-</div>
-`;
-
-exports[`Show with passed label 1`] = `
-<div
-  class="multiItemSelectionClass"
->
-  <div
-    class="header emptyList"
-  >
-    <button
-      class="button left"
-      type="button"
-    >
-      <span
-        aria-label="su-plus"
-        class="su-plus icon"
-      />
-    </button>
-    <div
-      class="label"
-    >
-      Select Snippets
-    </div>
-  </div>
-  <ul
-    class="list"
-  />
-</div>
-`;
-
-exports[`Show with passed values as items in right locale 1`] = `
+exports[`Show with items 1`] = `
 <div
   class="multiItemSelectionClass"
 >
@@ -545,5 +491,59 @@ exports[`Show with passed values as items in right locale 1`] = `
       </div>
     </li>
   </ul>
+</div>
+`;
+
+exports[`Show with passed icon 1`] = `
+<div
+  class="multiItemSelectionClass"
+>
+  <div
+    class="header emptyList"
+  >
+    <button
+      class="button left"
+      type="button"
+    >
+      <span
+        aria-label="su-document"
+        class="su-document icon"
+      />
+    </button>
+    <div
+      class="label"
+    />
+  </div>
+  <ul
+    class="list"
+  />
+</div>
+`;
+
+exports[`Show with passed label 1`] = `
+<div
+  class="multiItemSelectionClass"
+>
+  <div
+    class="header emptyList"
+  >
+    <button
+      class="button left"
+      type="button"
+    >
+      <span
+        aria-label="su-plus"
+        class="su-plus icon"
+      />
+    </button>
+    <div
+      class="label"
+    >
+      Select Snippets
+    </div>
+  </div>
+  <ul
+    class="list"
+  />
 </div>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/TextEditor/tests/adapters/CKEditor5.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/TextEditor/tests/adapters/CKEditor5.test.js
@@ -37,6 +37,7 @@ test('Pass formats to CKEditor5 component', () => {
 
     const options = {
         formats: {
+            name: 'formats',
             value: [
                 {
                     name: 'h2',
@@ -71,6 +72,7 @@ test('Pass formats to CKEditor5 component', () => {
 test('Throw error if passed formats is not an array', () => {
     const options = {
         formats: {
+            name: 'formats',
             value: 'Test',
         },
     };
@@ -92,6 +94,7 @@ test('Throw error if passed formats is not an array', () => {
 test('Throw error if passed formats is not an array', () => {
     const options = {
         formats: {
+            name: 'formats',
             value: [
                 {
                     name: 'h2',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MultiSelectionStore/MultiSelectionStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MultiSelectionStore/MultiSelectionStore.js
@@ -10,19 +10,21 @@ export default class MultiSelectionStore<T = string | number, U: {id: T} = Objec
     resourceKey: string;
     locale: ?IObservableValue<string>;
     idFilterParameter: string;
+    requestParameters: {[string]: any};
 
     constructor(
         resourceKey: string,
         selectedItemIds: Array<T>,
         locale: ?IObservableValue<string>,
-        idFilterParameter: string = 'ids'
+        idFilterParameter: string = 'ids',
+        requestParameters: {[string]: any} = {}
     ) {
         this.resourceKey = resourceKey;
         this.locale = locale;
         this.idFilterParameter = idFilterParameter;
-        if (selectedItemIds.length) {
-            this.loadItems(selectedItemIds);
-        }
+        this.requestParameters = requestParameters;
+
+        this.loadItems(selectedItemIds);
     }
 
     @action set(items: Array<U>) {
@@ -42,9 +44,13 @@ export default class MultiSelectionStore<T = string | number, U: {id: T} = Objec
         this.loading = loading;
     }
 
-    @action loadItems(itemIds: ?Array<T>) {
+    setRequestParameters(requestParameters: {[string]: string} ) {
+        this.requestParameters = requestParameters;
+    }
+
+    loadItems(itemIds: ?Array<T>) {
         if (!itemIds || itemIds.length === 0) {
-            this.items = [];
+            this.set([]);
             return;
         }
 
@@ -54,8 +60,9 @@ export default class MultiSelectionStore<T = string | number, U: {id: T} = Objec
             [this.idFilterParameter]: itemIds.join(','),
             limit: undefined,
             page: 1,
+            ...this.requestParameters,
         }).then(action((data) => {
-            this.items = data._embedded[this.resourceKey];
+            this.set(data._embedded[this.resourceKey]);
             this.setLoading(false);
         }));
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MultiSelectionStore/MultiSelectionStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MultiSelectionStore/MultiSelectionStore.js
@@ -10,14 +10,14 @@ export default class MultiSelectionStore<T = string | number, U: {id: T} = Objec
     resourceKey: string;
     locale: ?IObservableValue<string>;
     idFilterParameter: string;
-    requestParameters: {[string]: any};
+    requestParameters: {[string]: mixed};
 
     constructor(
         resourceKey: string,
         selectedItemIds: Array<T>,
         locale: ?IObservableValue<string>,
         idFilterParameter: string = 'ids',
-        requestParameters: {[string]: any} = {}
+        requestParameters: {[string]: mixed} = {}
     ) {
         this.resourceKey = resourceKey;
         this.locale = locale;
@@ -44,7 +44,7 @@ export default class MultiSelectionStore<T = string | number, U: {id: T} = Objec
         this.loading = loading;
     }
 
-    setRequestParameters(requestParameters: {[string]: string} ) {
+    setRequestParameters(requestParameters: {[string]: mixed} ) {
         this.requestParameters = requestParameters;
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MultiSelectionStore/tests/MultiSelectionStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MultiSelectionStore/tests/MultiSelectionStore.test.js
@@ -7,7 +7,7 @@ jest.mock('../../../services/ResourceRequester', () => ({
     getList: jest.fn().mockReturnValue(Promise.resolve({})),
 }));
 
-test('Should load items when being constructed', () => {
+test('Should load items with correct paramters when being constructed', () => {
     const listPromise = Promise.resolve({
         _embedded: {
             snippets: [
@@ -18,7 +18,13 @@ test('Should load items when being constructed', () => {
 
     ResourceRequester.getList.mockReturnValue(listPromise);
 
-    const selectionStore = new MultiSelectionStore('snippets', [1, 3, 4], observable.box('en'));
+    const selectionStore = new MultiSelectionStore(
+        'snippets',
+        [1, 3, 4],
+        observable.box('en'),
+        'ids',
+        {additionalKey: 'some-value'}
+    );
 
     expect(ResourceRequester.getList).toBeCalledWith(
         'snippets',
@@ -27,6 +33,7 @@ test('Should load items when being constructed', () => {
             limit: undefined,
             locale: 'en',
             page: 1,
+            additionalKey: 'some-value',
         }
     );
 
@@ -128,6 +135,57 @@ test('Should load items when being constructed without a locale', () => {
             limit: undefined,
             locale: undefined,
             page: 1,
+        }
+    );
+
+    return listPromise.then(() => {
+        expect(toJS(selectionStore.items)).toEqual([
+            {id: 1},
+        ]);
+    });
+});
+
+test('Should load items with requestParameters that are set via setRequestParameters method', () => {
+    const listPromise = Promise.resolve({
+        _embedded: {
+            snippets: [
+                {id: 1},
+            ],
+        },
+    });
+
+    ResourceRequester.getList.mockReturnValue(listPromise);
+
+    const selectionStore = new MultiSelectionStore(
+        'snippets',
+        [1, 3, 4],
+        undefined,
+        'ids',
+        {oldKey: 'old-value'}
+    );
+
+    expect(ResourceRequester.getList).toBeCalledWith(
+        'snippets',
+        {
+            ids: '1,3,4',
+            limit: undefined,
+            locale: undefined,
+            page: 1,
+            oldKey: 'old-value',
+        }
+    );
+
+    selectionStore.setRequestParameters({newKey: 'new-value'});
+    selectionStore.loadItems([1, 3, 4]);
+
+    expect(ResourceRequester.getList).toBeCalledWith(
+        'snippets',
+        {
+            ids: '1,3,4',
+            limit: undefined,
+            locale: undefined,
+            page: 1,
+            newKey: 'new-value',
         }
     );
 

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/containers/ContactAccountSelection/tests/__snapshots__/ContactAccountSelection.test.js.snap
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/containers/ContactAccountSelection/tests/__snapshots__/ContactAccountSelection.test.js.snap
@@ -250,7 +250,6 @@ exports[`Render loading ContactAccountSelection 1`] = `
     <div
       class="label"
     >
-      sulu_contact.contact_account_selection_label
       <div
         class="loader"
       >

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/MediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/MediaSelection.test.js
@@ -74,8 +74,14 @@ test('Pass content-locale of user to MultiMediaSelection if locale is not presen
 test('Set default display option if no value is passed', () => {
     const changeSpy = jest.fn();
     const schemaOptions = {
-        defaultDisplayOption: {value: 'left'},
-        displayOptions: {value: [{name: 'left', value: true}]},
+        defaultDisplayOption: {
+            name: 'defaultDisplayOption',
+            value: 'left',
+        },
+        displayOptions: {
+            name: 'displayOptions',
+            value: [{name: 'left', value: true}],
+        },
     };
 
     const formInspector = new FormInspector(
@@ -100,7 +106,10 @@ test('Set default display option if no value is passed', () => {
 test('Set types on MultiMediaSelection', () => {
     const changeSpy = jest.fn();
     const schemaOptions = {
-        types: {value: 'image,video'},
+        types: {
+            name: 'types',
+            value: 'image,video',
+        },
     };
 
     const formInspector = new FormInspector(
@@ -125,8 +134,14 @@ test('Set types on MultiMediaSelection', () => {
 test('Do not set default display option if value is passed', () => {
     const changeSpy = jest.fn();
     const schemaOptions = {
-        defaultDisplayOption: {value: 'left'},
-        displayOptions: {value: [{name: 'left', value: true}]},
+        defaultDisplayOption: {
+            name: 'defaultDisplayOption',
+            value: 'left',
+        },
+        displayOptions: {
+            name: 'displayOptions',
+            value: [{name: 'left', value: true}],
+        },
     };
 
     const formInspector = new FormInspector(
@@ -189,7 +204,7 @@ test('Should throw an error if displayOptions schemaOption is given but not an a
         <MediaSelection
             {...fieldTypeDefaultProps}
             formInspector={formInspector}
-            schemaOptions={{displayOptions: {value: true}}}
+            schemaOptions={{displayOptions: {name: 'displayOptions', value: true}}}
         />
     )).toThrow(/"displayOptions"/);
 });
@@ -206,7 +221,7 @@ test('Should throw an error if displayOptions schemaOption is given but not an a
         <MediaSelection
             {...fieldTypeDefaultProps}
             formInspector={formInspector}
-            schemaOptions={{displayOptions: {value: true}}}
+            schemaOptions={{displayOptions: {name: 'displayOptions', value: true}}}
         />
     )).toThrow(/"displayOptions"/);
 });
@@ -223,7 +238,7 @@ test('Should throw an error if displayOptions schemaOption is given but contains
         <MediaSelection
             {...fieldTypeDefaultProps}
             formInspector={formInspector}
-            schemaOptions={{displayOptions: {value: [{name: 'test', value: true}]}}}
+            schemaOptions={{displayOptions: {name: 'displayOptions', value: [{name: 'test', value: true}]}}}
         />
     )).toThrow(/"test"/);
 });
@@ -240,7 +255,7 @@ test('Should throw an error if types schemaOption is given but not an array', ()
         <MediaSelection
             {...fieldTypeDefaultProps}
             formInspector={formInspector}
-            schemaOptions={{types: {value: true}}}
+            schemaOptions={{types: {name: 'types', value: true}}}
         />
     )).toThrow(/"types"/);
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/SingleMediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/SingleMediaSelection.test.js
@@ -76,7 +76,7 @@ test('Pass content-locale of user to SingleMediaSelection if locale is not prese
 test('Set types on SingleMediaSelectionComponent', () => {
     const changeSpy = jest.fn();
     const schemaOptions = {
-        types: {value: 'image,video'},
+        types: {name: 'types', value: 'image,video'},
     };
 
     const formInspector = new FormInspector(
@@ -101,8 +101,14 @@ test('Set types on SingleMediaSelectionComponent', () => {
 test('Set default display option if no value is passed', () => {
     const changeSpy = jest.fn();
     const schemaOptions = {
-        defaultDisplayOption: {value: 'left'},
-        displayOptions: {value: [{name: 'left', value: 'true'}]},
+        defaultDisplayOption: {
+            name: 'defaultDisplayOption',
+            value: 'left',
+        },
+        displayOptions: {
+            name: 'displayOptions',
+            value: [{name: 'left', value: 'true'}],
+        },
     };
 
     const formInspector = new FormInspector(
@@ -127,8 +133,14 @@ test('Set default display option if no value is passed', () => {
 test('Do not set default display option if value is passed', () => {
     const changeSpy = jest.fn();
     const schemaOptions = {
-        defaultDisplayOption: {value: 'left'},
-        displayOptions: {value: [{name: 'left', value: 'true'}]},
+        defaultDisplayOption: {
+            name: 'defaultDisplayOption',
+            value: 'left',
+        },
+        displayOptions: {
+            name: 'displayOptions',
+            value: [{name: 'left', value: 'true'}],
+        },
     };
 
     const formInspector = new FormInspector(
@@ -191,7 +203,7 @@ test('Should throw an error if displayOptions schemaOption is given but not an a
         <SingleMediaSelection
             {...fieldTypeDefaultProps}
             formInspector={formInspector}
-            schemaOptions={{displayOptions: {value: true}}}
+            schemaOptions={{displayOptions: {name: 'displayOptions', value: true}}}
         />
     )).toThrow(/"displayOptions"/);
 });
@@ -208,7 +220,7 @@ test('Should throw an error if displayOptions schemaOption is given but not an a
         <SingleMediaSelection
             {...fieldTypeDefaultProps}
             formInspector={formInspector}
-            schemaOptions={{displayOptions: {value: [{name: 'test', value: true}]}}}
+            schemaOptions={{displayOptions: {name: 'displayOptions', value: [{name: 'test', value: true}]}}}
         />
     )).toThrow(/"displayOptions"/);
 });
@@ -225,7 +237,7 @@ test('Should throw an error if types schemaOption is given but not an array', ()
         <SingleMediaSelection
             {...fieldTypeDefaultProps}
             formInspector={formInspector}
-            schemaOptions={{types: {value: true}}}
+            schemaOptions={{types: {name: 'types', value: true}}}
         />
     )).toThrow(/"types"/);
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/SingleMediaUpload.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/SingleMediaUpload.test.js
@@ -34,15 +34,19 @@ test('Pass correct props', () => {
     );
     const schemaOptions = {
         collection_id: {
+            name: 'collection_id',
             value: 3,
         },
         empty_icon: {
+            name: 'empty_icon',
             value: 'su-icon',
         },
         image_size: {
+            name: 'image_size',
             value: 'sulu-400x400-inset',
         },
         upload_text: {
+            name: 'upload_text',
             infoText: 'Drag and drop',
         },
     };
@@ -72,9 +76,11 @@ test('Pass correct skin to props', () => {
     );
     const schemaOptions = {
         collection_id: {
+            name: 'collection_id',
             value: 2,
         },
         skin: {
+            name: 'skin',
             value: 'round',
         },
     };
@@ -99,9 +105,11 @@ test('Throw if emptyIcon is set but not a valid value', () => {
     );
     const schemaOptions = {
         collection_id: {
+            name: 'collection_id',
             value: 2,
         },
         empty_icon: {
+            name: 'empty_icon',
             value: [],
         },
     };
@@ -126,9 +134,11 @@ test('Throw if skin is set but not a valid value', () => {
     );
     const schemaOptions = {
         collection_id: {
+            name: 'collection_id',
             value: 2,
         },
         skin: {
+            name: 'skin',
             value: 'test',
         },
     };
@@ -153,9 +163,11 @@ test('Throw if image_size is set but not a valid value', () => {
     );
     const schemaOptions = {
         collection_id: {
+            name: 'collection_id',
             value: 2,
         },
         image_size: {
+            name: 'image_size',
             value: 3,
         },
     };
@@ -203,6 +215,7 @@ test('Call onChange and onFinish when upload has completed', () => {
     const media = {name: 'test.jpg'};
     const schemaOptions = {
         collection_id: {
+            name: 'collection_id',
             value: 2,
         },
     };
@@ -232,6 +245,7 @@ test('Create a MediaUploadStore when constructed', () => {
     );
     const schemaOptions = {
         collection_id: {
+            name: 'collection_id',
             value: 2,
         },
     };
@@ -257,6 +271,7 @@ test('Create MediaUploadStore with content-locale of user if locale is not prese
     );
     const schemaOptions = {
         collection_id: {
+            name: 'collection_id',
             value: 2,
         },
     };
@@ -288,6 +303,7 @@ test('Create a MediaUploadStore when constructed with data', () => {
     };
     const schemaOptions = {
         collection_id: {
+            name: 'collection_id',
             value: 2,
         },
     };

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/tests/fields/TeaserSelection.test.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/tests/fields/TeaserSelection.test.js
@@ -80,6 +80,7 @@ test('Pass presentations prop correctly to component', () => {
 
     const schemaOptions = {
         present_as: {
+            name: 'present_as',
             value: [
                 {name: 'test-1', title: 'Test 1'},
                 {name: 'test-2', title: 'Test 2'},
@@ -107,6 +108,7 @@ test('Throw error if present_as schemaOption is from wrong type', () => {
 
     const schemaOptions = {
         present_as: {
+            name: 'present_as',
             value: 'test',
         },
     };


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adds two schema-options to the `Selection` field-type. The `request_parameters` option allows to set static parameters that are appended to the requests made by the field-type and therefore is similar to the `ListViewBuilderInterface::addRequestParameters` method. 

The `resource_store_properties_to_request` option allows to pass the name of properties. The value of these properties then is appended to the requests made by the field-type. Furthermore, if the value of one of the property changes, the field-type fires a new request. This allows to implement a dependent selects (eg a city select that only displays the cities of the currently selected country). This option is similar to the `ListViewBuilderInterface::addResourceStorePropertiesToListRequest` method.

#### Why?

These options make the `Selection` field-type more versatile. For example, the `request_parameters` option can be used to filter selectable items by sending a specific type to the server and only return matching items. 

#### Example Usage

~~~xml
<property name="topics" type="topic_selection">
    <meta>
        <title>sulu_directory.topics</title>
    </meta>
    <params>
        <param name="request_parameters" type="collection">
            <param name="includeAssignPermissions" value="true" />
        </param>
        <param name="resource_store_properties_to_request" type="collection">
            <param name="assignedDirectoryIds" value="directories" />
        </param>
    </params>
</property>
~~~
