### PR TITLE
Make ControllerNameParser optional

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Command/ValidateWebspacesCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/ValidateWebspacesCommand.php
@@ -42,7 +42,7 @@ class ValidateWebspacesCommand extends Command
     private $structureMetadataFactory;
 
     /**
-     * @var ControllerNameParser
+     * @var ControllerNameParser|null
      */
     private $controllerNameConverter;
 
@@ -74,7 +74,7 @@ class ValidateWebspacesCommand extends Command
     public function __construct(
         Environment $twig,
         StructureMetadataFactoryInterface $structureMetadataFactory,
-        ControllerNameParser $controllerNameConverter,
+        ?ControllerNameParser $controllerNameConverter,
         StructureManagerInterface $structureManager,
         WebspaceStructureProvider $structureProvider,
         WebspaceManagerInterface $webspaceManager,
@@ -334,7 +334,9 @@ class ValidateWebspacesCommand extends Command
     private function validateControllerAction($controllerAction)
     {
         try {
-            $controllerAction = $this->controllerNameConverter->parse($controllerAction);
+            if ($this->controllerNameConverter) {
+                $controllerAction = $this->controllerNameConverter->parse($controllerAction);
+            }
         } catch (\InvalidArgumentException $e) {
         }
 

--- a/src/Sulu/Bundle/PageBundle/DependencyInjection/SuluPageExtension.php
+++ b/src/Sulu/Bundle/PageBundle/DependencyInjection/SuluPageExtension.php
@@ -274,7 +274,9 @@ class SuluPageExtension extends Extension implements PrependExtensionInterface
         $container->setParameter('sulu_page.seo', $config['seo']);
 
         // the service "controller_name_converter" is private use an alias to make it public
-        $container->setAlias('sulu_page.controller_name_converter', 'controller_name_converter')->setPublic(true);
+        if ($container->has('controller_name_converter')) {
+            $container->setAlias('sulu_page.controller_name_converter', 'controller_name_converter')->setPublic(true);
+        }
     }
 
     private function processSearch($config, LoaderInterface $loader, ContainerBuilder $container)

--- a/src/Sulu/Bundle/PageBundle/Resources/config/command.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/command.xml
@@ -50,12 +50,12 @@
                  class="Sulu\Bundle\PageBundle\Command\ValidateWebspacesCommand">
             <argument type="service" id="twig"/>
             <argument type="service" id="sulu_page.structure.factory"/>
-            <argument type="service" id="sulu_page.controller_name_converter"/>
+            <argument type="service" id="sulu_page.controller_name_converter" on-invalid="ignore"/>
             <argument type="service" id="sulu.content.structure_manager"/>
             <argument type="service" id="sulu.content.webspace_structure_provider"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="liip_theme.active_theme" on-invalid="null"/>
-            
+
             <tag name="console.command"/>
         </service>
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Command/ValidateWebspacesCommandTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Command/ValidateWebspacesCommandTest.php
@@ -33,11 +33,15 @@ class ValidateWebspacesCommandTest extends SuluTestCase
     {
         $application = new Application();
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
+        $controllerNameParser = null;
+        if ($this->getContainer()->has('sulu_page.controller_name_converter')) {
+            $controllerNameParser = $this->getContainer()->get('sulu_page.controller_name_converter');
+        }
 
         $command = new ValidateWebspacesCommand(
             $this->getContainer()->get('twig'),
             $this->getContainer()->get('sulu_page.structure.factory'),
-            $this->getContainer()->get('sulu_page.controller_name_converter'),
+            $controllerNameParser,
             $this->getContainer()->get('sulu.content.structure_manager'),
             $this->getContainer()->get('sulu.content.webspace_structure_provider'),
             $this->getContainer()->get('sulu_core.webspace.webspace_manager')


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | https://github.com/sulu/sulu/pull/4798
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Make ControllerNameParser optional.

#### Why?

The controller parser does not longer exist in Symfony 5 as there FQCN are used for controller action references. So we need to make the controller parser which is used by the `sulu:content:validate:webspaces` optional.
