### PR TITLE
Detach FormatOptions entities before deleting Media

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -701,6 +701,9 @@ class MediaManager implements MediaManagerInterface
                     // this will trigger massive-search deindex
                     $this->em->remove($fileVersionMeta);
                 }
+                foreach ($fileVersion->getFormatOptions() as $formatOption) {
+                    $this->em->detach($formatOption);
+                }
                 $this->em->detach($fileVersion);
             }
             $this->em->detach($file);

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -701,8 +701,8 @@ class MediaManager implements MediaManagerInterface
                     // this will trigger massive-search deindex
                     $this->em->remove($fileVersionMeta);
                 }
-                foreach ($fileVersion->getFormatOptions() as $formatOption) {
-                    $this->em->detach($formatOption);
+                foreach ($fileVersion->getFormatOptions() as $formatOptions) {
+                    $this->em->detach($formatOptions);
                 }
                 $this->em->detach($fileVersion);
             }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
@@ -21,6 +21,7 @@ use Sulu\Bundle\MediaBundle\Entity\CollectionType;
 use Sulu\Bundle\MediaBundle\Entity\File;
 use Sulu\Bundle\MediaBundle\Entity\FileVersion;
 use Sulu\Bundle\MediaBundle\Entity\FileVersionMeta;
+use Sulu\Bundle\MediaBundle\Entity\FormatOptions;
 use Sulu\Bundle\MediaBundle\Entity\Media;
 use Sulu\Bundle\MediaBundle\Entity\MediaType;
 use Sulu\Bundle\TagBundle\Entity\Tag;
@@ -291,6 +292,17 @@ class MediaControllerTest extends SuluTestCase
 
         $fileVersion->addMeta($fileVersionMeta);
         $fileVersion->setDefaultMeta($fileVersionMeta);
+
+        // create format options
+        $formatOptions = new FormatOptions();
+        $formatOptions->setFileVersion($fileVersion);
+        $formatOptions->setFormatKey('format-key-1');
+        $formatOptions->setCropX(50);
+        $formatOptions->setCropY(50);
+        $formatOptions->setCropWidth(100);
+        $formatOptions->setCropHeight(100);
+
+        $fileVersion->addFormatOptions($formatOptions);
 
         $file->addFileVersion($fileVersion);
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
@@ -25,6 +25,7 @@ use Sulu\Bundle\MediaBundle\Entity\CollectionRepositoryInterface;
 use Sulu\Bundle\MediaBundle\Entity\File;
 use Sulu\Bundle\MediaBundle\Entity\FileVersion;
 use Sulu\Bundle\MediaBundle\Entity\FileVersionMeta;
+use Sulu\Bundle\MediaBundle\Entity\FormatOptions;
 use Sulu\Bundle\MediaBundle\Entity\Media;
 use Sulu\Bundle\MediaBundle\Entity\MediaRepositoryInterface;
 use Sulu\Bundle\MediaBundle\Entity\MediaType;
@@ -259,6 +260,9 @@ class MediaManagerTest extends TestCase
         $fileVersionMeta = $this->prophesize(FileVersionMeta::class);
         $fileVersion->getMeta()->willReturn([$fileVersionMeta->reveal()]);
 
+        $formatOptions = $this->prophesize(FormatOptions::class);
+        $fileVersion->getFormatOptions()->willReturn([$formatOptions->reveal()]);
+
         $media = $this->prophesize(Media::class);
         $media->getCollection()->willReturn($collection);
         $media->getFiles()->willReturn([$file->reveal()]);
@@ -279,8 +283,9 @@ class MediaManagerTest extends TestCase
         $this->storage->remove(['segment' => '01', 'fileName' => 'test.jpg'])->shouldBeCalled();
         $this->em->detach($fileVersion->reveal())->shouldBeCalled();
         $this->em->detach($file->reveal())->shouldBeCalled();
-        $this->em->remove($media->reveal())->shouldBeCalled();
         $this->em->remove($fileVersionMeta->reveal())->shouldBeCalled();
+        $this->em->detach($formatOptions->reveal())->shouldBeCalled();
+        $this->em->remove($media->reveal())->shouldBeCalled();
         $this->em->flush()->shouldBeCalled();
 
         $this->mediaManager->delete(1, true);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5044 
| License | MIT

#### What's in this PR?

This PR adjusts the `delete()` method of the `MediaManager` to detach all `FormatOptions` of a `FileVersion` before deleting the media. 

#### Why?

This prevents the error described in #5044 .
