### PR TITLE
Normalize generated container class name

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,7 +5,7 @@ parameters:
         - ./
     level: 1
     symfony:
-        container_xml_path: %rootDir%/../../../var/cache/admin/dev/adminApp_KernelDevDebugContainer.xml
+        container_xml_path: %rootDir%/../../../var/cache/admin/dev/App_KernelDevDebugContainer.xml
     excludes_analyse:
         - %currentWorkingDirectory%/config/*
         - %currentWorkingDirectory%/flow_types/*

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
@@ -44,7 +44,7 @@ class PreviewKernel extends Kernel
     }
 
     /**
-     * The "getContainerClass" need to be normalized for preview and over contexts
+     * The "getContainerClass" need to be normalized for preview and other contexts
      * as it is used by the symfony cache component as prefix.
      *
      * @see SuluKernel::getContainerClass

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
@@ -43,6 +43,18 @@ class PreviewKernel extends Kernel
         $loader->load(implode(DIRECTORY_SEPARATOR, [__DIR__, '..', '..', 'Resources', 'config', 'config_preview.yml']));
     }
 
+    /**
+     * The "getContainerClass" need to be normalized for preview and over contexts
+     * as it is used by the symfony cache component as prefix.
+     *
+     * @see SuluKernel::getContainerClass
+     */
+    protected function getContainerClass()
+    {
+        // use parent class to normalize the generated container class.
+        return $this->generateContainerClass(get_parent_class());
+    }
+
     public function getRootDir()
     {
         if (null === $this->rootDir) {

--- a/src/Sulu/Component/HttpKernel/SuluKernel.php
+++ b/src/Sulu/Component/HttpKernel/SuluKernel.php
@@ -85,6 +85,41 @@ abstract class SuluKernel extends Kernel
         $this->load($loader, $confDir, '/{services}_' . $this->environment);
     }
 
+    /**
+     * The "getContainerClass" need to be normalized for preview and over contexts
+     * as its used by the symfony cache component as prefix.
+     *
+     * @see https://github.com/symfony/symfony/blob/v4.4.7/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php#L56
+     */
+    protected function getContainerClass()
+    {
+        return $this->generateContainerClass(static::class);
+    }
+
+    /**
+     * @internal
+     *
+     * This is only for internal use. To get the container class use `getContainerClass` instead.
+     *
+     * This is a copy of the symfony 5.0 getContainerClass which does not include $this->name.
+     *
+     * @see https://github.com/symfony/symfony/blob/v5.0.7/src/Symfony/Component/HttpKernel/Kernel.php#L394
+     *
+     * @param string $class
+     *
+     * @return string The container class
+     */
+    protected function generateContainerClass($class)
+    {
+        $class = false !== strpos($class, "@anonymous\0") ? get_parent_class($class) . str_replace('.', '_', ContainerBuilder::hash($class)) : $class;
+        $class = str_replace('\\', '_', $class) . ucfirst($this->environment) . ($this->debug ? 'Debug' : '') . 'Container';
+        if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $class)) {
+            throw new \InvalidArgumentException(sprintf('The environment "%s" contains invalid characters, it can only contain characters allowed in PHP class names.', $this->environment));
+        }
+
+        return $class;
+    }
+
     protected function configureRoutes(RouteCollectionBuilder $routes)
     {
         $confDir = $this->getProjectDir() . '/config';

--- a/src/Sulu/Component/HttpKernel/SuluKernel.php
+++ b/src/Sulu/Component/HttpKernel/SuluKernel.php
@@ -86,7 +86,7 @@ abstract class SuluKernel extends Kernel
     }
 
     /**
-     * The "getContainerClass" need to be normalized for preview and over contexts
+     * The "getContainerClass" need to be normalized for preview and other contexts
      * as its used by the symfony cache component as prefix.
      *
      * @see https://github.com/symfony/symfony/blob/v4.4.7/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php#L56
@@ -99,7 +99,8 @@ abstract class SuluKernel extends Kernel
     /**
      * @internal
      *
-     * This is only for internal use. To get the container class use `getContainerClass` instead.
+     * This is only used to support Symfony ^4.3 and 5 at the same time.
+     * To get the container class use `getContainerClass` instead.
      *
      * This is a copy of the symfony 5.0 getContainerClass which does not include $this->name.
      *


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | https://github.com/sulu/sulu/pull/5180, https://github.com/sulu/skeleton/pull/45, https://github.com/sulu/sulu/pull/5189
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix generated container class name.

#### Why?

In all contexts admin, website and preview the `getContainerClassName` should be the same as it is used by symfony as cache seed https://github.com/symfony/symfony/blob/v4.4.7/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php#L56
