### PR TITLE
Add Tree Transliteration Generator Decorator.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -124,7 +124,8 @@
         "symfony/var-dumper": "^4.3",
         "symfony/web-profiler-bundle": "^4.3",
         "symfony/web-server-bundle": "^4.3",
-        "handcraftedinthealps/zendsearch": "^2.0"
+        "handcraftedinthealps/zendsearch": "^2.0",
+        "ext-intl": "*"
     },
     "conflict": {
         "doctrine/dbal": "2.7.0",

--- a/src/Sulu/Component/Content/Tests/Unit/ResourceLocator/Strategy/TreeTransliteratorGeneratorDecoratorTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/ResourceLocator/Strategy/TreeTransliteratorGeneratorDecoratorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Tests\Functional\ResourceLocator\Strategy;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Component\Content\Types\ResourceLocator\Strategy\TreeGenerator;
+use Sulu\Component\Content\Types\ResourceLocator\Strategy\TreeTransliteratorGeneratorDecorator;
+
+class TreeTransliteratorGeneratorDecoratorTest extends TestCase
+{
+    public function testGenerate()
+    {
+        $generator = new TreeGenerator();
+
+        $transliterator = \Transliterator::create('Russian-Latin/BGN');
+        $decorated = new TreeTransliteratorGeneratorDecorator($generator, $transliterator);
+
+        $this->assertEquals('/kakvo-stava', $decorated->generate('какво-става'));
+        $this->assertEquals('/kakvo-stava/maniatsi', $decorated->generate('маниаци', '/kakvo-stava'));
+    }
+}

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/TreeTransliteratorGeneratorDecorator.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/TreeTransliteratorGeneratorDecorator.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Types\ResourceLocator\Strategy;
+
+/**
+ * Uses Intl component to transliterate generated titles.
+ */
+class TreeTransliteratorGeneratorDecorator implements ResourceLocatorGeneratorInterface
+{
+    /** @var ResourceLocatorGeneratorInterface */
+    private $originalGenerator;
+
+    /** @var \Transliterator */
+    private $transliterator;
+
+    public function __construct(ResourceLocatorGeneratorInterface $originalGenerator, \Transliterator $transliterator)
+    {
+        $this->originalGenerator = $originalGenerator;
+        $this->transliterator = $transliterator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generate($title, $parentPath = null)
+    {
+        $generated = $this->originalGenerator->generate($title, $parentPath);
+
+        return $this->transliterator->transliterate($generated);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets |
| Related issues/PRs |
| License | MIT
| Documentation PR | sulu/sulu-docs#489

#### What's in this PR?

Add the transliterator Tree Generator Decorator.

#### Why?

When cyrillic is used in Titles/names and we want to transliterate these somehow.

#### Example Usage

See docs PR.

#### BC Breaks/Deprecations

No

#### To Do
