### PR TITLE
Add sulu admin http client service

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -158,8 +158,12 @@
             <tag name="jms_serializer.event_subscriber"/>
         </service>
 
+        <service id="sulu_admin.http_client" class="Symfony\Contracts\HttpClient\HttpClientInterface">
+            <factory class="Symfony\Component\HttpClient\HttpClient" method="create"/>
+        </service>
+
         <service id="sulu_admin.download_build_command" class="Sulu\Bundle\AdminBundle\Command\DownloadBuildCommand">
-            <argument type="service" id="http_client" />
+            <argument type="service" id="sulu_admin.http_client" />
             <argument>%kernel.project_dir%</argument>
             <argument>%sulu.version%</argument>
             <tag name="console.command"/>
@@ -169,7 +173,7 @@
             id="sulu_admin.download_language_command"
             class="Sulu\Bundle\AdminBundle\Command\DownloadLanguageCommand"
         >
-            <argument type="service" id="http_client" />
+            <argument type="service" id="sulu_admin.http_client" />
             <argument type="service" id="filesystem" />
             <argument>%kernel.project_dir%</argument>
             <argument>%sulu_core.locales%</argument>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | part of #4798
| License | MIT
| Documentation PR | -

#### What's in this PR?

Add sulu admin http client service.

#### Why?

The `http_client` service is not available by default in Symfony 5 and the config to activate the `http_client` service does only exist since Symfony 4.4 so we have 2 possibilities.

**A.:** **Keep support for symfony 4.3** Create a custom http_client service like in this pull request. Disadvantage request by a custom http_client are not displayed in the symfony web profiler.

**B.:** **Drop support for `symfony/framework-bundle` 4.3** which basically means dropping whole symfony 4.3 support for sulu 2.1 then we could `prepend` the framework bundle configuration:

```yaml
framework:
     http_client:
           enabled: true
```
