### PR TITLE
Remove symfony/web-server-bundle

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,16 @@
 
 ## dev-master
 
+### WebServerBundle removed
+
+The Symfony WebServerBundle has been removed.
+Use for development the [Symfony Local Webserver](https://symfony.com/doc/current/setup/symfony_server.html)
+or the internal [php web server](https://www.php.net/manual/en/features.commandline.webserver.php) instead:
+
+```bash
+php -S localhost:8000 -t public/
+```
+
 ### Add key property to Role entity
 
 To allow for referencing `Role` entities by a human readable string, a `key` property was added to the `Role` entity.

--- a/composer.json
+++ b/composer.json
@@ -127,8 +127,7 @@
         "symfony/phpunit-bridge": "^4.3",
         "symfony/stopwatch": "^4.3",
         "symfony/var-dumper": "^4.3",
-        "symfony/web-profiler-bundle": "^4.3",
-        "symfony/web-server-bundle": "^4.3"
+        "symfony/web-profiler-bundle": "^4.3"
     },
     "conflict": {
         "doctrine/dbal": "2.7.0",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -45,7 +45,6 @@ return [
     DTL\Bundle\PhpcrMigrations\PhpcrMigrationsBundle::class => ['all' => true],
     Massive\Bundle\BuildBundle\MassiveBuildBundle::class => ['all' => true],
     Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true],
-    Symfony\Bundle\WebServerBundle\WebServerBundle::class => ['dev' => true, 'test' => true],
     Sulu\Bundle\TestBundle\SuluTestBundle::class => ['dev' => true, 'test' => true],
     Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true],
     // Admin


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | https://github.com/sulu/sulu/pull/4798,  https://github.com/sulu/skeleton/pull/46
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/503

#### What's in this PR?

Remove symfony/web-server-bundle.

#### Why?

The web server bundle is deprecated instead the raw php server or symfony cli should be used.

#### To Do

- [x] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md
