### PR TITLE
Include security systems of configured webspaces in PageAdmin

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -308,29 +308,57 @@ class PageAdmin extends Admin
             ];
         }
 
-        return [
-            'Sulu' => [
-                'Webspaces' => $webspaceContexts,
+        return array_merge(
+            [
+                'Sulu' => [
+                    'Webspaces' => $webspaceContexts,
+                ],
             ],
-        ];
+            $this->getWebspaceSecuritySystemContexts()
+        );
     }
 
     public function getSecurityContextsWithPlaceholder()
     {
-        return [
-            'Sulu' => [
-                'Webspaces' => [
-                    self::SECURITY_CONTEXT_PREFIX . '#webspace#' => [
-                        PermissionTypes::VIEW,
-                        PermissionTypes::ADD,
-                        PermissionTypes::EDIT,
-                        PermissionTypes::DELETE,
-                        PermissionTypes::LIVE,
-                        PermissionTypes::SECURITY,
+        return array_merge(
+            [
+                'Sulu' => [
+                    'Webspaces' => [
+                        self::SECURITY_CONTEXT_PREFIX . '#webspace#' => [
+                            PermissionTypes::VIEW,
+                            PermissionTypes::ADD,
+                            PermissionTypes::EDIT,
+                            PermissionTypes::DELETE,
+                            PermissionTypes::LIVE,
+                            PermissionTypes::SECURITY,
+                        ],
                     ],
                 ],
             ],
-        ];
+            $this->getWebspaceSecuritySystemContexts()
+        );
+    }
+
+    private function getWebspaceSecuritySystemContexts(): array
+    {
+        $webspaceSecuritySystemContexts = [];
+
+        /** @var Webspace $webspace */
+        foreach ($this->webspaceManager->getWebspaceCollection() as $webspace) {
+            $security = $webspace->getSecurity();
+            if (!$security) {
+                continue;
+            }
+
+            $system = $security->getSystem();
+            if (!$system) {
+                continue;
+            }
+
+            $webspaceSecuritySystemContexts[$system] = [];
+        }
+
+        return $webspaceSecuritySystemContexts;
     }
 
     public function getConfigKey(): ?string


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5161
| License | MIT

#### What's in this PR?

This PR adjusts the `PageAdmin` to include the security systems of the webspaces of the application in the result of the `getSecurityContexts()` method and the `getSecurityContextsWithPlaceholder()` method.

#### Why?

Because the `CreateRoleCommand` and the `SecuritySystemsSelect` rely on the result of these methods to display the available security systems. See #5161.
