### PR TITLE
Allow to add custom actions for items in List views

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,53 @@
 
 ## dev-master
 
+### Configuration of list item actions
+
+The prop of the `List` container which is used to configure the item actions was changed from `actions` to 
+`itemActionsProvider`. The new prop accepts a function that returns an array of actions for a given item.
+This allows to disable specific actions for specific items.
+
+```javascript
+// Before
+render() {
+    const actions = [
+        {
+            icon: 'su-process',
+            onClick: this.handleRestoreClick,
+        },
+    ];
+
+    return (
+        <List
+            actions={actions}
+            adapters={['table']}
+            store={this.listStore}
+        />
+    );
+}
+
+// After
+render() {
+    const itemActionsProvider = (item) => {
+        return [
+            {
+                icon: 'su-process',
+                onClick: this.handleRestoreClick,
+                disabled: item.disabled
+            },
+        ];
+    };
+
+    return (
+        <List
+            adapters={['table']}
+            itemActionsProvider={itemActionsProvider}
+            store={this.listStore}
+        />
+    );
+}
+```
+
 ### Configuration of list filters
 
 The old filter configuration on a list XML file was ignored until now. But the new list filtering functionality requires

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilder.php
@@ -141,6 +141,13 @@ class FormOverlayListViewBuilder implements FormOverlayListViewBuilderInterface
         return $this;
     }
 
+    public function addItemActions(array $itemActions): FormOverlayListViewBuilderInterface
+    {
+        $this->addItemActionsToView($this->view, $itemActions);
+
+        return $this;
+    }
+
     public function setBackView(string $backView): FormOverlayListViewBuilderInterface
     {
         $this->setBackViewToView($this->view, $backView);

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilderInterface.php
@@ -46,6 +46,11 @@ interface FormOverlayListViewBuilderInterface extends ViewBuilderInterface
      */
     public function addToolbarActions(array $toolbarActions): self;
 
+    /**
+     * @param ListItemAction[] $itemActions
+     */
+    public function addItemActions(array $itemActions): self;
+
     public function setDefaultLocale(string $locale): self;
 
     public function setItemDisabledCondition(string $itemDisabledCondition): self;

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ListItemAction.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ListItemAction.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Admin\View;
+
+use JMS\Serializer\Annotation\Groups;
+
+class ListItemAction
+{
+    /**
+     * @var string
+     * @Groups({"frontend"})
+     */
+    private $type;
+
+    /**
+     * @var array
+     * @Groups({"frontend"})
+     */
+    private $options;
+
+    public function __construct(string $type, array $options = [])
+    {
+        $this->type = $type;
+        $this->options = $options;
+    }
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function getOptions()
+    {
+        return $this->options;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilder.php
@@ -108,6 +108,13 @@ class ListViewBuilder implements ListViewBuilderInterface
         return $this;
     }
 
+    public function addItemActions(array $itemActions): ListViewBuilderInterface
+    {
+        $this->addItemActionsToView($this->view, $itemActions);
+
+        return $this;
+    }
+
     public function setAddView(string $addView): ListViewBuilderInterface
     {
         $this->setAddViewToView($this->view, $addView);

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilderInterface.php
@@ -42,6 +42,11 @@ interface ListViewBuilderInterface extends ViewBuilderInterface
      */
     public function addToolbarActions(array $toolbarActions): self;
 
+    /**
+     * @param ListItemAction[] $itemActions
+     */
+    public function addItemActions(array $itemActions): self;
+
     public function setDefaultLocale(string $locale): self;
 
     public function setItemDisabledCondition(string $itemDisabledCondition): self;

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilderTrait.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilderTrait.php
@@ -126,4 +126,16 @@ trait ListViewBuilderTrait
 
         $route->setOption('requestParameters', $newRequestParameters);
     }
+
+    /**
+     * @param ListItemAction[] $itemActions
+     */
+    private function addItemActionsToView(View $view, array $itemActions): void
+    {
+        $oldItemActions = $view->getOption('itemActions');
+        $newItemActions = $oldItemActions
+            ? array_merge($oldItemActions, $itemActions)
+            : $itemActions;
+        $view->setOption('itemActions', $newItemActions);
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
@@ -687,7 +687,6 @@ class List extends React.Component<Props> {
                         {translate('sulu_admin.order_warning_text')}
                     </Dialog>
                 }
-                {itemActions.map((itemAction) => itemAction.getNode())}
             </div>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
@@ -17,6 +17,7 @@ import SingleListOverlay from '../SingleListOverlay';
 import {translate} from '../../utils/Translator';
 import type {
     Action,
+    ItemAction,
     ResolveCopyArgument,
     ResolveDeleteArgument,
     ResolveMoveArgument,
@@ -42,6 +43,7 @@ type Props = {|
     disabled: boolean,
     disabledIds: Array<string | number>,
     header?: Node,
+    itemActions: Array<ItemAction>,
     itemDisabledCondition?: ?string,
     movable: boolean,
     onItemAdd?: (id: ?string | number) => void,
@@ -64,6 +66,7 @@ class List extends React.Component<Props> {
         deletable: true,
         disabled: false,
         disabledIds: [],
+        itemActions: [],
         movable: true,
         orderable: true,
         searchable: true,
@@ -471,6 +474,7 @@ class List extends React.Component<Props> {
             deletable,
             disabled,
             header,
+            itemActions,
             movable,
             onItemClick,
             onItemAdd,
@@ -554,6 +558,7 @@ class List extends React.Component<Props> {
                             adapterOptions={adapterOptions ? adapterOptions[this.currentAdapterKey] : undefined}
                             data={store.data}
                             disabledIds={this.disabledIds}
+                            itemActions={itemActions}
                             limit={store.limit.get()}
                             loading={store.loading}
                             onAllSelectionChange={selectable ? this.handleAllSelectionChange : undefined}
@@ -682,6 +687,7 @@ class List extends React.Component<Props> {
                         {translate('sulu_admin.order_warning_text')}
                     </Dialog>
                 }
+                {itemActions.map((itemAction) => itemAction.getNode())}
             </div>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
@@ -16,7 +16,7 @@ import userStore from '../../stores/userStore';
 import SingleListOverlay from '../SingleListOverlay';
 import {translate} from '../../utils/Translator';
 import type {
-    ItemAction,
+    ItemActionsProvider,
     ResolveCopyArgument,
     ResolveDeleteArgument,
     ResolveMoveArgument,
@@ -41,7 +41,7 @@ type Props = {|
     disabled: boolean,
     disabledIds: Array<string | number>,
     header?: Node,
-    itemActions: Array<ItemAction>,
+    itemActionsProvider?: ItemActionsProvider,
     itemDisabledCondition?: ?string,
     movable: boolean,
     onItemAdd?: (id: ?string | number) => void,
@@ -64,7 +64,6 @@ class List extends React.Component<Props> {
         deletable: true,
         disabled: false,
         disabledIds: [],
-        itemActions: [],
         movable: true,
         orderable: true,
         searchable: true,
@@ -471,7 +470,7 @@ class List extends React.Component<Props> {
             deletable,
             disabled,
             header,
-            itemActions,
+            itemActionsProvider,
             movable,
             onItemClick,
             onItemAdd,
@@ -554,7 +553,7 @@ class List extends React.Component<Props> {
                             adapterOptions={adapterOptions ? adapterOptions[this.currentAdapterKey] : undefined}
                             data={store.data}
                             disabledIds={this.disabledIds}
-                            itemActions={itemActions}
+                            itemActionsProvider={itemActionsProvider}
                             limit={store.limit.get()}
                             loading={store.loading}
                             onAllSelectionChange={selectable ? this.handleAllSelectionChange : undefined}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
@@ -16,7 +16,6 @@ import userStore from '../../stores/userStore';
 import SingleListOverlay from '../SingleListOverlay';
 import {translate} from '../../utils/Translator';
 import type {
-    Action,
     ItemAction,
     ResolveCopyArgument,
     ResolveDeleteArgument,
@@ -34,7 +33,6 @@ import listStyles from './list.scss';
 import ColumnOptionsOverlay from './ColumnOptionsOverlay';
 
 type Props = {|
-    actions?: Array<Action>,
     adapterOptions?: {[adapterKey: string]: {[key: string]: mixed}},
     adapters: Array<string>,
     allowActivateForDisabledItems: boolean,
@@ -467,7 +465,6 @@ class List extends React.Component<Props> {
 
     render() {
         const {
-            actions,
             adapterOptions,
             adapters,
             copyable,
@@ -552,7 +549,6 @@ class List extends React.Component<Props> {
                     {store.loading && store.pageCount === 0
                         ? <Loader />
                         : <Adapter
-                            actions={actions}
                             active={store.active.get()}
                             activeItems={store.activeItems}
                             adapterOptions={adapterOptions ? adapterOptions[this.currentAdapterKey] : undefined}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/README.md
@@ -28,6 +28,9 @@ have to be cancelled.
 
 The `List` component also takes an `onRowEditClick` callback, which is executed when a row has been clicked with
 the intent of editing it. The callback gets one parameter, which is the ID of the row to edit.
+Furthermore, the `List` allows to configure additional item specific actions via the `itemActionsProvider` callback. 
+The callback is executed for each item and should return an array of item-action configuration-objects. These 
+configuration-objects are used by the adapters to render elements to execute the respective actions for the item.
 
 ### Adapters
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TableAdapter.js
@@ -18,7 +18,7 @@ class TableAdapter extends AbstractTableAdapter {
 
     getButtons = (item: ?Object) => {
         const {
-            itemActions,
+            itemActionsProvider,
             onItemClick,
         } = this.props;
 
@@ -39,8 +39,8 @@ class TableAdapter extends AbstractTableAdapter {
             });
         }
 
-        if (itemActions) {
-            buttons.push(...itemActions.map((action) => action.getItemActionConfig(item)));
+        if (itemActionsProvider) {
+            buttons.push(...itemActionsProvider(item));
         }
 
         return buttons;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TableAdapter.js
@@ -18,7 +18,6 @@ class TableAdapter extends AbstractTableAdapter {
 
     getButtons = (item: ?Object) => {
         const {
-            actions,
             itemActions,
             onItemClick,
         } = this.props;
@@ -42,10 +41,6 @@ class TableAdapter extends AbstractTableAdapter {
 
         if (itemActions) {
             buttons.push(...itemActions.map((action) => action.getItemActionConfig(item)));
-        }
-
-        if (actions) {
-            buttons.push(...actions);
         }
 
         return buttons;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TableAdapter.js
@@ -19,6 +19,7 @@ class TableAdapter extends AbstractTableAdapter {
     getButtons = (item: ?Object) => {
         const {
             actions,
+            itemActions,
             onItemClick,
         } = this.props;
 
@@ -37,6 +38,10 @@ class TableAdapter extends AbstractTableAdapter {
                 icon: editPermission ? 'su-pen' : 'su-eye',
                 onClick: onItemClick,
             });
+        }
+
+        if (itemActions) {
+            buttons.push(...itemActions.map((action) => action.getItemActionConfig(item)));
         }
 
         if (actions) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TreeTableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TreeTableAdapter.js
@@ -26,6 +26,7 @@ class TreeTableAdapter extends AbstractTableAdapter {
 
     getButtons = (item: ?Object) => {
         const {
+            itemActions,
             onItemClick,
             onItemAdd,
         } = this.props;
@@ -56,6 +57,10 @@ class TreeTableAdapter extends AbstractTableAdapter {
                 icon: 'su-plus-circle',
                 onClick: onItemAdd,
             });
+        }
+
+        if (itemActions) {
+            buttons.push(...itemActions.map((action) => action.getItemActionConfig(item)));
         }
 
         return buttons;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TreeTableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TreeTableAdapter.js
@@ -26,7 +26,7 @@ class TreeTableAdapter extends AbstractTableAdapter {
 
     getButtons = (item: ?Object) => {
         const {
-            itemActions,
+            itemActionsProvider,
             onItemClick,
             onItemAdd,
         } = this.props;
@@ -59,8 +59,8 @@ class TreeTableAdapter extends AbstractTableAdapter {
             });
         }
 
-        if (itemActions) {
-            buttons.push(...itemActions.map((action) => action.getItemActionConfig(item)));
+        if (itemActionsProvider) {
+            buttons.push(...itemActionsProvider(item));
         }
 
         return buttons;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
@@ -252,12 +252,10 @@ test('Render TableAdapter with correct values', () => {
 });
 
 test('Render TableAdapter with itemActions', () => {
-    const actions = [
+    const actionsProvider = () => [
         {
-            getItemActionConfig: () => ({
-                icon: 'su-process',
-                onClick: undefined,
-            }),
+            icon: 'su-process',
+            onClick: undefined,
         },
     ];
 
@@ -271,10 +269,11 @@ test('Render TableAdapter with itemActions', () => {
 
     const listStore = new ListStore('test', 'test', 'list_test', {page: observable.box(1)});
 
-    const list = shallow(<List adapters={['table']} itemActions={actions} store={listStore} />);
+    // eslint-disable-next-line react/jsx-no-bind
+    const list = shallow(<List adapters={['table']} itemActionsProvider={actionsProvider} store={listStore} />);
 
     const tableAdapter = list.find('TableAdapter');
-    expect(tableAdapter.prop('itemActions')).toEqual(actions);
+    expect(tableAdapter.prop('itemActionsProvider')).toEqual(actionsProvider);
 });
 
 test('Render the adapter in non-selectable mode', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
@@ -251,11 +251,13 @@ test('Render TableAdapter with correct values', () => {
     expect(tableAdapter.prop('onAllSelectionChange')).toBeInstanceOf(Function);
 });
 
-test('Render TableAdapter with actions', () => {
+test('Render TableAdapter with itemActions', () => {
     const actions = [
         {
-            icon: 'su-process',
-            onClick: undefined,
+            getItemActionConfig: () => ({
+                icon: 'su-process',
+                onClick: undefined,
+            }),
         },
     ];
 
@@ -269,10 +271,10 @@ test('Render TableAdapter with actions', () => {
 
     const listStore = new ListStore('test', 'test', 'list_test', {page: observable.box(1)});
 
-    const list = shallow(<List actions={actions} adapters={['table']} store={listStore} />);
+    const list = shallow(<List adapters={['table']} itemActions={actions} store={listStore} />);
 
     const tableAdapter = list.find('TableAdapter');
-    expect(tableAdapter.prop('actions')).toEqual(actions);
+    expect(tableAdapter.prop('itemActions')).toEqual(actions);
 });
 
 test('Render the adapter in non-selectable mode', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
@@ -335,7 +335,6 @@ test('Render data with schema not containing all fields', () => {
 });
 
 test('Render data with pencil button when onItemEdit callback is passed', () => {
-    const rowEditClickSpy = jest.fn();
     const data = [
         {
             id: 1,
@@ -370,7 +369,7 @@ test('Render data with pencil button when onItemEdit callback is passed', () => 
         <TableAdapter
             {...listAdapterDefaultProps}
             data={data}
-            onItemClick={rowEditClickSpy}
+            onItemClick={jest.fn()}
             page={1}
             pageCount={3}
             schema={schema}
@@ -381,7 +380,6 @@ test('Render data with pencil button when onItemEdit callback is passed', () => 
 });
 
 test('Render correct button based on permissions when item permissions are provided', () => {
-    const rowEditClickSpy = jest.fn();
     const data = [
         {
             id: 1,
@@ -416,7 +414,7 @@ test('Render correct button based on permissions when item permissions are provi
         <TableAdapter
             {...listAdapterDefaultProps}
             data={data}
-            onItemClick={rowEditClickSpy}
+            onItemClick={jest.fn()}
             page={1}
             pageCount={3}
             schema={schema}
@@ -476,7 +474,6 @@ test('Render disabled rows based on given disabledIds prop', () => {
 });
 
 test('Render data with pencil button and given itemActions when onItemEdit callback is passed', () => {
-    const rowEditClickSpy = jest.fn();
     const data = [
         {
             id: 1,
@@ -527,7 +524,7 @@ test('Render data with pencil button and given itemActions when onItemEdit callb
             {...listAdapterDefaultProps}
             data={data}
             itemActions={actions}
-            onItemClick={rowEditClickSpy}
+            onItemClick={jest.fn()}
             page={1}
             pageCount={3}
             schema={schema}
@@ -670,7 +667,6 @@ test('Click on pencil should execute onItemClick callback', () => {
 });
 
 test('Click on itemAction should execute its callback', () => {
-    const rowEditClickSpy = jest.fn();
     const actionClickSpy = jest.fn();
     const data = [
         {
@@ -716,7 +712,7 @@ test('Click on itemAction should execute its callback', () => {
             {...listAdapterDefaultProps}
             data={data}
             itemActions={actions}
-            onItemClick={rowEditClickSpy}
+            onItemClick={jest.fn()}
             page={1}
             pageCount={3}
             schema={schema}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
@@ -504,18 +504,14 @@ test('Render data with pencil button and given itemActions when onItemEdit callb
             visibility: 'yes',
         },
     };
-    const actions = [
+    const actionsProvider = () => [
         {
-            getItemActionConfig: () => ({
-                icon: 'su-process',
-                onClick: undefined,
-            }),
+            icon: 'su-process',
+            onClick: undefined,
         },
         {
-            getItemActionConfig: () => ({
-                icon: 'su-trash',
-                onClick: undefined,
-            }),
+            icon: 'su-trash',
+            onClick: undefined,
         },
     ];
 
@@ -523,7 +519,8 @@ test('Render data with pencil button and given itemActions when onItemEdit callb
         <TableAdapter
             {...listAdapterDefaultProps}
             data={data}
-            itemActions={actions}
+            /* eslint-disable-next-line react/jsx-no-bind */
+            itemActionsProvider={actionsProvider}
             onItemClick={jest.fn()}
             page={1}
             pageCount={3}
@@ -668,18 +665,17 @@ test('Click on pencil should execute onItemClick callback', () => {
 
 test('Click on itemAction should execute its callback', () => {
     const actionClickSpy = jest.fn();
-    const data = [
-        {
-            id: 1,
-            title: 'Title 1',
-            description: 'Description 1',
-        },
-        {
-            id: 2,
-            title: 'Title 2',
-            description: 'Description 2',
-        },
-    ];
+    const item1 = {
+        id: 1,
+        title: 'Title 1',
+        description: 'Description 1',
+    };
+    const item2 = {
+        id: 2,
+        title: 'Title 2',
+        description: 'Description 2',
+    };
+    const data = [item1, item2];
     const schema = {
         title: {
             filterType: null,
@@ -698,26 +694,29 @@ test('Click on itemAction should execute its callback', () => {
             visibility: 'yes',
         },
     };
-    const actions = [
+    const actionsProvider = jest.fn(() => [
         {
-            getItemActionConfig: () => ({
-                icon: 'su-process',
-                onClick: actionClickSpy,
-            }),
+            icon: 'su-process',
+            onClick: actionClickSpy,
         },
-    ];
+    ]);
 
     const tableAdapter = shallow(
         <TableAdapter
             {...listAdapterDefaultProps}
             data={data}
-            itemActions={actions}
+            /* eslint-disable-next-line react/jsx-no-bind */
+            itemActionsProvider={actionsProvider}
             onItemClick={jest.fn()}
             page={1}
             pageCount={3}
             schema={schema}
         />
     );
+
+    expect(actionsProvider).toBeCalledWith(item1);
+    expect(actionsProvider).toBeCalledWith(item2);
+
     const buttons = tableAdapter.find('Table').prop('buttons');
     expect(buttons).toHaveLength(2);
     expect(buttons[1].icon).toBe('su-process');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
@@ -475,7 +475,7 @@ test('Render disabled rows based on given disabledIds prop', () => {
     expect(tableAdapter.find('Row').at(2).props().disabled).toEqual(true);
 });
 
-test('Render data with pencil button and given actions when onItemEdit callback is passed', () => {
+test('Render data with pencil button and given itemActions when onItemEdit callback is passed', () => {
     const rowEditClickSpy = jest.fn();
     const data = [
         {
@@ -509,20 +509,24 @@ test('Render data with pencil button and given actions when onItemEdit callback 
     };
     const actions = [
         {
-            icon: 'su-process',
-            onClick: undefined,
+            getItemActionConfig: () => ({
+                icon: 'su-process',
+                onClick: undefined,
+            }),
         },
         {
-            icon: 'su-trash',
-            onClick: undefined,
+            getItemActionConfig: () => ({
+                icon: 'su-trash',
+                onClick: undefined,
+            }),
         },
     ];
 
     const tableAdapter = render(
         <TableAdapter
             {...listAdapterDefaultProps}
-            actions={actions}
             data={data}
+            itemActions={actions}
             onItemClick={rowEditClickSpy}
             page={1}
             pageCount={3}
@@ -665,8 +669,9 @@ test('Click on pencil should execute onItemClick callback', () => {
     expect(rowEditClickSpy).toBeCalledWith(1);
 });
 
-test('Click on action should execute its callback', () => {
+test('Click on itemAction should execute its callback', () => {
     const rowEditClickSpy = jest.fn();
+    const actionClickSpy = jest.fn();
     const data = [
         {
             id: 1,
@@ -699,16 +704,18 @@ test('Click on action should execute its callback', () => {
     };
     const actions = [
         {
-            icon: 'su-process',
-            onClick: jest.fn(),
+            getItemActionConfig: () => ({
+                icon: 'su-process',
+                onClick: actionClickSpy,
+            }),
         },
     ];
 
     const tableAdapter = shallow(
         <TableAdapter
             {...listAdapterDefaultProps}
-            actions={actions}
             data={data}
+            itemActions={actions}
             onItemClick={rowEditClickSpy}
             page={1}
             pageCount={3}
@@ -720,7 +727,7 @@ test('Click on action should execute its callback', () => {
     expect(buttons[1].icon).toBe('su-process');
 
     buttons[1].onClick(1);
-    expect(actions[0].onClick).toBeCalledWith(1);
+    expect(actionClickSpy).toBeCalledWith(1);
 });
 
 test('Click on checkbox should call onItemSelectionChange callback', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
@@ -720,12 +720,16 @@ test('Click on itemAction should execute its callback', () => {
     const data = [item1];
     const schema = {
         title: {
+            filterType: null,
+            filterTypeParameters: null,
             label: 'Title',
             sortable: true,
             type: 'string',
             visibility: 'no',
         },
         description: {
+            filterType: null,
+            filterTypeParameters: null,
             label: 'Description',
             sortable: true,
             type: 'string',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
@@ -407,18 +407,14 @@ test('Render data with pencil button and given itemActions when onItemEdit callb
             visibility: 'yes',
         },
     };
-    const actions = [
+    const actionsProvider = () => [
         {
-            getItemActionConfig: () => ({
-                icon: 'su-process',
-                onClick: undefined,
-            }),
+            icon: 'su-process',
+            onClick: undefined,
         },
         {
-            getItemActionConfig: () => ({
-                icon: 'su-trash',
-                onClick: undefined,
-            }),
+            icon: 'su-trash',
+            onClick: undefined,
         },
     ];
 
@@ -426,7 +422,8 @@ test('Render data with pencil button and given itemActions when onItemEdit callb
         <TreeTableAdapter
             {...listAdapterDefaultProps}
             data={data}
-            itemActions={actions}
+            /* eslint-disable-next-line react/jsx-no-bind */
+            itemActionsProvider={actionsProvider}
             onItemClick={jest.fn()}
             schema={schema}
         />
@@ -711,7 +708,8 @@ test('Click on add should execute onItemAdd callback', () => {
 });
 
 test('Click on itemAction should execute its callback', () => {
-    const test1 = {
+    const actionClickSpy = jest.fn();
+    const item1 = {
         data: {
             id: 2,
             title: 'Test1',
@@ -719,9 +717,7 @@ test('Click on itemAction should execute its callback', () => {
         children: [],
         hasChildren: false,
     };
-    const data = [
-        test1,
-    ];
+    const data = [item1];
     const schema = {
         title: {
             label: 'Title',
@@ -736,25 +732,26 @@ test('Click on itemAction should execute its callback', () => {
             visibility: 'yes',
         },
     };
-    const actionClickSpy = jest.fn();
-    const actions = [
+    const actionsProvider = jest.fn(() => [
         {
-            getItemActionConfig: () => ({
-                icon: 'su-process',
-                onClick: actionClickSpy,
-            }),
+            icon: 'su-process',
+            onClick: actionClickSpy,
         },
-    ];
+    ]);
 
     const treeListAdapter = shallow(
         <TreeTableAdapter
             {...listAdapterDefaultProps}
             data={data}
-            itemActions={actions}
+            /* eslint-disable-next-line react/jsx-no-bind */
+            itemActionsProvider={actionsProvider}
             onItemAdd={jest.fn()}
             schema={schema}
         />
     );
+
+    expect(actionsProvider).toBeCalledWith(item1);
+
     const buttons = treeListAdapter.find('Table').prop('buttons');
     expect(buttons).toHaveLength(2);
     expect(buttons[1].icon).toBe('su-process');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
@@ -377,7 +377,7 @@ test('Execute onItemActivate respectively onItemDeactivate callback when an item
     expect(onItemDeactivateSpy).toBeCalledWith(3);
 });
 
-test('Render data with pencil button when onItemEdit callback is passed', () => {
+test('Render data with pencil button and given itemActions when onItemEdit callback is passed', () => {
     const rowEditClickSpy = jest.fn();
     const test1 = {
         data: {
@@ -408,10 +408,26 @@ test('Render data with pencil button when onItemEdit callback is passed', () => 
             visibility: 'yes',
         },
     };
+    const actions = [
+        {
+            getItemActionConfig: () => ({
+                icon: 'su-process',
+                onClick: undefined,
+            }),
+        },
+        {
+            getItemActionConfig: () => ({
+                icon: 'su-trash',
+                onClick: undefined,
+            }),
+        },
+    ];
+
     const treeListAdapter = render(
         <TreeTableAdapter
             {...listAdapterDefaultProps}
             data={data}
+            itemActions={actions}
             onItemClick={rowEditClickSpy}
             schema={schema}
         />
@@ -694,4 +710,58 @@ test('Click on add should execute onItemAdd callback', () => {
 
     buttons[0].onClick(1);
     expect(rowAddClickSpy).toBeCalledWith(1);
+});
+
+test('Click on itemAction should execute its callback', () => {
+    const test1 = {
+        data: {
+            id: 2,
+            title: 'Test1',
+        },
+        children: [],
+        hasChildren: false,
+    };
+    const data = [
+        test1,
+    ];
+    const schema = {
+        title: {
+            label: 'Title',
+            sortable: true,
+            type: 'string',
+            visibility: 'no',
+        },
+        description: {
+            label: 'Description',
+            sortable: true,
+            type: 'string',
+            visibility: 'yes',
+        },
+    };
+    const actionClickSpy = jest.fn();
+    const actions = [
+        {
+            getItemActionConfig: () => ({
+                icon: 'su-process',
+                onClick: actionClickSpy,
+            }),
+        },
+    ];
+
+    const rowAddClickSpy = jest.fn();
+    const treeListAdapter = shallow(
+        <TreeTableAdapter
+            {...listAdapterDefaultProps}
+            data={data}
+            itemActions={actions}
+            onItemAdd={rowAddClickSpy}
+            schema={schema}
+        />
+    );
+    const buttons = treeListAdapter.find('Table').prop('buttons');
+    expect(buttons).toHaveLength(2);
+    expect(buttons[1].icon).toBe('su-process');
+
+    buttons[1].onClick(1);
+    expect(actionClickSpy).toBeCalledWith(1);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
@@ -378,7 +378,6 @@ test('Execute onItemActivate respectively onItemDeactivate callback when an item
 });
 
 test('Render data with pencil button and given itemActions when onItemEdit callback is passed', () => {
-    const rowEditClickSpy = jest.fn();
     const test1 = {
         data: {
             id: 2,
@@ -428,7 +427,7 @@ test('Render data with pencil button and given itemActions when onItemEdit callb
             {...listAdapterDefaultProps}
             data={data}
             itemActions={actions}
-            onItemClick={rowEditClickSpy}
+            onItemClick={jest.fn()}
             schema={schema}
         />
     );
@@ -576,7 +575,6 @@ test('Render disabled rows based on given disabledIds prop', () => {
 });
 
 test('Render data with plus button when onItemAdd callback is passed', () => {
-    const rowAddClickSpy = jest.fn();
     const test1 = {
         data: {
             id: 2,
@@ -610,7 +608,7 @@ test('Render data with plus button when onItemAdd callback is passed', () => {
         <TreeTableAdapter
             {...listAdapterDefaultProps}
             data={data}
-            onItemAdd={rowAddClickSpy}
+            onItemAdd={jest.fn()}
             schema={schema}
         />
     );
@@ -748,13 +746,12 @@ test('Click on itemAction should execute its callback', () => {
         },
     ];
 
-    const rowAddClickSpy = jest.fn();
     const treeListAdapter = shallow(
         <TreeTableAdapter
             {...listAdapterDefaultProps}
             data={data}
             itemActions={actions}
-            onItemAdd={rowAddClickSpy}
+            onItemAdd={jest.fn()}
             schema={schema}
         />
     );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TableAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TableAdapter.test.js.snap
@@ -484,7 +484,7 @@ exports[`Render data with all different visibility types schema 1`] = `
 </section>
 `;
 
-exports[`Render data with pencil button and given actions when onItemEdit callback is passed 1`] = `
+exports[`Render data with pencil button and given itemActions when onItemEdit callback is passed 1`] = `
 <section>
   <div
     class="tableContainer dark"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TreeTableAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TreeTableAdapter.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Render data with pencil button when onItemEdit callback is passed 1`] = `
+exports[`Render data with pencil button and given itemActions when onItemEdit callback is passed 1`] = `
 <div
   class="tableContainer dark"
 >
@@ -18,6 +18,26 @@ exports[`Render data with pencil button when onItemEdit callback is passed 1`] =
             <span
               aria-label="su-pen"
               class="su-pen"
+            />
+          </span>
+        </th>
+        <th
+          class="headerButtonCell headerCell"
+        >
+          <span>
+            <span
+              aria-label="su-process"
+              class="su-process"
+            />
+          </span>
+        </th>
+        <th
+          class="headerButtonCell headerCell"
+        >
+          <span>
+            <span
+              aria-label="su-trash"
+              class="su-trash"
             />
           </span>
         </th>
@@ -44,6 +64,34 @@ exports[`Render data with pencil button when onItemEdit callback is passed 1`] =
               <span
                 aria-label="su-pen"
                 class="su-pen"
+              />
+            </button>
+          </div>
+        </td>
+        <td
+          class="buttonCell cell"
+        >
+          <div
+            class="cellContent"
+          >
+            <button>
+              <span
+                aria-label="su-process"
+                class="su-process"
+              />
+            </button>
+          </div>
+        </td>
+        <td
+          class="buttonCell cell"
+        >
+          <div
+            class="cellContent"
+          >
+            <button>
+              <span
+                aria-label="su-trash"
+                class="su-trash"
               />
             </button>
           </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/types.js
@@ -32,9 +32,7 @@ export type ItemActionConfig = {|
     onClick: ?(rowId: string | number, index: number) => void,
 |};
 
-export interface ItemAction {
-    getItemActionConfig(item: ?Object): ItemActionConfig,
-}
+export type ItemActionsProvider = (item: ?Object) => Array<ItemActionConfig>;
 
 export type ListAdapterProps = {|
     active: ?string | number,
@@ -42,7 +40,7 @@ export type ListAdapterProps = {|
     adapterOptions?: {[key: string]: mixed},
     data: Array<*>,
     disabledIds: Array<string | number>,
-    itemActions?: Array<ItemAction>,
+    itemActionsProvider?: ItemActionsProvider,
     limit: number,
     loading: boolean,
     onAllSelectionChange: ?(selected?: boolean) => void,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/types.js
@@ -36,12 +36,11 @@ export type Action = {|
 export type ItemActionConfig = {|
     disabled?: boolean,
     icon: string,
-    onClick: ?() => void,
+    onClick: ?(rowId: string | number, index: number) => void,
 |};
 
 export interface ItemAction {
     getItemActionConfig(item: ?Object): ItemActionConfig,
-    getNode(): Node,
 }
 
 export type ListAdapterProps = {|

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/types.js
@@ -26,11 +26,23 @@ export type Schema = {
 
 export type SortOrder = 'asc' | 'desc';
 
+// @deprecated
 export type Action = {|
     disabled?: boolean,
     icon: string,
     onClick: ?(itemId: string | number, index: number) => void,
 |};
+
+export type ItemActionConfig = {|
+    disabled?: boolean,
+    icon: string,
+    onClick: ?() => void,
+|};
+
+export interface ItemAction {
+    getItemActionConfig(item: ?Object): ItemActionConfig,
+    getNode(): Node,
+}
 
 export type ListAdapterProps = {|
     actions?: Array<Action>,
@@ -39,6 +51,7 @@ export type ListAdapterProps = {|
     adapterOptions?: {[key: string]: mixed},
     data: Array<*>,
     disabledIds: Array<string | number>,
+    itemActions?: Array<ItemAction>,
     limit: number,
     loading: boolean,
     onAllSelectionChange: ?(selected?: boolean) => void,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/types.js
@@ -26,13 +26,6 @@ export type Schema = {
 
 export type SortOrder = 'asc' | 'desc';
 
-// @deprecated
-export type Action = {|
-    disabled?: boolean,
-    icon: string,
-    onClick: ?(itemId: string | number, index: number) => void,
-|};
-
 export type ItemActionConfig = {|
     disabled?: boolean,
     icon: string,
@@ -44,7 +37,6 @@ export interface ItemAction {
 }
 
 export type ListAdapterProps = {|
-    actions?: Array<Action>,
     active: ?string | number,
     activeItems: ?Array<?string | number>,
     adapterOptions?: {[key: string]: mixed},

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/types.js
@@ -44,6 +44,5 @@ export type ToolbarConfig = {
 };
 
 export interface ToolbarAction {
-    getNode(): Node,
     getToolbarItemConfig(): ?ToolbarItemConfig,
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/types.js
@@ -42,7 +42,3 @@ export type ToolbarConfig = {
     showSuccess?: IObservableValue<boolean>,
     warnings?: Array<string>,
 };
-
-export interface ToolbarAction {
-    getToolbarItemConfig(): ?ToolbarItemConfig,
-}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -16,7 +16,9 @@ import {Config, resourceRouteRegistry} from './services';
 import initializer from './services/initializer';
 import ResourceTabs from './views/ResourceTabs';
 import List, {
+    listItemActionRegistry,
     listToolbarActionRegistry,
+    LinkItemAction as ListLinkItemAction,
     AddToolbarAction as ListAddToolbarAction,
     DeleteToolbarAction as ListDeleteToolbarAction,
     MoveToolbarAction as ListMoveToolbarAction,
@@ -127,6 +129,7 @@ initializer.addUpdateConfigHook('sulu_admin', (config: Object, initialized: bool
         registerBlockPreviewTransformers();
         registerListAdapters();
         registerListFieldTransformers();
+        registerListItemActions();
         registerFieldTypes(config.fieldTypeOptions);
         registerTextEditors();
         registerInternalLinkTypes(config.internalLinkTypes);
@@ -173,6 +176,10 @@ function registerListFieldTransformers() {
 
     // TODO: Remove this type when not needed anymore
     listFieldTransformerRegistry.add('title', new StringFieldTransformer());
+}
+
+function registerListItemActions() {
+    listItemActionRegistry.add('link', ListLinkItemAction);
 }
 
 function registerFieldTypes(fieldTypeOptions) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/registries/formToolbarActionRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/registries/formToolbarActionRegistry.test.js
@@ -20,7 +20,7 @@ test('Clear all toolbar actions', () => {
     expect(Object.keys(formToolbarActionRegistry.toolbarActions)).toHaveLength(0);
 });
 
-test('Add adapter', () => {
+test('Add toolbar action', () => {
     formToolbarActionRegistry.add('test1', AbstractFormToolbarAction);
     formToolbarActionRegistry.add('test2', AbstractFormToolbarAction);
 
@@ -28,11 +28,11 @@ test('Add adapter', () => {
     expect(formToolbarActionRegistry.get('test2')).toBe(AbstractFormToolbarAction);
 });
 
-test('Add adapter with existing key should throw', () => {
+test('Add toolbar action with existing key should throw', () => {
     formToolbarActionRegistry.add('test1', AbstractFormToolbarAction);
     expect(() => formToolbarActionRegistry.add('test1', AbstractFormToolbarAction)).toThrow(/test1/);
 });
 
-test('Get adapter of not existing key', () => {
+test('Get toolbar action of not existing key', () => {
     expect(() => formToolbarActionRegistry.get('XXX')).toThrow();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/AbstractFormToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/AbstractFormToolbarAction.js
@@ -1,11 +1,11 @@
 // @flow
 import type {Node} from 'react';
 import {ResourceFormStore} from '../../../containers/Form';
-import type {ToolbarAction, ToolbarItemConfig} from '../../../containers/Toolbar/types';
+import type {ToolbarItemConfig} from '../../../containers/Toolbar/types';
 import Router from '../../../services/Router';
 import Form from '../Form';
 
-export default class AbstractFormToolbarAction implements ToolbarAction {
+export default class AbstractFormToolbarAction {
     resourceFormStore: ResourceFormStore;
     form: Form;
     router: Router;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -216,13 +216,13 @@ class List extends React.Component<Props> {
             route: {
                 options: {
                     locales,
-                    toolbarActions: rawToolbarActions = [],
-                    itemActions: rawItemActions = [],
+                    toolbarActions = [],
+                    itemActions = [],
                 },
             },
         } = router;
 
-        rawToolbarActions.forEach((toolbarAction) => {
+        toolbarActions.forEach((toolbarAction) => {
             if (typeof toolbarAction !== 'object') {
                 throw new Error(
                     'The value of a toolbarAction entry must be an object, but ' + typeof toolbarAction + ' was given!'
@@ -239,7 +239,7 @@ class List extends React.Component<Props> {
             ));
         });
 
-        rawItemActions.forEach((itemAction) => {
+        itemActions.forEach((itemAction) => {
             if (typeof itemAction !== 'object') {
                 throw new Error(
                     'The value of a itemAction entry must be an object, but ' + typeof itemAction + ' was given!'

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -11,6 +11,7 @@ import type {ViewProps} from '../../containers/ViewRenderer';
 import type {Route} from '../../services/Router/types';
 import {translate} from '../../utils/Translator';
 import ResourceStore from '../../stores/ResourceStore';
+import type {ItemActionConfig} from '../../containers/List/types';
 import listToolbarActionRegistry from './registries/listToolbarActionRegistry';
 import listItemActionRegistry from './registries/listItemActionRegistry';
 import AbstractListToolbarAction from './toolbarActions/AbstractListToolbarAction';
@@ -325,6 +326,10 @@ class List extends React.Component<Props> {
         router.navigate(editView, {id: itemId, locale: this.locale.get()});
     };
 
+    getItemActionConfigs = (item: ?Object): Array<ItemActionConfig> => {
+        return this.itemActions.map((itemAction) => itemAction.getItemActionConfig(item));
+    };
+
     requestSelectionDelete = (allowConflictDelete: boolean = true) => {
         if (!this.list) {
             throw new Error('List not created yet.');
@@ -367,7 +372,7 @@ class List extends React.Component<Props> {
                 <ListContainer
                     adapters={adapters}
                     header={title && <h1>{title}</h1>}
-                    itemActions={[...this.itemActions]}
+                    itemActionsProvider={this.getItemActionConfigs}
                     itemDisabledCondition={itemDisabledCondition}
                     onItemAdd={onItemAdd || addView ? this.addItem : undefined}
                     onItemClick={onItemClick || editView ? this.handleItemClick : undefined}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/README.md
@@ -13,9 +13,11 @@ of the available options:
 | title                                | Title (or translation key) that is displayed above the actual list.           |
 | adapters                             | Array of list-adapters that are available to the user to display the list.    |
 | locales                              | Array of locales that are available in the locale chooser in the toolbar      |
-|                                      | of the view                                                                   |
-| toolbarActions                       | Array of toolbar-action registered in the `ToolbarActionRegistry` that should |
-|                                      | be shown in the toolbar of the view                                           |
+|                                      | of the view.                                                                  |
+| toolbarActions                       | Array of toolbar-actions registered in the `ListToolbarActionRegistry` that   |
+|                                      | should be shown in the toolbar of the view.                                   |
+| itemActions                          | Array of item-actions registered in the `ListItemActionRegistry` that should  |
+|                                      | be shown for each item of the list.                                           |
 | backView                             | Route to which the user will be navigated when the back button is clicked.    |
 | addView                              | Route to which the user will be navigated when the add button is clicked.     |
 | editView                             | Route to which the user will be navigated when the edit button of an item in  |

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/index.js
@@ -1,6 +1,9 @@
 // @flow
 import List from './List';
+import listItemActionRegistry from './registries/listItemActionRegistry';
 import listToolbarActionRegistry from './registries/listToolbarActionRegistry';
+import AbstractListItemAction from './itemActions/AbstractListItemAction';
+import LinkItemAction from './itemActions/LinkItemAction';
 import AbstractListToolbarAction from './toolbarActions/AbstractListToolbarAction';
 import AddToolbarAction from './toolbarActions/AddToolbarAction';
 import DeleteToolbarAction from './toolbarActions/DeleteToolbarAction';
@@ -10,10 +13,13 @@ import ExportToolbarAction from './toolbarActions/ExportToolbarAction';
 export default List;
 
 export {
+    AbstractListItemAction,
     AbstractListToolbarAction,
+    listItemActionRegistry,
     listToolbarActionRegistry,
     AddToolbarAction,
     DeleteToolbarAction,
+    LinkItemAction,
     MoveToolbarAction,
     ExportToolbarAction,
 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/itemActions/AbstractListItemAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/itemActions/AbstractListItemAction.js
@@ -1,0 +1,45 @@
+// @flow
+import type {Node} from 'react';
+import type {ItemActionConfig, ItemAction} from '../../../containers/List/types';
+import ResourceStore from '../../../stores/ResourceStore';
+import Router from '../../../services/Router';
+import List from '../../../views/List/List';
+import ListStore from '../../../containers/List/stores/ListStore';
+
+export default class AbstractListItemAction implements ItemAction {
+    listStore: ListStore;
+    list: List;
+    router: Router;
+    locales: ?Array<string>;
+    resourceStore: ?ResourceStore;
+    options: {[key: string]: mixed};
+
+    constructor(
+        listStore: ListStore,
+        list: List,
+        router: Router,
+        locales?: Array<string>,
+        resourceStore?: ResourceStore,
+        options: {[key: string]: mixed}
+    ) {
+        this.listStore = listStore;
+        this.list = list;
+        this.router = router;
+        this.locales = locales;
+        this.resourceStore = resourceStore;
+        this.options = options;
+    }
+
+    setLocales(locales: Array<string>) {
+        this.locales = locales;
+    }
+
+    getNode(): Node {
+        return null;
+    }
+
+    // eslint-disable-next-line no-unused-vars
+    getItemActionConfig(item: ?Object): ItemActionConfig {
+        throw new Error('The getItemActionConfig method must be implemented by the sub class!');
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/itemActions/AbstractListItemAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/itemActions/AbstractListItemAction.js
@@ -1,12 +1,12 @@
 // @flow
 import type {Node} from 'react';
-import type {ItemActionConfig, ItemAction} from '../../../containers/List/types';
+import type {ItemActionConfig} from '../../../containers/List/types';
 import ResourceStore from '../../../stores/ResourceStore';
 import Router from '../../../services/Router';
 import List from '../../../views/List/List';
 import ListStore from '../../../containers/List/stores/ListStore';
 
-export default class AbstractListItemAction implements ItemAction {
+export default class AbstractListItemAction {
     listStore: ListStore;
     list: List;
     router: Router;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/itemActions/LinkItemAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/itemActions/LinkItemAction.js
@@ -21,8 +21,8 @@ export default class LinkItemAction extends AbstractListItemAction {
         }
 
         const linkValue = item ? item[linkProperty] : null;
-        if (linkValue && linkProperty !== 'string') {
-            throw new Error('The value of the property given via  "link_property" must have a string value!');
+        if (linkValue && typeof linkValue !== 'string') {
+            throw new Error('The value of the property given via "link_property" must have a string value!');
         }
 
         return {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/itemActions/LinkItemAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/itemActions/LinkItemAction.js
@@ -1,0 +1,34 @@
+// @flow
+import AbstractListItemAction from './AbstractListItemAction';
+
+export default class LinkItemAction extends AbstractListItemAction {
+    handleDownloadClick = (linkUrl: string) => {
+        window.location.href = linkUrl;
+    };
+
+    getItemActionConfig(item: ?Object) {
+        const {
+            icon = 'su-link',
+            link_property: linkProperty,
+        } = this.options;
+
+        if (typeof icon !== 'string') {
+            throw new Error('The "icon" must have a string value!');
+        }
+
+        if (typeof linkProperty !== 'string') {
+            throw new Error('The "link_property" option cannot be null and must have a string value!');
+        }
+
+        const linkValue = item ? item[linkProperty] : null;
+        if (linkValue && linkProperty !== 'string') {
+            throw new Error('The value of the property given via  "link_property" must have a string value!');
+        }
+
+        return {
+            icon,
+            onClick: linkValue ? () => this.handleDownloadClick(linkValue) : null,
+            disabled: !linkValue,
+        };
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/registries/listItemActionRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/registries/listItemActionRegistry.js
@@ -1,0 +1,32 @@
+// @flow
+import AbstractListItemAction from '../itemActions/AbstractListItemAction';
+
+class ListItemActionRegistry {
+    listItemActions: {[name: string]: Class<AbstractListItemAction>} = {};
+
+    constructor() {
+        this.clear();
+    }
+
+    clear() {
+        this.listItemActions = {};
+    }
+
+    add(name: string, item: Class<AbstractListItemAction>) {
+        if (name in this.listItemActions) {
+            throw new Error('The key "' + name + '" has already been used for another ItemAction!');
+        }
+
+        this.listItemActions[name] = item;
+    }
+
+    get(name: string) {
+        if (!(name in this.listItemActions)) {
+            throw new Error('There is no ItemAction with key "' + name + '" registered!');
+        }
+
+        return this.listItemActions[name];
+    }
+}
+
+export default new ListItemActionRegistry();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
@@ -507,6 +507,275 @@ exports[`Should render the list with a title 1`] = `
 </div>
 `;
 
+exports[`Should render the list with nodes of given ToolbarActions 1`] = `
+Array [
+  <div
+    class="listContainer"
+  >
+    <div
+      class="headerContainer"
+    >
+      <h1
+        class="header"
+      >
+        Snippets
+      </h1>
+      <div
+        class="toolbar"
+      >
+        <label
+          class="input dark left collapsed hasAppendIcon"
+        >
+          <div
+            class="prependedContainer dark collapsed"
+          >
+            <span
+              aria-label="su-search"
+              class="su-search clickable icon dark iconClickable collapsed"
+              role="button"
+              tabindex="0"
+            />
+          </div>
+          <input
+            type="text"
+            value=""
+          />
+        </label>
+        <div>
+          <button
+            class="button icon"
+            type="button"
+          >
+            <span
+              aria-label="su-sort"
+              class="su-sort buttonIcon"
+            />
+            <span
+              aria-label="su-angle-down"
+              class="su-angle-down dropdownIcon"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="list"
+    >
+      <section>
+        <div
+          class="tableContainer dark"
+        >
+          <table
+            class="table"
+          >
+            <thead
+              class="header"
+            >
+              <tr>
+                <th
+                  class="headerCell"
+                >
+                  <span>
+                    <label
+                      class="label"
+                    >
+                      <span
+                        class="switch checkbox light"
+                      >
+                        <input
+                          type="checkbox"
+                          value=""
+                        />
+                        <span />
+                      </span>
+                    </label>
+                  </span>
+                </th>
+                <th
+                  class="headerCell clickable"
+                >
+                  <button>
+                    Description
+                  </button>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                class="row"
+              >
+                <td
+                  class="cell small"
+                >
+                  <div
+                    class="cellContent"
+                  >
+                    <label
+                      class="label"
+                    >
+                      <span
+                        class="switch checkbox dark"
+                      >
+                        <input
+                          type="checkbox"
+                          value="1"
+                        />
+                        <span />
+                      </span>
+                    </label>
+                  </div>
+                </td>
+                <td
+                  class="cell"
+                >
+                  <div
+                    class="cellContent"
+                  >
+                    Description 1
+                  </div>
+                </td>
+              </tr>
+              <tr
+                class="row"
+              >
+                <td
+                  class="cell small"
+                >
+                  <div
+                    class="cellContent"
+                  >
+                    <label
+                      class="label"
+                    >
+                      <span
+                        class="switch checkbox dark"
+                      >
+                        <input
+                          type="checkbox"
+                          value="2"
+                        />
+                        <span />
+                      </span>
+                    </label>
+                  </div>
+                </td>
+                <td
+                  class="cell"
+                >
+                  <div
+                    class="cellContent"
+                  >
+                    Description 2
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <nav
+          class="pagination"
+        >
+          <span
+            class="display"
+          >
+            :
+          </span>
+          <span>
+            <div
+              class="select"
+            >
+              <button
+                class="displayValue dark"
+                type="button"
+              >
+                <div
+                  aria-label="10"
+                  class="croppedText"
+                  title="10"
+                >
+                  <div
+                    aria-hidden="true"
+                    class="front"
+                  >
+                    1
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="back"
+                  >
+                    <span>
+                      0
+                    </span>
+                  </div>
+                  <div
+                    class="whole"
+                  >
+                    10
+                  </div>
+                </div>
+                <span
+                  aria-label="su-angle-down"
+                  class="su-angle-down toggle"
+                />
+              </button>
+            </div>
+          </span>
+          <div
+            class="loader"
+          />
+          <span>
+            Page:
+          </span>
+          <span
+            class="inputContainer"
+          >
+            <label
+              class="input dark center"
+            >
+              <input
+                inputmode="numeric"
+                type="text"
+                value="2"
+              />
+            </label>
+          </span>
+          <span
+            class="display"
+          >
+            of 3
+          </span>
+          <div
+            class="buttonGroup"
+          >
+            <button
+              class="button icon button"
+              type="button"
+            >
+              <span
+                aria-label="su-angle-left"
+                class="su-angle-left buttonIcon"
+              />
+            </button>
+            <button
+              class="button icon button"
+              type="button"
+            >
+              <span
+                aria-label="su-angle-right"
+                class="su-angle-right buttonIcon"
+              />
+            </button>
+          </div>
+        </nav>
+      </section>
+    </div>
+  </div>,
+  <div>
+    toolbar action node
+  </div>,
+]
+`;
+
 exports[`Should render the list with the correct resourceKey 1`] = `
 <div
   class="listContainer"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
@@ -512,50 +512,44 @@ Array [
   <div
     class="listContainer"
   >
+    <h1>
+      Snippets
+    </h1>
     <div
-      class="headerContainer"
+      class="toolbar"
     >
-      <h1
-        class="header"
+      <label
+        class="input dark left collapsed hasAppendIcon"
       >
-        Snippets
-      </h1>
-      <div
-        class="toolbar"
-      >
-        <label
-          class="input dark left collapsed hasAppendIcon"
+        <div
+          class="prependedContainer dark collapsed"
         >
-          <div
-            class="prependedContainer dark collapsed"
-          >
-            <span
-              aria-label="su-search"
-              class="su-search clickable icon dark iconClickable collapsed"
-              role="button"
-              tabindex="0"
-            />
-          </div>
-          <input
-            type="text"
-            value=""
+          <span
+            aria-label="su-search"
+            class="su-search clickable icon dark iconClickable collapsed"
+            role="button"
+            tabindex="0"
           />
-        </label>
-        <div>
-          <button
-            class="button icon"
-            type="button"
-          >
-            <span
-              aria-label="su-sort"
-              class="su-sort buttonIcon"
-            />
-            <span
-              aria-label="su-angle-down"
-              class="su-angle-down dropdownIcon"
-            />
-          </button>
         </div>
+        <input
+          type="text"
+          value=""
+        />
+      </label>
+      <div>
+        <button
+          class="button icon"
+          type="button"
+        >
+          <span
+            aria-label="su-sort"
+            class="su-sort buttonIcon"
+          />
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down dropdownIcon"
+          />
+        </button>
       </div>
     </div>
     <div
@@ -819,50 +813,44 @@ Array [
   <div
     class="listContainer"
   >
+    <h1>
+      Snippets
+    </h1>
     <div
-      class="headerContainer"
+      class="toolbar"
     >
-      <h1
-        class="header"
+      <label
+        class="input dark left collapsed hasAppendIcon"
       >
-        Snippets
-      </h1>
-      <div
-        class="toolbar"
-      >
-        <label
-          class="input dark left collapsed hasAppendIcon"
+        <div
+          class="prependedContainer dark collapsed"
         >
-          <div
-            class="prependedContainer dark collapsed"
-          >
-            <span
-              aria-label="su-search"
-              class="su-search clickable icon dark iconClickable collapsed"
-              role="button"
-              tabindex="0"
-            />
-          </div>
-          <input
-            type="text"
-            value=""
+          <span
+            aria-label="su-search"
+            class="su-search clickable icon dark iconClickable collapsed"
+            role="button"
+            tabindex="0"
           />
-        </label>
-        <div>
-          <button
-            class="button icon"
-            type="button"
-          >
-            <span
-              aria-label="su-sort"
-              class="su-sort buttonIcon"
-            />
-            <span
-              aria-label="su-angle-down"
-              class="su-angle-down dropdownIcon"
-            />
-          </button>
         </div>
+        <input
+          type="text"
+          value=""
+        />
+      </label>
+      <div>
+        <button
+          class="button icon"
+          type="button"
+        >
+          <span
+            aria-label="su-sort"
+            class="su-sort buttonIcon"
+          />
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down dropdownIcon"
+          />
+        </button>
       </div>
     </div>
     <div

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
@@ -507,6 +507,313 @@ exports[`Should render the list with a title 1`] = `
 </div>
 `;
 
+exports[`Should render the list with nodes of given ListItemActions 1`] = `
+Array [
+  <div
+    class="listContainer"
+  >
+    <div
+      class="headerContainer"
+    >
+      <h1
+        class="header"
+      >
+        Snippets
+      </h1>
+      <div
+        class="toolbar"
+      >
+        <label
+          class="input dark left collapsed hasAppendIcon"
+        >
+          <div
+            class="prependedContainer dark collapsed"
+          >
+            <span
+              aria-label="su-search"
+              class="su-search clickable icon dark iconClickable collapsed"
+              role="button"
+              tabindex="0"
+            />
+          </div>
+          <input
+            type="text"
+            value=""
+          />
+        </label>
+        <div>
+          <button
+            class="button icon"
+            type="button"
+          >
+            <span
+              aria-label="su-sort"
+              class="su-sort buttonIcon"
+            />
+            <span
+              aria-label="su-angle-down"
+              class="su-angle-down dropdownIcon"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="list"
+    >
+      <section>
+        <div
+          class="tableContainer dark"
+        >
+          <table
+            class="table"
+          >
+            <thead
+              class="header"
+            >
+              <tr>
+                <th
+                  class="headerButtonCell headerCell"
+                >
+                  <span>
+                    <span
+                      aria-label="su-eye"
+                      class="su-eye"
+                    />
+                  </span>
+                </th>
+                <th
+                  class="headerCell"
+                >
+                  <span>
+                    <label
+                      class="label"
+                    >
+                      <span
+                        class="switch checkbox light"
+                      >
+                        <input
+                          type="checkbox"
+                          value=""
+                        />
+                        <span />
+                      </span>
+                    </label>
+                  </span>
+                </th>
+                <th
+                  class="headerCell clickable"
+                >
+                  <button>
+                    Description
+                  </button>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                class="row"
+              >
+                <td
+                  class="buttonCell cell"
+                >
+                  <div
+                    class="cellContent"
+                  >
+                    <button>
+                      <span
+                        aria-label="su-eye"
+                        class="su-eye"
+                      />
+                    </button>
+                  </div>
+                </td>
+                <td
+                  class="cell small"
+                >
+                  <div
+                    class="cellContent"
+                  >
+                    <label
+                      class="label"
+                    >
+                      <span
+                        class="switch checkbox dark"
+                      >
+                        <input
+                          type="checkbox"
+                          value="1"
+                        />
+                        <span />
+                      </span>
+                    </label>
+                  </div>
+                </td>
+                <td
+                  class="cell"
+                >
+                  <div
+                    class="cellContent"
+                  >
+                    Description 1
+                  </div>
+                </td>
+              </tr>
+              <tr
+                class="row"
+              >
+                <td
+                  class="buttonCell cell"
+                >
+                  <div
+                    class="cellContent"
+                  >
+                    <button>
+                      <span
+                        aria-label="su-eye"
+                        class="su-eye"
+                      />
+                    </button>
+                  </div>
+                </td>
+                <td
+                  class="cell small"
+                >
+                  <div
+                    class="cellContent"
+                  >
+                    <label
+                      class="label"
+                    >
+                      <span
+                        class="switch checkbox dark"
+                      >
+                        <input
+                          type="checkbox"
+                          value="2"
+                        />
+                        <span />
+                      </span>
+                    </label>
+                  </div>
+                </td>
+                <td
+                  class="cell"
+                >
+                  <div
+                    class="cellContent"
+                  >
+                    Description 2
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <nav
+          class="pagination"
+        >
+          <span
+            class="display"
+          >
+            :
+          </span>
+          <span>
+            <div
+              class="select"
+            >
+              <button
+                class="displayValue dark"
+                type="button"
+              >
+                <div
+                  aria-label="10"
+                  class="croppedText"
+                  title="10"
+                >
+                  <div
+                    aria-hidden="true"
+                    class="front"
+                  >
+                    1
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="back"
+                  >
+                    <span>
+                      0
+                    </span>
+                  </div>
+                  <div
+                    class="whole"
+                  >
+                    10
+                  </div>
+                </div>
+                <span
+                  aria-label="su-angle-down"
+                  class="su-angle-down toggle"
+                />
+              </button>
+            </div>
+          </span>
+          <div
+            class="loader"
+          />
+          <span>
+            Page:
+          </span>
+          <span
+            class="inputContainer"
+          >
+            <label
+              class="input dark center"
+            >
+              <input
+                inputmode="numeric"
+                type="text"
+                value="2"
+              />
+            </label>
+          </span>
+          <span
+            class="display"
+          >
+            of 3
+          </span>
+          <div
+            class="buttonGroup"
+          >
+            <button
+              class="button icon button"
+              type="button"
+            >
+              <span
+                aria-label="su-angle-left"
+                class="su-angle-left buttonIcon"
+              />
+            </button>
+            <button
+              class="button icon button"
+              type="button"
+            >
+              <span
+                aria-label="su-angle-right"
+                class="su-angle-right buttonIcon"
+              />
+            </button>
+          </div>
+        </nav>
+      </section>
+    </div>
+  </div>,
+  <div>
+    item action node
+  </div>,
+]
+`;
+
 exports[`Should render the list with nodes of given ToolbarActions 1`] = `
 Array [
   <div

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/itemActions/LinkItemAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/itemActions/LinkItemAction.test.js
@@ -1,0 +1,116 @@
+// @flow
+import {observable} from 'mobx';
+import ListStore from '../../../../containers/List/stores/ListStore';
+import Router from '../../../../services/Router';
+import ResourceStore from '../../../../stores/ResourceStore';
+import List from '../../../../views/List';
+import LinkItemAction from '../../itemActions/LinkItemAction';
+
+jest.mock('../../../../utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
+
+jest.mock('../../../../containers/List/stores/ListStore', () => jest.fn(function() {
+    this.selectionIds = [];
+    this.selections = [];
+    this.deletingSelection = false;
+}));
+
+jest.mock('../../../../views/List/List', () => jest.fn(function() {
+    this.requestSelectionDelete = jest.fn();
+}));
+
+jest.mock('../../../../services/Router/Router', () => jest.fn());
+
+function createLinkItemAction(options = {}) {
+    const router = new Router({});
+    const listStore = new ListStore('test', 'test', 'test', {page: observable.box(1)});
+    const list = new List({
+        route: router.route,
+        router,
+    });
+    const locales = [];
+    const resourceStore = new ResourceStore('test');
+
+    return new LinkItemAction(listStore, list, router, locales, resourceStore, options);
+}
+
+test('Return correct icon action config for given item', () => {
+    const linkItemAction = createLinkItemAction({link_property: 'url', icon: 'su-eye'});
+
+    const item = {
+        url: 'www.sulu.io',
+    };
+
+    expect(linkItemAction.getItemActionConfig(item)).toEqual(expect.objectContaining({
+        disabled: false,
+        icon: 'su-eye',
+    }));
+});
+
+test('Return disabled icon action config if no item is given', () => {
+    const linkItemAction = createLinkItemAction({link_property: 'url', icon: 'su-eye'});
+
+    expect(linkItemAction.getItemActionConfig()).toEqual(expect.objectContaining({
+        disabled: true,
+        icon: 'su-eye',
+    }));
+});
+
+test('Return disabled icon action config if link_property of given icon is not set', () => {
+    const linkItemAction = createLinkItemAction({link_property: 'url', icon: 'su-eye'});
+
+    const item = {
+        otherProperty: 'www.sulu.io',
+    };
+
+    expect(linkItemAction.getItemActionConfig(item)).toEqual(expect.objectContaining({
+        disabled: true,
+        icon: 'su-eye',
+    }));
+});
+
+test('Open correct link for given item if onClick callback is fired', () => {
+    const linkItemAction = createLinkItemAction({link_property: 'url', icon: 'su-eye'});
+
+    const item = {
+        url: 'www.sulu.io',
+    };
+    const itemActionConfig = linkItemAction.getItemActionConfig(item);
+
+    delete window.location;
+    window.location = {};
+
+    const clickCallback = itemActionConfig.onClick;
+    if (!clickCallback) {
+        throw new Error('The onClick callback should not be undefined in this case');
+    }
+
+    clickCallback('row-id', 1);
+
+    expect(window.location.href).toEqual('www.sulu.io');
+});
+
+test('Throw error if "link_property" option is not set', () => {
+    const linkItemAction = createLinkItemAction({});
+
+    expect(() => linkItemAction.getItemActionConfig()).toThrow(/link_property/);
+});
+
+test('Throw error if given "icon" option is not a string', () => {
+    const linkItemAction = createLinkItemAction({icon: {}, link_property: 'url'});
+
+    expect(() => linkItemAction.getItemActionConfig()).toThrow(/icon/);
+});
+
+test('Throw error if given "link_property" option is not a string', () => {
+    const linkItemAction = createLinkItemAction({link_property: {}});
+
+    expect(() => linkItemAction.getItemActionConfig()).toThrow(/link_property/);
+});
+
+test('Throw error if value of "link_property" of given item is not a string', () => {
+    const linkItemAction = createLinkItemAction({link_property: 'url'});
+
+    expect(() => linkItemAction.getItemActionConfig({url: true})).toThrow(/link_property/);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/registries/listItemActionRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/registries/listItemActionRegistry.test.js
@@ -1,0 +1,32 @@
+// @flow
+import listItemActionRegistry from '../../registries/listITemActionRegistry';
+import AbstractListItemAction from '../../itemActions/AbstractListItemAction';
+
+beforeEach(() => {
+    listItemActionRegistry.clear();
+});
+
+test('Clear all item actions', () => {
+    listItemActionRegistry.add('test1', AbstractListItemAction);
+    expect(Object.keys(listItemActionRegistry.listItemActions)).toHaveLength(1);
+
+    listItemActionRegistry.clear();
+    expect(Object.keys(listItemActionRegistry.listItemActions)).toHaveLength(0);
+});
+
+test('Add item action', () => {
+    listItemActionRegistry.add('test1', AbstractListItemAction);
+    listItemActionRegistry.add('test2', AbstractListItemAction);
+
+    expect(listItemActionRegistry.get('test1')).toBe(AbstractListItemAction);
+    expect(listItemActionRegistry.get('test2')).toBe(AbstractListItemAction);
+});
+
+test('Add item action with existing key should throw', () => {
+    listItemActionRegistry.add('test1', AbstractListItemAction);
+    expect(() => listItemActionRegistry.add('test1', AbstractListItemAction)).toThrow(/test1/);
+});
+
+test('Get item action of not existing key', () => {
+    expect(() => listItemActionRegistry.get('XXX')).toThrow();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/registries/listItemActionRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/registries/listItemActionRegistry.test.js
@@ -1,5 +1,5 @@
 // @flow
-import listItemActionRegistry from '../../registries/listITemActionRegistry';
+import listItemActionRegistry from '../../registries/listItemActionRegistry';
 import AbstractListItemAction from '../../itemActions/AbstractListItemAction';
 
 beforeEach(() => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/registries/listToolbarActionRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/registries/listToolbarActionRegistry.test.js
@@ -17,7 +17,7 @@ test('Clear all toolbar actions', () => {
     expect(Object.keys(listToolbarActionRegistry.toolbarActions)).toHaveLength(0);
 });
 
-test('Add adapter', () => {
+test('Add toolbar action', () => {
     listToolbarActionRegistry.add('test1', AbstractListToolbarAction);
     listToolbarActionRegistry.add('test2', AbstractListToolbarAction);
 
@@ -25,11 +25,11 @@ test('Add adapter', () => {
     expect(listToolbarActionRegistry.get('test2')).toBe(AbstractListToolbarAction);
 });
 
-test('Add adapter with existing key should throw', () => {
+test('Add toolbar action with existing key should throw', () => {
     listToolbarActionRegistry.add('test1', AbstractListToolbarAction);
     expect(() => listToolbarActionRegistry.add('test1', AbstractListToolbarAction)).toThrow(/test1/);
 });
 
-test('Get adapter of not existing key', () => {
+test('Get toolbar action of not existing key', () => {
     expect(() => listToolbarActionRegistry.get('XXX')).toThrow();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/AbstractListToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/AbstractListToolbarAction.js
@@ -1,12 +1,12 @@
 // @flow
 import type {Node} from 'react';
-import type {ToolbarAction, ToolbarItemConfig} from '../../../containers/Toolbar/types';
+import type {ToolbarItemConfig} from '../../../containers/Toolbar/types';
 import ResourceStore from '../../../stores/ResourceStore';
 import Router from '../../../services/Router';
 import List from '../../../views/List/List';
 import ListStore from '../../../containers/List/stores/ListStore';
 
-export default class AbstractListToolbarAction implements ToolbarAction {
+export default class AbstractListToolbarAction {
     listStore: ListStore;
     list: List;
     router: Router;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/index.js
@@ -4,16 +4,20 @@ import Form, {
     formToolbarActionRegistry,
 } from './Form';
 import List, {
+    AbstractListItemAction,
     AbstractListToolbarAction,
+    listItemActionRegistry,
     listToolbarActionRegistry,
 } from './List';
 import Tabs from './Tabs';
 import ResourceTabs from './ResourceTabs';
 
 export {
+    AbstractListItemAction,
     AbstractListToolbarAction,
     AbstractFormToolbarAction,
     List,
+    listItemActionRegistry,
     listToolbarActionRegistry,
     Form,
     formToolbarActionRegistry,

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormOverlayListViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormOverlayListViewBuilderTest.php
@@ -412,4 +412,25 @@ class FormOverlayListViewBuilderTest extends TestCase
             $route->getOption('toolbarActions')
         );
     }
+
+    public function testBuildAddItemActions()
+    {
+        $linkItemAction = new ToolbarAction('sulu_admin.link');
+        $exportItemAction = new ToolbarAction('sulu_admin.export');
+        $downloadItemAction = new ToolbarAction('sulu_admin.download');
+
+        $route = (new FormOverlayListViewBuilder('sulu_role.list', '/roles'))
+            ->setResourceKey('roles')
+            ->setListKey('roles')
+            ->setFormKey('role_details')
+            ->addListAdapters(['tree'])
+            ->addItemActions([$linkItemAction, $exportItemAction])
+            ->addItemActions([$downloadItemAction])
+            ->getView();
+
+        $this->assertEquals(
+            [$linkItemAction, $exportItemAction, $downloadItemAction],
+            $route->getOption('itemActions')
+        );
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ListItemActionTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ListItemActionTest.php
@@ -13,10 +13,6 @@ namespace Sulu\Bundle\AdminBundle\Tests\Unit\Admin\View;
 
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\AdminBundle\Admin\View\ListItemAction;
-use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
-use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilder;
-use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
-use Sulu\Bundle\AdminBundle\Exception\ViewNotFoundException;
 
 class ListItemActionTest extends TestCase
 {

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ListItemActionTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ListItemActionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\Admin\View;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Admin\View\ListItemAction;
+use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilder;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
+use Sulu\Bundle\AdminBundle\Exception\ViewNotFoundException;
+
+class ListItemActionTest extends TestCase
+{
+    public function testGetType()
+    {
+        $toolbarAction = new ListItemAction('sulu_admin.link', ['link_property' => 'url']);
+
+        $this->assertSame('sulu_admin.link', $toolbarAction->getType());
+    }
+
+    public function testGetOptions()
+    {
+        $toolbarAction = new ListItemAction('sulu_admin.link', ['link_property' => 'url']);
+
+        $this->assertSame(['link_property' => 'url'], $toolbarAction->getOptions());
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ListViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ListViewBuilderTest.php
@@ -397,4 +397,24 @@ class ListViewBuilderTest extends TestCase
             $view->getOption('toolbarActions')
         );
     }
+
+    public function testBuildAddItemActions()
+    {
+        $linkItemAction = new ToolbarAction('sulu_admin.link');
+        $exportItemAction = new ToolbarAction('sulu_admin.export');
+        $downloadItemAction = new ToolbarAction('sulu_admin.download');
+
+        $view = (new ListViewBuilder('sulu_role.list', '/roles'))
+            ->setResourceKey('roles')
+            ->setListKey('roles')
+            ->addListAdapters(['tree'])
+            ->addItemActions([$linkItemAction, $exportItemAction])
+            ->addItemActions([$downloadItemAction])
+            ->getView();
+
+        $this->assertEquals(
+            [$linkItemAction, $exportItemAction, $downloadItemAction],
+            $view->getOption('itemActions')
+        );
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ToolbarActionTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ToolbarActionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\Admin\View;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilder;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
+use Sulu\Bundle\AdminBundle\Exception\ViewNotFoundException;
+
+class ToolbarActionTest extends TestCase
+{
+    public function testGetType()
+    {
+        $toolbarAction = new ToolbarAction('sulu_admin.delete', ['allow_conflict_deletion' => false]);
+
+        $this->assertSame('sulu_admin.delete', $toolbarAction->getType());
+    }
+
+    public function testGetOptions()
+    {
+        $toolbarAction = new ToolbarAction('sulu_admin.delete', ['allow_conflict_deletion' => false]);
+
+        $this->assertSame(['allow_conflict_deletion' => false], $toolbarAction->getOptions());
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ToolbarActionTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ToolbarActionTest.php
@@ -13,9 +13,6 @@ namespace Sulu\Bundle\AdminBundle\Tests\Unit\Admin\View;
 
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
-use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilder;
-use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
-use Sulu\Bundle\AdminBundle\Exception\ViewNotFoundException;
 
 class ToolbarActionTest extends TestCase
 {

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Persistence\ManagerRegistry;
 use Sulu\Bundle\AdminBundle\Admin\Admin;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItem;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
+use Sulu\Bundle\AdminBundle\Admin\View\ListItemAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
@@ -95,7 +96,8 @@ class ContactAdmin extends Admin
         if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::EDIT)) {
             $contactFormToolbarActions = [];
             $contactListToolbarActions = [];
-            $contactDocumentsToolbarAction = [];
+            $contactDocumentsToolbarActions = [];
+            $contactDocumentsItemActions = [];
 
             if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::ADD)) {
                 $contactListToolbarActions[] = new ToolbarAction('sulu_admin.add');
@@ -103,8 +105,8 @@ class ContactAdmin extends Admin
 
             if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::EDIT)) {
                 $contactFormToolbarActions[] = new ToolbarAction('sulu_admin.save');
-                $contactDocumentsToolbarAction[] = new ToolbarAction('sulu_contact.add_media');
-                $contactDocumentsToolbarAction[] = new ToolbarAction('sulu_contact.delete_media');
+                $contactDocumentsToolbarActions[] = new ToolbarAction('sulu_contact.add_media');
+                $contactDocumentsToolbarActions[] = new ToolbarAction('sulu_contact.delete_media');
             }
 
             if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::DELETE)) {
@@ -114,6 +116,10 @@ class ContactAdmin extends Admin
 
             if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::VIEW)) {
                 $contactListToolbarActions[] = new ToolbarAction('sulu_admin.export');
+                $contactDocumentsItemActions[] = new ListItemAction(
+                    'link',
+                    ['icon' => 'fa-cloud-download', 'link_property' => 'url']
+                );
             }
 
             $viewCollection->add(
@@ -167,7 +173,8 @@ class ContactAdmin extends Admin
                     ->setUserSettingsKey('contact_media')
                     ->setTabTitle('sulu_contact.documents')
                     ->addListAdapters(['table'])
-                    ->addToolbarActions($contactDocumentsToolbarAction)
+                    ->addToolbarActions($contactDocumentsToolbarActions)
+                    ->addItemActions($contactDocumentsItemActions)
                     ->addRouterAttributesToListRequest(['id' => 'contactId'])
                     ->setTabOrder(2048)
                     ->setParent(static::CONTACT_EDIT_FORM_VIEW)
@@ -177,7 +184,8 @@ class ContactAdmin extends Admin
         if ($this->securityChecker->hasPermission(static::ACCOUNT_SECURITY_CONTEXT, PermissionTypes::EDIT)) {
             $accountFormToolbarActions = [];
             $accountListToolbarActions = [];
-            $accountDocumentsToolbarAction = [];
+            $accountDocumentsToolbarActions = [];
+            $accountDocumentsItemActions = [];
 
             if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::ADD)) {
                 $accountListToolbarActions[] = new ToolbarAction('sulu_admin.add');
@@ -185,8 +193,8 @@ class ContactAdmin extends Admin
 
             if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::EDIT)) {
                 $accountFormToolbarActions[] = new ToolbarAction('sulu_admin.save');
-                $accountDocumentsToolbarAction[] = new ToolbarAction('sulu_contact.add_media');
-                $accountDocumentsToolbarAction[] = new ToolbarAction('sulu_contact.delete_media');
+                $accountDocumentsToolbarActions[] = new ToolbarAction('sulu_contact.add_media');
+                $accountDocumentsToolbarActions[] = new ToolbarAction('sulu_contact.delete_media');
             }
 
             if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::DELETE)) {
@@ -202,6 +210,10 @@ class ContactAdmin extends Admin
 
             if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::VIEW)) {
                 $accountListToolbarActions[] = new ToolbarAction('sulu_admin.export');
+                $accountDocumentsItemActions[] = new ListItemAction(
+                    'link',
+                    ['icon' => 'fa-cloud-download', 'link_property' => 'url']
+                );
             }
 
             $viewCollection->add(
@@ -274,7 +286,8 @@ class ContactAdmin extends Admin
                     ->setTabTitle('sulu_contact.documents')
                     ->addListAdapters(['table'])
                     ->addRouterAttributesToListRequest(['id' => 'contactId'])
-                    ->addToolbarActions($accountDocumentsToolbarAction)
+                    ->addToolbarActions($accountDocumentsToolbarActions)
+                    ->addItemActions($accountDocumentsItemActions)
                     ->setTabOrder(3072)
                     ->setParent(static::ACCOUNT_EDIT_FORM_VIEW)
             );

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -118,7 +118,7 @@ class ContactAdmin extends Admin
                 $contactListToolbarActions[] = new ToolbarAction('sulu_admin.export');
                 $contactDocumentsItemActions[] = new ListItemAction(
                     'link',
-                    ['icon' => 'fa-cloud-download', 'link_property' => 'url']
+                    ['icon' => 'su-download', 'link_property' => 'url']
                 );
             }
 
@@ -212,7 +212,7 @@ class ContactAdmin extends Admin
                 $accountListToolbarActions[] = new ToolbarAction('sulu_admin.export');
                 $accountDocumentsItemActions[] = new ListItemAction(
                     'link',
-                    ['icon' => 'fa-cloud-download', 'link_property' => 'url']
+                    ['icon' => 'su-download', 'link_property' => 'url']
                 );
             }
 

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/fields/PageSettingsVersions.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/fields/PageSettingsVersions.js
@@ -74,18 +74,18 @@ class PageSettingsVersions extends React.Component<Props> {
     };
 
     render() {
-        const actions = [
-            {
+        const restoreAction = {
+            getItemActionConfig: () => ({
                 icon: 'su-process',
                 onClick: this.handleRestoreClick,
-            },
-        ];
+            }),
+        };
 
         return (
             <Fragment>
                 <List
-                    actions={actions}
                     adapters={['table']}
+                    itemActions={[restoreAction]}
                     searchable={false}
                     selectable={false}
                     store={this.listStore}

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/fields/PageSettingsVersions.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/fields/PageSettingsVersions.js
@@ -73,19 +73,21 @@ class PageSettingsVersions extends React.Component<Props> {
             }));
     };
 
-    render() {
-        const restoreAction = {
-            getItemActionConfig: () => ({
+    getListItemActions = () => {
+        return [
+            {
                 icon: 'su-process',
                 onClick: this.handleRestoreClick,
-            }),
-        };
+            },
+        ];
+    };
 
+    render() {
         return (
             <Fragment>
                 <List
                     adapters={['table']}
-                    itemActions={[restoreAction]}
+                    itemActionsProvider={this.getListItemActions}
                     searchable={false}
                     selectable={false}
                     store={this.listStore}

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/tests/fields/PageSettingsVersions.test.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/tests/fields/PageSettingsVersions.test.js
@@ -132,7 +132,7 @@ test('Open and cancel restore overlay', () => {
     );
 
     expect(pageSettingsVersions.find('Dialog').prop('open')).toEqual(false);
-    pageSettingsVersions.find('List').prop('itemActions')[0].getItemActionConfig().onClick(3);
+    pageSettingsVersions.find('List').prop('itemActionsProvider')()[0].onClick(3);
     pageSettingsVersions.update();
     expect(pageSettingsVersions.find('Dialog').prop('open')).toEqual(true);
     pageSettingsVersions.find('Dialog').prop('onCancel')();
@@ -158,7 +158,7 @@ test('Open and confirm restore overlay', () => {
     );
 
     expect(pageSettingsVersions.find('Dialog').prop('open')).toEqual(false);
-    pageSettingsVersions.find('List').prop('itemActions')[0].getItemActionConfig().onClick(3);
+    pageSettingsVersions.find('List').prop('itemActionsProvider')()[0].onClick(3);
     pageSettingsVersions.update();
     expect(pageSettingsVersions.find('Dialog').prop('open')).toEqual(true);
     pageSettingsVersions.find('Dialog').prop('onConfirm')();

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/tests/fields/PageSettingsVersions.test.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/tests/fields/PageSettingsVersions.test.js
@@ -132,7 +132,7 @@ test('Open and cancel restore overlay', () => {
     );
 
     expect(pageSettingsVersions.find('Dialog').prop('open')).toEqual(false);
-    pageSettingsVersions.find('List').prop('actions')[0].onClick(3);
+    pageSettingsVersions.find('List').prop('itemActions')[0].getItemActionConfig().onClick(3);
     pageSettingsVersions.update();
     expect(pageSettingsVersions.find('Dialog').prop('open')).toEqual(true);
     pageSettingsVersions.find('Dialog').prop('onCancel')();
@@ -158,7 +158,7 @@ test('Open and confirm restore overlay', () => {
     );
 
     expect(pageSettingsVersions.find('Dialog').prop('open')).toEqual(false);
-    pageSettingsVersions.find('List').prop('actions')[0].onClick(3);
+    pageSettingsVersions.find('List').prop('itemActions')[0].getItemActionConfig().onClick(3);
     pageSettingsVersions.update();
     expect(pageSettingsVersions.find('Dialog').prop('open')).toEqual(true);
     pageSettingsVersions.find('Dialog').prop('onConfirm')();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adds a concept called `ListItemAction`. A `ListItemAction` is an action that can be executed for a specific item displayed in a list - eg. downloading the original file of a media or navigating to an item specific link.

To provide this functionality, the PR adds a `itemActions` prop to the `List` container and all `ListAdapter` components. This `itemActions`  prop replaces the previously existing `actions` prop that was introduced for a similar reason but was used in the core only a single time. In contrast to the old `actions` prop, the new `itemActions` prop allows to return a different `ItemActionConfig` depending on the given item. This PR implement the handling of the `itemActions` prop in the `TableAdapter` and the `TreeTableAdapter`.

Furthermore, this PR adds a `listItemActionRegistry` that allows to register a `ListItemAction` in the Javascript code and assign it to a `List` from within the PHP code. Therefore, the PR also adds a respective method to the existing `ListViewBuilder`. The concept and implementation of this `listItemActionRegistry` is similar to the implementation of the already existing `listToolbarActionRegistry`.

Finally, this PR adds a `LinkItemAction` as proof of concept. This `LinkItemAction` is added to the Documents tab of Contacts and Accounts to allow for downloading the origin file of assigned medias.

#### Why?

Because this feature would have been useful in multiple private projects in the past.. 🙂 

#### Example Usage

Implementing a `ListItemAction`:
~~~javascript
import AbstractListItemAction from './AbstractListItemAction';

export default class LogItemAction extends AbstractListItemAction {
    getItemActionConfig(item: ?Object) {
        return {
            icon: 'su-eye',
            onClick:() => {
                console.log(item)
            },
            disabled: false,
        };
    }
}
~~~

Registering a `ListItemAction`:
~~~javascript
listItemActionRegistry.add('log_item', LogItemAction);
~~~

Assigning a `ListItemAction`
~~~php
$this->viewBuilderFactory
    ->createListViewBuilder('sulu_contact.account_documents_list', '/documents')
    ->addItemActions([new ListItemAction('log_item')])
    ....
~~~

#### BC Breaks/Deprecations

* Removed the `actions` prop of the `List` container
* Removed the `actions` prop of all `ListAdapter` components
* Removed the `ToolbarAction` interface because it was not used anywhere as parameter type
