### PR TITLE
Fix width of content in blocks to avoid overflow

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/block.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/block.scss
@@ -6,6 +6,7 @@ $blockBorderColor: $silver;
 $blockHandleColor: $black;
 $blockHandleBackgroundColor: $silver;
 $blockCollapsedTextColor: $silver;
+$blockHandleWidth: 20px;
 
 .block {
     display: flex;
@@ -25,19 +26,18 @@ $blockCollapsedTextColor: $silver;
 
 .handle {
     display: flex;
-    flex-shrink: 0;
     align-items: center;
     justify-content: center;
     color: $blockHandleColor;
     background-color: $blockHandleBackgroundColor;
     border-radius: $blockBorderRadius 0 0 $blockBorderRadius;
-    width: 20px;
+    width: $blockHandleWidth;
 }
 
 .content {
+    width: calc(100% - $blockHandleWidth);
     font-size: 12px;
     line-height: 18px;
-    flex-grow: 1;
     padding: 30px 60px 30px 40px;
 }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5009
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR gives the content section of a block a fixed width.

#### Why?

Because otherwise the content of the block might overflow on the x-axis.

#### Example Usage

Use the following template and make sure that a page listed in the smart content has a very long title.

~~~xml
        <block name="test" default-type="test2">
            <types>
                <type name="test2">
                    <properties>
                        <property name="text" type="text_line">
                            <meta>
                                <title lang="en">Text</title>
                            </meta>
                        </property>
                        <property name="smart" type="smart_content">
                            <meta>
                                <title lang="en">Text</title>
                            </meta>
                        </property>
                    </properties>
                </type>
            </types>
        </block>
~~~