### PR TITLE
Add 'id' as a reserved property

### DIFF
--- a/src/Sulu/Component/Content/Metadata/Loader/XmlLegacyLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/XmlLegacyLoader.php
@@ -72,6 +72,8 @@ class XmlLegacyLoader implements LoaderInterface
         'shadow-base',
         'author',
         'authored',
+        'type',
+        'id',
     ];
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4100 and fixes #2147
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

Adds 'id' and 'type' to the array of reserved properties

#### Why?

Using 'id' or 'type' as a property name in a page template results in errors when trying to create/edit pages
