### PR TITLE
Make the datepicker elements clickable for the user

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,21 @@
 
 ## dev-master
 
+### Backdrop component
+
+Our `Backdrop` React component does not have the `local` and `open` props anymore. It is not supported anymore to render
+the backdrop in a portal. Instead it will be rendered right where it is put in the component tree, and if you want it to
+be in a `Portal` you have to put it there. The `open` prop has also been removed, since you can use conditional
+rendering to render the `Backdrop` only if needed.
+
+```javascript
+// Before
+<Backdrop open={open} />
+
+// After
+{open && <Backdrop />}
+```
+
 ### CacheClearer service changed
 
 The CacheClearer service `sulu_website.http_cache.clearer` constructor arguments has changed. The third argument the

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/tests/ArrowMenu.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/tests/ArrowMenu.test.js
@@ -117,7 +117,7 @@ test('Render ArrowMenu open', () => {
     expect(arrowMenu.find('ArrowMenu > button').text()).toEqual('Nice button');
 
     expect(arrowMenu.find('Popover').children()).toHaveLength(1);
-    expect(arrowMenu.find('Popover Backdrop').prop('open')).toEqual(true);
+    expect(arrowMenu.find('Popover Backdrop')).toHaveLength(1);
     expect(arrowMenu.render()).toMatchSnapshot();
 });
 
@@ -171,7 +171,7 @@ test('Render ArrowMenu open with falsy values', () => {
     expect(arrowMenu.find('ArrowMenu > button').text()).toEqual('Nice button');
 
     expect(arrowMenu.find('Popover').children()).toHaveLength(1);
-    expect(arrowMenu.find('Popover Backdrop').prop('open')).toEqual(true);
+    expect(arrowMenu.find('Popover Backdrop')).toHaveLength(1);
     expect(arrowMenu.render()).toMatchSnapshot();
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/tests/ArrowMenu.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/tests/ArrowMenu.test.js
@@ -116,7 +116,7 @@ test('Render ArrowMenu open', () => {
     expect(arrowMenu.children()).toHaveLength(2);
     expect(arrowMenu.find('ArrowMenu > button').text()).toEqual('Nice button');
 
-    expect(arrowMenu.find('Popover').children()).toHaveLength(2);
+    expect(arrowMenu.find('Popover').children()).toHaveLength(1);
     expect(arrowMenu.find('Popover Backdrop').prop('open')).toEqual(true);
     expect(arrowMenu.render()).toMatchSnapshot();
 });
@@ -170,7 +170,7 @@ test('Render ArrowMenu open with falsy values', () => {
     expect(arrowMenu.children()).toHaveLength(2);
     expect(arrowMenu.find('ArrowMenu > button').text()).toEqual('Nice button');
 
-    expect(arrowMenu.find('Popover').children()).toHaveLength(2);
+    expect(arrowMenu.find('Popover').children()).toHaveLength(1);
     expect(arrowMenu.find('Popover Backdrop').prop('open')).toEqual(true);
     expect(arrowMenu.render()).toMatchSnapshot();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Backdrop/Backdrop.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Backdrop/Backdrop.js
@@ -1,23 +1,17 @@
 // @flow
 import classNames from 'classnames';
-import {Portal} from 'react-portal';
 import React from 'react';
 import backdropStyles from './backdrop.scss';
 
-type Props = {
+type Props = {|
     fixed: boolean,
-    /** If true, the backdrop gets rendered in the placed element and not in the body. */
-    local: boolean,
     onClick?: () => void,
-    open: boolean,
     visible: boolean,
-};
+|};
 
 export default class Backdrop extends React.PureComponent<Props> {
     static defaultProps = {
         fixed: true,
-        local: false,
-        open: true,
         visible: true,
     };
 
@@ -29,9 +23,7 @@ export default class Backdrop extends React.PureComponent<Props> {
 
     render() {
         const {
-            open,
             visible,
-            local,
             fixed,
         } = this.props;
         const backdropClass = classNames(
@@ -41,16 +33,7 @@ export default class Backdrop extends React.PureComponent<Props> {
                 [backdropStyles.fixed]: fixed,
             }
         );
-        const backdrop = <div className={backdropClass} onClick={this.handleClick} role="button" />;
 
-        if (!open) {
-            return null;
-        }
-
-        if (local) {
-            return backdrop;
-        }
-
-        return <Portal>{backdrop}</Portal>;
+        return <div className={backdropClass} onClick={this.handleClick} role="button" />;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Backdrop/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Backdrop/README.md
@@ -1,23 +1,23 @@
 The `Backdrop` component serves as a simple solution to create a backdrop for overlays.
 
-Here is a basic example of the component. The open state of the backdrop is controlled by the `open` property.
-
 ```javascript
-intialState = {open: false};
-
-<div>
-    <button onClick={() => setState({open: true})}>Open Backdrop</button>
-    <Backdrop open={!!state.open} onClick={() => setState({open: false})} />
+<div style={{height: '200px', position: 'relative'}}>
+    <Backdrop fixed={false} />
 </div>
 ```
 
 This time the `visible` property is set to false, therefore the backdrop is invisible.
 
 ```javascript
-intialState = {open: false};
+<div style={{height: '200px', position: 'relative'}}>
+    <Backdrop fixed={false} visible={false} />
+</div>
+```
 
-<div>
-    <button onClick={() => setState({open: true})}>Open Backdrop</button>
-    <Backdrop visible={false} open={!!state.open} onClick={() => setState({open: false})} />
+The `Backdrop` also accepts an `onClick` handler.
+
+```javascript
+<div style={{height: '200px', position: 'relative'}}>
+    <Backdrop onClick={() => alert('You clicked the backdrop!')} fixed={false} />
 </div>
 ```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Backdrop/tests/Backdrop.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Backdrop/tests/Backdrop.test.js
@@ -1,7 +1,6 @@
 // @flow
-import {mount, shallow} from 'enzyme';
+import {render, shallow} from 'enzyme';
 import React from 'react';
-import pretty from 'pretty';
 import Backdrop from '../Backdrop';
 
 afterEach(() => {
@@ -10,37 +9,13 @@ afterEach(() => {
     }
 });
 
-test('The component should render in body when open', () => {
-    const body = document.body;
-    const view = mount(<Backdrop open={true} />).render();
-    expect(view.html()).toBe('');
-    expect(pretty(body ? body.innerHTML : '')).toMatchSnapshot();
-});
-
-test('The component should render normally when local property is set', () => {
-    const body = document.body;
-    const view = mount(<Backdrop local={true} open={true} />).render();
-    expect(view).toMatchSnapshot();
-    expect(body ? body.innerHTML : '').toBe('');
-});
-
-test('The component should not render local when closed', () => {
-    const body = document.body;
-    const view = mount(<Backdrop local={true} open={false} />).render();
-    expect(view).toMatchSnapshot();
-    expect(body ? body.innerHTML : '').toBe('');
-});
-
-test('The component should not render in the body when closed', () => {
-    const body = document.body;
-    const view = mount(<Backdrop open={false} />).render();
-    expect(view.html()).toBe(null);
-    expect(body ? body.innerHTML : '').toBe('');
+test('The component should render', () => {
+    expect(render(<Backdrop />)).toMatchSnapshot();
 });
 
 test('The component should call a function when clicked', () => {
     const onClickSpy = jest.fn();
-    const view = shallow(<Backdrop onClick={onClickSpy} open={true} />);
+    const view = shallow(<Backdrop onClick={onClickSpy} />);
 
     expect(onClickSpy).toHaveBeenCalledTimes(0);
     view.find('.backdrop').simulate('click');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Backdrop/tests/__snapshots__/Backdrop.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Backdrop/tests/__snapshots__/Backdrop.test.js.snap
@@ -1,14 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`The component should not render local when closed 1`] = `null`;
-
-exports[`The component should render in body when open 1`] = `
-"<div>
-  <div class=\\"backdrop visible fixed\\" role=\\"button\\"></div>
-</div>"
-`;
-
-exports[`The component should render normally when local property is set 1`] = `
+exports[`The component should render 1`] = `
 <div
   class="backdrop visible fixed"
   role="button"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColorPicker/tests/__snapshots__/ColorPicker.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColorPicker/tests/__snapshots__/ColorPicker.test.js.snap
@@ -130,8 +130,6 @@ exports[`ColorPicker should render when disabled 1`] = `
 exports[`ColorPicker should render with open overlay 1`] = `
 "<div>
   <div class=\\"backdrop fixed\\" role=\\"button\\"></div>
-</div>
-<div>
   <div class=\\"container\\">
     <div style=\\"top: 10px; left: 35px; position: fixed; pointer-events: auto;\\">
       <div style=\\"width: 200px; padding: 10px 10px 0px; box-sizing: initial; background: rgb(255, 255, 255); border-radius: 4px; box-shadow: 0 0 0 1px rgba(0,0,0,.15), 0 8px 16px rgba(0,0,0,.15);\\" class=\\"sketch-picker \\">

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/Toolbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/Toolbar.test.js.snap
@@ -30,8 +30,6 @@ exports[`Should render with active 1`] = `
 exports[`Should render with active 2`] = `
 "<div>
   <div class=\\"backdrop fixed\\" role=\\"button\\"></div>
-</div>
-<div>
   <div class=\\"container\\">
     <div class=\\"arrowMenuContainer\\" style=\\"top: 20px; left: 10px; position: fixed; pointer-events: auto;\\">
       <div class=\\"arrow top right\\"></div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/Dialog.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/Dialog.js
@@ -94,9 +94,9 @@ class Dialog extends React.Component<Props> {
 
         return (
             <Fragment>
-                <Backdrop open={visible} />
                 {visible &&
                     <Portal>
+                        <Backdrop local={true} />
                         <div
                             className={containerClass}
                             onTransitionEnd={this.handleTransitionEnd}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/Dialog.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/Dialog.js
@@ -96,7 +96,7 @@ class Dialog extends React.Component<Props> {
             <Fragment>
                 {visible &&
                     <Portal>
-                        <Backdrop local={true} />
+                        <Backdrop />
                         <div
                             className={containerClass}
                             onTransitionEnd={this.handleTransitionEnd}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/Dialog.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/Dialog.test.js
@@ -28,7 +28,6 @@ test('The component should render in body when open', () => {
     );
 
     expect(view.find('Backdrop')).toHaveLength(1);
-    expect(view.find('Backdrop').prop('open')).toEqual(true);
     expect(pretty(body ? body.innerHTML : '')).toMatchSnapshot();
 });
 
@@ -47,7 +46,6 @@ test('The component should render in body without cancel button', () => {
     );
 
     expect(view.find('Backdrop')).toHaveLength(1);
-    expect(view.find('Backdrop').prop('open')).toEqual(true);
     expect(pretty(body ? body.innerHTML : '')).toMatchSnapshot();
 });
 
@@ -70,7 +68,6 @@ test('The component should render in body with disabled confirm button', () => {
     );
 
     expect(view.find('Backdrop')).toHaveLength(1);
-    expect(view.find('Backdrop').prop('open')).toEqual(true);
     expect(pretty(body ? body.innerHTML : '')).toMatchSnapshot();
 });
 
@@ -93,7 +90,6 @@ test('The component should render in body with a large class', () => {
     );
 
     expect(view.find('Backdrop')).toHaveLength(1);
-    expect(view.find('Backdrop').prop('open')).toEqual(true);
     expect(pretty(body ? body.innerHTML : '')).toMatchSnapshot();
 });
 
@@ -116,7 +112,6 @@ test('The component should render in body with loader instead of confirm button'
     );
 
     expect(view.find('Backdrop')).toHaveLength(1);
-    expect(view.find('Backdrop').prop('open')).toEqual(true);
     expect(pretty(body ? body.innerHTML : '')).toMatchSnapshot();
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/__snapshots__/Dialog.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/__snapshots__/Dialog.test.js.snap
@@ -5,8 +5,6 @@ exports[`The component should not render in body when closed 1`] = `null`;
 exports[`The component should render in body when open 1`] = `
 "<div>
   <div class=\\"backdrop visible fixed\\" role=\\"button\\"></div>
-</div>
-<div>
   <div class=\\"dialogContainer open\\">
     <div class=\\"dialog\\">
       <section class=\\"content\\">
@@ -24,8 +22,6 @@ exports[`The component should render in body when open 1`] = `
 exports[`The component should render in body with a large class 1`] = `
 "<div>
   <div class=\\"backdrop visible fixed\\" role=\\"button\\"></div>
-</div>
-<div>
   <div class=\\"dialogContainer open\\">
     <div class=\\"dialog large\\">
       <section class=\\"content\\">
@@ -43,8 +39,6 @@ exports[`The component should render in body with a large class 1`] = `
 exports[`The component should render in body with disabled confirm button 1`] = `
 "<div>
   <div class=\\"backdrop visible fixed\\" role=\\"button\\"></div>
-</div>
-<div>
   <div class=\\"dialogContainer open\\">
     <div class=\\"dialog\\">
       <section class=\\"content\\">
@@ -62,8 +56,6 @@ exports[`The component should render in body with disabled confirm button 1`] = 
 exports[`The component should render in body with loader instead of confirm button 1`] = `
 "<div>
   <div class=\\"backdrop visible fixed\\" role=\\"button\\"></div>
-</div>
-<div>
   <div class=\\"dialogContainer open\\">
     <div class=\\"dialog\\">
       <section class=\\"content\\">
@@ -87,8 +79,6 @@ exports[`The component should render in body with loader instead of confirm butt
 exports[`The component should render in body without cancel button 1`] = `
 "<div>
   <div class=\\"backdrop visible fixed\\" role=\\"button\\"></div>
-</div>
-<div>
   <div class=\\"dialogContainer open\\">
     <div class=\\"dialog\\">
       <section class=\\"content\\">

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
@@ -98,8 +98,6 @@ exports[`MultiAutoComplete should render in disabled state 1`] = `
 exports[`Render the MultiAutoComplete with open suggestions list 1`] = `
 "<div>
   <div class=\\"backdrop fixed\\" role=\\"button\\"></div>
-</div>
-<div>
   <div class=\\"container\\">
     <ul class=\\"menu\\" style=\\"top: 10px; left: 10px; position: fixed; pointer-events: auto;\\">
       <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\"><button class=\\"suggestion\\"><span class=\\"column\\">Suggestion 1</span></button></li>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
@@ -102,7 +102,6 @@ class Overlay extends React.Component<Props> {
             confirmDisabled,
             confirmLoading,
             confirmText,
-            onClose,
             onConfirm,
             title,
             size,
@@ -126,9 +125,9 @@ class Overlay extends React.Component<Props> {
 
         return (
             <Fragment>
-                <Backdrop onClick={onClose} open={visible} />
                 {visible &&
                     <Portal>
+                        <Backdrop local={true} />
                         <div
                             className={containerClass}
                             onTransitionEnd={this.handleTransitionEnd}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
@@ -127,7 +127,7 @@ class Overlay extends React.Component<Props> {
             <Fragment>
                 {visible &&
                     <Portal>
-                        <Backdrop local={true} />
+                        <Backdrop />
                         <div
                             className={containerClass}
                             onTransitionEnd={this.handleTransitionEnd}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/Overlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/Overlay.test.js
@@ -28,7 +28,6 @@ test('The component should render in body when open', () => {
     );
 
     expect(view.find('Backdrop')).toHaveLength(1);
-    expect(view.find('Backdrop').prop('open')).toEqual(true);
     expect(pretty(body ? body.innerHTML : '')).toMatchSnapshot();
 });
 
@@ -49,7 +48,6 @@ test('The component should render with a disabled confirm button', () => {
     );
 
     expect(view.find('Backdrop')).toHaveLength(1);
-    expect(view.find('Backdrop').prop('open')).toEqual(true);
     expect(pretty(body ? body.innerHTML : '')).toMatchSnapshot();
 });
 
@@ -70,7 +68,6 @@ test('The component should render in body with loader instead of confirm button'
     );
 
     expect(view.find('Backdrop')).toHaveLength(1);
-    expect(view.find('Backdrop').prop('open')).toEqual(true);
     expect(pretty(body ? body.innerHTML : '')).toMatchSnapshot();
 });
 
@@ -95,7 +92,6 @@ test('The component should render in body with actions when open', () => {
     );
 
     expect(view.find('Backdrop')).toHaveLength(1);
-    expect(view.find('Backdrop').prop('open')).toEqual(true);
     expect(pretty(body ? body.innerHTML : '')).toMatchSnapshot();
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/Overlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/Overlay.test.js
@@ -117,27 +117,6 @@ test('The component should not render in body when closed', () => {
     expect(body ? body.innerHTML : '').toBe('');
 });
 
-test('The component should request to be closed on click on backdrop', () => {
-    const closeSpy = jest.fn();
-    const view = shallow(
-        <Overlay
-            confirmText="Apply"
-            onClose={closeSpy}
-            onConfirm={jest.fn()}
-            open={true}
-            title="My overlay title"
-        >
-            <p>My overlay content</p>
-        </Overlay>
-    );
-    const backdrop = view.find('Backdrop');
-    expect(backdrop.length).toBe(1);
-
-    expect(closeSpy).not.toBeCalled();
-    backdrop.props().onClick();
-    expect(closeSpy).toBeCalled();
-});
-
 test('The component should request to be closed when the close icon is clicked', () => {
     const closeSpy = jest.fn();
     const view = shallow(

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/__snapshots__/Overlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/__snapshots__/Overlay.test.js.snap
@@ -5,8 +5,6 @@ exports[`The component should not render in body when closed 1`] = `null`;
 exports[`The component should render in body when open 1`] = `
 "<div>
   <div class=\\"backdrop visible fixed\\" role=\\"button\\"></div>
-</div>
-<div>
   <div class=\\"container isDown\\">
     <div class=\\"overlay small\\">
       <section class=\\"content\\">
@@ -26,8 +24,6 @@ exports[`The component should render in body when open 1`] = `
 exports[`The component should render in body with actions when open 1`] = `
 "<div>
   <div class=\\"backdrop visible fixed\\" role=\\"button\\"></div>
-</div>
-<div>
   <div class=\\"container isDown\\">
     <div class=\\"overlay\\">
       <section class=\\"content\\">
@@ -49,8 +45,6 @@ exports[`The component should render in body with actions when open 1`] = `
 exports[`The component should render in body with loader instead of confirm button 1`] = `
 "<div>
   <div class=\\"backdrop visible fixed\\" role=\\"button\\"></div>
-</div>
-<div>
   <div class=\\"container isDown\\">
     <div class=\\"overlay\\">
       <section class=\\"content\\">
@@ -76,8 +70,6 @@ exports[`The component should render in body with loader instead of confirm butt
 exports[`The component should render with a disabled confirm button 1`] = `
 "<div>
   <div class=\\"backdrop visible fixed\\" role=\\"button\\"></div>
-</div>
-<div>
   <div class=\\"container isDown\\">
     <div class=\\"overlay\\">
       <section class=\\"content\\">

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
@@ -173,10 +173,8 @@ class Popover extends React.Component<Props> {
 
         return (
             <Fragment>
-                {backdrop &&
-                    <Backdrop onClick={this.handleBackdropClick} open={true} visible={false} />
-                }
                 <Portal>
+                    {backdrop && <Backdrop local={true} onClick={this.handleBackdropClick} visible={false} />}
                     <div className={popoverStyles.container}>
                         {children &&
                             children(this.setPopoverChildRef, styles, verticalPosition, horizontalPosition)

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
@@ -174,7 +174,7 @@ class Popover extends React.Component<Props> {
         return (
             <Fragment>
                 <Portal>
-                    {backdrop && <Backdrop local={true} onClick={this.handleBackdropClick} visible={false} />}
+                    {backdrop && <Backdrop onClick={this.handleBackdropClick} visible={false} />}
                     <div className={popoverStyles.container}>
                         {children &&
                             children(this.setPopoverChildRef, styles, verticalPosition, horizontalPosition)

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/tests/Popover.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/tests/Popover.test.js
@@ -55,7 +55,6 @@ test('The popover should render in body when open', () => {
         </Popover>
     );
     expect(view.find('Backdrop')).toHaveLength(1);
-    expect(view.find('Backdrop').prop('open')).toEqual(true);
     expect(pretty(body.innerHTML)).toMatchSnapshot();
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/tests/__snapshots__/Popover.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/tests/__snapshots__/Popover.test.js.snap
@@ -5,8 +5,6 @@ exports[`The popover should not render in body when not open 1`] = `""`;
 exports[`The popover should render in body when open 1`] = `
 "<div>
   <div class=\\"backdrop fixed\\" role=\\"button\\"></div>
-</div>
-<div>
   <div class=\\"container\\">
     <div style=\\"top: 1px; left: 2px; max-height: 30px; position: fixed; pointer-events: auto;\\">
       <div>My item 1</div>
@@ -20,8 +18,6 @@ exports[`The popover should render in body when open 1`] = `
 exports[`The popover should take its dimensions from the positioner 1`] = `
 "<div>
   <div class=\\"backdrop fixed\\" role=\\"button\\"></div>
-</div>
-<div>
   <div class=\\"container\\">
     <div style=\\"top: 1px; left: 2px; max-height: 30px; position: fixed; pointer-events: auto;\\">
       <div>My item 1</div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/__snapshots__/Select.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/__snapshots__/Select.test.js.snap
@@ -88,8 +88,6 @@ exports[`The component should open the popover when the display value is clicked
 exports[`The component should open the popover when the display value is clicked 2`] = `
 "<div>
   <div class=\\"backdrop fixed\\" role=\\"button\\"></div>
-</div>
-<div>
   <div class=\\"container\\">
     <ul class=\\"menu\\" style=\\"top: 10px; left: 10px; position: fixed; pointer-events: auto;\\">
       <li><button class=\\"option icon\\" style=\\"min-width: 210px;\\">Option 1</button></li>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
@@ -28,8 +28,6 @@ exports[`Render the SingleAutoComplete with open suggestions list 1`] = `
 exports[`Render the SingleAutoComplete with open suggestions list 2`] = `
 "<div>
   <div class=\\"backdrop fixed\\" role=\\"button\\"></div>
-</div>
-<div>
   <div class=\\"container\\">
     <ul class=\\"menu\\" style=\\"top: 10px; left: 10px; position: fixed; pointer-events: auto;\\">
       <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\"><button class=\\"suggestion\\"><span class=\\"column\\">Suggestion 1</span></button></li>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/Application.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/Application.js
@@ -195,13 +195,13 @@ class Application extends React.Component<Props>{
                                     </header>
                                 </main>
                                 <Sidebar className={sidebarClass} />
-                                <Backdrop
-                                    fixed={false}
-                                    local={true}
-                                    onClick={this.handleNavigationButtonClick}
-                                    open={this.navigationVisible && !this.navigationPinned}
-                                    visible={false}
-                                />
+                                {this.navigationVisible && !this.navigationPinned &&
+                                    <Backdrop
+                                        fixed={false}
+                                        onClick={this.handleNavigationButtonClick}
+                                        visible={false}
+                                    />
+                                }
                             </div>
                         </div>
                         <ProfileFormOverlay

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/GhostDialog.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/GhostDialog.test.js.snap
@@ -3,8 +3,6 @@
 exports[`Should render a Dialog 1`] = `
 "<div>
   <div class=\\"backdrop visible fixed\\" role=\\"button\\"></div>
-</div>
-<div>
   <div class=\\"dialogContainer open\\">
     <div class=\\"dialog\\">
       <section class=\\"content\\">

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/__snapshots__/MultiSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/__snapshots__/MultiSelection.test.js.snap
@@ -125,8 +125,6 @@ exports[`Render with disabled item 1`] = `
 exports[`Should open an overlay 1`] = `
 "<div>
   <div class=\\"backdrop visible fixed\\" role=\\"button\\"></div>
-</div>
-<div>
   <div class=\\"container\\">
     <div class=\\"overlay large\\">
       <section class=\\"content\\">

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/FilterOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/FilterOverlay.test.js
@@ -212,7 +212,7 @@ test('Render with all fields', () => {
             title="Test"
         />
     );
-    expect(filterOverlay.find('Portal').at(2).render()).toMatchSnapshot();
+    expect(filterOverlay.find('Portal').at(1).render()).toMatchSnapshot();
 });
 
 test('Render with no fields', () => {
@@ -248,7 +248,7 @@ test('Render with no fields', () => {
             title="Test"
         />
     );
-    expect(filterOverlay.find('Portal').at(2).render()).toMatchSnapshot();
+    expect(filterOverlay.find('Portal').at(1).render()).toMatchSnapshot();
 });
 
 test('Fill all fields using and update SmartContentStore on confirm', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/__snapshots__/FilterOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/__snapshots__/FilterOverlay.test.js.snap
@@ -1,49 +1,207 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Render with all fields 1`] = `
-<div
-  class="container isDown"
->
+Array [
   <div
-    class="overlay small"
+    class="backdrop visible fixed"
+    role="button"
+  />,
+  <div
+    class="container isDown"
   >
-    <section
-      class="content"
+    <div
+      class="overlay small"
     >
-      <header>
-        <h2>
-          Test
-        </h2>
-        <span
-          aria-label="su-times"
-          class="su-times clickable icon"
-          role="button"
-          tabindex="0"
-        />
-      </header>
-      <article>
-        <div
-          class="content"
-        >
-          <section
-            class="section"
+      <section
+        class="content"
+      >
+        <header>
+          <h2>
+            Test
+          </h2>
+          <span
+            aria-label="su-times"
+            class="su-times clickable icon"
+            role="button"
+            tabindex="0"
+          />
+        </header>
+        <article>
+          <div
+            class="content"
           >
-            <h3>
-              sulu_admin.data_source
-            </h3>
-            <div
-              class="source"
+            <section
+              class="section"
             >
-              <button
-                class="button secondary sourceButton"
-                type="button"
+              <h3>
+                sulu_admin.data_source
+              </h3>
+              <div
+                class="source"
               >
-                <span
-                  class="text"
+                <button
+                  class="button secondary sourceButton"
+                  type="button"
                 >
-                  sulu_admin.choose_data_source
-                </span>
-              </button>
+                  <span
+                    class="text"
+                  >
+                    sulu_admin.choose_data_source
+                  </span>
+                </button>
+                <label
+                  class="label"
+                >
+                  <span
+                    class="switch toggler"
+                  >
+                    <input
+                      type="checkbox"
+                      value=""
+                    />
+                    <span />
+                  </span>
+                  <div>
+                    sulu_admin.include_sub_elements
+                  </div>
+                </label>
+              </div>
+              <label
+                class="description"
+              >
+                sulu_admin.data_source: 
+              </label>
+            </section>
+            <section
+              class="section"
+            >
+              <h3>
+                sulu_admin.filter_by_categories
+              </h3>
+              <div
+                class="categories"
+              >
+                <button
+                  class="button secondary"
+                  type="button"
+                >
+                  <span
+                    class="text"
+                  >
+                    sulu_admin.choose_categories
+                  </span>
+                </button>
+                <div
+                  class="categoriesSelect"
+                >
+                  <div
+                    class="select"
+                  >
+                    <button
+                      class="displayValue default"
+                      type="button"
+                    >
+                      <div
+                        aria-label="sulu_admin.please_choose"
+                        class="croppedText"
+                        title="sulu_admin.please_choose"
+                      >
+                        <div
+                          aria-hidden="true"
+                          class="front"
+                        >
+                          sulu_admin.p
+                        </div>
+                        <div
+                          aria-hidden="true"
+                          class="back"
+                        >
+                          <span>
+                            lease_choose
+                          </span>
+                        </div>
+                        <div
+                          class="whole"
+                        >
+                          sulu_admin.please_choose
+                        </div>
+                      </div>
+                      <span
+                        aria-label="su-angle-down"
+                        class="su-angle-down toggle"
+                      />
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <label
+                class="description"
+              >
+                sulu_category.categories: 
+              </label>
+            </section>
+            <section
+              class="section"
+            >
+              <h3>
+                sulu_admin.filter_by_tags
+              </h3>
+              <div
+                class="tags"
+              >
+                <div
+                  class="tagsAutoComplete"
+                />
+                <div
+                  class="tagsSelect"
+                >
+                  <div
+                    class="select"
+                  >
+                    <button
+                      class="displayValue default"
+                      type="button"
+                    >
+                      <div
+                        aria-label="sulu_admin.please_choose"
+                        class="croppedText"
+                        title="sulu_admin.please_choose"
+                      >
+                        <div
+                          aria-hidden="true"
+                          class="front"
+                        >
+                          sulu_admin.p
+                        </div>
+                        <div
+                          aria-hidden="true"
+                          class="back"
+                        >
+                          <span>
+                            lease_choose
+                          </span>
+                        </div>
+                        <div
+                          class="whole"
+                        >
+                          sulu_admin.please_choose
+                        </div>
+                      </div>
+                      <span
+                        aria-label="su-angle-down"
+                        class="su-angle-down toggle"
+                      />
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </section>
+            <section
+              class="section"
+            >
+              <h3>
+                sulu_admin.target_groups
+              </h3>
               <label
                 class="label"
               >
@@ -57,412 +215,266 @@ exports[`Render with all fields 1`] = `
                   <span />
                 </span>
                 <div>
-                  sulu_admin.include_sub_elements
+                  sulu_admin.use_target_groups
                 </div>
               </label>
-            </div>
-            <label
-              class="description"
+            </section>
+            <section
+              class="section"
             >
-              sulu_admin.data_source: 
-            </label>
-          </section>
-          <section
-            class="section"
-          >
-            <h3>
-              sulu_admin.filter_by_categories
-            </h3>
-            <div
-              class="categories"
-            >
-              <button
-                class="button secondary"
-                type="button"
-              >
-                <span
-                  class="text"
-                >
-                  sulu_admin.choose_categories
-                </span>
-              </button>
+              <h3>
+                sulu_admin.sort_by
+              </h3>
               <div
-                class="categoriesSelect"
+                class="sorting"
               >
                 <div
-                  class="select"
-                >
-                  <button
-                    class="displayValue default"
-                    type="button"
-                  >
-                    <div
-                      aria-label="sulu_admin.please_choose"
-                      class="croppedText"
-                      title="sulu_admin.please_choose"
-                    >
-                      <div
-                        aria-hidden="true"
-                        class="front"
-                      >
-                        sulu_admin.p
-                      </div>
-                      <div
-                        aria-hidden="true"
-                        class="back"
-                      >
-                        <span>
-                          lease_choose
-                        </span>
-                      </div>
-                      <div
-                        class="whole"
-                      >
-                        sulu_admin.please_choose
-                      </div>
-                    </div>
-                    <span
-                      aria-label="su-angle-down"
-                      class="su-angle-down toggle"
-                    />
-                  </button>
-                </div>
-              </div>
-            </div>
-            <label
-              class="description"
-            >
-              sulu_category.categories: 
-            </label>
-          </section>
-          <section
-            class="section"
-          >
-            <h3>
-              sulu_admin.filter_by_tags
-            </h3>
-            <div
-              class="tags"
-            >
-              <div
-                class="tagsAutoComplete"
-              />
-              <div
-                class="tagsSelect"
-              >
-                <div
-                  class="select"
-                >
-                  <button
-                    class="displayValue default"
-                    type="button"
-                  >
-                    <div
-                      aria-label="sulu_admin.please_choose"
-                      class="croppedText"
-                      title="sulu_admin.please_choose"
-                    >
-                      <div
-                        aria-hidden="true"
-                        class="front"
-                      >
-                        sulu_admin.p
-                      </div>
-                      <div
-                        aria-hidden="true"
-                        class="back"
-                      >
-                        <span>
-                          lease_choose
-                        </span>
-                      </div>
-                      <div
-                        class="whole"
-                      >
-                        sulu_admin.please_choose
-                      </div>
-                    </div>
-                    <span
-                      aria-label="su-angle-down"
-                      class="su-angle-down toggle"
-                    />
-                  </button>
-                </div>
-              </div>
-            </div>
-          </section>
-          <section
-            class="section"
-          >
-            <h3>
-              sulu_admin.target_groups
-            </h3>
-            <label
-              class="label"
-            >
-              <span
-                class="switch toggler"
-              >
-                <input
-                  type="checkbox"
-                  value=""
-                />
-                <span />
-              </span>
-              <div>
-                sulu_admin.use_target_groups
-              </div>
-            </label>
-          </section>
-          <section
-            class="section"
-          >
-            <h3>
-              sulu_admin.sort_by
-            </h3>
-            <div
-              class="sorting"
-            >
-              <div
-                class="sortColumn"
-              >
-                <div
-                  class="select"
-                >
-                  <button
-                    class="displayValue default"
-                    type="button"
-                  >
-                    <div
-                      aria-label="sulu_admin.please_choose"
-                      class="croppedText"
-                      title="sulu_admin.please_choose"
-                    >
-                      <div
-                        aria-hidden="true"
-                        class="front"
-                      >
-                        sulu_admin.p
-                      </div>
-                      <div
-                        aria-hidden="true"
-                        class="back"
-                      >
-                        <span>
-                          lease_choose
-                        </span>
-                      </div>
-                      <div
-                        class="whole"
-                      >
-                        sulu_admin.please_choose
-                      </div>
-                    </div>
-                    <span
-                      aria-label="su-angle-down"
-                      class="su-angle-down toggle"
-                    />
-                  </button>
-                </div>
-              </div>
-              <div
-                class="sortOrder"
-              >
-                <div
-                  class="select"
-                >
-                  <button
-                    class="displayValue default"
-                    type="button"
-                  >
-                    <div
-                      aria-label="sulu_admin.please_choose"
-                      class="croppedText"
-                      title="sulu_admin.please_choose"
-                    >
-                      <div
-                        aria-hidden="true"
-                        class="front"
-                      >
-                        sulu_admin.p
-                      </div>
-                      <div
-                        aria-hidden="true"
-                        class="back"
-                      >
-                        <span>
-                          lease_choose
-                        </span>
-                      </div>
-                      <div
-                        class="whole"
-                      >
-                        sulu_admin.please_choose
-                      </div>
-                    </div>
-                    <span
-                      aria-label="su-angle-down"
-                      class="su-angle-down toggle"
-                    />
-                  </button>
-                </div>
-              </div>
-            </div>
-          </section>
-          <section
-            class="section"
-          >
-            <h3>
-              sulu_admin.present_as
-            </h3>
-            <div
-              class="presentation"
-            >
-              <div
-                class="select"
-              >
-                <button
-                  class="displayValue default"
-                  type="button"
+                  class="sortColumn"
                 >
                   <div
-                    aria-label="sulu_admin.please_choose"
-                    class="croppedText"
-                    title="sulu_admin.please_choose"
+                    class="select"
+                  >
+                    <button
+                      class="displayValue default"
+                      type="button"
+                    >
+                      <div
+                        aria-label="sulu_admin.please_choose"
+                        class="croppedText"
+                        title="sulu_admin.please_choose"
+                      >
+                        <div
+                          aria-hidden="true"
+                          class="front"
+                        >
+                          sulu_admin.p
+                        </div>
+                        <div
+                          aria-hidden="true"
+                          class="back"
+                        >
+                          <span>
+                            lease_choose
+                          </span>
+                        </div>
+                        <div
+                          class="whole"
+                        >
+                          sulu_admin.please_choose
+                        </div>
+                      </div>
+                      <span
+                        aria-label="su-angle-down"
+                        class="su-angle-down toggle"
+                      />
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="sortOrder"
+                >
+                  <div
+                    class="select"
+                  >
+                    <button
+                      class="displayValue default"
+                      type="button"
+                    >
+                      <div
+                        aria-label="sulu_admin.please_choose"
+                        class="croppedText"
+                        title="sulu_admin.please_choose"
+                      >
+                        <div
+                          aria-hidden="true"
+                          class="front"
+                        >
+                          sulu_admin.p
+                        </div>
+                        <div
+                          aria-hidden="true"
+                          class="back"
+                        >
+                          <span>
+                            lease_choose
+                          </span>
+                        </div>
+                        <div
+                          class="whole"
+                        >
+                          sulu_admin.please_choose
+                        </div>
+                      </div>
+                      <span
+                        aria-label="su-angle-down"
+                        class="su-angle-down toggle"
+                      />
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </section>
+            <section
+              class="section"
+            >
+              <h3>
+                sulu_admin.present_as
+              </h3>
+              <div
+                class="presentation"
+              >
+                <div
+                  class="select"
+                >
+                  <button
+                    class="displayValue default"
+                    type="button"
                   >
                     <div
-                      aria-hidden="true"
-                      class="front"
+                      aria-label="sulu_admin.please_choose"
+                      class="croppedText"
+                      title="sulu_admin.please_choose"
                     >
-                      sulu_admin.p
+                      <div
+                        aria-hidden="true"
+                        class="front"
+                      >
+                        sulu_admin.p
+                      </div>
+                      <div
+                        aria-hidden="true"
+                        class="back"
+                      >
+                        <span>
+                          lease_choose
+                        </span>
+                      </div>
+                      <div
+                        class="whole"
+                      >
+                        sulu_admin.please_choose
+                      </div>
                     </div>
-                    <div
-                      aria-hidden="true"
-                      class="back"
-                    >
-                      <span>
-                        lease_choose
-                      </span>
-                    </div>
-                    <div
-                      class="whole"
-                    >
-                      sulu_admin.please_choose
-                    </div>
-                  </div>
-                  <span
-                    aria-label="su-angle-down"
-                    class="su-angle-down toggle"
-                  />
-                </button>
+                    <span
+                      aria-label="su-angle-down"
+                      class="su-angle-down toggle"
+                    />
+                  </button>
+                </div>
               </div>
-            </div>
-          </section>
-          <section
-            class="section"
-          >
-            <h3>
-              sulu_admin.limit_result_to
-            </h3>
-            <div
-              class="limit"
+            </section>
+            <section
+              class="section"
             >
-              <label
-                class="input default left"
+              <h3>
+                sulu_admin.limit_result_to
+              </h3>
+              <div
+                class="limit"
               >
-                <input
-                  type="number"
-                  value=""
-                />
-              </label>
-            </div>
-          </section>
-        </div>
-      </article>
-      <footer>
-        <div
-          class="actions"
-        >
+                <label
+                  class="input default left"
+                >
+                  <input
+                    type="number"
+                    value=""
+                  />
+                </label>
+              </div>
+            </section>
+          </div>
+        </article>
+        <footer>
+          <div
+            class="actions"
+          >
+            <button
+              class="button link"
+              type="button"
+            >
+              <span
+                class="text"
+              >
+                sulu_admin.reset
+              </span>
+            </button>
+          </div>
           <button
-            class="button link"
+            class="button primary"
             type="button"
           >
             <span
               class="text"
             >
-              sulu_admin.reset
+              sulu_admin.confirm
             </span>
           </button>
-        </div>
-        <button
-          class="button primary"
-          type="button"
-        >
-          <span
-            class="text"
-          >
-            sulu_admin.confirm
-          </span>
-        </button>
-      </footer>
-    </section>
-  </div>
-</div>
+        </footer>
+      </section>
+    </div>
+  </div>,
+]
 `;
 
 exports[`Render with no fields 1`] = `
-<div
-  class="container isDown"
->
+Array [
   <div
-    class="overlay small"
+    class="backdrop visible fixed"
+    role="button"
+  />,
+  <div
+    class="container isDown"
   >
-    <section
-      class="content"
+    <div
+      class="overlay small"
     >
-      <header>
-        <h2>
-          Test
-        </h2>
-        <span
-          aria-label="su-times"
-          class="su-times clickable icon"
-          role="button"
-          tabindex="0"
-        />
-      </header>
-      <article>
-        <div
-          class="content"
-        />
-      </article>
-      <footer>
-        <div
-          class="actions"
-        >
+      <section
+        class="content"
+      >
+        <header>
+          <h2>
+            Test
+          </h2>
+          <span
+            aria-label="su-times"
+            class="su-times clickable icon"
+            role="button"
+            tabindex="0"
+          />
+        </header>
+        <article>
+          <div
+            class="content"
+          />
+        </article>
+        <footer>
+          <div
+            class="actions"
+          >
+            <button
+              class="button link"
+              type="button"
+            >
+              <span
+                class="text"
+              >
+                sulu_admin.reset
+              </span>
+            </button>
+          </div>
           <button
-            class="button link"
+            class="button primary"
             type="button"
           >
             <span
               class="text"
             >
-              sulu_admin.reset
+              sulu_admin.confirm
             </span>
           </button>
-        </div>
-        <button
-          class="button primary"
-          type="button"
-        >
-          <span
-            class="text"
-          >
-            sulu_admin.confirm
-          </span>
-        </button>
-      </footer>
-    </section>
-  </div>
-</div>
+        </footer>
+      </section>
+    </div>
+  </div>,
+]
 `;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #5138 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR makes sure the `Backdrop` of a `DatePicker` is behind the `DatePicker` it self. It does that by putting the `Backdrop` into the same `Portal` as the `DatePicker`, and renders it before the `DatePicker`.

Previously the functionality was dependant on the correct calls of the `createPortal` function. If the `createPortal` for the `Backdrop` was called after the one for the `DatePicker`, the order in the DOM was wrong, and therefore the user clicked on the invisible `Backdrop` instead of the `DatePicker`.

#### Why?

Because otherwise the user cannot click any date on the date picker.

#### BC Breaks/Deprecations

Some props might be removed from the `Backdrop` props, and its default behavior changes. But that's open for discussion

#### To Do

- [ ] Add breaking changes to UPGRADE.md
