### PR TITLE
Use configured security system name in Admin classes instead of hardcoding it

### DIFF
--- a/src/Sulu/Bundle/AudienceTargetingBundle/Admin/AudienceTargetingAdmin.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Admin/AudienceTargetingAdmin.php
@@ -50,14 +50,21 @@ class AudienceTargetingAdmin extends Admin
      */
     private $ruleCollection;
 
+    /**
+     * @var string
+     */
+    private $suluSecuritySystem;
+
     public function __construct(
         ViewBuilderFactoryInterface $viewBuilderFactory,
         RuleCollectionInterface $ruleCollection,
-        SecurityCheckerInterface $securityChecker
+        SecurityCheckerInterface $securityChecker,
+        string $suluSecuritySystem
     ) {
         $this->viewBuilderFactory = $viewBuilderFactory;
         $this->ruleCollection = $ruleCollection;
         $this->securityChecker = $securityChecker;
+        $this->suluSecuritySystem = $suluSecuritySystem;
     }
 
     public function configureNavigationItems(NavigationItemCollection $navigationItemCollection): void
@@ -142,7 +149,7 @@ class AudienceTargetingAdmin extends Admin
     public function getSecurityContexts()
     {
         return [
-            'Sulu' => [
+            $this->suluSecuritySystem => [
                 'Settings' => [
                     self::SECURITY_CONTEXT => [
                         PermissionTypes::VIEW,

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/services.xml
@@ -11,6 +11,7 @@
             <argument type="service" id="Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface"/>
             <argument type="service" id="sulu_audience_targeting.rules_collection"/>
             <argument type="service" id="sulu_security.security_checker"/>
+            <argument>%sulu_security.system%</argument>
 
             <tag name="sulu.admin"/>
             <tag name="sulu.context" context="admin"/>

--- a/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
+++ b/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
@@ -46,14 +46,21 @@ class CategoryAdmin extends Admin
      */
     private $localizationManager;
 
+    /**
+     * @var string
+     */
+    private $suluSecuritySystem;
+
     public function __construct(
         ViewBuilderFactoryInterface $viewBuilderFactory,
         SecurityCheckerInterface $securityChecker,
-        LocalizationManagerInterface $localizationManager
+        LocalizationManagerInterface $localizationManager,
+        string $suluSecuritySystem
     ) {
         $this->viewBuilderFactory = $viewBuilderFactory;
         $this->securityChecker = $securityChecker;
         $this->localizationManager = $localizationManager;
+        $this->suluSecuritySystem = $suluSecuritySystem;
     }
 
     public function configureNavigationItems(NavigationItemCollection $navigationItemCollection): void
@@ -165,7 +172,7 @@ class CategoryAdmin extends Admin
     public function getSecurityContexts()
     {
         return [
-            'Sulu' => [
+            $this->suluSecuritySystem => [
                 'Settings' => [
                     static::SECURITY_CONTEXT => [
                         PermissionTypes::VIEW,

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/services.xml
@@ -4,11 +4,13 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sulu_category.admin" class="Sulu\Bundle\CategoryBundle\Admin\CategoryAdmin">
-            <tag name="sulu.admin"/>
-            <tag name="sulu.context" context="admin"/>
             <argument type="service" id="Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface"/>
             <argument type="service" id="sulu_security.security_checker"/>
             <argument type="service" id="sulu.core.localization_manager"/>
+            <argument>%sulu_security.system%</argument>
+
+            <tag name="sulu.admin"/>
+            <tag name="sulu.context" context="admin"/>
         </service>
 
         <service id="sulu_category.category_manager" class="Sulu\Bundle\CategoryBundle\Category\CategoryManager" public="true">

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -56,14 +56,21 @@ class ContactAdmin extends Admin
      */
     private $managerRegistry;
 
+    /**
+     * @var string
+     */
+    private $suluSecuritySystem;
+
     public function __construct(
         ViewBuilderFactoryInterface $viewBuilderFactory,
         SecurityCheckerInterface $securityChecker,
-        ManagerRegistry $managerRegistry
+        ManagerRegistry $managerRegistry,
+        string $suluSecuritySystem
     ) {
         $this->viewBuilderFactory = $viewBuilderFactory;
         $this->securityChecker = $securityChecker;
         $this->managerRegistry = $managerRegistry;
+        $this->suluSecuritySystem = $suluSecuritySystem;
     }
 
     public function configureNavigationItems(NavigationItemCollection $navigationItemCollection): void
@@ -297,7 +304,7 @@ class ContactAdmin extends Admin
     public function getSecurityContexts()
     {
         return [
-            'Sulu' => [
+            $this->suluSecuritySystem => [
                 'Contacts' => [
                     static::CONTACT_SECURITY_CONTEXT => [
                         PermissionTypes::VIEW,

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
@@ -10,6 +10,7 @@
             <argument type="service" id="Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface"/>
             <argument type="service" id="sulu_security.security_checker" />
             <argument type="service" id="doctrine" />
+            <argument>%sulu_security.system%</argument>
 
             <tag name="sulu.admin"/>
             <tag name="sulu.context" context="admin"/>

--- a/src/Sulu/Bundle/CustomUrlBundle/Admin/CustomUrlAdmin.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Admin/CustomUrlAdmin.php
@@ -53,14 +53,21 @@ class CustomUrlAdmin extends Admin
      */
     private $securityChecker;
 
+    /**
+     * @var string
+     */
+    private $suluSecuritySystem;
+
     public function __construct(
         WebspaceManagerInterface $webspaceManager,
         ViewBuilderFactoryInterface $viewBuilderFactory,
-        SecurityCheckerInterface $securityChecker
+        SecurityCheckerInterface $securityChecker,
+        string $suluSecuritySystem
     ) {
         $this->webspaceManager = $webspaceManager;
         $this->viewBuilderFactory = $viewBuilderFactory;
         $this->securityChecker = $securityChecker;
+        $this->suluSecuritySystem = $suluSecuritySystem;
     }
 
     public function configureViews(ViewCollection $viewCollection): void
@@ -100,7 +107,7 @@ class CustomUrlAdmin extends Admin
         }
 
         return [
-             'Sulu' => [
+             $this->suluSecuritySystem => [
                  'Webspaces' => $webspaceContexts,
              ],
          ];
@@ -109,7 +116,7 @@ class CustomUrlAdmin extends Admin
     public function getSecurityContextsWithPlaceholder()
     {
         return [
-            'Sulu' => [
+            $this->suluSecuritySystem => [
                 'Webspaces' => [
                     self::getCustomUrlSecurityContext('#webspace#') => $this->getSecurityContextPermissions(),
                 ],

--- a/src/Sulu/Bundle/CustomUrlBundle/Resources/config/admin.xml
+++ b/src/Sulu/Bundle/CustomUrlBundle/Resources/config/admin.xml
@@ -8,6 +8,7 @@
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface"/>
             <argument type="service" id="sulu_security.security_checker"/>
+            <argument>%sulu_security.system%</argument>
 
             <tag name="sulu.admin"/>
             <tag name="sulu.context" context="admin"/>

--- a/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
+++ b/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
@@ -57,16 +57,23 @@ class MediaAdmin extends Admin
      */
     private $urlGenerator;
 
+    /**
+     * @var string
+     */
+    private $suluSecuritySystem;
+
     public function __construct(
         ViewBuilderFactoryInterface $viewBuilderFactory,
         SecurityCheckerInterface $securityChecker,
         LocalizationManager $localizationManager,
-        UrlGeneratorInterface $urlGenerator
+        UrlGeneratorInterface $urlGenerator,
+        string $suluSecuritySystem
     ) {
         $this->viewBuilderFactory = $viewBuilderFactory;
         $this->securityChecker = $securityChecker;
         $this->localizationManager = $localizationManager;
         $this->urlGenerator = $urlGenerator;
+        $this->suluSecuritySystem = $suluSecuritySystem;
     }
 
     public function configureNavigationItems(NavigationItemCollection $navigationItemCollection): void
@@ -152,7 +159,7 @@ class MediaAdmin extends Admin
     public function getSecurityContexts()
     {
         return [
-            'Sulu' => [
+            $this->suluSecuritySystem => [
                 'Media' => [
                     static::SECURITY_CONTEXT => [
                         PermissionTypes::VIEW,

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -126,12 +126,14 @@
         </service>
 
         <service id="sulu_media.admin" class="%sulu_media.admin.class%">
-            <tag name="sulu.admin"/>
-            <tag name="sulu.context" context="admin"/>
             <argument type="service" id="Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface"/>
             <argument type="service" id="sulu_security.security_checker"/>
             <argument type="service" id="sulu.core.localization_manager"/>
             <argument type="service" id="router"/>
+            <argument>%sulu_security.system%</argument>
+
+            <tag name="sulu.admin"/>
+            <tag name="sulu.context" context="admin"/>
         </service>
         <service id="sulu_media.collection_repository" class="%sulu_media.collection_repository.class%" public="true">
             <factory service="doctrine.orm.entity_manager" method="getRepository"/>

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -73,13 +73,19 @@ class PageAdmin extends Admin
      */
     private $versioningEnabled;
 
+    /**
+     * @var string
+     */
+    private $suluSecuritySystem;
+
     public function __construct(
         ViewBuilderFactoryInterface $viewBuilderFactory,
         WebspaceManagerInterface $webspaceManager,
         SecurityCheckerInterface $securityChecker,
         SessionManagerInterface $sessionManager,
         TeaserProviderPoolInterface $teaserProviderPool,
-        bool $versioningEnabled
+        bool $versioningEnabled,
+        string $suluSecuritySystem
     ) {
         $this->viewBuilderFactory = $viewBuilderFactory;
         $this->webspaceManager = $webspaceManager;
@@ -87,6 +93,7 @@ class PageAdmin extends Admin
         $this->sessionManager = $sessionManager;
         $this->teaserProviderPool = $teaserProviderPool;
         $this->versioningEnabled = $versioningEnabled;
+        $this->suluSecuritySystem = $suluSecuritySystem;
     }
 
     public function configureNavigationItems(NavigationItemCollection $navigationItemCollection): void
@@ -309,7 +316,7 @@ class PageAdmin extends Admin
         }
 
         return [
-            'Sulu' => [
+            $this->suluSecuritySystem => [
                 'Webspaces' => $webspaceContexts,
             ],
         ];
@@ -318,7 +325,7 @@ class PageAdmin extends Admin
     public function getSecurityContextsWithPlaceholder()
     {
         return [
-            'Sulu' => [
+            $this->suluSecuritySystem => [
                 'Webspaces' => [
                     self::SECURITY_CONTEXT_PREFIX . '#webspace#' => [
                         PermissionTypes::VIEW,

--- a/src/Sulu/Bundle/PageBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/services.xml
@@ -11,14 +11,16 @@
     <services>
         <!-- admin class -->
         <service id="sulu_page.admin" class="%sulu_page.admin.class%">
-            <tag name="sulu.admin"/>
-            <tag name="sulu.context" context="admin"/>
             <argument type="service" id="Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="sulu_security.security_checker"/>
             <argument type="service" id="sulu.phpcr.session"/>
             <argument type="service" id="sulu_page.teaser.provider_pool" />
             <argument>%sulu_document_manager.versioning.enabled%</argument>
+            <argument>%sulu_security.system%</argument>
+
+            <tag name="sulu.admin"/>
+            <tag name="sulu.context" context="admin"/>
         </service>
 
         <!-- content -->

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Admin/PageAdminTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Admin/PageAdminTest.php
@@ -96,7 +96,8 @@ class PageAdminTest extends TestCase
             $this->securityChecker->reveal(),
             $this->sessionManager->reveal(),
             $this->teaserProviderPool->reveal(),
-            false
+            false,
+            'sulu-security-system'
         );
 
         $viewCollection = new ViewCollection();
@@ -120,7 +121,8 @@ class PageAdminTest extends TestCase
             $this->securityChecker->reveal(),
             $this->sessionManager->reveal(),
             $this->teaserProviderPool->reveal(),
-            true
+            true,
+            'sulu-security-system'
         );
 
         $config = $admin->getConfig();
@@ -136,7 +138,8 @@ class PageAdminTest extends TestCase
             $this->securityChecker->reveal(),
             $this->sessionManager->reveal(),
             $this->teaserProviderPool->reveal(),
-            false
+            false,
+            'sulu-security-system'
         );
 
         $config = $admin->getConfig();

--- a/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
+++ b/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
@@ -71,18 +71,25 @@ class SecurityAdmin extends Admin
      */
     private $resources;
 
+    /**
+     * @var string
+     */
+    private $suluSecuritySystem;
+
     public function __construct(
         ViewBuilderFactoryInterface $viewBuilderFactory,
         SecurityCheckerInterface $securityChecker,
         UrlGeneratorInterface $urlGenerator,
         TranslatorInterface $translator,
-        array $resources
+        array $resources,
+        string $suluSecuritySystem
     ) {
         $this->viewBuilderFactory = $viewBuilderFactory;
         $this->securityChecker = $securityChecker;
         $this->urlGenerator = $urlGenerator;
         $this->translator = $translator;
         $this->resources = $resources;
+        $this->suluSecuritySystem = $suluSecuritySystem;
     }
 
     public function configureNavigationItems(NavigationItemCollection $navigationItemCollection): void
@@ -99,7 +106,7 @@ class SecurityAdmin extends Admin
     public function getSecurityContexts()
     {
         return [
-            'Sulu' => [
+            $this->suluSecuritySystem => [
                 'Security' => [
                     static::ROLE_SECURITY_CONTEXT => [
                         PermissionTypes::VIEW,

--- a/src/Sulu/Bundle/SecurityBundle/Build/UserBuilder.php
+++ b/src/Sulu/Bundle/SecurityBundle/Build/UserBuilder.php
@@ -18,6 +18,16 @@ use Sulu\Bundle\CoreBundle\Build\SuluBuilder;
  */
 class UserBuilder extends SuluBuilder
 {
+    /**
+     * @var string
+     */
+    private $suluSecuritySystem;
+
+    public function __construct(string $suluSecuritySystem)
+    {
+        $this->suluSecuritySystem = $suluSecuritySystem;
+    }
+
     public function getName()
     {
         return 'user';
@@ -33,7 +43,7 @@ class UserBuilder extends SuluBuilder
         $user = 'admin';
         $password = 'admin';
         $roleName = 'User';
-        $system = 'Sulu';
+        $system = $this->suluSecuritySystem;
         $locale = 'en';
         $doctrine = $this->container->get('doctrine')->getManager();
         $userRep = $this->container->get('sulu.repository.user');

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -69,6 +69,8 @@
             <argument type="service" id="router"/>
             <argument type="service" id="translator"/>
             <argument>%sulu_admin.resources%</argument>
+            <argument>%sulu_security.system%</argument>
+
             <tag name="sulu.admin"/>
             <tag name="sulu.context" context="admin"/>
         </service>
@@ -247,6 +249,8 @@
         </service>
 
         <service id="sulu_security.build.user" class="%sulu_security.build.user.class%">
+            <argument>%sulu_security.system%</argument>
+
             <tag name="massive_build.builder" />
         </service>
 

--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -57,6 +57,11 @@ class SnippetAdmin extends Admin
     private $defaultEnabled;
 
     /**
+     * @var string
+     */
+    private $suluSecuritySystem;
+
+    /**
      * Returns security context for default-snippets in given webspace.
      *
      * @param string $webspaceKey
@@ -72,12 +77,14 @@ class SnippetAdmin extends Admin
         ViewBuilderFactoryInterface $viewBuilderFactory,
         SecurityCheckerInterface $securityChecker,
         WebspaceManagerInterface $webspaceManager,
-        $defaultEnabled
+        $defaultEnabled,
+        string $suluSecuritySystem
     ) {
         $this->viewBuilderFactory = $viewBuilderFactory;
         $this->securityChecker = $securityChecker;
         $this->webspaceManager = $webspaceManager;
         $this->defaultEnabled = $defaultEnabled;
+        $this->suluSecuritySystem = $suluSecuritySystem;
     }
 
     public function configureNavigationItems(NavigationItemCollection $navigationItemCollection): void
@@ -198,7 +205,7 @@ class SnippetAdmin extends Admin
                 ];
             }
 
-            $contexts['Sulu']['Webspaces'] = $webspaceContexts;
+            $contexts[$this->suluSecuritySystem]['Webspaces'] = $webspaceContexts;
         }
 
         return $contexts;
@@ -214,7 +221,7 @@ class SnippetAdmin extends Admin
                 PermissionTypes::EDIT,
             ];
 
-            $contexts['Sulu']['Webspaces'] = $webspaceContexts;
+            $contexts[$this->suluSecuritySystem]['Webspaces'] = $webspaceContexts;
         }
 
         return $contexts;
@@ -223,7 +230,7 @@ class SnippetAdmin extends Admin
     private function getGlobalSnippetsSecurityContext()
     {
         return [
-            'Sulu' => [
+            $this->suluSecuritySystem => [
                 'Global' => [
                     static::SECURITY_CONTEXT => [
                         PermissionTypes::VIEW,

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/admin.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/admin.xml
@@ -8,6 +8,7 @@
             <argument type="service" id="sulu_security.security_checker"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument>%sulu_snippet.content-type.default_enabled%</argument>
+            <argument>%sulu_security.system%</argument>
 
             <tag name="sulu.admin"/>
             <tag name="sulu.context" context="admin"/>

--- a/src/Sulu/Bundle/TagBundle/Admin/TagAdmin.php
+++ b/src/Sulu/Bundle/TagBundle/Admin/TagAdmin.php
@@ -40,12 +40,19 @@ class TagAdmin extends Admin
      */
     private $securityChecker;
 
+    /**
+     * @var string
+     */
+    private $suluSecuritySystem;
+
     public function __construct(
         ViewBuilderFactoryInterface $viewBuilderFactory,
-        SecurityCheckerInterface $securityChecker
+        SecurityCheckerInterface $securityChecker,
+        string $suluSecuritySystem
     ) {
         $this->viewBuilderFactory = $viewBuilderFactory;
         $this->securityChecker = $securityChecker;
+        $this->suluSecuritySystem = $suluSecuritySystem;
     }
 
     public function configureNavigationItems(NavigationItemCollection $navigationItemCollection): void
@@ -126,7 +133,7 @@ class TagAdmin extends Admin
     public function getSecurityContexts()
     {
         return [
-            'Sulu' => [
+            $this->suluSecuritySystem => [
                 'Settings' => [
                     static::SECURITY_CONTEXT => [
                         PermissionTypes::VIEW,

--- a/src/Sulu/Bundle/TagBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/TagBundle/Resources/config/services.xml
@@ -4,10 +4,12 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sulu_tag.admin" class="Sulu\Bundle\TagBundle\Admin\TagAdmin">
-            <tag name="sulu.admin"/>
-            <tag name="sulu.context" context="admin"/>
             <argument type="service" id="Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface"/>
             <argument type="service" id="sulu_security.security_checker"/>
+            <argument>%sulu_security.system%</argument>
+
+            <tag name="sulu.admin"/>
+            <tag name="sulu.context" context="admin"/>
         </service>
 
         <service id="sulu_tag.tag_manager" class="Sulu\Bundle\TagBundle\Tag\TagManager" public="true">

--- a/src/Sulu/Bundle/WebsiteBundle/Admin/WebsiteAdmin.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Admin/WebsiteAdmin.php
@@ -56,16 +56,23 @@ class WebsiteAdmin extends Admin
      */
     private $urlGenerator;
 
+    /**
+     * @var string
+     */
+    private $suluSecuritySystem;
+
     public function __construct(
         ViewBuilderFactoryInterface $viewBuilderFactory,
         WebspaceManagerInterface $webspaceManager,
         SecurityCheckerInterface $securityChecker,
-        UrlGeneratorInterface $urlGenerator
+        UrlGeneratorInterface $urlGenerator,
+        string $suluSecuritySystem
     ) {
         $this->viewBuilderFactory = $viewBuilderFactory;
         $this->webspaceManager = $webspaceManager;
         $this->securityChecker = $securityChecker;
         $this->urlGenerator = $urlGenerator;
+        $this->suluSecuritySystem = $suluSecuritySystem;
     }
 
     public function configureViews(ViewCollection $viewCollection): void
@@ -105,7 +112,7 @@ class WebsiteAdmin extends Admin
         }
 
         return [
-            'Sulu' => [
+            $this->suluSecuritySystem => [
                 'Webspaces' => $webspaceContexts,
             ],
         ];
@@ -114,7 +121,7 @@ class WebsiteAdmin extends Admin
     public function getSecurityContextsWithPlaceholder()
     {
         return [
-            'Sulu' => [
+            $this->suluSecuritySystem => [
                 'Webspaces' => [
                     self::getAnalyticsSecurityContext('#webspace#') => $this->getSecurityContextPermissions(),
                 ],

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -75,6 +75,7 @@
             <argument type="service" id="sulu_core.webspace.webspace_manager" />
             <argument type="service" id="sulu_security.security_checker" />
             <argument type="service" id="router"/>
+            <argument>%sulu_security.system%</argument>
 
             <tag name="sulu.admin"/>
             <tag name="sulu.context" context="admin"/>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adjust the `getSecurityContexts()` method of various (i hope i catched all of them) `Admin` classes to use the configured security system name instead of hardcoding `Sulu`.

#### Why?

Because the name of the security system used by the Sulu admin can be configured via `sulu_security.system`. If this is set to something other than `Sulu`, it is not possible to assign admin related permissions to a role of the configured system.

A positive side effect of this is that it makes it understandable what the key of the array returned by the `getSecurityContexts()` method represents.

#### BC Breaks/Deprecations

The constructor of various Admin classes was changed to inject the `sulu_security.system` parameter.
