### PR TITLE
Add select type for SelectionFieldFilterType

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/MultiSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/MultiSelect.js
@@ -10,6 +10,7 @@ type Props<T: string | number> = {|
     allSelectedText?: string,
     noneSelectedText?: string,
     onChange: (values: Array<T>) => void,
+    onClose?: () => void,
     values: Array<T>,
 |};
 
@@ -81,7 +82,7 @@ export default class MultiSelect<T: string | number> extends React.PureComponent
     };
 
     render() {
-        const {children, disabled, icon, skin} = this.props;
+        const {children, disabled, icon, onClose, skin} = this.props;
 
         return (
             <Select
@@ -90,6 +91,7 @@ export default class MultiSelect<T: string | number> extends React.PureComponent
                 displayValue={this.displayValue}
                 icon={icon}
                 isOptionSelected={this.isOptionSelected}
+                onClose={onClose}
                 onSelect={this.handleSelect}
                 selectedVisualization="checkbox"
                 skin={skin}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/README.md
@@ -1,24 +1,26 @@
-The `MultiSelectComponent` allows the user to select many options out of many.
-The component follows the
+The `MultiSelectComponent` allows the user to select many options out of many.  The component follows the
 [recommendation of React for form components](https://facebook.github.io/react/docs/forms.html):
-The component itself holds no internal state and is solely dependent on the passed properties.
-Moreover, it provides a possibility to pass a callback which gets called when the user changes an option.
+The component itself holds no internal state and is solely dependent on the passed properties. Moreover, it provides a
+possibility to pass an `onChange` callback which gets called when the user changes an option and an `onBlur` callback
+that is called when the select is closed.
 
 ```javascript
 initialState = {contributors: []};
+const onClose = () => console.log('The overlay was closed with the selection: ' + state.contributors.join(', '));
 const onChange = (contributors) => setState({contributors});
 
 <div style={{maxWidth: '200px'}}>
     <MultiSelect
-        values={state.contributors}
-        noneSelectedText="Choose contributors"
         allSelectedText="All"
+        noneSelectedText="Choose contributors"
+        onClose={onClose}
         onChange={onChange}
+        values={state.contributors}
     >
-        <MultiSelect.Option value="page-1">Linus Torvald</MultiSelect.Option>
-        <MultiSelect.Option value="page-2">Dennis Ritchie</MultiSelect.Option>
-        <MultiSelect.Option value="page-3">Larry Page</MultiSelect.Option>
-        <MultiSelect.Option value="page-4">Bill Gates</MultiSelect.Option>
+        <MultiSelect.Option value="linus">Linus Torvald</MultiSelect.Option>
+        <MultiSelect.Option value="dennis">Dennis Ritchie</MultiSelect.Option>
+        <MultiSelect.Option value="larry">Larry Page</MultiSelect.Option>
+        <MultiSelect.Option value="bill">Bill Gates</MultiSelect.Option>
         <MultiSelect.Divider />
         <MultiSelect.Action onClick={() => {/* do something */}}>Add new contributor</MultiSelect.Action>
     </MultiSelect>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/tests/MultiSelect.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/tests/MultiSelect.test.js
@@ -161,3 +161,17 @@ test('The component should trigger the change callback on select with a removed 
     select.find(Select).props().onSelect('option-2');
     expect(onChangeSpy).toHaveBeenCalledWith(['option-1']);
 });
+
+test('The component should trigger the close callback when the MultiSelect is closed', () => {
+    const closeSpy = jest.fn();
+    const select = shallow(
+        <MultiSelect onChange={jest.fn()} onClose={closeSpy}>
+            <Option value="option-1">Option 1</Option>
+            <Option value="option-2">Option 2</Option>
+        </MultiSelect>
+    );
+
+    expect(closeSpy).not.toBeCalled();
+    select.find(Select).prop('onClose')();
+    expect(closeSpy).toBeCalled();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Select.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Select.js
@@ -20,6 +20,7 @@ type Props<T> = {|
     closeOnSelect: boolean,
     displayValue: string,
     isOptionSelected: (option: Element<typeof Option>) => boolean,
+    onClose?: () => void,
     onSelect: (value: T) => void,
     selectedVisualization?: OptionSelectedVisualization,
 |};
@@ -49,6 +50,12 @@ class Select<T> extends React.Component<Props<T>> {
     };
 
     @action closeOptionList = () => {
+        const {onClose} = this.props;
+
+        if (onClose) {
+            onClose();
+        }
+
         this.open = false;
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/Select.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/Select.test.js
@@ -159,6 +159,26 @@ test('The component should trigger the select callback and close the popover whe
     expect(document.body.innerHTML).toBe('');
 });
 
+test('The component should call the onClose callback when it is closing', () => {
+    const closeSpy = jest.fn();
+    const isOptionSelected = jest.fn().mockReturnValue(false);
+    const select = mount(
+        <Select
+            displayValue="My text"
+            isOptionSelected={isOptionSelected}
+            onClose={closeSpy}
+            onSelect={jest.fn()}
+        >
+            <Option value="option-1">Option 1</Option>
+            <Option value="option-2">Option 2</Option>
+        </Select>
+    );
+    select.instance().handleDisplayValueClick();
+    expect(closeSpy).not.toBeCalled();
+    select.find('Popover').simulate('click');
+    expect(closeSpy).toBeCalled();
+});
+
 test('The component should pass the centered child node to the popover', () => {
     const onSelect = jest.fn();
     const isOptionSelected = jest.fn((child) => child.props.value === 'option-3');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/SelectionFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/SelectionFieldFilterType.js
@@ -15,6 +15,7 @@ const TYPE_SELECT = 'select';
 class SelectionFieldFilterType extends AbstractFieldFilterType<?Array<string | number>> {
     selectionStore: MultiSelectionStore<string | number>;
     selectionStoreDisposer: () => void;
+    // Used to buffer the select value, because everytime the value variable changes a request is sent to load data
     @observable selectValue: Array<string | number> = [];
     valueDisposer: () => void;
 
@@ -45,7 +46,7 @@ class SelectionFieldFilterType extends AbstractFieldFilterType<?Array<string | n
         this.valueDisposer = autorun(() => {
             const value = toJS(this.value || []);
 
-            if (!equals(value, untracked(() => this.selectionStore.ids))) {
+            if (!equals(value, untracked(() => toJS(this.selectionStore.ids)))) {
                 this.selectionStore.loadItems(value);
             }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/SelectionFieldFilterType.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/SelectionFieldFilterType.test.js
@@ -37,6 +37,22 @@ test('Pass correct props to MultiAutoComplete', () => {
     }));
 });
 
+test('Pass correct props to Select', () => {
+    const selectionFieldFilterType = new SelectionFieldFilterType(
+        jest.fn(),
+        {displayProperty: 'name', resourceKey: 'accounts', type: 'select'},
+        [4, 6]
+    );
+
+    const selectionFieldFilterTypeForm = shallow(selectionFieldFilterType.getFormNode());
+
+    expect(selectionFieldFilterTypeForm.find('ResourceMultiSelect').props()).toEqual(expect.objectContaining({
+        displayProperty: 'name',
+        resourceKey: 'accounts',
+        values: [4, 6],
+    }));
+});
+
 test('Destroy should call disposers', () => {
     const selectionFieldFilterType = new SelectionFieldFilterType(
         jest.fn(),
@@ -53,16 +69,33 @@ test('Destroy should call disposers', () => {
     expect(selectionFieldFilterType.valueDisposer).toBeCalledWith();
 });
 
-test('Call onChange handler when selection changes', () => {
+test('Call onChange handler when selection changes for auto_complete type', () => {
     const changeSpy = jest.fn();
     const selectionFieldFilterType = new SelectionFieldFilterType(
         changeSpy,
-        {displayProperty: 'firstName', resourceKey: 'contacts'},
+        {displayProperty: 'firstName', resourceKey: 'contacts', type: 'multi_auto_complete'},
         undefined
     );
 
     selectionFieldFilterType.selectionStore.ids.push(4, 7);
 
+    expect(changeSpy).toBeCalledWith([4, 7]);
+});
+
+test('Call onChange handler when selection changes for select type after select is closed', () => {
+    const changeSpy = jest.fn();
+    const selectionFieldFilterType = new SelectionFieldFilterType(
+        changeSpy,
+        {displayProperty: 'firstName', resourceKey: 'contacts', type: 'select'},
+        undefined
+    );
+
+    const selectionFieldFilterTypeForm = shallow(selectionFieldFilterType.getFormNode());
+    changeSpy.mockReset();
+    selectionFieldFilterTypeForm.find('ResourceMultiSelect').prop('onChange')([4, 7]);
+
+    expect(changeSpy).not.toBeCalled();
+    selectionFieldFilterTypeForm.find('ResourceMultiSelect').prop('onClose')();
     expect(changeSpy).toBeCalledWith([4, 7]);
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/SelectionFieldFilterType.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/SelectionFieldFilterType.test.js
@@ -69,6 +69,48 @@ test('Destroy should call disposers', () => {
     expect(selectionFieldFilterType.valueDisposer).toBeCalledWith();
 });
 
+test('Setting a new value should update the select', () => {
+    const selectionFieldFilterType = new SelectionFieldFilterType(
+        jest.fn(),
+        {displayProperty: 'name', resourceKey: 'accounts', type: 'select'},
+        [4, 6]
+    );
+
+    const selectionFieldFilterTypeForm1 = shallow(selectionFieldFilterType.getFormNode());
+    expect(selectionFieldFilterTypeForm1.find('ResourceMultiSelect').prop('values')).toEqual([4, 6]);
+
+    selectionFieldFilterType.setValue([4, 5]);
+    const selectionFieldFilterTypeForm2 = shallow(selectionFieldFilterType.getFormNode());
+    expect(selectionFieldFilterTypeForm2.find('ResourceMultiSelect').prop('values')).toEqual([4, 5]);
+});
+
+test('Setting a new value should update the selectionStore', () => {
+    const selectionFieldFilterType = new SelectionFieldFilterType(
+        jest.fn(),
+        {displayProperty: 'name', resourceKey: 'accounts', type: 'select'},
+        [4, 6]
+    );
+
+    expect(selectionFieldFilterType.selectionStore.loadItems).toBeCalledWith([4, 6]);
+    selectionFieldFilterType.setValue([4, 7]);
+    expect(selectionFieldFilterType.selectionStore.loadItems).toBeCalledWith([4, 7]);
+});
+
+test('Setting the same value should not update the selectionStore', () => {
+    const selectionFieldFilterType = new SelectionFieldFilterType(
+        jest.fn(),
+        {displayProperty: 'name', resourceKey: 'accounts', type: 'select'},
+        [4, 6]
+    );
+
+    // $FlowFixMe
+    selectionFieldFilterType.selectionStore.ids = [4, 6];
+    selectionFieldFilterType.selectionStore.loadItems.mockReset();
+
+    selectionFieldFilterType.setValue([4, 6]);
+    expect(selectionFieldFilterType.selectionStore.loadItems).not.toBeCalledWith([4, 6]);
+});
+
 test('Call onChange handler when selection changes for auto_complete type', () => {
     const changeSpy = jest.fn();
     const selectionFieldFilterType = new SelectionFieldFilterType(

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceMultiSelect/ResourceMultiSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceMultiSelect/ResourceMultiSelect.js
@@ -15,6 +15,7 @@ type Props<T: string | number> = {|
     idProperty: string,
     noneSelectedText?: string,
     onChange: (values: Array<T>, valueObjects?: Array<Object>) => void,
+    onClose?: () => void,
     requestParameters: Object,
     resourceKey: string,
     values: Array<T>,
@@ -76,9 +77,10 @@ class ResourceMultiSelect<T: string | number> extends React.Component<Props<T>> 
         const {
             allSelectedText,
             disabled,
-            noneSelectedText,
             displayProperty,
             idProperty,
+            noneSelectedText,
+            onClose,
             values,
         } = this.props;
 
@@ -92,6 +94,7 @@ class ResourceMultiSelect<T: string | number> extends React.Component<Props<T>> 
                 disabled={disabled}
                 noneSelectedText={noneSelectedText}
                 onChange={this.handleChange}
+                onClose={onClose}
                 values={values}
             >
                 {this.resourceListStore.data.map((object, index) => ((

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceMultiSelect/tests/ResourceMultiSelect.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceMultiSelect/tests/ResourceMultiSelect.test.js
@@ -301,3 +301,33 @@ test('The component should trigger the change callback', () => {
     resourceMultiSelect.find(MultiSelectComponent).props().onChange([5, 99]);
     expect(onChangeSpy).toHaveBeenCalledWith([5, 99], expectedValues);
 });
+
+test('The component should trigger the close callback', () => {
+    // $FlowFixMe
+    ResourceListStore.mockImplementation(function() {
+        this.loading = false;
+        this.data = [
+            {
+                'id': 2,
+                'name': 'Test ABC',
+                'someOtherProperty': 'No no',
+            },
+        ];
+    });
+
+    const closeSpy = jest.fn();
+
+    const resourceMultiSelect = shallow(
+        <ResourceMultiSelect
+            displayProperty="name"
+            onChange={jest.fn()}
+            onClose={closeSpy}
+            resourceKey="test"
+            values={[99]}
+        />
+    );
+
+    expect(closeSpy).not.toBeCalled();
+    resourceMultiSelect.find(MultiSelectComponent).prop('onClose')();
+    expect(closeSpy).toBeCalled();
+});

--- a/src/Sulu/Bundle/ContactBundle/Controller/PositionController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/PositionController.php
@@ -77,10 +77,17 @@ class PositionController extends AbstractRestController implements ClassResource
      *
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function cgetAction()
+    public function cgetAction(Request $request)
     {
+        $filter = [];
+        $ids = $request->get('ids');
+
+        if ($ids) {
+            $filter['id'] = explode(',', $ids);
+        }
+
         $list = new CollectionRepresentation(
-            $this->positionRepository->findBy([], ['position' => 'ASC']),
+            $this->positionRepository->findBy($filter, ['position' => 'ASC']),
             self::$entityKey
         );
 

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
@@ -15,6 +15,17 @@
         </join>
     </joins>
 
+    <joins name="position">
+        <join>
+            <entity-name>SuluContactBundle:AccountContact</entity-name>
+            <field-name>%sulu.model.contact.class%.accountContacts</field-name>
+        </join>
+        <join>
+            <entity-name>SuluContactBundle:Position</entity-name>
+            <field-name>SuluContactBundle:AccountContact.position</field-name>
+        </join>
+    </joins>
+
     <joins name="accountContact">
         <join>
             <entity-name>SuluContactBundle:AccountContact</entity-name>
@@ -255,6 +266,21 @@
             <filter type="text" />
         </property>
 
+        <identity-property name="positionId" visibility="never" translation="sulu_contact.position">
+            <field-name>position</field-name>
+            <entity-name>SuluContactBundle:AccountContact</entity-name>
+
+            <joins ref="position"/>
+
+            <filter type="selection">
+                <params>
+                    <param name="displayProperty" value="position" />
+                    <param name="resourceKey" value="contact_positions" />
+                    <param name="type" value="select" />
+                </params>
+            </filter>
+        </identity-property>
+
         <property
             name="position"
             translation="sulu_contact.position"
@@ -263,18 +289,7 @@
             <field-name>position</field-name>
             <entity-name>SuluContactBundle:Position</entity-name>
 
-            <joins>
-                <join>
-                    <entity-name>SuluContactBundle:AccountContact</entity-name>
-                    <field-name>%sulu.model.contact.class%.accountContacts</field-name>
-                </join>
-                <join>
-                    <entity-name>SuluContactBundle:Position</entity-name>
-                    <field-name>SuluContactBundle:AccountContact.position</field-name>
-                </join>
-            </joins>
-
-            <filter type="text" />
+            <joins ref="position"/>
         </property>
 
         <group-concat-property

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/PositionControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/PositionControllerTest.php
@@ -47,6 +47,27 @@ class PositionControllerTest extends SuluTestCase
         $this->assertEquals('CFO', $positions[1]->position);
     }
 
+    public function testCgetActionWithIds()
+    {
+        $position1 = $this->createPosition('CEO');
+        $position2 = $this->createPosition('CFO');
+        $position3 = $this->createPosition('COO');
+
+        $this->em->flush();
+
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', '/api/contact-positions?ids=' . $position1->getId() . ',' . $position3->getId());
+
+        $response = json_decode($client->getResponse()->getContent());
+        $positions = $response->_embedded->contact_positions;
+
+        $this->assertCount(2, $positions);
+        $this->assertEquals($position1->getId(), $positions[0]->id);
+        $this->assertEquals('CEO', $positions[0]->position);
+        $this->assertEquals($position3->getId(), $positions[1]->id);
+        $this->assertEquals('COO', $positions[1]->position);
+    }
+
     public function testCdeleteAction()
     {
         $position1 = $this->createPosition('CEO');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #5035, dependant on #5138
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR introduces a new `type` parameter for the `selection` filter. This allows to render the possible values as a simple select dropdown instead of an auto complete field.

#### Why?

Because sometimes this variant is more comfortable to use.

#### Example Usage

~~~xml
 <filter type="selection">                                                                
    <params>                          
        <param name="displayProperty" value="name" />                                                                                                                                          
        <param name="resourceKey" value="accounts" />                                                                                                                                          
        <param name="type" value="select" /><!-- Can also be set to "auto_complete", which is the default value -->                                                                                                                                          
    </params>                         
</filter>                             
~~~

#### To Do

- [ ] Create a documentation PR (Actually the list XML part does not have its own documentation yet)
- [x] Fix the z-index problem already mentioned in #5035, because this makes the dropdown ignore its changes when the "OK" button of the `FieldFilterItem` is clicked without closing the select dropdown first by clicking somewhere outsie the `FieldFilterItem`.
