### PR TITLE
Allow to filter with only from or to date

### DIFF
--- a/src/Sulu/Component/Rest/ListBuilder/Filter/DateTimeFilterType.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Filter/DateTimeFilterType.php
@@ -21,13 +21,27 @@ class DateTimeFilterType implements FilterTypeInterface
         FieldDescriptorInterface $fieldDescriptor,
         $options
     ): void {
-        if (!is_array($options) || !isset($options['from']) || !isset($options['to'])) {
+        if (!is_array($options) || (!isset($options['from']) && !isset($options['to']))) {
             throw new InvalidFilterTypeOptionsException(
-                'The DateTimeFilterType requires its options to be an array with a "from" and "to" key!'
+                'The DateTimeFilterType requires its options to be an array with a "from" or "to" key!'
             );
         }
 
-        $listBuilder->between($fieldDescriptor, [$options['from'], $options['to']]);
+        if (isset($options['from']) && isset($options['to'])) {
+            $listBuilder->between($fieldDescriptor, [$options['from'], $options['to']]);
+        } elseif (isset($options['from']) && !isset($options['to'])) {
+            $listBuilder->where(
+                $fieldDescriptor,
+                $options['from'],
+                ListBuilderInterface::WHERE_COMPARATOR_GREATER
+            );
+        } elseif (!isset($options['from']) && isset($options['to'])) {
+            $listBuilder->where(
+                $fieldDescriptor,
+                $options['to'],
+                ListBuilderInterface::WHERE_COMPARATOR_LESS
+            );
+        }
     }
 
     public static function getDefaultIndexName(): string

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/DateTimeFilterTypeTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/DateTimeFilterTypeTest.php
@@ -55,12 +55,54 @@ class DateTimeFilterTypeTest extends TestCase
         $this->listBuilder->between($fieldDescriptor->reveal(), $expected)->shouldBeCalled();
     }
 
+    public function provideFilterFromOnly()
+    {
+        return [
+            ['created', ['from' => '2020-02-05'], '2020-02-05'],
+            ['changed', ['from' => '2013-08-01'], '2013-08-01'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFilterFromOnly
+     */
+    public function testFilterFromOnly($fieldName, $value, $expected)
+    {
+        $fieldDescriptor = $this->prophesize(FieldDescriptor::class);
+
+        $this->dateTimeFilterType->filter($this->listBuilder->reveal(), $fieldDescriptor->reveal(), $value);
+
+        $this->listBuilder
+             ->where($fieldDescriptor->reveal(), $expected, ListBuilderInterface::WHERE_COMPARATOR_GREATER)
+             ->shouldBeCalled();
+    }
+
+    public function provideFilterToOnly()
+    {
+        return [
+            ['created', ['to' => '2020-02-05'], '2020-02-05'],
+            ['changed', ['to' => '2013-08-01'], '2013-08-01'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFilterToOnly
+     */
+    public function testFilterToOnly($fieldName, $value, $expected)
+    {
+        $fieldDescriptor = $this->prophesize(FieldDescriptor::class);
+
+        $this->dateTimeFilterType->filter($this->listBuilder->reveal(), $fieldDescriptor->reveal(), $value);
+
+        $this->listBuilder
+             ->where($fieldDescriptor->reveal(), $expected, ListBuilderInterface::WHERE_COMPARATOR_LESS)
+             ->shouldBeCalled();
+    }
+
     public function provideFilterWithInvalidOptions()
     {
         return [
             [[]],
-            [['from' => '2019-10-01']],
-            [['to' => '2020-10-01']],
             ['Test'],
         ];
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR allows to filter only for the `from` or `to` date. It's working same as when both values are set, just that omitting it means it goes back or forth into infinity.