### PR TITLE
Add single-category-selection configuration

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
@@ -5,7 +5,7 @@ import type {IObservableValue} from 'mobx';
 import type {FieldTypeProps} from '../../../types';
 import ResourceSingleSelect from '../../../containers/ResourceSingleSelect';
 import SingleAutoComplete from '../../../containers/SingleAutoComplete';
-import SingleSelectionComponent from '../../../containers/SingleSelection';
+import SingleSelectionContainer from '../../../containers/SingleSelection';
 import userStore from '../../../stores/userStore';
 import {translate} from '../../../utils/Translator';
 
@@ -105,6 +105,9 @@ export default class SingleSelection extends React.Component<Props>
                 types: {
                     value: types,
                 } = {},
+                request_parameters: {
+                    value: requestParameters = [],
+                } = {},
             } = {},
             value,
         } = this.props;
@@ -132,6 +135,10 @@ export default class SingleSelection extends React.Component<Props>
             throw new Error('The "form_options_to_list_options" option has to be an array if defined!');
         }
 
+        if (requestParameters && !Array.isArray(requestParameters)) {
+            throw new Error('The "request_parameters" option has to be an array if defined!');
+        }
+
         const formListOptions = formOptionsToListOptions
             ? formOptionsToListOptions.reduce((currentOptions, formOption) => {
                 if (!formOption.name) {
@@ -150,14 +157,24 @@ export default class SingleSelection extends React.Component<Props>
                 ...formListOptions,
                 ...typeOptions,
             }
-            : undefined;
+            : {};
+
+        if (requestParameters) {
+            requestParameters.forEach((parameter) => {
+                listOptions[parameter.name] = parameter.value;
+            });
+
+            requestParameters.forEach((parameter) => {
+                detailOptions[parameter.name] = parameter.value;
+            });
+        }
 
         if (detailOptions && typeof detailOptions !== 'object') {
             throw new Error('The "detail_options" option has to be an array if defined!');
         }
 
         return (
-            <SingleSelectionComponent
+            <SingleSelectionContainer
                 adapter={adapter}
                 allowDeselectForDisabledItems={!!allowDeselectForDisabledItems}
                 detailOptions={detailOptions}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
@@ -135,7 +135,7 @@ export default class SingleSelection extends React.Component<Props>
             throw new Error('The "form_options_to_list_options" option has to be an array if defined!');
         }
 
-        if (requestParameters && !Array.isArray(requestParameters)) {
+        if (!Array.isArray(requestParameters)) {
             throw new Error('The "request_parameters" option has to be an array if defined!');
         }
 
@@ -162,9 +162,6 @@ export default class SingleSelection extends React.Component<Props>
         if (requestParameters) {
             requestParameters.forEach((parameter) => {
                 listOptions[parameter.name] = parameter.value;
-            });
-
-            requestParameters.forEach((parameter) => {
                 detailOptions[parameter.name] = parameter.value;
             });
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
@@ -411,7 +411,7 @@ test('Pass correct props to SingleItemSelection', () => {
         emptyText: 'sulu_contact.nothing',
         icon: 'su-account',
         itemDisabledCondition: undefined,
-        listOptions: undefined,
+        listOptions: {},
         overlayTitle: 'sulu_contact.overlay_title',
         resourceKey: 'accounts',
         value,
@@ -484,6 +484,43 @@ test('Throw an error if form_options_to_list_options schema option is not an arr
             value={value}
         />
     )).toThrow('"form_options_to_list_options"');
+});
+
+test('Throw an error if request_parameters schema option is not an array', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+
+    const value = 3;
+
+    const fieldTypeOptions = {
+        default_type: 'list_overlay',
+        resource_key: 'accounts',
+        types: {
+            list_overlay: {
+                adapter: 'table',
+                display_properties: ['name'],
+                empty_text: 'sulu_contact.nothing',
+                icon: 'su-account',
+                overlay_title: 'sulu_contact.overlay_title',
+            },
+        },
+    };
+
+    const schemaOptions = {
+        request_parameters: {
+            name: 'request_parameters',
+            value: 'test',
+        },
+    };
+
+    expect(() => shallow(
+        <SingleSelection
+            {...fieldTypeDefaultProps}
+            fieldTypeOptions={fieldTypeOptions}
+            formInspector={formInspector}
+            schemaOptions={schemaOptions}
+            value={value}
+        />
+    )).toThrow('"request_parameters"');
 });
 
 test('Throw an error if item_disabled_condition schema option is not a string', () => {
@@ -641,6 +678,15 @@ test('Pass correct props with schema-options type to SingleItemSelection', () =>
             name: 'types',
             value: 'test',
         },
+        request_parameters: {
+            name: 'request_parameters',
+            value: [
+                {
+                    name: 'rootKey',
+                    value: 'testRootKey',
+                },
+            ],
+        },
     };
 
     const singleSelection = shallow(
@@ -659,6 +705,7 @@ test('Pass correct props with schema-options type to SingleItemSelection', () =>
         allowDeselectForDisabledItems: false,
         detailOptions: {
             'ghost-content': true,
+            rootKey: 'testRootKey',
         },
         disabled: true,
         disabledIds: [],
@@ -670,6 +717,7 @@ test('Pass correct props with schema-options type to SingleItemSelection', () =>
             segment: 'developer',
             webspace: 'sulu',
             types: 'test',
+            rootKey: 'testRootKey',
         },
         overlayTitle: 'sulu_contact.overlay_title',
         resourceKey: 'accounts',

--- a/src/Sulu/Bundle/CategoryBundle/Content/Types/CategorySelection.php
+++ b/src/Sulu/Bundle/CategoryBundle/Content/Types/CategorySelection.php
@@ -20,8 +20,6 @@ use Sulu\Component\Content\ContentTypeExportInterface;
 class CategorySelection extends ComplexContentType implements ContentTypeExportInterface
 {
     /**
-     * Responsible for persisting the categories in the database.
-     *
      * @var CategoryManagerInterface
      */
     private $categoryManager;

--- a/src/Sulu/Bundle/CategoryBundle/Content/Types/SingleCategorySelection.php
+++ b/src/Sulu/Bundle/CategoryBundle/Content/Types/SingleCategorySelection.php
@@ -19,8 +19,6 @@ use Sulu\Component\Content\SimpleContentType;
 class SingleCategorySelection extends SimpleContentType implements ContentTypeExportInterface
 {
     /**
-     * Responsible for persisting the categories in the database.
-     *
      * @var CategoryManagerInterface
      */
     private $categoryManager;

--- a/src/Sulu/Bundle/CategoryBundle/Content/Types/SingleCategorySelection.php
+++ b/src/Sulu/Bundle/CategoryBundle/Content/Types/SingleCategorySelection.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CategoryBundle\Content\Types;
+
+use Sulu\Bundle\CategoryBundle\Category\CategoryManagerInterface;
+use Sulu\Component\Content\Compat\PropertyInterface;
+use Sulu\Component\Content\ContentTypeExportInterface;
+use Sulu\Component\Content\SimpleContentType;
+
+class SingleCategorySelection extends SimpleContentType implements ContentTypeExportInterface
+{
+    /**
+     * Responsible for persisting the categories in the database.
+     *
+     * @var CategoryManagerInterface
+     */
+    private $categoryManager;
+
+    public function __construct(CategoryManagerInterface $categoryManager)
+    {
+        parent::__construct('single_category_selection');
+
+        $this->categoryManager = $categoryManager;
+    }
+
+    public function getContentData(PropertyInterface $property)
+    {
+        $id = $property->getValue();
+        if (!$id) {
+            return null;
+        }
+
+        $entity = $this->categoryManager->findById($id);
+        $category = $this->categoryManager->getApiObject($entity, $property->getStructure()->getLanguageCode());
+
+        return $category->toArray();
+    }
+}

--- a/src/Sulu/Bundle/CategoryBundle/DependencyInjection/SuluCategoryExtension.php
+++ b/src/Sulu/Bundle/CategoryBundle/DependencyInjection/SuluCategoryExtension.php
@@ -119,6 +119,22 @@ class SuluCategoryExtension extends Extension implements PrependExtensionInterfa
                                 ],
                             ],
                         ],
+                        'single_selection' => [
+                            'single_category_selection' => [
+                                'default_type' => 'list_overlay',
+                                'resource_key' => 'categories',
+                                'types' => [
+                                    'list_overlay' => [
+                                        'adapter' => 'tree_table_slim',
+                                        'list_key' => 'categories',
+                                        'display_properties' => ['name'],
+                                        'empty_text' => 'sulu_category.no_category_selected',
+                                        'icon' => 'fa-tags',
+                                        'overlay_title' => 'sulu_category.single_category_selection_overlay_title',
+                                    ],
+                                ],
+                            ],
+                        ],
                     ],
                 ]
             );

--- a/src/Sulu/Bundle/CategoryBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/translations/admin.de.json
@@ -5,5 +5,7 @@
     "sulu_category.keywords": "Schlüsselwörter",
     "sulu_category.keyword": "Schlüsselwort",
     "sulu_category.multiple_usage": "Mehrfachverwendung",
-    "sulu_category.all_categories": "Alle Kategorien"
+    "sulu_category.all_categories": "Alle Kategorien",
+    "sulu_category.no_category_selected": "Keine Kategorie ausgewählt",
+    "sulu_category.single_category_selection_overlay_title": "Kategorie auswählen"
 }

--- a/src/Sulu/Bundle/CategoryBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/translations/admin.en.json
@@ -5,5 +5,7 @@
     "sulu_category.keywords": "Keywords",
     "sulu_category.keyword": "Keyword",
     "sulu_category.multiple_usage": "Multiple Usage",
-    "sulu_category.all_categories": "All categories"
+    "sulu_category.all_categories": "All categories",
+    "sulu_category.no_category_selected": "No category selected",
+    "sulu_category.single_category_selection_overlay_title": "Choose category"
 }

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Content/Types/SingleCategorySelectionTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Content/Types/SingleCategorySelectionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CategoryBundle\Tests\Unit\Content\Types;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Sulu\Bundle\CategoryBundle\Api\Category;
+use Sulu\Bundle\CategoryBundle\Category\CategoryManagerInterface;
+use Sulu\Bundle\CategoryBundle\Content\Types\SingleCategorySelection;
+use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
+use Sulu\Component\Content\Compat\Property;
+use Sulu\Component\Content\Compat\StructureInterface;
+
+class SingleCategorySelectonTest extends TestCase
+{
+    public function testGetContentData()
+    {
+        $entity = $this->prophesize(CategoryInterface::class);
+
+        $category = $this->prophesize(Category::class);
+        $category->toArray()->willReturn(['title' => 'Sulu is awesome']);
+
+        $structure = $this->prophesize(StructureInterface::class);
+        $structure->getLanguageCode()->willReturn('de');
+
+        $property = $this->prophesize(Property::class);
+        $property->getValue()->willReturn(1);
+        $property->getStructure()->willReturn($structure->reveal());
+
+        $categoryManager = $this->prophesize(CategoryManagerInterface::class);
+        $categoryManager->findById(1)->willReturn($entity);
+        $categoryManager->getApiObject($entity, 'de')->willReturn($category);
+
+        $categoryList = new SingleCategorySelection($categoryManager->reveal());
+
+        $result = $categoryList->getContentData($property->reveal());
+
+        $this->assertEquals(['title' => 'Sulu is awesome'], $result);
+    }
+
+    public function testGetContentDataNullPropertyValue()
+    {
+        $property = $this->prophesize(Property::class);
+        $property->getValue()->willReturn(null);
+
+        $categoryManager = $this->prophesize(CategoryManagerInterface::class);
+        $categoryManager->findById(Argument::any())->shouldNotBeCalled();
+
+        $categoryList = new SingleCategorySelection($categoryManager->reveal());
+
+        $result = $categoryList->getContentData($property->reveal());
+
+        $this->assertNull($result);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/500

#### What's in this PR?

This PR add the configuration for `single_category_selection` and add the `request_parameter` schema-param to the single-selection.

#### Example Usage

~~~xml
        <property name="languageCategory" type="single_category_selection">
            <meta>
                <title>app.language_category</title>
            </meta>

            <params>
                <param name="request_parameters" type="collection">
                    <param name="rootKey" value="test"/>
                </param>
            </params>
        </property>
~~~

#### TODO

 - [x] Docs
 - [x] Content Type