### PR TITLE
Fix preview image in Media list

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
@@ -204,28 +204,14 @@ class MediaController extends AbstractMediaController implements
         $listBuilder->setParameter('locale', $locale);
         $listResponse = $listBuilder->execute();
 
-        $previewImageIds = [];
-        foreach ($listResponse as $listItem) {
-            $previewImageId = $listItem['previewImageId'] ?? null;
-            if ($previewImageId) {
-                $previewImageIds[] = $previewImageId;
-            }
-        }
-        $previewImageFormats = $this->mediaManager->getFormatUrls($previewImageIds, $locale);
-
         for ($i = 0, $length = count($listResponse); $i < $length; ++$i) {
-            $previewImageId = $listResponse[$i]['previewImageId'] ?? null;
-            if ($previewImageId) {
-                $format = $previewImageFormats[$previewImageId];
-            } else {
-                $format = $this->formatManager->getFormats(
-                    $listResponse[$i]['id'],
-                    $listResponse[$i]['name'],
-                    $listResponse[$i]['version'],
-                    $listResponse[$i]['subVersion'],
-                    $listResponse[$i]['mimeType']
-                );
-            }
+            $format = $this->formatManager->getFormats(
+                $listResponse[$i]['previewImageId'] ?? $listResponse[$i]['id'],
+                $listResponse[$i]['previewImageName'] ?? $listResponse[$i]['name'],
+                $listResponse[$i]['previewImageVersion'] ?? $listResponse[$i]['version'],
+                $listResponse[$i]['previewImageSubVersion'] ?? $listResponse[$i]['subVersion'],
+                $listResponse[$i]['previewImageMimeType'] ?? $listResponse[$i]['mimeType']
+            );
 
             if (0 < count($format)) {
                 $listResponse[$i]['thumbnails'] = $format;
@@ -335,6 +321,10 @@ class MediaController extends AbstractMediaController implements
 
         // field which will be needed afterwards to generate route
         $listBuilder->addSelectField($fieldDescriptors['previewImageId']);
+        $listBuilder->addSelectField($fieldDescriptors['previewImageName']);
+        $listBuilder->addSelectField($fieldDescriptors['previewImageVersion']);
+        $listBuilder->addSelectField($fieldDescriptors['previewImageSubVersion']);
+        $listBuilder->addSelectField($fieldDescriptors['previewImageMimeType']);
         $listBuilder->addSelectField($fieldDescriptors['version']);
         $listBuilder->addSelectField($fieldDescriptors['subVersion']);
         $listBuilder->addSelectField($fieldDescriptors['name']);

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
@@ -206,14 +206,16 @@ class MediaController extends AbstractMediaController implements
 
         $previewImageIds = [];
         foreach ($listResponse as $listItem) {
-            if ($listItem['previewImageId']) {
-                $previewImageIds[] = $listItem['previewImageId'];
+            $previewImageId = $listItem['previewImageId'] ?? null;
+            if ($previewImageId) {
+                $previewImageIds[] = $previewImageId;
             }
         }
         $previewImageFormats = $this->mediaManager->getFormatUrls($previewImageIds, $locale);
 
         for ($i = 0, $length = count($listResponse); $i < $length; ++$i) {
-            if ($previewImageId = $listResponse[$i]['previewImageId']) {
+            $previewImageId = $listResponse[$i]['previewImageId'] ?? null;
+            if ($previewImageId) {
                 $format = $previewImageFormats[$previewImageId];
             } else {
                 $format = $this->formatManager->getFormats(

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/lists/media.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/lists/media.xml
@@ -8,6 +8,23 @@
             <field-name>%sulu.model.media.class%.type</field-name>
         </join>
     </joins>
+    <joins name="previewImageFileVersion">
+        <join>
+            <entity-name>PreviewImage_%sulu.model.media.class%</entity-name>
+            <field-name>%sulu.model.media.class%.previewImage</field-name>
+        </join>
+
+        <join>
+            <entity-name>PreviewImage_SuluMediaBundle:File</entity-name>
+            <field-name>PreviewImage_%sulu.model.media.class%.files</field-name>
+        </join>
+
+        <join>
+            <entity-name>PreviewImage_SuluMediaBundle:FileVersion</entity-name>
+            <field-name>PreviewImage_SuluMediaBundle:File.fileVersions</field-name>
+            <condition>PreviewImage_SuluMediaBundle:FileVersion.version = PreviewImage_SuluMediaBundle:File.version</condition>
+        </join>
+    </joins>
     <joins name="file">
         <join>
             <entity-name>SuluMediaBundle:File</entity-name>
@@ -51,6 +68,34 @@
             <field-name>previewImage</field-name>
             <entity-name>%sulu.model.media.class%</entity-name>
         </identity-property>
+
+        <property name="previewImageName" visibility="never">
+            <field-name>name</field-name>
+            <entity-name>PreviewImage_SuluMediaBundle:FileVersion</entity-name>
+
+            <joins ref="previewImageFileVersion"/>
+        </property>
+
+        <property name="previewImageVersion" visibility="never">
+            <field-name>version</field-name>
+            <entity-name>PreviewImage_SuluMediaBundle:FileVersion</entity-name>
+
+            <joins ref="previewImageFileVersion"/>
+        </property>
+
+        <property name="previewImageSubVersion" visibility="never">
+            <field-name>subVersion</field-name>
+            <entity-name>PreviewImage_SuluMediaBundle:FileVersion</entity-name>
+
+            <joins ref="previewImageFileVersion"/>
+        </property>
+
+        <property name="previewImageMimeType" visibility="never">
+            <field-name>mimeType</field-name>
+            <entity-name>PreviewImage_SuluMediaBundle:FileVersion</entity-name>
+
+            <joins ref="previewImageFileVersion"/>
+        </property>
 
         <property name="changed" translation="sulu_admin.changed" visibility="no" type="datetime">
             <field-name>changed</field-name>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/lists/media.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/lists/media.xml
@@ -10,19 +10,19 @@
     </joins>
     <joins name="previewImageFileVersion">
         <join>
-            <entity-name>PreviewImage_%sulu.model.media.class%</entity-name>
+            <entity-name>%sulu.model.media.class%PreviewImage</entity-name>
             <field-name>%sulu.model.media.class%.previewImage</field-name>
         </join>
 
         <join>
-            <entity-name>PreviewImage_SuluMediaBundle:File</entity-name>
-            <field-name>PreviewImage_%sulu.model.media.class%.files</field-name>
+            <entity-name>SuluMediaBundle:FilePreviewImage</entity-name>
+            <field-name>%sulu.model.media.class%PreviewImage.files</field-name>
         </join>
 
         <join>
-            <entity-name>PreviewImage_SuluMediaBundle:FileVersion</entity-name>
-            <field-name>PreviewImage_SuluMediaBundle:File.fileVersions</field-name>
-            <condition>PreviewImage_SuluMediaBundle:FileVersion.version = PreviewImage_SuluMediaBundle:File.version</condition>
+            <entity-name>SuluMediaBundle:FileVersionPreviewImage</entity-name>
+            <field-name>SuluMediaBundle:FilePreviewImage.fileVersions</field-name>
+            <condition>SuluMediaBundle:FileVersionPreviewImage.version = SuluMediaBundle:FilePreviewImage.version</condition>
         </join>
     </joins>
     <joins name="file">
@@ -71,28 +71,28 @@
 
         <property name="previewImageName" visibility="never">
             <field-name>name</field-name>
-            <entity-name>PreviewImage_SuluMediaBundle:FileVersion</entity-name>
+            <entity-name>SuluMediaBundle:FileVersionPreviewImage</entity-name>
 
             <joins ref="previewImageFileVersion"/>
         </property>
 
         <property name="previewImageVersion" visibility="never">
             <field-name>version</field-name>
-            <entity-name>PreviewImage_SuluMediaBundle:FileVersion</entity-name>
+            <entity-name>SuluMediaBundle:FileVersionPreviewImage</entity-name>
 
             <joins ref="previewImageFileVersion"/>
         </property>
 
         <property name="previewImageSubVersion" visibility="never">
             <field-name>subVersion</field-name>
-            <entity-name>PreviewImage_SuluMediaBundle:FileVersion</entity-name>
+            <entity-name>SuluMediaBundle:FileVersionPreviewImage</entity-name>
 
             <joins ref="previewImageFileVersion"/>
         </property>
 
         <property name="previewImageMimeType" visibility="never">
             <field-name>mimeType</field-name>
-            <entity-name>PreviewImage_SuluMediaBundle:FileVersion</entity-name>
+            <entity-name>SuluMediaBundle:FileVersionPreviewImage</entity-name>
 
             <joins ref="previewImageFileVersion"/>
         </property>

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
@@ -530,27 +530,42 @@ class MediaControllerTest extends SuluTestCase
 
     public function testCgetWithPreview()
     {
-        $preview1 = $this->createMedia('photo');
-        $preview2 = $this->createMedia('photo2');
-        $this->createMedia('photo', 'en-gb', 'image', $preview1);
+        $preview1 = $this->createMedia('preview-image-1');
+        $preview2 = $this->createMedia('preview-image-2');
+        $this->createMedia('photo1', 'en-gb', 'image', $preview1);
         $this->createMedia('photo2', 'en-gb', 'image', $preview2);
         $client = $this->createAuthenticatedClient();
 
         $client->request(
             'GET',
-            '/api/media?locale=en-gb'
+            '/api/media?locale=en-gb&sortBy=name'
         );
 
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
 
         $this->assertNotEmpty($response);
+        $this->assertStringContainsString('photo1', $response->_embedded->media[0]->url);
         $this->assertStringContainsString(
-            $preview1->getId() . '-photo.jpg',
+            $preview1->getId() . '-preview-image-1.jpg',
+            $response->_embedded->media[0]->thumbnails->{'sulu-400x400'}
+        );
+
+        $this->assertStringContainsString('photo2', $response->_embedded->media[1]->url);
+        $this->assertStringContainsString(
+            $preview2->getId() . '-preview-image-2.jpg',
+            $response->_embedded->media[1]->thumbnails->{'sulu-400x400'}
+        );
+
+        $this->assertStringContainsString('preview-image-1', $response->_embedded->media[2]->url);
+        $this->assertStringContainsString(
+            $preview1->getId() . '-preview-image-1.jpg',
             $response->_embedded->media[2]->thumbnails->{'sulu-400x400'}
         );
+
+        $this->assertStringContainsString('preview-image-2', $response->_embedded->media[3]->url);
         $this->assertStringContainsString(
-            $preview2->getId() . '-photo2.jpg',
+            $preview2->getId() . '-preview-image-2.jpg',
             $response->_embedded->media[3]->thumbnails->{'sulu-400x400'}
         );
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR fixes the Media list to display the preview image of a media, if one is set. 

This can be tested by the following steps:
1. Upload a `.xls` file (eg [this example file](https://file-examples.com/wp-content/uploads/2017/02/file_example_XLS_10.xls))
2. Edit the `.xls` file and set a preview image
3. Navigate back to the media list and see the preview image

#### Why?

Because we want to display the preview image, if the user sets one.
Also, this finally fixes the `MediaControllerTest::testCgetWithPreview` test that annoyed me for quite some time 🙂 

