### PR TITLE
Fix endless reloading if single_media_selection contains deleted image

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/SingleMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/SingleMediaSelection.js
@@ -59,11 +59,12 @@ class SingleMediaSelection extends React.Component<Props> {
         );
     }
 
-    componentDidUpdate() {
+    componentDidUpdate(prevProps: Props) {
         const newId = toJS(this.props.value.id);
+        const oldId = toJS(prevProps.value.id);
         const loadedId = this.singleMediaSelectionStore.item ? this.singleMediaSelectionStore.item.id : undefined;
 
-        if (loadedId !== newId) {
+        if (oldId !== newId && loadedId !== newId) {
             this.singleMediaSelectionStore.loadItem(newId);
         }
     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/tests/SingleMediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/tests/SingleMediaSelection.test.js
@@ -268,6 +268,26 @@ test('Should not call the onChange callback if the component props change', () =
     expect(changeSpy).not.toBeCalled();
 });
 
+test('Should not call the loadItem callback if the component props id change to same value', () => {
+    // $FlowFixMe
+    SingleSelectionStore.mockImplementationOnce(function() {
+        this.loadItem = jest.fn();
+    });
+
+    const changeSpy = jest.fn();
+
+    const singleMediaSelection = shallow(
+        <SingleMediaSelection
+            locale={observable.box('en')}
+            onChange={changeSpy}
+            value={{displayOption: undefined, id: 5}}
+        />
+    );
+
+    singleMediaSelection.setProps({value: {id: 5}});
+    expect(singleMediaSelection.instance().singleMediaSelectionStore.loadItem).not.toBeCalled();
+});
+
 test('Correct props should be passed to SingleItemSelection component', () => {
     const singleMediaSelection = shallow(
         <SingleMediaSelection


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5177 
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR makes sure the `SingleMediaSelection` does not endlessly reload if the linked media has been deleted.