### PR TITLE
Remove deprecated twig spaceless tag and fix sitemap index for multiple providers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,7 +99,7 @@
         "symfony/validator": "^4.3",
         "symfony/yaml": "^4.3",
         "toflar/psr6-symfony-http-cache-store": "^1.1 || ^2.0",
-        "twig/twig": "^1.41 || ^2.0"
+        "twig/twig": "^1.41 || ^2.9"
     },
     "require-dev": {
         "google/cloud-storage": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -99,7 +99,7 @@
         "symfony/validator": "^4.3",
         "symfony/yaml": "^4.3",
         "toflar/psr6-symfony-http-cache-store": "^1.1 || ^2.0",
-        "twig/twig": "^1.41 || ^2.9"
+        "twig/twig": "^1.41 || ^2.10"
     },
     "require-dev": {
         "google/cloud-storage": "^1.0",

--- a/src/Sulu/Bundle/PageBundle/Resources/config/export.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/export.xml
@@ -4,7 +4,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
         <parameter key="sulu_page.export.webspace.formats" type="collection">
-            <parameter key="1.2.xliff">SuluPageBundle:Export:Webspace/1.2.xliff.twig</parameter>
+            <parameter key="1.2.xliff">@SuluPage/Export/Webspace/1.2.xliff.twig</parameter>
         </parameter>
     </parameters>
 

--- a/src/Sulu/Bundle/PageBundle/Resources/views/Export/Snippet/1.2.xliff.twig
+++ b/src/Sulu/Bundle/PageBundle/Resources/views/Export/Snippet/1.2.xliff.twig
@@ -1,4 +1,4 @@
-{% extends "SuluPageBundle:Export:Snippet/base.export.twig" %}
+{% extends "@SuluPage/Export/Snippet/base.export.twig" %}
 
 {% block main %}
 <?xml version="1.0" encoding="utf-8"?>
@@ -8,36 +8,33 @@
 </xliff>
 {% endblock main %}
 
-{% if false %} {# avoid output of block directly #}
-    {# Output page #}
-    {% block snippet %}
+{% block snippet %}
     <file source-language="{{ document.locale }}" datatype="plaintext" original="{{ document.uuid }}">
         <body>
         {{- parent() -}}
         </body>
     </file>
-    {% endblock snippet %}
+{% endblock snippet %}
 
-    {# view #}
-    {%- block view -%}
-        {% apply spaceless %}
-        {% set attributes = '' %}
-        {% set target = '' %}
-        {%- if options.translate is defined and not options.translate -%}
-            {% set attributes = attributes  ~ ' translate="no"' %}
-            {% set target = value %}
-        {%- endif -%}
-        {% if type == 'text_editor' %}
-            {% set attributes = attributes ~ ' datatype="html"' %}
-        {% endif %}
-        {% endapply %}
-        {% autoescape false %}
+{# view #}
+{%- block view -%}
+    {% apply spaceless %}
+    {% set attributes = '' %}
+    {% set target = '' %}
+    {%- if options.translate is defined and not options.translate -%}
+        {% set attributes = attributes  ~ ' translate="no"' %}
+        {% set target = value %}
+    {%- endif -%}
+    {% if type == 'text_editor' %}
+        {% set attributes = attributes ~ ' datatype="html"' %}
+    {% endif %}
+    {% endapply %}
+    {% autoescape false %}
 
             <!-- {{ name }}: {{ type }} -->
             <trans-unit id="{{ sulu_content_type_export_counter() }}" resname="{{ name }}"{{ attributes }}>
                 <source>{{ sulu_content_type_export_escape(value) }}</source>
                 <target>{{ sulu_content_type_export_escape(target) }}</target>
             </trans-unit>
-        {% endautoescape %}
-    {%- endblock view -%}
-{% endif %}
+    {% endautoescape %}
+{%- endblock view -%}

--- a/src/Sulu/Bundle/PageBundle/Resources/views/Export/Snippet/1.2.xliff.twig
+++ b/src/Sulu/Bundle/PageBundle/Resources/views/Export/Snippet/1.2.xliff.twig
@@ -20,7 +20,7 @@
 
     {# view #}
     {%- block view -%}
-        {% spaceless %}
+        {% apply spaceless %}
         {% set attributes = '' %}
         {% set target = '' %}
         {%- if options.translate is defined and not options.translate -%}
@@ -30,7 +30,7 @@
         {% if type == 'text_editor' %}
             {% set attributes = attributes ~ ' datatype="html"' %}
         {% endif %}
-        {% endspaceless %}
+        {% endapply %}
         {% autoescape false %}
 
             <!-- {{ name }}: {{ type }} -->

--- a/src/Sulu/Bundle/PageBundle/Resources/views/Export/Snippet/base.export.twig
+++ b/src/Sulu/Bundle/PageBundle/Resources/views/Export/Snippet/base.export.twig
@@ -6,10 +6,10 @@
     {# Iterate over the snippets #}
     {%- block snippets -%}
         {%- for document in snippetData -%}
-            {% spaceless %}
+            {% apply spaceless %}
                 {% set content = document.content %}
                 {% set prefix = '' %}
-            {% endspaceless %}{{ block('snippet') }}
+            {% endapply %}{{ block('snippet') }}
         {%- endfor -%}
     {%- endblock snippets -%}
 
@@ -44,12 +44,12 @@
 
     {# Output model #}
     {%- block model -%}
-        {% spaceless %}
+        {% apply spaceless %}
             {% set name = prefix ~ property.name %}
             {% set options = property.options|default('') %}
             {% set value = property.value %}
             {% set type = property.type|default('') %}
-        {% endspaceless %}{{- block('view') -}}
+        {% endapply %}{{- block('view') -}}
     {%- endblock model -%}
 
     {# View #}

--- a/src/Sulu/Bundle/PageBundle/Resources/views/Export/Webspace/1.2.xliff.twig
+++ b/src/Sulu/Bundle/PageBundle/Resources/views/Export/Webspace/1.2.xliff.twig
@@ -20,7 +20,7 @@
 
     {# view #}
     {%- block view -%}
-        {% spaceless %}
+        {% apply spaceless %}
         {% set attributes = '' %}
         {% set target = '' %}
         {%- if options.translate is defined and not options.translate -%}
@@ -30,7 +30,7 @@
         {% if type == 'text_editor' %}
             {% set attributes = attributes ~ ' datatype="html"' %}
         {% endif %}
-        {% endspaceless %}
+        {% endapply %}
         {% autoescape false %}
 
             <!-- {{ name }}: {{ type }} -->

--- a/src/Sulu/Bundle/PageBundle/Resources/views/Export/Webspace/1.2.xliff.twig
+++ b/src/Sulu/Bundle/PageBundle/Resources/views/Export/Webspace/1.2.xliff.twig
@@ -1,4 +1,4 @@
-{% extends "SuluPageBundle:Export:Webspace/base.export.twig" %}
+{% extends "@SuluPage/Export/Webspace/base.export.twig" %}
 
 {% block main %}
 <?xml version="1.0" encoding="utf-8"?>
@@ -8,36 +8,34 @@
 </xliff>
 {% endblock main %}
 
-{% if false %} {# avoid output of block directly #}
-    {# Output page #}
-    {% block page %}
+{# Output page #}
+{% block page %}
     <file source-language="{{ document.locale }}" datatype="plaintext" original="{{ document.uuid }}">
         <body>
         {{- parent() -}}
         </body>
     </file>
-    {% endblock page %}
+{% endblock page %}
 
-    {# view #}
-    {%- block view -%}
-        {% apply spaceless %}
-        {% set attributes = '' %}
-        {% set target = '' %}
-        {%- if options.translate is defined and not options.translate -%}
-            {% set attributes = attributes  ~ ' translate="no"' %}
-            {% set target = value %}
-        {%- endif -%}
-        {% if type == 'text_editor' %}
-            {% set attributes = attributes ~ ' datatype="html"' %}
-        {% endif %}
-        {% endapply %}
-        {% autoescape false %}
+{# view #}
+{%- block view -%}
+    {% apply spaceless %}
+    {% set attributes = '' %}
+    {% set target = '' %}
+    {%- if options.translate is defined and not options.translate -%}
+        {% set attributes = attributes  ~ ' translate="no"' %}
+        {% set target = value %}
+    {%- endif -%}
+    {% if type == 'text_editor' %}
+        {% set attributes = attributes ~ ' datatype="html"' %}
+    {% endif %}
+    {% endapply %}
+    {% autoescape false %}
 
             <!-- {{ name }}: {{ type }} -->
             <trans-unit id="{{ sulu_content_type_export_counter() }}" resname="{{ name }}"{{ attributes }}>
                 <source>{{ sulu_content_type_export_escape(value) }}</source>
                 <target>{{ sulu_content_type_export_escape(target) }}</target>
             </trans-unit>
-        {% endautoescape %}
-    {%- endblock view -%}
-{% endif %}
+    {% endautoescape %}
+{%- endblock view -%}

--- a/src/Sulu/Bundle/PageBundle/Resources/views/Export/Webspace/base.export.twig
+++ b/src/Sulu/Bundle/PageBundle/Resources/views/Export/Webspace/base.export.twig
@@ -6,12 +6,12 @@
     {# Iterate over the pages #}
     {%- block pages -%}
         {%- for document in documents -%}
-            {% spaceless %}
+            {% apply spaceless %}
                 {% set settings = document.settings %}
                 {% set content = document.content %}
                 {% set extensions = document.extensions %}
                 {% set prefix = '' %}
-            {% endspaceless %}{{ block('page') }}
+            {% endapply %}{{ block('page') }}
         {%- endfor -%}
     {%- endblock pages -%}
 
@@ -65,12 +65,12 @@
 
     {# Output model #}
     {%- block model -%}
-        {% spaceless %}
+        {% apply spaceless %}
             {% set name = prefix ~ property.name %}
             {% set options = property.options|default('') %}
             {% set value = property.value %}
             {% set type = property.type|default('') %}
-        {% endspaceless %}{{- block('view') -}}
+        {% endapply %}{{- block('view') -}}
     {%- endblock model -%}
 
     {# View #}

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/export.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/export.xml
@@ -4,7 +4,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
         <parameter key="sulu_snippet.export.snippet.formats" type="collection">
-            <parameter key="1.2.xliff">SuluPageBundle:Export:Snippet/1.2.xliff.twig</parameter>
+            <parameter key="1.2.xliff">@SuluPage/Export/Snippet/1.2.xliff.twig</parameter>
         </parameter>
     </parameters>
 

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/SitemapController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/SitemapController.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
@@ -94,6 +95,13 @@ class SitemapController
 
                         break;
                     }
+                }
+
+                if (!$sitemapAlias) {
+                    throw new NotFoundHttpException(sprintf(
+                        'No sitemaps found for "%s".',
+                        $request->getHttpHost()
+                    ));
                 }
 
                 return $this->sitemapPaginatedAction($request, $sitemapAlias, 1);

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/SitemapController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/SitemapController.php
@@ -86,9 +86,17 @@ class SitemapController
         if (!$response) {
             $sitemap = $this->xmlSitemapRenderer->renderIndex($request->getScheme(), $request->getHost());
             if (!$sitemap) {
-                $aliases = array_keys($this->sitemapProviderPool->getProviders());
+                $sitemapAlias = null;
 
-                return $this->sitemapPaginatedAction($request, reset($aliases), 1);
+                foreach ($this->sitemapProviderPool->getProviders() as $sitemapAlias => $provider) {
+                    if ($provider->getMaxPage($request->getScheme(), $request->getHost()) > 0) {
+                        $sitemapAlias = $provider->getAlias();
+
+                        break;
+                    }
+                }
+
+                return $this->sitemapPaginatedAction($request, $sitemapAlias, 1);
             }
 
             $response = new Response($sitemap);

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Sitemap/sitemap-index.xml.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Sitemap/sitemap-index.xml.twig
@@ -2,7 +2,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     {% import _self as self %}
-    {% for sitemap in sitemaps if sitemap.maxPage %}
+    {% for sitemap in sitemaps|filter(sitemap => sitemap.maxPage) %}
     {% for page in range(1, sitemap.maxPage) %}
     <sitemap>
         {{ self.loc(sitemap.alias, page, scheme|default(), domain|default()) }}

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Sitemap/sitemap-index.xml.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Sitemap/sitemap-index.xml.twig
@@ -1,4 +1,4 @@
-{% spaceless %}
+{% apply spaceless %}
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     {% import _self as self %}
@@ -14,7 +14,7 @@
     {% endfor %}
     {% endfor %}
 </sitemapindex>
-{% endspaceless %}
+{% endapply %}
 
 {% macro loc(alias, page, scheme, domain) %}
     {% if scheme|default() and domain|default() %}

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/XmlSitemapRenderer.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/XmlSitemapRenderer.php
@@ -91,8 +91,7 @@ class XmlSitemapRenderer implements XmlSitemapRendererInterface
      */
     private function needsIndex($scheme, $host)
     {
-        return 1 < count($this->sitemapProviderPool->getProviders())
-        || 1 < array_reduce(
+        return 1 < array_reduce(
             $this->sitemapProviderPool->getIndex($scheme, $host),
             function($v1, Sitemap $v2) {
                 return $v1 + $v2->getMaxPage();

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/TestSitemapProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/TestSitemapProvider.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Tests\Application;
+
+use Sulu\Bundle\WebsiteBundle\Sitemap\Sitemap;
+use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapProviderInterface;
+use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapUrl;
+
+class TestSitemapProvider implements SitemapProviderInterface
+{
+    public function build($page, $scheme, $host)
+    {
+        if ('sulu.index' !== $host) {
+            return [];
+        }
+
+        return [
+            new SitemapUrl('http://sulu.io/world', 'en', 'en'),
+        ];
+    }
+
+    public function createSitemap($scheme, $host)
+    {
+        return new Sitemap('test', $this->getMaxPage($scheme, $host));
+    }
+
+    public function getAlias()
+    {
+        return 'test';
+    }
+
+    public function getMaxPage($scheme, $host)
+    {
+        if ('sulu.index' !== $host) {
+            return 0;
+        }
+
+        return 1;
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/services.yml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/services.yml
@@ -6,3 +6,8 @@ services:
     sulu_website_test.analytics.repository:
         alias: sulu_website.analytics.repository
         public: true
+
+    sulu_website_test.test_sitemap_provider:
+        class: Sulu\Bundle\WebsiteBundle\Tests\Application\TestSitemapProvider
+        tags:
+            - { name: sulu.sitemap.provider }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/webspaces/test_with_index.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/webspaces/test_with_index.xml
@@ -65,4 +65,3 @@
         </portal>
     </portals>
 </webspace>
-

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/webspaces/test_with_index.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/webspaces/test_with_index.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<webspace xmlns="http://schemas.sulu.io/webspace/webspace"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.1.xsd">
+
+    <name>test CMF</name>
+    <key>test_with_index</key>
+
+    <localizations>
+        <localization language="en" default="true" />
+    </localizations>
+
+    <theme>default</theme>
+
+    <default-templates>
+        <default-template type="page">default</default-template>
+        <default-template type="homepage">overview</default-template>
+    </default-templates>
+
+    <navigation>
+        <contexts>
+            <context key="main">
+                <meta>
+                    <title lang="en">Mainnavigation</title>
+                </meta>
+            </context>
+            <context key="footer">
+                <meta>
+                    <title lang="en">Footernavigation</title>
+                </meta>
+            </context>
+        </contexts>
+    </navigation>
+
+    <resource-locator>
+        <strategy>tree_leaf_edit</strategy>
+    </resource-locator>
+
+    <portals>
+        <portal>
+            <name>test CMF</name>
+            <key>test_with_index</key>
+
+            <localizations>
+                <localization language="en" default="true"/>
+            </localizations>
+
+            <environments>
+                <environment type="prod">
+                    <urls>
+                        <url language="en">sulu.index</url>
+                    </urls>
+                </environment>
+                <environment type="dev">
+                    <urls>
+                        <url language="en">sulu.index</url>
+                    </urls>
+                </environment>
+                <environment type="test">
+                    <urls>
+                        <url language="en">sulu.index</url>
+                    </urls>
+                </environment>
+            </environments>
+        </portal>
+    </portals>
+</webspace>
+

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/SitemapControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/SitemapControllerTest.php
@@ -150,8 +150,6 @@ class SitemapControllerTest extends WebsiteTestCase
         $crawler = $client->request('GET', 'http://sulu.index/sitemap.xml');
         $this->assertHttpStatusCode(200, $client->getResponse());
 
-        echo $client->getResponse()->getContent();
-
         $this->assertSame('http://sulu.index/sitemaps/test-1.xml', $crawler->filterXPath('//sitemapindex/sitemap[1]/loc[1]')->text());
         $this->assertSame('http://sulu.index/sitemaps/pages-1.xml', $crawler->filterXPath('//sitemapindex/sitemap[2]/loc[1]')->text());
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/SitemapControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/SitemapControllerTest.php
@@ -143,4 +143,16 @@ class SitemapControllerTest extends WebsiteTestCase
         $crawler->registerNamespace('x', 'http://www.sitemaps.org/schemas/sitemap/0.9');
         $this->assertHttpStatusCode(404, $client->getResponse());
     }
+
+    public function testSitemapIndexFile()
+    {
+        $client = $this->createWebsiteClient();
+        $crawler = $client->request('GET', 'http://sulu.index/sitemap.xml');
+        $this->assertHttpStatusCode(200, $client->getResponse());
+
+        echo $client->getResponse()->getContent();
+
+        $this->assertSame('http://sulu.index/sitemaps/test-1.xml', $crawler->filterXPath('//sitemapindex/sitemap[1]/loc[1]')->text());
+        $this->assertSame('http://sulu.index/sitemaps/pages-1.xml', $crawler->filterXPath('//sitemapindex/sitemap[2]/loc[1]')->text());
+    }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/XmlSitemapRendererTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/XmlSitemapRendererTest.php
@@ -57,10 +57,27 @@ class XmlSitemapRendererTest extends TestCase
         $this->providerPoolInterface->getProvider('pages')->willReturn($pagesProvider);
         $this->providerPoolInterface->getIndex('http', 'sulu.io')->willReturn($sitemaps);
 
-        $this->engine->render(
-            '@SuluWebsite/Sitemap/sitemap-index.xml.twig',
-            ['sitemaps' => $sitemaps]
-        )->willReturn('<html/>');
+        $this->assertEquals(null, $this->renderer->renderIndex('http', 'sulu.io'));
+    }
+
+    public function testRenderIndexNoNeedMultipleProviders()
+    {
+        $sitemaps = [
+            new Sitemap('test', 0),
+            new Sitemap('pages', 1),
+        ];
+
+        $pagesProvider = $this->prophesize(SitemapProviderInterface::class);
+        $testProvider = $this->prophesize(SitemapProviderInterface::class);
+        $this->providerPoolInterface->getProviders()->willReturn([
+            'test' => $testProvider->reveal(),
+            'pages' => $pagesProvider->reveal(),
+        ]);
+        $this->providerPoolInterface->hasProvider('pages')->willReturn(true);
+        $this->providerPoolInterface->hasProvider('test')->willReturn(true);
+        $this->providerPoolInterface->getProvider('pages')->willReturn($pagesProvider);
+        $this->providerPoolInterface->getProvider('test')->willReturn($testProvider);
+        $this->providerPoolInterface->getIndex('http', 'sulu.io')->willReturn($sitemaps);
 
         $this->assertEquals(null, $this->renderer->renderIndex('http', 'sulu.io'));
     }

--- a/src/Sulu/Component/Export/Export.php
+++ b/src/Sulu/Component/Export/Export.php
@@ -236,7 +236,7 @@ class Export
 
         $templatePath = $this->formatFilePaths[$format];
 
-        if (!$this->templating->exists($templatePath)) {
+        if (!$this->templating->getLoader()->exists($templatePath)) {
             throw new \Exception(sprintf('No template file "%s" found for Snippet export', $format));
         }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Currently on some places we use deprecated `spaceless` and on others we used the newer `apply spaceless` (e.g.: https://github.com/sulu/sulu/blob/2.0.0/src/Sulu/Bundle/WebsiteBundle/Resources/views/Sitemap/sitemap.xml.twig#L1). I adjusted all to use the newer version and set the min version to twig to `2.9`.

Apply is availabe since [1.40](https://twig.symfony.com/doc/1.x/tags/apply.html) / [2.9](https://twig.symfony.com/doc/2.x/tags/apply.html)

When adding tests for sitemap index I found also out the if there are multiple providers and only one does return data for the current host still a sitemap index was rendered. This is also fixed in this pull request else the others tests would fail, because I needed to add an additional sitemap provider to test the sitemap index file.

#### Why?

Avoid deprecation messages in our twig files and an error on master branch where we support twig 3.0 where spaceless tag does not longer exist.
