### PR TITLE
Hide ColumnOptions in Selection FieldType

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -446,6 +446,7 @@ class Selection extends React.Component<Props> {
                     disabled={!!disabled}
                     itemDisabledCondition={itemDisabledCondition}
                     searchable={false}
+                    showColumnOptions={false}
                     store={this.listStore}
                 />
             </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -753,6 +753,7 @@ test('Should pass correct props to list component', () => {
         disabled: true,
         itemDisabledCondition: 'status == "inactive"',
         searchable: false,
+        showColumnOptions: false,
     }));
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
@@ -50,6 +50,7 @@ type Props = {|
     orderable: boolean,
     searchable: boolean,
     selectable: boolean,
+    showColumnOptions: boolean,
     store: ListStore,
     toolbarClassName?: string,
 |};
@@ -69,6 +70,7 @@ class List extends React.Component<Props> {
         orderable: true,
         searchable: true,
         selectable: true,
+        showColumnOptions: true,
     };
 
     @observable currentAdapterKey: string;
@@ -122,6 +124,10 @@ class List extends React.Component<Props> {
 
         // TODO do not hardcode "id", but use some kind of metadata instead
         return [...disabledIds, ...disabledItems.map((item) => item.id)];
+    }
+
+    @computed get showColumnOptions(): boolean {
+        return this.currentAdapter.hasColumnOptions && this.props.showColumnOptions;
     }
 
     constructor(props: Props) {
@@ -509,8 +515,6 @@ class List extends React.Component<Props> {
         const searchable = this.props.searchable && Adapter.searchable;
         const filterable = filterableFields && Object.keys(filterableFields).length > 0;
 
-        const {hasColumnOptions} = this.currentAdapter;
-
         if (store.forbidden) {
             return <PermissionHint />;
         }
@@ -518,7 +522,7 @@ class List extends React.Component<Props> {
         return (
             <div className={listStyles.listContainer}>
                 {header}
-                {!schemaLoading && (searchable || adapters.length > 1 || filterable || hasColumnOptions) &&
+                {!schemaLoading && (searchable || adapters.length > 1 || filterable || this.showColumnOptions) &&
                     <div className={toolbarClass}>
                         {searchable &&
                             <Search onSearch={this.handleSearch} value={store.searchTerm.get()} />
@@ -528,7 +532,7 @@ class List extends React.Component<Props> {
                             onChange={this.handleFilterChange}
                             value={store.filterOptions.get()}
                         />
-                        {hasColumnOptions &&
+                        {this.showColumnOptions &&
                             <Fragment>
                                 <ArrowMenu
                                     anchorElement={

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
@@ -223,6 +223,19 @@ test('Render toolbar with given toolbar class', () => {
     expect(list.find('.toolbar').prop('className')).toEqual(expect.stringContaining('test-class'));
 });
 
+test('Do not render toolbar if list is not searchable and adapter has column options but List deactivated them', () => {
+    class NewTestAdapter extends TestAdapter {
+        static hasColumnOptions = true;
+    }
+    listAdapterRegistry.get.mockReturnValue(NewTestAdapter);
+
+    const listStore = new ListStore('test', 'test', 'list_test', {page: observable.box(1)});
+
+    const list = shallow(<List adapters={['table']} searchable={false} showColumnOptions={false} store={listStore} />);
+
+    expect(list.find('.toolbar').exists()).toBeFalsy();
+});
+
 test('Do not render toolbar if list is not searchable and adapter has no column options', () => {
     class NewTestAdapter extends TestAdapter {
         static hasColumnOptions = false;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #5100 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR introduces a new `showColumnOptions` prop for the `List` container, that allows to hide the  column options.

#### Why?

Because otherwise the column options are also shown in the `selection` field type, as you can see e.g. in the page excerpt and taxonomies tab (the categories and audience targeting selections have the column options displayed, although they should not).