### PR TITLE
Register CategoryManagerInterface::class as alias for sulu_category.category_manager service

### DIFF
--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/services.xml
@@ -10,6 +10,7 @@
             <argument type="service" id="sulu_security.security_checker"/>
             <argument type="service" id="sulu.core.localization_manager"/>
         </service>
+
         <service id="sulu_category.category_manager" class="Sulu\Bundle\CategoryBundle\Category\CategoryManager" public="true">
             <argument type="service" id="sulu.repository.category"/>
             <argument type="service" id="sulu.repository.category_meta"/>
@@ -19,6 +20,8 @@
             <argument type="service" id="doctrine.orm.entity_manager"/>
             <argument type="service" id="event_dispatcher"/>
         </service>
+        <service id="Sulu\Bundle\CategoryBundle\Category\CategoryManagerInterface" alias="sulu_category.category_manager"/>
+
         <service id="sulu_category.content.type.category_selection" class="Sulu\Bundle\CategoryBundle\Content\Types\CategorySelection">
             <tag name="sulu.content.type" alias="category_selection"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />


### PR DESCRIPTION
#### Why?

To allow for autowiring the `sulu_category.category_manager` service.