### PR TITLE
Fix minimum size calculation for crops

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/ImageRectangleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/ImageRectangleSelection.js
@@ -3,7 +3,7 @@ import {action, computed, observable} from 'mobx';
 import log from 'loglevel';
 import {observer} from 'mobx-react';
 import React from 'react';
-import RectangleSelection, {RoundingNormalizer} from '../RectangleSelection';
+import RectangleSelection from '../RectangleSelection';
 import type {SelectionData} from '../RectangleSelection';
 import withContainerSize from '../withContainerSize';
 import imageRectangleSelectionStyles from './imageRectangleSelection.scss';
@@ -21,7 +21,6 @@ type Props = {|
 @observer
 class ImageRectangleSelection extends React.Component<Props> {
     image: Image;
-    rounding = new RoundingNormalizer();
     @observable imageLoaded = false;
 
     naturalHorizontalToScaled = (h: number) => h * this.imageResizedWidth / this.image.naturalWidth;
@@ -80,7 +79,7 @@ class ImageRectangleSelection extends React.Component<Props> {
 
     handleRectangleSelectionChange = (data: ?SelectionData) => {
         const {onChange} = this.props;
-        onChange(data ? this.rounding.normalize(this.scaledDataToNatural(data)) : undefined);
+        onChange(data ? this.scaledDataToNatural(data) : undefined);
     };
 
     @computed get minDimensions() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/ImageRectangleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/ImageRectangleSelection.js
@@ -83,19 +83,44 @@ class ImageRectangleSelection extends React.Component<Props> {
         onChange(data ? this.rounding.normalize(this.scaledDataToNatural(data)) : undefined);
     };
 
+    @computed get minDimensions() {
+        const {minHeight, minWidth, containerHeight, containerWidth} = this.props;
+
+        let height = minHeight;
+        let width = minWidth;
+
+        if (height && height > containerHeight) {
+            height = containerHeight;
+            width = minWidth && minHeight ? height * minWidth / minHeight : undefined;
+        }
+
+        if (width && width > containerWidth) {
+            width = containerWidth;
+            height = minHeight && minWidth ? width * minHeight / minWidth : undefined;
+        }
+
+        return {width, height};
+    }
+
+    @computed get minWidth() {
+        return this.minDimensions.width;
+    }
+
+    @computed get minHeight() {
+        return this.minDimensions.height;
+    }
+
     render() {
         if (!this.imageLoaded || !this.props.containerWidth || !this.props.containerHeight) {
             return null;
         }
 
-        const minWidth = this.props.minWidth ? this.naturalHorizontalToScaled(this.props.minWidth) : null;
-        const minHeight = this.props.minHeight ? this.naturalVerticalToScaled(this.props.minHeight) : null;
         const value = this.props.value ? this.naturalDataToScaled(this.props.value) : undefined;
 
         return (
             <RectangleSelection
-                minHeight={minHeight}
-                minWidth={minWidth}
+                minHeight={this.minHeight}
+                minWidth={this.minWidth}
                 onChange={this.handleRectangleSelectionChange}
                 round={false}
                 value={value}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/tests/ImageRectangleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/tests/ImageRectangleSelection.test.js
@@ -5,6 +5,10 @@ import {ImageRectangleSelection} from '../ImageRectangleSelection';
 
 jest.mock('../../../utils/DOM/afterElementsRendered');
 
+jest.mock('../../../utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
+
 jest.mock('../../withContainerSize/withContainerSize');
 
 test('The component should render with image source', () => {
@@ -99,28 +103,37 @@ test('The component should pass a value of undefined', () => {
     expect(changeSpy).toBeCalledWith(undefined);
 });
 
-test('The component should render with minWidth and minHeight', () => {
-    const view = mount(
-        <ImageRectangleSelection
-            containerHeight={360}
-            containerWidth={640}
-            image="//:0"
-            minHeight={300}
-            minWidth={600}
-        />
-    );
+test.each([
+    [300, 600, 360, 640, 300, 600],
+    [200, 200, 300, 400, 200, 200],
+    [800, 800, 300, 400, 300, 300],
+    [800, 1000, 200, 400, 200, 250],
+    [1000, 800, 200, 400, 200, 160],
+])(
+    'The component should render with minHeight %s, minWidth %s, containerHeight %s and containerWidth %s',
+    (minHeight, minWidth, containerHeight, containerWidth, expectedMinHeight, expectedMinWidth) => {
+        const view = mount(
+            <ImageRectangleSelection
+                containerHeight={containerHeight}
+                containerWidth={containerWidth}
+                image="//:0"
+                minHeight={minHeight}
+                minWidth={minWidth}
+            />
+        );
 
-    const onImageLoad = view.instance().image.onload;
-    view.instance().image = {
-        naturalWidth: 1920,
-        naturalHeight: 1080,
-    };
-    onImageLoad();
+        const onImageLoad = view.instance().image.onload;
+        view.instance().image = {
+            naturalWidth: 1920,
+            naturalHeight: 1080,
+        };
+        onImageLoad();
 
-    view.update();
+        view.update();
 
-    const rectangle = view.find('RectangleSelection');
-    expect(rectangle.length).toBe(1);
-    expect(rectangle.props().minWidth).toBe(200);
-    expect(rectangle.props().minHeight).toBe(100);
-});
+        const rectangle = view.find('RectangleSelection');
+        expect(rectangle.length).toBe(1);
+        expect(rectangle.props().minHeight).toEqual(expectedMinHeight);
+        expect(rectangle.props().minWidth).toEqual(expectedMinWidth);
+    }
+);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5155
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR changes the way the min size of the crop is calculated. Previously it was based on the ratio between the real and the displayed size, which is only correct for the values that are passed. If the reqeusted format is bigger than the full image the calculation was wrong, because it was downsizing too less.