### PR TITLE
Add missing service aliases

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -346,6 +346,7 @@
             <argument type="service" id="sulu_media.system_collections.cache"/>
             <argument>%kernel.default_locale%</argument>
         </service>
+        <service id="Sulu\Component\Media\SystemCollections\SystemCollectionManagerInterface" alias="sulu_media.system_collections.manager"/>
 
         <service id="sulu_media.system_collections.builder" class="Sulu\Component\Media\SystemCollections\SystemCollectionBuilder">
             <tag name="massive_build.builder" />

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -102,6 +102,7 @@
 
         <service id="sulu_security.salt_generator" class="%sulu_security.salt_generator.class%" public="true">
         </service>
+        <service id="%sulu_security.salt_generator.class%" alias="sulu_security.salt_generator"/>
 
         <service id="sulu_security.token_generator" class="%sulu_security.token_generator.class%" public="true">
         </service>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add aliases for the `sulu_media.system_collections.manager` and `sulu_security.salt_generator` services.

#### Why?

The aliases are needed to use the services using a `ServiceSubscriber`
