### PR TITLE
Remove kernel.root_dir requirement from cache clearer

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,11 @@
 
 ## dev-master
 
+### CacheClearer service changed
+
+The CacheClearer service `sulu_website.http_cache.clearer` constructor arguments has changed. The third argument the
+`$kernelRootDir` has been removed. If you did overwrite or extend this service you need to update the constructor call of it.
+
 ### Router attributes
 
 The `Router` service now interprets more into the URL parameters that are passed to it. In addition to parsing numbers,

--- a/src/Sulu/Bundle/WebsiteBundle/Cache/CacheClearer.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Cache/CacheClearer.php
@@ -25,11 +25,6 @@ class CacheClearer implements CacheClearerInterface
     /**
      * @var string
      */
-    private $kernelRootDir;
-
-    /**
-     * @var string
-     */
     private $kernelEnvironment;
 
     /**
@@ -60,13 +55,11 @@ class CacheClearer implements CacheClearerInterface
     public function __construct(
         Filesystem $filesystem,
         $kernelEnvironment,
-        $kernelRootDir,
         RequestStack $requestStack,
         EventDispatcherInterface $eventDispatcher,
-        $varDir = null,
+        string $varDir,
         ?CacheManager $cacheManager
     ) {
-        $this->kernelRootDir = $kernelRootDir;
         $this->kernelEnvironment = $kernelEnvironment;
         $this->filesystem = $filesystem;
         $this->varDir = $varDir;
@@ -92,7 +85,7 @@ class CacheClearer implements CacheClearerInterface
 
         $path = sprintf(
             '%s/cache/common/%s/http_cache',
-            $this->varDir ?: $this->kernelRootDir,
+            $this->varDir,
             $this->kernelEnvironment
         );
 

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -244,7 +244,6 @@
         <service id="sulu_website.http_cache.clearer" class="Sulu\Bundle\WebsiteBundle\Cache\CacheClearer" public="true">
             <argument type="service" id="filesystem"/>
             <argument type="string">%kernel.environment%</argument>
-            <argument type="string">%kernel.root_dir%</argument>
             <argument type="service" id="request_stack"/>
             <argument type="service" id="event_dispatcher"/>
             <argument>%kernel.project_dir%/var</argument>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | part of #4798
| License | MIT
| Documentation PR | -

#### What's in this PR?

Remove kernel.root_dir requirement from cache clearer.

#### Why?

The kernel.root_dir is deprecated since symfony 4 and should not longer be used.

#### BC Breaks/Deprecations

The CacheClearer constructor arguments changed.

#### To Do

- [ ] ~~Create a documentation PR~~
- [x] Add breaking changes to UPGRADE.md
