### PR TITLE
Allow to remove undefined filter

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/AbstractFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/AbstractFieldFilterType.js
@@ -29,7 +29,7 @@ export default class AbstractFieldFilterType<T> {
     }
 
     // eslint-disable-next-line no-unused-vars
-    getValueNode(value: T): ?Promise<Node> {
-        return null;
+    getValueNode(value: T): Promise<Node> {
+        return Promise.resolve(null);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/BooleanFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/BooleanFieldFilterType.js
@@ -30,7 +30,7 @@ class BooleanFieldFilterType extends AbstractFieldFilterType<?boolean> {
 
     getValueNode(value: ?boolean) {
         if (value === undefined) {
-            return null;
+            return Promise.resolve(null);
         }
 
         return Promise.resolve(translate(value ? 'sulu_admin.yes' : 'sulu_admin.no'));

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/DateTimeFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/DateTimeFieldFilterType.js
@@ -40,10 +40,14 @@ class DateTimeFieldFilterType extends AbstractFieldFilterType<?{from?: Date, to?
 
     getValueNode(value: ?{from?: Date, to?: Date}) {
         if (!value) {
-            return null;
+            return Promise.resolve(null);
         }
 
         const {from, to} = value;
+
+        if (!from && !to) {
+            return Promise.resolve(null);
+        }
 
         return Promise.resolve(formatDate(from) + ' - ' + formatDate(to));
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/DropdownFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/DropdownFieldFilterType.js
@@ -22,11 +22,15 @@ class DropdownFieldFilterType extends AbstractFieldFilterType<?Array<string>> {
         return options;
     }
 
+    handleChange = (values: Array<string>) => {
+        this.onChange(values.length > 0 ? values : undefined);
+    };
+
     getFormNode() {
-        const {onChange, value} = this;
+        const {value} = this;
 
         return (
-            <MultiSelect onChange={onChange} values={value || []}>
+            <MultiSelect onChange={this.handleChange} values={value || []}>
                 {Object.keys(this.options).map((optionKey) => (
                     <MultiSelect.Option
                         key={optionKey}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/DropdownFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/DropdownFieldFilterType.js
@@ -39,9 +39,9 @@ class DropdownFieldFilterType extends AbstractFieldFilterType<?Array<string>> {
         );
     }
 
-    getValueNode(values: ?Array<string>): ?Promise<string> {
+    getValueNode(values: ?Array<string>) {
         if (!values) {
-            return null;
+            return Promise.resolve(null);
         }
 
         return Promise.resolve(values.map((value) => translate(this.options[value])).join(', '));

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/TextFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/TextFieldFilterType.js
@@ -21,10 +21,6 @@ class TextFieldFilterType extends AbstractFieldFilterType<?{eq: string}> {
     }
 
     getValueNode(value: ?{eq: string}) {
-        if (!value) {
-            return null;
-        }
-
         return Promise.resolve(value ? value.eq : null);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
@@ -202,8 +202,11 @@ export default class ListStore {
                 : {};
 
             if (!equals(oldFilteredValue, newFilteredValue)) {
-                ListStore.setFilterSetting(this.listKey, this.userSettingsKey, change.newValue);
                 callResetForChangedObservable(change);
+            }
+
+            if (!equals(oldValue, newValue)) {
+                ListStore.setFilterSetting(this.listKey, this.userSettingsKey, change.newValue);
             }
 
             return change;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/BooleanFieldFilterType.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/BooleanFieldFilterType.test.js
@@ -41,16 +41,11 @@ test('Call onChange handler with new value', () => {
 test.each([
     [true, 'sulu_admin.yes'],
     [false, 'sulu_admin.no'],
-    [undefined, undefined],
+    [undefined, null],
 ])('Return value node with value "%s"', (value, expectedValueNode) => {
     const booleanFieldFilterType = new BooleanFieldFilterType(jest.fn(), {}, undefined);
 
     const valueNodePromise = booleanFieldFilterType.getValueNode(value);
-
-    if (expectedValueNode === undefined) {
-        expect(valueNodePromise).toEqual(null);
-        return;
-    }
 
     if (!valueNodePromise) {
         throw new Error('The getValueNode function must return a promise!');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/DateTimeFieldFilterType.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/DateTimeFieldFilterType.test.js
@@ -82,16 +82,12 @@ test('Call onChange handler with to value and existing value', () => {
 test.each([
     [{from: new Date('2018-03-07'), to: new Date('2018-08-02')}, '03/07/2018 - 08/02/2018'],
     [{from: new Date('2017-11-07'), to: new Date('2017-12-11')}, '11/07/2017 - 12/11/2017'],
-    [undefined, undefined],
+    [undefined, null],
+    [{}, null],
 ])('Return value node with value "%s"', (value, expectedValueNode) => {
     const dateTimeFieldFilterType = new DateTimeFieldFilterType(jest.fn(), {}, undefined);
 
     const valueNodePromise = dateTimeFieldFilterType.getValueNode(value);
-
-    if (expectedValueNode === undefined) {
-        expect(valueNodePromise).toEqual(null);
-        return;
-    }
 
     if (!valueNodePromise) {
         throw new Error('The getValueNode function must return a promise!');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/DropdownFieldFilterType.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/DropdownFieldFilterType.test.js
@@ -65,6 +65,16 @@ test('Call onChange handler with new value', () => {
     expect(changeSpy).toBeCalledWith(['test']);
 });
 
+test('Call onChange handler with undefined if the new selection is empty', () => {
+    const changeSpy = jest.fn();
+    const dropdownFieldFilterType = new DropdownFieldFilterType(changeSpy, {options: {test: 'test'}}, undefined);
+    const dropdownFieldFilterTypeForm = mount(dropdownFieldFilterType.getFormNode());
+
+    dropdownFieldFilterTypeForm.find('MultiSelect').prop('onChange')([]);
+
+    expect(changeSpy).toBeCalledWith(undefined);
+});
+
 test.each([
     [['audio', 'video'], 'Audio, Video'],
     [['image'], 'Image'],

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/DropdownFieldFilterType.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/DropdownFieldFilterType.test.js
@@ -68,7 +68,7 @@ test('Call onChange handler with new value', () => {
 test.each([
     [['audio', 'video'], 'Audio, Video'],
     [['image'], 'Image'],
-    [undefined, undefined],
+    [undefined, null],
 ])('Return value node with value "%s"', (value, expectedValueNode) => {
     const dropdownFieldFilterType = new DropdownFieldFilterType(
         jest.fn(),
@@ -77,11 +77,6 @@ test.each([
     );
 
     const valueNodePromise = dropdownFieldFilterType.getValueNode(value);
-
-    if (expectedValueNode === undefined) {
-        expect(valueNodePromise).toEqual(null);
-        return;
-    }
 
     if (!valueNodePromise) {
         throw new Error('The getValueNode function must return a promise!');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/TextFieldFilterType.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/TextFieldFilterType.test.js
@@ -44,3 +44,17 @@ test.each([
         expect(valueNode).toEqual(value);
     });
 });
+
+test('Return value node for null', () => {
+    const textFieldFilterType = new TextFieldFilterType(jest.fn(), {}, undefined);
+
+    const valueNodePromise = textFieldFilterType.getValueNode(null);
+
+    if (!valueNodePromise) {
+        throw new Error('The getValueNode function must return a promise!');
+    }
+
+    return valueNodePromise.then((valueNode) => {
+        expect(valueNode).toEqual(null);
+    });
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
@@ -81,12 +81,13 @@ test('The filter value should be updated when set from the outside', () => {
         .toBeCalledWith('sulu_admin.list_store.tests.list_test.filter', {test: {eq: 'Test'}});
 });
 
-test('The filter value should not be updated when set from the outside and only an undefined value was added', () => {
+test('The filter value should be updated when set from the outside and only an undefined value was added', () => {
     const listStore = new ListStore('tests', 'tests', 'list_test', {page: observable.box()});
     expect(listStore.filterOptions.get()).toEqual({});
 
     listStore.filterOptions.set({test: undefined});
-    expect(userStore.setPersistentSetting).not.toBeCalled();
+    expect(userStore.setPersistentSetting)
+        .toBeCalledWith('sulu_admin.list_store.tests.list_test.filter', {test: undefined});
 });
 
 test('The filter value should be updated when set from the outside and only a single false value was added', () => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | introduced in #5035 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR also saves the user settings, when only undefined values are removed. But the list should still not reload.

#### Why?

Because otherwise the list will set the stored user setting as default again, when the last item is `undefined` and removed.