### PR TITLE
Add sticky ckeditor toolbar

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/block.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/block.scss
@@ -57,7 +57,7 @@ $blockSelectedColor: $blueZodiac;
     align-items: center;
     justify-content: center;
     flex-grow: 0;
-    flex-shrink: 1;
+    flex-shrink: 0;
     color: $blockHandleColor;
     background-color: $blockHandleBackgroundColor;
     overflow: hidden;
@@ -67,7 +67,6 @@ $blockSelectedColor: $blueZodiac;
     flex-grow: 1;
     font-size: 12px;
     line-height: 18px;
-    overflow: auto; /* avoid overflowing of text editor on small screens - avoid hidden for absolute elements */
 }
 
 .children {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
@@ -78,6 +78,9 @@ $textEditorUnpublishedLinkColor: $gold;
     }
 
     .ck.ck-editor__top {
+        position: sticky;
+        top: 0;
+
         .ck.ck-toolbar {
             padding: 5px 10px;
 
@@ -174,7 +177,6 @@ $textEditorUnpublishedLinkColor: $gold;
             border-color: $textEditorBackgroundColor !important;
             line-height: 20px;
             min-height: 100px;
-            max-height: calc(100vh - $toolbarHeight - $snackbarHeight - $tabMenuHeight - $viewPaddingVertical - 8px);
         }
 
         .ck-widget.table {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
@@ -80,6 +80,7 @@ $textEditorUnpublishedLinkColor: $gold;
     .ck.ck-editor__top {
         position: sticky;
         top: 0;
+        z-index: 1;
 
         .ck.ck-toolbar {
             padding: 5px 10px;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/formOverlay.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/formOverlay.scss
@@ -1,6 +1,7 @@
 @import '../Application/variables.scss';
 
 .form {
-    /* this container should not have a overflow hidden as that would break position sticky for texteditor and blocks */
+    /* this container should not have a overflow hidden with position relative
+     * as that would break position sticky for texteditor and blocks */
     padding: $viewPaddingVertical $viewPaddingHorizontal;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/formOverlay.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/formOverlay.scss
@@ -1,7 +1,6 @@
 @import '../Application/variables.scss';
 
 .form {
-    // this container should not have a overflow hidden as that would break position sticky for texteditor and blocks
-    margin: $viewPaddingVertical $viewPaddingHorizontal;
-    position: relative;
+    /* this container should not have a overflow hidden as that would break position sticky for texteditor and blocks */
+    padding: $viewPaddingVertical $viewPaddingHorizontal;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/formOverlay.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/formOverlay.scss
@@ -2,6 +2,7 @@
 
 .form {
     /* this container should not have a overflow hidden with position relative
-     * as that would break position sticky for texteditor and blocks */
+     * as that would break position sticky for texteditor and blocks
+     * see also: https://github.com/sulu/sulu/pull/5129/files#r913270661 */
     padding: $viewPaddingVertical $viewPaddingHorizontal;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/formOverlay.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/formOverlay.scss
@@ -1,7 +1,7 @@
 @import '../Application/variables.scss';
 
 .form {
+    // this container should not have a overflow hidden as that would break position sticky for texteditor and blocks
     margin: $viewPaddingVertical $viewPaddingHorizontal;
-    overflow: hidden;
     position: relative;
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Make the ckeditor toolbar sticky.

#### Why?

I personally think the max-height is annoying because there is never a nice UX when having 2 scrollbars in a view. I would make the text editor grow and make the toolbar sticky at current state.

![sticky-ckeditor-before](https://user-images.githubusercontent.com/1698337/177216563-7db1ff2d-4f4b-4359-a530-68b67089e906.gif)

#### New implementation

Form:

![sticky-ckeditor](https://user-images.githubusercontent.com/1698337/177216444-b74e9b99-f87b-4c8d-b427-f82adbc1f537.gif)

Overlay:

![sticky-ckeditor-2](https://user-images.githubusercontent.com/1698337/177216449-ebccd7d9-0ee9-4280-a74c-2b2824931c01.gif)

#### To Do

- [x] Create a documentation PR
- [x] Find a way that sticky top 0 works
   - [x] e.g.: Get ride of the -60px margin-top on tabs container base padding top of the view https://github.com/sulu/sulu/pull/6676
- [x] Check if it works correctly in a Form inside a Overlay
