### PR TITLE
Fix error when using smart content media provider without includeSubFolders

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
@@ -477,6 +477,16 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
                 [],
                 [],
             ],
+            // datasource sub folder without includeSubFolders
+            [
+                ['dataSource' => 1],
+                null,
+                0,
+                null,
+                array_slice($this->mediaData, 0, 1),
+                [],
+                [],
+            ],
             // datasource sub folder with tags
             [
                 ['dataSource' => 0, 'includeSubFolders' => true, 'tags' => [0], 'tagOperator' => 'or'],

--- a/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
+++ b/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
@@ -77,7 +77,7 @@ trait DataProviderRepositoryTrait
 
         $parameter = array_merge($parameter, $this->append($queryBuilder, 'c', $locale, $options));
         if (isset($filters['dataSource'])) {
-            $includeSubFolders = $this->getBoolean($filters['includeSubFolders'] ?: false);
+            $includeSubFolders = $this->getBoolean($filters['includeSubFolders'] ?? false);
             $parameter = array_merge(
                 $parameter,
                 $this->appendDatasource($filters['dataSource'], $includeSubFolders, $queryBuilder, 'c')

--- a/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
@@ -74,4 +74,31 @@ class DataProviderRepositoryTraitTest extends TestCase
         // this makes problems if also a limit is used
         $queryBuilder->distinct()->shouldBeCalled();
     }
+
+    public function testFindByFiltersIdsWithDatasourceWithoutIncludeSubFolders()
+    {
+        $findByFiltersIdsReflection = new \ReflectionMethod(
+            get_class($this->dataProviderRepositoryTrait),
+            'findByFiltersIds'
+        );
+        $findByFiltersIdsReflection->setAccessible(true);
+
+        $query = $this->prophesize(Query::class);
+        $query->setFirstResult(0)->willReturn($query);
+        $query->setMaxResults(Argument::any())->willReturn($query);
+        $query->getScalarResult()->willReturn([]);
+        $queryBuilder = $this->prophesize(QueryBuilder::class);
+        $queryBuilder->select(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->distinct(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->orderBy(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->getQuery()->willReturn($query);
+
+        $this->dataProviderRepositoryTrait->method('createQueryBuilder')->willReturn($queryBuilder->reveal());
+
+        $findByFiltersIdsReflection->invoke($this->dataProviderRepositoryTrait, ['dataSource' => 3], 1, 5, null, 'de');
+
+        // using distinct here is essential, since due to our joins multiple rows might be returned
+        // this makes problems if also a limit is used
+        $queryBuilder->distinct()->shouldBeCalled();
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | 
| License | MIT
| Documentation PR | 

#### What's in this PR?

A bugfix for smart content with the media provider.

#### Why?

When you add a smart content property using the media provider, the admin will give an error if you select a source without selecting the "include sub elements" option.

The AJAX error response without the fix : 
`{
    "code": 0,
    "message": "Notice: Undefined index: includeSubFolders",
    "errors": [
        "ErrorException: Notice: Undefined index: includeSubFolders in /var/www/html/vendor/sulu/sulu/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php:80\nStack trace:\n#0 /var/www/html/vendor/sulu/sulu/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php(39): Sulu\\Bundle\\MediaBundle\\Entity\\MediaDataProviderRepository->findByFiltersIds(Array, 1, NULL, NULL, 'nl', Array)\n#1 /var/www/html/vendor/sulu/sulu/src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php(77): Sulu\\Bundle\\MediaBundle\\Entity\\MediaDataProviderRepository->parentFindByFilters(Array, 1, NULL, NULL, 'nl', Array)\n#2 /var/www/html/vendor/sulu/sulu/src/Sulu/Component/SmartContent/Orm/BaseDataProvider.php(138): Sulu\\Bundle\\MediaBundle\\Entity\\MediaDataProviderRepository->findByFilters(Array, 1, NULL, NULL, 'nl', Array)\n#3 /var/www/html/vendor/sulu/sulu/src/Sulu/Component/SmartContent/Orm/BaseDataProvider.php(101): Sulu\\Component\\SmartContent\\Orm\\BaseDataProvider->resolveFilters(Array, 'nl', NULL, 1, NULL, Array)\n#4 /var/www/html/vendor/sulu/sulu/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php(87): Sulu\\Component\\SmartContent\\Orm\\BaseDataProvider->resolveDataItems(Array, Array, Array, NULL, 1, NULL)\n#5 /var/www/html/vendor/sulu/sulu/src/Sulu/Bundle/PageBundle/Controller/SmartContentItemController.php(100): Sulu\\Component\\Media\\SmartContent\\MediaDataProvider->resolveDataItems(Array, Array, Array, NULL)\n#6 /var/www/html/vendor/symfony/http-kernel/HttpKernel.php(146): Sulu\\Bundle\\PageBundle\\Controller\\SmartContentItemController->getItemsAction(Object(Symfony\\Component\\HttpFoundation\\Request))\n#7 /var/www/html/vendor/symfony/http-kernel/HttpKernel.php(68): Symfony\\Component\\HttpKernel\\HttpKernel->handleRaw(Object(Symfony\\Component\\HttpFoundation\\Request), 1)\n#8 /var/www/html/vendor/symfony/http-kernel/Kernel.php(201): Symfony\\Component\\HttpKernel\\HttpKernel->handle(Object(Symfony\\Component\\HttpFoundation\\Request), 1, true)\n#9 /var/www/html/public/index.php(62): Symfony\\Component\\HttpKernel\\Kernel->handle(Object(Symfony\\Component\\HttpFoundation\\Request))\n#10 {main}"
    ]
}`

This small fix makes sure it will work as expected.
