### PR TITLE
Fix sorting of category medias

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,15 @@
 # Upgrade
 
+## release/2.0
+
+### Add position to category medias
+
+Currently the category media sorting was not saved for this the following database update is needed:
+
+```sql
+ALTER TABLE ca_category_translation_medias ADD id INT AUTO_INCREMENT NOT NULL, ADD position INT DEFAULT 0 NOT NULL, DROP PRIMARY KEY, ADD PRIMARY KEY (id);
+```
+
 ## 2.0.4
 
 ### Replace {host} placeholder right after loading webspaces

--- a/src/Sulu/Bundle/CategoryBundle/Entity/CategoryTranslation.php
+++ b/src/Sulu/Bundle/CategoryBundle/Entity/CategoryTranslation.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\CategoryBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Sulu\Bundle\MediaBundle\Entity\Media;
 use Sulu\Component\Security\Authentication\UserInterface;
 
 /**
@@ -32,7 +31,7 @@ class CategoryTranslation implements CategoryTranslationInterface
     protected $description;
 
     /**
-     * @var Media[]
+     * @var CategoryTranslationMedia[]
      */
     protected $medias;
 
@@ -108,12 +107,36 @@ class CategoryTranslation implements CategoryTranslationInterface
 
     public function getMedias()
     {
-        return $this->medias;
+        $medias = [];
+
+        foreach ($this->medias as $media) {
+            $medias[] = $media->getMedia();
+        }
+
+        return $medias;
     }
 
     public function setMedias($medias)
     {
-        $this->medias = $medias;
+        $position = 0;
+        foreach ($this->medias as $media) {
+            $mediaEntity = $medias[$position] ?? null;
+            ++$position;
+
+            if (!$mediaEntity) {
+                $this->medias->removeElement($media);
+
+                continue;
+            }
+
+            $media->setMedia($mediaEntity);
+            $media->setPosition($position);
+        }
+
+        for (; $position < count($medias); ++$position) {
+            $media = new CategoryTranslationMedia($this, $medias[$position], $position + 1);
+            $this->medias->add($media);
+        }
     }
 
     public function setLocale($locale)

--- a/src/Sulu/Bundle/CategoryBundle/Entity/CategoryTranslationMedia.php
+++ b/src/Sulu/Bundle/CategoryBundle/Entity/CategoryTranslationMedia.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CategoryBundle\Entity;
+
+use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
+
+class CategoryTranslationMedia
+{
+    /**
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @var CategoryTranslationInterface
+     */
+    protected $categoryTranslation;
+
+    /**
+     * @var MediaInterface
+     */
+    protected $media;
+
+    /**
+     * @var int
+     */
+    protected $position = 0;
+
+    public function __construct(CategoryTranslationInterface $categoryTranslation, MediaInterface $media, int $position)
+    {
+        $this->categoryTranslation = $categoryTranslation;
+        $this->media = $media;
+        $this->position = $position;
+    }
+
+    public function setCategoryTranslation(CategoryTranslationInterface $categoryTranslation): self
+    {
+        $this->categoryTranslation = $categoryTranslation;
+
+        return $this;
+    }
+
+    public function getCategoryTranslation(): CategoryTranslationInterface
+    {
+        return $this->categoryTranslation;
+    }
+
+    public function getMedia()
+    {
+        return $this->media;
+    }
+
+    public function setMedia(MediaInterface $media): self
+    {
+        $this->media = $media;
+
+        return $this;
+    }
+
+    public function setPosition(int $position): self
+    {
+        $this->position = $position;
+
+        return $this;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+}

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/CategoryTranslation.orm.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/CategoryTranslation.orm.xml
@@ -12,19 +12,14 @@
         <field name="locale" column="locale" type="string" length="5"/>
         <field name="description" type="text" column="description" nullable="true"/>
 
-        <many-to-many field="medias" target-entity="Sulu\Bundle\MediaBundle\Entity\MediaInterface">
-            <join-table name="ca_category_translation_medias">
-                <join-columns>
-                    <join-column name="idCategoryTranslations" referenced-column-name="id" on-delete="CASCADE" nullable="false"/>
-                </join-columns>
-                <inverse-join-columns>
-                    <join-column name="idMedia" referenced-column-name="id" on-delete="CASCADE" nullable="false"/>
-                </inverse-join-columns>
-            </join-table>
+        <one-to-many field="medias" target-entity="Sulu\Bundle\CategoryBundle\Entity\CategoryTranslationMedia" mapped-by="categoryTranslation" orphan-removal="true">
+            <cascade>
+                <cascade-persist />
+            </cascade>
             <order-by>
-                <order-by-field name="id" direction="ASC"/>
+                <order-by-field name="position" direction="ASC"/>
             </order-by>
-        </many-to-many>
+        </one-to-many>
 
         <many-to-one field="category" target-entity="Sulu\Bundle\CategoryBundle\Entity\CategoryInterface" inversed-by="translations">
             <cascade>

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/CategoryTranslationMedia.orm.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/CategoryTranslationMedia.orm.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Sulu\Bundle\CategoryBundle\Entity\CategoryTranslationMedia" table="ca_category_translation_medias">
+        <id name="id" type="integer" column="id">
+            <generator strategy="AUTO"/>
+        </id>
+
+        <field name="position" column="position" type="integer">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+
+        <many-to-one field="categoryTranslation" target-entity="Sulu\Bundle\CategoryBundle\Entity\CategoryTranslation" inversed-by="medias">
+            <join-columns>
+                <join-column name="idCategoryTranslations" referenced-column-name="id" on-delete="CASCADE" nullable="false"/>
+            </join-columns>
+        </many-to-one>
+
+        <many-to-one field="media" target-entity="Sulu\Bundle\MediaBundle\Entity\MediaInterface">
+            <join-columns>
+                <join-column name="idMedia" referenced-column-name="id" on-delete="CASCADE" nullable="false"/>
+            </join-columns>
+        </many-to-one>
+    </entity>
+</doctrine-mapping>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5073 
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix sorting of category medias

#### Why?

The categories are sortable in the UI so the position should also be saved to the database.

#### BC Breaks/Deprecations

Documented in the UPGRADE.md

#### To Do

- [ ] ~~Create a documentation PR~~
- [x] Add breaking changes to UPGRADE.md
