### PR TITLE
Fix handling of content-type header in Website and SearchController

### DIFF
--- a/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
+++ b/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
@@ -99,13 +99,23 @@ class WebsiteSearchController
             throw new NotFoundHttpException();
         }
 
-        return new Response($this->twig->render(
+        $response = new Response($this->twig->render(
             $template,
             $this->parameterResolver->resolve(
                 ['query' => $query, 'hits' => $hits],
                 $this->requestAnalyzer
             )
         ));
+
+        // we need to set the content type ourselves here
+        // else symfony will use the accept header of the client and the page could be cached with false content-type
+        // see following symfony issue: https://github.com/symfony/symfony/issues/35694
+        $mimeType = $request->getMimeType($request->getRequestFormat());
+        if ($mimeType) {
+            $response->headers->set('Content-Type', $mimeType);
+        }
+
+        return $response;
     }
 
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
@@ -43,9 +43,11 @@ abstract class WebsiteController extends AbstractController
         $preview = false,
         $partial = false
     ) {
+        /** @var Request $request */
+        $request = $this->getRequest();
+
         // extract format twig file
         if (!$preview) {
-            $request = $this->getRequest();
             $requestFormat = $request->getRequestFormat();
         } else {
             $requestFormat = 'html';
@@ -83,6 +85,15 @@ abstract class WebsiteController extends AbstractController
         }
 
         $response = new Response($content);
+
+        // we need to set the content type ourselves here
+        // else symfony will use the accept header of the client and the page could be cached with false content-type
+        // see following symfony issue: https://github.com/symfony/symfony/issues/35694
+        $mimeType = $request->getMimeType($requestFormat);
+
+        if ($mimeType) {
+            $response->headers->set('Content-Type', $mimeType);
+        }
 
         if (!$preview && $this->getCacheTimeLifeEnhancer()) {
             $this->getCacheTimeLifeEnhancer()->enhance($response, $structure);
@@ -142,7 +153,7 @@ abstract class WebsiteController extends AbstractController
     /**
      * Returns the current request from the request stack.
      *
-     * @return null|Request
+     * @return Request
      *
      * @deprecated will be remove with 2.0
      */

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/config_website.yml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/config_website.yml
@@ -3,3 +3,10 @@ imports:
 
 framework:
     router: { resource: "%kernel.project_dir%/config/routing_website.yml" }
+
+twig:
+    paths: ['%kernel.project_dir%/templates']
+
+fos_rest:
+    zone:
+        - { path: ^/admin/* }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/templates/pages/default.xml
@@ -7,8 +7,8 @@
 
     <key>default</key>
 
-    <view>ClientWebsiteBundle:templates:animals</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <view>default</view>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/templates/pages/overview.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/templates/pages/overview.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" ?>
 <template xmlns="http://schemas.sulu.io/template/template"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template.xsd">
-
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd"
+>
     <key>overview</key>
 
-    <view>page.html.twig</view>
-    <controller>SuluPageBundle:Default:index</controller>
+    <view>default</view>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <properties>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/templates/pages/simple.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/templates/pages/simple.xml
@@ -7,8 +7,8 @@
 
     <key>default</key>
 
-    <view>ClientWebsiteBundle:templates:animals</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <view>default</view>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/templates/default.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/templates/default.html.twig
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="{{ app.reqest.locale }}">
+<head>
+    <title>{{ content.title }}</title>
+</head>
+<body>
+    {% block content %}
+        <h1>
+            {{- content.title -}}
+        </h1>
+    {% endblock %}
+</body>
+</html>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/WebsiteControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/WebsiteControllerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Tests\Functional\Controller;
+
+use Sulu\Bundle\TestBundle\Testing\WebsiteTestCase;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+class WebsiteControllerTest extends WebsiteTestCase
+{
+    public function setUp(): void
+    {
+        $this->initPhpcr();
+    }
+
+    public function testPage()
+    {
+        /** @var KernelBrowser $client */
+        $client = $this->createWebsiteClient();
+
+        $client->request('GET', 'http://sulu.lo/');
+
+        $response = $client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+    }
+
+    public function testPage406ForNotExistFormat()
+    {
+        $client = $this->createWebsiteClient();
+        $client->request('GET', 'http://sulu.lo/.xml');
+
+        $response = $client->getResponse();
+        $this->assertHttpStatusCode(406, $response);
+    }
+
+    public function testPageClientAcceptHeaderNotUsed()
+    {
+        $client = $this->createWebsiteClient();
+        $client->request('GET', 'http://sulu.lo/', [], [], [
+            'HTTP_ACCEPT' => 'text/plain',
+        ]);
+
+        $response = $client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        // The accept header need to ignore so the http cache will have the correct content type in it
+        $this->assertStringStartsWith(
+            'text/html',
+            $response->headers->get('Content-Type')
+        );
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Controller/DefaultControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Controller/DefaultControllerTest.php
@@ -79,6 +79,7 @@ class DefaultControllerTest extends TestCase
     public function testValidTemplate()
     {
         $this->request->getRequestFormat()->willReturn('html')->shouldBeCalled();
+        $this->request->getMimeType('html')->willReturn('text/html')->shouldBeCalled();
         $this->twigLoader->exists('pages/default.html.twig')->willReturn(true)->shouldBeCalled();
         $this->parameterResolver->resolve(Argument::any(), Argument::any(), Argument::any(), false)
             ->willReturn(['argument' => 'value'])->shouldBeCalled();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | https://github.com/symfony/symfony/issues/36136
| License | MIT
| Documentation PR | -

#### What's in this PR?

Set the content-type header manually to avoid autodetection of symfony and so avoid a false cache page.

#### Why?

Symfony changed the behaviour in 4.4 and will use the `Accept` header of the client to set the `Content-Type` so if the first request does not accept `text/html` it will be cached as `text/plain` and you then the source code instead of the rendered html.
