### PR TITLE
Add key property to Role entity

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,25 @@
 
 ## dev-master
 
+### Add key property to Role entity
+
+To allow for referencing `Role` entities by a human readable string, a `key` property was added to the `Role` entity.
+Furthermore, the `key` property is used for generating the identifier of a role instead of the `name` property now.
+The following statements update the database to include the new property and set the key of each existing Role to 
+keep backwards compatibility:
+
+```sql
+DROP INDEX UNIQ_13B749A05E237E06 ON se_roles;
+ALTER TABLE se_roles ADD `role_key` VARCHAR(60) DEFAULT NULL;
+UPDATE se_roles SET `role_key` = `name` WHERE `role_key` IS NULL;
+CREATE UNIQUE INDEX UNIQ_13B749A03EF22FDB ON se_roles (role_key);
+```
+
+### Remove getRole() method of Role entity
+
+The `getRole()` method of the `Role` class was removed as it is not part of the `RoleInterface`. 
+Use the `getIdentifier()` instead.
+
 ### Backdrop component
 
 Our `Backdrop` React component does not have the `local` and `open` props anymore. It is not supported anymore to render

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,9 +5,8 @@
 ### Add key property to Role entity
 
 To allow for referencing `Role` entities by a human readable string, a `key` property was added to the `Role` entity.
-Furthermore, the `key` property is used for generating the identifier of a role instead of the `name` property now.
-The following statements update the database to include the new property and set the key of each existing Role to 
-keep backwards compatibility:
+Furthermore, if the `key` is set, it is used for generating the identifier of a role instead of the `name` property.
+The following statements update the database to include the new property:
 
 ```sql
 DROP INDEX UNIQ_13B749A05E237E06 ON se_roles;

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,8 +9,7 @@ Furthermore, if the `key` is set, it is used for generating the identifier of a 
 The following statements update the database to include the new property:
 
 ```sql
-DROP INDEX UNIQ_13B749A05E237E06 ON se_roles;
-ALTER TABLE se_roles ADD `role_key` VARCHAR(60) DEFAULT NULL;
+ALTER TABLE se_roles ADD role_key VARCHAR(60) DEFAULT NULL;
 CREATE UNIQUE INDEX UNIQ_13B749A03EF22FDB ON se_roles (role_key);
 ```
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -12,14 +12,8 @@ keep backwards compatibility:
 ```sql
 DROP INDEX UNIQ_13B749A05E237E06 ON se_roles;
 ALTER TABLE se_roles ADD `role_key` VARCHAR(60) DEFAULT NULL;
-UPDATE se_roles SET `role_key` = `name` WHERE `role_key` IS NULL;
 CREATE UNIQUE INDEX UNIQ_13B749A03EF22FDB ON se_roles (role_key);
 ```
-
-### Remove getRole() method of Role entity
-
-The `getRole()` method of the `Role` class was removed as it is not part of the `RoleInterface`. 
-Use the `getIdentifier()` instead.
 
 ### Backdrop component
 

--- a/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
@@ -21,7 +21,6 @@ use Sulu\Component\Rest\AbstractRestController;
 use Sulu\Component\Rest\Exception\EntityNotFoundException;
 use Sulu\Component\Rest\Exception\InvalidArgumentException;
 use Sulu\Component\Rest\Exception\RestException;
-use Sulu\Component\Rest\Exception\UniqueConstraintViolationException as SuluUniqueConstraintViolationException;
 use Sulu\Component\Rest\ListBuilder\CollectionRepresentation;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilderFactoryInterface;
 use Sulu\Component\Rest\ListBuilder\ListRepresentation;

--- a/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
@@ -126,7 +126,7 @@ class RoleController extends AbstractRestController implements ClassResourceInte
      */
     public function cgetAction(Request $request)
     {
-        if ('true' == $request->get('flat')) {
+        if ('true' == $request->query->get('flat')) {
             $listBuilder = $this->doctrineListBuilderFactory->create($this->roleClass);
 
             $this->restHelper->initializeListBuilder($listBuilder, $this->getFieldDescriptors());
@@ -186,9 +186,9 @@ class RoleController extends AbstractRestController implements ClassResourceInte
      */
     public function postAction(Request $request)
     {
-        $name = $request->get('name');
-        $key = $request->get('key');
-        $system = $request->get('system');
+        $name = $request->request->get('name');
+        $key = $request->request->get('key');
+        $system = $request->request->get('system');
 
         try {
             if (null === $name) {
@@ -204,14 +204,14 @@ class RoleController extends AbstractRestController implements ClassResourceInte
             $role->setKey($key);
             $role->setSystem($system);
 
-            $permissions = $request->get('permissions');
+            $permissions = $request->request->get('permissions');
             if (!empty($permissions)) {
                 foreach ($permissions as $permissionData) {
                     $this->addPermission($role, $permissionData);
                 }
             }
 
-            $securityTypeData = $request->get('securityType');
+            $securityTypeData = $request->request->get('securityType');
             if ($this->checkSecurityTypeData($securityTypeData)) {
                 $this->setSecurityType($role, $securityTypeData);
             }
@@ -242,8 +242,9 @@ class RoleController extends AbstractRestController implements ClassResourceInte
     {
         /** @var RoleInterface $role */
         $role = $this->roleRepository->findRoleById($id);
-        $name = $request->get('name');
-        $key = $request->get('key');
+        $name = $request->request->get('name');
+        $key = $request->request->get('key');
+        $system = $request->request->get('system');
 
         try {
             if (!$role) {
@@ -251,13 +252,13 @@ class RoleController extends AbstractRestController implements ClassResourceInte
             } else {
                 $role->setName($name);
                 $role->setKey($key);
-                $role->setSystem($request->get('system'));
+                $role->setSystem($system);
 
-                if (!$this->processPermissions($role, $request->get('permissions', []))) {
+                if (!$this->processPermissions($role, $request->request->get('permissions', []))) {
                     throw new RestException('Could not update dependencies!');
                 }
 
-                $securityTypeData = $request->get('securityType');
+                $securityTypeData = $request->request->get('securityType');
                 if ($this->checkSecurityTypeData($securityTypeData)) {
                     $this->setSecurityType($role, $securityTypeData);
                 } else {

--- a/src/Sulu/Bundle/SecurityBundle/DependencyInjection/SuluSecurityExtension.php
+++ b/src/Sulu/Bundle/SecurityBundle/DependencyInjection/SuluSecurityExtension.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\SecurityBundle\DependencyInjection;
 
 use Sulu\Bundle\PersistenceBundle\DependencyInjection\PersistenceExtensionTrait;
-use Sulu\Bundle\SecurityBundle\Exception\RoleNameAlreadyExistsException;
+use Sulu\Bundle\SecurityBundle\Exception\RoleKeyAlreadyExistsException;
 use Sulu\Bundle\SecurityBundle\Security\Exception\EmailNotUniqueException;
 use Sulu\Bundle\SecurityBundle\Security\Exception\UsernameNotUniqueException;
 use Sulu\Component\HttpKernel\SuluKernel;
@@ -60,7 +60,7 @@ class SuluSecurityExtension extends Extension implements PrependExtensionInterfa
                 [
                     'exception' => [
                         'codes' => [
-                            RoleNameAlreadyExistsException::class => 409,
+                            RoleKeyAlreadyExistsException::class => 409,
                             UsernameNotUniqueException::class => 409,
                             EmailNotUniqueException::class => 409,
                         ],

--- a/src/Sulu/Bundle/SecurityBundle/DependencyInjection/SuluSecurityExtension.php
+++ b/src/Sulu/Bundle/SecurityBundle/DependencyInjection/SuluSecurityExtension.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\SecurityBundle\DependencyInjection;
 
 use Sulu\Bundle\PersistenceBundle\DependencyInjection\PersistenceExtensionTrait;
 use Sulu\Bundle\SecurityBundle\Exception\RoleKeyAlreadyExistsException;
+use Sulu\Bundle\SecurityBundle\Exception\RoleNameAlreadyExistsException;
 use Sulu\Bundle\SecurityBundle\Security\Exception\EmailNotUniqueException;
 use Sulu\Bundle\SecurityBundle\Security\Exception\UsernameNotUniqueException;
 use Sulu\Component\HttpKernel\SuluKernel;
@@ -60,6 +61,7 @@ class SuluSecurityExtension extends Extension implements PrependExtensionInterfa
                 [
                     'exception' => [
                         'codes' => [
+                            RoleNameAlreadyExistsException::class => 409,
                             RoleKeyAlreadyExistsException::class => 409,
                             UsernameNotUniqueException::class => 409,
                             EmailNotUniqueException::class => 409,

--- a/src/Sulu/Bundle/SecurityBundle/Entity/Role.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/Role.php
@@ -103,7 +103,7 @@ class Role implements RoleInterface
      */
     public function getRole()
     {
-        @trigger_error(sprintf('The "%s" method is deprecated since Sulu 2.1, use "%s" instead.', __METHOD__, 'getIdentifier'), E_USER_DEPRECATED)
+        @trigger_error(sprintf('The "%s" method is deprecated since Sulu 2.1, use "%s" instead.', __METHOD__, 'getIdentifier'), E_USER_DEPRECATED);
 
         return $this->getIdentifier();
     }

--- a/src/Sulu/Bundle/SecurityBundle/Entity/Role.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/Role.php
@@ -98,9 +98,26 @@ class Role implements RoleInterface
         return $this->id;
     }
 
+    /**
+     * @deprecated since 2.1 and will be removed in 3.0. Use "getIdentifier" instead.
+     */
+    public function getRole()
+    {
+        @trigger_error(sprintf('The "%s" method is deprecated since Sulu 2.1, use "%s" instead.', __METHOD__, 'getIdentifier'), E_USER_DEPRECATED)
+
+        return $this->getIdentifier();
+    }
+
     public function getIdentifier()
     {
-        return 'ROLE_SULU_' . strtoupper($this->getKey());
+        $key = $this->getKey();
+
+        // keep backwards compatibility as name was used for generating identifier before key was introduced
+        if (!$key) {
+            $key = $this->getName();
+        }
+
+        return 'ROLE_SULU_' . strtoupper($key);
     }
 
     /**

--- a/src/Sulu/Bundle/SecurityBundle/Entity/Role.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/Role.php
@@ -39,6 +39,11 @@ class Role implements RoleInterface
     /**
      * @var string
      */
+    private $key;
+
+    /**
+     * @var string
+     */
     private $system;
 
     /**
@@ -93,14 +98,9 @@ class Role implements RoleInterface
         return $this->id;
     }
 
-    public function getRole()
-    {
-        return 'ROLE_SULU_' . strtoupper($this->name);
-    }
-
     public function getIdentifier()
     {
-        return 'ROLE_SULU_' . strtoupper($this->getName());
+        return 'ROLE_SULU_' . strtoupper($this->getKey());
     }
 
     /**
@@ -125,6 +125,18 @@ class Role implements RoleInterface
     public function getName()
     {
         return $this->name;
+    }
+
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    public function setKey($key)
+    {
+        $this->key = $key;
+
+        return $this;
     }
 
     /**

--- a/src/Sulu/Bundle/SecurityBundle/Exception/RoleKeyAlreadyExistsException.php
+++ b/src/Sulu/Bundle/SecurityBundle/Exception/RoleKeyAlreadyExistsException.php
@@ -12,22 +12,22 @@
 namespace Sulu\Bundle\SecurityBundle\Exception;
 
 /**
- * Exception is thrown when a Role is created or updated with an already existing name.
+ * Exception is thrown when a Role is created or updated with an already existing key.
  */
-class RoleNameAlreadyExistsException extends \Exception
+class RoleKeyAlreadyExistsException extends \Exception
 {
     /**
      * @var string
      */
-    private $name;
+    private $key;
 
     /**
-     * @param string $name
+     * @param string $key
      */
-    public function __construct($name)
+    public function __construct($key)
     {
-        $this->name = $name;
-        parent::__construct(sprintf('Role "%s" already exists', $name), 1101);
+        $this->key = $key;
+        parent::__construct(sprintf('Role with key "%s" already exists', $key), 1101);
     }
 
     /**
@@ -35,8 +35,8 @@ class RoleNameAlreadyExistsException extends \Exception
      *
      * @return string
      */
-    public function getName()
+    public function getKey()
     {
-        return $this->name;
+        return $this->key;
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/Exception/RoleNameAlreadyExistsException.php
+++ b/src/Sulu/Bundle/SecurityBundle/Exception/RoleNameAlreadyExistsException.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\Exception;
+
+/**
+ * Exception is thrown when a Role is created or updated with an already existing name.
+ */
+class RoleNameAlreadyExistsException extends \Exception
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @param string $name
+     */
+    public function __construct($name)
+    {
+        $this->name = $name;
+        parent::__construct(sprintf('Role "%s" already exists', $name), 1101);
+    }
+
+    /**
+     * Returns the non-unique name of the role.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/Role.orm.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/Role.orm.xml
@@ -8,7 +8,7 @@
             <generator strategy="AUTO"/>
         </id>
 
-        <field name="name" type="string" column="name" length="60"/>
+        <field name="name" type="string" column="name" length="60" unique="true"/>
         <field name="key" type="string" length="60" column="role_key" nullable="true" unique="true"/>
         <field name="system" type="string" column="securitySystem" length="60"/>
 

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/Role.orm.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/Role.orm.xml
@@ -8,7 +8,8 @@
             <generator strategy="AUTO"/>
         </id>
 
-        <field name="name" type="string" column="name" length="60" unique="true"/>
+        <field name="name" type="string" column="name" length="60"/>
+        <field name="key" type="string" length="60" column="role_key" nullable="true" unique="true"/>
         <field name="system" type="string" column="securitySystem" length="60"/>
 
         <many-to-one field="securityType" target-entity="Sulu\Bundle\SecurityBundle\Entity\SecurityType"

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/forms/role_details.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/forms/role_details.xml
@@ -15,12 +15,6 @@
             </params>
         </property>
 
-        <property name="key" type="text_line" colspan="9">
-            <meta>
-                <title>sulu_admin.key</title>
-            </meta>
-        </property>
-
         <property name="system" type="single_select" mandatory="true" colspan="3">
             <meta>
                 <title>sulu_security.system</title>
@@ -37,6 +31,12 @@
                     value="service('sulu_security.security_systems_select_helper').getDefaultValue()"
                 />
             </params>
+        </property>
+
+        <property name="key" type="text_line" colspan="9">
+            <meta>
+                <title>sulu_admin.key</title>
+            </meta>
         </property>
 
         <section name="permissions_section">

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/forms/role_details.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/forms/role_details.xml
@@ -15,7 +15,13 @@
             </params>
         </property>
 
-        <property name="system" type="single_select" mandatory="true" colspan="3" spaceAfter="9">
+        <property name="key" type="text_line" colspan="9">
+            <meta>
+                <title>sulu_admin.key</title>
+            </meta>
+        </property>
+
+        <property name="system" type="single_select" mandatory="true" colspan="3">
             <meta>
                 <title>sulu_security.system</title>
             </meta>

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/lists/roles.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/lists/roles.xml
@@ -24,6 +24,18 @@
         </property>
 
         <property
+            name="key"
+            visibility="no"
+            searchability="yes"
+            translation="sulu_admin.key"
+        >
+            <field-name>key</field-name>
+            <entity-name>%sulu.model.role.class%</entity-name>
+
+            <filter type="text" />
+        </property>
+
+        <property
             name="system"
             visibility="always"
             searchability="yes"

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
@@ -503,6 +503,25 @@ class RoleControllerTest extends SuluTestCase
         $this->assertStringContainsString('11230', $response->message);
     }
 
+    public function testPutWithExistingName()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request(
+            'PUT',
+            '/api/roles/' . $this->role2->getId(),
+            [
+                'name' => 'Sulu Administrator',
+                'system' => 'Sulu',
+            ]
+        );
+
+        $response = json_decode($client->getResponse()->getContent());
+
+        $this->assertHttpStatusCode(409, $client->getResponse());
+        $this->assertEquals(1101, $response->code);
+    }
+
     public function testPutWithExistingKey()
     {
         $client = $this->createAuthenticatedClient();

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
@@ -59,6 +59,7 @@ class RoleControllerTest extends SuluTestCase
 
         $role = new Role();
         $role->setName('Sulu Administrator');
+        $role->setKey('sulu_administrator');
         $role->setSystem('Sulu');
         $role->setSecurityType($this->securityType1);
         $this->em->persist($role);
@@ -110,6 +111,7 @@ class RoleControllerTest extends SuluTestCase
 
         $this->assertEquals(2, count($response->_embedded->roles));
         $this->assertEquals('Sulu Administrator', $response->_embedded->roles[0]->name);
+        $this->assertEquals('sulu_administrator', $response->_embedded->roles[0]->key);
         $this->assertEquals('Sulu', $response->_embedded->roles[0]->system);
     }
 
@@ -121,6 +123,7 @@ class RoleControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
 
         $this->assertEquals('Sulu Administrator', $response->name);
+        $this->assertEquals('sulu_administrator', $response->key);
         $this->assertEquals('Sulu', $response->system);
         $this->assertEquals(2, count($response->permissions));
         $this->assertEquals('context1', $response->permissions[0]->context);
@@ -151,6 +154,7 @@ class RoleControllerTest extends SuluTestCase
             '/api/roles',
             [
                 'name' => 'Portal Manager',
+                'key' => 'portal_manager',
                 'system' => 'Sulu',
                 'permissions' => [
                     [
@@ -187,6 +191,7 @@ class RoleControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
 
         $this->assertEquals('Portal Manager', $response->name);
+        $this->assertEquals('portal_manager', $response->key);
         $this->assertEquals('Sulu', $response->system);
         $this->assertEquals(2, count($response->permissions));
         $this->assertEquals('portal1', $response->permissions[0]->context);
@@ -215,6 +220,7 @@ class RoleControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
 
         $this->assertEquals('Portal Manager', $response->name);
+        $this->assertEquals('portal_manager', $response->key);
         $this->assertEquals('Sulu', $response->system);
         $this->assertEquals(2, count($response->permissions));
         $this->assertEquals('portal1', $response->permissions[0]->context);
@@ -245,6 +251,7 @@ class RoleControllerTest extends SuluTestCase
             '/api/roles/' . $this->role1->getId(),
             [
                 'name' => 'Portal Manager',
+                'key' => 'portal_manager',
                 'system' => 'Sulu',
                 'permissions' => [
                     [
@@ -295,6 +302,7 @@ class RoleControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
 
         $this->assertEquals('Portal Manager', $response->name);
+        $this->assertEquals('portal_manager', $response->key);
         $this->assertEquals('Sulu', $response->system);
         $this->assertEquals('portal1', $response->permissions[0]->context);
         $this->assertEquals(true, $response->permissions[0]->permissions->view);
@@ -330,6 +338,7 @@ class RoleControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
 
         $this->assertEquals('Portal Manager', $response->name);
+        $this->assertEquals('portal_manager', $response->key);
         $this->assertEquals('Sulu', $response->system);
         $this->assertEquals(true, $response->permissions[0]->permissions->view);
         $this->assertEquals(true, $response->permissions[0]->permissions->add);
@@ -494,7 +503,7 @@ class RoleControllerTest extends SuluTestCase
         $this->assertStringContainsString('11230', $response->message);
     }
 
-    public function testPutWithExistingName()
+    public function testPutWithExistingKey()
     {
         $client = $this->createAuthenticatedClient();
 
@@ -502,7 +511,8 @@ class RoleControllerTest extends SuluTestCase
             'PUT',
             '/api/roles/' . $this->role2->getId(),
             [
-                'name' => 'Sulu Administrator',
+                'name' => 'Sulu Administrator 2',
+                'key' => 'sulu_administrator',
                 'system' => 'Sulu',
             ]
         );
@@ -571,6 +581,9 @@ class RoleControllerTest extends SuluTestCase
 
         $this->assertEquals('Sulu Administrator', $response->_embedded->roles[0]->name);
         $this->assertEquals('Sulu Editor', $response->_embedded->roles[1]->name);
+
+        $this->assertEquals('sulu_administrator', $response->_embedded->roles[0]->key);
+        $this->assertEquals(null, $response->_embedded->roles[1]->key);
 
         $this->assertEquals('Sulu', $response->_embedded->roles[0]->system);
         $this->assertEquals('Sulu', $response->_embedded->roles[1]->system);

--- a/src/Sulu/Component/Security/Authentication/RoleInterface.php
+++ b/src/Sulu/Component/Security/Authentication/RoleInterface.php
@@ -39,6 +39,22 @@ interface RoleInterface extends AuditableInterface, SecurityIdentityInterface
     public function getName();
 
     /**
+     * Set key.
+     *
+     * @param string $key
+     *
+     * @return RoleInterface
+     */
+    public function setKey($key);
+
+    /**
+     * Get key.
+     *
+     * @return string
+     */
+    public function getKey();
+
+    /**
      * Set system.
      *
      * @param string $system


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | no
| Related issues/PRs | #3675
| License | MIT

#### What's in this PR?

This PR adds a `key` property to the `Role` entity. The `key` property is implemented similar to the `key` property of the `Category` entity. 

Furthermore, it adjust the logic to use the `key` property instead of the `name` property for generating the identifier of a role. The identifier of a role is used for restricting access of a user in the [Symfony security configuration](https://symfony.com/doc/current/security.html#securing-url-patterns-access-control).

#### Why?

At the moment, we use the `name` property for generating the identifier of a role. This means that changing the `name` of a role might break the Symfony security configuration of the project. See #3675 for more information.

I am aware that this is not a perfect solution, but it is a solution that improves the current situation and is implementable with relatively low effort and small BC breaks. We can still implement something like `System Roles` in the future.

#### BC Breaks/Deprecations

See `UPGRADE.MD`