### PR TITLE
Show hint for missing permissions in forms

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PermissionHint/PermissionHint.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PermissionHint/PermissionHint.js
@@ -1,0 +1,20 @@
+// @flow
+import React from 'react';
+import {translate} from '../../utils/Translator';
+import Icon from '../Icon';
+import permissionHintStyles from './permissionHint.scss';
+
+type Props = {||};
+
+export default class PermissionHint extends React.Component<Props> {
+    render() {
+        return (
+            <div className={permissionHintStyles.permissionHint}>
+                <div className={permissionHintStyles.permissionIcon}>
+                    <Icon name="su-lock" />
+                </div>
+                {translate('sulu_admin.no_permissions')}
+            </div>
+        );
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PermissionHint/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PermissionHint/README.md
@@ -1,0 +1,5 @@
+This component shows a simple indicator telling the user that some permissions are missing for the desired operation.
+
+```javascript
+<PermissionHint />
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PermissionHint/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PermissionHint/index.js
@@ -1,0 +1,4 @@
+// @flow
+import PermissionHint from './PermissionHint';
+
+export default PermissionHint;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PermissionHint/permissionHint.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PermissionHint/permissionHint.scss
@@ -1,0 +1,15 @@
+@import 'sulu-admin-bundle/containers/Application/colors.scss';
+
+$permissionHintColor: $gray;
+
+.permission-hint {
+    font-size: 18px;
+    font-weight: bold;
+    color: $permissionHintColor;
+    width: 100%;
+    text-align: center;
+}
+
+.permission-icon {
+    font-size: 32px;
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PermissionHint/tests/PermissionHint.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PermissionHint/tests/PermissionHint.test.js
@@ -1,0 +1,12 @@
+// @flow
+import React from 'react';
+import {render} from 'enzyme';
+import PermissionHint from '../PermissionHint';
+
+jest.mock('../../../utils/Translator', () => ({
+    translate: (key) => key,
+}));
+
+test('Render PermissionHint', () => {
+    expect(render(<PermissionHint />)).toMatchSnapshot();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PermissionHint/tests/__snapshots__/PermissionHint.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PermissionHint/tests/__snapshots__/PermissionHint.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Render PermissionHint 1`] = `
+<div
+  class="permissionHint"
+>
+  <div
+    class="permissionIcon"
+  >
+    <span
+      aria-label="su-lock"
+      class="su-lock"
+    />
+  </div>
+  sulu_admin.no_permissions
+</div>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
@@ -4,6 +4,7 @@ import {observer} from 'mobx-react';
 import React, {Fragment} from 'react';
 import log from 'loglevel';
 import Loader from '../../components/Loader';
+import PermissionHint from '../../components/PermissionHint';
 import Router from '../../services/Router';
 import Renderer from './Renderer';
 import type {FormStoreInterface} from './types';
@@ -131,6 +132,10 @@ class Form extends React.Component<Props> {
                 availableLocales,
             },
         } = store;
+
+        if (store.forbidden) {
+            return <PermissionHint />;
+        }
 
         return store.loading
             ? <Loader />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
@@ -168,6 +168,10 @@ export default class AbstractFormStore
         return toJS(this.evaluatedSchema);
     }
 
+    get forbidden(): boolean {
+        return false;
+    }
+
     isFieldModified(dataPath: string): boolean {
         return this.modifiedFields.includes(dataPath);
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
@@ -165,6 +165,10 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
         return this.resourceStore.deleting;
     }
 
+    @computed get forbidden(): boolean {
+        return this.resourceStore.forbidden;
+    }
+
     @computed get dirty(): boolean {
         return this.resourceStore.dirty;
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Form.test.js
@@ -63,6 +63,16 @@ test('Should render form using renderer', () => {
     expect(form).toMatchSnapshot();
 });
 
+test('Render permission hint if permissions are missing', () => {
+    const submitSpy = jest.fn();
+    const store = new ResourceFormStore(new ResourceStore('snippet', '1'), 'snippet');
+    // $FlowFixMe
+    store.forbidden = true;
+
+    const form = render(<Form onSubmit={submitSpy} store={store} />);
+    expect(form).toMatchSnapshot();
+});
+
 test('Should call onSubmit callback', () => {
     const errorSpy = jest.fn();
     const submitSpy = jest.fn();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Form.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Form.test.js.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Render permission hint if permissions are missing 1`] = `
+<div
+  class="permissionHint"
+>
+  <div
+    class="permissionIcon"
+  >
+    <span
+      aria-label="su-lock"
+      class="su-lock"
+    />
+  </div>
+  sulu_admin.no_permissions
+</div>
+`;
+
 exports[`Should render form using renderer 1`] = `
 <div
   class="grid grid"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/MemoryFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/MemoryFormStore.test.js
@@ -629,3 +629,9 @@ test('Validate should return false if errors occured', () => {
 
     expect(memoryFormStore.validate()).toEqual(false);
 });
+
+test('Forbidden flag should always be set to false', () => {
+    const memoryFormStore = new MemoryFormStore({}, {}, {required: ['title']});
+
+    expect(memoryFormStore.forbidden).toEqual(false);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
@@ -628,6 +628,16 @@ test('Loading flag should be set to false after data and schema have been loadin
     resourceFormStore.destroy();
 });
 
+test.each([true, false])('Forbidden flag should be set as %s', (forbidden) => {
+    const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box()});
+    const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets');
+
+    resourceStore.forbidden = forbidden;
+
+    expect(resourceFormStore.forbidden).toBe(forbidden);
+    resourceFormStore.destroy();
+});
+
 test('Save the store should call the resourceStore save function', () => {
     const resourceFormStore = new ResourceFormStore(
         new ResourceStore('snippets', '3', {locale: observable.box()}),

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -97,6 +97,7 @@ export interface FormStoreInterface {
     dirty: boolean,
     errors: Object,
     +finishField: (dataPath: string) => void,
+    +forbidden: boolean,
     +getSchemaEntryByPath: (schemaPath: string) => SchemaEntry,
     +getValueByPath: (path: string) => mixed,
     +getValuesByTag: (tagName: string) => Array<mixed>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
@@ -10,8 +10,8 @@ import jexl from 'jexl';
 import ArrowMenu from '../../components/ArrowMenu';
 import Button from '../../components/Button';
 import Dialog from '../../components/Dialog';
-import Icon from '../../components/Icon';
 import Loader from '../../components/Loader';
+import PermissionHint from '../../components/PermissionHint';
 import userStore from '../../stores/userStore';
 import SingleListOverlay from '../SingleListOverlay';
 import {translate} from '../../utils/Translator';
@@ -530,14 +530,7 @@ class List extends React.Component<Props> {
         const searchable = this.props.searchable && Adapter.searchable;
 
         if (store.forbidden) {
-            return (
-                <div className={listStyles.permissionHint}>
-                    <div className={listStyles.permissionIcon}>
-                        <Icon name="su-lock" />
-                    </div>
-                    {translate('sulu_admin.no_permissions')}
-                </div>
-            );
+            return <PermissionHint />;
         }
 
         return (

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/list.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/list.scss
@@ -2,7 +2,6 @@
 
 $listToolbarHeight: 30px;
 $listHeaderMarginBottom: 40px;
-$permissionHintColor: $gray;
 
 .list-container {
     display: flex;
@@ -46,16 +45,4 @@ $permissionHintColor: $gray;
             margin-right: 0;
         }
     }
-}
-
-.permission-hint {
-    font-size: 18px;
-    font-weight: bold;
-    color: $permissionHintColor;
-    width: 100%;
-    text-align: center;
-}
-
-.permission-icon {
-    font-size: 32px;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
@@ -19,6 +19,7 @@ test('Should be marked as initialized after loading the data', () => {
 
     return promise.then(() => {
         expect(resourceStore.initialized).toBe(true);
+        expect(resourceStore.forbidden).toBe(false);
     });
 });
 
@@ -31,6 +32,27 @@ test('Should be marked as not dirty after loading the data', () => {
 
     return promise.then(() => {
         expect(resourceStore.dirty).toBe(false);
+        expect(resourceStore.forbidden).toBe(false);
+    });
+});
+
+test('Should be marked as forbidden if loading failed with 403 and not forbidden if next request succeeds', (done) => {
+    const promise = Promise.reject({status: 403});
+    ResourceRequester.get.mockReturnValue(promise);
+    const resourceStore = new ResourceStore('snippets', '1');
+
+    setTimeout(() => {
+        expect(resourceStore.forbidden).toBe(true);
+
+        const promise = Promise.resolve({});
+        ResourceRequester.get.mockReturnValue(promise);
+
+        resourceStore.load();
+
+        setTimeout(() => {
+            expect(resourceStore.forbidden).toBe(false);
+            done();
+        });
     });
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -28,9 +28,7 @@ jest.mock('../registries/formToolbarActionRegistry', () => ({
 }));
 
 jest.mock('../../../services/ResourceRequester', () => ({
-    get: jest.fn().mockReturnValue({
-        then: jest.fn(),
-    }),
+    get: jest.fn().mockReturnValue(Promise.resolve({})),
     put: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/MediaVersionUpload.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/MediaVersionUpload.test.js
@@ -15,9 +15,7 @@ jest.mock('sulu-admin-bundle/containers/Form/stores/metadataStore', () => ({
 }));
 
 jest.mock('sulu-admin-bundle/services/ResourceRequester', () => ({
-    get: jest.fn().mockReturnValue({
-        then: jest.fn(),
-    }),
+    get: jest.fn().mockReturnValue(Promise.resolve({})),
 }));
 
 test('Pass ResourceStore from FormInspector to MediaVersionUpload component', () => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaVersionUpload/tests/MediaVersionUpload.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaVersionUpload/tests/MediaVersionUpload.test.js
@@ -12,9 +12,7 @@ jest.mock('sulu-admin-bundle/utils/Translator', () => ({
 }));
 
 jest.mock('sulu-admin-bundle/services/ResourceRequester', () => ({
-    get: jest.fn().mockReturnValue({
-        then: jest.fn(),
-    }),
+    get: jest.fn().mockReturnValue(Promise.resolve({})),
     put: jest.fn().mockReturnValue(Promise.resolve({})),
 }));
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes parts of #2300
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR shows a hint for missing permissions, when a form is loaded which is not granted access for the current user. This can easily happen when single languages are restricted for certain users.