### PR TITLE
Fix sulu view in web profiler without symfony templating

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Profiler/layout.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% macro logo() %}
     <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix sulu view in web profiler without symfony templating.

#### Why?

The symfony/templating syntax can not longer be used.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
