### PR TITLE
WIP: Add support for sqlite

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
     MAILER_URL: null://localhost
     SULU_ADMIN_EMAIL:
     PHPCR_TRANSPORT: doctrinedbal
-    DATABASE_URL: sqlite:///c:/sulu_test.db?mode=0666
+    DATABASE_URL: "sqlite://:memory:"
     DATABASE_CHARSET: utf8mb4
     DATABASE_COLLATE: utf8mb4_unicode_ci
     SYMFONY_DEPRECATIONS_HELPER: weak

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,11 +9,10 @@ environment:
     MAILER_URL: null://localhost
     SULU_ADMIN_EMAIL:
     PHPCR_TRANSPORT: doctrinedbal
-    DATABASE_URL: mysql://root:root@127.0.0.1/sulu_test?serverVersion=5.7
+    DATABASE_URL: sqlite:///c:/sulu_test.db?mode=0666
     DATABASE_CHARSET: utf8mb4
     DATABASE_COLLATE: utf8mb4_unicode_ci
     SYMFONY_DEPRECATIONS_HELPER: weak
-    MYSQL_VERSION: 8.0.17
     NODEJS_VERSION: "12"
     matrix:
         - PHP_VERSION: 7.2.5
@@ -35,10 +34,6 @@ install:
     - ps: Set-Service wuauserv -StartupType Manual
     - ps: Install-Product node $env:NODEJS_VERSION
 
-    - choco install mysql --version %MYSQL_VERSION%
-    - cd C:\tools\mysql\current\bin
-    - mysql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
-
     - IF NOT EXIST C:\tools\composer.phar (
           cd C:\tools
           && appveyor DownloadFile https://getcomposer.org/composer.phar
@@ -57,7 +52,6 @@ install:
     - echo extension=php_mbstring.dll >> php.ini
     - echo extension=php_gd2.dll >> php.ini
     - echo extension=php_intl.dll >> php.ini
-    - echo extension=php_pdo_mysql.dll >> php.ini
     - echo extension=php_pdo_sqlite.dll >> php.ini
     - echo extension=php_fileinfo.dll >> php.ini
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
     MAILER_URL: null://localhost
     SULU_ADMIN_EMAIL:
     PHPCR_TRANSPORT: doctrinedbal
-    DATABASE_URL: "sqlite://:memory:"
+    DATABASE_URL: sqlite:///c:/sulu_test.db?mode=0666
     DATABASE_CHARSET: utf8mb4
     DATABASE_COLLATE: utf8mb4_unicode_ci
     SYMFONY_DEPRECATIONS_HELPER: weak

--- a/bin/runtests
+++ b/bin/runtests
@@ -217,7 +217,7 @@ function init_dbal()
 {
     write_info('Creating database');
     exec_sf_cmd(
-        'doctrine:database:create',
+        'doctrine:database:create --if-not-exists',
         false,
         false
     );

--- a/composer.json
+++ b/composer.json
@@ -173,6 +173,9 @@
         "psr-0": {
             "Sulu\\": "src/"
         },
+        "files": [
+            "src/Sulu/Bundle/CoreBundle/Doctrine/SQLite/GroupConcat.php"
+        ],
         "exclude-from-classmap": [
             "src/Sulu/Component/*/Tests/",
             "src/Sulu/Bundle/*/Tests/"

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/SQLiteCompilerPass.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/SQLiteCompilerPass.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CoreBundle\DependencyInjection\Compiler;
+
+use Sulu\Bundle\CoreBundle\Doctrine\SQLiteForeignKeyActivationSubscriber;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class SQLiteCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$this->isSQLiteConnection($container)) {
+            return;
+        }
+
+        $sqliteForeignKeyActivationSubscriberDefinition = new Definition(
+            SQLiteForeignKeyActivationSubscriber::class
+        );
+
+        $sqliteForeignKeyActivationSubscriberDefinition->addTag(
+            'doctrine.event_subscriber',
+            [
+                'connection' => 'default',
+            ]
+        );
+
+        $container->setDefinition(
+            'sulu_core.sqlite_foreign_key_activation_subscriber',
+            $sqliteForeignKeyActivationSubscriberDefinition
+        );
+    }
+
+    private function isSQLiteConnection(ContainerBuilder $container)
+    {
+        $connectionDefinition = $container->getDefinition('doctrine.dbal.default_connection');
+
+        $configuration = $connectionDefinition->getArgument(0);
+
+        if (empty($configuration['url'])) {
+            // if no url is set check if driver is set to sqlite or pdo_sqlite
+            if (isset($configuration['driver'])
+                && false !== strpos($configuration['driver'], 'sqlite')
+            ) {
+                return true;
+            }
+
+            return false;
+        }
+
+        $databaseUrl = $container->resolveEnvPlaceholders($configuration['url'], true);
+
+        if (0 !== strpos($databaseUrl, 'sqlite')) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/SQLiteCompilerPass.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/SQLiteCompilerPass.php
@@ -16,6 +16,9 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
+/**
+ * @internal
+ */
 class SQLiteCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
@@ -50,7 +53,7 @@ class SQLiteCompilerPass implements CompilerPassInterface
         if (empty($configuration['url'])) {
             // if no url is set check if driver is set to sqlite or pdo_sqlite
             if (isset($configuration['driver'])
-                && false !== strpos($configuration['driver'], 'sqlite')
+                && false !== strpos(strtolower($configuration['driver']), 'sqlite')
             ) {
                 return true;
             }
@@ -60,7 +63,7 @@ class SQLiteCompilerPass implements CompilerPassInterface
 
         $databaseUrl = $container->resolveEnvPlaceholders($configuration['url'], true);
 
-        if (0 !== strpos($databaseUrl, 'sqlite')) {
+        if (0 !== strpos(strtolower($databaseUrl), 'sqlite')) {
             return false;
         }
 

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/SQLiteCompilerPass.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/SQLiteCompilerPass.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Bundle\CoreBundle\DependencyInjection\Compiler;
 
-use Sulu\Bundle\CoreBundle\Doctrine\SQLiteForeignKeyActivationSubscriber;
+use Sulu\Bundle\CoreBundle\Doctrine\SQLite\ForeignKeyActivationSubscriber;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -25,7 +25,7 @@ class SQLiteCompilerPass implements CompilerPassInterface
         }
 
         $sqliteForeignKeyActivationSubscriberDefinition = new Definition(
-            SQLiteForeignKeyActivationSubscriber::class
+            ForeignKeyActivationSubscriber::class
         );
 
         $sqliteForeignKeyActivationSubscriberDefinition->addTag(

--- a/src/Sulu/Bundle/CoreBundle/Doctrine/SQLite/ForeignKeyActivationSubscriber.php
+++ b/src/Sulu/Bundle/CoreBundle/Doctrine/SQLite/ForeignKeyActivationSubscriber.php
@@ -15,6 +15,9 @@ use Doctrine\Common\EventSubscriber;
 use Doctrine\DBAL\Event\ConnectionEventArgs;
 use Doctrine\DBAL\Events;
 
+/**
+ * @internal
+ */
 class ForeignKeyActivationSubscriber implements EventSubscriber
 {
     public function getSubscribedEvents()

--- a/src/Sulu/Bundle/CoreBundle/Doctrine/SQLite/ForeignKeyActivationSubscriber.php
+++ b/src/Sulu/Bundle/CoreBundle/Doctrine/SQLite/ForeignKeyActivationSubscriber.php
@@ -9,13 +9,13 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\CoreBundle\Doctrine;
+namespace Sulu\Bundle\CoreBundle\Doctrine\SQLite;
 
 use Doctrine\Common\EventSubscriber;
 use Doctrine\DBAL\Event\ConnectionEventArgs;
 use Doctrine\DBAL\Events;
 
-class SQLiteForeignKeyActivationSubscriber implements EventSubscriber
+class ForeignKeyActivationSubscriber implements EventSubscriber
 {
     public function getSubscribedEvents()
     {

--- a/src/Sulu/Bundle/CoreBundle/Doctrine/SQLite/GroupConcat.php
+++ b/src/Sulu/Bundle/CoreBundle/Doctrine/SQLite/GroupConcat.php
@@ -20,6 +20,9 @@ use Doctrine\ORM\Query\SqlWalker;
 use Oro\ORM\Query\AST\Functions\String\GroupConcat as Base;
 use Oro\ORM\Query\AST\Platform\Functions\PlatformFunctionNode;
 
+/**
+ * @internal
+ */
 class GroupConcat extends PlatformFunctionNode
 {
     /**

--- a/src/Sulu/Bundle/CoreBundle/Doctrine/SQLite/GroupConcat.php
+++ b/src/Sulu/Bundle/CoreBundle/Doctrine/SQLite/GroupConcat.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+/**
+ * @see Oro\ORM\Query\AST\FunctionFactory::create()
+ */
+
+namespace Oro\ORM\Query\AST\Platform\Functions\Sqlite;
+
+use Doctrine\ORM\Query\AST\Node;
+use Doctrine\ORM\Query\SqlWalker;
+use Oro\ORM\Query\AST\Functions\String\GroupConcat as Base;
+use Oro\ORM\Query\AST\Platform\Functions\PlatformFunctionNode;
+
+class GroupConcat extends PlatformFunctionNode
+{
+    /**
+     * @see Oro\ORM\Query\AST\Platform\Functions\Mysql\GroupConcat::getSql()
+     */
+    public function getSql(SqlWalker $sqlWalker)
+    {
+        $isDistinct = !empty($this->parameters[Base::DISTINCT_KEY]);
+        $result = 'GROUP_CONCAT(' . ($isDistinct ? 'DISTINCT ' : '');
+
+        $fields = [];
+        /** @var Node[] $pathExpressions */
+        $pathExpressions = $this->parameters[Base::PARAMETER_KEY];
+        foreach ($pathExpressions as $pathExp) {
+            $fields[] = $pathExp->dispatch($sqlWalker);
+        }
+
+        $result .= sprintf('%s', implode(', ', $fields));
+
+        if (!empty($this->parameters[Base::ORDER_KEY])) {
+            $result .= ' ' . $sqlWalker->walkOrderByClause($this->parameters[Base::ORDER_KEY]);
+        }
+
+        if (isset($this->parameters[Base::SEPARATOR_KEY])) {
+            $result .= ', ' . $sqlWalker->walkStringPrimary($this->parameters[Base::SEPARATOR_KEY]);
+        }
+
+        $result .= ')';
+
+        return $result;
+    }
+}

--- a/src/Sulu/Bundle/CoreBundle/Doctrine/SQLiteForeignKeyActivationSubscriber.php
+++ b/src/Sulu/Bundle/CoreBundle/Doctrine/SQLiteForeignKeyActivationSubscriber.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CoreBundle\Doctrine;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\DBAL\Event\ConnectionEventArgs;
+use Doctrine\DBAL\Events;
+
+class SQLiteForeignKeyActivationSubscriber implements EventSubscriber
+{
+    public function getSubscribedEvents()
+    {
+        return [
+            Events::postConnect,
+        ];
+    }
+
+    public function postConnect(ConnectionEventArgs $args)
+    {
+        if ('sqlite' !== strtolower($args->getConnection()->getDatabasePlatform()->getName())) {
+            return;
+        }
+
+        $args->getConnection()->exec('PRAGMA foreign_keys = ON;');
+    }
+}

--- a/src/Sulu/Bundle/CoreBundle/SuluCoreBundle.php
+++ b/src/Sulu/Bundle/CoreBundle/SuluCoreBundle.php
@@ -18,6 +18,7 @@ use Sulu\Bundle\CoreBundle\DependencyInjection\Compiler\RegisterContentTypesComp
 use Sulu\Bundle\CoreBundle\DependencyInjection\Compiler\RegisterLocalizationProvidersPass;
 use Sulu\Bundle\CoreBundle\DependencyInjection\Compiler\RemoveForeignContextServicesPass;
 use Sulu\Bundle\CoreBundle\DependencyInjection\Compiler\ReplacersCompilerPass;
+use Sulu\Bundle\CoreBundle\DependencyInjection\Compiler\SQLiteCompilerPass;
 use Sulu\Component\Symfony\CompilerPass\TaggedServiceCollectorCompilerPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -30,6 +31,7 @@ class SuluCoreBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new RegisterContentTypesCompilerPass());
+        $container->addCompilerPass(new SQLiteCompilerPass());
         $container->addCompilerPass(new RegisterLocalizationProvidersPass());
         $container->addCompilerPass(new RemoveForeignContextServicesPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1024);
         $container->addCompilerPass(new ReplacersCompilerPass(__DIR__ . '/DataFixtures/replacers.xml'));


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum TODO

#### What's in this PR?

Add support for sqlite.

#### Why?

Sqlite is used mostly for development and to speed up tests. 

#### Example Usage

~~~php
DATABASE_URL=sqlite:////tmp/sulu_test.db
~~~

#### BC Breaks/Deprecations

No BC Break the service is only registered when the connection dsn uses sqlite.

#### To Do

- [ ] Create a documentation PR
- [x] Fix GROUP_CONCAT
- [ ] Add `?foreign-keys=true` to doctrine/dbal
   - [ ] Move ForeignKeyActivationSubscriber to doctrine/dbal
   - [ ] Activate foreignKeys for sqlite platform when flag is set
