### PR TITLE
Add generation for route field-type

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/FormInspector.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/FormInspector.js
@@ -40,6 +40,10 @@ export default class FormInspector {
         return this.formStore.getValuesByTag(tagName);
     }
 
+    getPathsByTag(tagName: string): Array<string> {
+        return this.formStore.getPathsByTag(tagName);
+    }
+
     getSchemaEntryByPath(schemaPath: string) {
         return this.formStore.getSchemaEntryByPath(schemaPath);
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
@@ -54,17 +54,27 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
                 return;
             }
 
-            const parts = formInspector.getValuesByTag(PART_TAG)
-                .filter((part) => part !== null && part !== undefined);
+            const partEntries = formInspector.getPathsByTag(PART_TAG)
+                .map((path: string) => [path, formInspector.getValueByPath(path)])
+                .filter(([, value: mixed]) => !!value)
+                .map(([path: string, value: mixed]) => {
+                    // path is a jsonpointer but the api controller requires property names
+                    if (path.startsWith('/')) {
+                        return [path.substr(1), value];
+                    }
 
-            if (parts.length === 0) {
+                    return [path, value];
+                });
+
+            if (partEntries.length === 0) {
                 return;
             }
 
             Requester.post(
                 generationUrl,
                 {
-                    parts,
+                    parts: Object.fromEntries(partEntries),
+                    resourceKey: formInspector.resourceKey,
                     locale: formInspector.locale ? formInspector.locale.get() : undefined,
                     ...formInspector.options,
                 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
@@ -287,9 +287,9 @@ test('Should request a new URL if no URL was defined', () => {
 
     const finishFieldHandler = formInspector.addFinishFieldHandler.mock.calls[0][0];
 
-    formInspector.getPathsByTag.mockReturnValue(['/ti', '/tle']);
-    formInspector.getValueByPath.mockReturnValueOnce('te');
-    formInspector.getValueByPath.mockReturnValueOnce('st');
+    formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
+    formInspector.getValueByPath.mockReturnValueOnce('title-value');
+    formInspector.getValueByPath.mockReturnValueOnce('subtitle-value');
     formInspector.getSchemaEntryByPath.mockReturnValue({
         tags: [
             {name: 'sulu.rlp.part'},
@@ -304,14 +304,14 @@ test('Should request a new URL if no URL was defined', () => {
 
     expect(formInspector.getSchemaEntryByPath).toBeCalledWith('/url');
     expect(formInspector.getPathsByTag).toBeCalledWith('sulu.rlp.part');
-    expect(formInspector.getValueByPath).toBeCalledWith('/ti');
-    expect(formInspector.getValueByPath).toBeCalledWith('/tle');
+    expect(formInspector.getValueByPath).toBeCalledWith('/title');
+    expect(formInspector.getValueByPath).toBeCalledWith('/subtitle');
     expect(Requester.post).toBeCalledWith(
         '/admin/api/resourcelocators?action=generate',
         {
             locale: 'en',
             resourceKey: 'tests',
-            parts: {ti: 'te', tle: 'st'},
+            parts: {title: 'title-value', subtitle: 'subtitle-value'},
         }
     );
 
@@ -387,9 +387,9 @@ test('Should request a new URL including the options from the ResourceFormStore 
 
     const finishFieldHandler = formInspector.addFinishFieldHandler.mock.calls[0][0];
 
-    formInspector.getPathsByTag.mockReturnValue(['/ti', '/tle']);
-    formInspector.getValueByPath.mockReturnValueOnce('te');
-    formInspector.getValueByPath.mockReturnValueOnce('st');
+    formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
+    formInspector.getValueByPath.mockReturnValueOnce('title-value');
+    formInspector.getValueByPath.mockReturnValueOnce('subtitle-value');
     formInspector.getSchemaEntryByPath.mockReturnValue({
         tags: [
             {name: 'sulu.rlp.part'},
@@ -405,13 +405,13 @@ test('Should request a new URL including the options from the ResourceFormStore 
 
     expect(formInspector.getSchemaEntryByPath).toBeCalledWith('/url');
     expect(formInspector.getPathsByTag).toBeCalledWith('sulu.rlp.part');
-    expect(formInspector.getValueByPath).toBeCalledWith('/ti');
-    expect(formInspector.getValueByPath).toBeCalledWith('/tle');
+    expect(formInspector.getValueByPath).toBeCalledWith('/title');
+    expect(formInspector.getValueByPath).toBeCalledWith('/subtitle');
     expect(Requester.post).toBeCalledWith(
         '/admin/api/resourcelocators?action=generate',
         {
             locale: undefined,
-            parts: {ti: 'te', tle: 'st'},
+            parts: {title: 'title-value', subtitle: 'subtitle-value'},
             resourceKey: 'test',
             webspace: 'example',
         }
@@ -471,7 +471,7 @@ test('Should not request a new URL if only empty parts are available', () => {
 
     const finishFieldHandler = formInspector.addFinishFieldHandler.mock.calls[0][0];
 
-    formInspector.getPathsByTag.mockReturnValue(['/ti', '/tle']);
+    formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
     formInspector.getValueByPath.mockReturnValueOnce(null);
     formInspector.getValueByPath.mockReturnValueOnce(undefined);
     formInspector.getSchemaEntryByPath.mockReturnValue({
@@ -483,8 +483,8 @@ test('Should not request a new URL if only empty parts are available', () => {
 
     expect(formInspector.getSchemaEntryByPath).toBeCalledWith('/url');
     expect(formInspector.getPathsByTag).toBeCalledWith('sulu.rlp.part');
-    expect(formInspector.getValueByPath).toBeCalledWith('/ti');
-    expect(formInspector.getValueByPath).toBeCalledWith('/tle');
+    expect(formInspector.getValueByPath).toBeCalledWith('/title');
+    expect(formInspector.getValueByPath).toBeCalledWith('/subtitle');
     expect(Requester.post).not.toBeCalled();
 });
 
@@ -506,9 +506,9 @@ test('Should not request a new URL if a field without the "sulu.rlp.part" tag ha
 
     const finishFieldHandler = formInspector.addFinishFieldHandler.mock.calls[0][0];
 
-    formInspector.getPathsByTag.mockReturnValue(['/ti', '/tle']);
-    formInspector.getValueByPath.mockReturnValueOnce('te');
-    formInspector.getValueByPath.mockReturnValueOnce('st');
+    formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
+    formInspector.getValueByPath.mockReturnValueOnce('title-value');
+    formInspector.getValueByPath.mockReturnValueOnce('subtitle-value');
     formInspector.getSchemaEntryByPath.mockReturnValue({
         tags: [
             {name: 'sulu.rlp'},
@@ -539,9 +539,9 @@ test('Should not request a new URL if a field without any tags has finished edit
 
     const finishFieldHandler = formInspector.addFinishFieldHandler.mock.calls[0][0];
 
-    formInspector.getPathsByTag.mockReturnValue(['/ti', '/tle']);
-    formInspector.getValueByPath.mockReturnValueOnce('te');
-    formInspector.getValueByPath.mockReturnValueOnce('st');
+    formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
+    formInspector.getValueByPath.mockReturnValueOnce('title-value');
+    formInspector.getValueByPath.mockReturnValueOnce('subtitle-value');
     finishFieldHandler('/block/0/url', '/url');
 
     expect(formInspector.getSchemaEntryByPath).toBeCalledWith('/url');
@@ -576,9 +576,9 @@ test('Should not request a new URL if the resource locator field has already bee
 
     const finishFieldHandler = formInspector.addFinishFieldHandler.mock.calls[0][0];
 
-    formInspector.getPathsByTag.mockReturnValue(['/ti', '/tle']);
-    formInspector.getValueByPath.mockReturnValueOnce('te');
-    formInspector.getValueByPath.mockReturnValueOnce('st');
+    formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
+    formInspector.getValueByPath.mockReturnValueOnce('title-value');
+    formInspector.getValueByPath.mockReturnValueOnce('subtitle-value');
     formInspector.getSchemaEntryByPath.mockReturnValue({
         tags: [
             {name: 'sulu.rlp.part'},

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -98,6 +98,7 @@ export interface FormStoreInterface {
     errors: Object,
     +finishField: (dataPath: string) => void,
     +forbidden: boolean,
+    +getPathsByTag: (tagName: string) => Array<string>,
     +getSchemaEntryByPath: (schemaPath: string) => SchemaEntry,
     +getValueByPath: (path: string) => mixed,
     +getValuesByTag: (tagName: string) => Array<mixed>,

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/ResourcelocatorControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/ResourcelocatorControllerTest.php
@@ -39,7 +39,7 @@ class ResourcelocatorControllerTest extends SuluTestCase
     public function testGenerate()
     {
         $this->client->request('POST', '/api/resourcelocators?action=generate', [
-            'parts' => ['test1', 'test2'],
+            'parts' => ['title' => 'test1', 'discription' => 'test2'],
             'locale' => 'en',
             'webspace' => 'sulu_io',
         ]);
@@ -65,7 +65,7 @@ class ResourcelocatorControllerTest extends SuluTestCase
 
         $this->client->request('POST', '/api/resourcelocators?action=generate', [
             'parentId' => $parentPage['id'],
-            'parts' => ['test1', 'test2'],
+            'parts' => ['title' => 'test1', 'discription' => 'test2'],
             'locale' => 'en',
             'webspace' => 'sulu_io',
         ]);
@@ -90,7 +90,7 @@ class ResourcelocatorControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $this->client->getResponse());
 
         $this->client->request('POST', '/api/resourcelocators?action=generate', [
-            'parts' => ['test'],
+            'parts' => ['title' => 'test'],
             'locale' => 'en',
             'webspace' => 'sulu_io',
         ]);

--- a/src/Sulu/Bundle/RouteBundle/DependencyInjection/SuluRouteExtension.php
+++ b/src/Sulu/Bundle/RouteBundle/DependencyInjection/SuluRouteExtension.php
@@ -48,13 +48,16 @@ class SuluRouteExtension extends Extension implements PrependExtensionInterface
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
         $container->setParameter('sulu_route.mappings', $config['mappings']);
+
+        $resourceKeyMappings = [];
+        foreach ($config['mappings'] as $entityClass => $mapping) {
+            $resourceKeyMappings[$mapping['resource_key']] = $mapping;
+            $resourceKeyMappings[$mapping['resource_key']]['entityClass'] = $entityClass;
+        }
+
         $container->setParameter(
             'sulu_route.resource_key_mappings',
-            array_flip(
-                array_map(function($mapping) {
-                    return $mapping['resource_key'];
-                }, $config['mappings'])
-            )
+            $resourceKeyMappings
         );
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));

--- a/src/Sulu/Bundle/RouteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/RouteBundle/Resources/config/services.xml
@@ -14,6 +14,7 @@
             <argument type="service" id="fos_rest.view_handler"/>
             <argument type="service" id="sulu.repository.route"/>
             <argument type="service" id="doctrine.orm.entity_manager"/>
+            <argument type="service" id="sulu_route.generator.route_generator"/>
             <argument>%sulu_route.resource_key_mappings%</argument>
 
             <tag name="sulu.context" context="admin"/>

--- a/src/Sulu/Bundle/RouteBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/RouteBundle/Resources/js/index.js
@@ -4,7 +4,7 @@ import {fieldRegistry, ResourceLocator} from 'sulu-admin-bundle/containers';
 import initializer from 'sulu-admin-bundle/services/initializer';
 
 initializer.addUpdateConfigHook('sulu_admin', () => {
-    const generationUrl = resourceRouteRegistry.getListUrl('routes', {action: 'generate'});
+    const routeGenerationUrl = resourceRouteRegistry.getListUrl('routes', {action: 'generate'});
 
     fieldRegistry.add(
         'route',
@@ -14,7 +14,7 @@ initializer.addUpdateConfigHook('sulu_admin', () => {
             modeResolver: () => {
                 return Promise.resolve('full');
             },
-            generationUrl: generationUrl,
+            generationUrl: routeGenerationUrl,
             options: {history: true},
         }
     );

--- a/src/Sulu/Bundle/RouteBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/RouteBundle/Resources/js/index.js
@@ -1,14 +1,21 @@
 // @flow
+import {resourceRouteRegistry} from 'sulu-admin-bundle/services/ResourceRequester';
 import {fieldRegistry, ResourceLocator} from 'sulu-admin-bundle/containers';
+import initializer from 'sulu-admin-bundle/services/initializer';
 
-fieldRegistry.add(
-    'route',
-    ResourceLocator,
-    {
-        historyResourceKey: 'routes',
-        modeResolver: () => {
-            return Promise.resolve('full');
-        },
-        options: {history: true},
-    }
-);
+initializer.addUpdateConfigHook('sulu_admin', () => {
+    const generationUrl = resourceRouteRegistry.getListUrl('routes', {action: 'generate'});
+
+    fieldRegistry.add(
+        'route',
+        ResourceLocator,
+        {
+            historyResourceKey: 'routes',
+            modeResolver: () => {
+                return Promise.resolve('full');
+            },
+            generationUrl: generationUrl,
+            options: {history: true},
+        }
+    );
+});

--- a/src/Sulu/Bundle/RouteBundle/Tests/Application/config/config.yml
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Application/config/config.yml
@@ -29,4 +29,4 @@ sulu_route:
             resource_key: tests
             generator: schema
             options:
-                route_schema: "/{object.getTitle()}"
+                route_schema: "/prefix/{object['year']}/{object['title']}"

--- a/src/Sulu/Bundle/RouteBundle/Tests/Functional/Controller/RouteControllerTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Functional/Controller/RouteControllerTest.php
@@ -24,6 +24,28 @@ class RouteControllerTest extends SuluTestCase
 
     const TEST_LOCALE = 'de';
 
+    public function testGenerate()
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->request(
+            'POST',
+            '/api/routes?action=generate',
+            [
+                'locale' => self::TEST_LOCALE,
+                'resourceKey' => self::TEST_RESOURCE_KEY,
+                'parts' => [
+                    'title' => 'test',
+                    'year' => '2019',
+                ],
+            ]
+        );
+
+        $result = json_decode($client->getResponse()->getContent(), true);
+        $this->assertHttpStatusCode(200, $client->getResponse());
+
+        $this->assertEquals($result['resourcelocator'], '/prefix/2019/test');
+    }
+
     public function testCGetAction()
     {
         $this->purgeDatabase();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR enables route-generation inside the form without saving for route field-type.

#### Why?

This is a missing feature for article and content-bundle.

#### BC Breaks/Deprecations

Yes - the resource-locator sends now the rlp parts as an object (associated array) to the resource-locator generation API.
