### PR TITLE
Add download counter for media list view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* 1.6.32 (2020-02-17)
+    * FEATURE            [MediaBundle]             Added download counter to list view of medias.
+
 * 1.6.31 (2020-02-11)
     * BUGFIX      #5026  [Content]                 Add reserved property names
     * BUGFIX      #4998  [ContentBundle]           Fix assigning more than 10 teasers when using elasticsearch

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/list-builder/Media.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/list-builder/Media.xml
@@ -109,6 +109,13 @@
             <orm:joins ref="fileVersion"/>
         </property>
 
+        <property name="downloadCounter" list:translation="media.media.downloadCounter">
+            <orm:field-name>downloadCounter</orm:field-name>
+            <orm:entity-name>SuluMediaBundle:FileVersion</orm:entity-name>
+
+            <orm:joins ref="fileVersion"/>
+        </property>
+
         <property name="storageOptions" display="never">
             <orm:field-name>storageOptions</orm:field-name>
             <orm:entity-name>SuluMediaBundle:FileVersion</orm:entity-name>

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/sulu/backend.de.xlf
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/sulu/backend.de.xlf
@@ -26,6 +26,10 @@
                 <source>media.media.mime-type</source>
                 <target>MIME-Type</target>
             </trans-unit>
+            <trans-unit id="3c8f1c7c02abd468cc0794e987e2b212" resname="media.media.downloadCounter">
+                <source>media.media.downloadCounter</source>
+                <target>Anzahl Downloads</target>
+            </trans-unit>
             <trans-unit id="6f5e8f5b65fd4e7ae7ec509e742cc85f" resname="media.media.thumbnails">
                 <source>media.media.thumbnails</source>
                 <target>Vorschaubild</target>

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/sulu/backend.en.xlf
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/sulu/backend.en.xlf
@@ -26,6 +26,10 @@
                 <source>media.media.mime-type</source>
                 <target>MIME-Type</target>
             </trans-unit>
+            <trans-unit id="3c8f1c7c02abd468cc0794e987e2b212" resname="media.media.downloadCounter">
+                <source>media.media.downloadCounter</source>
+                <target>Downloads count</target>
+            </trans-unit>
             <trans-unit id="6f5e8f5b65fd4e7ae7ec509e742cc85f" resname="media.media.thumbnails">
                 <source>media.media.thumbnails</source>
                 <target>Thumbnail</target>

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/sulu/backend.fr.xlf
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/sulu/backend.fr.xlf
@@ -26,6 +26,10 @@
                 <source>media.media.mime-type</source>
                 <target>MIME-Type</target>
             </trans-unit>
+            <trans-unit id="3c8f1c7c02abd468cc0794e987e2b212" resname="media.media.downloadCounter">
+                <source>media.media.downloadCounter</source>
+                <target>Nombre de téléchargements</target>
+            </trans-unit>
             <trans-unit id="6f5e8f5b65fd4e7ae7ec509e742cc85f" resname="media.media.thumbnails">
                 <source>media.media.thumbnails</source>
                 <target>Vignette</target>

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/sulu/backend.nl.xlf
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/sulu/backend.nl.xlf
@@ -26,6 +26,10 @@
                 <source>media.media.mime-type</source>
                 <target>MIME-Type</target>
             </trans-unit>
+            <trans-unit id="3c8f1c7c02abd468cc0794e987e2b212" resname="media.media.downloadCounter">
+                <source>media.media.downloadCounter</source>
+                <target>Aantal downloads</target>
+            </trans-unit>
             <trans-unit id="6f5e8f5b65fd4e7ae7ec509e742cc85f" resname="media.media.thumbnails">
                 <source>media.media.thumbnails</source>
                 <target>Thumbnail</target>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

Adds a field for the Download counter in the media list view.

#### Why?

Sadly there is no Issue for this problem, but we needed it.

#### Example Usage

You can change the list view style in the options.

#### To Do

- [ ] Maybe Create a documentation PR
- [ ] Maybe Adapt Tests

#### Screen Shots:
![image](https://user-images.githubusercontent.com/29226459/74672095-d780f900-51ac-11ea-9bca-b4eaa000d6e4.png)