### PR TITLE
Allow non-scalar routing parameters in the frontend

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,11 @@
 
 ## dev-master
 
+### Router attributes
+
+The `Router` service now interprets more into the URL parameters that are passed to it. In addition to parsing numbers,
+boolean and strings to its JS equivalents, it will now do the same for `undefined` and dates in the format `yyyy-mm-dd`.
+
 ### Configuration of list item actions
 
 The prop of the `List` container which is used to configure the item actions was changed from `actions` to 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/registries/resourceRouteRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/registries/resourceRouteRegistry.js
@@ -2,6 +2,7 @@
 import {isObservableArray, toJS} from 'mobx';
 import symfonyRouting from 'fos-jsrouting/router';
 import type {EndpointConfiguration} from '../types';
+import {transformDateForUrl} from '../../../utils/Date';
 
 function transformParameters(parameters) {
     return Object.keys(parameters)
@@ -12,19 +13,11 @@ function transformParameters(parameters) {
             transformedParameters[parameterKey] = Array.isArray(value) || isObservableArray(value)
                 ? value.join(',')
                 : value instanceof Date
-                    ? transformDate(value)
+                    ? transformDateForUrl(value)
                     : value instanceof Object ? transformParameters(value) : toJS(value);
 
             return transformedParameters;
         }, {});
-}
-
-function transformDate(value: Date) {
-    const year = value.getFullYear().toString();
-    const month = (value.getMonth() + 1).toString();
-    const date = value.getDate().toString();
-
-    return year + '-' + (month[1] ? month : '0' + month) + '-' + (date[1] ? date : '0' + date);
 }
 
 class ResourceRouteRegistry {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/registries/resourceRouteRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/registries/resourceRouteRegistry.js
@@ -7,14 +7,24 @@ function transformParameters(parameters) {
     return Object.keys(parameters)
         .filter((parameterKey) => parameters[parameterKey] !== undefined)
         .reduce((transformedParameters, parameterKey) => {
-            const parameterValue = parameters[parameterKey];
+            const value = parameters[parameterKey];
 
-            transformedParameters[parameterKey] = Array.isArray(parameterValue) || isObservableArray(parameterValue)
-                ? parameterValue.join(',')
-                : toJS(parameterValue);
+            transformedParameters[parameterKey] = Array.isArray(value) || isObservableArray(value)
+                ? value.join(',')
+                : value instanceof Date
+                    ? transformDate(value)
+                    : value instanceof Object ? transformParameters(value) : toJS(value);
 
             return transformedParameters;
         }, {});
+}
+
+function transformDate(value: Date) {
+    const year = value.getFullYear().toString();
+    const month = (value.getMonth() + 1).toString();
+    const date = value.getDate().toString();
+
+    return year + '-' + (month[1] ? month : '0' + month) + '-' + (date[1] ? date : '0' + date);
 }
 
 class ResourceRouteRegistry {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/registries/resourceRouteRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/registries/resourceRouteRegistry.js
@@ -4,18 +4,21 @@ import symfonyRouting from 'fos-jsrouting/router';
 import type {EndpointConfiguration} from '../types';
 import {transformDateForUrl} from '../../../utils/Date';
 
+function transformParameter(parameter) {
+    return Array.isArray(parameter) || isObservableArray(parameter)
+        ? parameter.map(transformParameter).join(',')
+        : parameter instanceof Date
+            ? transformDateForUrl(parameter)
+            : parameter instanceof Object ? transformParameters(parameter) : toJS(parameter);
+}
+
 function transformParameters(parameters) {
     return Object.keys(parameters)
         .filter((parameterKey) => parameters[parameterKey] !== undefined)
         .reduce((transformedParameters, parameterKey) => {
             const value = parameters[parameterKey];
 
-            transformedParameters[parameterKey] = Array.isArray(value) || isObservableArray(value)
-                ? value.join(',')
-                : value instanceof Date
-                    ? transformDateForUrl(value)
-                    : value instanceof Object ? transformParameters(value) : toJS(value);
-
+            transformedParameters[parameterKey] = transformParameter(value);
             return transformedParameters;
         }, {});
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/tests/registries/resourceRouteRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/tests/registries/resourceRouteRegistry.test.js
@@ -40,6 +40,26 @@ test('Set and get endpoints for given key with date parameter', () => {
         .toEqual('get_snippets?value=2020-09-07');
 });
 
+test('Set and get endpoints for given key with date array parameter', () => {
+    SymfonyRouting.generate.mockImplementation((routeName, {dates}) => {
+        return routeName + '?dates=' + dates;
+    });
+
+    resourceRouteRegistry.setEndpoints({
+        snippets: {
+            routes: {
+                detail: 'get_snippet',
+                list: 'get_snippets',
+            },
+        },
+    });
+
+    expect(resourceRouteRegistry.getDetailUrl('snippets', {dates: [new Date('2013-12-24'), new Date('2020-12-24')]}))
+        .toEqual('get_snippet?dates=2013-12-24,2020-12-24');
+    expect(resourceRouteRegistry.getListUrl('snippets', {dates: [new Date('2020-09-07'), new Date('2020-11-05')]}))
+        .toEqual('get_snippets?dates=2020-09-07,2020-11-05');
+});
+
 test('Throw exception when getting detail url for not existing key', () => {
     expect(() => resourceRouteRegistry.getDetailUrl('not-existing')).toThrow(/"not-existing"/);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/tests/registries/resourceRouteRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/tests/registries/resourceRouteRegistry.test.js
@@ -60,6 +60,23 @@ test('Set and get endpoints for given key with date array parameter', () => {
         .toEqual('get_snippets?dates=2020-09-07,2020-11-05');
 });
 
+test('Set and get endpoints for given key with date in object parameter', () => {
+    resourceRouteRegistry.setEndpoints({
+        snippets: {
+            routes: {
+                detail: 'get_snippet',
+                list: 'get_snippets',
+            },
+        },
+    });
+
+    resourceRouteRegistry.getDetailUrl('snippets', {value: {name: 'test', date: new Date('2020-09-07')}});
+    expect(SymfonyRouting.generate).toBeCalledWith('get_snippet', {'value': {'name': 'test', 'date': '2020-09-07'}});
+
+    resourceRouteRegistry.getListUrl('snippets', {value: {name: 'test', date: new Date('2020-09-07')}});
+    expect(SymfonyRouting.generate).toBeCalledWith('get_snippets', {'value': {'name': 'test', 'date': '2020-09-07'}});
+});
+
 test('Throw exception when getting detail url for not existing key', () => {
     expect(() => resourceRouteRegistry.getDetailUrl('not-existing')).toThrow(/"not-existing"/);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/tests/registries/resourceRouteRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/tests/registries/resourceRouteRegistry.test.js
@@ -20,11 +20,31 @@ test('Set and get endpoints for given key', () => {
     expect(resourceRouteRegistry.getListUrl('snippets', {value: 2})).toEqual('get_snippets?value=2');
 });
 
+test('Set and get endpoints for given key with date parameter', () => {
+    SymfonyRouting.generate.mockImplementation((routeName, {value}) => {
+        return routeName + '?value=' + value;
+    });
+
+    resourceRouteRegistry.setEndpoints({
+        snippets: {
+            routes: {
+                detail: 'get_snippet',
+                list: 'get_snippets',
+            },
+        },
+    });
+
+    expect(resourceRouteRegistry.getDetailUrl('snippets', {value: new Date('2013-12-24')}))
+        .toEqual('get_snippet?value=2013-12-24');
+    expect(resourceRouteRegistry.getListUrl('snippets', {value: new Date('2020-09-07')}))
+        .toEqual('get_snippets?value=2020-09-07');
+});
+
 test('Throw exception when getting detail url for not existing key', () => {
     expect(() => resourceRouteRegistry.getDetailUrl('not-existing')).toThrow(/"not-existing"/);
 });
 
-test('Throw exception when getting detail url for not existing key', () => {
+test('Throw exception when getting list url for not existing key', () => {
     expect(() => resourceRouteRegistry.getListUrl('not-existing')).toThrow(/"not-existing"/);
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/README.md
@@ -111,8 +111,6 @@ router.bind('value', value, 'default');
 value.get(); // returns something
 
 value.set('anything'); // will navigate to /page?value=anything
-
-router.unbind('value', value); // unbind to avoid leaking listeners
 ```
 
 Mind that the bindings will be cleared on every `navigate` call. This is necessary to avoid superfluous updates because

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -7,6 +7,76 @@ import pathToRegexp, {compile} from 'path-to-regexp';
 import type {AttributeMap, Route, UpdateAttributesHook, UpdateRouteHook, UpdateRouteMethod} from './types';
 import routeRegistry from './registries/routeRegistry';
 
+const OBJECT_DELIMITER = '.';
+
+function tryParse(value: string) {
+    if (value === 'true') {
+        return true;
+    }
+
+    if (value === 'false') {
+        return false;
+    }
+
+    if (value === 'undefined') {
+        return undefined;
+    }
+
+    if (isNaN(value)) {
+        return value;
+    }
+
+    return parseFloat(value);
+}
+
+function addValueToSearchParameters(searchParameters: URLSearchParams, value: Object, path: string) {
+    if (Array.isArray(value)) {
+        addArrayToSearchParameters(searchParameters, value, path);
+    } else if (typeof value === 'object') {
+        addObjectToSearchParameters(searchParameters, value, path);
+    } else {
+        searchParameters.set(path, value);
+    }
+}
+
+function addObjectToSearchParameters(searchParameters: URLSearchParams, value: Object, path: string) {
+    for (const key in value) {
+        const childPath = path + OBJECT_DELIMITER + key;
+        if (typeof value[key] === 'object') {
+            addValueToSearchParameters(searchParameters, value[key], childPath);
+        } else {
+            searchParameters.set(childPath, value[key]);
+        }
+    }
+}
+
+function addArrayToSearchParameters(searchParameters: URLSearchParams, values: Array<*>, path: string) {
+    values.forEach((value, index) => {
+        searchParameters.append(path + '[' + index + ']', value);
+    });
+}
+
+function addAttributesFromSearchParameters(attributes: Object, value: string, key: string) {
+    if (key.includes(OBJECT_DELIMITER)) {
+        const keyParts = key.split(OBJECT_DELIMITER);
+        if (!attributes[keyParts[0]]) {
+            attributes[keyParts[0]] = {};
+        }
+
+        addAttributesFromSearchParameters(attributes[keyParts[0]], value, keyParts.slice(1).join(OBJECT_DELIMITER));
+    } else if (key.includes('[') && key.includes(']')) {
+        const arrayKey = key.slice(0, key.indexOf('['));
+
+        if (!attributes[arrayKey]) {
+            attributes[arrayKey] = [];
+        }
+
+        attributes[arrayKey].push(tryParse(value));
+    } else {
+        attributes[key] = tryParse(value);
+    }
+}
+
 export default class Router {
     history: Object;
     @observable route: Route;
@@ -82,7 +152,11 @@ export default class Router {
         this.updateAttributesHooks.push(hook);
     }
 
-    @action bind(key: string, value: IObservableValue<*>, defaultValue: ?string | number | boolean = undefined) {
+    @action bind(
+        key: string,
+        value: IObservableValue<*>,
+        defaultValue: ?string | number | boolean | Object = undefined
+    ) {
         if (key in this.attributes && value.get() !== this.attributes[key]) {
             // when the bound parameter is bound set the state of the passed observable to the current value once
             // required because otherwise the parameter will be overridden on the initial start of the application
@@ -123,12 +197,12 @@ export default class Router {
 
             const attributes = {};
             for (let i = 1; i < match.length; i++) {
-                attributes[names[i - 1].name] = Router.tryParse(match[i]);
+                attributes[names[i - 1].name] = tryParse(match[i]);
             }
 
             const search = new URLSearchParams(queryString);
             search.forEach((value, key) => {
-                attributes[key] = Router.tryParse(value);
+                addAttributesFromSearchParameters(attributes, value, key);
             });
 
             this.handleNavigation(name, attributes, this.navigate);
@@ -139,7 +213,7 @@ export default class Router {
         const attributes = {};
         const search = new URLSearchParams(queryString);
         search.forEach((value, key) => {
-            attributes[key] = Router.tryParse(value);
+            attributes[key] = tryParse(value);
         });
 
         this.attributes = attributes;
@@ -238,11 +312,12 @@ export default class Router {
         const url = compile(this.route.path)(attributes);
         const searchParameters = new URLSearchParams();
         Object.keys(attributes).forEach((key) => {
-            const value = attributes[key];
+            const value = toJS(attributes[key]);
             if (keyNames.includes(key) || value == this.bindingDefaults.get(key)) {
                 return;
             }
-            searchParameters.set(key, value);
+
+            addValueToSearchParameters(searchParameters, value, key);
         });
 
         const queryString = searchParameters.toString();
@@ -270,21 +345,5 @@ export default class Router {
             && this.route.name === route.name
             && equal(this.attributes, attributes)
         );
-    }
-
-    static tryParse(value: string) {
-        if (value === 'true') {
-            return true;
-        }
-
-        if (value === 'false') {
-            return false;
-        }
-
-        if (isNaN(value)) {
-            return value;
-        }
-
-        return parseFloat(value);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -24,7 +24,7 @@ function tryParse(value: ?string) {
     }
 
     if (value && value.match(/\d\d\d\d-\d\d-\d\d/)) {
-        const date = new Date(value);
+        const date = new Date(value + ' 00:00'); // The time is necessary to avoid timezone issues
         if (date.toString() !== 'Invalid Date') {
             return date;
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -37,6 +37,20 @@ function tryParse(value: ?string) {
     return parseFloat(value);
 }
 
+function equalBindings(value1, value2) {
+    if (typeof(value1) !== 'object' || typeof(value2) !== 'object') {
+        return value1 == value2;
+    }
+
+    const objectKeys = Object.keys(value1);
+
+    if (!equal(objectKeys, Object.keys(value2))) {
+        return false;
+    }
+
+    return objectKeys.every((key) => equalBindings(value1[key], value2[key]));
+}
+
 function addValueToSearchParameters(searchParameters: URLSearchParams, value: Object, path: string) {
     if (Array.isArray(value)) {
         addArrayToSearchParameters(searchParameters, value, path);
@@ -302,7 +316,7 @@ export default class Router {
                 : this.bindingDefaults.get(key);
 
             // Type unsafe comparison to not trigger a new navigation when only data type changes
-            if (value != observableValue.get()) {
+            if (!equalBindings(value, observableValue.get())) {
                 observableValue.set(value);
             }
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -69,7 +69,7 @@ function addValueToSearchParameters(searchParameters: URLSearchParams, value: Ob
 
 function addArrayToSearchParameters(searchParameters: URLSearchParams, values: Array<*>, path: string) {
     values.forEach((value, index) => {
-        searchParameters.append(path + '[' + index + ']', value);
+        addValueToSearchParameters(searchParameters, value, path + '[' + index + ']');
     });
 }
 
@@ -80,11 +80,7 @@ function addDateToSearchParameters(searchParameters: URLSearchParams, value: Dat
 function addObjectToSearchParameters(searchParameters: URLSearchParams, value: Object, path: string) {
     for (const key in value) {
         const childPath = path + OBJECT_DELIMITER + key;
-        if (typeof value[key] === 'object') {
-            addValueToSearchParameters(searchParameters, value[key], childPath);
-        } else {
-            searchParameters.set(childPath, value[key]);
-        }
+        addValueToSearchParameters(searchParameters, value[key], childPath);
     }
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -42,6 +42,10 @@ function equalBindings(value1, value2) {
         return value1 == value2;
     }
 
+    if (value1 instanceof Date && value2 instanceof Date) {
+        return value1.getTime() === value2.getTime();
+    }
+
     const objectKeys = Object.keys(value1);
 
     if (!equal(objectKeys, Object.keys(value2))) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
@@ -183,6 +183,36 @@ test('Navigate to route with array search parameters using state', () => {
     expect(history.location.search).toBe('?page=1&ids%5B0%5D=1&ids%5B1%5D=2&ids%5B2%5D=3');
 });
 
+test('Navigate to route with dates in array search parameters using state', () => {
+    routeRegistry.getAll.mockReturnValue({
+        page: {
+            name: 'page',
+            type: 'form',
+            path: '/pages/:uuid',
+            options: {
+                type: 'page',
+            },
+            attributeDefaults: {},
+        },
+    });
+
+    const history = createMemoryHistory();
+    const router = new Router(history);
+
+    router.navigate(
+        'page',
+        {uuid: 'some-uuid', page: 1, dates: [new Date('2020-03-10 00:00'), new Date('2020-03-20 00:00')]}
+    );
+    expect(isObservable(router.route)).toBe(true);
+    expect(router.route.type).toBe('form');
+    expect(router.route.options.type).toBe('page');
+    expect(router.attributes.uuid).toBe('some-uuid');
+    expect(router.attributes.page).toBe(1);
+    expect(router.attributes.dates).toEqual([new Date('2020-03-10 00:00'), new Date('2020-03-20 00:00')]);
+    expect(history.location.pathname).toBe('/pages/some-uuid');
+    expect(history.location.search).toBe('?page=1&dates%5B0%5D=2020-03-10&dates%5B1%5D=2020-03-20');
+});
+
 test('Navigate to route with array nested in object search parameters using state', () => {
     routeRegistry.getAll.mockReturnValue({
         page: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
@@ -123,6 +123,96 @@ test('Navigate to route with search parameters using state', () => {
     expect(history.location.search).toBe('?page=1&sort=title');
 });
 
+test('Navigate to route with object search parameters using state', () => {
+    routeRegistry.getAll.mockReturnValue({
+        page: {
+            name: 'page',
+            type: 'form',
+            path: '/pages/:uuid',
+            options: {
+                type: 'page',
+            },
+            attributeDefaults: {},
+        },
+    });
+
+    const history = createMemoryHistory();
+    const router = new Router(history);
+
+    router.navigate(
+        'page',
+        {uuid: 'some-uuid', page: 1, filter: {firstName: {eq: 'Max'}, lastName: {eq: 'Mustermann'}}}
+    );
+    expect(isObservable(router.route)).toBe(true);
+    expect(router.route.type).toBe('form');
+    expect(router.route.options.type).toBe('page');
+    expect(router.attributes.uuid).toBe('some-uuid');
+    expect(router.attributes.page).toBe(1);
+    expect(router.attributes.filter).toEqual({firstName: {eq: 'Max'}, lastName: {eq: 'Mustermann'}});
+    expect(history.location.pathname).toBe('/pages/some-uuid');
+    expect(history.location.search).toBe('?page=1&filter.firstName.eq=Max&filter.lastName.eq=Mustermann');
+});
+
+test('Navigate to route with array search parameters using state', () => {
+    routeRegistry.getAll.mockReturnValue({
+        page: {
+            name: 'page',
+            type: 'form',
+            path: '/pages/:uuid',
+            options: {
+                type: 'page',
+            },
+            attributeDefaults: {},
+        },
+    });
+
+    const history = createMemoryHistory();
+    const router = new Router(history);
+
+    router.navigate(
+        'page',
+        {uuid: 'some-uuid', page: 1, ids: [1, 2, 3]}
+    );
+    expect(isObservable(router.route)).toBe(true);
+    expect(router.route.type).toBe('form');
+    expect(router.route.options.type).toBe('page');
+    expect(router.attributes.uuid).toBe('some-uuid');
+    expect(router.attributes.page).toBe(1);
+    expect(router.attributes.ids).toEqual([1, 2, 3]);
+    expect(history.location.pathname).toBe('/pages/some-uuid');
+    expect(history.location.search).toBe('?page=1&ids%5B0%5D=1&ids%5B1%5D=2&ids%5B2%5D=3');
+});
+
+test('Navigate to route with array nested in object search parameters using state', () => {
+    routeRegistry.getAll.mockReturnValue({
+        page: {
+            name: 'page',
+            type: 'form',
+            path: '/pages/:uuid',
+            options: {
+                type: 'page',
+            },
+            attributeDefaults: {},
+        },
+    });
+
+    const history = createMemoryHistory();
+    const router = new Router(history);
+
+    router.navigate(
+        'page',
+        {uuid: 'some-uuid', page: 1, filter: {ids: [1, 2, 3]}}
+    );
+    expect(isObservable(router.route)).toBe(true);
+    expect(router.route.type).toBe('form');
+    expect(router.route.options.type).toBe('page');
+    expect(router.attributes.uuid).toBe('some-uuid');
+    expect(router.attributes.page).toBe(1);
+    expect(router.attributes.filter).toEqual({ids: [1, 2, 3]});
+    expect(history.location.pathname).toBe('/pages/some-uuid');
+    expect(history.location.search).toBe('?page=1&filter.ids%5B0%5D=1&filter.ids%5B1%5D=2&filter.ids%5B2%5D=3');
+});
+
 test('Navigate to route without parameters using state', () => {
     routeRegistry.getAll.mockReturnValue({
         page: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
@@ -1070,6 +1070,56 @@ test('Binding should be updated if another object is set', () => {
     expect(filter.set.mock.calls).toContainEqual([{test: {eq: 'Test'}}]);
 });
 
+test('Binding should not be updated if the same date is set again', () => {
+    routeRegistry.getAll.mockReturnValue({
+        list: {
+            name: 'list',
+            type: 'list',
+            path: '/list',
+            attributeDefaults: {},
+        },
+    });
+
+    const from = jest.fn(() => ({
+        get: jest.fn().mockReturnValue(new Date('2020-02-02')),
+        set: jest.fn(),
+        observe: jest.fn(),
+        intercept: jest.fn(),
+    }))();
+
+    const history = createMemoryHistory();
+    const router = new Router(history);
+    router.bind('from', from);
+
+    router.navigate('list', {from: new Date('2020-02-02')});
+    expect(from.set.mock.calls).not.toContainEqual([new Date('2020-02-02')]);
+});
+
+test('Binding should be updated if the date changes', () => {
+    routeRegistry.getAll.mockReturnValue({
+        list: {
+            name: 'list',
+            type: 'list',
+            path: '/list',
+            attributeDefaults: {},
+        },
+    });
+
+    const from = jest.fn(() => ({
+        get: jest.fn().mockReturnValue(new Date('2020-02-02')),
+        set: jest.fn(),
+        observe: jest.fn(),
+        intercept: jest.fn(),
+    }))();
+
+    const history = createMemoryHistory();
+    const router = new Router(history);
+    router.bind('from', from);
+
+    router.navigate('list', {from: new Date('2020-02-03')});
+    expect(from.set.mock.calls).toContainEqual([new Date('2020-02-03')]);
+});
+
 test('Navigate to child route using state', () => {
     const formRoute = extendObservable({}, {
         name: 'sulu_snippet.form',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
@@ -1020,6 +1020,56 @@ test('Binding should not be updated if only data type changes', () => {
     expect(page.set.mock.calls).not.toContainEqual(['2']);
 });
 
+test('Binding should not be updated if the same object is set again', () => {
+    routeRegistry.getAll.mockReturnValue({
+        list: {
+            name: 'list',
+            type: 'list',
+            path: '/list',
+            attributeDefaults: {},
+        },
+    });
+
+    const filter = jest.fn(() => ({
+        get: jest.fn().mockReturnValue({}),
+        set: jest.fn(),
+        observe: jest.fn(),
+        intercept: jest.fn(),
+    }))();
+
+    const history = createMemoryHistory();
+    const router = new Router(history);
+    router.bind('filter', filter);
+
+    router.navigate('list', {filter: {}});
+    expect(filter.set.mock.calls).not.toContainEqual([{}]);
+});
+
+test('Binding should be updated if another object is set', () => {
+    routeRegistry.getAll.mockReturnValue({
+        list: {
+            name: 'list',
+            type: 'list',
+            path: '/list',
+            attributeDefaults: {},
+        },
+    });
+
+    const filter = jest.fn(() => ({
+        get: jest.fn().mockReturnValue({}),
+        set: jest.fn(),
+        observe: jest.fn(),
+        intercept: jest.fn(),
+    }))();
+
+    const history = createMemoryHistory();
+    const router = new Router(history);
+    router.bind('filter', filter);
+
+    router.navigate('list', {filter: {test: {eq: 'Test'}}});
+    expect(filter.set.mock.calls).toContainEqual([{test: {eq: 'Test'}}]);
+});
+
 test('Navigate to child route using state', () => {
     const formRoute = extendObservable({}, {
         name: 'sulu_snippet.form',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
@@ -213,6 +213,66 @@ test('Navigate to route with array nested in object search parameters using stat
     expect(history.location.search).toBe('?page=1&filter.ids%5B0%5D=1&filter.ids%5B1%5D=2&filter.ids%5B2%5D=3');
 });
 
+test('Navigate to route with date search parameters using state', () => {
+    routeRegistry.getAll.mockReturnValue({
+        page: {
+            name: 'page',
+            type: 'form',
+            path: '/pages/:uuid',
+            options: {
+                type: 'page',
+            },
+            attributeDefaults: {},
+        },
+    });
+
+    const history = createMemoryHistory();
+    const router = new Router(history);
+
+    router.navigate(
+        'page',
+        {uuid: 'some-uuid', page: 1, from: new Date('2020-02-28')}
+    );
+    expect(isObservable(router.route)).toBe(true);
+    expect(router.route.type).toBe('form');
+    expect(router.route.options.type).toBe('page');
+    expect(router.attributes.uuid).toBe('some-uuid');
+    expect(router.attributes.page).toBe(1);
+    expect(router.attributes.from).toEqual(new Date('2020-02-28'));
+    expect(history.location.pathname).toBe('/pages/some-uuid');
+    expect(history.location.search).toBe('?page=1&from=2020-02-28');
+});
+
+test('Navigate to route with string representing invalid date search parameters using state', () => {
+    routeRegistry.getAll.mockReturnValue({
+        page: {
+            name: 'page',
+            type: 'form',
+            path: '/pages/:uuid',
+            options: {
+                type: 'page',
+            },
+            attributeDefaults: {},
+        },
+    });
+
+    const history = createMemoryHistory();
+    const router = new Router(history);
+
+    router.navigate(
+        'page',
+        {uuid: 'some-uuid', page: 1, from: '2020-02-32'}
+    );
+    expect(isObservable(router.route)).toBe(true);
+    expect(router.route.type).toBe('form');
+    expect(router.route.options.type).toBe('page');
+    expect(router.attributes.uuid).toBe('some-uuid');
+    expect(router.attributes.page).toBe(1);
+    expect(router.attributes.from).toEqual('2020-02-32');
+    expect(history.location.pathname).toBe('/pages/some-uuid');
+    expect(history.location.search).toBe('?page=1&from=2020-02-32');
+});
+
 test('Navigate to route without parameters using state', () => {
     routeRegistry.getAll.mockReturnValue({
         page: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
@@ -231,14 +231,14 @@ test('Navigate to route with date search parameters using state', () => {
 
     router.navigate(
         'page',
-        {uuid: 'some-uuid', page: 1, from: new Date('2020-02-28')}
+        {uuid: 'some-uuid', page: 1, from: new Date('2020-02-28 00:00')}
     );
     expect(isObservable(router.route)).toBe(true);
     expect(router.route.type).toBe('form');
     expect(router.route.options.type).toBe('page');
     expect(router.attributes.uuid).toBe('some-uuid');
     expect(router.attributes.page).toBe(1);
-    expect(router.attributes.from).toEqual(new Date('2020-02-28'));
+    expect(router.attributes.from).toEqual(new Date('2020-02-28 00:00'));
     expect(history.location.pathname).toBe('/pages/some-uuid');
     expect(history.location.search).toBe('?page=1&from=2020-02-28');
 });
@@ -426,6 +426,30 @@ test('Update observable attribute on route change', () => {
     history.push('/list/de');
     expect(router.attributes.locale).toBe('de');
     expect(history.location.pathname).toBe('/list/de');
+});
+
+test('Update date observable attribute on route change', () => {
+    routeRegistry.getAll.mockReturnValue({
+        list: {
+            name: 'list',
+            type: 'list',
+            path: '/list',
+            attributeDefaults: {},
+        },
+    });
+
+    const date = observable.box();
+
+    const history = createMemoryHistory();
+    const router = new Router(history);
+
+    router.bind('date', date);
+
+    router.navigate('list', {date: new Date('2020-02-29 00:00')});
+    expect(router.attributes.date).toEqual(new Date('2020-02-29 00:00'));
+
+    history.push('/list?date=2020-02-29');
+    expect(router.attributes.date).toEqual(new Date('2020-02-29 00:00'));
 });
 
 test('Update boolean observable attribute on route change', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Date/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Date/README.md
@@ -1,0 +1,5 @@
+The `Date` module contains useful functions when working with dates.
+
+The `transformDateForUrl` function will create a date in the format of `yyyy-mm-dd` for a given date, ensuring that the
+month and day number will contain a leading `0` if lower than 10, which means that they will always consist of two
+digits.

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Date/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Date/index.js
@@ -1,0 +1,4 @@
+// @flow
+import transformDateForUrl from './transformDateForUrl';
+
+export {transformDateForUrl};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Date/tests/transformDateForUrl.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Date/tests/transformDateForUrl.test.js
@@ -1,0 +1,11 @@
+// @flow
+import transformDateForUrl from '../transformDateForUrl';
+
+test.each([
+    [new Date('2020-02-28'), '2020-02-28'],
+    [new Date('2000-08-31'), '2000-08-31'],
+    [new Date('2006-12-31'), '2006-12-31'],
+    [new Date('1940-12-01'), '1940-12-01'],
+])('Transform date "%s"', (date, expectedValue) => {
+    expect(transformDateForUrl(date)).toEqual(expectedValue);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Date/transformDateForUrl.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Date/transformDateForUrl.js
@@ -1,0 +1,9 @@
+// @flow
+
+export default function(value: Date) {
+    const year = value.getFullYear().toString();
+    const month = (value.getMonth() + 1).toString();
+    const date = value.getDate().toString();
+
+    return year + '-' + (month[1] ? month : '0' + month) + '-' + (date[1] ? date : '0' + date);
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | extracts c8d6b514c10e0a54f721a00cec4d92f633926609, parts of 0ce0e153572cff3cdabb613911782dee39191825, b878502fd1e2eb5460218333b89ea1a9c0b6a320 and 2f73e8cbc9f0b32efce6ac27ebda6677e36a62b7, 52fa43d596f7168d7e6c01f8645c5aadf07d8673 and c1dd535e246723439e1575489ef4a07b750e2311 from #5035
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR allows to add non-scalar values as routing parameters (date, objects, arrays) in the frontend.

#### Why?

Because #5035 needs more complicated routing paramters in order to work.

#### Example

```diff
diff --git a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
index 718a48eee3..15d7219df9 100644
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -24,6 +24,7 @@ class MediaOverview extends React.Component<ViewProps> {
     mediaPage: IObservableValue<number> = observable.box();
     locale: IObservableValue<string> = observable.box();
     collectionId: IObservableValue<?number | string> = observable.box();
+    dateObject: IObservableValue<*> = observable.box({to: new Date(), from: new Date()});
     @observable mediaListStore: ListStore;
     @observable collectionListStore: ListStore;
     @observable collectionStore: CollectionStore;
@@ -66,6 +67,7 @@ class MediaOverview extends React.Component<ViewProps> {
         router.bind('mediaLimit', this.mediaListStore.limit, 10);
         router.bind('mediaSortColumn', this.mediaListStore.sortColumn);
         router.bind('mediaSortOrder', this.mediaListStore.sortOrder);
+        router.bind('dateObject', this.dateObject);
     }
 
     componentWillUnmount() {
@@ -124,6 +126,7 @@ class MediaOverview extends React.Component<ViewProps> {
                 page: this.mediaPage,
                 locale: this.locale,
                 collection: this.collectionId,
+                dateObject: this.dateObject,
             },
             options
         );
```