### PR TITLE
Fix support for custom url protocols

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/tests/Url.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/tests/Url.test.js
@@ -184,6 +184,22 @@ test('Call onChange callback with correct mail address', () => {
     expect(url.find('.error')).toHaveLength(0);
 });
 
+test('Call onChange callback with correct value with custom protocol', () => {
+    const changeSpy = jest.fn();
+    const url = shallow(<Url onChange={changeSpy} protocols={['custom-protocol:']} value={undefined} />);
+    url.find('input').prop('onChange')({
+        currentTarget: {
+            value: '012345ABC',
+        },
+    });
+    url.find('input').prop('onBlur')();
+
+    expect(changeSpy).toBeCalledWith('custom-protocol:012345ABC');
+    expect(url.find('SingleSelect').prop('value')).toEqual('custom-protocol:');
+    expect(url.find('input').prop('value')).toEqual('012345ABC');
+    expect(url.find('.error')).toHaveLength(0);
+});
+
 test('Call onChange callback with undefined if incorrect mail address is entered', () => {
     const changeSpy = jest.fn();
     const url = shallow(<Url onChange={changeSpy} protocols={['mailto:']} value={undefined} />);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/ExternalLinkPlugin/ExternalLinkOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/ExternalLinkPlugin/ExternalLinkOverlay.js
@@ -145,7 +145,6 @@ class ExternalLinkOverlay extends React.Component<Props> {
                             onBlur={this.handleUrlBlur}
                             onChange={this.handleUrlChange}
                             onProtocolChange={this.handleProtocolChange}
-                            protocols={['http://', 'https://', 'ftp://', 'ftps://', 'mailto:']}
                             valid={true}
                             value={this.url}
                         />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Url.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Url.js
@@ -60,35 +60,34 @@ export default class Url extends React.Component<FieldTypeProps<?string>> {
                     value: defaults = [],
                 } = {},
                 schemes: {
-                    value: schemes = [
-                        {name: 'http://'},
-                        {name: 'https://'},
-                        {name: 'ftp://'},
-                        {name: 'ftps://'},
-                    ],
+                    value: schemes = undefined,
                 } = {},
             } = {},
             value,
         } = this.props;
 
-        if (!Array.isArray(schemes) || schemes.length === 0) {
-            throw new Error('The "schemes" schema option must contain some values!');
-        }
+        let protocols = undefined;
 
-        const protocols = schemes.map((scheme) => {
-            if (typeof scheme.name !== 'string') {
-                throw new Error(
-                    'Every schema in the "schemes" schemaOption must contain a string string name'
-                );
+        if (schemes) {
+            if (!Array.isArray(schemes) || schemes.length === 0) {
+                throw new Error('The "schemes" schema option must contain some values!');
             }
-            return scheme.name;
-        });
+
+            protocols = schemes.map((scheme) => {
+                if (typeof scheme.name !== 'string') {
+                    throw new Error(
+                        'Every schema in the "schemes" schemaOption must contain a string string name'
+                    );
+                }
+                return scheme.name;
+            });
+        }
 
         if (!Array.isArray(defaults)) {
             throw new Error('The "defaults" schema option must be an array!');
         }
 
-        let defaultProtocol = protocols[0];
+        let defaultProtocol = protocols ? protocols[0] : undefined;
         const defaultScheme = defaults.find((defaultOption) => defaultOption.name === 'scheme');
 
         if (defaultScheme && defaultScheme.value) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Url.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Url.test.js
@@ -65,6 +65,27 @@ test('Pass props correctly to Url component', () => {
     expect(url.find(UrlComponent).prop('disabled')).toEqual(true);
 });
 
+test('Pass no schemaOptions to Url component and render correct defaults', () => {
+    const schemaOptions = {};
+
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+    const url = shallow(
+        <Url
+            {...fieldTypeDefaultProps}
+            disabled={true}
+            formInspector={formInspector}
+            schemaOptions={schemaOptions}
+            value="http://www.sulu.io"
+        />
+    );
+
+    expect(url.find(UrlComponent).prop('protocols')).toEqual(
+        ['http://', 'https://', 'ftp://', 'ftps://', 'mailto:', 'tel:']
+    );
+    expect(url.find(UrlComponent).prop('value')).toEqual('http://www.sulu.io');
+    expect(url.find(UrlComponent).prop('disabled')).toEqual(true);
+});
+
 test('Not call changed when only protocol is given', () => {
     const schemaOptions = {
         defaults: {
@@ -87,7 +108,9 @@ test('Not call changed when only protocol is given', () => {
         />
     );
 
-    expect(url.find(UrlComponent).prop('protocols')).toEqual(['http://', 'https://', 'ftp://', 'ftps://']);
+    expect(url.find(UrlComponent).prop('protocols')).toEqual(
+        ['http://', 'https://', 'ftp://', 'ftps://', 'mailto:', 'tel:']
+    );
     expect(url.find(UrlComponent).prop('defaultProtocol')).toEqual('http://');
     expect(changeSpy).not.toBeCalled();
 });
@@ -114,7 +137,9 @@ test('Pass correct default props to Url component', () => {
         />
     );
 
-    expect(url.find(UrlComponent).prop('protocols')).toEqual(['http://', 'https://', 'ftp://', 'ftps://']);
+    expect(url.find(UrlComponent).prop('protocols')).toEqual(
+        ['http://', 'https://', 'ftp://', 'ftps://', 'mailto:', 'tel:']
+    );
     expect(changeSpy).toBeCalledWith('http://github.com');
 });
 

--- a/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/__snapshots__/LocationOverlay.test.js.snap
+++ b/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/__snapshots__/LocationOverlay.test.js.snap
@@ -90,7 +90,7 @@ Array [
                         >
                           <div
                             class="leaflet-tile-container leaflet-zoom-animated"
-                            style="left: 0px; top: 0px;"
+                            style="z-index: 18; left: 0px; top: 0px;"
                           >
                             <img
                               alt=""
@@ -536,7 +536,7 @@ Array [
                         >
                           <div
                             class="leaflet-tile-container leaflet-zoom-animated"
-                            style="left: 0px; top: 0px;"
+                            style="z-index: 18; left: 0px; top: 0px;"
                           >
                             <img
                               alt=""

--- a/src/Sulu/Bundle/PageBundle/Content/Types/Url.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/Url.php
@@ -41,6 +41,8 @@ class Url extends SimpleContentType
                 [
                     'http://' => new PropertyParameter('http://', ''),
                     'https://' => new PropertyParameter('https://', ''),
+                    'mailto:' => new PropertyParameter('mailto:', ''),
+                    'tel:' => new PropertyParameter('tel:', ''),
                     'ftp://' => new PropertyParameter('ftp://', ''),
                     'ftps://' => new PropertyParameter('ftps://', ''),
                 ],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | part of #5082
| Related issues/PRs | -
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/499

#### What's in this PR?

Fix support for custom url protocols and add `tel:` as default.

#### Why?

We should only validate protocols we know how to validate other protocols should just be ignored as valid. 

#### To Do

- [x] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
