### PR TITLE
Fixing TwigException parameter types

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Preview/Exception/PreviewRendererException.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Exception/PreviewRendererException.php
@@ -24,7 +24,7 @@ abstract class PreviewRendererException extends PreviewException
     private $object;
 
     /**
-     * @var string
+     * @var int|string
      */
     private $id;
 
@@ -42,7 +42,7 @@ abstract class PreviewRendererException extends PreviewException
      * @param string $message
      * @param int $code
      * @param mixed $object
-     * @param string $id
+     * @param int|string $id
      * @param string $webspaceKey
      * @param string $locale
      * @param \Exception $previous

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Exception/RouteDefaultsProviderNotFoundException.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Exception/RouteDefaultsProviderNotFoundException.php
@@ -17,8 +17,8 @@ namespace Sulu\Bundle\PreviewBundle\Preview\Exception;
 class RouteDefaultsProviderNotFoundException extends PreviewRendererException
 {
     /**
-     * @param string $object
-     * @param int $id
+     * @param mixed $object
+     * @param int|string $id
      * @param mixed $webspaceKey
      * @param string $locale
      */

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Exception/TemplateNotFoundException.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Exception/TemplateNotFoundException.php
@@ -18,8 +18,8 @@ class TemplateNotFoundException extends PreviewRendererException
 {
     /**
      * @param \InvalidArgumentException $exception
-     * @param int $object
-     * @param mixed $id
+     * @param mixed $object
+     * @param int|string $id
      * @param string $webspaceKey
      * @param string $locale
      */

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Exception/TwigException.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Exception/TwigException.php
@@ -19,8 +19,8 @@ use Twig\Error\Error;
 class TwigException extends PreviewRendererException
 {
     /**
-     * @param int $object
-     * @param mixed $id
+     * @param mixed $object
+     * @param int|string $id
      * @param string $webspaceKey
      * @param string $locale
      */

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Exception/UnexpectedException.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Exception/UnexpectedException.php
@@ -18,8 +18,8 @@ class UnexpectedException extends PreviewRendererException
 {
     /**
      * @param \Exception $exception
-     * @param int $object
-     * @param mixed $id
+     * @param mixed $object
+     * @param int|string $id
      * @param string $webspaceKey
      * @param string $locale
      */

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Exception/WebspaceLocalizationNotFoundException.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Exception/WebspaceLocalizationNotFoundException.php
@@ -17,8 +17,8 @@ namespace Sulu\Bundle\PreviewBundle\Preview\Exception;
 class WebspaceLocalizationNotFoundException extends PreviewRendererException
 {
     /**
-     * @param object $object
-     * @param int $id
+     * @param mixed $object
+     * @param int|string $id
      * @param string $webspaceKey
      * @param string $locale
      */

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Exception/WebspaceNotFoundException.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Exception/WebspaceNotFoundException.php
@@ -17,8 +17,8 @@ namespace Sulu\Bundle\PreviewBundle\Preview\Exception;
 class WebspaceNotFoundException extends PreviewRendererException
 {
     /**
-     * @param object $object
-     * @param int $id
+     * @param mixed $object
+     * @param int|string $id
      * @param string $webspaceKey
      * @param string $locale
      */


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?
Currently TwigException uses
https://github.com/sulu/sulu/blob/ade35fff4cb8ced777c726dcb730c5c5f5720960/src/Sulu/Bundle/PreviewBundle/Preview/Exception/TwigException.php#L22
https://github.com/sulu/sulu/blob/ade35fff4cb8ced777c726dcb730c5c5f5720960/src/Sulu/Bundle/PreviewBundle/Preview/Exception/TwigException.php#L23

The parent uses:
https://github.com/sulu/sulu/blob/ade35fff4cb8ced777c726dcb730c5c5f5720960/src/Sulu/Bundle/PreviewBundle/Preview/Exception/PreviewRendererException.php#L44
https://github.com/sulu/sulu/blob/ade35fff4cb8ced777c726dcb730c5c5f5720960/src/Sulu/Bundle/PreviewBundle/Preview/Exception/PreviewRendererException.php#L45


And I matched those types.


#### Why?
Just wrong PHPDoc types and PHPStorm pointed that out.

#### BC Breaks/Deprecations

None

#### To Do

Nothing
