### PR TITLE
Register MediaManagerInterface::class as alias for sulu_media.media_manager service

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -234,6 +234,7 @@
             <argument>%sulu_media.media.max_file_size%</argument>
             <argument type="service" id="sulu.repository.target_group" on-invalid="null"/>
         </service>
+        <service id="Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface" alias="sulu_media.media_manager" />
 
         <service id="sulu_media.type_manager" class="%sulu_media.type_manager.class%">
             <argument type="service" id="doctrine.orm.entity_manager" />


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR registers `Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface` as alias for the `sulu_media.media_manager` service.

#### Why?

To allow for autowiring the `sulu_media.media_manager` service.