### PR TITLE
Use correct default scheme for sulu_content_path

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/Resources/config/webspace.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/webspace.xml
@@ -42,6 +42,7 @@
             </argument>
             <argument>%kernel.environment%</argument>
             <argument>%router.request_context.host%</argument>
+            <argument>%router.request_context.scheme%</argument>
 
             <tag name="sulu.localization_provider"/>
         </service>

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManagerInterface.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManagerInterface.php
@@ -75,7 +75,7 @@ interface WebspaceManagerInterface extends LocalizationProviderInterface
         string $languageCode,
         ?string $webspaceKey = null,
         ?string $domain = null,
-        string $scheme = 'http'
+        ?string $scheme = null
     ): array;
 
     /**
@@ -87,7 +87,7 @@ interface WebspaceManagerInterface extends LocalizationProviderInterface
         string $languageCode,
         ?string $webspaceKey = null,
         ?string $domain = null,
-        string $scheme = 'http'
+        ?string $scheme = null
     ): ?string;
 
     /**

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
@@ -78,7 +78,8 @@ class WebspaceManagerTest extends WebspaceTestCase
                 'cache_class' => 'WebspaceCollectionCache' . uniqid(),
             ],
             'test',
-            'sulu.io'
+            'sulu.io',
+            'http'
         );
     }
 
@@ -574,7 +575,8 @@ class WebspaceManagerTest extends WebspaceTestCase
                 'cache_class' => 'WebspaceCollectionCache' . uniqid(),
             ],
             'test',
-            'sulu.io'
+            'sulu.io',
+            'http'
         );
 
         $webspaces = $this->webspaceManager->getWebspaceCollection();
@@ -676,6 +678,25 @@ class WebspaceManagerTest extends WebspaceTestCase
 
         $result = $this->webspaceManager->findUrlsByResourceLocator('/test', 'dev', 'de_at', 'sulu_io', null, 'https');
         $this->assertEquals(['https://sulu.lo/test'], $result);
+    }
+
+    public function testFindUrlsByResourceLocatorWithSchemeNull()
+    {
+        $result = $this->webspaceManager->findUrlsByResourceLocator(
+            '/test',
+            'dev',
+            'en_us',
+            'massiveart',
+            null,
+            null
+        );
+
+        $this->assertCount(2, $result);
+        $this->assertContains('http://massiveart.lo/en-us/w/test', $result);
+        $this->assertContains('http://massiveart.lo/en-us/s/test', $result);
+
+        $result = $this->webspaceManager->findUrlsByResourceLocator('/test', 'dev', 'de_at', 'sulu_io', null, null);
+        $this->assertEquals(['http://sulu.lo/test'], $result);
     }
 
     public function testFindUrlsByResourceLocatorRoot()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | #5024 
| License | MIT
| Documentation PR | -

#### What's in this PR?

Make scheme in sulu_content_path optional and use the correct default scheme from the router context if generating routes.

#### Why?

Currently the scheme is required and we should use when generating routes from cli as default the `%router.request_context.scheme%` parameter. See https://symfony.com/doc/4.1/console/request_context.html#configuring-the-request-context-globally. This avoids that sulu behave different to symfony routes.

#### Example Usage

Apply the following patch to the sulu skeleton

<details>

<summary>patch.diff</summary>

~~~php
diff --git a/config/services.yaml b/config/services.yaml
index 9ef2ff7..4df6ccf 100644
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -2,6 +2,9 @@
 # http://symfony.com/doc/current/book/service_container.html
 parameters:
     default_locale: en
+    router.request_context.host: 'example.org:8181'
+    router.request_context.scheme: 'https'
+#    router.request_context.base_url: 'my/path'
 
 services:
     # default configuration for services in *this* file
diff --git a/config/webspaces/example.xml b/config/webspaces/example.xml
index 39e5aa5..2d36f2e 100644
--- a/config/webspaces/example.xml
+++ b/config/webspaces/example.xml
@@ -42,22 +42,22 @@
             <environments>
                 <environment type="prod">
                     <urls>
-                        <url language="en">{host}</url>
+                        <url>{host}/{localization}</url>
                     </urls>
                 </environment>
                 <environment type="stage">
                     <urls>
-                        <url language="en">{host}</url>
+                        <url>{host}/{localization}</url>
                     </urls>
                 </environment>
                 <environment type="test">
                     <urls>
-                        <url language="en">{host}</url>
+                        <url>{host}/{localization}</url>
                     </urls>
                 </environment>
                 <environment type="dev">
                     <urls>
-                        <url language="en">{host}</url>
+                        <url>{host}/{localization}</url>
                     </urls>
                 </environment>
             </environments>
diff --git a/src/Command/RouteTestCommand.php b/src/Command/RouteTestCommand.php
new file mode 100644
index 0000000..8e1a59e
--- /dev/null
+++ b/src/Command/RouteTestCommand.php
@@ -0,0 +1,90 @@
+<?php
+
+namespace App\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Routing\RouterInterface;
+use Twig\Environment;
+
+class RouteTestCommand extends Command
+{
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var Environment
+     */
+    private $twig;
+
+    /**
+     * RouteTestCommand constructor.
+     * @param RouterInterface $router
+     */
+    public function __construct(RouterInterface $router, Environment $twig)
+    {
+        $this->router = $router;
+        $this->twig = $twig;
+
+        parent::__construct('app:test:route');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $suluContentPath = trim($this->twig->render('test.html.twig'));
+        $expectedSuluContentPath = 'https://example.org:8181/test-page';
+
+        $routeOnlyPrefix = $this->router->generate(
+            'sulu_search.website_search',
+            [
+                'prefix' => '/en',
+            ],
+            0
+        );
+        $expectedRouteOnlyPrefix = 'https://example.org:8181/en/search';
+
+        $routeWithCustomHost = $this->router->generate(
+            'sulu_search.website_search',
+            [
+                'prefix' => '/en',
+                'host' => 'mytestdomain.com',
+            ],
+            0
+        );
+        $expectedRouteWithCustomHost = 'https://example.org:8181/en/search?host=mytestdomain.com';
+
+        $symfonyRoute = $this->router->generate('sulu_website.sitemap_index', [], 0);
+        $expectedSymfonyRoute = 'https://example.org:8181/sitemap.xml';
+
+        $data = [
+            [
+                'generatedRoute' => $suluContentPath,
+                'expectedRoute' => $expectedSuluContentPath,
+                'match' => $suluContentPath === $expectedSuluContentPath,
+            ],
+            [
+                'generatedRoute' => $routeOnlyPrefix,
+                'expectedRoute' => $expectedRouteOnlyPrefix,
+                'match' => $routeOnlyPrefix === $expectedRouteOnlyPrefix,
+            ],
+            [
+                'generatedRoute' => $routeWithCustomHost,
+                'expectedRoute' => $expectedRouteWithCustomHost,
+                'match' => $routeWithCustomHost === $expectedRouteWithCustomHost,
+            ],
+            [
+                'generatedRoute' => $symfonyRoute,
+                'expectedRoute' => $expectedSymfonyRoute,
+                'match' => $symfonyRoute === $expectedSymfonyRoute,
+            ],
+        ];
+
+        $ui = new SymfonyStyle($input, $output);
+
+        $ui->table(array_keys($data[0]), $data);
+    }
+}
diff --git a/templates/test.html.twig b/templates/test.html.twig
new file mode 100644
index 0000000..643d5d8
--- /dev/null
+++ b/templates/test.html.twig
@@ -0,0 +1 @@
+{{ sulu_content_path('/test-page', 'example', 'de') }}
~~~

</details>

#### BC Breaks/Deprecations

The `$scheme` will now also allow `null` but think its a very internal interface which we could change as we also did extend the constructor in #5024 for this service so if somebody extended the WebspaceManager he also need to do that also there.

#### TODO

 - [x] Add test
