### PR TITLE
Add tags to metadata and add filter for metadata provider

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
+++ b/src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
@@ -63,6 +63,24 @@ class FormMetadataMapper
         return new SchemaMetadata($this->mapSchemaProperties($itemsMetadata));
     }
 
+    /**
+     * @param mixed[] $tagsMetadata
+     */
+    public function mapTags(array $tagsMetadata): array
+    {
+        $tags = [];
+        foreach ($tagsMetadata as $tagMetadata) {
+            $tag = new TagMetadata();
+            $tag->setName($tagMetadata['name']);
+            $tag->setPriority($tagMetadata['priority'] ?? null);
+            $tag->setAttributes($tagMetadata['attributes'] ?? []);
+
+            $tags[] = $tag;
+        }
+
+        return $tags;
+    }
+
     private function mapSection(ContentSectionMetadata $property, string $locale): SectionMetadata
     {
         $section = new SectionMetadata($property->getName());
@@ -119,12 +137,7 @@ class FormMetadataMapper
     private function mapProperty(ContentPropertyMetadata $property, string $locale): FieldMetadata
     {
         $field = new FieldMetadata($property->getName());
-        foreach ($property->getTags() as $tag) {
-            $fieldTag = new TagMetadata();
-            $fieldTag->setName($tag['name']);
-            $fieldTag->setPriority($tag['priority']);
-            $field->addTag($fieldTag);
-        }
+        $field->setTags($this->mapTags($property->getTags()));
 
         $field->setLabel($property->getTitle($locale));
         $field->setDisabledCondition($property->getDisabledCondition());

--- a/src/Sulu/Bundle/AdminBundle/FormMetadata/FormXmlLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/FormMetadata/FormXmlLoader.php
@@ -101,6 +101,7 @@ class FormXmlLoader extends AbstractLoader
     private function mapFormsMetadata(ExternalFormMetadata $formMetadata, string $locale): FormMetadata
     {
         $form = new FormMetadata();
+        $form->setTags($this->formMetadataMapper->mapTags($formMetadata->getTags()));
         $form->setItems($this->formMetadataMapper->mapChildren($formMetadata->getChildren(), $locale));
 
         $schema = $this->formMetadataMapper->mapSchema($formMetadata->getProperties());

--- a/src/Sulu/Bundle/AdminBundle/FormMetadata/FormXmlLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/FormMetadata/FormXmlLoader.php
@@ -72,6 +72,7 @@ class FormXmlLoader extends AbstractLoader
         $form = new ExternalFormMetadata();
         $form->setResource($resource);
         $form->setKey($xpath->query('/x:form/x:key')->item(0)->nodeValue);
+        $form->setTags($this->loadStructureTags('/x:form/x:tag', $xpath));
 
         $propertiesNode = $xpath->query('/x:form/x:properties')->item(0);
         $properties = $this->propertiesXmlParser->load(

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FieldMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FieldMetadata.php
@@ -158,4 +158,12 @@ class FieldMetadata extends ItemMetadata
     {
         $this->tags[] = $tag;
     }
+
+    /**
+     * @param TagMetadata[] $tags
+     */
+    public function setTags(array $tags): void
+    {
+        $this->tags = $tags;
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
@@ -118,15 +118,19 @@ class FormMetadata extends AbstractMetadata
         return $this->tags;
     }
 
-    public function getTag(string $name): ?TagMetadata
+    /**
+     * @return TagMetadata[]
+     */
+    public function getTagsByName(string $name): array
     {
+        $tags = [];
         foreach ($this->getTags() as $tag) {
             if ($tag->getName() === $name) {
-                return $tag;
+                $tags[] = $tag;
             }
         }
 
-        return null;
+        return $tags;
     }
 
     public function addTag(TagMetadata $tag): void

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
@@ -44,6 +44,11 @@ class FormMetadata extends AbstractMetadata
      */
     private $key;
 
+    /**
+     * @var TagMetadata[]
+     */
+    protected $tags;
+
     public function setName(string $name)
     {
         $this->name = $name;
@@ -103,6 +108,38 @@ class FormMetadata extends AbstractMetadata
     public function getSchema(): SchemaMetadata
     {
         return $this->schema;
+    }
+
+    /**
+     * @return TagMetadata[]
+     */
+    public function getTags(): array
+    {
+        return $this->tags;
+    }
+
+    public function getTag(string $name): ?TagMetadata
+    {
+        foreach ($this->getTags() as $tag) {
+            if ($tag->getName() === $name) {
+                return $tag;
+            }
+        }
+
+        return null;
+    }
+
+    public function addTag(TagMetadata $tag): void
+    {
+        $this->tags[] = $tag;
+    }
+
+    /**
+     * @param TagMetadata[] $tags
+     */
+    public function setTags(array $tags): void
+    {
+        $this->tags = $tags;
     }
 
     public function merge(self $otherForm): FormMetadata

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
@@ -57,8 +57,7 @@ class FormMetadataProvider implements MetadataProviderInterface
             }
 
             if (array_key_exists('tags', $metadataOptions)) {
-                $tags = $metadataOptions['tags'];
-                foreach ($tags as $tagName => $tagAttributes) {
+                foreach ($metadataOptions['tags'] as $tagName => $tagAttributes) {
                     if (!is_array($tagAttributes)) {
                         $tagAttributes = filter_var($tagAttributes, FILTER_VALIDATE_BOOLEAN);
                     }
@@ -98,7 +97,7 @@ class FormMetadataProvider implements MetadataProviderInterface
         }
 
         foreach ($tags as $tag) {
-            if (!$tag->matchAttributes($tagAttributes)) {
+            if (!$tag->hasAttributes($tagAttributes)) {
                 return false;
             }
         }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
@@ -55,9 +55,29 @@ class FormMetadataProvider implements MetadataProviderInterface
             foreach ($form->getForms() as $formType) {
                 $this->evaluateFormItemExpressions($formType->getItems());
             }
+
+            if (array_key_exists('tags', $metadataOptions)) {
+                $tags = $metadataOptions['tags'];
+                $tagAttributes = $metadataOptions['tagAttributes'] ?? [];
+                foreach ($tags as $tagName => $tagValue) {
+                    $this->filterByTag($form, $tagName, $tagValue, $tagAttributes[$tagName] ?? 'value');
+                }
+            }
         }
 
         return $form;
+    }
+
+    private function filterByTag(TypedFormMetadata $form, string $tagName, string $tagValue, string $tagAttribute): void
+    {
+        foreach ($form->getForms() as $formKey => $childForm) {
+            $tag = $childForm->getTag($tagName);
+            $actualTagValue = $tag ? $tag->getAttribute($tagAttribute) : '';
+
+            if ($actualTagValue !== $tagValue) {
+                $form->removeForm($formKey);
+            }
+        }
     }
 
     /**

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
@@ -130,6 +130,7 @@ class StructureFormMetadataLoader implements FormMetadataLoaderInterface, CacheW
 
         foreach ($structuresMetadata as $structureMetadata) {
             $form = new FormMetadata();
+            $form->setTags($this->formMetadataMapper->mapTags($structureMetadata->getTags()));
             $form->setName($structureMetadata->getName());
             $form->setTitle($structureMetadata->getTitle($locale) ?? ucfirst($structureMetadata->getName()));
             $form->setItems($this->formMetadataMapper->mapChildren($structureMetadata->getChildren(), $locale));

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TagMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TagMetadata.php
@@ -65,8 +65,8 @@ class TagMetadata
 
     public function hasAttributes(array $attributes): bool
     {
-        foreach ($this->attributes as $key => $value) {
-            if (($attributes[$key] ?? null) !== $value) {
+        foreach ($attributes as $key => $value) {
+            if (!array_key_exists($key, $this->attributes) || $this->attributes[$key] !== $value) {
                 return false;
             }
         }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TagMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TagMetadata.php
@@ -19,9 +19,14 @@ class TagMetadata
     private $name;
 
     /**
-     * @var ?int
+     * @var int|null
      */
     private $priority;
+
+    /**
+     * @var array
+     */
+    private $attributes = [];
 
     public function getName(): string
     {
@@ -33,7 +38,7 @@ class TagMetadata
         $this->name = $name;
     }
 
-    public function getPriority(): int
+    public function getPriority(): ?int
     {
         return $this->priority;
     }
@@ -41,5 +46,20 @@ class TagMetadata
     public function setPriority(?int $priority): void
     {
         $this->priority = $priority;
+    }
+
+    public function setAttributes(array $attributes): void
+    {
+        $this->attributes = $attributes;
+    }
+
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+
+    public function getAttribute(string $name)
+    {
+        return $this->attributes[$name] ?? null;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TagMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TagMetadata.php
@@ -62,4 +62,15 @@ class TagMetadata
     {
         return $this->attributes[$name] ?? null;
     }
+
+    public function matchAttributes(array $attributes): bool
+    {
+        foreach ($this->attributes as $key => $value) {
+            if (($attributes[$key] ?? null) !== $value) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TagMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TagMetadata.php
@@ -63,7 +63,7 @@ class TagMetadata
         return $this->attributes[$name] ?? null;
     }
 
-    public function matchAttributes(array $attributes): bool
+    public function hasAttributes(array $attributes): bool
     {
         foreach ($this->attributes as $key => $value) {
             if (($attributes[$key] ?? null) !== $value) {

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TypedFormMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TypedFormMetadata.php
@@ -32,6 +32,9 @@ class TypedFormMetadata extends AbstractMetadata
         unset($this->forms[$key]);
     }
 
+    /**
+     * @return FormMetadata[]
+     */
     public function getForms(): array
     {
         return $this->forms;

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/forms/form.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/forms/form.xml
@@ -5,6 +5,8 @@
 >
     <key>form</key>
 
+    <tag name="test" value="test-value"/>
+
     <properties>
         <property name="formOfAddress" type="single_select" mandatory="true" colspan="3" spaceAfter="9">
             <meta>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/default.xml
@@ -18,6 +18,7 @@
 
     <tag name="test" value="test-value"/>
     <tag name="test2" test="test-value2"/>
+    <tag name="test3" value="test-value"/>
 
     <properties>
         <property name="title" type="text_line" mandatory="true">

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/default.xml
@@ -16,6 +16,9 @@
         <title lang="en">Animals</title>
     </meta>
 
+    <tag name="test" value="test-value"/>
+    <tag name="test2" test="test-value2"/>
+
     <properties>
         <property name="title" type="text_line" mandatory="true">
             <meta>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/overview.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/overview.xml
@@ -11,6 +11,8 @@
     <controller>SuluPageBundle:Default:index</controller>
     <cacheLifetime>2400</cacheLifetime>
 
+    <tag name="test3"/>
+
     <properties>
         <property name="title" type="text_line" mandatory="true">
             <tag name="sulu.rlp.part" />

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/overview.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/overview.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" ?>
+
 <template xmlns="http://schemas.sulu.io/template/template"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template.xsd">
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd"
+>
 
     <key>overview</key>
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
@@ -53,25 +53,45 @@ class FormMetadataProviderTest extends KernelTestCase
 
     public function testGetMetadataTagFiltered()
     {
-        $typedForm = $this->formMetadataProvider->getMetadata('page', 'de', ['tags' => ['test' => 'test-value']]);
+        $typedForm = $this->formMetadataProvider->getMetadata(
+            'page',
+            'de',
+            ['tags' => ['test' => ['exists' => true, 'value' => 'test-value']]]
+        );
         $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
         $this->assertCount(1, $typedForm->getForms());
         $this->assertEquals(['default'], array_keys($typedForm->getForms()));
 
-        $typedForm = $this->formMetadataProvider->getMetadata('page', 'de', ['tags' => ['test' => 'test-value2']]);
+        $typedForm = $this->formMetadataProvider->getMetadata(
+            'page',
+            'de',
+            ['tags' => ['test' => ['exists' => true, 'value' => 'test-value2']]]
+        );
         $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
         $this->assertCount(0, $typedForm->getForms());
 
-        $typedForm = $this->formMetadataProvider->getMetadata('page', 'de', ['tags' => ['test2' => 'test-value2']]);
+        $typedForm = $this->formMetadataProvider->getMetadata(
+            'page',
+            'de',
+            ['tags' => ['test2' => ['exists' => true, 'value' => 'test-value2']]]
+        );
         $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
         $this->assertCount(0, $typedForm->getForms());
 
-        $typedForm = $this->formMetadataProvider->getMetadata('page', 'de', ['tags' => ['test2' => 'test-value2'], 'tagAttributes' => ['test2' => 'test']]);
+        $typedForm = $this->formMetadataProvider->getMetadata(
+            'page',
+            'de',
+            ['tags' => ['test2' => ['exists' => true, 'test' => 'test-value2']]]
+        );
         $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
         $this->assertCount(1, $typedForm->getForms());
         $this->assertEquals(['default'], array_keys($typedForm->getForms()));
 
-        $typedForm = $this->formMetadataProvider->getMetadata('page', 'de', ['tags' => ['test' => '']]);
+        $typedForm = $this->formMetadataProvider->getMetadata(
+            'page',
+            'de',
+            ['tags' => ['test' => ['exists' => false]]]
+        );
         $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
         $this->assertCount(1, $typedForm->getForms());
         $this->assertEquals(['overview'], array_keys($typedForm->getForms()));

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
@@ -81,7 +81,7 @@ class FormMetadataProviderTest extends KernelTestCase
         $typedForm = $this->formMetadataProvider->getMetadata(
             'page',
             'de',
-            ['tags' => ['test2' => ['exists' => true, 'test' => 'test-value2']]]
+            ['tags' => ['test2' => ['test' => 'test-value2']]]
         );
         $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
         $this->assertCount(1, $typedForm->getForms());

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
@@ -50,4 +50,30 @@ class FormMetadataProviderTest extends KernelTestCase
         $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
         $this->assertCount(2, $typedForm->getForms());
     }
+
+    public function testGetMetadataTagFiltered()
+    {
+        $typedForm = $this->formMetadataProvider->getMetadata('page', 'de', ['tags' => ['test' => 'test-value']]);
+        $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
+        $this->assertCount(1, $typedForm->getForms());
+        $this->assertEquals(['default'], array_keys($typedForm->getForms()));
+
+        $typedForm = $this->formMetadataProvider->getMetadata('page', 'de', ['tags' => ['test' => 'test-value2']]);
+        $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
+        $this->assertCount(0, $typedForm->getForms());
+
+        $typedForm = $this->formMetadataProvider->getMetadata('page', 'de', ['tags' => ['test2' => 'test-value2']]);
+        $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
+        $this->assertCount(0, $typedForm->getForms());
+
+        $typedForm = $this->formMetadataProvider->getMetadata('page', 'de', ['tags' => ['test2' => 'test-value2'], 'tagAttributes' => ['test2' => 'test']]);
+        $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
+        $this->assertCount(1, $typedForm->getForms());
+        $this->assertEquals(['default'], array_keys($typedForm->getForms()));
+
+        $typedForm = $this->formMetadataProvider->getMetadata('page', 'de', ['tags' => ['test' => '']]);
+        $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
+        $this->assertCount(1, $typedForm->getForms());
+        $this->assertEquals(['overview'], array_keys($typedForm->getForms()));
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
@@ -104,5 +104,14 @@ class FormMetadataProviderTest extends KernelTestCase
         $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
         $this->assertCount(1, $typedForm->getForms());
         $this->assertEquals(['default'], array_keys($typedForm->getForms()));
+
+        $typedForm = $this->formMetadataProvider->getMetadata(
+            'page',
+            'de',
+            ['tags' => ['test3' => ['value' => 'test-value']]]
+        );
+        $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
+        $this->assertCount(1, $typedForm->getForms());
+        $this->assertEquals(['default'], array_keys($typedForm->getForms()));
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
@@ -56,7 +56,7 @@ class FormMetadataProviderTest extends KernelTestCase
         $typedForm = $this->formMetadataProvider->getMetadata(
             'page',
             'de',
-            ['tags' => ['test' => ['exists' => true, 'value' => 'test-value']]]
+            ['tags' => ['test' => ['value' => 'test-value']]]
         );
         $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
         $this->assertCount(1, $typedForm->getForms());
@@ -65,7 +65,7 @@ class FormMetadataProviderTest extends KernelTestCase
         $typedForm = $this->formMetadataProvider->getMetadata(
             'page',
             'de',
-            ['tags' => ['test' => ['exists' => true, 'value' => 'test-value2']]]
+            ['tags' => ['test' => ['value' => 'test-value2']]]
         );
         $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
         $this->assertCount(0, $typedForm->getForms());
@@ -73,7 +73,7 @@ class FormMetadataProviderTest extends KernelTestCase
         $typedForm = $this->formMetadataProvider->getMetadata(
             'page',
             'de',
-            ['tags' => ['test2' => ['exists' => true, 'value' => 'test-value2']]]
+            ['tags' => ['test2' => ['value' => 'test-value2']]]
         );
         $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
         $this->assertCount(0, $typedForm->getForms());
@@ -90,10 +90,19 @@ class FormMetadataProviderTest extends KernelTestCase
         $typedForm = $this->formMetadataProvider->getMetadata(
             'page',
             'de',
-            ['tags' => ['test' => ['exists' => false]]]
+            ['tags' => ['test' => false]]
         );
         $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
         $this->assertCount(1, $typedForm->getForms());
         $this->assertEquals(['overview'], array_keys($typedForm->getForms()));
+
+        $typedForm = $this->formMetadataProvider->getMetadata(
+            'page',
+            'de',
+            ['tags' => ['test' => true]]
+        );
+        $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
+        $this->assertCount(1, $typedForm->getForms());
+        $this->assertEquals(['default'], array_keys($typedForm->getForms()));
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
@@ -40,7 +40,7 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
         $this->assertEquals('overview', $overviewForm->getName());
         $this->assertEquals('Overview', $overviewForm->getTitle());
         $this->assertCount(6, $overviewForm->getItems());
-        $this->assertCount(0, $overviewForm->getTags());
+        $this->assertCount(1, $overviewForm->getTags());
         $this->assertNotNull($overviewForm->getSchema());
         $this->assertInstanceOf(SchemaMetadata::class, $overviewForm->getSchema());
 
@@ -49,7 +49,7 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
         $this->assertEquals('default', $defaultForm->getName());
         $this->assertEquals('Animals', $defaultForm->getTitle());
         $this->assertCount(5, $defaultForm->getItems());
-        $this->assertCount(2, $defaultForm->getTags());
+        $this->assertCount(3, $defaultForm->getTags());
         $this->assertNotNull($defaultForm->getSchema());
         $this->assertInstanceOf(SchemaMetadata::class, $defaultForm->getSchema());
     }
@@ -65,7 +65,7 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
         $this->assertEquals('overview', $overviewForm->getName());
         $this->assertEquals('Overview', $overviewForm->getTitle());
         $this->assertCount(6, $overviewForm->getItems());
-        $this->assertCount(0, $overviewForm->getTags());
+        $this->assertCount(1, $overviewForm->getTags());
         $this->assertNotNull($overviewForm->getSchema());
         $this->assertInstanceOf(SchemaMetadata::class, $overviewForm->getSchema());
 
@@ -74,7 +74,7 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
         $this->assertEquals('default', $defaultForm->getName());
         $this->assertEquals('Tiers', $defaultForm->getTitle());
         $this->assertCount(5, $defaultForm->getItems());
-        $this->assertCount(2, $defaultForm->getTags());
+        $this->assertCount(3, $defaultForm->getTags());
         $this->assertNotNull($defaultForm->getSchema());
         $this->assertInstanceOf(SchemaMetadata::class, $defaultForm->getSchema());
     }
@@ -98,7 +98,7 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
         $this->assertEquals('default', $defaultForm->getName());
         $this->assertEquals('Tiers', $defaultForm->getTitle());
         $this->assertCount(5, $defaultForm->getItems());
-        $this->assertCount(2, $defaultForm->getTags());
+        $this->assertCount(3, $defaultForm->getTags());
         $this->assertNotNull($defaultForm->getSchema());
         $this->assertInstanceOf(SchemaMetadata::class, $defaultForm->getSchema());
     }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\AdminBundle\Tests\Functional\Metadata\FormMetadata;
 
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\StructureFormMetadataLoader;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
 use Sulu\Bundle\TestBundle\Testing\KernelTestCase;
@@ -39,6 +40,7 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
         $this->assertEquals('overview', $overviewForm->getName());
         $this->assertEquals('Overview', $overviewForm->getTitle());
         $this->assertCount(6, $overviewForm->getItems());
+        $this->assertCount(0, $overviewForm->getTags());
         $this->assertNotNull($overviewForm->getSchema());
         $this->assertInstanceOf(SchemaMetadata::class, $overviewForm->getSchema());
 
@@ -47,6 +49,7 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
         $this->assertEquals('default', $defaultForm->getName());
         $this->assertEquals('Animals', $defaultForm->getTitle());
         $this->assertCount(5, $defaultForm->getItems());
+        $this->assertCount(2, $defaultForm->getTags());
         $this->assertNotNull($defaultForm->getSchema());
         $this->assertInstanceOf(SchemaMetadata::class, $defaultForm->getSchema());
     }
@@ -62,6 +65,7 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
         $this->assertEquals('overview', $overviewForm->getName());
         $this->assertEquals('Overview', $overviewForm->getTitle());
         $this->assertCount(6, $overviewForm->getItems());
+        $this->assertCount(0, $overviewForm->getTags());
         $this->assertNotNull($overviewForm->getSchema());
         $this->assertInstanceOf(SchemaMetadata::class, $overviewForm->getSchema());
 
@@ -70,6 +74,7 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
         $this->assertEquals('default', $defaultForm->getName());
         $this->assertEquals('Tiers', $defaultForm->getTitle());
         $this->assertCount(5, $defaultForm->getItems());
+        $this->assertCount(2, $defaultForm->getTags());
         $this->assertNotNull($defaultForm->getSchema());
         $this->assertInstanceOf(SchemaMetadata::class, $defaultForm->getSchema());
     }
@@ -93,6 +98,7 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
         $this->assertEquals('default', $defaultForm->getName());
         $this->assertEquals('Tiers', $defaultForm->getTitle());
         $this->assertCount(5, $defaultForm->getItems());
+        $this->assertCount(2, $defaultForm->getTags());
         $this->assertNotNull($defaultForm->getSchema());
         $this->assertInstanceOf(SchemaMetadata::class, $defaultForm->getSchema());
     }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
@@ -35,6 +35,33 @@ class FormMetadataMapperTest extends TestCase
         $this->formMetadataMapper = new FormMetadataMapper();
     }
 
+    public function testMapTags()
+    {
+        $result = $this->formMetadataMapper->mapTags([
+            [
+                'name' => 'test_tag',
+                'priority' => 1,
+                'attributes' => [
+                    'test' => 1,
+                ],
+            ],
+            [
+                'name' => 'test_tag2',
+            ],
+        ]);
+
+        $this->assertCount(2, $result);
+
+        $this->assertEquals('test_tag', $result[0]->getName());
+        $this->assertEquals(1, $result[0]->getPriority());
+        $this->assertEquals(['test' => 1], $result[0]->getAttributes());
+        $this->assertEquals(1, $result[0]->getAttribute('test'));
+
+        $this->assertEquals('test_tag2', $result[1]->getName());
+        $this->assertEquals(null, $result[1]->getPriority());
+        $this->assertEquals([], $result[1]->getAttributes());
+    }
+
     public function testMapPropertiesEnglish()
     {
         $form = $this->createFormWithBasicProperties();

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
@@ -48,9 +48,7 @@ class FormXmlLoaderTest extends TestCase
 
     public function testLoadForm()
     {
-        /**
-         * @var LocalizedFormMetadataCollection
-         */
+        /** @var LocalizedFormMetadataCollection */
         $formMetadataCollection = $this->loader->load($this->getFormDirectory() . 'form.xml');
 
         $this->assertInstanceOf(LocalizedFormMetadataCollection::class, $formMetadataCollection);
@@ -58,6 +56,11 @@ class FormXmlLoaderTest extends TestCase
         $this->assertCount(2, $formMetadataCollection->getItems());
 
         $formMetadata = $formMetadataCollection->get('en');
+
+        $this->assertCount(1, $formMetadata->getTags());
+        $this->assertCount(1, $formMetadata->getTagsByName('test'));
+        $this->assertEquals('test', $formMetadata->getTagsByName('test')[0]->getName());
+        $this->assertEquals(['value' => 'test-value'], $formMetadata->getTagsByName('test')[0]->getAttributes());
 
         $this->assertEquals('form', $formMetadata->getKey());
         $this->assertCount(4, $formMetadata->getItems());

--- a/src/Sulu/Component/Content/Metadata/Loader/schema/form-1.0.xsd
+++ b/src/Sulu/Component/Content/Metadata/Loader/schema/form-1.0.xsd
@@ -16,11 +16,12 @@
     <xs:element name="form" type="formType"/>
 
     <xs:complexType name="formType">
-        <xs:all>
+        <xs:choice maxOccurs="unbounded">
             <xs:element type="xs:string" name="key" minOccurs="1" maxOccurs="1"/>
+            <xs:element type="tagType" name="tag" maxOccurs="unbounded"/>
             <xs:element type="propertiesType" name="properties" minOccurs="1" maxOccurs="1"/>
             <xs:element type="schemaType" name="schema" minOccurs="0" maxOccurs="1"/>
-        </xs:all>
+        </xs:choice>
         <xs:attributeGroup ref="defaultAttributes"/>
     </xs:complexType>
 </xs:schema>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add tags to form metadata and the ability to filter types by tags.

#### Why?

This is needed in the article bundle to allow article-type based forms.

#### Example Usage

~~~php
$this->viewBuilderFactory->createPreviewFormViewBuilder(static::EDIT_FORM_VIEW_DETAILS . '_' . $typeKey, '/details')
    ->setResourceKey('articles')
    ->addMetadataRequestParameters([
       'tags[sulu_article.type]' => $typeConfig['type'] ? true : false,
       'tags[sulu_article.type][type]' => $typeConfig['type'],
    ])
~~~

OR:

~~~php
$this->viewBuilderFactory->createPreviewFormViewBuilder(static::EDIT_FORM_VIEW_DETAILS . '_' . $typeKey, '/details')
    ->setResourceKey('articles')
    ->addMetadataRequestParameters([
       'tags[sulu_article.type][type]' => $typeConfig['type'],
    ])
~~~

#### To Do

- [x] Add tests
