### PR TITLE
Add command to clear http-cache

### DIFF
--- a/src/Sulu/Bundle/HttpCacheBundle/Command/ClearHttpCacheCommand.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Command/ClearHttpCacheCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\HttpCacheBundle\Command;
+
+use Sulu\Bundle\WebsiteBundle\Cache\CacheClearerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class ClearHttpCacheCommand extends Command
+{
+    protected static $defaultName = 'sulu:http-cache:clear';
+
+    /**
+     * @var CacheClearerInterface
+     */
+    private $cacheClearer;
+
+    public function __construct(CacheClearerInterface $cacheClearer)
+    {
+        parent::__construct(self::$defaultName);
+
+        $this->cacheClearer = $cacheClearer;
+    }
+
+    protected function configure()
+    {
+        $this->setDescription('Clear HTTP-Cache.');
+        $this->setHelp(
+            <<<'EOT'
+The <info>%command.name%</info> command clears the whole http-cache.
+EOT
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->cacheClearer->clear();
+
+        $io = new SymfonyStyle($input, $output);
+        $io->success('HTTP-Cache cleared successfully');
+    }
+}

--- a/src/Sulu/Bundle/HttpCacheBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/HttpCacheBundle/Resources/config/services.xml
@@ -4,5 +4,10 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sulu_http_cache.cache_lifetime.resolver" class="Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeResolver"/>
+        <service id="sulu_http_cache.command.clear" class="Sulu\Bundle\HttpCacheBundle\Command\ClearHttpCacheCommand">
+            <argument type="service" id="sulu_website.http_cache.clearer"/>
+
+            <tag name="console.command"/>
+        </service>
     </services>
 </container>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add a command to clear the whole http-cache.

#### Why?

This is needed for continuous deployment to clear the cache after deployment if necessary.

#### Example Usage

~~~bash
bin/console sulu:http-cache:clear
~~~

#### BC Breaks/Deprecations

New method on the interface of the CacheClearer service.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
