### PR TITLE
Add reflection-docblock conflict to avoid test failures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -129,12 +129,13 @@
     "conflict": {
         "doctrine/dbal": "2.7.0",
         "doctrine/lexer": "1.0.0",
-        "symfony/doctrine-bridge": "< 3.4.0",
-        "symfony/http-foundation": "4.3.4",
         "jackalope/jackalope": "< 1.3.4",
-        "jackalope/jackalope-jackrabbit": "< 1.3.0",
         "jackalope/jackalope-doctrine-dbal": "< 1.3.0",
-        "phpcr/phpcr-utils": "1.2.0 - 1.2.10 || 1.3.0 - 1.3.2"
+        "jackalope/jackalope-jackrabbit": "< 1.3.0",
+        "phpcr/phpcr-utils": "1.2.0 - 1.2.10 || 1.3.0 - 1.3.2",
+        "phpdocumentor/reflection-docblock": "5.0.0",
+        "symfony/doctrine-bridge": "< 3.4.0",
+        "symfony/http-foundation": "4.3.4"
     },
     "replace": {
         "sulu/document-manager": "self.version",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | phpDocumentor/ReflectionDocBlock#203
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes our tests failure cause by an external library for now. I have already created a testcase in the other library: phpDocumentor/ReflectionDocBlock#203

#### Why?

Because otherwise our tests fail.