### PR TITLE
Fix problem with Contacts in Search Index

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Search/EventListener/HitListener.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/EventListener/HitListener.php
@@ -41,7 +41,13 @@ class HitListener
         }
 
         $document = $event->getHit()->getDocument();
-        if ('/' !== $document->getUrl()[0]) {
+        $url = $document->getUrl();
+
+        if (!$url) {
+            return;
+        }
+
+        if ('/' == substr($url, 0,1)) {
             // is absolute URL
 
             return;

--- a/src/Sulu/Bundle/ContentBundle/Search/EventListener/HitListener.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/EventListener/HitListener.php
@@ -47,7 +47,7 @@ class HitListener
             return;
         }
 
-        if ('/' == substr($url, 0,1)) {
+        if ('/' != substr($url, 0, 1)) {
             // is absolute URL
 
             return;

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Search/EventListener/HitListenerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Search/EventListener/HitListenerTest.php
@@ -74,6 +74,14 @@ class HitListenerTest extends \PHPUnit_Framework_TestCase
         $this->listener->onHit($this->event->reveal());
     }
 
+    public function testOnHitNoUrl()
+    {
+        $this->document->getUrl()->willReturn(null);
+        $this->document->setUrl(Argument::any())->shouldNotBeCalled();
+
+        $this->listener->onHit($this->event->reveal());
+    }
+
     public function testOnHitAbsolute()
     {
         $this->requestAnalyzer->getResourceLocatorPrefix()->willReturn('/en');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | Yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | no Ticket existing
| Related issues/PRs | none
| License | MIT
| Documentation PR | no documentation

#### What's in this PR?

It is a fix to use the indizes for e.g. search. Some indizes aint working without that fix. E.g. Contact.

#### Why?

There exists a problem with the indizes where Contacts would not be able to be searched.

#### Example Usage

```php
$contactHits = $this->searchManager
     ->createSearch($queryString)
     ->locale($locale)
     ->index('contact')
     ->execute();
```
