### PR TITLE
Improve test performance by removing some routes that are not neccessary anymore

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
@@ -1,8 +1,3 @@
-sulu_tag_api:
-    type: rest
-    resource: "@SuluTagBundle/Resources/config/routing_api.yml"
-    prefix:   /admin/api
-
 sulu_admin:
     resource: "@SuluAdminBundle/Resources/config/routing.yml"
     prefix: /admin
@@ -11,16 +6,6 @@ sulu_admin_api:
     resource: "@SuluAdminBundle/Resources/config/routing_api.yml"
     type: rest
     prefix: /admin/api
-
-sulu_contact_api:
-    type: rest
-    resource: "@SuluContactBundle/Resources/config/routing_api.yml"
-    prefix: /admin/api
-
-sulu_security:
-    type: rest
-    resource: "@SuluSecurityBundle/Resources/config/routing.yml"
-    prefix: /admin/security
 
 sulu_security_api:
     type: rest
@@ -36,55 +21,9 @@ sulu_media:
     resource: "@SuluMediaBundle/Resources/config/routing.yml"
     prefix: /admin/media
 
-sulu_media_website:
-    resource: "@SuluMediaBundle/Resources/config/routing_website.yml"
-
-sulu_media_api:
-    type: rest
-    resource: "@SuluMediaBundle/Resources/config/routing_api.yml"
-    prefix: /admin/api
-
-sulu_category_api:
-    type: rest
-    resource: "@SuluCategoryBundle/Resources/config/routing_api.yml"
-    prefix: /admin/api
-
-sulu_snippet_api:
-    type: rest
-    resource: "@SuluSnippetBundle/Resources/config/routing_api.yml"
-    prefix: /admin/api
-
-sulu_location:
-    resource: "@SuluLocationBundle/Resources/config/routing.yml"
-    prefix: /admin/location
-
 sulu_website:
     resource: "@SuluWebsiteBundle/Resources/config/routing.yml"
     prefix: /admin/website
-
-sulu_website_api:
-    type: rest
-    resource: "@SuluWebsiteBundle/Resources/config/routing_api.yml"
-    prefix: /admin/api
-
-sulu_core:
-    type: rest
-    resource: "@SuluCoreBundle/Resources/config/routing_api.yml"
-    prefix: /admin/api
-
-sulu_custom_urls_api:
-    type: rest
-    resource: "@SuluCustomUrlBundle/Resources/config/routing_api.yml"
-    prefix: /admin/api
-
-sulu_route_api:
-    type: rest
-    resource: "@SuluRouteBundle/Resources/config/routing_api.yml"
-    prefix: /admin/api
-
-sulu_search:
-    resource: "@SuluSearchBundle/Resources/config/routing.yml"
-    prefix: /admin/search
 
 sulu_preview:
     resource: "@SuluPreviewBundle/Resources/config/routing.yml"

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -11,29 +11,23 @@
 
 namespace Sulu\Bundle\AdminBundle\Tests\Functional\Controller;
 
-use Doctrine\ORM\EntityManager;
 use Sulu\Bundle\MediaBundle\DataFixtures\ORM\LoadCollectionTypes;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
 class AdminControllerTest extends SuluTestCase
 {
-    /**
-     * @var EntityManager
-     */
-    protected $em;
-
     public function setUp(): void
     {
         $this->client = $this->createAuthenticatedClient();
         $this->purgeDatabase();
-        $this->initPhpcr();
-        $this->em = $this->getEntityManager();
-        $collectionType = new LoadCollectionTypes();
-        $collectionType->load($this->getEntityManager());
     }
 
     public function testGetConfig()
     {
+        $this->initPhpcr();
+        $collectionType = new LoadCollectionTypes();
+        $collectionType->load($this->getEntityManager());
+
         $client = $this->client;
         $client->request('GET', '/admin/config');
 

--- a/src/Sulu/Bundle/ContactBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Application/config/routing.yml
@@ -7,50 +7,12 @@ sulu_contact_api:
     resource: "@SuluContactBundle/Resources/config/routing_api.yml"
     prefix: /api
 
-# The following route are necessary to get AdminController::configAction work.
-# Can be removed once its content is not hardcoded anymore.
 sulu_media:
     resource: "@SuluMediaBundle/Resources/config/routing.yml"
     prefix:
-
-sulu_snippet_api:
-    type: rest
-    resource: "@SuluSnippetBundle/Resources/config/routing_api.yml"
-    prefix: /admin
-
-sulu_pages_api:
-    type: rest
-    resource: "@SuluPageBundle/Resources/config/routing_api.yml"
-    prefix: /admin
-
-sulu_core_api:
-    type: rest
-    resource: "@SuluCoreBundle/Resources/config/routing_api.yml"
-    prefix: /admin
-
-sulu_categories_api:
-    type: rest
-    resource: "@SuluCategoryBundle/Resources/config/routing_api.yml"
-    prefix: /admin
-
-sulu_media_api:
-    type: rest
-    resource: "@SuluMediaBundle/Resources/config/routing_api.yml"
-    prefix: /admin
-
-sulu_tag_api:
-    type: rest
-    resource: "@SuluTagBundle/Resources/config/routing_api.yml"
-    prefix: /admin
-
 sulu_security_api:
     type: rest
     resource: "@SuluSecurityBundle/Resources/config/routing_api.yml"
-    prefix: /admin
-
-sulu_security:
-    type: rest
-    resource: "@SuluSecurityBundle/Resources/config/routing.yml"
     prefix: /admin
 
 sulu_website:

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -25,32 +25,12 @@ class AdminControllerTest extends SuluTestCase
 {
     public function setUp(): void
     {
-        $this->initPhpcr();
         $this->purgeDatabase();
-        $em = $this->getEntityManager();
-        //
-        // force id = 1
-        $metadata = $em->getClassMetaData(CollectionType::class);
-        $metadata->setIdGenerator(new \Doctrine\ORM\Id\AssignedGenerator());
-        $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
-
-        $collectionType1 = new CollectionType();
-        $collectionType1->setId(1);
-        $collectionType1->setName('Default Collection Type');
-        $collectionType1->setKey('collection.default');
-
-        $collectionType2 = new CollectionType();
-        $collectionType2->setId(2);
-        $collectionType2->setName('System Collections');
-        $collectionType2->setKey('collection.system');
-
-        $em->persist($collectionType1);
-        $em->persist($collectionType2);
-        $em->flush();
     }
 
     public function testContactsConfig()
     {
+        $this->initPhpcr();
         $em = $this->getEntityManager();
 
         $addressType1 = new AddressType();
@@ -168,6 +148,7 @@ class AdminControllerTest extends SuluTestCase
 
     public function testContactFormMetadataAction()
     {
+        $this->createCollectionTypes();
         $client = $this->createAuthenticatedClient();
 
         $client->request('GET', '/admin/metadata/form/contact_details');
@@ -187,6 +168,7 @@ class AdminControllerTest extends SuluTestCase
 
     public function testAccountFormMetadataAction()
     {
+        $this->createCollectionTypes();
         $client = $this->createAuthenticatedClient();
 
         $client->request('GET', '/admin/metadata/form/account_details');
@@ -202,5 +184,27 @@ class AdminControllerTest extends SuluTestCase
         $schema = $response->schema;
 
         $this->assertEquals(['name'], $schema->required);
+    }
+
+    private function createCollectionTypes()
+    {
+        $em = $this->getEntityManager();
+        $metadata = $em->getClassMetaData(CollectionType::class);
+        $metadata->setIdGenerator(new \Doctrine\ORM\Id\AssignedGenerator());
+        $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
+
+        $collectionType1 = new CollectionType();
+        $collectionType1->setId(1);
+        $collectionType1->setName('Default Collection Type');
+        $collectionType1->setKey('collection.default');
+
+        $collectionType2 = new CollectionType();
+        $collectionType2->setId(2);
+        $collectionType2->setName('System Collections');
+        $collectionType2->setKey('collection.system');
+
+        $em->persist($collectionType1);
+        $em->persist($collectionType2);
+        $em->flush();
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Application/config/routing.yml
@@ -20,48 +20,15 @@ sulu_search:
     type: portal
     resource: "@SuluSearchBundle/Resources/config/routing_website.yml"
 
-# The following route are necessary to get AdminController::configAction work.
-# Can be removed once its content is not hardcoded anymore.
-
 sulu_pages_api:
     type: rest
     resource: "@SuluPageBundle/Resources/config/routing_api.yml"
-    prefix: /api
-
-sulu_contact_api:
-    type: rest
-    resource: "@SuluContactBundle/Resources/config/routing_api.yml"
-    prefix: /api
-
-sulu_snippet_api:
-    type: rest
-    resource: "@SuluSnippetBundle/Resources/config/routing_api.yml"
-    prefix: /api
-
-sulu_core_api:
-    type: rest
-    resource: "@SuluCoreBundle/Resources/config/routing_api.yml"
-    prefix: /api
-
-sulu_categories_api:
-    type: rest
-    resource: "@SuluCategoryBundle/Resources/config/routing_api.yml"
-    prefix: /api
-
-sulu_tag_api:
-    type: rest
-    resource: "@SuluTagBundle/Resources/config/routing_api.yml"
     prefix: /api
 
 sulu_security_api:
     type: rest
     resource: "@SuluSecurityBundle/Resources/config/routing_api.yml"
     prefix: /api
-
-sulu_security:
-    type: rest
-    resource: "@SuluSecurityBundle/Resources/config/routing.yml"
-    prefix: /admin
 
 sulu_website:
     type: rest

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/routing.yml
@@ -24,16 +24,9 @@ sulu_security_api:
     type: rest
     prefix: /api
 
-# The following route are necessary to get AdminController::configAction work.
-# Can be removed once its content is not hardcoded anymore.
 sulu_preview:
     type: rest
     resource: "@SuluPreviewBundle/Resources/config/routing.yml"
-    prefix: /admin
-
-sulu_security:
-    type: rest
-    resource: "@SuluSecurityBundle/Resources/config/routing.yml"
     prefix: /admin
 
 sulu_website:

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Application/config/routing.yml
@@ -12,8 +12,6 @@ sulu_admin:
     resource: "@SuluAdminBundle/Resources/config/routing.yml"
     prefix: /admin
 
-# The following route are necessary to get AdminController::configAction work.
-# Can be removed once its content is not hardcoded anymore.
 sulu_preview:
     type: rest
     resource: "@SuluPreviewBundle/Resources/config/routing.yml"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #4597
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR removes a few routes that are unnecessary in the tests because of #4597.

#### Why?

Because then appveyor might stop stalling. And better perfomance is always better :slightly_smiling_face: 