### PR TITLE
Use array-move package directly instead of deprecated version from react-sortable-hoc

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import {action, observable, toJS} from 'mobx';
 import {observer} from 'mobx-react';
-import {arrayMove} from 'react-sortable-hoc';
+import {arrayMove} from '../../utils';
 import {translate} from '../../utils/Translator';
 import Button from '../Button';
 import SortableBlockList from './SortableBlockList';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
@@ -16,6 +16,7 @@
         "@ckeditor/ckeditor5-paragraph": "^11.0.0",
         "@ckeditor/ckeditor5-ui": "^14.0.0",
         "ajv": "^6.1.1",
+        "array-move": "2.2.1",
         "classnames": "^2.2.5",
         "debounce": "^1.0.2",
         "fast-deep-equal": "^3.1.1",

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/index.js
@@ -1,5 +1,5 @@
 // @flow
-import {arrayMove} from 'react-sortable-hoc';
+import arrayMove from 'array-move';
 import {buildQueryString} from './Request';
 import {translate} from './Translator';
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR uses the `array-move` package to sort arrays, because the one from `react-sortable-hoc´ is deprecated