### PR TITLE
Register RouteManagerInterface::class as alias for sulu_route.manager.route_manager service

### DIFF
--- a/src/Sulu/Bundle/RouteBundle/Resources/config/manager.xml
+++ b/src/Sulu/Bundle/RouteBundle/Resources/config/manager.xml
@@ -14,5 +14,6 @@
             <argument type="service" id="sulu_route.manager.conflict_resolver.auto_increment"/>
             <argument type="service" id="sulu.repository.route"/>
         </service>
+        <service id="Sulu\Bundle\RouteBundle\Manager\RouteManagerInterface" alias="sulu_route.manager.route_manager" />
     </services>
 </container>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### Why?

To allow for autowiring the sulu_route.manager.route_manager service.