### PR TITLE
Fix disabled request analyzer for esi requests

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/RouterListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/RouterListener.php
@@ -55,7 +55,7 @@ class RouterListener implements EventSubscriberInterface
         // Would be nice to also only call this if the _requestAnalyzer attribute is set, but it's set on the next line
         $this->requestAnalyzer->analyze($request);
         $this->baseRouteListener->onKernelRequest($event);
-        if (false !== $request->attributes->get(static::REQUEST_ANALYZER, true)) {
+        if (false !== $request->attributes->getBoolean(static::REQUEST_ANALYZER, true)) {
             $this->requestAnalyzer->validate($request);
         }
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/EventListener/RouterListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/EventListener/RouterListenerTest.php
@@ -70,6 +70,17 @@ class RouterListenerTest extends \PHPUnit_Framework_TestCase
         $this->routerListener->onKernelRequest($this->event->reveal());
     }
 
+    public function testAnalyzeRequestDisabledByEsiInProdEnv()
+    {
+        $request = new Request([], [], ['_requestAnalyzer' => '0']);
+        $this->event->getRequest()->willReturn($request);
+
+        $this->requestAnalyzer->analyze($request)->shouldBeCalled();
+        $this->requestAnalyzer->validate($request)->shouldNotBeCalled();
+
+        $this->routerListener->onKernelRequest($this->event->reveal());
+    }
+
     public function testAnalyzeRequestDefault()
     {
         $request = new Request();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Use `getBoolean` value for getting `_requestAnalyzer` attribute to support esi correctly.  

#### Why?

When disabling the requestAnalyzer for a esi request like here:

 ```twig
    {{ render_esi(controller('SuluFormBundle:FormWebsite:token', {
        'form': form.parent.vars.name,
        'html': true,
        _requestAnalyzer: false }))
    }}
```

On **PROD** environment the esi will generate a url with `/_fragment?...&_requestAnalyer=0` which will then by symfony set as request.attributes. As it is a string it currently does not work and if you called controller does not match sulu will throw a `UrlMatchNotFoundException`.

#### Example Usage

~~~php
    {{ render_esi(controller('SuluFormBundle:FormWebsite:token', {
        'form': form.parent.vars.name,
        'html': true,
        _requestAnalyzer: false }))
    }}
~~~

Configure a webspace like e.g.:

```xml
<url lang="en">yourdomain.com/en</url>
```
