### PR TITLE
Add default sorting for PageDataProvider

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleSelect/SingleSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleSelect/SingleSelect.js
@@ -40,13 +40,7 @@ export default class SingleSelect<T: string | number> extends React.PureComponen
     }
 
     isOptionSelected = (option: Element<typeof SingleSelect.Option>): boolean => {
-        const {value} = this.props;
-
-        if (value == null) {
-            return false;
-        }
-
-        return option.props.value === value && !option.props.disabled;
+        return option.props.value === this.props.value && !option.props.disabled;
     };
 
     // TODO: Remove explicit type annotation when flow bug is fixed

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleSelect/tests/SingleSelect.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleSelect/tests/SingleSelect.test.js
@@ -139,6 +139,19 @@ test('The component should select the correct option', () => {
     expect(isOptionSelected({props: {value: 'option-3', disabled: false}})).toBe(false);
 });
 
+test('The component should select the correct option if value is undefined', () => {
+    const select = shallow(
+        <SingleSelect value={undefined}>
+            <Option value={undefined}>undefined</Option>
+            <Divider />
+            <Option value="value">Value</Option>
+        </SingleSelect>
+    );
+    const isOptionSelected = select.find(Select).props().isOptionSelected;
+    expect(isOptionSelected({props: {value: undefined, disabled: false}})).toBe(true);
+    expect(isOptionSelected({props: {value: 'value', disabled: false}})).toBe(false);
+});
+
 test('The component should also select the option with the value 0', () => {
     const select = shallow(
         <SingleSelect value={0}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/FilterOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/FilterOverlay.js
@@ -26,7 +26,7 @@ type Props = {|
     presentations: {[key: string]: string},
     sections: Array<string>,
     smartContentStore: SmartContentStore,
-    sortings: {[key: string]: string},
+    sortings: Array<{name: ?string, value: string}>,
     title: string,
 |};
 
@@ -166,9 +166,9 @@ class FilterOverlay extends React.Component<Props> {
     };
 
     @action handleSortByChange = (sortBy: string | number) => {
-        if (typeof sortBy !== 'string') {
+        if (sortBy !== undefined && typeof sortBy !== 'string') {
             throw new Error(
-                'The field for sorting must be a string, but "' + sortBy + '" was given.'
+                'The field for sorting must be a string or undefined, but "' + sortBy + '" was given.'
                 + ' This should not happen and is likely a bug.'
             );
         }
@@ -333,9 +333,9 @@ class FilterOverlay extends React.Component<Props> {
                                 <div className={filterOverlayStyles.sorting}>
                                     <div className={filterOverlayStyles.sortColumn}>
                                         <SingleSelect onChange={this.handleSortByChange} value={this.sortBy}>
-                                            {Object.keys(sortings).map((sortKey) => (
-                                                <SingleSelect.Option key={sortKey} value={sortKey}>
-                                                    {sortings[sortKey]}
+                                            {sortings.map((sorting, index) => (
+                                                <SingleSelect.Option key={index} value={sorting.name}>
+                                                    {translate(sorting.value)}
                                                 </SingleSelect.Option>
                                             ))}
                                         </SingleSelect>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/SmartContent.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/SmartContent.js
@@ -28,7 +28,6 @@ class SmartContent extends React.Component<Props> {
 
     config: SmartContentConfig;
     sections: Array<string> = [];
-    sortings: {[key: string]: string};
 
     @observable showFilterOverlay = false;
 
@@ -69,11 +68,6 @@ class SmartContent extends React.Component<Props> {
         if (this.config.limit) {
             this.sections.push('limit');
         }
-
-        this.sortings = this.config.sorting.reduce((sortings, sorting) => {
-            sortings[sorting.name] = translate(sorting.value);
-            return sortings;
-        }, {});
     }
 
     @action handleFilterClick = () => {
@@ -121,7 +115,7 @@ class SmartContent extends React.Component<Props> {
                     presentations={presentations}
                     sections={this.sections}
                     smartContentStore={store}
-                    sortings={this.sortings}
+                    sortings={this.config.sorting}
                     title={translate('sulu_admin.filter_overlay_title', {fieldLabel})}
                 />
             </Fragment>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/FilterOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/FilterOverlay.test.js
@@ -46,7 +46,7 @@ test('Do not display if open is set to false', () => {
             presentations={{}}
             sections={[]}
             smartContentStore={smartContentStore}
-            sortings={{}}
+            sortings={[]}
             title="Test"
         />
     );
@@ -85,7 +85,7 @@ test('Pass rootKey for categories to options for category list', () => {
             presentations={{}}
             sections={['categories']}
             smartContentStore={smartContentStore}
-            sortings={{}}
+            sortings={[]}
             title="Test"
         />
     );
@@ -125,7 +125,7 @@ test('Render with ListOverlays if smartContentStore is loaded', () => {
             presentations={{}}
             sections={['datasource', 'categories', 'tags', 'audienceTargeting', 'sorting', 'presentation', 'limit']}
             smartContentStore={smartContentStore}
-            sortings={{}}
+            sortings={[]}
             title="Test"
         />
     );
@@ -165,7 +165,7 @@ test('Render without ListOverlays if smartContentStore is not loaded', () => {
             presentations={{}}
             sections={['datasource', 'categories', 'tags', 'audienceTargeting', 'sorting', 'presentation', 'limit']}
             smartContentStore={smartContentStore}
-            sortings={{}}
+            sortings={[]}
             title="Test"
         />
     );
@@ -202,7 +202,7 @@ test('Render with all fields', () => {
             presentations={{}}
             sections={['datasource', 'categories', 'tags', 'audienceTargeting', 'sorting', 'presentation', 'limit']}
             smartContentStore={smartContentStore}
-            sortings={{}}
+            sortings={[]}
             title="Test"
         />
     );
@@ -238,7 +238,7 @@ test('Render with no fields', () => {
             presentations={{}}
             sections={[]}
             smartContentStore={smartContentStore}
-            sortings={{}}
+            sortings={[]}
             title="Test"
         />
     );
@@ -278,10 +278,10 @@ test('Fill all fields using and update SmartContentStore on confirm', () => {
             }}
             sections={['datasource', 'categories', 'tags', 'audienceTargeting', 'sorting', 'presentation', 'limit']}
             smartContentStore={smartContentStore}
-            sortings={{
-                title: 'Title',
-                changed: 'Changed',
-            }}
+            sortings={[
+                {name: 'title', value: 'Title'},
+                {name: 'changed', value: 'Changed'},
+            ]}
             title="Test"
         />
     );
@@ -417,10 +417,10 @@ test('Prefill all fields with correct values', () => {
             }}
             sections={['datasource', 'categories', 'tags', 'audienceTargeting', 'sorting', 'presentation', 'limit']}
             smartContentStore={smartContentStore}
-            sortings={{
-                title: 'Title',
-                created: 'Created',
-            }}
+            sortings={[
+                {name: 'title', value: 'Title'},
+                {name: 'created', value: 'Created'},
+            ]}
             title="Test"
         />
     );
@@ -494,10 +494,10 @@ test('Reset all fields when reset action is clicked', () => {
             }}
             sections={['datasource', 'categories', 'tags', 'audienceTargeting', 'sorting', 'presentation', 'limit']}
             smartContentStore={smartContentStore}
-            sortings={{
-                title: 'Title',
-                created: 'Created',
-            }}
+            sortings={[
+                {name: 'title', value: 'Title'},
+                {name: 'created', value: 'Created'},
+            ]}
             title="Test"
         />
     );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/SmartContent.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/SmartContent.test.js
@@ -146,7 +146,9 @@ test('Open and closes the FilterOverlay when the icon is clicked', () => {
         tags: false,
         categories: true,
         audienceTargeting: false,
-        sorting: [{name: 'title', value: 'Title'}],
+        sorting: [
+            {name: 'title', value: 'Title'},
+        ],
         presentAs: true,
         limit: false,
     });
@@ -166,7 +168,7 @@ test('Open and closes the FilterOverlay when the icon is clicked', () => {
     smartContent.find('FilterOverlay').prop('onClose')();
     expect(smartContent.find('FilterOverlay').prop('open')).toEqual(false);
     expect(smartContent.find('FilterOverlay').prop('title')).toEqual('sulu_admin.filter_overlay_title');
-    expect(smartContent.find('FilterOverlay').prop('sortings')).toEqual({title: 'Title'});
+    expect(smartContent.find('FilterOverlay').prop('sortings')).toEqual([{name: 'title', value: 'Title'}]);
     expect(translate).toBeCalledWith('sulu_admin.filter_overlay_title', {fieldLabel: 'Test'});
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/types.js
@@ -25,7 +25,7 @@ export type SortOrder = 'asc' | 'desc';
 export type Conjunction = 'or' | 'and';
 
 export type Sorting = {
-    name: string,
+    name: ?string,
     value: string,
 };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -25,6 +25,7 @@
     "sulu_admin.yes": "Ja",
     "sulu_admin.no": "Nein",
     "sulu_admin.type": "Typ",
+    "sulu_admin.default": "Standard",
     "sulu_admin.error_required": "Dieses Feld muss ausgefüllt werden",
     "sulu_admin.error_minlength": "Die minimale Länge dieses Feldes wurde unterschritten",
     "sulu_admin.error_minitems": "Dieses Feld hat zu wenig Zuweisungen",

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -25,6 +25,7 @@
     "sulu_admin.yes": "Yes",
     "sulu_admin.no": "No",
     "sulu_admin.type": "Type",
+    "sulu_admin.default": "Default",
     "sulu_admin.error_required": "This field must have a value",
     "sulu_admin.error_minlength": "The minimal length of this field was undershot",
     "sulu_admin.error_minitems": "This field has too few selections",

--- a/src/Sulu/Bundle/PageBundle/Controller/SmartContentItemController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/SmartContentItemController.php
@@ -72,6 +72,9 @@ class SmartContentItemController extends AbstractRestController
         if (isset($filters['sortBy'])) {
             $filters['sortBy'] = $this->getRequestParameter($request, 'sortBy');
         }
+        if (isset($filters['includeSubFolders'])) {
+            $filters['includeSubFolders'] = $filters['includeSubFolders'] === 'true';
+        }
         $filters = array_filter($filters);
         $options = [
             'webspaceKey' => $this->getRequestParameter($request, 'webspace'),

--- a/src/Sulu/Bundle/PageBundle/Controller/SmartContentItemController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/SmartContentItemController.php
@@ -73,7 +73,7 @@ class SmartContentItemController extends AbstractRestController
             $filters['sortBy'] = $this->getRequestParameter($request, 'sortBy');
         }
         if (isset($filters['includeSubFolders'])) {
-            $filters['includeSubFolders'] = $filters['includeSubFolders'] === 'true';
+            $filters['includeSubFolders'] = 'true' === $filters['includeSubFolders'];
         }
         $filters = array_filter($filters);
         $options = [

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/SmartContent/QueryBuilderTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/SmartContent/QueryBuilderTest.php
@@ -480,6 +480,7 @@ class QueryBuilderTest extends SuluTestCase
                 'dataSource' => $root->getIdentifier(),
                 'includeSubFolders' => true,
                 'audienceTargeting' => false,
+                'sortBy' => 'title',
             ],
         ]);
 
@@ -569,9 +570,16 @@ class QueryBuilderTest extends SuluTestCase
         ]);
 
         $result = $this->contentQuery->execute('sulu_io', ['en'], $builder);
-        $this->assertCount(2, $result);
-        $this->assertEquals('Family', $result[0]['title']);
-        $this->assertEquals('Single', $result[1]['title']);
+        $titles = array_map(
+            function($item) {
+                return $item['title'];
+            },
+            $result
+        );
+
+        $this->assertCount(2, $titles);
+        $this->assertContains('Family', $titles);
+        $this->assertContains('Single', $titles);
     }
 
     public function tagsProvider()
@@ -1107,23 +1115,30 @@ class QueryBuilderTest extends SuluTestCase
 
         $result = $this->contentQuery->execute('sulu_io', ['en'], $builder);
 
-        $this->assertEquals('/news', $result[0]['path']);
-        $this->assertEquals('/news/news-0', $result[1]['path']);
-        $this->assertEquals('/news/news-1', $result[2]['path']);
-        $this->assertEquals('/news/news-10', $result[3]['path']);
-        $this->assertEquals('/news/news-11', $result[4]['path']);
-        $this->assertEquals('/news/news-12', $result[5]['path']);
-        $this->assertEquals('/news/news-13', $result[6]['path']);
-        $this->assertEquals('/news/news-14', $result[7]['path']);
-        $this->assertEquals('/news/news-2', $result[8]['path']);
-        $this->assertEquals('/news/news-3', $result[9]['path']);
-        $this->assertEquals('/news/news-4', $result[10]['path']);
-        $this->assertEquals('/news/news-5', $result[11]['path']);
-        $this->assertEquals('/news/news-6', $result[12]['path']);
-        $this->assertEquals('/news/news-7', $result[13]['path']);
-        $this->assertEquals('/news/news-8', $result[14]['path']);
-        $this->assertEquals('/news/news-9', $result[15]['path']);
-        $this->assertEquals('/products', $result[16]['path']);
+        $paths = array_map(
+            function($item) {
+                return $item['path'];
+            },
+            $result
+        );
+
+        $this->assertContains('/news', $paths);
+        $this->assertContains('/news/news-0', $paths);
+        $this->assertContains('/news/news-1', $paths);
+        $this->assertContains('/news/news-10', $paths);
+        $this->assertContains('/news/news-11', $paths);
+        $this->assertContains('/news/news-12', $paths);
+        $this->assertContains('/news/news-13', $paths);
+        $this->assertContains('/news/news-14', $paths);
+        $this->assertContains('/news/news-2', $paths);
+        $this->assertContains('/news/news-3', $paths);
+        $this->assertContains('/news/news-4', $paths);
+        $this->assertContains('/news/news-5', $paths);
+        $this->assertContains('/news/news-6', $paths);
+        $this->assertContains('/news/news-7', $paths);
+        $this->assertContains('/news/news-8', $paths);
+        $this->assertContains('/news/news-9', $paths);
+        $this->assertContains('/products', $paths);
     }
 
     public function testExtension()

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/SmartContent/QueryBuilderTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/SmartContent/QueryBuilderTest.php
@@ -1101,15 +1101,12 @@ class QueryBuilderTest extends SuluTestCase
                     'dataSource' => $root->getIdentifier(),
                     'orderBy' => [],
                     'includeSubFolders' => true,
-                ]
+                ],
             ]
         );
 
         $result = $this->contentQuery->execute('sulu_io', ['en'], $builder);
 
-        var_dump(array_map(function($item) {
-            return $item['path'];
-        }, $result));die();
         $this->assertEquals('/news', $result[0]['path']);
         $this->assertEquals('/news/news-0', $result[1]['path']);
         $this->assertEquals('/news/news-1', $result[2]['path']);

--- a/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
+++ b/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
@@ -121,6 +121,7 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
             ->enableDatasource('pages', 'pages', 'column_list')
             ->enableSorting(
                 [
+                    ['column' => null, 'title' => 'sulu_admin.default'],
                     ['column' => 'title', 'title' => 'sulu_admin.title'],
                     ['column' => 'published', 'title' => 'sulu_admin.published'],
                     ['column' => 'created', 'title' => 'sulu_admin.created'],

--- a/src/Sulu/Component/Content/SmartContent/QueryBuilder.php
+++ b/src/Sulu/Component/Content/SmartContent/QueryBuilder.php
@@ -181,7 +181,12 @@ class QueryBuilder extends ContentQueryBuilder
         $sortBy = $this->getConfig('sortBy');
 
         if ($sortBy) {
-            $sql2Order[] = 'page.[i18n:' . $locale . '-' . $sortBy . '] ' . $sortOrder;
+            $order = 'page.[i18n:' . $locale . '-' . $sortBy . '] ';
+            if (!in_array($sortBy, ['published', 'created', 'changed', 'authored'])) {
+                $order = sprintf('lower(%s)', $order);
+            }
+
+            $sql2Order[] = $order . $sortOrder;
         } elseif (!$this->getConfig('includeSubFolders', false)) {
             $sql2Order[] = 'page.[sulu:order] ' . $sortOrder;
         }

--- a/src/Sulu/Component/Content/SmartContent/QueryBuilder.php
+++ b/src/Sulu/Component/Content/SmartContent/QueryBuilder.php
@@ -178,17 +178,11 @@ class QueryBuilder extends ContentQueryBuilder
             ? 'DESC' : 'ASC';
 
         $sql2Order = [];
-        $sortBy = $this->getConfig('sortBy', []);
+        $sortBy = $this->getConfig('sortBy');
 
-        if (!empty($sortBy)) {
-            // TODO implement more generic
-            $order = 'page.[i18n:' . $locale . '-' . $sortBy . '] ';
-            if (!in_array($sortBy, ['published', 'created', 'changed', 'authored'])) {
-                $order = sprintf('lower(%s)', $order);
-            }
-
-            $sql2Order[] = $order . ' ' . $sortOrder;
-        } else {
+        if ($sortBy) {
+            $sql2Order[] = 'page.[i18n:' . $locale . '-' . $sortBy . '] ' . $sortOrder;
+        } elseif (!$this->getConfig('includeSubFolders', false)) {
             $sql2Order[] = 'page.[sulu:order] ' . $sortOrder;
         }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5017
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR allows to set the default sort order for the `PageDataProvider`. This is the admin order as given in our webspace page tree if the "Include sub folder" toggle is not set, and an alphabetic representation if the toggle is set.