### PR TITLE
Fix build download for other platforms

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Command/DownloadBuildCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/DownloadBuildCommand.php
@@ -162,6 +162,7 @@ class DownloadBuildCommand extends Command
 
     private function hash($content)
     {
-        return hash('sha256', $content);
+        // we remove all whitespaces as the developer could change the indention or/and the line breaks of this files
+        return hash('sha256', preg_replace('/\s+/', '', $content));
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5031 
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix build download for other platforms by removing all whitespaces in hash check.

#### Why?

When the developer using different Line breaks or have other indention of the file the hash check currently fails. With removing the whitespaces before the hash check this will fix proble,.

#### Example Usage

Change whitespaces or change linbreaks in and run:

~~~php
bin/console sulu:admin:download-build
~~~
