### PR TITLE
Disallow add, delete and edit operations on SystemCollections

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -76,12 +76,14 @@ class MediaCollection extends React.Component<Props> {
             uploadOverlayOpen,
         } = this.props;
 
-        const {permissions} = collectionStore;
+        const {locked, permissions} = collectionStore;
 
-        const addable = permissions.add !== undefined ? permissions.add : MediaCollection.addable;
-        const editable = permissions.edit !== undefined ? permissions.edit : MediaCollection.editable;
-        const deletable = permissions.delete !== undefined ? permissions.delete : MediaCollection.deletable;
-        const securable = permissions.security !== undefined ? permissions.security : MediaCollection.securable;
+        const addable = !locked && (permissions.add !== undefined ? permissions.add : MediaCollection.addable);
+        const editable = !locked && (permissions.edit !== undefined ? permissions.edit : MediaCollection.editable);
+        const deletable = !locked
+            && (permissions.delete !== undefined ? permissions.delete : MediaCollection.deletable);
+        const securable = !locked
+            && (permissions.security !== undefined ? permissions.security : MediaCollection.securable);
 
         return (
             <MultiMediaDropzone

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
@@ -4,6 +4,7 @@ import {mount, render} from 'enzyme';
 import {extendObservable as mockExtendObservable, observable} from 'mobx';
 import MediaCollection from '../MediaCollection';
 import MediaCardOverviewAdapter from '../../List/adapters/MediaCardOverviewAdapter';
+
 const MEDIA_RESOURCE_KEY = 'media';
 const COLLECTIONS_RESOURCE_KEY = 'collections';
 const SETTINGS_KEY = 'media_collection_test';
@@ -249,6 +250,56 @@ test('Render the MediaCollection', () => {
         />
     );
     expect(mediaCollection).toMatchSnapshot();
+});
+
+test('Render the MediaCollection without dropdown button when collection is a system collection', () => {
+    const page = observable.box();
+    const locale = observable.box();
+    const collectionNavigateSpy = jest.fn();
+    const ListStore = require('sulu-admin-bundle/containers').ListStore;
+    const mediaListStore = new ListStore(
+        MEDIA_RESOURCE_KEY,
+        SETTINGS_KEY,
+        USER_SETTINGS_KEY,
+        {
+            page,
+            locale,
+        }
+    );
+    const collectionListStore = new ListStore(
+        COLLECTIONS_RESOURCE_KEY,
+        SETTINGS_KEY,
+        USER_SETTINGS_KEY,
+        {
+            page,
+            locale,
+        }
+    );
+    const CollectionStore = require('../../../stores/CollectionStore').default;
+    const collectionStore = new CollectionStore(1, locale);
+
+    collectionStore.resourceStore.data = {
+        title: 'Title',
+        locked: true,
+        _permissions: {},
+    };
+
+    const mediaCollection = mount(
+        <MediaCollection
+            collectionListStore={collectionListStore}
+            collectionStore={collectionStore}
+            locale={locale}
+            mediaListAdapters={['media_card_overview']}
+            mediaListStore={mediaListStore}
+            onCollectionNavigate={collectionNavigateSpy}
+            onUploadOverlayClose={jest.fn()}
+            onUploadOverlayOpen={jest.fn()}
+            uploadOverlayOpen={false}
+        />
+    );
+
+    expect(mediaCollection.find('Button[icon="su-plus"]')).toHaveLength(0);
+    expect(mediaCollection.find('DropdownButton')).toHaveLength(0);
 });
 
 test('Render the MediaCollection without dropdown button when permissions are missing', () => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/CollectionStore/CollectionStore.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/CollectionStore/CollectionStore.js
@@ -39,6 +39,14 @@ export default class CollectionStore {
         return this.resourceStore.id;
     }
 
+    @computed get locked(): boolean {
+        if (this.loading) {
+            return false;
+        }
+
+        return this.resourceStore.data.locked;
+    }
+
     @computed get permissions(): {[key: string]: boolean} {
         if (this.resourceStore.loading || !this.resourceStore.id) {
             return {};

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/CollectionStore/tests/CollectionStore.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/CollectionStore/tests/CollectionStore.test.js
@@ -44,6 +44,28 @@ test('After loading the collection info should be set', (done) => {
     );
 });
 
+test.each([true, false])('Should have a locked value of %s', (locked, done) => {
+    ResourceRequester.get.mockReturnValue(Promise.resolve({
+        id: 2,
+        title: 'test',
+        locked,
+    }));
+
+    const locale = observable.box('en');
+    const collectionStore = new CollectionStore(1, locale);
+
+    expect(collectionStore.locked).toEqual(false);
+
+    when(
+        () => !collectionStore.loading,
+        () => {
+            expect(collectionStore.locked).toEqual(locked);
+            collectionStore.destroy();
+            done();
+        }
+    );
+});
+
 test('Should return an empty permission object if still loading', () => {
     const collectionStore = new CollectionStore(1, observable.box('en'));
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
@@ -273,9 +273,6 @@ class CollectionControllerTest extends SuluTestCase
         return array_values($result);
     }
 
-    /**
-     * @description Test Collection GET by ID
-     */
     public function testGetById()
     {
         $client = $this->createAuthenticatedClient();
@@ -314,9 +311,6 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertEquals(date('Y-m-d'), date('Y-m-d', strtotime($response->changed)));
     }
 
-    /**
-     * @description Test GET all Collections
-     */
     public function testCGet()
     {
         for ($i = 1; $i <= 15; ++$i) {
@@ -393,9 +387,6 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertCount(2, $response->_embedded->collections);
     }
 
-    /**
-     * @description Test GET Collections filtered by parent
-     */
     public function testCGetFlatWithParent()
     {
         $collection = $this->createCollection($this->collectionType1);
@@ -428,9 +419,6 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertCount(5, $response->_embedded->collections);
     }
 
-    /**
-     * @description Test GET all Collections with pagination and sorted by title
-     */
     public function testcGetPaginated()
     {
         $this->createCollection(
@@ -519,10 +507,6 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertEquals('Test Collection', $response->_embedded->collections[0]->title);
     }
 
-    /**
-     * @description Tests the cGET action with a pagination. Only the collections of the desired
-     * level should be returned and in the right amount, although they have children.
-     */
     public function testcGetPaginatedWithChildren()
     {
         $parent = $this->createCollection(
@@ -562,9 +546,6 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertEquals(1, $response->_embedded->collections[1]->objectCount);
     }
 
-    /**
-     * @description Test GET for non existing Resource (404)
-     */
     public function testGetByIdNotExisting()
     {
         $client = $this->createAuthenticatedClient();
@@ -581,9 +562,6 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertTrue(isset($response->message));
     }
 
-    /**
-     * @description Test POST to create a new Collection
-     */
     public function testPost()
     {
         $client = $this->createAuthenticatedClient();
@@ -685,9 +663,6 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertEquals('This Description 2 is only for testing', $responseSecondEntity->description);
     }
 
-    /**
-     * @description Test POST to create a new nested Collection
-     */
     public function testPostNested()
     {
         $client = $this->createAuthenticatedClient();
@@ -783,9 +758,6 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertEquals(2 + $this->getAmountOfSystemCollections(), $response->total);
     }
 
-    /**
-     * @description Test POST to create a new Collection
-     */
     public function testPostWithoutDetails()
     {
         $client = $this->createAuthenticatedClient();
@@ -908,9 +880,6 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertEquals('Test Collection 2', $responseSecondEntity->title);
     }
 
-    /**
-     * @description Test POST to create a new Collection
-     */
     public function testPostWithNotExistingType()
     {
         $client = $this->createAuthenticatedClient();
@@ -943,9 +912,6 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertTrue(isset($response->message));
     }
 
-    /**
-     * @description Test PUT Action
-     */
     public function testPut()
     {
         $client = $this->createAuthenticatedClient();
@@ -1032,9 +998,6 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertEquals('en-gb', $responseFirstEntity->locale);
     }
 
-    /**
-     * @description Test PUT Action
-     */
     public function testPutWithoutLocale()
     {
         $client = $this->createAuthenticatedClient();
@@ -1125,9 +1088,6 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertNull($response['_embedded']['breadcrumb']);
     }
 
-    /**
-     * @description Test PUT action without details
-     */
     public function testPutNoDetails()
     {
         $client = $this->createAuthenticatedClient();
@@ -1176,9 +1136,6 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertNotNull($response->type->id);
     }
 
-    /**
-     * @description Test PUT on a none existing Object
-     */
     public function testPutNotExisting()
     {
         $client = $this->createAuthenticatedClient();
@@ -1199,9 +1156,6 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(404, $client->getResponse());
     }
 
-    /**
-     * @description Test DELETE
-     */
     public function testDeleteById()
     {
         $client = $this->createAuthenticatedClient();
@@ -1221,9 +1175,6 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertTrue(isset($response->message));
     }
 
-    /**
-     * @description Test DELETE on none existing Object
-     */
     public function testDeleteByIdNotExisting()
     {
         $client = $this->createAuthenticatedClient();
@@ -1233,7 +1184,7 @@ class CollectionControllerTest extends SuluTestCase
 
         $client->request('GET', '/api/collections?locale=en&flat=true');
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(1, $response->total);
+        $this->assertEquals(2, $response->total);
     }
 
     private function prepareTree()
@@ -1503,9 +1454,6 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertEquals($ids[5], $breadcrumb[1]['id']);
     }
 
-    /**
-     * @description Test Collection GET by ID with a depth
-     */
     public function testGetByIdWithDepth()
     {
         list($titles, $ids) = $this->prepareTree();
@@ -1577,9 +1525,6 @@ class CollectionControllerTest extends SuluTestCase
         );
     }
 
-    /**
-     * @description Test move a Collection
-     */
     public function testMove()
     {
         list($titles, $ids) = $this->prepareTree();
@@ -1674,5 +1619,24 @@ class CollectionControllerTest extends SuluTestCase
         );
 
         $this->assertHttpStatusCode(403, $client->getResponse());
+    }
+
+    public function testDeleteSystemCollection()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $collectionId = $client->getContainer()->get('sulu_media.system_collections.manager')->getSystemCollection(
+            'sulu_media'
+        );
+
+        $client->request('DELETE', '/api/collections/' . $collectionId);
+        $this->assertHttpStatusCode(403, $client->getResponse());
+
+        $client->request(
+            'GET',
+            '/api/collections/' . $collectionId . '?locale=en'
+        );
+
+        $this->assertHttpStatusCode(200, $client->getResponse());
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5005 
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR only shows the add, delete and edit operations on Collections not being a SystemCollection.