### PR TITLE
Improve php-cs-fixer execution by caching binary

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -17,12 +17,14 @@ jobs:
             - name: Get php-cs-fixer path
               id: php-cs-fixer-path
               run: echo "::set-output name=path::${{ steps.php-cs-fixer-dir.outputs.dir }}/php-cs-fixer.phar"
-            - name: Cache dependencies
+            - name: Cache php-cs-fixer
+              id: php-cs-fixer-cache
               uses: actions/cache@v1
               with:
                   path: ${{ steps.php-cs-fixer-dir.outputs.dir }}
                   key: php-cs-fixer
             - name: Download php-cs-fixer
+              if: steps.php-cs-fixer-cache.outputs.cache-hit != 'true'
               run: curl "https://cs.symfony.com/download/php-cs-fixer-v2.phar" --output ${{ steps.php-cs-fixer-path.outputs.path }} && chmod +x ${{ steps.php-cs-fixer-path.outputs.path }}
             - name: Run php-cs-fixer
               run: ./${{ steps.php-cs-fixer-path.outputs.path }} fix --dry-run --diff


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #5072
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR caches the php-cs-fixer binary.

#### Why?

Because this should result in better performance of the task. Also, this way the cache is actually used, and not only confusingly uploaded at the end.