### PR TITLE
Fix ResourceRouteRegistry to accept boxed observable inside of parameters

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/registries/resourceRouteRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/registries/resourceRouteRegistry.js
@@ -16,7 +16,7 @@ function transformParameters(parameters) {
     return Object.keys(parameters)
         .filter((parameterKey) => parameters[parameterKey] !== undefined)
         .reduce((transformedParameters, parameterKey) => {
-            const value = parameters[parameterKey];
+            const value = toJS(parameters[parameterKey]);
 
             transformedParameters[parameterKey] = transformParameter(value);
             return transformedParameters;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/tests/registries/resourceRouteRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/tests/registries/resourceRouteRegistry.test.js
@@ -1,5 +1,6 @@
 // @flow
 import SymfonyRouting from 'fos-jsrouting/router';
+import {observable} from 'mobx';
 import resourceRouteRegistry from '../../registries/resourceRouteRegistry';
 
 test('Set and get endpoints for given key', () => {
@@ -38,6 +39,26 @@ test('Set and get endpoints for given key with date parameter', () => {
         .toEqual('get_snippet?value=2013-12-24');
     expect(resourceRouteRegistry.getListUrl('snippets', {value: new Date('2020-09-07')}))
         .toEqual('get_snippets?value=2020-09-07');
+});
+
+test('Set and get endpoints for given key with boxed observable parameter', () => {
+    SymfonyRouting.generate.mockImplementation((routeName, {value}) => {
+        return routeName + '?value=' + value;
+    });
+
+    resourceRouteRegistry.setEndpoints({
+        snippets: {
+            routes: {
+                detail: 'get_snippet',
+                list: 'get_snippets',
+            },
+        },
+    });
+
+    expect(resourceRouteRegistry.getDetailUrl('snippets', {value: observable.box('boxed-value')}))
+        .toEqual('get_snippet?value=boxed-value');
+    expect(resourceRouteRegistry.getListUrl('snippets', {value: observable.box('boxed-value')}))
+        .toEqual('get_snippets?value=boxed-value');
 });
 
 test('Set and get endpoints for given key with date array parameter', () => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### Why?

For example, the `SetUnpublishedToolbarAction` passes the current locale as boxed observable. Without this fix, this will lead to the following error: `Uncaught RangeError: Maximum call stack size exceeded`
