### PR TITLE
Allow to reusing MultiSelectionStore by passing it to the MultiAutoComplete

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,6 +7,12 @@
 The `Router` service now interprets more into the URL parameters that are passed to it. In addition to parsing numbers,
 boolean and strings to its JS equivalents, it will now do the same for `undefined` and dates in the format `yyyy-mm-dd`.
 
+### Passing MultiSelectionStore to MultiAutoComplete
+
+The `MultiAutoComplete` container component now accepts the `MultiSelectionStore` via the `store` prop, instead of
+creating it on its own. Therefore the `filterParameter`, `locale`, `onChange`, `resourceKey` and `value` prop have been
+removed. Instead a `MultiSelectionStore` has to be created manually and passed via the `store` prop.
+
 ### Configuration of list item actions
 
 The prop of the `List` container which is used to configure the item actions was changed from `actions` to 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -23,9 +23,9 @@ const USER_SETTINGS_KEY = 'selection';
 @observer
 class Selection extends React.Component<Props> {
     listStore: ?ListStore;
-    selectionStore: ?MultiSelectionStore<string | number>;
+    autoCompleteSelectionStore: ?MultiSelectionStore<string | number>;
     changeListDisposer: ?() => *;
-    changeSelectionDisposer: ?() => *;
+    changeAutoCompleteSelectionDisposer: ?() => *;
     changeListOptionsDisposer: ?() => *;
     changeLocaleDisposer: ?() => *;
 
@@ -146,18 +146,18 @@ class Selection extends React.Component<Props> {
         } else if (this.type === 'auto_complete') {
             const {value} = this.props;
 
-            this.selectionStore = new MultiSelectionStore(
+            this.autoCompleteSelectionStore = new MultiSelectionStore(
                 resourceKey,
                 value || [],
                 this.locale,
                 this.autoCompleteFilterParameter
             );
 
-            this.changeSelectionDisposer = reaction(
-                () => this.selectionStore
-                    ? this.selectionStore.items.map((item) => item[this.autoCompleteIdProperty])
+            this.changeAutoCompleteSelectionDisposer = reaction(
+                () => this.autoCompleteSelectionStore
+                    ? this.autoCompleteSelectionStore.items.map((item) => item[this.autoCompleteIdProperty])
                     : [],
-                this.handleSelectionChange
+                this.handleAutoCompleteSelectionChange
             );
         }
     }
@@ -167,8 +167,8 @@ class Selection extends React.Component<Props> {
             this.changeListDisposer();
         }
 
-        if (this.changeSelectionDisposer) {
-            this.changeSelectionDisposer();
+        if (this.changeAutoCompleteSelectionDisposer) {
+            this.changeAutoCompleteSelectionDisposer();
         }
 
         if (this.changeListOptionsDisposer) {
@@ -356,7 +356,7 @@ class Selection extends React.Component<Props> {
     };
 
     renderAutoComplete() {
-        if (!this.selectionStore) {
+        if (!this.autoCompleteSelectionStore) {
             throw new Error('The SelectionStore has not been initialized! This should not happen and is likely a bug.');
         }
 
@@ -391,7 +391,7 @@ class Selection extends React.Component<Props> {
                 id={dataPath}
                 idProperty={idProperty}
                 searchProperties={searchProperties}
-                selectionStore={this.selectionStore}
+                selectionStore={this.autoCompleteSelectionStore}
             />
         );
     }
@@ -457,16 +457,16 @@ class Selection extends React.Component<Props> {
         }
     };
 
-    handleSelectionChange = (selectedIds: Array<string | number>) => {
+    handleAutoCompleteSelectionChange = (selectedIds: Array<string | number>) => {
         const {onChange, onFinish, value} = this.props;
 
-        if (!this.selectionStore) {
+        if (!this.autoCompleteSelectionStore) {
             throw new Error(
                 'The SelectionStore has not been initialized! This should not happen and is likely a bug.'
             );
         }
 
-        if (this.selectionStore.loading) {
+        if (this.autoCompleteSelectionStore.loading) {
             return;
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -368,7 +368,6 @@ class Selection extends React.Component<Props> {
                     auto_complete: {
                         allow_add: allowAdd,
                         display_property: displayProperty,
-                        id_property: idProperty,
                         search_properties: searchProperties,
                     },
                 },
@@ -389,7 +388,7 @@ class Selection extends React.Component<Props> {
                 disabled={!!disabled}
                 displayProperty={displayProperty}
                 id={dataPath}
-                idProperty={idProperty}
+                idProperty={this.autoCompleteIdProperty}
                 searchProperties={searchProperties}
                 selectionStore={this.autoCompleteSelectionStore}
             />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import {computed, observable, intercept, toJS, reaction} from 'mobx';
 import type {IObservableValue} from 'mobx';
-import equal from 'fast-deep-equal';
+import equals from 'fast-deep-equal';
 import {observer} from 'mobx-react';
 import FormInspector from '../FormInspector';
 import List from '../../../containers/List';
@@ -87,7 +87,7 @@ class Selection extends React.Component<Props> {
                     formInspector
                 );
 
-                if (!equal(this.requestOptions, newRequestOptions)) {
+                if (!equals(this.requestOptions, newRequestOptions)) {
                     this.requestOptions = newRequestOptions;
                 }
             }
@@ -159,6 +159,21 @@ class Selection extends React.Component<Props> {
                     : [],
                 this.handleAutoCompleteSelectionChange
             );
+        }
+    }
+
+    componentDidUpdate() {
+        const {value} = this.props;
+
+        if (
+            this.type === 'auto_complete'
+            && this.autoCompleteSelectionStore
+            && !equals(
+                this.autoCompleteSelectionStore.items.map((item) => item[this.autoCompleteIdProperty]),
+                toJS(value)
+            )
+        ) {
+            this.autoCompleteSelectionStore.loadItems(value);
         }
     }
 
@@ -450,7 +465,7 @@ class Selection extends React.Component<Props> {
             return;
         }
 
-        if (!equal(toJS(value), toJS(selectedIds))) {
+        if (!equals(toJS(value), toJS(selectedIds))) {
             onChange(selectedIds);
             onFinish();
         }
@@ -469,7 +484,7 @@ class Selection extends React.Component<Props> {
             return;
         }
 
-        if (!equal(toJS(value), toJS(selectedIds))) {
+        if (!equals(toJS(value), toJS(selectedIds))) {
             onChange(selectedIds);
             onFinish();
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -17,6 +17,7 @@ jest.mock('../../../../stores/MultiSelectionStore', () => jest.fn(
         this.locale = locale;
         this.loading = false;
         this.idFilterParameter = idFilterParameter;
+        this.loadItems = jest.fn();
 
         mockExtendObservable(this, {
             items: [],
@@ -1231,6 +1232,92 @@ test('Should pass props with schema-options type correctly to MultiAutoComplete 
         searchProperties: ['name'],
         selectionStore: selection.instance().autoCompleteSelectionStore,
     }));
+});
+
+test('Should trigger a reload of the items if the value prop changes', () => {
+    const value = [1, 6, 8];
+
+    const fieldTypeOptions = {
+        default_type: 'auto_complete',
+        resource_key: 'snippets',
+        types: {
+            auto_complete: {
+                display_property: 'name',
+                filter_parameter: 'names',
+                id_property: 'uuid',
+                search_properties: ['name'],
+            },
+        },
+    };
+
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            new ResourceStore('pages', 1),
+            'pages'
+        )
+    );
+
+    userStore.contentLocale = 'de';
+
+    const selection = shallow(
+        <Selection
+            {...fieldTypeDefaultProps}
+            disabled={true}
+            fieldTypeOptions={fieldTypeOptions}
+            formInspector={formInspector}
+            value={value}
+        />
+    );
+
+    expect(selection.instance().autoCompleteSelectionStore.loadItems).not.toBeCalled();
+
+    selection.instance().autoCompleteSelectionStore.items = [{uuid: 1}, {uuid: 6}, {uuid: 8}];
+
+    selection.setProps({value: [3, 4, 7]});
+
+    expect(selection.instance().autoCompleteSelectionStore.loadItems).toBeCalledWith([3, 4, 7]);
+});
+
+test('Should not trigger a reload of the items if the value prop changes to the same value again', () => {
+    const value = [1, 6, 8];
+
+    const fieldTypeOptions = {
+        default_type: 'auto_complete',
+        resource_key: 'snippets',
+        types: {
+            auto_complete: {
+                display_property: 'name',
+                filter_parameter: 'names',
+                id_property: 'uuid',
+                search_properties: ['name'],
+            },
+        },
+    };
+
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            new ResourceStore('pages', 1),
+            'pages'
+        )
+    );
+
+    userStore.contentLocale = 'de';
+
+    const selection = shallow(
+        <Selection
+            {...fieldTypeDefaultProps}
+            disabled={true}
+            fieldTypeOptions={fieldTypeOptions}
+            formInspector={formInspector}
+            value={value}
+        />
+    );
+
+    selection.instance().autoCompleteSelectionStore.items = [{uuid: 1}, {uuid: 6}, {uuid: 8}];
+
+    selection.setProps({value: [1, 6, 8]});
+
+    expect(selection.instance().autoCompleteSelectionStore.loadItems).not.toBeCalled();
 });
 
 test('Throw an error if a none string was passed to schema-options', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -650,11 +650,11 @@ test('Should call the disposers for list selections and locale and ListStore if 
     const changeListDisposerSpy = jest.fn();
     const changeLocaleDisposerSpy = jest.fn();
     const changeListOptionsDisposerSpy = jest.fn();
-    const changeSelectionDisposerSpy = jest.fn();
+    const changeAutoCompleteSelectionDisposerSpy = jest.fn();
     selection.instance().changeListDisposer = changeListDisposerSpy;
     selection.instance().changeLocaleDisposer = changeLocaleDisposerSpy;
     selection.instance().changeListOptionsDisposer = changeListOptionsDisposerSpy;
-    selection.instance().changeSelectionDisposer = changeSelectionDisposerSpy;
+    selection.instance().changeAutoCompleteSelectionDisposer = changeAutoCompleteSelectionDisposerSpy;
     const listStoreDestroy = selection.instance().listStore.destroy;
 
     selection.unmount();
@@ -662,7 +662,7 @@ test('Should call the disposers for list selections and locale and ListStore if 
     expect(changeListDisposerSpy).toBeCalledWith();
     expect(changeLocaleDisposerSpy).toBeCalledWith();
     expect(changeListOptionsDisposerSpy).toBeCalledWith();
-    expect(changeSelectionDisposerSpy).toBeCalledWith();
+    expect(changeAutoCompleteSelectionDisposerSpy).toBeCalledWith();
     expect(listStoreDestroy).toBeCalledWith();
 });
 
@@ -1128,10 +1128,10 @@ test('Should pass props correctly to MultiAutoComplete component', () => {
         displayProperty: 'name',
         idProperty: 'uuid',
         searchProperties: ['name'],
-        selectionStore: selection.instance().selectionStore,
+        selectionStore: selection.instance().autoCompleteSelectionStore,
     }));
 
-    expect(selection.instance().selectionStore.idFilterParameter).toEqual('names');
+    expect(selection.instance().autoCompleteSelectionStore.idFilterParameter).toEqual('names');
 });
 
 test('Should pass locale from userStore to MultiAutoComplete component if form has no locale', () => {
@@ -1169,7 +1169,7 @@ test('Should pass locale from userStore to MultiAutoComplete component if form h
         />
     );
 
-    expect(selection.instance().selectionStore.locale.get()).toEqual('de');
+    expect(selection.instance().autoCompleteSelectionStore.locale.get()).toEqual('de');
 });
 
 test('Should pass props with schema-options type correctly to MultiAutoComplete component', () => {
@@ -1228,7 +1228,7 @@ test('Should pass props with schema-options type correctly to MultiAutoComplete 
         displayProperty: 'name',
         idProperty: 'uuid',
         searchProperties: ['name'],
-        selectionStore: selection.instance().selectionStore,
+        selectionStore: selection.instance().autoCompleteSelectionStore,
     }));
 });
 
@@ -1347,8 +1347,8 @@ test('Should call onChange and onFinish callback when content of selectionStore 
         />
     );
 
-    selection.instance().selectionStore.dataLoading = false;
-    selection.instance().selectionStore.items = [
+    selection.instance().autoCompleteSelectionStore.dataLoading = false;
+    selection.instance().autoCompleteSelectionStore.items = [
         {uuid: 1},
         {uuid: 2},
         {uuid: 3},

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -4,6 +4,7 @@ import {extendObservable as mockExtendObservable, observable, toJS} from 'mobx';
 import {mount, shallow} from 'enzyme';
 import fieldTypeDefaultProps from '../../../../utils/TestHelper/fieldTypeDefaultProps';
 import {translate} from '../../../../utils/Translator';
+import MultiSelectionStore from '../../../../stores/MultiSelectionStore';
 import ResourceStore from '../../../../stores/ResourceStore';
 import userStore from '../../../../stores/userStore';
 import List from '../../../List';
@@ -1122,7 +1123,7 @@ test('Should pass props correctly to MultiAutoComplete component', () => {
         />
     );
 
-    expect(selection.find('MultiAutoComplete').props()).toEqual(expect.objectContaining({
+    expect(selection.find('MultiAutoComplete').at(0).props()).toEqual(expect.objectContaining({
         allowAdd: false,
         disabled: true,
         displayProperty: 'name',
@@ -1131,7 +1132,7 @@ test('Should pass props correctly to MultiAutoComplete component', () => {
         selectionStore: selection.instance().autoCompleteSelectionStore,
     }));
 
-    expect(selection.instance().autoCompleteSelectionStore.idFilterParameter).toEqual('names');
+    expect(MultiSelectionStore).toBeCalledWith('snippets', value, locale, 'names');
 });
 
 test('Should pass locale from userStore to MultiAutoComplete component if form has no locale', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -1234,7 +1234,7 @@ test('Should pass props with schema-options type correctly to MultiAutoComplete 
     }));
 });
 
-test('Should trigger a reload of the items if the value prop changes', () => {
+test('Should trigger a reload of the auto_complete items if the value prop changes', () => {
     const value = [1, 6, 8];
 
     const fieldTypeOptions = {
@@ -1278,7 +1278,7 @@ test('Should trigger a reload of the items if the value prop changes', () => {
     expect(selection.instance().autoCompleteSelectionStore.loadItems).toBeCalledWith([3, 4, 7]);
 });
 
-test('Should not trigger a reload of the items if the value prop changes to the same value again', () => {
+test('Should not trigger a reload of the auto_complete items if the value prop changes to the same value again', () => {
     const value = [1, 6, 8];
 
     const fieldTypeOptions = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/MultiAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/MultiAutoComplete.js
@@ -1,9 +1,6 @@
 // @flow
 import React from 'react';
-import {reaction, toJS} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
-import equals from 'fast-deep-equal';
 import MultiAutoCompleteComponent from '../../components/MultiAutoComplete';
 import SearchStore from '../../stores/SearchStore';
 import MultiSelectionStore from '../../stores/MultiSelectionStore';
@@ -12,15 +9,11 @@ type Props = {|
     allowAdd: boolean,
     disabled: boolean,
     displayProperty: string,
-    filterParameter: string,
     id?: string,
     idProperty: string,
-    locale?: ?IObservableValue<string>,
-    onChange: (value: Array<string | number>) => void,
     options: Object,
-    resourceKey: string,
     searchProperties: Array<string>,
-    value: ?Array<string | number>,
+    selectionStore: MultiSelectionStore<string | number>,
 |};
 
 @observer
@@ -28,74 +21,45 @@ class MultiAutoComplete extends React.Component<Props> {
     static defaultProps = {
         allowAdd: false,
         disabled: false,
-        filterParameter: 'ids',
         idProperty: 'id',
         options: {},
     };
 
     searchStore: SearchStore;
-    selectionStore: MultiSelectionStore<string | number>;
-    changeDisposer: () => *;
 
     constructor(props: Props) {
         super(props);
 
         const {
-            filterParameter,
-            idProperty,
-            locale,
             options,
-            resourceKey,
             searchProperties,
-            value,
+            selectionStore,
         } = this.props;
 
-        this.searchStore = new SearchStore(resourceKey, searchProperties, options);
-        this.selectionStore = new MultiSelectionStore(resourceKey, value || [], locale, filterParameter);
-        this.changeDisposer = reaction(
-            () => (this.selectionStore.items.map((item) => item[idProperty])),
-            (loadedItemIds: Array<string | number>) => {
-                const {onChange, value} = this.props;
-
-                if (!equals(toJS(value), toJS(loadedItemIds))) {
-                    onChange(loadedItemIds);
-                }
-            }
-        );
-    }
-
-    componentWillUnmount() {
-        this.changeDisposer();
-    }
-
-    componentDidUpdate(prevProps: Props) {
-        const {value} = this.props;
-
-        if (!equals(prevProps.value, value)) {
-            this.selectionStore.loadItems(value);
-        }
+        this.searchStore = new SearchStore(selectionStore.resourceKey, searchProperties, options);
     }
 
     handleChange = (value: Array<Object>) => {
-        this.selectionStore.set(value);
+        const {selectionStore} = this.props;
+        selectionStore.set(value);
         this.searchStore.clearSearchResults();
     };
 
     handleSearch = (query: string) => {
-        this.searchStore.search(query, this.selectionStore.items.map((item) => item.id));
+        const {selectionStore} = this.props;
+        this.searchStore.search(query, selectionStore.ids);
     };
 
     render() {
         const {
-            props: {
-                allowAdd,
-                disabled,
-                displayProperty,
-                id,
-                idProperty,
-                searchProperties,
-            },
-        } = this;
+            allowAdd,
+            disabled,
+            displayProperty,
+            id,
+            idProperty,
+            searchProperties,
+            selectionStore,
+        } = this.props;
 
         return (
             <MultiAutoCompleteComponent
@@ -104,12 +68,12 @@ class MultiAutoComplete extends React.Component<Props> {
                 displayProperty={displayProperty}
                 id={id}
                 idProperty={idProperty}
-                loading={this.searchStore.loading || this.selectionStore.loading}
+                loading={this.searchStore.loading || selectionStore.loading}
                 onChange={this.handleChange}
                 onSearch={this.handleSearch}
                 searchProperties={searchProperties}
                 suggestions={this.searchStore.searchResults}
-                value={this.selectionStore.items || []}
+                value={selectionStore.items || []}
             />
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/README.md
@@ -1,6 +1,5 @@
-This component uses the [`MultiAutoComplete` component](#multiautocomplete) and attaches it to one of the registered
-resources. The component will then read the suggestions from the resources with the given `resourceKey`. The `value` is
-the currently selected object. There are two properties describing which properties of the fields are used, the
-`displayProperty` describes which property from the object is read to the input field and the `searchProperties` define
-which fields of the object will be searched and displayed in the suggestion list. The `onChange` callback will be
-called with the selected object when a suggestion is selected.
+This component uses the [`MultiAutoComplete` component](#multiautocomplete) and attaches it to a `MultiSelectionStore`.
+This store will contain the currently selected valued from the `MultiAutoComplete` container. The `displayProperty`
+indicates which of the properties of the items in the `MultiSelectionStore` will be used to display the items. The
+`idProperty` prop is the property of the object, that will be used to determine the unique identifier for an item. To
+define which properties will be searched by the `MultiAutoComplete` the `searchProperties` prop can be used.

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/tests/MultiAutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/tests/MultiAutoComplete.test.js
@@ -1,14 +1,20 @@
 // @flow
 import React from 'react';
 import {mount, shallow, render} from 'enzyme';
-import {extendObservable as mockExtendObservable, observable} from 'mobx';
+import {extendObservable as mockExtendObservable} from 'mobx';
 import MultiAutoComplete from '../MultiAutoComplete';
 import MultiAutoCompleteComponent from '../../../components/MultiAutoComplete';
 import SearchStore from '../../../stores/SearchStore';
 import MultiSelectionStore from '../../../stores/MultiSelectionStore';
 
 jest.mock('../../../stores/SearchStore', () => jest.fn());
-jest.mock('../../../stores/MultiSelectionStore', () => jest.fn());
+jest.mock('../../../stores/MultiSelectionStore', () => jest.fn(function(resourceKey) {
+    this.resourceKey = resourceKey;
+    this.set = jest.fn();
+    this.loading = false;
+
+    mockExtendObservable(this, {ids: [], items: []});
+}));
 
 test('Render in loading state', () => {
     // $FlowFixMe
@@ -17,22 +23,13 @@ test('Render in loading state', () => {
         this.loading = true;
     });
 
-    // $FlowFixMe
-    MultiSelectionStore.mockImplementation(function() {
-        this.set = jest.fn();
-        this.loading = true;
-        mockExtendObservable(this, {
-            items: [],
-        });
-    });
+    const selectionStore = new MultiSelectionStore('contact', []);
 
     expect(render(
         <MultiAutoComplete
             displayProperty="name"
-            onChange={jest.fn()}
-            resourceKey="test"
             searchProperties={[]}
-            value={undefined}
+            selectionStore={selectionStore}
         />
     )).toMatchSnapshot();
 });
@@ -44,22 +41,14 @@ test('Pass loading flag if MultiSelectionStore and SearchStore is loading', () =
         this.loading = true;
     });
 
-    // $FlowFixMe
-    MultiSelectionStore.mockImplementation(function() {
-        this.set = jest.fn();
-        this.loading = true;
-        mockExtendObservable(this, {
-            items: [],
-        });
-    });
+    const selectionStore = new MultiSelectionStore('contact', []);
+    selectionStore.loading = true;
 
     const multiAutoComplete = shallow(
         <MultiAutoComplete
             displayProperty="name"
-            onChange={jest.fn()}
-            resourceKey="test"
             searchProperties={[]}
-            value={undefined}
+            selectionStore={selectionStore}
         />
     );
 
@@ -73,22 +62,13 @@ test('Pass loading flag if only SearchStore is loading', () => {
         this.loading = true;
     });
 
-    // $FlowFixMe
-    MultiSelectionStore.mockImplementation(function() {
-        this.set = jest.fn();
-        this.loading = false;
-        mockExtendObservable(this, {
-            items: [],
-        });
-    });
+    const selectionStore = new MultiSelectionStore('contact', []);
 
     const multiAutoComplete = shallow(
         <MultiAutoComplete
             displayProperty="name"
-            onChange={jest.fn()}
-            resourceKey="test"
             searchProperties={[]}
-            value={undefined}
+            selectionStore={selectionStore}
         />
     );
 
@@ -102,22 +82,14 @@ test('Pass loading flag if only MultiSelectionStore is loading', () => {
         this.loading = false;
     });
 
-    // $FlowFixMe
-    MultiSelectionStore.mockImplementation(function() {
-        this.set = jest.fn();
-        this.loading = true;
-        mockExtendObservable(this, {
-            items: [],
-        });
-    });
+    const selectionStore = new MultiSelectionStore('contact', []);
+    selectionStore.loading = true;
 
     const multiAutoComplete = shallow(
         <MultiAutoComplete
             displayProperty="name"
-            onChange={jest.fn()}
-            resourceKey="test"
             searchProperties={[]}
-            value={undefined}
+            selectionStore={selectionStore}
         />
     );
 
@@ -128,22 +100,15 @@ test('Pass allowAdd and idProperty prop to component', () => {
     // $FlowFixMe
     SearchStore.mockImplementation(function() {});
 
-    // $FlowFixMe
-    MultiSelectionStore.mockImplementation(function() {
-        mockExtendObservable(this, {
-            items: [],
-        });
-    });
+    const selectionStore = new MultiSelectionStore('contact', []);
 
     const multiAutoComplete = shallow(
         <MultiAutoComplete
             allowAdd={true}
             displayProperty="name"
             idProperty="name"
-            onChange={jest.fn()}
-            resourceKey="test"
             searchProperties={[]}
-            value={undefined}
+            selectionStore={selectionStore}
         />
     );
 
@@ -165,22 +130,13 @@ test('Render with loaded suggestions', () => {
         this.loading = false;
     });
 
-    // $FlowFixMe
-    MultiSelectionStore.mockImplementation(function() {
-        this.set = jest.fn();
-        this.loading = false;
-        mockExtendObservable(this, {
-            items: [],
-        });
-    });
+    const selectionStore = new MultiSelectionStore('contact', []);
 
     const multiAutoComplete = mount(
         <MultiAutoComplete
             displayProperty="name"
-            onChange={jest.fn()}
-            resourceKey="contact"
             searchProperties={['name', 'number']}
-            value={undefined}
+            selectionStore={selectionStore}
         />
     );
 
@@ -200,27 +156,17 @@ test('Render with given value', () => {
         this.loading = false;
     });
 
-    // $FlowFixMe
-    MultiSelectionStore.mockImplementation(function() {
-        this.set = jest.fn();
-        this.loading = false;
-        mockExtendObservable(this, {
-            items: [],
-        });
-    });
+    const selectionStore = new MultiSelectionStore('contact', []);
 
     const multiAutoComplete = mount(
         <MultiAutoComplete
             displayProperty="name"
-            onChange={jest.fn()}
-            resourceKey="test"
             searchProperties={[]}
-            value={[1, 2]}
+            selectionStore={selectionStore}
         />
     );
 
-    expect(MultiSelectionStore).toBeCalledWith('test', [1, 2], undefined, 'ids');
-    multiAutoComplete.instance().selectionStore.items = [
+    selectionStore.items = [
         {id: 1, name: 'James Bond', number: '007'},
         {id: 2, name: 'John Doe', number: '005'},
     ];
@@ -235,151 +181,23 @@ test('Render in disabled state', () => {
         this.loading = false;
     });
 
-    // $FlowFixMe
-    MultiSelectionStore.mockImplementation(function() {
-        this.set = jest.fn();
-        this.loading = false;
-        mockExtendObservable(this, {
-            items: [],
-        });
-    });
+    const selectionStore = new MultiSelectionStore('contact', []);
 
     const multiAutoComplete = mount(
         <MultiAutoComplete
             disabled={true}
             displayProperty="name"
-            onChange={jest.fn()}
-            resourceKey="test"
             searchProperties={[]}
-            value={[1, 2]}
+            selectionStore={selectionStore}
         />
     );
 
-    expect(MultiSelectionStore).toBeCalledWith('test', [1, 2], undefined, 'ids');
-    multiAutoComplete.instance().selectionStore.items = [
+    selectionStore.items = [
         {id: 1, name: 'James Bond', number: '007'},
         {id: 2, name: 'John Doe', number: '005'},
     ];
 
     expect(multiAutoComplete.render()).toMatchSnapshot();
-});
-
-test('Do not load items if passed value has not changed', () => {
-    // $FlowFixMe
-    SearchStore.mockImplementation(function() {
-        this.searchResults = [];
-        this.loading = false;
-    });
-
-    // $FlowFixMe
-    MultiSelectionStore.mockImplementation(function() {
-        this.items = [];
-        this.loadItems = jest.fn();
-    });
-
-    const multiAutoComplete = mount(
-        <MultiAutoComplete
-            displayProperty="name"
-            onChange={jest.fn()}
-            resourceKey="test"
-            searchProperties={[]}
-            value={[1, 2]}
-        />
-    );
-
-    multiAutoComplete.setProps({displayProperty: 'title'});
-
-    expect(multiAutoComplete.instance().selectionStore.loadItems).not.toBeCalled();
-});
-
-test('Load items if passed value has changed', () => {
-    // $FlowFixMe
-    SearchStore.mockImplementation(function() {
-        this.searchResults = [];
-        this.loading = false;
-    });
-
-    // $FlowFixMe
-    MultiSelectionStore.mockImplementation(function() {
-        this.items = [];
-        this.loadItems = jest.fn();
-    });
-
-    const multiAutoComplete = mount(
-        <MultiAutoComplete
-            displayProperty="name"
-            onChange={jest.fn()}
-            resourceKey="test"
-            searchProperties={[]}
-            value={[1, 2]}
-        />
-    );
-
-    multiAutoComplete.setProps({value: undefined});
-
-    expect(multiAutoComplete.instance().selectionStore.loadItems).toBeCalledWith(undefined);
-});
-
-test('Pass filterParameter to MultiSelectionStore', () => {
-    // $FlowFixMe
-    SearchStore.mockImplementation(function() {
-        this.searchResults = [];
-        this.loading = false;
-    });
-
-    // $FlowFixMe
-    MultiSelectionStore.mockImplementation(function() {
-        this.set = jest.fn();
-        this.loading = false;
-        mockExtendObservable(this, {
-            items: [],
-        });
-    });
-
-    mount(
-        <MultiAutoComplete
-            displayProperty="name"
-            filterParameter="names"
-            onChange={jest.fn()}
-            resourceKey="tags"
-            searchProperties={[]}
-            value={[1, 2]}
-        />
-    );
-
-    expect(MultiSelectionStore).toBeCalledWith('tags', [1, 2], undefined, 'names');
-});
-
-test('Pass locale to MultiSelectionStore', () => {
-    const locale = observable.box('en');
-    // $FlowFixMe
-    SearchStore.mockImplementation(function() {
-        this.searchResults = [];
-        this.loading = false;
-    });
-
-    // $FlowFixMe
-    MultiSelectionStore.mockImplementation(function() {
-        this.set = jest.fn();
-        this.loading = false;
-        mockExtendObservable(this, {
-            items: [],
-        });
-    });
-
-    mount(
-        <MultiAutoComplete
-            displayProperty="name"
-            filterParameter="names"
-            locale={locale}
-            onChange={jest.fn()}
-            resourceKey="tags"
-            searchProperties={[]}
-            value={[1, 2]}
-        />
-    );
-
-    expect(MultiSelectionStore).toBeCalledWith('tags', [1, 2], locale, 'names');
 });
 
 test('Search using store when new search value is retrieved from MultiAutoComplete component', () => {
@@ -390,22 +208,13 @@ test('Search using store when new search value is retrieved from MultiAutoComple
         this.search = jest.fn();
     });
 
-    // $FlowFixMe
-    MultiSelectionStore.mockImplementation(function() {
-        this.set = jest.fn();
-        this.loading = false;
-        mockExtendObservable(this, {
-            items: [],
-        });
-    });
+    const selectionStore = new MultiSelectionStore('contact', []);
 
     const multiAutoComplete = shallow(
         <MultiAutoComplete
             displayProperty="name"
-            onChange={jest.fn()}
-            resourceKey="contact"
             searchProperties={[]}
-            value={undefined}
+            selectionStore={selectionStore}
         />
     );
 
@@ -422,35 +231,24 @@ test('Search using store with excluded-ids when new search value is retrieved fr
         this.search = jest.fn();
     });
 
-    // $FlowFixMe
-    MultiSelectionStore.mockImplementation(function() {
-        this.set = jest.fn();
-        this.loading = false;
-        mockExtendObservable(this, {
-            items: [],
-        });
-    });
+    const selectionStore = new MultiSelectionStore('contact', []);
 
     const multiAutoComplete = shallow(
         <MultiAutoComplete
             displayProperty="name"
-            onChange={jest.fn()}
-            resourceKey="contact"
             searchProperties={[]}
-            value={undefined}
+            selectionStore={selectionStore}
         />
     );
 
-    multiAutoComplete.instance().selectionStore.items = [
-        {id: 1},
-        {id: 3},
-    ];
+    // $FlowFixMe
+    selectionStore.ids = [1, 3];
     multiAutoComplete.find('MultiAutoComplete').simulate('search', 'James');
 
     expect(multiAutoComplete.instance().searchStore.search).toBeCalledWith('James', [1, 3]);
 });
 
-test('Call onChange and clear search result when chosen option has been selected', () => {
+test('Clear search result when chosen option has been selected with idProperty', () => {
     // $FlowFixMe
     SearchStore.mockImplementation(function() {
         this.searchResults = [data];
@@ -458,59 +256,7 @@ test('Call onChange and clear search result when chosen option has been selected
         this.clearSearchResults = jest.fn();
     });
 
-    // $FlowFixMe
-    MultiSelectionStore.mockImplementation(function() {
-        this.set = jest.fn();
-        this.loading = false;
-        mockExtendObservable(this, {
-            items: [],
-        });
-    });
-
-    const changeSpy = jest.fn();
-
-    const data = {
-        id: 7,
-        name: 'James Bond',
-        number: '007',
-    };
-
-    const multiAutoComplete = mount(
-        <MultiAutoComplete
-            displayProperty="name"
-            onChange={changeSpy}
-            resourceKey="contact"
-            searchProperties={[]}
-            value={[]}
-        />
-    );
-
-    multiAutoComplete.find('MultiAutoComplete > MultiAutoComplete').prop('onChange')(data);
-    expect(multiAutoComplete.instance().selectionStore.set).toBeCalledWith(data);
-    multiAutoComplete.instance().selectionStore.items = [data];
-
-    expect(changeSpy).toBeCalledWith([7]);
-    expect(multiAutoComplete.instance().searchStore.clearSearchResults).toBeCalledWith();
-});
-
-test('Call onChange and clear search result when chosen option has been selected with idProperty', () => {
-    // $FlowFixMe
-    SearchStore.mockImplementation(function() {
-        this.searchResults = [data];
-        this.loading = false;
-        this.clearSearchResults = jest.fn();
-    });
-
-    // $FlowFixMe
-    MultiSelectionStore.mockImplementation(function() {
-        this.set = jest.fn();
-        this.loading = false;
-        mockExtendObservable(this, {
-            items: [],
-        });
-    });
-
-    const changeSpy = jest.fn();
+    const selectionStore = new MultiSelectionStore('contact', []);
 
     const data = {
         id: 7,
@@ -522,141 +268,31 @@ test('Call onChange and clear search result when chosen option has been selected
         <MultiAutoComplete
             displayProperty="name"
             idProperty="number"
-            onChange={changeSpy}
-            resourceKey="contact"
             searchProperties={[]}
-            value={[]}
+            selectionStore={selectionStore}
         />
     );
 
     multiAutoComplete.find('MultiAutoComplete > MultiAutoComplete').prop('onChange')(data);
-    expect(multiAutoComplete.instance().selectionStore.set).toBeCalledWith(data);
-    multiAutoComplete.instance().selectionStore.items = [data];
+    expect(selectionStore.set).toBeCalledWith(data);
 
-    expect(changeSpy).toBeCalledWith(['007']);
     expect(multiAutoComplete.instance().searchStore.clearSearchResults).toBeCalledWith();
-});
-
-test('Should call the onChange callback if the value of the selection-store changes', () => {
-    // $FlowFixMe
-    MultiSelectionStore.mockImplementation(function() {
-        this.set = jest.fn();
-        this.loading = false;
-        mockExtendObservable(this, {
-            items: [],
-        });
-    });
-
-    const changeSpy = jest.fn();
-
-    const multiAutoComplete = mount(
-        <MultiAutoComplete
-            displayProperty="name"
-            onChange={changeSpy}
-            resourceKey="contact"
-            searchProperties={[]}
-            value={[]}
-        />
-    );
-
-    multiAutoComplete.instance().selectionStore.items = [{id: 22}, {id: 23}];
-    expect(changeSpy).toBeCalledWith([22, 23]);
-});
-
-test('Should not call onChange callback if an unrelated observable that is accessed in the callback changes', () => {
-    // $FlowFixMe
-    MultiSelectionStore.mockImplementation(function() {
-        this.set = jest.fn();
-        this.loading = false;
-        mockExtendObservable(this, {
-            items: [],
-        });
-    });
-
-    const unrelatedObservable = observable.box(22);
-    const changeSpy = jest.fn(() => {
-        jest.fn()(unrelatedObservable.get());
-    });
-
-    const multiAutoComplete = mount(
-        <MultiAutoComplete
-            displayProperty="name"
-            onChange={changeSpy}
-            resourceKey="contact"
-            searchProperties={[]}
-            value={[]}
-        />
-    );
-
-    // change callback should be called when item of the store mock changes
-    multiAutoComplete.instance().selectionStore.items = [{id: 22}, {id: 23}];
-    expect(changeSpy).toBeCalledWith([22, 23]);
-    expect(changeSpy).toHaveBeenCalledTimes(1);
-
-    // change callback should not be called when the unrelated observable changes
-    unrelatedObservable.set(55);
-    expect(changeSpy).toHaveBeenCalledTimes(1);
-});
-
-test('Should call disposer when component unmounts', () => {
-    const suggestions = [
-        {id: 7, number: '007', name: 'James Bond'},
-        {id: 6, number: '006', name: 'John Doe'},
-    ];
-
-    // $FlowFixMe
-    SearchStore.mockImplementation(function() {
-        this.searchResults = suggestions;
-        this.loading = false;
-    });
-
-    // $FlowFixMe
-    MultiSelectionStore.mockImplementation(function() {
-        this.set = jest.fn();
-        this.loading = false;
-        mockExtendObservable(this, {
-            items: [],
-        });
-    });
-
-    const multiAutoComplete = mount(
-        <MultiAutoComplete
-            displayProperty="name"
-            onChange={jest.fn()}
-            resourceKey="contact"
-            searchProperties={['name', 'number']}
-            value={undefined}
-        />
-    );
-
-    const changeDisposerSpy = jest.fn();
-    multiAutoComplete.instance().changeDisposer = changeDisposerSpy;
-    multiAutoComplete.unmount();
-
-    expect(changeDisposerSpy).toBeCalledWith();
 });
 
 test('Construct SearchStore with correct parameters on mount', () => {
     // $FlowFixMe
     SearchStore.mockImplementation(function() {});
 
-    // $FlowFixMe
-    MultiSelectionStore.mockImplementation(function() {
-        mockExtendObservable(this, {
-            items: [],
-        });
-    });
+    const selectionStore = new MultiSelectionStore('contact', []);
 
     shallow(
         <MultiAutoComplete
             allowAdd={true}
             displayProperty="name"
             idProperty="name"
-            onChange={jest.fn()}
             options={{country: 'US'}}
-            resourceKey="contact"
             searchProperties={['firstName', 'lastName']}
-            value={undefined}
+            selectionStore={selectionStore}
         />
     );
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
@@ -53,6 +53,7 @@ class MultiSelection extends React.Component<Props> {
 
         const {locale, options, resourceKey, value} = this.props;
 
+        // TODO instead of creating the store here and passing the props required for this, we should pass a store prop
         this.selectionStore = new MultiSelectionStore(resourceKey, value, locale, 'ids', options);
 
         this.changeSelectionDisposer = reaction(

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
@@ -47,6 +47,7 @@ class SingleSelection extends React.Component<Props> {
 
         const {detailOptions, locale, resourceKey, value} = this.props;
 
+        // TODO instead of creating the store here and passing the props required for this, we should pass a store prop
         this.singleSelectionStore = new SingleSelectionStore(resourceKey, value, locale, detailOptions);
         this.changeDisposer = reaction(
             () => this.singleSelectionStore.item === undefined

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/FilterOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/FilterOverlay.js
@@ -10,6 +10,7 @@ import Overlay from '../../components/Overlay';
 import MultiListOverlay from '../../containers/MultiListOverlay';
 import SingleListOverlay from '../../containers/SingleListOverlay';
 import MultiAutoComplete from '../../containers/MultiAutoComplete';
+import MultiSelectionStore from '../../stores/MultiSelectionStore';
 import {translate} from '../../utils/Translator';
 import SmartContentStore from './stores/SmartContentStore';
 import type {Conjunction, FilterCriteria, SortOrder} from './types';
@@ -46,15 +47,22 @@ class FilterOverlay extends React.Component<Props> {
     @observable showDataSourceDialog: boolean = false;
     @observable showCategoryDialog: boolean = false;
     updateFilterCriteriaDisposer: () => void;
+    tagSelectionStore: MultiSelectionStore<string | number>;
+    tagSelectionStoreDisposer: () => void;
 
     constructor(props: Props) {
         super(props);
 
         this.updateFilterCriteriaDisposer = autorun(() => this.updateFilterCriteria(this.props.smartContentStore));
+        this.tagSelectionStore = new MultiSelectionStore('tags', this.tags || [], undefined, 'names');
+        this.tagSelectionStoreDisposer = autorun(() => {
+            this.tags = this.tagSelectionStore.items.map((item) => item.name);
+        });
     }
 
     componentWillUnmount() {
         this.updateFilterCriteriaDisposer();
+        this.tagSelectionStoreDisposer();
     }
 
     @action updateFilterCriteria = (smartContentStore: SmartContentStore) => {
@@ -144,10 +152,6 @@ class FilterOverlay extends React.Component<Props> {
         }
 
         this.categoryOperator = categoryOperator;
-    };
-
-    @action handleTagsChange = (tags: Array<string | number>) => {
-        this.tags = tags;
     };
 
     @action handleTagOperatorChange = (tagOperator: string | number) => {
@@ -293,12 +297,9 @@ class FilterOverlay extends React.Component<Props> {
                                     <div className={filterOverlayStyles.tagsAutoComplete}>
                                         <MultiAutoComplete
                                             displayProperty="name"
-                                            filterParameter="names"
                                             idProperty="name"
-                                            onChange={this.handleTagsChange}
-                                            resourceKey="tags"
                                             searchProperties={['name']}
-                                            value={this.tags}
+                                            selectionStore={this.tagSelectionStore}
                                         />
                                     </div>
                                     <div className={filterOverlayStyles.tagsSelect}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MultiSelectionStore/MultiSelectionStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MultiSelectionStore/MultiSelectionStore.js
@@ -36,11 +36,6 @@ export default class MultiSelectionStore<T = string | number, U: {id: T} = Objec
         this.items = items;
     }
 
-    getById(id: T) {
-        // TODO use metadata instead of hardcoded id
-        return this.items.find((item) => item.id === id);
-    }
-
     @action removeById(id: T) {
         // TODO use metadata instead of hardcoded id
         this.items.splice(this.items.findIndex((item) => item.id === id), 1);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MultiSelectionStore/MultiSelectionStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MultiSelectionStore/MultiSelectionStore.js
@@ -1,5 +1,5 @@
 // @flow
-import {action, observable} from 'mobx';
+import {action, computed, observable} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import {arrayMove} from '../../utils';
 import {ResourceRequester} from '../../services';
@@ -27,8 +27,18 @@ export default class MultiSelectionStore<T = string | number, U: {id: T} = Objec
         this.loadItems(selectedItemIds);
     }
 
+    @computed get ids(): Array<T> {
+        // TODO use metadata instead of hardcoded id
+        return this.items.map((item) => item.id);
+    }
+
     @action set(items: Array<U>) {
         this.items = items;
+    }
+
+    getById(id: T) {
+        // TODO use metadata instead of hardcoded id
+        return this.items.find((item) => item.id === id);
     }
 
     @action removeById(id: T) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MultiSelectionStore/tests/MultiSelectionStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MultiSelectionStore/tests/MultiSelectionStore.test.js
@@ -55,6 +55,31 @@ test('Should not load items but replace current selection with empty array when 
     expect(toJS(selectionStore.items)).toEqual([]);
 });
 
+test('Should return item ids', () => {
+    const selectionStore = new MultiSelectionStore('snippets', [], observable.box('en'));
+    selectionStore.items = [{id: 1}, {id: 4}];
+
+    expect(toJS(selectionStore.ids)).toEqual([1, 4]);
+});
+
+test('Should return the item with the given ID', () => {
+    const selectionStore = new MultiSelectionStore('snippets', [], observable.box('en'));
+    const item1 = {id: 1};
+    const item2 = {id: 4};
+    selectionStore.items = [item1, item2];
+
+    expect(selectionStore.getById(4)).toEqual(item2);
+});
+
+test('Should return undefined if the given ID does not exist', () => {
+    const selectionStore = new MultiSelectionStore('snippets', [], observable.box('en'));
+    const item1 = {id: 1};
+    const item2 = {id: 4};
+    selectionStore.items = [item1, item2];
+
+    expect(selectionStore.getById(5)).toEqual(undefined);
+});
+
 test('Should load items with different filterParameter when being constructed', () => {
     const listPromise = Promise.resolve({
         _embedded: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MultiSelectionStore/tests/MultiSelectionStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MultiSelectionStore/tests/MultiSelectionStore.test.js
@@ -62,24 +62,6 @@ test('Should return item ids', () => {
     expect(toJS(selectionStore.ids)).toEqual([1, 4]);
 });
 
-test('Should return the item with the given ID', () => {
-    const selectionStore = new MultiSelectionStore('snippets', [], observable.box('en'));
-    const item1 = {id: 1};
-    const item2 = {id: 4};
-    selectionStore.items = [item1, item2];
-
-    expect(selectionStore.getById(4)).toEqual(item2);
-});
-
-test('Should return undefined if the given ID does not exist', () => {
-    const selectionStore = new MultiSelectionStore('snippets', [], observable.box('en'));
-    const item1 = {id: 1};
-    const item2 = {id: 4};
-    selectionStore.items = [item1, item2];
-
-    expect(selectionStore.getById(5)).toEqual(undefined);
-});
-
 test('Should load items with different filterParameter when being constructed', () => {
     const listPromise = Promise.resolve({
         _embedded: {

--- a/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/__snapshots__/LocationOverlay.test.js.snap
+++ b/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/__snapshots__/LocationOverlay.test.js.snap
@@ -90,7 +90,7 @@ Array [
                         >
                           <div
                             class="leaflet-tile-container leaflet-zoom-animated"
-                            style="left: 0px; top: 0px;"
+                            style="z-index: 18; left: 0px; top: 0px;"
                           >
                             <img
                               alt=""
@@ -536,7 +536,7 @@ Array [
                         >
                           <div
                             class="leaflet-tile-container leaflet-zoom-animated"
-                            style="left: 0px; top: 0px;"
+                            style="z-index: 18; left: 0px; top: 0px;"
                           >
                             <img
                               alt=""


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | extracts parts of 28ee000668f12642121777573238297388df2c58 and very small part of b9675176a43d5b397326482ca9519743d864d29a from #5035 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR changes the `MultiAutoComplete` container component to accept the `MultiSelectionStore` instead of creating it on its own.

#### Why?

Because this way it is possible to reuse the same store for multiple things, which will result in less requests. Required for the `SelectionFieldFilterType` in #5035.

#### BC Breaks/Deprecations

It changes the interface of the `MultiAutoComplete` container component.

#### To Do

- [x] Update `README.md`
- [x] Add breaking changes to UPGRADE.md
