### PR TITLE
Add support for Symfony RoutingConfigurator in Kernel

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,7 +9,28 @@ Use for development the [Symfony Local Webserver](https://symfony.com/doc/curren
 or the internal [php web server](https://www.php.net/manual/en/features.commandline.webserver.php) instead:
 
 ```bash
-php -S localhost:8000 -t public/
+php -S localhost:8000 -t public/ config/router.php
+```
+
+### Kernel accept RoutingConfigurator
+
+To support both the new RoutingConfigurator and the deprecated RouteCollectionBuilder in the SuluKernel the following method have been changed.
+Remove the type hints if you did override this methods in your Kernel:
+
+**before**
+
+```php
+protected function configureRoutes(RouteCollectionBuilder $routes) {}
+
+protected function import(RouteCollectionBuilder $routes, $confDir, $pattern) {}
+```
+
+**after**
+
+```php
+protected function import($routes, $confDir, $pattern) {}
+
+protected function configureRoutes($routes)
 ```
 
 ### Add key property to Role entity

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -14,8 +14,8 @@ php -S localhost:8000 -t public/ config/router.php
 
 ### Kernel accept RoutingConfigurator
 
-To support both the new RoutingConfigurator and the deprecated RouteCollectionBuilder in the SuluKernel the following method have been changed.
-Remove the type hints if you did override this methods in your Kernel:
+To support both the new `RoutingConfigurator` and the deprecated `RouteCollectionBuilder` in the SuluKernel the following methods have been changed.
+Remove the type hints if you overwrote these methods in your `Kernel`:
 
 **before**
 

--- a/src/Sulu/Component/HttpKernel/SuluKernel.php
+++ b/src/Sulu/Component/HttpKernel/SuluKernel.php
@@ -17,6 +17,7 @@ use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\Resource\GlobResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 
 /**
@@ -85,7 +86,10 @@ abstract class SuluKernel extends Kernel
         $this->load($loader, $confDir, '/{services}_' . $this->environment);
     }
 
-    protected function configureRoutes(RouteCollectionBuilder $routes)
+    /**
+     * @param RouteCollectionBuilder|RoutingConfigurator $routes Is a RouteCollectionBuilder for Symfony <= 4.4
+     */
+    protected function configureRoutes($routes)
     {
         $confDir = $this->getProjectDir() . '/config';
 
@@ -109,7 +113,10 @@ abstract class SuluKernel extends Kernel
         }
     }
 
-    protected function import(RouteCollectionBuilder $routes, $confDir, $pattern)
+    /**
+     * @param RouteCollectionBuilder|RoutingConfigurator $routes Is a RouteCollectionBuilder for Symfony <= 4.4
+     */
+    protected function import($routes, $confDir, $pattern)
     {
         $configExtensions = $this->getConfigExtensions();
         $reversedConfigExtensions = $this->getReversedConfigExtensions();
@@ -119,7 +126,7 @@ abstract class SuluKernel extends Kernel
 
         foreach ($configFiles as $resource) {
             if (!in_array($resource, $excludedConfigFiles)) {
-                $routes->import($resource, '/');
+                $routes->import($resource);
             }
         }
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes (does mostly not effect any projects)
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Add support for Symfony RoutingConfigurator in Kernel.

#### Why?

In Symfony 5 the configureRoutes will get a RoutingConfigurator instead of RouteCollectionBuilder. To support both we need to remove the typehint.

#### To Do

- [x] Add breaking changes to UPGRADE.md
