### PR TITLE
Add object-shorthand eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -60,6 +60,7 @@
         "comma-spacing": "error",
         "key-spacing": "error",
         "object-curly-spacing": "error",
+        "object-shorthand": "error",
         "no-alert": "error",
         "no-console": "error",
         "no-prototype-builtins": "off",

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ package-lock.json
 node_modules/
 yarn.lock
 .php_cs.cache
+.eslintcache
 
 # phpunit
 .phpunit

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "repository": "https://github.com/sulu/sulu.git",
     "scripts": {
         "preinstall": "node preinstall.js",
-        "lint:js": "eslint .",
+        "lint:js": "eslint . --cache",
         "lint:scss": "stylelint src/Sulu/Bundle/*/Resources/js/**/*.scss",
         "flow": "flow",
         "test": "jest",

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/SingleItemSection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/SingleItemSection.js
@@ -34,7 +34,7 @@ export default class SingleItemSection extends React.PureComponent<Props> {
                 {
                     active: value === item.props.value,
                     onClick: this.handleItemClick,
-                    icon: icon,
+                    icon,
                 }
             );
         });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/ColumnList.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/ColumnList.test.js
@@ -6,7 +6,7 @@ import Column from '../Column';
 import Item from '../Item';
 
 jest.mock('../columnList.scss', () => new Proxy({}, {
-    get: function(target, key) {
+    get(target, key) {
         if (key === '__esModule') {
             return false;
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
@@ -182,7 +182,7 @@ class DatePicker extends React.Component<Props> {
         const inputProps = {
             placeholder: placeholder ? placeholder : this.getFormat(),
             valid: valid && !this.showError,
-            disabled: disabled,
+            disabled,
             icon: fieldOptions.dateFormat ? 'su-calendar' : 'su-clock',
         };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/InfiniteScroller/tests/InfiniteScroller.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/InfiniteScroller/tests/InfiniteScroller.test.js
@@ -6,7 +6,7 @@ import InfiniteScroller from '../InfiniteScroller';
 window.getComputedStyle = jest.fn();
 
 jest.mock('../../../utils/Translator', () => ({
-    translate: function(key) {
+    translate(key) {
         switch (key) {
             case 'sulu_admin.reached_end_of_list':
                 return 'Last page reached';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Matrix.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Matrix.js
@@ -42,7 +42,7 @@ export default class Matrix extends React.PureComponent<Props> {
             row,
             {
                 ...row.props,
-                disabled: disabled,
+                disabled,
                 key: `matrix-row-${index}`,
                 onChange: this.handleChange,
                 values: values.hasOwnProperty(row.props.name) ? values[row.props.name] : {},

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Row.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Row.js
@@ -58,7 +58,7 @@ class Row extends React.Component<Props> {
             item,
             {
                 ...item.props,
-                disabled: disabled,
+                disabled,
                 key: `matrix-item-${index}`,
                 onChange: this.handleChange,
                 value: values[item.props.name],

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/tests/Matrix.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/tests/Matrix.test.js
@@ -12,7 +12,7 @@ afterEach(() => {
 });
 
 jest.mock('../../../utils/Translator', () => ({
-    translate: function(key) {
+    translate(key) {
         switch (key) {
             case 'sulu_admin.activate_all':
                 return 'Activate all';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/tests/Pagination.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/tests/Pagination.test.js
@@ -4,7 +4,7 @@ import React from 'react';
 import Pagination from '../Pagination';
 
 jest.mock('../../../utils/Translator', () => ({
-    translate: function(key) {
+    translate(key) {
         switch (key) {
             case 'sulu_admin.page':
                 return 'Page';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Body.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Body.js
@@ -35,11 +35,11 @@ export default class Body<T: number | string> extends React.PureComponent<Props<
         return React.Children.map(originalRows, (row, index) => React.cloneElement(
             row,
             {
-                buttons: buttons,
+                buttons,
                 ...row.props,
                 key: `body-row-${index}`,
                 rowIndex: index,
-                selectMode: selectMode,
+                selectMode,
                 selectInFirstCell: this.props.selectInFirstCell,
                 onSelectionChange: this.props.onRowSelectionChange ? this.handleRowSelectionChange : undefined,
                 onExpand: this.handleRowExpand,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Header.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Header.js
@@ -77,7 +77,7 @@ export default class Header extends React.PureComponent<Props> {
                 {
                     ...props,
                     key,
-                    children: children,
+                    children,
                 }
             );
         });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Table.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Table.js
@@ -55,7 +55,7 @@ class Table<T: string | number> extends React.Component<Props<T>> {
         return React.cloneElement(
             originalHeader,
             {
-                allSelected: allSelected,
+                allSelected,
                 buttons: [...buttons, ...(originalHeader.props.buttons || [])],
                 onAllSelectionChange: onAllSelectionChange ? this.handleAllSelectionChange : undefined,
                 selectMode,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tabs/Tabs.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tabs/Tabs.js
@@ -27,7 +27,7 @@ export default class Tabs extends React.PureComponent<Props> {
                 tab,
                 {
                     ...tab.props,
-                    index: index,
+                    index,
                     selected: this.isSelected(index),
                     onClick: this.handleSelectionChange,
                 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Controls.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Controls.js
@@ -28,7 +28,7 @@ export default class Controls extends React.PureComponent<Props> {
                 child,
                 {
                     ...child.props,
-                    skin: skin,
+                    skin,
                 }
             );
         });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Items.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Items.js
@@ -94,7 +94,7 @@ class Items extends React.Component<Props> {
                                 {React.cloneElement(item, {
                                     ...item.props,
                                     showText: this.showText,
-                                    skin: skin,
+                                    skin,
                                 })}
                             </li>
                         ))

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Toolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Toolbar.js
@@ -40,7 +40,7 @@ export default class Toolbar extends React.PureComponent<Props> {
                 child,
                 {
                     ...child.props,
-                    skin: skin,
+                    skin,
                 }
             );
         });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/metadataStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/metadataStore.js
@@ -17,7 +17,7 @@ class MetadataStore {
                 const schemaTypes = {};
                 Object.keys(types).forEach((key) => {
                     schemaTypes[key] = {
-                        key: key,
+                        key,
                         title: types[key].title || key,
                     };
                 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/Search.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/Search.test.js
@@ -4,7 +4,7 @@ import React from 'react';
 import Search from '../Search';
 
 jest.mock('../../../utils/Translator', () => ({
-    translate: function(key) {
+    translate(key) {
         return key;
     },
 }));

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/FolderAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/FolderAdapter.test.js
@@ -5,7 +5,7 @@ import listAdapterDefaultProps from '../../../../utils/TestHelper/listAdapterDef
 import FolderAdapter from '../../adapters/FolderAdapter';
 
 jest.mock('../../../../utils/Translator', () => ({
-    translate: function(key) {
+    translate(key) {
         switch (key) {
             case 'sulu_admin.object':
                 return 'Object';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
@@ -7,7 +7,7 @@ import StringFieldTransformer from '../../fieldTransformers/StringFieldTransform
 import listFieldTransformerRegistry from '../../registries/listFieldTransformerRegistry';
 
 jest.mock('../../../../utils/Translator', () => ({
-    translate: function(key) {
+    translate(key) {
         switch (key) {
             case 'sulu_admin.page':
                 return 'Page';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
@@ -5,7 +5,7 @@ import listAdapterDefaultProps from '../../../../utils/TestHelper/listAdapterDef
 import TreeTableAdapter from '../../adapters/TreeTableAdapter';
 
 jest.mock('../../../../utils/Translator', () => ({
-    translate: function(key) {
+    translate(key) {
         switch (key) {
             case 'sulu_admin.page':
                 return 'Page';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceMultiSelect/tests/ResourceMultiSelect.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceMultiSelect/tests/ResourceMultiSelect.test.js
@@ -202,7 +202,7 @@ test('Render with data and requestParameters when resourceKey props changed', ()
     );
 
     resourceMultiSelect.setProps({
-        requestParameters: requestParameters,
+        requestParameters,
         displayProperty: 'name',
         onChange: jest.fn(),
         resourceKey: 'test2',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/ViewRenderer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/ViewRenderer.test.js
@@ -328,7 +328,7 @@ test('Clear bindings of router when same view with a different rerender attribut
             webspace: 'sulu',
         },
         clearBindings: jest.fn(),
-        route: route,
+        route,
     };
 
     shallow(<ViewRenderer router={router} />);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/metadataStore/metadataStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/metadataStore/metadataStore.js
@@ -15,8 +15,8 @@ class MetadataStore {
 
     loadMetadata(type: string, key: string, metadataOptions: Object = {}): Promise<Object> {
         const parameters = {
-            type: type,
-            key: key,
+            type,
+            key,
             ...metadataOptions,
         };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/userStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/userStore.js
@@ -101,7 +101,7 @@ class UserStore {
     login = (user: string, password: string) => {
         this.setLoading(true);
 
-        return Requester.post(Config.endpoints.loginCheck, {username: user, password: password})
+        return Requester.post(Config.endpoints.loginCheck, {username: user, password})
             .then(() => this.handleLogin(user))
             .catch((error) => {
                 this.setLoading(false);
@@ -118,7 +118,7 @@ class UserStore {
 
         if (this.forgotPasswordSuccess) {
             // if email was already sent use different api
-            return Requester.post(Config.endpoints.forgotPasswordResend, {user: user})
+            return Requester.post(Config.endpoints.forgotPasswordResend, {user})
                 .then(() => {
                     this.setLoading(false);
                 })
@@ -130,7 +130,7 @@ class UserStore {
                 });
         }
 
-        return Requester.post(Config.endpoints.forgotPasswordReset, {user: user})
+        return Requester.post(Config.endpoints.forgotPasswordReset, {user})
             .then(() => {
                 this.setLoading(false);
                 this.setForgotPasswordSuccess(true);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -1873,7 +1873,7 @@ test('Should pass metadataRequestParameters options to Form View', () => {
             formKey: 'snippets',
             locales: [],
             toolbarActions: [],
-            metadataRequestParameters: metadataRequestParameters,
+            metadataRequestParameters,
         },
     };
     const router = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/FormOverlayList.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/FormOverlayList.test.js
@@ -41,7 +41,7 @@ jest.mock('../../../containers/Form/stores/ResourceFormStore', () => jest.fn(
     (resourceStore, formKey, options, metadataOptions) => {
         return {
             id: resourceStore.id,
-            metadataOptions: metadataOptions,
+            metadataOptions,
         };
     }
 ));
@@ -211,7 +211,7 @@ test('Should pass metadataRequestParameters options to Form View', () => {
             options: {
                 formKey: 'test-form-key',
                 resourceKey: 'test-resource-key',
-                metadataRequestParameters: metadataRequestParameters,
+                metadataRequestParameters,
             },
         },
     }: any);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
@@ -103,7 +103,7 @@ jest.mock(
         this.resourceKey = resourceKey;
         this.id = id;
         this.data = {
-            id: id,
+            id,
             title: 'Sulu rocks',
             locale: 'de',
         };
@@ -124,7 +124,7 @@ jest.mock('../../../containers/List/registries/listFieldTransformerRegistry', ()
 }));
 
 jest.mock('../../../utils/Translator', () => ({
-    translate: function(key) {
+    translate(key) {
         switch (key) {
             case 'sulu_admin.page':
                 return 'Page';
@@ -596,7 +596,7 @@ test('Should navigate to defined route on back button click', () => {
 
     const list = mount(<List router={router} />);
     list.instance().locale = {
-        get: function() {
+        get() {
             return 'de';
         },
     };
@@ -741,7 +741,7 @@ test('Should navigate when add button is clicked and locales have been passed in
 
     const list = mount(<List router={router} />);
     list.instance().locale = {
-        get: function() {
+        get() {
             return 'de';
         },
     };
@@ -834,7 +834,7 @@ test('Should navigate when pencil button is clicked and locales have been passed
 
     const list = mount(<List router={router} />);
     list.instance().locale = {
-        get: function() {
+        get() {
             return 'de';
         },
     };
@@ -1033,7 +1033,7 @@ test('Should render the locale dropdown with the options from router', () => {
 
     const list = mount(<List router={router} />);
     list.instance().locale = {
-        get: function() {
+        get() {
             return 'de';
         },
     };
@@ -1063,7 +1063,7 @@ test('Should render the locale dropdown with the options from props', () => {
 
     const list = mount(<List locales={['en', 'de']} router={router} />);
     list.instance().locale = {
-        get: function() {
+        get() {
             return 'de';
         },
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/PreviewForm/tests/PreviewForm.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/PreviewForm/tests/PreviewForm.test.js
@@ -45,7 +45,7 @@ test('Should render Form view', () => {
         },
     };
     const router = {
-        route: route,
+        route,
     };
 
     const PreviewForm = require('../PreviewForm').default;
@@ -62,7 +62,7 @@ test('Should initialize preview sidebar per default when previewCondition is not
         options: {},
     };
     const router = {
-        route: route,
+        route,
     };
 
     // require preview form to trigger call of withSidebar mock and retrieve passed function
@@ -95,7 +95,7 @@ test('Should initialize preview sidebar when previewCondition evaluates to true'
         },
     };
     const router = {
-        route: route,
+        route,
     };
 
     // require preview form to trigger call of withSidebar mock and retrieve passed function
@@ -128,7 +128,7 @@ test('Should not initialize preview sidebar when previewCondition evaluates to t
         },
     };
     const router = {
-        route: route,
+        route,
     };
 
     // require preview form to trigger call of withSidebar mock and retrieve passed function

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
@@ -6,7 +6,7 @@ import ResourceTabs from '../ResourceTabs';
 import ResourceStore from '../../../stores/ResourceStore';
 
 jest.mock('../../../utils/Translator', () => ({
-    translate: function(key) {
+    translate(key) {
         switch (key) {
             case 'tabTitle1':
                 return 'Tab Titel 1';

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/containers/Form/tests/fields/ContactDetails.test.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/containers/Form/tests/fields/ContactDetails.test.js
@@ -40,7 +40,7 @@ test('Pass props correctly to ContactDetails component', () => {
     expect(bic.props()).toEqual(expect.objectContaining({
         onBlur: finishSpy,
         onChange: changeSpy,
-        value: value,
+        value,
     }));
 });
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/MediaCardAdapter.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/MediaCardAdapter.test.js
@@ -5,7 +5,7 @@ import {listAdapterDefaultProps} from 'sulu-admin-bundle/utils/TestHelper';
 import MediaCardAdapter from '../../adapters/MediaCardAdapter';
 
 jest.mock('sulu-admin-bundle/utils', () => ({
-    translate: function(key) {
+    translate(key) {
         switch (key) {
             case 'sulu_media.copy_url':
                 return 'Copy URL';
@@ -27,7 +27,7 @@ test('Render a basic Masonry view with MediaCards', () => {
             mimeType: 'image/png',
             size: 12345,
             url: 'http://lorempixel.com/500/500',
-            thumbnails: thumbnails,
+            thumbnails,
         },
         {
             ghostLocale: 'en',
@@ -36,7 +36,7 @@ test('Render a basic Masonry view with MediaCards', () => {
             mimeType: 'image/jpeg',
             size: 54321,
             url: 'http://lorempixel.com/500/500',
-            thumbnails: thumbnails,
+            thumbnails,
         },
     ];
     const mediaCardAdapter = render(
@@ -66,7 +66,7 @@ test('MediaCard should call the the appropriate handler', () => {
             mimeType: 'image/png',
             size: 12345,
             url: 'http://lorempixel.com/500/500',
-            thumbnails: thumbnails,
+            thumbnails,
         },
         {
             id: 2,
@@ -74,7 +74,7 @@ test('MediaCard should call the the appropriate handler', () => {
             mimeType: 'image/jpeg',
             size: 54321,
             url: 'http://lorempixel.com/500/500',
-            thumbnails: thumbnails,
+            thumbnails,
         },
     ];
     const mediaCardAdapter = shallow(

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/MediaCardOverviewAdapter.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/MediaCardOverviewAdapter.test.js
@@ -7,7 +7,7 @@ import MediaCardOverviewAdapter from '../../adapters/MediaCardOverviewAdapter';
 jest.mock('sulu-admin-bundle/services/initializer', () => jest.fn());
 
 jest.mock('sulu-admin-bundle/utils', () => ({
-    translate: function(key) {
+    translate(key) {
         switch (key) {
             case 'sulu_media.copy_url':
                 return 'Copy URL';
@@ -29,7 +29,7 @@ test('Render a basic Masonry view with the MediaCardOverviewAdapter', () => {
             mimeType: 'image/png',
             size: 12345,
             url: 'http://lorempixel.com/500/500',
-            thumbnails: thumbnails,
+            thumbnails,
         },
         {
             id: 2,
@@ -37,7 +37,7 @@ test('Render a basic Masonry view with the MediaCardOverviewAdapter', () => {
             mimeType: 'image/jpeg',
             size: 54321,
             url: 'http://lorempixel.com/500/500',
-            thumbnails: thumbnails,
+            thumbnails,
         },
     ];
     const mediaCardAdapter = render(

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
@@ -45,7 +45,7 @@ jest.mock('sulu-admin-bundle/containers', () => {
                     mimeType: 'image/png',
                     size: 12345,
                     url: 'http://lorempixel.com/500/500',
-                    thumbnails: thumbnails,
+                    thumbnails,
                 },
                 {
                     id: 2,
@@ -53,7 +53,7 @@ jest.mock('sulu-admin-bundle/containers', () => {
                     mimeType: 'image/jpeg',
                     size: 54321,
                     url: 'http://lorempixel.com/500/500',
-                    thumbnails: thumbnails,
+                    thumbnails,
                 },
             ];
 
@@ -134,7 +134,7 @@ jest.mock('sulu-admin-bundle/containers/List/registries/listAdapterRegistry', ()
     const getAllAdaptersMock = jest.fn();
 
     return {
-        getAllAdaptersMock: getAllAdaptersMock,
+        getAllAdaptersMock,
         add: jest.fn(),
         get: jest.fn((key) => getAllAdaptersMock()[key]),
         getOptions: jest.fn().mockReturnValue({}),

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/MediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/MediaSelectionOverlay.js
@@ -45,7 +45,7 @@ class MediaSelectionOverlay extends React.Component<Props> {
             USER_SETTINGS_KEY,
             {
                 page: observable.box(),
-                locale: locale,
+                locale,
                 parentId: collectionId,
             }
         );
@@ -82,8 +82,8 @@ class MediaSelectionOverlay extends React.Component<Props> {
             {
                 page: observable.box(),
                 collection: collectionId,
-                excludedIds: excludedIds,
-                locale: locale,
+                excludedIds,
+                locale,
             },
             options
         );

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/tests/MultiMediaDropzone.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/tests/MultiMediaDropzone.test.js
@@ -9,7 +9,7 @@ import MediaUploadStore from '../../../stores/MediaUploadStore';
 jest.useFakeTimers();
 
 jest.mock('sulu-admin-bundle/utils', () => ({
-    translate: function(key) {
+    translate(key) {
         switch (key) {
             case 'sulu_media.drop_files_to_upload':
                 return 'Upload files by dropping them here';

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/tests/MultiMediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/tests/MultiMediaSelection.test.js
@@ -217,7 +217,7 @@ test('Should add the selected medias to the selection store on confirm', () => {
             mimeType: 'image/png',
             size: 12345,
             url: 'http://lorempixel.com/500/500',
-            thumbnails: thumbnails,
+            thumbnails,
         },
         {
             id: 2,
@@ -225,7 +225,7 @@ test('Should add the selected medias to the selection store on confirm', () => {
             mimeType: 'image/jpeg',
             size: 54321,
             url: 'http://lorempixel.com/500/500',
-            thumbnails: thumbnails,
+            thumbnails,
         },
     ];
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -44,7 +44,7 @@ jest.mock('sulu-admin-bundle/containers', () => {
                     mimeType: 'image/png',
                     size: 12345,
                     url: 'http://lorempixel.com/500/500',
-                    thumbnails: thumbnails,
+                    thumbnails,
                 },
                 {
                     id: 2,
@@ -52,7 +52,7 @@ jest.mock('sulu-admin-bundle/containers', () => {
                     mimeType: 'image/jpeg',
                     size: 54321,
                     url: 'http://lorempixel.com/500/500',
-                    thumbnails: thumbnails,
+                    thumbnails,
                 },
             ];
 
@@ -137,7 +137,7 @@ jest.mock('sulu-admin-bundle/containers/List/registries/listAdapterRegistry', ()
     const getAllAdaptersMock = jest.fn();
 
     return {
-        getAllAdaptersMock: getAllAdaptersMock,
+        getAllAdaptersMock,
         add: jest.fn(),
         get: jest.fn((key) => getAllAdaptersMock()[key]),
         getOptions: jest.fn().mockReturnValue({}),
@@ -290,7 +290,7 @@ test('Router navigate should be called when a media was clicked', () => {
     mediaOverview.find('.media').at(0).simulate('click');
     expect(router.navigate).toBeCalledWith(
         'sulu_media.form.details',
-        {'id': 1, 'locale': locale}
+        {'id': 1, locale}
     );
 });
 

--- a/src/Sulu/Bundle/RouteBundle/Resources/js/containers/Form/tests/fields/PageTreeRoute.test.js
+++ b/src/Sulu/Bundle/RouteBundle/Resources/js/containers/Form/tests/fields/PageTreeRoute.test.js
@@ -90,7 +90,7 @@ test('Render a PageTreeRoute', () => {
     const modeResolver = jest.fn().mockImplementation(() => modePromise);
 
     const fieldTypeOptions = {
-        modeResolver: modeResolver,
+        modeResolver,
     };
 
     const value = {
@@ -143,7 +143,7 @@ test('Render a PageTreeRoute without value', () => {
     const modeResolver = jest.fn().mockImplementation(() => modePromise);
 
     const fieldTypeOptions = {
-        modeResolver: modeResolver,
+        modeResolver,
     };
 
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('pages'), 'test'));

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/Permissions.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/Permissions.js
@@ -145,7 +145,7 @@ class Permissions extends React.Component<Props> {
                 const newContextPermission: ContextPermission = {
                     'id': undefined,
                     'context': securityContextKey,
-                    'permissions': permissions,
+                    permissions,
                 };
                 newContextPermissions.push(newContextPermission);
             });

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/RoleAssignments.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/RoleAssignments.js
@@ -46,7 +46,7 @@ class RoleAssignments extends React.Component<Props> {
         for (const role of rolesToAdd) {
             newValue.push({
                 locales: [],
-                role: role,
+                role,
             });
         }
 

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -48,7 +48,7 @@ module.exports = { // eslint-disable-line
     sections: [
         {
             name: 'Components',
-            components: function() {
+            components() {
                 let folders = glob.sync('./src/Sulu/Bundle/*/Resources/js/components/*');
                 // filter out higher order components
                 folders = folders
@@ -65,7 +65,7 @@ module.exports = { // eslint-disable-line
         },
         {
             name: 'Containers',
-            components: function() {
+            components() {
                 let folders = glob.sync('./src/Sulu/Bundle/*/Resources/js/containers/*');
                 // filter out containers
                 folders = folders


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Add object-shorthand eslint rule and activate eslint cache by default. 

I personally not sure about the rule configuraiton but was requested by danrot to use shorthand syntax in #5101. 

#### Why?

For consistence.

#### BC Breaks/Deprecations

No bc breaks

#### To Do

- [ ] ~~Create a documentation PR~~
- [ ] ~~Add breaking changes to UPGRADE.md~~
