### PR TITLE
Fix aliases for joins without relations

### DIFF
--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineJoinDescriptor.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineJoinDescriptor.php
@@ -95,6 +95,10 @@ class DoctrineJoinDescriptor
             return $this->entityName;
         }
 
+        if (false === strpos($this->join, '.')) {
+            return $this->join;
+        }
+
         return $this->encodeAlias($this->join);
     }
 

--- a/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/FieldDescriptorFactoryTest.php
+++ b/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/FieldDescriptorFactoryTest.php
@@ -245,6 +245,12 @@ class FieldDescriptorFactoryTest extends \PHPUnit_Framework_TestCase
                         'method' => 'LEFT',
                         'condition' => 'SuluContactBundle_ContactAddress.locale = \'de\'',
                     ],
+                    'user' => [
+                        'entity-name' => 'user',
+                        'field-name' => 'SuluSecurityBundle:User',
+                        'method' => 'LEFT',
+                        'condition' => 'user.idContacts = contact.id',
+                    ],
                 ],
             ],
         ];

--- a/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/Resources/options.xml
+++ b/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/Resources/options.xml
@@ -13,6 +13,12 @@
                     <orm:method>LEFT</orm:method>
                     <orm:condition>SuluContactBundle:ContactAddress.locale = ':locale'</orm:condition>
                 </orm:join>
+                <orm:join>
+                    <orm:entity-name>user</orm:entity-name>
+                    <orm:field-name>SuluSecurityBundle:User</orm:field-name>
+                    <orm:method>LEFT</orm:method>
+                    <orm:condition>user.idContacts = contact.id</orm:condition>
+                </orm:join>
             </orm:joins>
         </property>
     </properties>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Do not escape join without relation to allow aliases in none relation joins.

#### Why?

Currently if you have a join to an entity without a relation you can not set an alias.

Without alias:

```xml
    <joins name="dimension">
        <join>
            <entity-name>%sulu.model.dimension.class%</entity-name>
            <condition>%sulu.model.dimension.class%.locale = :locale AND %sulu.model.dimension.class%.stage = 'draft'</condition>
        </join>
    </joins>
```

With alias:

```xml
    <joins name="dimension">
        <join>
            <entity-name>dimension</entity-name><!-- is the alias -->
            <field-name>%sulu.model.dimension.class%</field-name> <!-- is the join -->
            <condition>dimension.locale = :locale AND dimension.stage = 'draft'</condition>
        </join>
    </joins>
```

As the join get escaped, but this escaping should only be happen for relation joins not when joining a entity witout relation. E.g.:

```php
leftJoin(Dimension::class, 'dimension');
```

In this case the encodeAlias accidently does also replace the `Dimension::class` which should only happen when using a relation join.

This is where it is used: https://github.com/sulu/sulu/blob/eec5c72cb6cd86dbaf9cecaf37fd967e6e3028ad/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php#L560-L577

#### Example Usage

~~~xml
<?xml version="1.0" ?>
<list xmlns="http://schemas.sulu.io/list-builder/list">
    <key>examples</key>

    <joins name="dimension">
        <join>
            <entity-name>dimension</entity-name><!-- is the alias -->
            <field-name>%sulu.model.dimension.class%</field-name> <!-- is the join -->
            <condition>dimension.locale = :locale AND dimension.stage = 'draft'</condition>
        </join>
    </joins>

    <joins name="unlocalizeddimension">
        <join>
            <entity-name>unlocalizeddimension</entity-name><!-- is the alias -->
            <field-name>%sulu.model.dimension.class%</field-name> <!-- is the join -->
            <condition>unlocalizeddimension.locale IS NULL AND dimension.stage = 'draft'</condition>
        </join>
    </joins>

    <properties>
        <property name="id" translation="sulu_admin.id">
            <field-name>id</field-name>
            <entity-name>Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\Example</entity-name>
        </property>

        <property name="dimensionId" visibility="never">
            <field-name>id</field-name>
            <entity-name>dimension</entity-name>

            <joins ref="dimension"/>
        </property>

        <property name="unlocalizeddimensionId" visibility="never">
            <field-name>id</field-name>
            <entity-name>unlocalizeddimension</entity-name>

            <joins ref="unlocalizeddimension"/>
        </property>
    </properties>
</list>
~~~

#### BC Breaks/Deprecations

Describe BC breaks/deprecations here. (remove this section if not needed)

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
