### PR TITLE
Add default values to schema for attributes inside of list xml files

### DIFF
--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/Resources/schema/list-2.0.xsd
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/Resources/schema/list-2.0.xsd
@@ -147,7 +147,7 @@
         <xs:attribute type="xs:string" name="type" default="string"/>
         <xs:attribute type="xs:boolean" name="sortable" default="true"/>
         <xs:attribute name="filter-type" type="xs:string"/>
-        <xs:attribute name="visibility">
+        <xs:attribute name="visibility" default="no">
             <xs:simpleType>
                 <xs:restriction base="xs:string">
                     <xs:enumeration value="yes" />
@@ -157,7 +157,7 @@
                 </xs:restriction>
             </xs:simpleType>
         </xs:attribute>
-        <xs:attribute name="searchability">
+        <xs:attribute name="searchability" default="never">
             <xs:simpleType>
                 <xs:restriction base="xs:string">
                     <xs:enumeration value="yes" />


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR add the default values for the `visibility` and `searchability` attribute inside of list comfiguration files.

#### Why?

Because I would like to see the default values for these attributes in my IDE 🙂 
