### PR TITLE
Focus elements in FieldFilterTypes where appropriate

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
@@ -15,6 +15,7 @@ import './datePicker.scss';
 type Props = {|
     disabled: boolean,
     id?: string,
+    inputRef?: (ref: ?ElementRef<'input'>) => void,
     onChange: (value: ?Date) => void,
     options: {
         dateFormat?: ?string | boolean,
@@ -161,6 +162,7 @@ class DatePicker extends React.Component<Props> {
             <Input
                 {...props}
                 id={this.props.id}
+                inputRef={this.props.inputRef}
                 onBlur={this.handleInputBlur}
                 onChange={handleInputChange}
                 onIconClick={!props.disabled ? this.handleOpenOverlay : undefined}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/tests/DatePicker.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/tests/DatePicker.test.js
@@ -28,6 +28,13 @@ test('DatePicker should render when disabled', () => {
     expect(datePicker.render()).toMatchSnapshot();
 });
 
+test('DatePicker should pass input to inputRef prop', () => {
+    const inputRefSpy = jest.fn();
+    const datePicker = mount(<DatePicker inputRef={inputRefSpy} onChange={jest.fn()} value={undefined} />);
+
+    expect(inputRefSpy).toBeCalledWith(datePicker.find('input').instance());
+});
+
 test('DatePicker should open overlay on icon-click', () => {
     const onChange = jest.fn();
     const datePicker = mount(<DatePicker onChange={onChange} value={null} />);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/MultiAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/MultiAutoComplete.js
@@ -18,6 +18,7 @@ type Props = {|
     displayProperty: string,
     id?: string,
     idProperty: string,
+    inputRef?: (ref: ?ElementRef<'input'>) => void,
     loading: boolean,
     onChange: (value: Array<Object>) => void,
     onFinish?: () => void,
@@ -48,9 +49,15 @@ class MultiAutoComplete extends React.Component<Props> {
         }
     };
 
-    @action setInputRef = (inputRef: ?ElementRef<'input'>) => {
+    @action setInputRef = (ref: ?ElementRef<'input'>) => {
+        const {inputRef} = this.props;
+
         if (inputRef) {
-            this.inputRef = inputRef;
+            inputRef(ref);
+        }
+
+        if (ref) {
+            this.inputRef = ref;
         }
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/MultiAutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/MultiAutoComplete.test.js
@@ -86,6 +86,24 @@ test('Render the MultiAutoComplete with open suggestions list', () => {
     expect(pretty(document.body ? document.body.innerHTML : '')).toMatchSnapshot();
 });
 
+test('Should assign input as ref to inputRef', () => {
+    const inputRefSpy = jest.fn();
+
+    const multiAutoComplete = mount(
+        <MultiAutoComplete
+            displayProperty="name"
+            inputRef={inputRefSpy}
+            onChange={jest.fn()}
+            onSearch={jest.fn()}
+            searchProperties={[]}
+            suggestions={[]}
+            value={[]}
+        />
+    );
+
+    expect(inputRefSpy).toBeCalledWith(multiAutoComplete.find('input').instance());
+});
+
 test('Clicking a suggestion should call onChange with value of the Suggestion and focus input afterwards', () => {
     const changeSpy = jest.fn();
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/DateTimeFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/DateTimeFieldFilterType.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import type {ElementRef} from 'react';
 import DatePicker from '../../../components/DatePicker';
 import AbstractFieldFilterType from './AbstractFieldFilterType';
 import dateTimeFieldFilterTypeStyles from './dateTimeFieldFilterType.scss';
@@ -27,12 +28,22 @@ class DateTimeFieldFilterType extends AbstractFieldFilterType<?{from?: Date, to?
         this.handleChange('to', value);
     };
 
+    setInputRef = (ref: ?ElementRef<'input'>) => {
+        if (ref) {
+            ref.focus();
+        }
+    };
+
     getFormNode() {
         const {value} = this;
 
         return (
             <div className={dateTimeFieldFilterTypeStyles.dateTimeFieldFilterType}>
-                <DatePicker onChange={this.handleFromChange} value={value ? value.from : undefined} />
+                <DatePicker
+                    inputRef={this.setInputRef}
+                    onChange={this.handleFromChange}
+                    value={value ? value.from : undefined}
+                />
                 <DatePicker onChange={this.handleToChange} value={value ? value.to : undefined} />
             </div>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/DateTimeFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/DateTimeFieldFilterType.js
@@ -28,11 +28,11 @@ class DateTimeFieldFilterType extends AbstractFieldFilterType<?{from?: Date, to?
         this.handleChange('to', value);
     };
 
-    setInputRef = (ref: ?ElementRef<'input'>) => {
+    setInputRef(ref: ?ElementRef<'input'>) {
         if (ref) {
             ref.focus();
         }
-    };
+    }
 
     getFormNode() {
         const {value} = this;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/DateTimeFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/DateTimeFieldFilterType.js
@@ -28,7 +28,7 @@ class DateTimeFieldFilterType extends AbstractFieldFilterType<?{from?: Date, to?
         this.handleChange('to', value);
     };
 
-    setInputRef(ref: ?ElementRef<'input'>) {
+    setFromInputRef(ref: ?ElementRef<'input'>) {
         if (ref) {
             ref.focus();
         }
@@ -40,7 +40,7 @@ class DateTimeFieldFilterType extends AbstractFieldFilterType<?{from?: Date, to?
         return (
             <div className={dateTimeFieldFilterTypeStyles.dateTimeFieldFilterType}>
                 <DatePicker
-                    inputRef={this.setInputRef}
+                    inputRef={this.setFromInputRef}
                     onChange={this.handleFromChange}
                     value={value ? value.from : undefined}
                 />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/NumberFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/NumberFieldFilterType.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import type {ElementRef} from 'react';
 import {computed} from 'mobx';
 import Input from '../../../components/Input';
 import SingleSelect from '../../../components/SingleSelect';
@@ -51,6 +52,12 @@ class NumberFieldFilterType extends AbstractFieldFilterType<?{[string]: ?number}
         return getNumberFromValue(this.value);
     }
 
+    setInputRef(ref: ?ElementRef<'input'>) {
+        if (ref) {
+            ref.focus();
+        }
+    }
+
     handleOperatorChange = (operatorValue: ?string) => {
         if (!operatorValue) {
             throw new Error('The operator cannot be changed to undefined! This should not happen and is likely a bug.');
@@ -74,6 +81,7 @@ class NumberFieldFilterType extends AbstractFieldFilterType<?{[string]: ?number}
                     <SingleSelect.Option value="gt">{operatorMapping.gt}</SingleSelect.Option>
                 </SingleSelect>
                 <Input
+                    inputRef={this.setInputRef}
                     onChange={this.handleInputChange}
                     type="number"
                     value={this.number}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/SelectionFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/SelectionFieldFilterType.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import type {ElementRef} from 'react';
 import {autorun, computed, toJS, untracked, when} from 'mobx';
 import equals from 'fast-deep-equal';
 import MultiSelectionStore from '../../../stores/MultiSelectionStore';
@@ -72,11 +73,18 @@ class SelectionFieldFilterType extends AbstractFieldFilterType<?Array<string | n
         return displayProperty;
     }
 
+    setInputRef(ref: ?ElementRef<'input'>) {
+        if (ref) {
+            ref.focus();
+        }
+    }
+
     getFormNode() {
         return (
             <div className={selectionFieldFilterTypeStyles.selectionFieldFilterType}>
                 <MultiAutoComplete
                     displayProperty={this.displayProperty}
+                    inputRef={this.setInputRef}
                     searchProperties={[this.displayProperty]}
                     selectionStore={this.selectionStore}
                 />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/TextFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/TextFieldFilterType.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import type {ElementRef} from 'react';
 import Input from '../../../components/Input';
 import AbstractFieldFilterType from './AbstractFieldFilterType';
 
@@ -9,11 +10,18 @@ class TextFieldFilterType extends AbstractFieldFilterType<?{eq: string}> {
         onChange(value ? {eq: value} : undefined);
     };
 
+    setInputRef(ref: ?ElementRef<'input'>) {
+        if (ref) {
+            ref.focus();
+        }
+    }
+
     getFormNode() {
         const {value} = this;
 
         return (
             <Input
+                inputRef={this.setInputRef}
                 onChange={this.handleChange}
                 value={value ? value.eq : undefined}
             />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/MultiAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/MultiAutoComplete.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import type {ElementRef} from 'react';
 import {observer} from 'mobx-react';
 import MultiAutoCompleteComponent from '../../components/MultiAutoComplete';
 import SearchStore from '../../stores/SearchStore';
@@ -11,6 +12,7 @@ type Props = {|
     displayProperty: string,
     id?: string,
     idProperty: string,
+    inputRef?: (ref: ?ElementRef<'input'>) => void,
     options: Object,
     searchProperties: Array<string>,
     selectionStore: MultiSelectionStore<string | number>,
@@ -57,6 +59,7 @@ class MultiAutoComplete extends React.Component<Props> {
             displayProperty,
             id,
             idProperty,
+            inputRef,
             searchProperties,
             selectionStore,
         } = this.props;
@@ -68,6 +71,7 @@ class MultiAutoComplete extends React.Component<Props> {
                 displayProperty={displayProperty}
                 id={id}
                 idProperty={idProperty}
+                inputRef={inputRef}
                 loading={this.searchStore.loading || selectionStore.loading}
                 onChange={this.handleChange}
                 onSearch={this.handleSearch}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/tests/MultiAutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/tests/MultiAutoComplete.test.js
@@ -34,6 +34,22 @@ test('Render in loading state', () => {
     )).toMatchSnapshot();
 });
 
+test('Should assign input as ref to inputRef', () => {
+    const inputRefSpy = jest.fn();
+    const selectionStore = new MultiSelectionStore('contact', []);
+
+    const multiAutoComplete = mount(
+        <MultiAutoComplete
+            displayProperty="name"
+            inputRef={inputRefSpy}
+            searchProperties={[]}
+            selectionStore={selectionStore}
+        />
+    );
+
+    expect(inputRefSpy).toBeCalledWith(multiAutoComplete.find('input').instance());
+});
+
 test('Pass loading flag if MultiSelectionStore and SearchStore is loading', () => {
     // $FlowFixMe
     SearchStore.mockImplementation(function() {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #5035 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds the possibility to retrieve the refs for input elements of the `MultiAutoComplete` and `DateTime` component. This is done to set the focus on these elements in there respective `FieldFilterType`s.

#### Why?

Because this results in a better usability, because less clicks are necessary to setup a filter.