### PR TITLE
Avoid setting limit if the default limit has already been set

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -84,6 +84,16 @@ export default class Router {
     }
 
     @action bind(key: string, value: IObservableValue<*>, defaultValue: ?string | number | boolean = undefined) {
+        this.bindings.set(key, value);
+        this.bindingDefaults.set(key, defaultValue);
+
+        if (this.attributes[key] === undefined && value.get() === defaultValue) {
+            // when the bound parameter already has the default value set, and the passed attribute has a value of
+            // undefined, then we should not set it to undefined to set it back to the default value afterwards
+            // if we would to that, registered intercepts would be called, although nothing changed
+            return;
+        }
+
         if (key in this.attributes && value.get() !== this.attributes[key]) {
             // when the bound parameter is bound set the state of the passed observable to the current value once
             // required because otherwise the parameter will be overridden on the initial start of the application
@@ -94,9 +104,6 @@ export default class Router {
             // when the observable value is not set we want it to be the default value
             value.set(defaultValue);
         }
-
-        this.bindings.set(key, value);
-        this.bindingDefaults.set(key, defaultValue);
     }
 
     @action clearBindings() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
@@ -602,6 +602,33 @@ test('Binding should set default attribute', () => {
     expect(router.url).toBe('/page/en');
 });
 
+test('Binding should not touch observable value when default attribute is already set', () => {
+    routeRegistry.getAll.mockReturnValue({
+        page: new Route({
+            name: 'page',
+            type: 'page',
+            path: '/page/:locale',
+        }),
+    });
+
+    const locale = observable.box('en');
+    let observableChanged = false;
+
+    locale.intercept((change) => {
+        observableChanged = true;
+        return change;
+    });
+
+    const history = createMemoryHistory();
+    const router = new Router(history);
+    router.attributes.locale = undefined;
+
+    router.bind('locale', locale, 'en');
+    router.handleNavigation('page', {}, router.navigate);
+    expect(router.attributes.locale).toBe('en');
+    expect(observableChanged).toEqual(false);
+});
+
 test('Binding should update URL with fixed attributes', () => {
     routeRegistry.getAll.mockReturnValue({
         page: new Route({


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR avoids setting the value of the `observable.box` passed to the `Router.bind` function, if it would just be set to `undefined` and back to its original value. That happens when the `Router` has the parameter already set to `undefined`, and the passed `observable.box` already would have the default value.

#### Why?

When a list is loaded with the default limit of 10, it always sends a `settings` request setting the limit to 10, although it has already been 10 previously.