### PR TITLE
Use central cache directory for symfony filesystem cache pool

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -214,7 +214,7 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
                 'framework',
                 [
                     'cache' => [
-                        'directory' => '%sulu.common_cache_dir%',
+                        'directory' => '%sulu.common_cache_dir%/pools',
                     ],
                 ]
             );

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -208,6 +208,17 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
                 ]
             );
         }
+
+        if ($container->hasExtension('framework')) {
+            $container->prependExtensionConfig(
+                'framework',
+                [
+                    'cache' => [
+                        'directory' => '%sulu.common_cache_dir%',
+                    ],
+                ]
+            );
+        }
     }
 
     public function load(array $configs, ContainerBuilder $container)


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | https://github.com/sulu/skeleton/pull/45
| License | MIT
| Documentation PR | -

#### What's in this PR?

Use central cache directory for symfony filesystem cache pool.

#### Why?

When change the cache adapter to something like like apc or redis which is more common in production it would behave the same as using the same directory. So there should be no difference when using the filesystem cache or something else and in future we want to go more to be single kernel. 