### PR TITLE
Adjust size of Loader in ResourceMultiSelect to prevent height changes

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceMultiSelect/ResourceMultiSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceMultiSelect/ResourceMultiSelect.js
@@ -83,7 +83,7 @@ class ResourceMultiSelect<T: string | number> extends React.Component<Props<T>> 
         } = this.props;
 
         if (this.resourceListStore.loading || !this.resourceListStore.data) {
-            return <Loader />;
+            return <Loader size={30} />;
         }
 
         return (

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceMultiSelect/tests/__snapshots__/ResourceMultiSelect.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceMultiSelect/tests/__snapshots__/ResourceMultiSelect.test.js.snap
@@ -45,7 +45,7 @@ exports[`Render in disabled state 1`] = `
 exports[`Render in loading state 1`] = `
 <div
   class="spinner"
-  style="width:40px;height:40px"
+  style="width:30px;height:30px"
 >
   <div
     class="doubleBounce1"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### Why?

Because right now, the loader that is displayed during loading is higher than the `MultiSelectComponent` that is displayed after the data is loaded. This means that the height of the component changes unnecessarily after the data is loaded. This causes a "jump" in the ui as the position of all elements below the component is changed. 

Example: https://sulu.rocks/admin/#/contacts/2/permissions 