### PR TITLE
Collapse the preview toolbar on small screens

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Controls.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Controls.js
@@ -5,11 +5,11 @@ import classNames from 'classnames';
 import type {Group, Item, Skin} from './types';
 import controlsStyles from './controls.scss';
 
-type Props = {
+type Props = {|
     children: ChildrenArray<Item | Group | false>,
     grow?: boolean,
     skin?: Skin,
-};
+|};
 
 export default class Controls extends React.PureComponent<Props> {
     static defaultProps = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Items.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Items.js
@@ -8,10 +8,10 @@ import debounce from 'debounce';
 import type {Item, Skin} from './types';
 import itemsStyles from './items.scss';
 
-type Props = {
-    children: ChildrenArray<Item>,
+type Props = {|
+    children: ChildrenArray<false | Item>,
     skin?: Skin,
-};
+|};
 
 const DEBOUNCE_TIME = 200;
 
@@ -90,7 +90,7 @@ class Items extends React.Component<Props> {
                 <ul className={itemsClass} ref={this.setChildRef}>
                     {children &&
                         React.Children.map(children, (item, index) => (
-                            <li key={index}>
+                            item && <li key={index}>
                                 {React.cloneElement(item, {
                                     ...item.props,
                                     showText: this.showText,

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
@@ -254,57 +254,59 @@ class Preview extends React.Component<Props> {
                     </div>
                 }
                 <Toolbar skin="dark">
-                    <Toolbar.Controls>
+                    <Toolbar.Controls grow={true}>
                         <Toolbar.Button
                             icon={sidebarStore.size === 'medium' ? 'su-arrow-left' : 'su-arrow-right'}
                             onClick={this.handleToggleSidebarClick}
                         />
-                        <Toolbar.Select
-                            icon="su-expand"
-                            onChange={this.handleDeviceSelectChange}
-                            options={this.availableDeviceOptions}
-                            value={this.selectedDeviceOption}
-                        />
-                        {previewWebspaceChooser &&
+                        <Toolbar.Items>
                             <Toolbar.Select
-                                icon="su-webspace"
-                                onChange={this.handleWebspaceChange}
-                                options={this.webspaceOptions}
-                                value={this.previewStore.webspace}
+                                icon="su-expand"
+                                onChange={this.handleDeviceSelectChange}
+                                options={this.availableDeviceOptions}
+                                value={this.selectedDeviceOption}
                             />
-                        }
-                        {!!this.targetGroupsStore &&
-                            <Toolbar.Select
-                                icon="su-user"
-                                loading={this.targetGroupsStore.loading}
-                                onChange={this.handleTargetGroupChange}
-                                options={
-                                    [
-                                        {label: translate('sulu_audience_targeting.no_target_group'), value: -1},
-                                        ...(this.targetGroupsStore
-                                            ? this.targetGroupsStore.data.map((targetGroup) => ({
-                                                label: targetGroup.title,
-                                                value: targetGroup.id,
-                                            }))
-                                            : []
-                                        ),
-                                    ]
-                                }
-                                value={this.previewStore && this.previewStore.targetGroup}
-                            />
-                        }
-                        <Toolbar.Button
-                            icon="su-sync"
-                            onClick={this.handleRefreshClick}
-                        >
-                            {translate('sulu_preview.reload')}
-                        </Toolbar.Button>
-                        <Toolbar.Button
-                            icon="su-link"
-                            onClick={this.handlePreviewWindowClick}
-                        >
-                            {translate('sulu_preview.open_in_window')}
-                        </Toolbar.Button>
+                            {previewWebspaceChooser &&
+                                <Toolbar.Select
+                                    icon="su-webspace"
+                                    onChange={this.handleWebspaceChange}
+                                    options={this.webspaceOptions}
+                                    value={this.previewStore.webspace}
+                                />
+                            }
+                            {!!this.targetGroupsStore &&
+                                <Toolbar.Select
+                                    icon="su-user"
+                                    loading={this.targetGroupsStore.loading}
+                                    onChange={this.handleTargetGroupChange}
+                                    options={
+                                        [
+                                            {label: translate('sulu_audience_targeting.no_target_group'), value: -1},
+                                            ...(this.targetGroupsStore
+                                                ? this.targetGroupsStore.data.map((targetGroup) => ({
+                                                    label: targetGroup.title,
+                                                    value: targetGroup.id,
+                                                }))
+                                                : []
+                                            ),
+                                        ]
+                                    }
+                                    value={this.previewStore && this.previewStore.targetGroup}
+                                />
+                            }
+                            <Toolbar.Button
+                                icon="su-sync"
+                                onClick={this.handleRefreshClick}
+                            >
+                                {translate('sulu_preview.reload')}
+                            </Toolbar.Button>
+                            <Toolbar.Button
+                                icon="su-link"
+                                onClick={this.handlePreviewWindowClick}
+                            >
+                                {translate('sulu_preview.open_in_window')}
+                            </Toolbar.Button>
+                        </Toolbar.Items>
                     </Toolbar.Controls>
                 </Toolbar>
             </div>

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/Preview.test.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/Preview.test.js
@@ -11,6 +11,10 @@ import Preview from '../Preview';
 
 window.open = jest.fn().mockReturnValue({addEventListener: jest.fn()});
 
+window.ResizeObserver = jest.fn(function() {
+    this.observe = jest.fn();
+});
+
 jest.mock('debounce', () => jest.fn((value) => value));
 
 jest.mock('../stores/PreviewStore', () => jest.fn(function() {

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/__snapshots__/Preview.test.js.snap
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/__snapshots__/Preview.test.js.snap
@@ -20,7 +20,7 @@ exports[`Dont react or update preview when data is changed during formstore is l
     class="toolbar dark"
   >
     <div
-      class="controls dark"
+      class="controls dark grow"
     >
       <button
         class="button dark"
@@ -31,68 +31,84 @@ exports[`Dont react or update preview when data is changed during formstore is l
         />
       </button>
       <div
-        class="select dark"
+        class="itemsContainer"
       >
-        <button
-          class="button dark"
+        <ul
+          class="items dark"
         >
-          <span
-            aria-label="su-expand"
-            class="su-expand icon"
-          />
-          <span
-            class="label"
-          >
-            sulu_preview.auto
-          </span>
-          <span
-            aria-label="su-angle-down"
-            class="su-angle-down dropdownIcon"
-          />
-        </button>
+          <li>
+            <div
+              class="select dark"
+            >
+              <button
+                class="button dark"
+              >
+                <span
+                  aria-label="su-expand"
+                  class="su-expand icon"
+                />
+                <span
+                  class="label"
+                >
+                  sulu_preview.auto
+                </span>
+                <span
+                  aria-label="su-angle-down"
+                  class="su-angle-down dropdownIcon"
+                />
+              </button>
+            </div>
+          </li>
+          <li>
+            <div
+              class="select dark"
+            >
+              <button
+                class="button dark"
+              >
+                <span
+                  aria-label="su-webspace"
+                  class="su-webspace icon"
+                />
+                <span
+                  aria-label="su-angle-down"
+                  class="su-angle-down dropdownIcon"
+                />
+              </button>
+            </div>
+          </li>
+          <li>
+            <button
+              class="button dark"
+            >
+              <span
+                aria-label="su-sync"
+                class="su-sync icon"
+              />
+              <span
+                class="label"
+              >
+                sulu_preview.reload
+              </span>
+            </button>
+          </li>
+          <li>
+            <button
+              class="button dark"
+            >
+              <span
+                aria-label="su-link"
+                class="su-link icon"
+              />
+              <span
+                class="label"
+              >
+                sulu_preview.open_in_window
+              </span>
+            </button>
+          </li>
+        </ul>
       </div>
-      <div
-        class="select dark"
-      >
-        <button
-          class="button dark"
-        >
-          <span
-            aria-label="su-webspace"
-            class="su-webspace icon"
-          />
-          <span
-            aria-label="su-angle-down"
-            class="su-angle-down dropdownIcon"
-          />
-        </button>
-      </div>
-      <button
-        class="button dark"
-      >
-        <span
-          aria-label="su-sync"
-          class="su-sync icon"
-        />
-        <span
-          class="label"
-        >
-          sulu_preview.reload
-        </span>
-      </button>
-      <button
-        class="button dark"
-      >
-        <span
-          aria-label="su-link"
-          class="su-link icon"
-        />
-        <span
-          class="label"
-        >
-          sulu_preview.open_in_window
-        </span>
-      </button>
     </div>
   </nav>
 </div>
@@ -121,7 +137,7 @@ exports[`Dont react or update preview when data is changed during preview-store 
     class="toolbar dark"
   >
     <div
-      class="controls dark"
+      class="controls dark grow"
     >
       <button
         class="button dark"
@@ -132,68 +148,84 @@ exports[`Dont react or update preview when data is changed during preview-store 
         />
       </button>
       <div
-        class="select dark"
+        class="itemsContainer"
       >
-        <button
-          class="button dark"
+        <ul
+          class="items dark"
         >
-          <span
-            aria-label="su-expand"
-            class="su-expand icon"
-          />
-          <span
-            class="label"
-          >
-            sulu_preview.auto
-          </span>
-          <span
-            aria-label="su-angle-down"
-            class="su-angle-down dropdownIcon"
-          />
-        </button>
+          <li>
+            <div
+              class="select dark"
+            >
+              <button
+                class="button dark"
+              >
+                <span
+                  aria-label="su-expand"
+                  class="su-expand icon"
+                />
+                <span
+                  class="label"
+                >
+                  sulu_preview.auto
+                </span>
+                <span
+                  aria-label="su-angle-down"
+                  class="su-angle-down dropdownIcon"
+                />
+              </button>
+            </div>
+          </li>
+          <li>
+            <div
+              class="select dark"
+            >
+              <button
+                class="button dark"
+              >
+                <span
+                  aria-label="su-webspace"
+                  class="su-webspace icon"
+                />
+                <span
+                  aria-label="su-angle-down"
+                  class="su-angle-down dropdownIcon"
+                />
+              </button>
+            </div>
+          </li>
+          <li>
+            <button
+              class="button dark"
+            >
+              <span
+                aria-label="su-sync"
+                class="su-sync icon"
+              />
+              <span
+                class="label"
+              >
+                sulu_preview.reload
+              </span>
+            </button>
+          </li>
+          <li>
+            <button
+              class="button dark"
+            >
+              <span
+                aria-label="su-link"
+                class="su-link icon"
+              />
+              <span
+                class="label"
+              >
+                sulu_preview.open_in_window
+              </span>
+            </button>
+          </li>
+        </ul>
       </div>
-      <div
-        class="select dark"
-      >
-        <button
-          class="button dark"
-        >
-          <span
-            aria-label="su-webspace"
-            class="su-webspace icon"
-          />
-          <span
-            aria-label="su-angle-down"
-            class="su-angle-down dropdownIcon"
-          />
-        </button>
-      </div>
-      <button
-        class="button dark"
-      >
-        <span
-          aria-label="su-sync"
-          class="su-sync icon"
-        />
-        <span
-          class="label"
-        >
-          sulu_preview.reload
-        </span>
-      </button>
-      <button
-        class="button dark"
-      >
-        <span
-          aria-label="su-link"
-          class="su-link icon"
-        />
-        <span
-          class="label"
-        >
-          sulu_preview.open_in_window
-        </span>
-      </button>
     </div>
   </nav>
 </div>
@@ -221,7 +253,7 @@ exports[`React and update preview when data is changed 1`] = `
     class="toolbar dark"
   >
     <div
-      class="controls dark"
+      class="controls dark grow"
     >
       <button
         class="button dark"
@@ -232,68 +264,84 @@ exports[`React and update preview when data is changed 1`] = `
         />
       </button>
       <div
-        class="select dark"
+        class="itemsContainer"
       >
-        <button
-          class="button dark"
+        <ul
+          class="items dark"
         >
-          <span
-            aria-label="su-expand"
-            class="su-expand icon"
-          />
-          <span
-            class="label"
-          >
-            sulu_preview.auto
-          </span>
-          <span
-            aria-label="su-angle-down"
-            class="su-angle-down dropdownIcon"
-          />
-        </button>
+          <li>
+            <div
+              class="select dark"
+            >
+              <button
+                class="button dark"
+              >
+                <span
+                  aria-label="su-expand"
+                  class="su-expand icon"
+                />
+                <span
+                  class="label"
+                >
+                  sulu_preview.auto
+                </span>
+                <span
+                  aria-label="su-angle-down"
+                  class="su-angle-down dropdownIcon"
+                />
+              </button>
+            </div>
+          </li>
+          <li>
+            <div
+              class="select dark"
+            >
+              <button
+                class="button dark"
+              >
+                <span
+                  aria-label="su-webspace"
+                  class="su-webspace icon"
+                />
+                <span
+                  aria-label="su-angle-down"
+                  class="su-angle-down dropdownIcon"
+                />
+              </button>
+            </div>
+          </li>
+          <li>
+            <button
+              class="button dark"
+            >
+              <span
+                aria-label="su-sync"
+                class="su-sync icon"
+              />
+              <span
+                class="label"
+              >
+                sulu_preview.reload
+              </span>
+            </button>
+          </li>
+          <li>
+            <button
+              class="button dark"
+            >
+              <span
+                aria-label="su-link"
+                class="su-link icon"
+              />
+              <span
+                class="label"
+              >
+                sulu_preview.open_in_window
+              </span>
+            </button>
+          </li>
+        </ul>
       </div>
-      <div
-        class="select dark"
-      >
-        <button
-          class="button dark"
-        >
-          <span
-            aria-label="su-webspace"
-            class="su-webspace icon"
-          />
-          <span
-            aria-label="su-angle-down"
-            class="su-angle-down dropdownIcon"
-          />
-        </button>
-      </div>
-      <button
-        class="button dark"
-      >
-        <span
-          aria-label="su-sync"
-          class="su-sync icon"
-        />
-        <span
-          class="label"
-        >
-          sulu_preview.reload
-        </span>
-      </button>
-      <button
-        class="button dark"
-      >
-        <span
-          aria-label="su-link"
-          class="su-link icon"
-        />
-        <span
-          class="label"
-        >
-          sulu_preview.open_in_window
-        </span>
-      </button>
     </div>
   </nav>
 </div>
@@ -325,7 +373,7 @@ exports[`Render correct preview 1`] = `
     class="toolbar dark"
   >
     <div
-      class="controls dark"
+      class="controls dark grow"
     >
       <button
         class="button dark"
@@ -336,68 +384,84 @@ exports[`Render correct preview 1`] = `
         />
       </button>
       <div
-        class="select dark"
+        class="itemsContainer"
       >
-        <button
-          class="button dark"
+        <ul
+          class="items dark"
         >
-          <span
-            aria-label="su-expand"
-            class="su-expand icon"
-          />
-          <span
-            class="label"
-          >
-            sulu_preview.auto
-          </span>
-          <span
-            aria-label="su-angle-down"
-            class="su-angle-down dropdownIcon"
-          />
-        </button>
+          <li>
+            <div
+              class="select dark"
+            >
+              <button
+                class="button dark"
+              >
+                <span
+                  aria-label="su-expand"
+                  class="su-expand icon"
+                />
+                <span
+                  class="label"
+                >
+                  sulu_preview.auto
+                </span>
+                <span
+                  aria-label="su-angle-down"
+                  class="su-angle-down dropdownIcon"
+                />
+              </button>
+            </div>
+          </li>
+          <li>
+            <div
+              class="select dark"
+            >
+              <button
+                class="button dark"
+              >
+                <span
+                  aria-label="su-webspace"
+                  class="su-webspace icon"
+                />
+                <span
+                  aria-label="su-angle-down"
+                  class="su-angle-down dropdownIcon"
+                />
+              </button>
+            </div>
+          </li>
+          <li>
+            <button
+              class="button dark"
+            >
+              <span
+                aria-label="su-sync"
+                class="su-sync icon"
+              />
+              <span
+                class="label"
+              >
+                sulu_preview.reload
+              </span>
+            </button>
+          </li>
+          <li>
+            <button
+              class="button dark"
+            >
+              <span
+                aria-label="su-link"
+                class="su-link icon"
+              />
+              <span
+                class="label"
+              >
+                sulu_preview.open_in_window
+              </span>
+            </button>
+          </li>
+        </ul>
       </div>
-      <div
-        class="select dark"
-      >
-        <button
-          class="button dark"
-        >
-          <span
-            aria-label="su-webspace"
-            class="su-webspace icon"
-          />
-          <span
-            aria-label="su-angle-down"
-            class="su-angle-down dropdownIcon"
-          />
-        </button>
-      </div>
-      <button
-        class="button dark"
-      >
-        <span
-          aria-label="su-sync"
-          class="su-sync icon"
-        />
-        <span
-          class="label"
-        >
-          sulu_preview.reload
-        </span>
-      </button>
-      <button
-        class="button dark"
-      >
-        <span
-          aria-label="su-link"
-          class="su-link icon"
-        />
-        <span
-          class="label"
-        >
-          sulu_preview.open_in_window
-        </span>
-      </button>
     </div>
   </nav>
 </div>
@@ -423,7 +487,7 @@ exports[`Render correct preview with target groups 1`] = `
     class="toolbar dark"
   >
     <div
-      class="controls dark"
+      class="controls dark grow"
     >
       <button
         class="button dark"
@@ -434,84 +498,102 @@ exports[`Render correct preview with target groups 1`] = `
         />
       </button>
       <div
-        class="select dark"
+        class="itemsContainer"
       >
-        <button
-          class="button dark"
+        <ul
+          class="items dark"
         >
-          <span
-            aria-label="su-expand"
-            class="su-expand icon"
-          />
-          <span
-            class="label"
-          >
-            sulu_preview.auto
-          </span>
-          <span
-            aria-label="su-angle-down"
-            class="su-angle-down dropdownIcon"
-          />
-        </button>
+          <li>
+            <div
+              class="select dark"
+            >
+              <button
+                class="button dark"
+              >
+                <span
+                  aria-label="su-expand"
+                  class="su-expand icon"
+                />
+                <span
+                  class="label"
+                >
+                  sulu_preview.auto
+                </span>
+                <span
+                  aria-label="su-angle-down"
+                  class="su-angle-down dropdownIcon"
+                />
+              </button>
+            </div>
+          </li>
+          <li>
+            <div
+              class="select dark"
+            >
+              <button
+                class="button dark"
+              >
+                <span
+                  aria-label="su-webspace"
+                  class="su-webspace icon"
+                />
+                <span
+                  aria-label="su-angle-down"
+                  class="su-angle-down dropdownIcon"
+                />
+              </button>
+            </div>
+          </li>
+          <li>
+            <div
+              class="select dark"
+            >
+              <button
+                class="button dark"
+              >
+                <span
+                  aria-label="su-user"
+                  class="su-user icon"
+                />
+                <span
+                  aria-label="su-angle-down"
+                  class="su-angle-down dropdownIcon"
+                />
+              </button>
+            </div>
+          </li>
+          <li>
+            <button
+              class="button dark"
+            >
+              <span
+                aria-label="su-sync"
+                class="su-sync icon"
+              />
+              <span
+                class="label"
+              >
+                sulu_preview.reload
+              </span>
+            </button>
+          </li>
+          <li>
+            <button
+              class="button dark"
+            >
+              <span
+                aria-label="su-link"
+                class="su-link icon"
+              />
+              <span
+                class="label"
+              >
+                sulu_preview.open_in_window
+              </span>
+            </button>
+          </li>
+        </ul>
       </div>
-      <div
-        class="select dark"
-      >
-        <button
-          class="button dark"
-        >
-          <span
-            aria-label="su-webspace"
-            class="su-webspace icon"
-          />
-          <span
-            aria-label="su-angle-down"
-            class="su-angle-down dropdownIcon"
-          />
-        </button>
-      </div>
-      <div
-        class="select dark"
-      >
-        <button
-          class="button dark"
-        >
-          <span
-            aria-label="su-user"
-            class="su-user icon"
-          />
-          <span
-            aria-label="su-angle-down"
-            class="su-angle-down dropdownIcon"
-          />
-        </button>
-      </div>
-      <button
-        class="button dark"
-      >
-        <span
-          aria-label="su-sync"
-          class="su-sync icon"
-        />
-        <span
-          class="label"
-        >
-          sulu_preview.reload
-        </span>
-      </button>
-      <button
-        class="button dark"
-      >
-        <span
-          aria-label="su-link"
-          class="su-link icon"
-        />
-        <span
-          class="label"
-        >
-          sulu_preview.open_in_window
-        </span>
-      </button>
     </div>
   </nav>
 </div>
@@ -537,7 +619,7 @@ exports[`Render nothing if separate window is opened and rerender if it is close
     class="toolbar dark"
   >
     <div
-      class="controls dark"
+      class="controls dark grow"
     >
       <button
         class="button dark"
@@ -548,68 +630,84 @@ exports[`Render nothing if separate window is opened and rerender if it is close
         />
       </button>
       <div
-        class="select dark"
+        class="itemsContainer"
       >
-        <button
-          class="button dark"
+        <ul
+          class="items dark"
         >
-          <span
-            aria-label="su-expand"
-            class="su-expand icon"
-          />
-          <span
-            class="label"
-          >
-            sulu_preview.auto
-          </span>
-          <span
-            aria-label="su-angle-down"
-            class="su-angle-down dropdownIcon"
-          />
-        </button>
+          <li>
+            <div
+              class="select dark"
+            >
+              <button
+                class="button dark"
+              >
+                <span
+                  aria-label="su-expand"
+                  class="su-expand icon"
+                />
+                <span
+                  class="label"
+                >
+                  sulu_preview.auto
+                </span>
+                <span
+                  aria-label="su-angle-down"
+                  class="su-angle-down dropdownIcon"
+                />
+              </button>
+            </div>
+          </li>
+          <li>
+            <div
+              class="select dark"
+            >
+              <button
+                class="button dark"
+              >
+                <span
+                  aria-label="su-webspace"
+                  class="su-webspace icon"
+                />
+                <span
+                  aria-label="su-angle-down"
+                  class="su-angle-down dropdownIcon"
+                />
+              </button>
+            </div>
+          </li>
+          <li>
+            <button
+              class="button dark"
+            >
+              <span
+                aria-label="su-sync"
+                class="su-sync icon"
+              />
+              <span
+                class="label"
+              >
+                sulu_preview.reload
+              </span>
+            </button>
+          </li>
+          <li>
+            <button
+              class="button dark"
+            >
+              <span
+                aria-label="su-link"
+                class="su-link icon"
+              />
+              <span
+                class="label"
+              >
+                sulu_preview.open_in_window
+              </span>
+            </button>
+          </li>
+        </ul>
       </div>
-      <div
-        class="select dark"
-      >
-        <button
-          class="button dark"
-        >
-          <span
-            aria-label="su-webspace"
-            class="su-webspace icon"
-          />
-          <span
-            aria-label="su-angle-down"
-            class="su-angle-down dropdownIcon"
-          />
-        </button>
-      </div>
-      <button
-        class="button dark"
-      >
-        <span
-          aria-label="su-sync"
-          class="su-sync icon"
-        />
-        <span
-          class="label"
-        >
-          sulu_preview.reload
-        </span>
-      </button>
-      <button
-        class="button dark"
-      >
-        <span
-          aria-label="su-link"
-          class="su-link icon"
-        />
-        <span
-          class="label"
-        >
-          sulu_preview.open_in_window
-        </span>
-      </button>
     </div>
   </nav>
 </div>
@@ -635,7 +733,7 @@ exports[`Render nothing if separate window is opened and rerender if it is close
     class="toolbar dark"
   >
     <div
-      class="controls dark"
+      class="controls dark grow"
     >
       <button
         class="button dark"
@@ -646,68 +744,84 @@ exports[`Render nothing if separate window is opened and rerender if it is close
         />
       </button>
       <div
-        class="select dark"
+        class="itemsContainer"
       >
-        <button
-          class="button dark"
+        <ul
+          class="items dark"
         >
-          <span
-            aria-label="su-expand"
-            class="su-expand icon"
-          />
-          <span
-            class="label"
-          >
-            sulu_preview.auto
-          </span>
-          <span
-            aria-label="su-angle-down"
-            class="su-angle-down dropdownIcon"
-          />
-        </button>
+          <li>
+            <div
+              class="select dark"
+            >
+              <button
+                class="button dark"
+              >
+                <span
+                  aria-label="su-expand"
+                  class="su-expand icon"
+                />
+                <span
+                  class="label"
+                >
+                  sulu_preview.auto
+                </span>
+                <span
+                  aria-label="su-angle-down"
+                  class="su-angle-down dropdownIcon"
+                />
+              </button>
+            </div>
+          </li>
+          <li>
+            <div
+              class="select dark"
+            >
+              <button
+                class="button dark"
+              >
+                <span
+                  aria-label="su-webspace"
+                  class="su-webspace icon"
+                />
+                <span
+                  aria-label="su-angle-down"
+                  class="su-angle-down dropdownIcon"
+                />
+              </button>
+            </div>
+          </li>
+          <li>
+            <button
+              class="button dark"
+            >
+              <span
+                aria-label="su-sync"
+                class="su-sync icon"
+              />
+              <span
+                class="label"
+              >
+                sulu_preview.reload
+              </span>
+            </button>
+          </li>
+          <li>
+            <button
+              class="button dark"
+            >
+              <span
+                aria-label="su-link"
+                class="su-link icon"
+              />
+              <span
+                class="label"
+              >
+                sulu_preview.open_in_window
+              </span>
+            </button>
+          </li>
+        </ul>
       </div>
-      <div
-        class="select dark"
-      >
-        <button
-          class="button dark"
-        >
-          <span
-            aria-label="su-webspace"
-            class="su-webspace icon"
-          />
-          <span
-            aria-label="su-angle-down"
-            class="su-angle-down dropdownIcon"
-          />
-        </button>
-      </div>
-      <button
-        class="button dark"
-      >
-        <span
-          aria-label="su-sync"
-          class="su-sync icon"
-        />
-        <span
-          class="label"
-        >
-          sulu_preview.reload
-        </span>
-      </button>
-      <button
-        class="button dark"
-      >
-        <span
-          aria-label="su-link"
-          class="su-link icon"
-        />
-        <span
-          class="label"
-        >
-          sulu_preview.open_in_window
-        </span>
-      </button>
     </div>
   </nav>
 </div>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR makes the toolbar of the Preview shrink, i.e. make the texts disappear, on small screens. It behaves the same way the main toolbar on top does.