### PR TITLE
Fixed correct locale for article route generation

### DIFF
--- a/src/Sulu/Bundle/RouteBundle/Generator/SymfonyExpressionTokenProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Generator/SymfonyExpressionTokenProvider.php
@@ -42,9 +42,6 @@ class SymfonyExpressionTokenProvider implements TokenProviderInterface
         try {
             if (method_exists($entity, 'getLocale')) {
                 $this->translator->setLocale($entity->getLocale());
-            } elseif(is_a($entity->getLocale, \Closure::class)) {
-                $getLocale = $entity->getLocale;
-                $this->translator->setLocale($getLocale());
             }
 
             $result = $this->expressionLanguage->evaluate($name, ['object' => $entity, 'translator' => $this->translator]);

--- a/src/Sulu/Bundle/RouteBundle/Generator/SymfonyExpressionTokenProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Generator/SymfonyExpressionTokenProvider.php
@@ -37,9 +37,9 @@ class SymfonyExpressionTokenProvider implements TokenProviderInterface
 
     public function provide($entity, $name)
     {
-        try {
-            $locale = $this->translator->getLocale();
+        $locale = $this->translator->getLocale();
 
+        try {
             if (method_exists($entity, 'getLocale')) {
                 $this->translator->setLocale($entity->getLocale());
             }

--- a/src/Sulu/Bundle/RouteBundle/Generator/SymfonyExpressionTokenProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Generator/SymfonyExpressionTokenProvider.php
@@ -50,6 +50,8 @@ class SymfonyExpressionTokenProvider implements TokenProviderInterface
             return $result;
         } catch (\Exception $e) {
             throw new CannotEvaluateTokenException($name, $entity, $e);
+        } finally {
+            $this->translator->setLocale($locale);
         }
     }
 }

--- a/src/Sulu/Bundle/RouteBundle/Generator/SymfonyExpressionTokenProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Generator/SymfonyExpressionTokenProvider.php
@@ -39,7 +39,11 @@ class SymfonyExpressionTokenProvider implements TokenProviderInterface
     {
         try {
             $locale = $this->translator->getLocale();
-            $this->translator->setLocale($entity->getLocale());
+
+            if (method_exists($entity, 'getLocale')) {
+                $this->translator->setLocale($entity->getLocale());
+            }
+
             $result = $this->expressionLanguage->evaluate($name, ['object' => $entity, 'translator' => $this->translator]);
             $this->translator->setLocale($locale);
 

--- a/src/Sulu/Bundle/RouteBundle/Generator/SymfonyExpressionTokenProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Generator/SymfonyExpressionTokenProvider.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\RouteBundle\Generator;
 
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Enables to use the symfony expression language in route tokens.

--- a/src/Sulu/Bundle/RouteBundle/Generator/SymfonyExpressionTokenProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Generator/SymfonyExpressionTokenProvider.php
@@ -38,7 +38,12 @@ class SymfonyExpressionTokenProvider implements TokenProviderInterface
     public function provide($entity, $name)
     {
         try {
-            return $this->expressionLanguage->evaluate($name, ['object' => $entity, 'translator' => $this->translator]);
+            $locale = $this->translator->getLocale();
+            $this->translator->setLocale($entity->getLocale());
+            $result = $this->expressionLanguage->evaluate($name, ['object' => $entity, 'translator' => $this->translator]);
+            $this->translator->setLocale($locale);
+
+            return $result;
         } catch (\Exception $e) {
             throw new CannotEvaluateTokenException($name, $entity, $e);
         }

--- a/src/Sulu/Bundle/RouteBundle/Generator/SymfonyExpressionTokenProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Generator/SymfonyExpressionTokenProvider.php
@@ -42,6 +42,9 @@ class SymfonyExpressionTokenProvider implements TokenProviderInterface
         try {
             if (method_exists($entity, 'getLocale')) {
                 $this->translator->setLocale($entity->getLocale());
+            } elseif(is_a($entity->getLocale, \Closure::class)) {
+                $getLocale = $entity->getLocale;
+                $this->translator->setLocale($getLocale());
             }
 
             $result = $this->expressionLanguage->evaluate($name, ['object' => $entity, 'translator' => $this->translator]);

--- a/src/Sulu/Bundle/RouteBundle/Generator/SymfonyExpressionTokenProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Generator/SymfonyExpressionTokenProvider.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\RouteBundle\Generator;
 
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
-use Symfony\Contracts\Translation\TranslatorInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Enables to use the symfony expression language in route tokens.

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/SymfonyExpressionTokenProviderTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/SymfonyExpressionTokenProviderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of Sulu.
  *

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/SymfonyExpressionTokenProviderTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/SymfonyExpressionTokenProviderTest.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * This file is part of Sulu.
  *
@@ -14,16 +13,21 @@ namespace Sulu\Bundle\RouteBundle\Tests\Unit\Generator;
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\RouteBundle\Generator\CannotEvaluateTokenException;
 use Sulu\Bundle\RouteBundle\Generator\SymfonyExpressionTokenProvider;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class SymfonyExpressionTokenProviderTest extends TestCase
 {
     public function testResolve()
     {
         $translator = $this->prophesize(TranslatorInterface::class);
+        $translator->getLocale()->willReturn('de');
+        $translator->setLocale()->willReturn('en')->shouldBeCalled();
+        $translator->setLocale()->willReturn('de')->shouldBeCalled();
         $entity = new \stdClass();
+        $entity->getLocale = function () {
+            return 'en';
+        };
         $entity->name = 'TEST';
-
         $provider = new SymfonyExpressionTokenProvider($translator->reveal());
         $this->assertEquals('TEST', $provider->provide($entity, 'object.name'));
     }
@@ -31,10 +35,14 @@ class SymfonyExpressionTokenProviderTest extends TestCase
     public function testResolveTranslation()
     {
         $translator = $this->prophesize(TranslatorInterface::class);
+        $translator->getLocale()->willReturn('de');
+        $translator->setLocale()->willReturn('en')->shouldBeCalled();
+        $translator->setLocale()->willReturn('de')->shouldBeCalled();
         $translator->trans('test-key')->willReturn('TEST');
-
         $entity = new \stdClass();
-
+        $entity->getLocale = function () {
+            return 'en';
+        };
         $provider = new SymfonyExpressionTokenProvider($translator->reveal());
         $this->assertEquals('TEST', $provider->provide($entity, 'translator.trans("test-key")'));
     }
@@ -42,10 +50,8 @@ class SymfonyExpressionTokenProviderTest extends TestCase
     public function testResolveNotExists()
     {
         $this->expectException(CannotEvaluateTokenException::class);
-
         $translator = $this->prophesize(TranslatorInterface::class);
         $entity = new \stdClass();
-
         $provider = new SymfonyExpressionTokenProvider($translator->reveal());
         $provider->provide($entity, 'object.title');
     }

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/SymfonyExpressionTokenProviderTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/SymfonyExpressionTokenProviderTest.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\RouteBundle\Tests\Unit\Generator;
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\RouteBundle\Generator\CannotEvaluateTokenException;
 use Sulu\Bundle\RouteBundle\Generator\SymfonyExpressionTokenProvider;
+use Sulu\Bundle\RouteBundle\Model\RoutableInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class SymfonyExpressionTokenProviderTest extends TestCase
@@ -22,9 +23,10 @@ class SymfonyExpressionTokenProviderTest extends TestCase
     {
         $translator = $this->prophesize(TranslatorInterface::class);
         $translator->getLocale()->willReturn('de');
-        $translator->setLocale('en')->shouldBeCalled();
         $translator->setLocale('de')->shouldBeCalled();
-        $entity = new \stdClass();
+        $entity = $this->prophesize(RoutableInterface::class);
+        $entity->getLocale()->willReturn('en');
+
         $entity->getLocale = function() {
             return 'en';
         };
@@ -37,10 +39,11 @@ class SymfonyExpressionTokenProviderTest extends TestCase
     {
         $translator = $this->prophesize(TranslatorInterface::class);
         $translator->getLocale()->willReturn('de');
-        $translator->setLocale('en')->shouldBeCalled();
         $translator->setLocale('de')->shouldBeCalled();
         $translator->trans('test-key')->willReturn('TEST');
-        $entity = new \stdClass();
+        $entity = $this->prophesize(RoutableInterface::class);
+        $entity->getLocale()->willReturn('en');
+
         $entity->getLocale = function() {
             return 'en';
         };

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/SymfonyExpressionTokenProviderTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/SymfonyExpressionTokenProviderTest.php
@@ -22,6 +22,7 @@ class SymfonyExpressionTokenProviderTest extends TestCase
     {
         $translator = $this->prophesize(TranslatorInterface::class);
         $translator->getLocale()->willReturn('de');
+        $translator->setLocale('en')->shouldBeCalled();
         $translator->setLocale('de')->shouldBeCalled();
         $entity = new \stdClass();
         $entity->getLocale = function() {
@@ -36,6 +37,7 @@ class SymfonyExpressionTokenProviderTest extends TestCase
     {
         $translator = $this->prophesize(TranslatorInterface::class);
         $translator->getLocale()->willReturn('de');
+        $translator->setLocale('en')->shouldBeCalled();
         $translator->setLocale('de')->shouldBeCalled();
         $translator->trans('test-key')->willReturn('TEST');
         $entity = new \stdClass();

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/SymfonyExpressionTokenProviderTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/SymfonyExpressionTokenProviderTest.php
@@ -24,7 +24,7 @@ class SymfonyExpressionTokenProviderTest extends TestCase
         $translator->setLocale()->willReturn('en')->shouldBeCalled();
         $translator->setLocale()->willReturn('de')->shouldBeCalled();
         $entity = new \stdClass();
-        $entity->getLocale = function () {
+        $entity->getLocale = function() {
             return 'en';
         };
         $entity->name = 'TEST';
@@ -40,7 +40,7 @@ class SymfonyExpressionTokenProviderTest extends TestCase
         $translator->setLocale()->willReturn('de')->shouldBeCalled();
         $translator->trans('test-key')->willReturn('TEST');
         $entity = new \stdClass();
-        $entity->getLocale = function () {
+        $entity->getLocale = function() {
             return 'en';
         };
         $provider = new SymfonyExpressionTokenProvider($translator->reveal());

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/SymfonyExpressionTokenProviderTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/SymfonyExpressionTokenProviderTest.php
@@ -22,8 +22,7 @@ class SymfonyExpressionTokenProviderTest extends TestCase
     {
         $translator = $this->prophesize(TranslatorInterface::class);
         $translator->getLocale()->willReturn('de');
-        $translator->setLocale()->willReturn('en')->shouldBeCalled();
-        $translator->setLocale()->willReturn('de')->shouldBeCalled();
+        $translator->setLocale('de')->shouldBeCalled();
         $entity = new \stdClass();
         $entity->getLocale = function() {
             return 'en';
@@ -37,8 +36,7 @@ class SymfonyExpressionTokenProviderTest extends TestCase
     {
         $translator = $this->prophesize(TranslatorInterface::class);
         $translator->getLocale()->willReturn('de');
-        $translator->setLocale()->willReturn('en')->shouldBeCalled();
-        $translator->setLocale()->willReturn('de')->shouldBeCalled();
+        $translator->setLocale('de')->shouldBeCalled();
         $translator->trans('test-key')->willReturn('TEST');
         $entity = new \stdClass();
         $entity->getLocale = function() {

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/SymfonyExpressionTokenProviderTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/SymfonyExpressionTokenProviderTest.php
@@ -14,7 +14,7 @@ namespace Sulu\Bundle\RouteBundle\Tests\Unit\Generator;
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\RouteBundle\Generator\CannotEvaluateTokenException;
 use Sulu\Bundle\RouteBundle\Generator\SymfonyExpressionTokenProvider;
-use Symfony\Contracts\Translation\TranslatorInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class SymfonyExpressionTokenProviderTest extends TestCase
 {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fixes the route generation in articles that have translated routes.

#### Why?

Wrong Route Translation when adding new Article: https://github.com/sulu/SuluArticleBundle/issues/432