### PR TITLE
Replace host right after loading webspaces to avoid repeating this logic

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,13 @@
 # Upgrade
 
+## 2.0.4
+
+### Replace {host} placeholder right after loading webspaces
+
+Previously a `host` parameter had to be passed when a route of type `portal` was generated on a webspace containing a
+`{host}` placeholder in its URL. This is not necessary anymore, and if you still do it, it will cause a `host` query
+parameter to be added to the generated URL.
+
 ## 2.0.3
 
 When upgrading also have a look at the changes in the

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/request_analyzer.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/request_analyzer.xml
@@ -35,7 +35,6 @@
                  class="Sulu\Component\Webspace\Analyzer\Attributes\WebsiteRequestProcessor">
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="sulu.content.mapper"/>
-            <argument type="service" id="sulu_core.webspace.webspace_manager.url_replacer"/>
             <argument type="string">%kernel.environment%</argument>
 
             <tag name="sulu.context" context="website"/>

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/webspace.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/webspace.xml
@@ -32,6 +32,7 @@
         <service id="sulu_core.webspace.webspace_manager" class="Sulu\Component\Webspace\Manager\WebspaceManager" public="true">
             <argument type="service" id="sulu_core.webspace.loader.delegator"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager.url_replacer"/>
+            <argument type="service" id="request_stack"/>
             <argument type="collection">
                 <argument key="config_dir">%sulu_core.webspace.config_dir%</argument>
                 <argument key="cache_dir">%sulu.cache_dir%</argument>
@@ -40,6 +41,7 @@
                 <argument key="base_class">%sulu_core.webspace.base_class%</argument>
             </argument>
             <argument>%kernel.environment%</argument>
+            <argument>%router.request_context.host%</argument>
 
             <tag name="sulu.localization_provider"/>
         </service>

--- a/src/Sulu/Bundle/HttpCacheBundle/Cache/CacheManager.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Cache/CacheManager.php
@@ -14,8 +14,6 @@ namespace Sulu\Bundle\HttpCacheBundle\Cache;
 use FOS\HttpCache\ProxyClient\Invalidation\BanCapable;
 use FOS\HttpCacheBundle\CacheManager as FOSCacheManager;
 use Ramsey\Uuid\Uuid;
-use Sulu\Component\Webspace\Url\ReplacerInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Sulu cache manager wraps the FOSCacheManager to check for every operation if the current proxy client supports the
@@ -28,7 +26,8 @@ class CacheManager implements CacheManagerInterface
      */
     private $fosCacheManager;
 
-    public function __construct(FOSCacheManager $fosCacheManager) {
+    public function __construct(FOSCacheManager $fosCacheManager)
+    {
         $this->fosCacheManager = $fosCacheManager;
     }
 

--- a/src/Sulu/Bundle/HttpCacheBundle/Cache/CacheManager.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Cache/CacheManager.php
@@ -18,8 +18,8 @@ use Sulu\Component\Webspace\Url\ReplacerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
- * Sulu cache manager wraps the FOSCacheManager to check if a host replacer is in the path
- * and also checks for every operation if the current proxy client supports the method otherwise just return.
+ * Sulu cache manager wraps the FOSCacheManager to check for every operation if the current proxy client supports the
+ * method otherwise just return.
  */
 class CacheManager implements CacheManagerInterface
 {
@@ -28,25 +28,8 @@ class CacheManager implements CacheManagerInterface
      */
     private $fosCacheManager;
 
-    /**
-     * @var ReplacerInterface
-     */
-    private $replacer;
-
-    /**
-     * @var null|string
-     */
-    private $requestHost;
-
-    public function __construct(
-        FOSCacheManager $fosCacheManager,
-        RequestStack $requestStack,
-        ReplacerInterface $replacer
-    ) {
+    public function __construct(FOSCacheManager $fosCacheManager) {
         $this->fosCacheManager = $fosCacheManager;
-        $this->replacer = $replacer;
-        $this->requestHost =
-            $requestStack->getCurrentRequest() ? $requestStack->getCurrentRequest()->getHttpHost() : null;
     }
 
     /**
@@ -56,15 +39,6 @@ class CacheManager implements CacheManagerInterface
     {
         if (!$this->fosCacheManager->supports(FOSCacheManager::PATH)) {
             return;
-        }
-
-        // replacer host replacer if available
-        if ($this->replacer->hasHostReplacer($path)) {
-            if (!$this->requestHost) {
-                return;
-            }
-
-            $path = $this->replacer->replaceHost($path, $this->requestHost);
         }
 
         $this->fosCacheManager->invalidatePath($path, $headers);

--- a/src/Sulu/Bundle/HttpCacheBundle/EventSubscriber/InvalidationSubscriber.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/EventSubscriber/InvalidationSubscriber.php
@@ -264,7 +264,6 @@ class InvalidationSubscriber implements EventSubscriberInterface
     /**
      * Returns all urls of the given locale which are associated with the given document.
      * The returned array contains all current urls and all history urls.
-     * The returned urls can contain placeholders (eg {host}).
      *
      * @param ResourceSegmentBehavior $document
      * @param string $locale

--- a/src/Sulu/Bundle/HttpCacheBundle/Resources/config/cache-manager.xml
+++ b/src/Sulu/Bundle/HttpCacheBundle/Resources/config/cache-manager.xml
@@ -5,8 +5,6 @@
     <services>
         <service id="sulu_http_cache.cache_manager" class="Sulu\Bundle\HttpCacheBundle\Cache\CacheManager">
             <argument type="service" id="fos_http_cache.cache_manager"/>
-            <argument type="service" id="request_stack"/>
-            <argument type="service" id="sulu_core.webspace.webspace_manager.url_replacer"/>
         </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/Cache/CacheManagerTest.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/Cache/CacheManagerTest.php
@@ -70,9 +70,9 @@ class CacheManagerTest extends TestCase
         $this->cacheManager->invalidateTag($tag);
     }
 
-    public function testInvalidatePathWithHostReplacer()
+    public function testInvalidatePath()
     {
-        $path = 'http://{host}/test';
+        $path = 'http://sulu.lo/test';
 
         // proxy client doesn't support path invalidation
         $this->fosCacheManager->supports(FOSCacheManager::PATH)->willReturn(false);
@@ -83,11 +83,6 @@ class CacheManagerTest extends TestCase
         $this->fosCacheManager->supports(FOSCacheManager::PATH)->willReturn(true);
         $this->fosCacheManager->invalidatePath(Argument::any())->shouldNotBeCalled();
         $this->cacheManager->invalidatePath($path);
-
-        // set the host correctly
-        $request = $this->prophesize(Request::class);
-        $request->getHttpHost()->willReturn('sulu.lo');
-        $this->requestStack->getCurrentRequest()->willReturn($request->reveal());
 
         $this->cacheManager = new CacheManager(
             $this->fosCacheManager->reveal(),

--- a/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/Cache/CacheManagerTest.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/Cache/CacheManagerTest.php
@@ -16,9 +16,6 @@ use FOS\HttpCacheBundle\CacheManager as FOSCacheManager;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sulu\Bundle\HttpCacheBundle\Cache\CacheManager;
-use Sulu\Component\Webspace\Url\Replacer;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 class CacheManagerTest extends TestCase
 {
@@ -32,27 +29,11 @@ class CacheManagerTest extends TestCase
      */
     private $fosCacheManager;
 
-    /**
-     * @var RequestStack
-     */
-    private $requestStack;
-
-    /**
-     * @var Replacer
-     */
-    private $urlReplacer;
-
     public function setUp(): void
     {
         $this->fosCacheManager = $this->prophesize(FOSCacheManager::class);
-        $this->requestStack = $this->prophesize(RequestStack::class);
-        $this->urlReplacer = new Replacer();
 
-        $this->cacheManager = new CacheManager(
-            $this->fosCacheManager->reveal(),
-            $this->requestStack->reveal(),
-            $this->urlReplacer
-        );
+        $this->cacheManager = new CacheManager($this->fosCacheManager->reveal());
     }
 
     public function testInvalidateTag()
@@ -72,31 +53,20 @@ class CacheManagerTest extends TestCase
 
     public function testInvalidatePath()
     {
-        $path = 'http://sulu.lo/test';
-
-        // proxy client doesn't support path invalidation
-        $this->fosCacheManager->supports(FOSCacheManager::PATH)->willReturn(false);
-        $this->fosCacheManager->invalidatePath(Argument::any())->shouldNotBeCalled();
-        $this->cacheManager->invalidatePath($path);
-
-        // proxy client supports path invalidation
-        $this->fosCacheManager->supports(FOSCacheManager::PATH)->willReturn(true);
-        $this->fosCacheManager->invalidatePath(Argument::any())->shouldNotBeCalled();
-        $this->cacheManager->invalidatePath($path);
-
-        $this->cacheManager = new CacheManager(
-            $this->fosCacheManager->reveal(),
-            $this->requestStack->reveal(),
-            $this->urlReplacer
-        );
-
         $this->fosCacheManager->supports(FOSCacheManager::PATH)->willReturn(true);
         $this->fosCacheManager->invalidatePath('http://sulu.lo/test', Argument::cetera())->shouldBeCalled();
 
         $this->fosCacheManager->supports(FOSCacheManager::REFRESH)->willReturn(true);
         $this->fosCacheManager->refreshPath('http://sulu.lo/test', Argument::cetera())->shouldBeCalled();
 
-        $this->cacheManager->invalidatePath($path);
+        $this->cacheManager->invalidatePath('http://sulu.lo/test');
+    }
+
+    public function testInvalidatePathWithoutSupport()
+    {
+        $this->fosCacheManager->supports(FOSCacheManager::PATH)->willReturn(false);
+        $this->fosCacheManager->invalidatePath(Argument::any())->shouldNotBeCalled();
+        $this->cacheManager->invalidatePath('http://sulu.lo/test');
     }
 
     public function testInvalidateDomain()

--- a/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/EventSubscriber/InvalidationSubscriberTest.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/EventSubscriber/InvalidationSubscriberTest.php
@@ -142,9 +142,9 @@ class InvalidationSubscriberTest extends TestCase
         $resourceLocator1 = '/path/to/1';
         $resourceLocator2 = '/path/to/2';
 
-        $url1 = '{host}/path/to/1';
-        $url2 = '{host}/path/to/2';
-        $url3 = '{host}/other/to/2';
+        $url1 = 'sulu.lo/path/to/1';
+        $url2 = 'sulu.lo/path/to/2';
+        $url3 = 'sulu.lo/other/to/2';
 
         $document = $this->prophesize(BasePageDocument::class);
         $document->getPublished()->willReturn(true);
@@ -293,8 +293,8 @@ class InvalidationSubscriberTest extends TestCase
         $resourceLocator1 = '/path/to/1';
         $resourceLocator2 = '/path/to/2';
 
-        $url1 = '{host}/path/to/1';
-        $url2 = '{host}/path/to/2';
+        $url1 = 'sulu.lo/path/to/1';
+        $url2 = 'sulu.lo/path/to/2';
 
         $document = $this->prophesize(BasePageDocument::class);
         $document->getPublished()->willReturn(true);
@@ -404,9 +404,9 @@ class InvalidationSubscriberTest extends TestCase
         $resourceLocatorDe1 = '/pfad/zu/1';
         $resourceLocatorEn2 = '/path/to/2';
 
-        $urlEn1 = '{host}/path/to/1';
-        $urlDe1 = '{host}/other/to/2';
-        $urlEn2 = '{host}/path/to/2';
+        $urlEn1 = 'sulu.lo/path/to/1';
+        $urlDe1 = 'sulu.lo/other/to/2';
+        $urlEn2 = 'sulu.lo/path/to/2';
 
         $document = $this->prophesize(BasePageDocument::class);
         $document->getPublished()->willReturn(true);

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -27,7 +27,6 @@ use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\PortalInformation;
 use Sulu\Component\Webspace\Url;
-use Sulu\Component\Webspace\Url\ReplacerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -67,11 +67,6 @@ class PreviewRenderer implements PreviewRendererInterface
     private $eventDispatcher;
 
     /**
-     * @var ReplacerInterface
-     */
-    private $replacer;
-
-    /**
      * @var array
      */
     private $previewDefaults;
@@ -92,12 +87,6 @@ class PreviewRenderer implements PreviewRendererInterface
     private $targetGroupHeader;
 
     /**
-     * @param RouteDefaultsProviderInterface $routeDefaultsProvider
-     * @param RequestStack $requestStack
-     * @param KernelFactoryInterface $kernelFactory
-     * @param WebspaceManagerInterface $webspaceManager
-     * @param EventDispatcherInterface $eventDispatcher
-     * @param array $previewDefaults
      * @param string $environment
      * @param string $targetGroupHeader
      */
@@ -107,7 +96,6 @@ class PreviewRenderer implements PreviewRendererInterface
         KernelFactoryInterface $kernelFactory,
         WebspaceManagerInterface $webspaceManager,
         EventDispatcherInterface $eventDispatcher,
-        ReplacerInterface $replacer,
         array $previewDefaults,
         $environment,
         $targetGroupHeader = null
@@ -117,7 +105,6 @@ class PreviewRenderer implements PreviewRendererInterface
         $this->kernelFactory = $kernelFactory;
         $this->webspaceManager = $webspaceManager;
         $this->eventDispatcher = $eventDispatcher;
-        $this->replacer = $replacer;
         $this->previewDefaults = $previewDefaults;
         $this->environment = $environment;
         $this->targetGroupHeader = $targetGroupHeader;
@@ -171,6 +158,8 @@ class PreviewRenderer implements PreviewRendererInterface
                 'postParameters' => $request,
                 'portalInformation' => $portalInformation,
                 'scheme' => $currentRequest->getScheme(),
+                'host' => $currentRequest->getHost(),
+                'port' => $currentRequest->getPort(),
             ]
         );
 
@@ -242,7 +231,6 @@ class PreviewRenderer implements PreviewRendererInterface
     {
         // get server parameters
         $server = [];
-        $host = null;
         // FIXME default scheme and port should be configurable.
         $scheme = 'http';
         $port = 80;
@@ -250,11 +238,10 @@ class PreviewRenderer implements PreviewRendererInterface
         if ($currentRequest) {
             $server = $currentRequest->server->all();
             $scheme = $currentRequest->getScheme();
-            $host = $currentRequest->getHost();
             $port = $currentRequest->getPort();
         }
 
-        $portalUrl = $scheme . '://' . $this->replacer->replaceHost($portalInformation->getUrl(), $host);
+        $portalUrl = $scheme . '://' . $portalInformation->getUrl();
         $portalUrlParts = parse_url($portalUrl);
 
         $serverName = null;

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/services.xml
@@ -27,7 +27,6 @@
             <argument type="service" id="sulu_preview.preview.kernel_factory"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="event_dispatcher"/>
-            <argument type="service" id="sulu_core.webspace.webspace_manager.url_replacer"/>
             <argument type="collection" />
             <argument type="string">%kernel.environment%</argument>
             <argument type="expression">

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Application/config/webspaces/sulu.io.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Application/config/webspaces/sulu.io.xml
@@ -63,6 +63,13 @@
                         <url>sulu.lo/{localization}</url>
                     </urls>
                 </environment>
+                <environment type="test">
+                    <urls>
+                        <url language="en">sulu.us</url>
+                        <url language="de">www.sulu.io</url>
+                        <url>sulu.lo/{localization}</url>
+                    </urls>
+                </environment>
                 <environment type="stage">
                     <urls>
                         <url>stage.sulu.lo/{localization}</url>

--- a/src/Sulu/Bundle/WebsiteBundle/Command/DumpSitemapCommand.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Command/DumpSitemapCommand.php
@@ -35,11 +35,6 @@ class DumpSitemapCommand extends Command
     private $sitemapDumper;
 
     /**
-     * @var ReplacerInterface
-     */
-    private $urlReplacer;
-
-    /**
      * @var Filesystem
      */
     private $filesystem;
@@ -72,7 +67,6 @@ class DumpSitemapCommand extends Command
     public function __construct(
         WebspaceManagerInterface $webspaceManager,
         XmlSitemapDumperInterface $sitemapDumper,
-        ReplacerInterface $urlReplacer,
         Filesystem $filesystem,
         string $baseDirectory,
         string $environment,
@@ -83,7 +77,6 @@ class DumpSitemapCommand extends Command
 
         $this->webspaceManager = $webspaceManager;
         $this->sitemapDumper = $sitemapDumper;
-        $this->urlReplacer = $urlReplacer;
         $this->filesystem = $filesystem;
         $this->environment = $environment;
         $this->baseDirectory = $baseDirectory;
@@ -116,10 +109,6 @@ class DumpSitemapCommand extends Command
         $hosts = [];
         foreach ($portalInformations as $portalInformation) {
             $portalUrl = $portalInformation->getUrl();
-            if ($this->urlReplacer->hasHostReplacer($portalUrl)) {
-                $portalUrl = $this->urlReplacer->replaceHost($portalUrl, $this->defaultHost);
-            }
-
             $urlParts = parse_url($this->scheme . '://' . $portalUrl);
             $hosts[] = $urlParts['host'];
         }

--- a/src/Sulu/Bundle/WebsiteBundle/Command/DumpSitemapCommand.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Command/DumpSitemapCommand.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\WebsiteBundle\Command;
 
 use Sulu\Bundle\WebsiteBundle\Sitemap\XmlSitemapDumperInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
-use Sulu\Component\Webspace\Url\ReplacerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/command.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/command.xml
@@ -6,7 +6,6 @@
         <service id="sulu_website.command.dump_sitemap" class="Sulu\Bundle\WebsiteBundle\Command\DumpSitemapCommand">
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="sulu_website.sitemap.xml_dumper"/>
-            <argument type="service" id="sulu_core.webspace.webspace_manager.url_replacer"/>
             <argument type="service" id="filesystem"/>
             <argument>%sulu_website.sitemap.dump_dir%</argument>
             <argument>%kernel.environment%</argument>

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/PortalLoader.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/PortalLoader.php
@@ -47,7 +47,7 @@ class PortalLoader extends Loader
                     $importedRoute->getDefaults(),
                     array_merge(['prefix' => '.*', 'host' => '.+'], $importedRoute->getRequirements()),
                     $importedRoute->getOptions(),
-                    (!empty($importedRoute->getHost()) ? $importedRoute->getHost() : '{host}'),
+                    $importedRoute->getHost(),
                     $importedRoute->getSchemes(),
                     $importedRoute->getMethods(),
                     $condition . (!empty($importedCondition) ? ' and (' . $importedCondition . ')' : '')

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/PortalLoaderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/PortalLoaderTest.php
@@ -87,8 +87,8 @@ class PortalLoaderTest extends TestCase
 
         $this->assertEquals('{prefix}/example/route1', $routeCollection->get('route1')->getPath());
         $this->assertEquals('{prefix}/route2', $routeCollection->get('route2')->getPath());
-        $this->assertEquals('{host}', $routeCollection->get('route1')->getHost());
-        $this->assertEquals('{host}', $routeCollection->get('route2')->getHost());
+        $this->assertEquals('', $routeCollection->get('route1')->getHost());
+        $this->assertEquals('', $routeCollection->get('route2')->getHost());
         $this->assertEquals($this->condition, $routeCollection->get('route1')->getCondition());
         $this->assertEquals($this->condition, $routeCollection->get('route2')->getCondition());
     }
@@ -115,8 +115,8 @@ class PortalLoaderTest extends TestCase
 
         $this->assertEquals('{prefix}/example/route1', $routeCollection->get('route1')->getPath());
         $this->assertEquals('{prefix}/route2', $routeCollection->get('route2')->getPath());
-        $this->assertEquals('{host}', $routeCollection->get('route1')->getHost());
-        $this->assertEquals('{host}', $routeCollection->get('route2')->getHost());
+        $this->assertEquals('', $routeCollection->get('route1')->getHost());
+        $this->assertEquals('', $routeCollection->get('route2')->getHost());
         $this->assertEquals($this->condition, $routeCollection->get('route1')->getCondition());
         $this->assertEquals($this->condition, $routeCollection->get('route2')->getCondition());
     }
@@ -139,7 +139,7 @@ class PortalLoaderTest extends TestCase
         $this->assertInstanceOf(PortalRoute::class, $routeCollection->get('route'));
 
         $this->assertEquals('{prefix}/route', $routeCollection->get('route')->getPath());
-        $this->assertEquals('{host}', $routeCollection->get('route')->getHost());
+        $this->assertEquals('', $routeCollection->get('route')->getHost());
         $this->assertEquals($this->condition, $routeCollection->get('route')->getCondition());
     }
 

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
@@ -15,7 +15,6 @@ use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\Webspace\Analyzer\Exception\UrlMatchNotFoundException;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\PortalInformation;
-use Sulu\Component\Webspace\Url\ReplacerInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 /**

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
@@ -38,20 +38,13 @@ class WebsiteRequestProcessor implements RequestProcessorInterface
      */
     private $environment;
 
-    /**
-     * @var ReplacerInterface
-     */
-    private $replacer;
-
     public function __construct(
         WebspaceManagerInterface $webspaceManager,
         ContentMapperInterface $contentMapper,
-        ReplacerInterface $replacer,
         $environment
     ) {
         $this->webspaceManager = $webspaceManager;
         $this->contentMapper = $contentMapper;
-        $this->replacer = $replacer;
         $this->environment = $environment;
     }
 
@@ -62,12 +55,6 @@ class WebsiteRequestProcessor implements RequestProcessorInterface
     {
         $host = $requestAttributes->getAttribute('host');
         $url = $host . $requestAttributes->getAttribute('path');
-        foreach ($this->webspaceManager->getPortalInformations($this->environment) as $portalInformation) {
-            $portalUrl = $this->replacer->replaceHost($portalInformation->getUrl(), $host);
-            $portalInformation->setUrl($portalUrl);
-            $portalRedirect = $this->replacer->replaceHost($portalInformation->getRedirect(), $host);
-            $portalInformation->setRedirect($portalRedirect);
-        }
 
         $portalInformations = $this->webspaceManager->findPortalInformationsByUrl(
             $url,

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -124,10 +124,6 @@ class WebspaceManager implements WebspaceManagerInterface
             function(PortalInformation $portalInformation) use ($host) {
                 $portalHost = $portalInformation->getHost();
 
-                if ($this->urlReplacer->hasHostReplacer($portalHost)) {
-                    $portalHost = $this->urlReplacer->replaceHost($portalHost, $host);
-                }
-
                 // add a slash to avoid problems with "example.co" and "example.com"
                 return false !== strpos($portalHost . '/', $host . '/');
             }
@@ -471,10 +467,6 @@ class WebspaceManager implements WebspaceManagerInterface
         if (false !== strpos($portalUrl, '/')) {
             // trim slash when resourceLocator is not domain root
             $resourceLocator = rtrim($resourceLocator, '/');
-        }
-
-        if ($domain && $this->urlReplacer->hasHostReplacer($portalUrl)) {
-            $portalUrl = $this->urlReplacer->replaceHost($portalUrl, $domain);
         }
 
         return rtrim(sprintf('%s://%s', $scheme, $portalUrl), '/') . $resourceLocator;

--- a/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
@@ -24,7 +24,6 @@ use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\PortalInformation;
-use Sulu\Component\Webspace\Url\ReplacerInterface;
 use Sulu\Component\Webspace\Webspace;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
@@ -48,11 +47,6 @@ class RequestAnalyzerTest extends TestCase
     private $contentMapper;
 
     /**
-     * @var ReplacerInterface
-     */
-    private $replacer;
-
-    /**
      * @var RequestStack
      */
     private $requestStack;
@@ -62,14 +56,13 @@ class RequestAnalyzerTest extends TestCase
         $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
         $this->contentMapper = $this->prophesize(ContentMapperInterface::class);
         $this->requestStack = $this->prophesize(RequestStack::class);
-        $this->replacer = $this->prophesize(ReplacerInterface::class);
 
         $this->requestAnalyzer = new RequestAnalyzer(
             $this->requestStack->reveal(),
             [
                 new UrlRequestProcessor(),
                 new WebsiteRequestProcessor(
-                    $this->webspaceManager->reveal(), $this->contentMapper->reveal(), $this->replacer->reveal(), 'prod'
+                    $this->webspaceManager->reveal(), $this->contentMapper->reveal(), 'prod'
                 ),
                 new PortalInformationRequestProcessor(),
             ]

--- a/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoader11Test.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoader11Test.php
@@ -91,7 +91,7 @@ class XmlFileLoader11Test extends WebspaceTestCase
 
         $this->assertEquals('de_at', $webspace->getPortals()[0]->getDefaultLocalization()->getLocale());
 
-        $this->assertEquals(3, count($webspace->getPortals()[0]->getEnvironments()));
+        $this->assertEquals(4, count($webspace->getPortals()[0]->getEnvironments()));
 
         $environmentProd = $webspace->getPortals()[0]->getEnvironment('prod');
         $this->assertEquals('prod', $environmentProd->getType());
@@ -108,6 +108,22 @@ class XmlFileLoader11Test extends WebspaceTestCase
         $this->assertEquals(null, $environmentProd->getUrls()[1]->getSegment());
         $this->assertEquals(null, $environmentProd->getUrls()[1]->getCountry());
         $this->assertEquals('sulu.at', $environmentProd->getUrls()[1]->getRedirect());
+
+        $environmentTest = $webspace->getPortals()[0]->getEnvironment('test');
+        $this->assertEquals('test', $environmentTest->getType());
+        $this->assertEquals(2, count($environmentTest->getUrls()));
+        $this->assertEquals('sulu.at', $environmentTest->getUrls()[0]->getUrl());
+        $this->assertTrue($environmentTest->getUrls()[0]->isMain());
+        $this->assertEquals('de', $environmentTest->getUrls()[0]->getLanguage());
+        $this->assertEquals(null, $environmentTest->getUrls()[0]->getSegment());
+        $this->assertEquals('at', $environmentTest->getUrls()[0]->getCountry());
+        $this->assertEquals(null, $environmentTest->getUrls()[0]->getRedirect());
+        $this->assertEquals('www.sulu.at', $environmentTest->getUrls()[1]->getUrl());
+        $this->assertFalse($environmentTest->getUrls()[1]->isMain());
+        $this->assertEquals(null, $environmentTest->getUrls()[1]->getLanguage());
+        $this->assertEquals(null, $environmentTest->getUrls()[1]->getSegment());
+        $this->assertEquals(null, $environmentTest->getUrls()[1]->getCountry());
+        $this->assertEquals('sulu.at', $environmentTest->getUrls()[1]->getRedirect());
 
         $environmentDev = $webspace->getPortals()[0]->getEnvironment('dev');
         $this->assertEquals('dev', $environmentDev->getType());

--- a/tests/Resources/DataFixtures/Webspace/multiple/massiveart.xml
+++ b/tests/Resources/DataFixtures/Webspace/multiple/massiveart.xml
@@ -85,6 +85,11 @@
                         <url>{language}.massiveart-ca.{country}/{segment}</url>
                     </urls>
                 </environment>
+                <environment type="test">
+                    <urls>
+                        <url>{language}.massiveart-ca.{country}/{segment}</url>
+                    </urls>
+                </environment>
                 <environment type="dev">
                     <urls>
                         <url>massiveart-ca.lo/{localization}/{segment}</url>

--- a/tests/Resources/DataFixtures/Webspace/valid/sulu.io.xml
+++ b/tests/Resources/DataFixtures/Webspace/valid/sulu.io.xml
@@ -65,6 +65,12 @@
                         <url redirect="sulu.at">www.sulu.at</url>
                     </urls>
                 </environment>
+                <environment type="test">
+                    <urls>
+                        <url language="de" country="at">sulu.at</url>
+                        <url redirect="sulu.at">www.sulu.at</url>
+                    </urls>
+                </environment>
                 <environment type="dev">
                     <urls>
                         <url language="de" country="at">sulu.lo</url>

--- a/tests/Resources/DataFixtures/Webspace/valid/sulu.io_hostReplacer.xml
+++ b/tests/Resources/DataFixtures/Webspace/valid/sulu.io_hostReplacer.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<webspace xmlns="http://schemas.sulu.io/webspace/webspace"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.1.xsd">
+
+    <name>Sulu CMF</name>
+    <key>sulu_io_host_replacement</key>
+
+    <navigation>
+        <contexts>
+            <context key="main">
+                <meta>
+                    <title lang="de">Hauptnavigation</title>
+                    <title lang="en">Mainnavigation</title>
+                </meta>
+            </context>
+        </contexts>
+    </navigation>
+
+    <localizations>
+        <localization language="de" country="at" default="true"/>
+    </localizations>
+
+    <default-templates>
+        <default-template type="page">default</default-template>
+        <default-template type="homepage">overview</default-template>
+    </default-templates>
+
+    <portals>
+        <portal>
+            <name>Sulu CMF AT</name>
+            <key>sulucmf_at_host_replacement</key>
+
+            <environments>
+                <environment type="test">
+                    <urls>
+                        <url>{host}/{localization}</url>
+                    </urls>
+                </environment>
+            </environments>
+        </portal>
+    </portals>
+</webspace>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5020
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR will replace the host immediately after the webspace collection is loaded from the cache. This has the advantage, that nobody else has to take care of the `{host}` placeholder.

#### Why?

Because it solves #5020, and allows to delete other code handling the exact same thing.

#### BC Breaks/Deprecations

The `{host}` placeholder is not available anymore. Code that relies on that is not necessary and anymore and can be deleted. In case somebody abused that placeholder for something else, that code might not work anymore.

#### To Do

- [x] Delete code not being necessary anymore