### PR TITLE
Add autowiring for MediaManagerInterface

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -235,6 +235,8 @@
             <argument type="service" id="sulu.repository.target_group" on-invalid="null"/>
         </service>
 
+        <service id="Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface" alias="sulu_media.media_manager"/>
+
         <service id="sulu_media.type_manager" class="%sulu_media.type_manager.class%">
             <argument type="service" id="doctrine.orm.entity_manager" />
             <argument>%sulu_media.media.types%</argument>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add autowiring for MediaManagerInterface.

#### Why?

Easier usage of the media manager.


```bash
bin/websiteconsole debug:container Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface
```

or:

```php
__construct(MediaManagerInterface $mediaManager) {
}
```