### PR TITLE
Add size and skin props to Chip component

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Chip/Chip.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Chip/Chip.js
@@ -9,6 +9,7 @@ type Props<T> = {|
     disabled: boolean,
     onClick?: (value: T) => void,
     onDelete?: (value: T) => void,
+    size: 'small' | 'medium',
     skin: 'primary' | 'secondary',
     value: T,
 |};
@@ -16,6 +17,7 @@ type Props<T> = {|
 export default class Chip<T> extends React.Component<Props<T>> {
     static defaultProps = {
         disabled: false,
+        size: 'small',
         skin: 'secondary',
     };
 
@@ -36,11 +38,12 @@ export default class Chip<T> extends React.Component<Props<T>> {
     };
 
     render() {
-        const {children, disabled, onClick, onDelete, skin} = this.props;
+        const {children, disabled, onClick, onDelete, size, skin} = this.props;
 
         const chipClass = classNames(
             chipStyles.chip,
             chipStyles[skin],
+            chipStyles[size],
             {
                 [chipStyles.disabled]: disabled,
                 [chipStyles.clickable]: !!onClick,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Chip/Chip.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Chip/Chip.js
@@ -9,12 +9,14 @@ type Props<T> = {|
     disabled: boolean,
     onClick?: (value: T) => void,
     onDelete?: (value: T) => void,
+    skin: 'primary' | 'secondary',
     value: T,
 |};
 
 export default class Chip<T> extends React.Component<Props<T>> {
     static defaultProps = {
         disabled: false,
+        skin: 'secondary',
     };
 
     handleClick = () => {
@@ -34,10 +36,11 @@ export default class Chip<T> extends React.Component<Props<T>> {
     };
 
     render() {
-        const {children, disabled, onClick, onDelete} = this.props;
+        const {children, disabled, onClick, onDelete, skin} = this.props;
 
         const chipClass = classNames(
             chipStyles.chip,
+            chipStyles[skin],
             {
                 [chipStyles.disabled]: disabled,
                 [chipStyles.clickable]: !!onClick,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Chip/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Chip/README.md
@@ -1,9 +1,16 @@
 Chips are compact elements that represent an attribute in its used context. It can e.g. be used to display tags in a tag
-selection or can indicate that a list is filtered.
+selection or can indicate that a list is filtered. The `size` and `skin` properties allow you to configure how the Chip
+looks.
 
 ```javascript
 <div style={{backgroundColor: 'white', padding: '10px'}}>
     <Chip>Tag 1</Chip>
+</div>
+<div style={{backgroundColor: 'white', padding: '10px'}}>
+    <Chip skin="primary">Tag 2</Chip>
+</div>
+<div style={{backgroundColor: 'white', padding: '10px'}}>
+    <Chip size="medium" skin="primary">Tag 3</Chip>
 </div>
 ```
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Chip/chip.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Chip/chip.scss
@@ -12,8 +12,6 @@ $chipDisabledBackgroundColor: $silver;
     display: inline-block;
     font-size: 12px;
     line-height: 18px;
-    height: 18px;
-    margin: 5px 10px 5px 0;
     padding: 0 10px;
     position: relative;
     white-space: nowrap;
@@ -43,4 +41,12 @@ $chipDisabledBackgroundColor: $silver;
         background-color: $chipSecondaryBackgroundColor;
         color: $chipSecondaryColor;
     }
+}
+
+.small {
+    height: 18px;
+}
+
+.medium {
+    height: 30px;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Chip/chip.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Chip/chip.scss
@@ -1,10 +1,12 @@
 @import '../../containers/Application/colors.scss';
 
-$chipBackgroundColor: $wildSand;
+$chipPrimaryBackgroundColor: $shakespeare;
+$chipPrimaryColor: $white;
+$chipSecondaryBackgroundColor: $wildSand;
+$chipSecondaryColor: $black;
 $chipDisabledBackgroundColor: $silver;
 
 .chip {
-    background-color: $chipBackgroundColor;
     border: none;
     border-radius: 3px;
     display: inline-block;
@@ -27,4 +29,18 @@ $chipDisabledBackgroundColor: $silver;
 
 .disabled {
     background-color: $chipDisabledBackgroundColor;
+}
+
+.primary {
+    &.chip {
+        background-color: $chipPrimaryBackgroundColor;
+        color: $chipPrimaryColor;
+    }
+}
+
+.secondary {
+    &.chip {
+        background-color: $chipSecondaryBackgroundColor;
+        color: $chipSecondaryColor;
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Chip/tests/Chip.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Chip/tests/Chip.test.js
@@ -3,19 +3,23 @@ import React from 'react';
 import {render, shallow} from 'enzyme';
 import Chip from '../Chip';
 
-test('Should render item with children', () => {
+test('Should render chip with children', () => {
     expect(render(<Chip value={{}}>Name</Chip>)).toMatchSnapshot();
 });
 
-test('Should render item with delete icon', () => {
+test('Should render primary chip with children', () => {
+    expect(render(<Chip skin="primary" value={{}}>Name</Chip>)).toMatchSnapshot();
+});
+
+test('Should render chip with delete icon', () => {
     expect(render(<Chip onDelete={jest.fn()} value={{}}>Name</Chip>)).toMatchSnapshot();
 });
 
-test('Should render item without delete icon in disabled state', () => {
+test('Should render chip without delete icon in disabled state', () => {
     expect(render(<Chip disabled={true} onDelete={jest.fn()} value={{}}>Name</Chip>)).toMatchSnapshot();
 });
 
-test('Should render item as clickable', () => {
+test('Should render chip as clickable', () => {
     expect(render(<Chip onClick={jest.fn()} value={{}}>Name</Chip>)).toMatchSnapshot();
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Chip/tests/Chip.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Chip/tests/Chip.test.js
@@ -7,8 +7,8 @@ test('Should render chip with children', () => {
     expect(render(<Chip value={{}}>Name</Chip>)).toMatchSnapshot();
 });
 
-test('Should render primary chip with children', () => {
-    expect(render(<Chip skin="primary" value={{}}>Name</Chip>)).toMatchSnapshot();
+test('Should render medium, primary chip with children', () => {
+    expect(render(<Chip size="medium" skin="primary" value={{}}>Name</Chip>)).toMatchSnapshot();
 });
 
 test('Should render chip with delete icon', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Chip/tests/__snapshots__/Chip.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Chip/tests/__snapshots__/Chip.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Should render chip as clickable 1`] = `
 <button
-  class="chip secondary clickable"
+  class="chip secondary small clickable"
 >
   Name
 </button>
@@ -10,7 +10,7 @@ exports[`Should render chip as clickable 1`] = `
 
 exports[`Should render chip with children 1`] = `
 <button
-  class="chip secondary"
+  class="chip secondary small"
 >
   Name
 </button>
@@ -18,7 +18,7 @@ exports[`Should render chip with children 1`] = `
 
 exports[`Should render chip with delete icon 1`] = `
 <button
-  class="chip secondary"
+  class="chip secondary small"
 >
   Name
   <span
@@ -32,15 +32,15 @@ exports[`Should render chip with delete icon 1`] = `
 
 exports[`Should render chip without delete icon in disabled state 1`] = `
 <button
-  class="chip secondary disabled"
+  class="chip secondary small disabled"
 >
   Name
 </button>
 `;
 
-exports[`Should render primary chip with children 1`] = `
+exports[`Should render medium, primary chip with children 1`] = `
 <button
-  class="chip primary"
+  class="chip primary medium"
 >
   Name
 </button>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Chip/tests/__snapshots__/Chip.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Chip/tests/__snapshots__/Chip.test.js.snap
@@ -1,24 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Should render item as clickable 1`] = `
+exports[`Should render chip as clickable 1`] = `
 <button
-  class="chip clickable"
+  class="chip secondary clickable"
 >
   Name
 </button>
 `;
 
-exports[`Should render item with children 1`] = `
+exports[`Should render chip with children 1`] = `
 <button
-  class="chip"
+  class="chip secondary"
 >
   Name
 </button>
 `;
 
-exports[`Should render item with delete icon 1`] = `
+exports[`Should render chip with delete icon 1`] = `
 <button
-  class="chip"
+  class="chip secondary"
 >
   Name
   <span
@@ -30,9 +30,17 @@ exports[`Should render item with delete icon 1`] = `
 </button>
 `;
 
-exports[`Should render item without delete icon in disabled state 1`] = `
+exports[`Should render chip without delete icon in disabled state 1`] = `
 <button
-  class="chip disabled"
+  class="chip secondary disabled"
+>
+  Name
+</button>
+`;
+
+exports[`Should render primary chip with children 1`] = `
+<button
+  class="chip primary"
 >
   Name
 </button>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/MultiAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/MultiAutoComplete.js
@@ -182,14 +182,15 @@ class MultiAutoComplete extends React.Component<Props> {
                     </div>
                     <div className={multiAutoCompleteStyles.items}>
                         {value.map((item) => (
-                            <Chip
-                                disabled={disabled}
-                                key={item[idProperty]}
-                                onDelete={this.handleDelete}
-                                value={item}
-                            >
-                                {item[displayProperty]}
-                            </Chip>
+                            <span className={multiAutoCompleteStyles.chip} key={item[idProperty]}>
+                                <Chip
+                                    disabled={disabled}
+                                    onDelete={this.handleDelete}
+                                    value={item}
+                                >
+                                    {item[displayProperty]}
+                                </Chip>
+                            </span>
                         ))}
                         <input
                             className={inputClass}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/multiAutoComplete.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/multiAutoComplete.scss
@@ -14,6 +14,10 @@ $multiAutoCompleteDisabledBackgroundColor: $wildSand;
     display: flex;
     align-items: center;
 
+    .chip {
+        margin: 5px 10px 5px 0;
+    }
+
     .input {
         border: none;
         font-size: 12px;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/MultiAutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/MultiAutoComplete.test.js
@@ -82,7 +82,7 @@ test('Render the MultiAutoComplete with open suggestions list', () => {
     multiAutoComplete.instance().inputValue = 'test';
     multiAutoComplete.update();
 
-    expect(multiAutoComplete.find('.chip').text()).toEqual('Test');
+    expect(multiAutoComplete.find('Chip').text()).toEqual('Test');
     expect(pretty(document.body ? document.body.innerHTML : '')).toMatchSnapshot();
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
@@ -16,7 +16,7 @@ exports[`MultiAutoComplete should render 1`] = `
     class="items"
   >
     <button
-      class="chip"
+      class="chip secondary"
     >
       Test
       <span
@@ -27,7 +27,7 @@ exports[`MultiAutoComplete should render 1`] = `
       />
     </button>
     <button
-      class="chip"
+      class="chip secondary"
     >
       Test 2
       <span
@@ -61,12 +61,12 @@ exports[`MultiAutoComplete should render in disabled state 1`] = `
     class="items"
   >
     <button
-      class="chip disabled"
+      class="chip secondary disabled"
     >
       Test
     </button>
     <button
-      class="chip disabled"
+      class="chip secondary disabled"
     >
       Test 2
     </button>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
@@ -15,28 +15,36 @@ exports[`MultiAutoComplete should render 1`] = `
   <div
     class="items"
   >
-    <button
-      class="chip secondary"
+    <span
+      class="chip"
     >
-      Test
-      <span
-        aria-label="su-times"
-        class="su-times clickable icon"
-        role="button"
-        tabindex="0"
-      />
-    </button>
-    <button
-      class="chip secondary"
+      <button
+        class="chip secondary small"
+      >
+        Test
+        <span
+          aria-label="su-times"
+          class="su-times clickable icon"
+          role="button"
+          tabindex="0"
+        />
+      </button>
+    </span>
+    <span
+      class="chip"
     >
-      Test 2
-      <span
-        aria-label="su-times"
-        class="su-times clickable icon"
-        role="button"
-        tabindex="0"
-      />
-    </button>
+      <button
+        class="chip secondary small"
+      >
+        Test 2
+        <span
+          aria-label="su-times"
+          class="su-times clickable icon"
+          role="button"
+          tabindex="0"
+        />
+      </button>
+    </span>
     <input
       class="input mousetrap"
       value=""
@@ -60,16 +68,24 @@ exports[`MultiAutoComplete should render in disabled state 1`] = `
   <div
     class="items"
   >
-    <button
-      class="chip secondary disabled"
+    <span
+      class="chip"
     >
-      Test
-    </button>
-    <button
-      class="chip secondary disabled"
+      <button
+        class="chip secondary small disabled"
+      >
+        Test
+      </button>
+    </span>
+    <span
+      class="chip"
     >
-      Test 2
-    </button>
+      <button
+        class="chip secondary small disabled"
+      >
+        Test 2
+      </button>
+    </span>
     <input
       class="input mousetrap"
       disabled=""

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
@@ -16,12 +16,12 @@ exports[`Render in disabled state 1`] = `
     class="items"
   >
     <button
-      class="chip disabled"
+      class="chip secondary disabled"
     >
       James Bond
     </button>
     <button
-      class="chip disabled"
+      class="chip secondary disabled"
     >
       John Doe
     </button>
@@ -80,7 +80,7 @@ exports[`Render with given value 1`] = `
     class="items"
   >
     <button
-      class="chip"
+      class="chip secondary"
     >
       James Bond
       <span
@@ -91,7 +91,7 @@ exports[`Render with given value 1`] = `
       />
     </button>
     <button
-      class="chip"
+      class="chip secondary"
     >
       John Doe
       <span

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
@@ -15,16 +15,24 @@ exports[`Render in disabled state 1`] = `
   <div
     class="items"
   >
-    <button
-      class="chip secondary disabled"
+    <span
+      class="chip"
     >
-      James Bond
-    </button>
-    <button
-      class="chip secondary disabled"
+      <button
+        class="chip secondary small disabled"
+      >
+        James Bond
+      </button>
+    </span>
+    <span
+      class="chip"
     >
-      John Doe
-    </button>
+      <button
+        class="chip secondary small disabled"
+      >
+        John Doe
+      </button>
+    </span>
     <input
       class="input mousetrap"
       disabled=""
@@ -79,28 +87,36 @@ exports[`Render with given value 1`] = `
   <div
     class="items"
   >
-    <button
-      class="chip secondary"
+    <span
+      class="chip"
     >
-      James Bond
-      <span
-        aria-label="su-times"
-        class="su-times clickable icon"
-        role="button"
-        tabindex="0"
-      />
-    </button>
-    <button
-      class="chip secondary"
+      <button
+        class="chip secondary small"
+      >
+        James Bond
+        <span
+          aria-label="su-times"
+          class="su-times clickable icon"
+          role="button"
+          tabindex="0"
+        />
+      </button>
+    </span>
+    <span
+      class="chip"
     >
-      John Doe
-      <span
-        aria-label="su-times"
-        class="su-times clickable icon"
-        role="button"
-        tabindex="0"
-      />
-    </button>
+      <button
+        class="chip secondary small"
+      >
+        John Doe
+        <span
+          aria-label="su-times"
+          class="su-times clickable icon"
+          role="button"
+          tabindex="0"
+        />
+      </button>
+    </span>
     <input
       class="input mousetrap"
       value=""


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | Extracts 9c735cc007ea5391c35593e106281e1f6284f040 and e7bccf51edcc10e3efa015c08a00000a315b28a0 from #5035 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR allows to further customize the `Chip` component.

#### Why?

Because in #5035 we need a bigger representation of them.

#### To Do

- [x] Create a documentation PR
