### PR TITLE
Add missing exit code for all commands

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Command/DownloadBuildCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/DownloadBuildCommand.php
@@ -145,6 +145,8 @@ class DownloadBuildCommand extends Command
         }
 
         unlink($tempFileZip);
+
+        return 0;
     }
 
     private function getLocaleFileHash(string $path)

--- a/src/Sulu/Bundle/CategoryBundle/Command/RecoverCommand.php
+++ b/src/Sulu/Bundle/CategoryBundle/Command/RecoverCommand.php
@@ -126,6 +126,8 @@ class RecoverCommand extends Command
         if (true === $success) {
             $output->writeln('<info>Recovery complete<info>');
         }
+
+        return 0;
     }
 
     /**

--- a/src/Sulu/Bundle/ContactBundle/Command/AccountRecoverCommand.php
+++ b/src/Sulu/Bundle/ContactBundle/Command/AccountRecoverCommand.php
@@ -126,6 +126,8 @@ class AccountRecoverCommand extends Command
         if (true === $success) {
             $output->writeln('<info>Recovery complete<info>');
         }
+
+        return 0;
     }
 
     /**

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/FixturesLoadCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/FixturesLoadCommand.php
@@ -146,5 +146,7 @@ EOT
             '<info>Done. Executed </info>%s</info><info> fixtures.</info>',
             count($fixtures)
         ));
+
+        return 0;
     }
 }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/InitializeCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/InitializeCommand.php
@@ -51,10 +51,10 @@ class InitializeCommand extends Command
             ->addOption('force', null, InputOption::VALUE_NONE, 'Do not ask for confiration.')
             ->setHelp(<<<'EOT'
 Initialize the PHPCR content repository. This command
-will call registered initializers. 
+will call registered initializers.
 
     <info>$ %command.full_name%</info>
-    
+
 WARNING: Initializers SHOULD be idempotent and it SHOULD be safe to run this
          command multiple times - but as we have no control over which initializers are
          registered and what they do this cannot be guaranteed, so use at your own
@@ -73,10 +73,12 @@ EOT
             if (false === $this->questionHelper->ask($input, $output, $question)) {
                 $output->writeln('Cancelled');
 
-                return;
+                return 0;
             }
         }
 
         $this->initializer->initialize($output, $purge);
+
+        return 0;
     }
 }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/SubscriberDebugCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/SubscriberDebugCommand.php
@@ -79,6 +79,8 @@ class SubscriberDebugCommand extends Command
         $table->setHeaders(['Class', 'Method', 'Priority']);
         $table->setRows($rows);
         $table->render();
+
+        return 0;
     }
 
     private function getPriority($eventName, $methodName, $listener)
@@ -132,5 +134,7 @@ class SubscriberDebugCommand extends Command
             ]);
         }
         $table->render();
+
+        return 0;
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Command/ClearCacheCommand.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/ClearCacheCommand.php
@@ -47,5 +47,7 @@ class ClearCacheCommand extends Command
 
         $output->writeln('Clearing the Sulu media format cache.');
         $this->cacheClearer->clear($cache);
+
+        return 0;
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Command/FormatCacheCleanupCommand.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/FormatCacheCleanupCommand.php
@@ -114,6 +114,8 @@ class FormatCacheCleanupCommand extends Command
         } else {
             $ui->success($message);
         }
+
+        return 0;
     }
 
     private function mediaExists($mediaId)

--- a/src/Sulu/Bundle/MediaBundle/Command/InitCommand.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/InitCommand.php
@@ -52,5 +52,7 @@ class InitCommand extends Command
         } else {
             $output->writeLn('Directory "' . $this->formatCacheDir . '"" already exists');
         }
+
+        return 0;
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Command/MediaTypeUpdateCommand.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/MediaTypeUpdateCommand.php
@@ -80,5 +80,7 @@ class MediaTypeUpdateCommand extends Command
         } else {
             $output->writeln('<comment>Nothing to update</comment>');
         }
+
+        return 0;
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Command/CleanupHistoryCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/CleanupHistoryCommand.php
@@ -92,6 +92,8 @@ EOT
         } else {
             $output->writeln('<info>Dry run complete</info>');
         }
+
+        return 0;
     }
 
     private function cleanSession(OutputInterface $output, SessionInterface $session, $path, $dryRun)

--- a/src/Sulu/Bundle/PageBundle/Command/ContentLocaleCopyCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/ContentLocaleCopyCommand.php
@@ -107,6 +107,8 @@ EOT
         } else {
             $this->output->writeln('<info>Dry run complete</info>');
         }
+
+        return 0;
     }
 
     private function copyNodes($webspaceKey, $srcLocale, $destLocale, $overwrite)

--- a/src/Sulu/Bundle/PageBundle/Command/MaintainResourceLocatorCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/MaintainResourceLocatorCommand.php
@@ -94,6 +94,8 @@ class MaintainResourceLocatorCommand extends Command
         }
 
         $this->liveSession->save();
+
+        return 0;
     }
 
     private function upgradeWebspace(Webspace $webspace, OutputInterface $output)

--- a/src/Sulu/Bundle/PageBundle/Command/ValidatePagesCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/ValidatePagesCommand.php
@@ -157,5 +157,7 @@ class ValidatePagesCommand extends Command
         } else {
             $output->writeln(sprintf('<ok>%s Errors found</ok>', $result));
         }
+
+        return 0;
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Command/ValidateWebspacesCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/ValidateWebspacesCommand.php
@@ -120,6 +120,8 @@ class ValidateWebspacesCommand extends Command
 
             return 1;
         }
+
+        return 0;
     }
 
     /**

--- a/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
@@ -196,6 +196,8 @@ class WebspaceCopyCommand extends Command
         }
 
         $this->output->writeln('<info>Done</info>');
+
+        return 0;
     }
 
     /**

--- a/src/Sulu/Bundle/PageBundle/Command/WebspaceExportCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/WebspaceExportCommand.php
@@ -79,7 +79,7 @@ class WebspaceExportCommand extends Command
         if (!$helper->ask($input, $output, $question)) {
             $output->writeln('<error>Abort!</error>');
 
-            return;
+            return 0;
         }
 
         $output->writeln('<info>Continue!</info>');

--- a/src/Sulu/Bundle/RouteBundle/Command/UpdateRouteCommand.php
+++ b/src/Sulu/Bundle/RouteBundle/Command/UpdateRouteCommand.php
@@ -131,5 +131,7 @@ EOT
 
         //$progressBar->finish();
         $output->writeln('');
+
+        return 0;
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/Command/CreateRoleCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/CreateRoleCommand.php
@@ -121,6 +121,8 @@ class CreateRoleCommand extends Command
                 $role->getSystem()
             )
         );
+
+        return 0;
     }
 
     /**

--- a/src/Sulu/Bundle/SecurityBundle/Command/CreateUserCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/CreateUserCommand.php
@@ -191,6 +191,8 @@ class CreateUserCommand extends Command
         $output->writeln(
             sprintf('Created user "<comment>%s</comment>" in role "<comment>%s</comment>"', $username, $roleName)
         );
+
+        return 0;
     }
 
     /**

--- a/src/Sulu/Bundle/SnippetBundle/Command/SnippetExportCommand.php
+++ b/src/Sulu/Bundle/SnippetBundle/Command/SnippetExportCommand.php
@@ -47,5 +47,7 @@ class SnippetExportCommand extends Command
         $file = $this->snippetExporter->export($locale, $output, '1.2.xliff');
 
         file_put_contents($target, $file);
+
+        return 0;
     }
 }

--- a/src/Sulu/Bundle/SnippetBundle/Command/SnippetImportCommand.php
+++ b/src/Sulu/Bundle/SnippetBundle/Command/SnippetImportCommand.php
@@ -80,7 +80,7 @@ class SnippetImportCommand extends Command
         if (!$helper->ask($input, $output, $question)) {
             $output->writeln('<error>Abort!</error>');
 
-            return;
+            return 0;
         }
 
         $output->writeln('<info>Continue!</info>');

--- a/src/Sulu/Bundle/SnippetBundle/Command/SnippetLocaleCopyCommand.php
+++ b/src/Sulu/Bundle/SnippetBundle/Command/SnippetLocaleCopyCommand.php
@@ -125,6 +125,8 @@ EOT
         } else {
             $this->output->writeln('<info>Dry run complete</info>');
         }
+
+        return 0;
     }
 
     private function copyDocuments($srcLocale, $destLocale, $overwrite)

--- a/src/Sulu/Bundle/WebsiteBundle/Command/DumpSitemapCommand.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Command/DumpSitemapCommand.php
@@ -117,6 +117,8 @@ class DumpSitemapCommand extends Command
         foreach ($hosts as $host) {
             $this->sitemapDumper->dumpHost($this->scheme, $host);
         }
+
+        return 0;
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | part of #4798
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add missing exit status for all commands.

#### Why?

Having commands without exit status is deprecated all commands need to return int in Symfony 5.

#### BC Breaks/Deprecations

None.

#### To Do

- [ ] ~~Create a documentation PR~~
- [ ] ~~Add breaking changes to UPGRADE.md~~
