### PR TITLE
Remove unneeded type attribute in script tags

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/views/Admin/main.html.twig
+++ b/src/Sulu/Bundle/AdminBundle/Resources/views/Admin/main.html.twig
@@ -11,7 +11,7 @@
     <body>
         <div id="application">
         </div>
-        <script type="text/javascript">
+        <script>
             {% autoescape false %}
             const SULU_CONFIG = Object.freeze({
                 initialLoginState: {{ is_granted('IS_AUTHENTICATED_REMEMBERED') ? 'true' : 'false' }},

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/views/Template/hit-script.html.twig
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/views/Template/hit-script.html.twig
@@ -1,4 +1,4 @@
-<script type="text/javascript">
+<script>
     var request = new XMLHttpRequest();
     request.open('POST', '{{ url }}');
     request.setRequestHeader('{{ urlHeader }}', document.URL);

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Analytics/matomo/head-close.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Analytics/matomo/head-close.html.twig
@@ -1,4 +1,4 @@
-<script type="text/javascript">
+<script>
     var _paq = _paq || [];
     _paq.push(['trackPageView']);
     _paq.push(['enableLinkTracking']);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Remove unneeded type attribute from script tags. 

#### Why?

Avoid warnings w3c warnings like:

<img width="565" alt="Bildschirmfoto 2020-01-29 um 09 48 32" src="https://user-images.githubusercontent.com/1698337/73341361-c6fbf380-427c-11ea-8a78-29d703518488.png">
