### PR TITLE
Allow usage of twig ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,7 +99,7 @@
         "symfony/validator": "^4.3",
         "symfony/yaml": "^4.3",
         "toflar/psr6-symfony-http-cache-store": "^1.1 || ^2.0",
-        "twig/twig": "^1.41 || ^2.0"
+        "twig/twig": "^1.41 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "contao/imagine-svg": "^0.2.2",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | part of #4798
| License | MIT
| Documentation PR | -

#### What's in this PR?

Allow usage and installation of twig ^3.0

#### Why?

To allow also the newer version of twig to be installed, will also be needed for Symfony 5 upgrade.

