### PR TITLE
Fix SuluSecurityListener with InvokeableControllers

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/EventListener/SuluSecurityListener.php
+++ b/src/Sulu/Bundle/SecurityBundle/EventListener/SuluSecurityListener.php
@@ -41,8 +41,18 @@ class SuluSecurityListener
      */
     public function onKernelController(FilterControllerEvent $event)
     {
-        $controllerDefinition = $event->getController();
-        $controller = $controllerDefinition[0];
+        $controller = $event->getController();
+        $action = '__invoke';
+
+        if (is_array($controller)) {
+            if (isset($controller[1])) {
+                $action = $controller[1];
+            }
+
+            if (isset($controller[0])) {
+                $controller = $controller[0];
+            }
+        }
 
         if (
             !$controller instanceof SecuredControllerInterface &&
@@ -61,7 +71,7 @@ class SuluSecurityListener
                 $permission = PermissionTypes::VIEW;
                 break;
             case 'POST':
-                if ('postAction' == $controllerDefinition[1]) { // means that the ClassResourceInterface has to be used
+                if (in_array($action, ['postAction', '__invoke'])) { // means that the ClassResourceInterface has to be used
                     $permission = PermissionTypes::ADD;
                 } else {
                     $permission = PermissionTypes::EDIT;

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/SuluSecurityListenerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/SuluSecurityListenerTest.php
@@ -170,6 +170,28 @@ class SuluSecurityListenerTest extends TestCase
             ->shouldHaveBeenCalled();
     }
 
+    /**
+     * @dataProvider provideInvokeMethodActionMapping
+     */
+    public function testCallableControllerPermission($method, $permission)
+    {
+        $request = $this->prophesize(Request::class);
+        $request->getMethod()->willReturn($method);
+        $request->get('id')->willReturn('1');
+
+        $controller = $this->prophesize(SecuredControllerInterface::class);
+        $controller->getSecurityContext()->willReturn('security.context');
+        $controller->getLocale(Argument::any())->willReturn('de');
+
+        $this->filterControllerEvent->getRequest()->willReturn($request->reveal());
+        $this->filterControllerEvent->getController()->willReturn($controller->reveal());
+
+        $this->securityListener->onKernelController($this->filterControllerEvent->reveal());
+
+        $this->securityChecker->checkPermission(Argument::any(), $permission, Argument::any())
+            ->shouldHaveBeenCalled();
+    }
+
     public function testLocale()
     {
         $request = $this->prophesize(Request::class);
@@ -215,6 +237,17 @@ class SuluSecurityListenerTest extends TestCase
             ['PUT', 'putAction', 'edit'],
             ['PATCH', 'patchAction', 'edit'],
             ['DELETE', 'deleteAction', 'delete'],
+        ];
+    }
+
+    public static function provideInvokeMethodActionMapping()
+    {
+        return [
+            ['GET', 'view'],
+            ['POST', 'add'],
+            ['PUT', 'edit'],
+            ['PATCH', 'edit'],
+            ['DELETE', 'delete'],
         ];
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix problems with callable classes as controller actions

#### Why?

The SuluSecurityController have problems if the given controller is a callable by itself with a `__invoke` function. 

#### Example Usage

[InvokeableController](https://symfony.com/doc/4.4/controller/service.html#invokable-controllers)

~~~php
use Symfony\Component\HttpFoundation\Response;
use Symfony\Component\Routing\Annotation\Route;

/**
 * @Route("/api/admin/my-resource", name="my")
 */
class MyAction {
       public function __invoke(Request $request, $id) {
             return new JsonResponse(['id' => 1, 'name' => 'Test']);
       }
}
~~~
