### PR TITLE
Redesign list to make space for filter feature

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Breadcrumb/item.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Breadcrumb/item.scss
@@ -4,7 +4,8 @@ $itemTextColor: $silver;
 $itemTextColorActive: $black;
 
 .item {
-    font-size: 30px;
+    font-size: 24px;
+    line-height: 30px;
     color: $itemTextColor;
     background-color: transparent;
     border: none;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/pagination.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/pagination.scss
@@ -13,7 +13,7 @@ $buttonActiveColor: $blueZodiac;
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-top: 30px;
+    margin-top: 20px;
 }
 
 .loader {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/application.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/application.scss
@@ -3,7 +3,7 @@
 @import '../../components/Toolbar/variables.scss';
 
 .loader {
-    margin-top: calc($toolbarHeight + $viewPadding);
+    margin-top: calc($toolbarHeight + $viewPaddingHorizontal);
 }
 
 .root {
@@ -45,7 +45,7 @@
     flex-direction: column;
     flex-grow: 1;
     overflow-y: auto;
-    padding: $viewPadding;
+    padding: $viewPaddingVertical $viewPaddingHorizontal;
 }
 
 .main {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/global.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/global.scss
@@ -33,14 +33,14 @@ body {
 
 h1 {
     color: $h1TextColor;
-    margin: 0 0 30px;
-    font-size: 30px;
+    margin: 0 0 20px;
+    font-size: 24px;
     font-weight: 600;
 }
 
 h2 {
     color: $h2TextColor;
-    font-size: 22px;
+    font-size: 20px;
     font-weight: bold;
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/variables.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/variables.scss
@@ -1,8 +1,9 @@
-$viewPadding: 60px;
+$viewPaddingHorizontal: 60px;
+$viewPaddingVertical: 40px;
 $viewMinWidth: 420px;
 $viewMaxWidth: 1140px;
 
 $sidebarShrinkAnimationDuration: 700ms;
 $navigationMoveAnimationDuration: 500ms;
 
-$sidebarMaxWidth: calc(100% - $viewMinWidth - 2 * $viewPadding);
+$sidebarMaxWidth: calc(100% - $viewMinWidth - 2 * $viewPaddingHorizontal);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
@@ -107,7 +107,7 @@ $textEditorUnpublishedLinkColor: $gold;
             border-color: $textEditorBackgroundColor !important;
             line-height: 20px;
             min-height: 100px;
-            max-height: calc(100vh - $toolbarHeight - $snackbarHeight - $tabMenuHeight - $viewPadding - 8px);
+            max-height: calc(100vh - $toolbarHeight - $snackbarHeight - $tabMenuHeight - $viewPaddingVertical - 8px);
         }
 
         .ck-widget.table {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/cardCollection.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/cardCollection.scss
@@ -1,5 +1,5 @@
 @import 'sulu-admin-bundle/containers/Application/variables.scss';
 
 .overlay {
-    padding: $viewPadding;
+    padding: $viewPaddingVertical $viewPaddingHorizontal;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
@@ -50,6 +50,7 @@ type Props = {|
     searchable: boolean,
     selectable: boolean,
     store: ListStore,
+    toolbarClassName?: string,
 |};
 
 const USER_SETTING_PREFIX = 'sulu_admin.list';
@@ -476,6 +477,7 @@ class List extends React.Component<Props> {
             orderable,
             selectable,
             store,
+            toolbarClassName,
         } = this.props;
         const Adapter = this.currentAdapter;
 
@@ -484,6 +486,11 @@ class List extends React.Component<Props> {
             {
                 [listStyles.disabled]: disabled,
             }
+        );
+
+        const toolbarClass = classNames(
+            listStyles.toolbar,
+            toolbarClassName
         );
 
         const searchable = this.props.searchable && Adapter.searchable;
@@ -496,7 +503,7 @@ class List extends React.Component<Props> {
             <div className={listStyles.listContainer}>
                 {header}
                 {!store.schemaLoading && (searchable || adapters.length > 1) &&
-                    <div className={listStyles.toolbar}>
+                    <div className={toolbarClass}>
                         {searchable &&
                             <Search onSearch={this.handleSearch} value={store.searchTerm.get()} />
                         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
@@ -461,47 +461,6 @@ class List extends React.Component<Props> {
         this.props.store.changeUserSchema(schema);
     };
 
-    renderAdapterOptionsButton() {
-        return (
-            <div>
-                <Button
-                    icon="su-sort"
-                    onClick={this.handleAdapterOptionsButtonClick}
-                    showDropdownIcon={true}
-                    skin="icon"
-                />
-            </div>
-        );
-    }
-
-    renderAdapterOptions() {
-        if (!this.currentAdapter.hasColumnOptions) {
-            return null;
-        }
-
-        return (
-            <Fragment>
-                <ArrowMenu
-                    anchorElement={this.renderAdapterOptionsButton()}
-                    onClose={this.handleAdapterOptionsClose}
-                    open={this.adapterOptionsOpen}
-                >
-                    <ArrowMenu.Section>
-                        <ArrowMenu.Action onClick={this.handleColumnOptionsOpen}>
-                            {translate('sulu_admin.column_options')}
-                        </ArrowMenu.Action>
-                    </ArrowMenu.Section>
-                </ArrowMenu>
-                <ColumnOptionsOverlay
-                    onClose={this.handleColumnOptionsClose}
-                    onConfirm={this.handleColumnOptionsChange}
-                    open={this.columnOptionsOpen}
-                    schema={this.props.store.userSchema}
-                />
-            </Fragment>
-        );
-    }
-
     render() {
         const {
             actions,
@@ -542,7 +501,36 @@ class List extends React.Component<Props> {
                             {searchable &&
                                 <Search onSearch={this.handleSearch} value={store.searchTerm.get()} />
                             }
-                            {this.renderAdapterOptions()}
+                            {this.currentAdapter.hasColumnOptions &&
+                                <Fragment>
+                                    <ArrowMenu
+                                        anchorElement={
+                                            <div>
+                                                <Button
+                                                    icon="su-sort"
+                                                    onClick={this.handleAdapterOptionsButtonClick}
+                                                    showDropdownIcon={true}
+                                                    skin="icon"
+                                                />
+                                            </div>
+                                        }
+                                        onClose={this.handleAdapterOptionsClose}
+                                        open={this.adapterOptionsOpen}
+                                    >
+                                        <ArrowMenu.Section>
+                                            <ArrowMenu.Action onClick={this.handleColumnOptionsOpen}>
+                                                {translate('sulu_admin.column_options')}
+                                            </ArrowMenu.Action>
+                                        </ArrowMenu.Section>
+                                    </ArrowMenu>
+                                    <ColumnOptionsOverlay
+                                        onClose={this.handleColumnOptionsClose}
+                                        onConfirm={this.handleColumnOptionsChange}
+                                        open={this.columnOptionsOpen}
+                                        schema={this.props.store.userSchema}
+                                    />
+                                </Fragment>
+                            }
                             <AdapterSwitch
                                 adapters={adapters}
                                 currentAdapter={this.currentAdapterKey}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
@@ -494,49 +494,47 @@ class List extends React.Component<Props> {
 
         return (
             <div className={listStyles.listContainer}>
-                {(header || searchable || adapters.length > 1) &&
-                    <div className={listStyles.headerContainer}>
-                        {header}
-                        <div className={listStyles.toolbar}>
-                            {searchable &&
-                                <Search onSearch={this.handleSearch} value={store.searchTerm.get()} />
-                            }
-                            {this.currentAdapter.hasColumnOptions &&
-                                <Fragment>
-                                    <ArrowMenu
-                                        anchorElement={
-                                            <div>
-                                                <Button
-                                                    icon="su-sort"
-                                                    onClick={this.handleAdapterOptionsButtonClick}
-                                                    showDropdownIcon={true}
-                                                    skin="icon"
-                                                />
-                                            </div>
-                                        }
-                                        onClose={this.handleAdapterOptionsClose}
-                                        open={this.adapterOptionsOpen}
-                                    >
-                                        <ArrowMenu.Section>
-                                            <ArrowMenu.Action onClick={this.handleColumnOptionsOpen}>
-                                                {translate('sulu_admin.column_options')}
-                                            </ArrowMenu.Action>
-                                        </ArrowMenu.Section>
-                                    </ArrowMenu>
-                                    <ColumnOptionsOverlay
-                                        onClose={this.handleColumnOptionsClose}
-                                        onConfirm={this.handleColumnOptionsChange}
-                                        open={this.columnOptionsOpen}
-                                        schema={this.props.store.userSchema}
-                                    />
-                                </Fragment>
-                            }
-                            <AdapterSwitch
-                                adapters={adapters}
-                                currentAdapter={this.currentAdapterKey}
-                                onAdapterChange={this.handleAdapterChange}
-                            />
-                        </div>
+                {header}
+                {!store.schemaLoading && (searchable || adapters.length > 1) &&
+                    <div className={listStyles.toolbar}>
+                        {searchable &&
+                            <Search onSearch={this.handleSearch} value={store.searchTerm.get()} />
+                        }
+                        {this.currentAdapter.hasColumnOptions &&
+                            <Fragment>
+                                <ArrowMenu
+                                    anchorElement={
+                                        <div>
+                                            <Button
+                                                icon="su-sort"
+                                                onClick={this.handleAdapterOptionsButtonClick}
+                                                showDropdownIcon={true}
+                                                skin="icon"
+                                            />
+                                        </div>
+                                    }
+                                    onClose={this.handleAdapterOptionsClose}
+                                    open={this.adapterOptionsOpen}
+                                >
+                                    <ArrowMenu.Section>
+                                        <ArrowMenu.Action onClick={this.handleColumnOptionsOpen}>
+                                            {translate('sulu_admin.column_options')}
+                                        </ArrowMenu.Action>
+                                    </ArrowMenu.Section>
+                                </ArrowMenu>
+                                <ColumnOptionsOverlay
+                                    onClose={this.handleColumnOptionsClose}
+                                    onConfirm={this.handleColumnOptionsChange}
+                                    open={this.columnOptionsOpen}
+                                    schema={this.props.store.userSchema}
+                                />
+                            </Fragment>
+                        }
+                        <AdapterSwitch
+                            adapters={adapters}
+                            currentAdapter={this.currentAdapterKey}
+                            onAdapterChange={this.handleAdapterChange}
+                        />
                     </div>
                 }
                 <div className={listClass}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/columnOptions.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/columnOptions.scss
@@ -12,7 +12,7 @@ $optionDisabledBackgroundColor: $mercury;
 .overlay {
     display: flex;
     flex-direction: column;
-    padding: $viewPadding;
+    padding: $viewPaddingVertical $viewPaddingHorizontal;
 
     &.sorting {
         user-select: none;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/list.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/list.scss
@@ -20,21 +20,11 @@ $listHeaderMarginBottom: 40px;
     }
 }
 
-.header-container {
-    display: flex;
-    flex-grow: 0;
-    margin-bottom: $listHeaderMarginBottom;
-    align-items: center;
-
-    .toolbar {
-        flex-grow: 1;
-    }
-}
-
 .toolbar {
     display: flex;
     justify-content: flex-end;
     align-items: center;
+    margin-bottom: 20px;
 
     & > * {
         height: $listToolbarHeight;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
@@ -202,6 +202,17 @@ test('Do not render Loader instead of Adapter if no page count is given', () => 
     expect(render(<List adapters={['table']} store={listStore} />)).toMatchSnapshot();
 });
 
+test('Render toolbar with given toolbar class', () => {
+    const listStore = new ListStore('test', 'test', 'list_test', {page: observable.box(1)});
+    // $FlowFixMe
+    listStore.loading = true;
+    listStore.pageCount = undefined;
+
+    const list = shallow(<List adapters={['table']} store={listStore} toolbarClassName="test-class" />);
+
+    expect(list.find('.toolbar').prop('className')).toEqual(expect.stringContaining('test-class'));
+});
+
 test('Render TableAdapter with correct values', () => {
     listAdapterRegistry.get.mockReturnValue(TableAdapter);
     mockStructureStrategyData = [

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/__snapshots__/List.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/__snapshots__/List.test.js.snap
@@ -5,30 +5,26 @@ exports[`Do not render Loader instead of Adapter if no page count is given 1`] =
   class="listContainer"
 >
   <div
-    class="headerContainer"
+    class="toolbar"
   >
-    <div
-      class="toolbar"
+    <label
+      class="input dark left collapsed hasAppendIcon"
     >
-      <label
-        class="input dark left collapsed hasAppendIcon"
+      <div
+        class="prependedContainer dark collapsed"
       >
-        <div
-          class="prependedContainer dark collapsed"
-        >
-          <span
-            aria-label="su-search"
-            class="su-search clickable icon dark iconClickable collapsed"
-            role="button"
-            tabindex="0"
-          />
-        </div>
-        <input
-          type="text"
-          value=""
+        <span
+          aria-label="su-search"
+          class="su-search clickable icon dark iconClickable collapsed"
+          role="button"
+          tabindex="0"
         />
-      </label>
-    </div>
+      </div>
+      <input
+        type="text"
+        value=""
+      />
+    </label>
   </div>
   <div
     class="list"
@@ -45,30 +41,26 @@ exports[`Render Loader instead of Adapter if nothing was loaded yet 1`] = `
   class="listContainer"
 >
   <div
-    class="headerContainer"
+    class="toolbar"
   >
-    <div
-      class="toolbar"
+    <label
+      class="input dark left collapsed hasAppendIcon"
     >
-      <label
-        class="input dark left collapsed hasAppendIcon"
+      <div
+        class="prependedContainer dark collapsed"
       >
-        <div
-          class="prependedContainer dark collapsed"
-        >
-          <span
-            aria-label="su-search"
-            class="su-search clickable icon dark iconClickable collapsed"
-            role="button"
-            tabindex="0"
-          />
-        </div>
-        <input
-          type="text"
-          value=""
+        <span
+          aria-label="su-search"
+          class="su-search clickable icon dark iconClickable collapsed"
+          role="button"
+          tabindex="0"
         />
-      </label>
-    </div>
+      </div>
+      <input
+        type="text"
+        value=""
+      />
+    </label>
   </div>
   <div
     class="list"
@@ -107,34 +99,30 @@ exports[`Render the adapter in disabled state 1`] = `
 <div
   class="listContainer"
 >
+  <h1>
+    Title
+  </h1>
   <div
-    class="headerContainer"
+    class="toolbar"
   >
-    <h1>
-      Title
-    </h1>
-    <div
-      class="toolbar"
+    <label
+      class="input dark left collapsed hasAppendIcon"
     >
-      <label
-        class="input dark left collapsed hasAppendIcon"
+      <div
+        class="prependedContainer dark collapsed"
       >
-        <div
-          class="prependedContainer dark collapsed"
-        >
-          <span
-            aria-label="su-search"
-            class="su-search clickable icon dark iconClickable collapsed"
-            role="button"
-            tabindex="0"
-          />
-        </div>
-        <input
-          type="text"
-          value=""
+        <span
+          aria-label="su-search"
+          class="su-search clickable icon dark iconClickable collapsed"
+          role="button"
+          tabindex="0"
         />
-      </label>
-    </div>
+      </div>
+      <input
+        type="text"
+        value=""
+      />
+    </label>
   </div>
   <div
     class="list disabled"
@@ -150,16 +138,9 @@ exports[`Render the adapter in non-searchable mode 1`] = `
 <div
   class="listContainer"
 >
-  <div
-    class="headerContainer"
-  >
-    <h1>
-      Title
-    </h1>
-    <div
-      class="toolbar"
-    />
-  </div>
+  <h1>
+    Title
+  </h1>
   <div
     class="list"
   >
@@ -174,16 +155,9 @@ exports[`Render the adapter in non-searchable mode if searchable is set to true 
 <div
   class="listContainer"
 >
-  <div
-    class="headerContainer"
-  >
-    <h1>
-      Title
-    </h1>
-    <div
-      class="toolbar"
-    />
-  </div>
+  <h1>
+    Title
+  </h1>
   <div
     class="list"
   >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ProfileFormOverlay/profileFormOverlay.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ProfileFormOverlay/profileFormOverlay.scss
@@ -1,5 +1,5 @@
 @import '../../containers/Application/variables.scss';
 
 .overlay {
-    padding: $viewPadding;
+    padding: $viewPaddingVertical $viewPaddingHorizontal;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/resourceLocatorHistory.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/resourceLocatorHistory.scss
@@ -2,5 +2,5 @@
 
 .resource-locator-history-overlay,
 .loader {
-    padding: $viewPadding;
+    padding: $viewPaddingVertical $viewPaddingHorizontal;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceSingleSelect/editOverlay.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceSingleSelect/editOverlay.scss
@@ -1,5 +1,5 @@
 @import 'sulu-admin-bundle/containers/Application/variables.scss';
 
 .overlay {
-    padding: $viewPadding;
+    padding: $viewPaddingVertical $viewPaddingHorizontal;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/formOverlayList.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/formOverlayList.scss
@@ -3,7 +3,7 @@
 @import '../../components/ColumnList/variables.scss';
 
 .form {
-    margin: $viewPadding;
+    margin: $viewPaddingVertical $viewPaddingHorizontal;
     overflow: hidden;
     position: relative;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -13,7 +13,6 @@ import {translate} from '../../utils/Translator';
 import ResourceStore from '../../stores/ResourceStore';
 import listToolbarActionRegistry from './registries/listToolbarActionRegistry';
 import AbstractListToolbarAction from './toolbarActions/AbstractListToolbarAction';
-import listStyles from './list.scss';
 
 const DEFAULT_USER_SETTINGS_KEY = 'list';
 const DEFAULT_LIMIT = 10;
@@ -349,7 +348,7 @@ class List extends React.Component<Props> {
             <Fragment>
                 <ListContainer
                     adapters={adapters}
-                    header={title && <h1 className={listStyles.header}>{title}</h1>}
+                    header={title && <h1>{title}</h1>}
                     itemDisabledCondition={itemDisabledCondition}
                     onItemAdd={onItemAdd || addView ? this.addItem : undefined}
                     onItemClick={onItemClick || editView ? this.handleItemClick : undefined}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/list.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/list.scss
@@ -1,3 +1,0 @@
-.header {
-    margin: 0;
-}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
@@ -254,50 +254,44 @@ exports[`Should render the list with a title 1`] = `
 <div
   class="listContainer"
 >
+  <h1>
+    Snippets
+  </h1>
   <div
-    class="headerContainer"
+    class="toolbar"
   >
-    <h1
-      class="header"
+    <label
+      class="input dark left collapsed hasAppendIcon"
     >
-      Snippets
-    </h1>
-    <div
-      class="toolbar"
-    >
-      <label
-        class="input dark left collapsed hasAppendIcon"
+      <div
+        class="prependedContainer dark collapsed"
       >
-        <div
-          class="prependedContainer dark collapsed"
-        >
-          <span
-            aria-label="su-search"
-            class="su-search clickable icon dark iconClickable collapsed"
-            role="button"
-            tabindex="0"
-          />
-        </div>
-        <input
-          type="text"
-          value=""
+        <span
+          aria-label="su-search"
+          class="su-search clickable icon dark iconClickable collapsed"
+          role="button"
+          tabindex="0"
         />
-      </label>
-      <div>
-        <button
-          class="button icon"
-          type="button"
-        >
-          <span
-            aria-label="su-sort"
-            class="su-sort buttonIcon"
-          />
-          <span
-            aria-label="su-angle-down"
-            class="su-angle-down dropdownIcon"
-          />
-        </button>
       </div>
+      <input
+        type="text"
+        value=""
+      />
+    </label>
+    <div>
+      <button
+        class="button icon"
+        type="button"
+      >
+        <span
+          aria-label="su-sort"
+          class="su-sort buttonIcon"
+        />
+        <span
+          aria-label="su-angle-down"
+          class="su-angle-down dropdownIcon"
+        />
+      </button>
     </div>
   </div>
   <div
@@ -517,50 +511,44 @@ exports[`Should render the list with the correct resourceKey 1`] = `
 <div
   class="listContainer"
 >
+  <h1>
+    Test 1
+  </h1>
   <div
-    class="headerContainer"
+    class="toolbar"
   >
-    <h1
-      class="header"
+    <label
+      class="input dark left collapsed hasAppendIcon"
     >
-      Test 1
-    </h1>
-    <div
-      class="toolbar"
-    >
-      <label
-        class="input dark left collapsed hasAppendIcon"
+      <div
+        class="prependedContainer dark collapsed"
       >
-        <div
-          class="prependedContainer dark collapsed"
-        >
-          <span
-            aria-label="su-search"
-            class="su-search clickable icon dark iconClickable collapsed"
-            role="button"
-            tabindex="0"
-          />
-        </div>
-        <input
-          type="text"
-          value=""
+        <span
+          aria-label="su-search"
+          class="su-search clickable icon dark iconClickable collapsed"
+          role="button"
+          tabindex="0"
         />
-      </label>
-      <div>
-        <button
-          class="button icon"
-          type="button"
-        >
-          <span
-            aria-label="su-sort"
-            class="su-sort buttonIcon"
-          />
-          <span
-            aria-label="su-angle-down"
-            class="su-angle-down dropdownIcon"
-          />
-        </button>
       </div>
+      <input
+        type="text"
+        value=""
+      />
+    </label>
+    <div>
+      <button
+        class="button icon"
+        type="button"
+      >
+        <span
+          aria-label="su-sort"
+          class="su-sort buttonIcon"
+        />
+        <span
+          aria-label="su-angle-down"
+          class="su-angle-down dropdownIcon"
+        />
+      </button>
     </div>
   </div>
   <div

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/exportToolbarAction.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/exportToolbarAction.scss
@@ -1,5 +1,5 @@
 @import 'sulu-admin-bundle/containers/Application/variables.scss';
 
 .overlay {
-    padding: $viewPadding;
+    padding: $viewPaddingVertical $viewPaddingHorizontal;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/tabs.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/tabs.scss
@@ -1,5 +1,5 @@
 @import '../../containers/Application/variables.scss';
 
 .tabs-container {
-    margin: -$viewPadding -$viewPadding $viewPadding;
+    margin: -$viewPaddingVertical -$viewPaddingHorizontal $viewPaddingVertical;
 }

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/ruleOverlay.scss
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/ruleOverlay.scss
@@ -1,5 +1,5 @@
 @import 'sulu-admin-bundle/containers/Application/variables.scss';
 
 .overlay {
-    padding: $viewPadding;
+    padding: $viewPaddingVertical $viewPaddingHorizontal;
 }

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/views/List/toolbarActions/addContactToolbarAction.scss
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/views/List/toolbarActions/addContactToolbarAction.scss
@@ -1,5 +1,5 @@
 @import 'sulu-admin-bundle/containers/Application/variables.scss';
 
 .overlay {
-    padding: $viewPadding;
+    padding: $viewPaddingVertical $viewPaddingHorizontal;
 }

--- a/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/locationOverlay.scss
+++ b/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/locationOverlay.scss
@@ -2,7 +2,7 @@
 @import 'sulu-admin-bundle/containers/Application/variables.scss';
 
 .container {
-    padding: $viewPadding;
+    padding: $viewPaddingVertical $viewPaddingHorizontal;
 }
 
 .map {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/singleMediaDropzone.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/singleMediaDropzone.scss
@@ -3,10 +3,12 @@
 $uploadIconColor: $scorpion;
 $uploadInfoTextColor: $scorpion;
 $uploadIndicatorBackgroundColor: rgba($alabaster, .8);
-$mediaContainerBreakpoint: 520px; /* $dropzoneSize + 2 * $viewPadding because calc doesn't work for media-queries */
 $imageBorderColor: $silver;
 $emptyBackgroundColor: $white;
 $emptyColor: $alto;
+
+/* $dropzoneSize + 2 * $viewPaddingHorizontal because calc doesn't work for media-queries */
+$mediaContainerBreakpoint: 520px;
 
 .media-container {
     position: relative;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/collectionFormOverlay.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/collectionFormOverlay.scss
@@ -2,5 +2,5 @@
 
 .overlay {
     width: 500px;
-    padding: $viewPadding;
+    padding: $viewPaddingVertical $viewPaddingHorizontal;
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/permissionFormOverlay.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/permissionFormOverlay.scss
@@ -1,5 +1,5 @@
 @import 'sulu-admin-bundle/containers/Application/variables.scss';
 
 .overlay {
-    padding: $viewPadding;
+    padding: $viewPaddingVertical $viewPaddingHorizontal;
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
@@ -235,31 +235,27 @@ exports[`Render the MediaCollection 1`] = `
       class="listContainer"
     >
       <div
-        class="headerContainer"
+        class="toolbar"
       >
-        <div
-          class="toolbar"
+        <label
+          class="input dark left collapsed hasAppendIcon"
         >
-          <label
-            class="input dark left collapsed hasAppendIcon"
+          <div
+            class="prependedContainer dark collapsed"
           >
-            <div
-              class="prependedContainer dark collapsed"
-            >
-              <span
-                aria-label="su-search"
-                class="su-search clickable icon dark iconClickable collapsed"
-                role="button"
-                tabindex="0"
-              />
-            </div>
-            <input
-              placeholder="sulu_admin.list_search_placeholder"
-              type="text"
-              value=""
+            <span
+              aria-label="su-search"
+              class="su-search clickable icon dark iconClickable collapsed"
+              role="button"
+              tabindex="0"
             />
-          </label>
-        </div>
+          </div>
+          <input
+            placeholder="sulu_admin.list_search_placeholder"
+            type="text"
+            value=""
+          />
+        </label>
       </div>
       <div
         class="list"
@@ -773,31 +769,27 @@ exports[`Render the MediaCollection for all media 1`] = `
       class="listContainer"
     >
       <div
-        class="headerContainer"
+        class="toolbar"
       >
-        <div
-          class="toolbar"
+        <label
+          class="input dark left collapsed hasAppendIcon"
         >
-          <label
-            class="input dark left collapsed hasAppendIcon"
+          <div
+            class="prependedContainer dark collapsed"
           >
-            <div
-              class="prependedContainer dark collapsed"
-            >
-              <span
-                aria-label="su-search"
-                class="su-search clickable icon dark iconClickable collapsed"
-                role="button"
-                tabindex="0"
-              />
-            </div>
-            <input
-              placeholder="sulu_admin.list_search_placeholder"
-              type="text"
-              value=""
+            <span
+              aria-label="su-search"
+              class="su-search clickable icon dark iconClickable collapsed"
+              role="button"
+              tabindex="0"
             />
-          </label>
-        </div>
+          </div>
+          <input
+            placeholder="sulu_admin.list_search_placeholder"
+            type="text"
+            value=""
+          />
+        </label>
       </div>
       <div
         class="list"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/mediaSelectionOverlay.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/mediaSelectionOverlay.scss
@@ -2,7 +2,7 @@
 
 .overlay {
     width: 1170px;
-    padding: $viewPadding;
+    padding: $viewPaddingVertical $viewPaddingHorizontal;
     display: flex;
 
     @media (max-width: 1280px) {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
@@ -264,31 +264,27 @@ Array [
                   class="listContainer"
                 >
                   <div
-                    class="headerContainer"
+                    class="toolbar"
                   >
-                    <div
-                      class="toolbar"
+                    <label
+                      class="input dark left collapsed hasAppendIcon"
                     >
-                      <label
-                        class="input dark left collapsed hasAppendIcon"
+                      <div
+                        class="prependedContainer dark collapsed"
                       >
-                        <div
-                          class="prependedContainer dark collapsed"
-                        >
-                          <span
-                            aria-label="su-search"
-                            class="su-search clickable icon dark iconClickable collapsed"
-                            role="button"
-                            tabindex="0"
-                          />
-                        </div>
-                        <input
-                          placeholder="sulu_admin.list_search_placeholder"
-                          type="text"
-                          value=""
+                        <span
+                          aria-label="su-search"
+                          class="su-search clickable icon dark iconClickable collapsed"
+                          role="button"
+                          tabindex="0"
                         />
-                      </label>
-                    </div>
+                      </div>
+                      <input
+                        placeholder="sulu_admin.list_search_placeholder"
+                        type="text"
+                        value=""
+                      />
+                    </label>
                   </div>
                   <div
                     class="list"
@@ -878,31 +874,27 @@ Array [
                   class="listContainer"
                 >
                   <div
-                    class="headerContainer"
+                    class="toolbar"
                   >
-                    <div
-                      class="toolbar"
+                    <label
+                      class="input dark left collapsed hasAppendIcon"
                     >
-                      <label
-                        class="input dark left collapsed hasAppendIcon"
+                      <div
+                        class="prependedContainer dark collapsed"
                       >
-                        <div
-                          class="prependedContainer dark collapsed"
-                        >
-                          <span
-                            aria-label="su-search"
-                            class="su-search clickable icon dark iconClickable collapsed"
-                            role="button"
-                            tabindex="0"
-                          />
-                        </div>
-                        <input
-                          placeholder="sulu_admin.list_search_placeholder"
-                          type="text"
-                          value=""
+                        <span
+                          aria-label="su-search"
+                          class="su-search clickable icon dark iconClickable collapsed"
+                          role="button"
+                          tabindex="0"
                         />
-                      </label>
-                    </div>
+                      </div>
+                      <input
+                        placeholder="sulu_admin.list_search_placeholder"
+                        type="text"
+                        value=""
+                      />
+                    </label>
                   </div>
                   <div
                     class="list"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaVersionUpload/cropOverlay.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaVersionUpload/cropOverlay.scss
@@ -6,7 +6,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    padding: 30px $viewPadding;
+    padding: $viewPaddingVertical $viewPaddingHorizontal;
     height: $overlayContentMaxHeight;
 }
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaVersionUpload/focusPointOverlay.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaVersionUpload/focusPointOverlay.scss
@@ -5,6 +5,6 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: $viewPadding;
+    padding: $viewPaddingVertical $viewPaddingHorizontal;
     height: $overlayContentMaxHeight;
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/__snapshots__/MediaOverview.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/__snapshots__/MediaOverview.test.js.snap
@@ -245,60 +245,56 @@ exports[`Render a simple MediaOverview 1`] = `
         class="listContainer"
       >
         <div
-          class="headerContainer"
+          class="toolbar"
         >
-          <div
-            class="toolbar"
+          <label
+            class="input dark left collapsed hasAppendIcon"
           >
-            <label
-              class="input dark left collapsed hasAppendIcon"
-            >
-              <div
-                class="prependedContainer dark collapsed"
-              >
-                <span
-                  aria-label="su-search"
-                  class="su-search clickable icon dark iconClickable collapsed"
-                  role="button"
-                  tabindex="0"
-                />
-              </div>
-              <input
-                placeholder="sulu_admin.list_search_placeholder"
-                type="text"
-                value=""
-              />
-            </label>
             <div
-              class="buttonGroup"
+              class="prependedContainer dark collapsed"
             >
-              <button
-                class="button icon active button"
-                type="button"
-              >
-                <span
-                  class="text"
-                >
-                  <span
-                    aria-label="su-th-large"
-                    class="su-th-large"
-                  />
-                </span>
-              </button>
-              <button
-                class="button icon button"
-                type="button"
-              >
-                <span
-                  class="text"
-                >
-                  <span
-                    aria-label="su-align-justify"
-                    class="su-align-justify"
-                  />
-                </span>
-              </button>
+              <span
+                aria-label="su-search"
+                class="su-search clickable icon dark iconClickable collapsed"
+                role="button"
+                tabindex="0"
+              />
             </div>
+            <input
+              placeholder="sulu_admin.list_search_placeholder"
+              type="text"
+              value=""
+            />
+          </label>
+          <div
+            class="buttonGroup"
+          >
+            <button
+              class="button icon active button"
+              type="button"
+            >
+              <span
+                class="text"
+              >
+                <span
+                  aria-label="su-th-large"
+                  class="su-th-large"
+                />
+              </span>
+            </button>
+            <button
+              class="button icon button"
+              type="button"
+            >
+              <span
+                class="text"
+              >
+                <span
+                  aria-label="su-align-justify"
+                  class="su-align-justify"
+                />
+              </span>
+            </button>
           </div>
         </div>
         <div

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/PageList.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/PageList.js
@@ -172,6 +172,7 @@ class PageList extends React.Component<Props> {
                     searchable={false}
                     selectable={false}
                     store={this.listStore}
+                    toolbarClassName={pageListStyles.listToolbar}
                 />
                 {this.cacheClearToolbarAction.getNode()}
             </div>

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/pageList.scss
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/pageList.scss
@@ -8,3 +8,7 @@
     height: calc(100% - $tabMenuHeight - 8px);
     margin-top: calc(-$webspaceTabsWebspaceSelectMargin - 38px);
 }
+
+.list-toolbar {
+    margin-bottom: 28px;
+}

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/tests/__snapshots__/PageList.test.js.snap
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/tests/__snapshots__/PageList.test.js.snap
@@ -8,7 +8,7 @@ exports[`Render PageList 1`] = `
     class="listContainer"
   >
     <div
-      class="toolbar"
+      class="toolbar listToolbar"
     >
       <div
         class="buttonGroup"

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/tests/__snapshots__/PageList.test.js.snap
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/tests/__snapshots__/PageList.test.js.snap
@@ -8,41 +8,37 @@ exports[`Render PageList 1`] = `
     class="listContainer"
   >
     <div
-      class="headerContainer"
+      class="toolbar"
     >
       <div
-        class="toolbar"
+        class="buttonGroup"
       >
-        <div
-          class="buttonGroup"
+        <button
+          class="button icon active button"
+          type="button"
         >
-          <button
-            class="button icon active button"
-            type="button"
+          <span
+            class="text"
           >
             <span
-              class="text"
-            >
-              <span
-                aria-label="su-columns"
-                class="su-columns"
-              />
-            </span>
-          </button>
-          <button
-            class="button icon button"
-            type="button"
+              aria-label="su-columns"
+              class="su-columns"
+            />
+          </span>
+        </button>
+        <button
+          class="button icon button"
+          type="button"
+        >
+          <span
+            class="text"
           >
             <span
-              class="text"
-            >
-              <span
-                aria-label="su-columns"
-                class="su-columns"
-              />
-            </span>
-          </button>
-        </div>
+              aria-label="su-columns"
+              class="su-columns"
+            />
+          </span>
+        </button>
       </div>
     </div>
     <div


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #5035 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR rearranges the list.

Includes c53f2843361b3fd9f9f60e8ab310d16b41f47cf0 and replaces parts of ea98d55cb2080e1a5a515769f777b1e288995811

#### Why?

Because we need some space for the filter feature implemented in #5035. 

#### BC Breaks/Deprecations

A few css adaptions might not work anymore, not sure if we want to list all of these in the future :thinking: 

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
- [x] Check `WebspaceSelect` especially in combination with `TreeTable` in `PageList`