### PR TITLE
Fix display column options in List container even when searching is disabled

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
@@ -502,7 +502,7 @@ class List extends React.Component<Props> {
         return (
             <div className={listStyles.listContainer}>
                 {header}
-                {!store.schemaLoading && (searchable || adapters.length > 1) &&
+                {!store.schemaLoading && (searchable || this.currentAdapter.hasColumnOptions || adapters.length > 1) &&
                     <div className={toolbarClass}>
                         {searchable &&
                             <Search onSearch={this.handleSearch} value={store.searchTerm.get()} />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
@@ -213,6 +213,45 @@ test('Render toolbar with given toolbar class', () => {
     expect(list.find('.toolbar').prop('className')).toEqual(expect.stringContaining('test-class'));
 });
 
+test('Do not render toolbar if list is not searchable and adapter has no column options', () => {
+    class NewTestAdapter extends TestAdapter {
+        static hasColumnOptions = false;
+    }
+    listAdapterRegistry.get.mockReturnValue(NewTestAdapter);
+
+    const listStore = new ListStore('test', 'test', 'list_test', {page: observable.box(1)});
+
+    const list = shallow(<List adapters={['table']} searchable={false} store={listStore} />);
+
+    expect(list.find('.toolbar').exists()).toBeFalsy();
+});
+
+test('Render toolbar if list is not searchable and adapter has no column options', () => {
+    class NewTestAdapter extends TestAdapter {
+        static hasColumnOptions = true;
+    }
+    listAdapterRegistry.get.mockReturnValue(NewTestAdapter);
+
+    const listStore = new ListStore('test', 'test', 'list_test', {page: observable.box(1)});
+
+    const list = shallow(<List adapters={['table']} searchable={false} store={listStore} />);
+
+    expect(list.find('.toolbar').exists()).toBeTruthy();
+});
+
+test('Render toolbar with multiple adapters if list is not searchable and adapter has no column options', () => {
+    class NewTestAdapter extends TestAdapter {
+        static hasColumnOptions = false;
+    }
+    listAdapterRegistry.get.mockReturnValue(NewTestAdapter);
+
+    const listStore = new ListStore('test', 'test', 'list_test', {page: observable.box(1)});
+
+    const list = shallow(<List adapters={['table', 'other-table']} searchable={false} store={listStore} />);
+
+    expect(list.find('.toolbar').exists()).toBeTruthy();
+});
+
 test('Render TableAdapter with correct values', () => {
     listAdapterRegistry.get.mockReturnValue(TableAdapter);
     mockStructureStrategyData = [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adjusts the `List` container to still render the column-options dropdown when searching is disabled for the `List` container.

#### Why?

Because it should still be possible to change the displayed columns even if the list is not searchable.
