### PR TITLE
Deprecate sulu_security.system configuration option

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Admin/Admin.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Admin.php
@@ -21,6 +21,7 @@ use Sulu\Bundle\AdminBundle\Admin\View\ViewProviderInterface;
  */
 abstract class Admin implements ViewProviderInterface, NavigationProviderInterface
 {
+    const SULU_ADMIN_SECURITY_SYSTEM = 'Sulu';
     const SETTINGS_NAVIGATION_ITEM = 'sulu_admin.settings';
 
     public static function getPriority(): int

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Admin/AudienceTargetingAdmin.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Admin/AudienceTargetingAdmin.php
@@ -142,7 +142,7 @@ class AudienceTargetingAdmin extends Admin
     public function getSecurityContexts()
     {
         return [
-            'Sulu' => [
+            self::SULU_ADMIN_SECURITY_SYSTEM => [
                 'Settings' => [
                     self::SECURITY_CONTEXT => [
                         PermissionTypes::VIEW,

--- a/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
+++ b/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
@@ -165,7 +165,7 @@ class CategoryAdmin extends Admin
     public function getSecurityContexts()
     {
         return [
-            'Sulu' => [
+            self::SULU_ADMIN_SECURITY_SYSTEM => [
                 'Settings' => [
                     static::SECURITY_CONTEXT => [
                         PermissionTypes::VIEW,

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -284,7 +284,7 @@ class ContactAdmin extends Admin
     public function getSecurityContexts()
     {
         return [
-            'Sulu' => [
+            self::SULU_ADMIN_SECURITY_SYSTEM => [
                 'Contacts' => [
                     static::CONTACT_SECURITY_CONTEXT => [
                         PermissionTypes::VIEW,

--- a/src/Sulu/Bundle/CustomUrlBundle/Admin/CustomUrlAdmin.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Admin/CustomUrlAdmin.php
@@ -100,7 +100,7 @@ class CustomUrlAdmin extends Admin
         }
 
         return [
-             'Sulu' => [
+            self::SULU_ADMIN_SECURITY_SYSTEM => [
                  'Webspaces' => $webspaceContexts,
              ],
          ];
@@ -109,7 +109,7 @@ class CustomUrlAdmin extends Admin
     public function getSecurityContextsWithPlaceholder()
     {
         return [
-            'Sulu' => [
+            self::SULU_ADMIN_SECURITY_SYSTEM => [
                 'Webspaces' => [
                     self::getCustomUrlSecurityContext('#webspace#') => $this->getSecurityContextPermissions(),
                 ],

--- a/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
+++ b/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
@@ -152,7 +152,7 @@ class MediaAdmin extends Admin
     public function getSecurityContexts()
     {
         return [
-            'Sulu' => [
+            self::SULU_ADMIN_SECURITY_SYSTEM => [
                 'Media' => [
                     static::SECURITY_CONTEXT => [
                         PermissionTypes::VIEW,

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -310,7 +310,7 @@ class PageAdmin extends Admin
 
         return array_merge(
             [
-                'Sulu' => [
+                self::SULU_ADMIN_SECURITY_SYSTEM => [
                     'Webspaces' => $webspaceContexts,
                 ],
             ],
@@ -322,7 +322,7 @@ class PageAdmin extends Admin
     {
         return array_merge(
             [
-                'Sulu' => [
+                self::SULU_ADMIN_SECURITY_SYSTEM => [
                     'Webspaces' => [
                         self::SECURITY_CONTEXT_PREFIX . '#webspace#' => [
                             PermissionTypes::VIEW,

--- a/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
+++ b/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
@@ -99,7 +99,7 @@ class SecurityAdmin extends Admin
     public function getSecurityContexts()
     {
         return [
-            'Sulu' => [
+            self::SULU_ADMIN_SECURITY_SYSTEM => [
                 'Security' => [
                     static::ROLE_SECURITY_CONTEXT => [
                         PermissionTypes::VIEW,

--- a/src/Sulu/Bundle/SecurityBundle/Build/UserBuilder.php
+++ b/src/Sulu/Bundle/SecurityBundle/Build/UserBuilder.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\SecurityBundle\Build;
 
+use Sulu\Bundle\AdminBundle\Admin\Admin;
 use Sulu\Bundle\CoreBundle\Build\SuluBuilder;
 
 /**
@@ -33,7 +34,7 @@ class UserBuilder extends SuluBuilder
         $user = 'admin';
         $password = 'admin';
         $roleName = 'User';
-        $system = 'Sulu';
+        $system = Admin::SULU_ADMIN_SECURITY_SYSTEM;
         $locale = 'en';
         $doctrine = $this->container->get('doctrine')->getManager();
         $userRep = $this->container->get('sulu.repository.user');

--- a/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Configuration.php
@@ -29,6 +29,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('system')
                     ->defaultValue('Sulu')
+                    ->setDeprecated('The %node% option is deprecated and will be removed. Setting this option in the admin context will break the permissions registered by the bundles.')
                 ->end()
                 ->arrayNode('checker')
                     ->canBeEnabled()

--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -198,7 +198,7 @@ class SnippetAdmin extends Admin
                 ];
             }
 
-            $contexts['Sulu']['Webspaces'] = $webspaceContexts;
+            $contexts[self::SULU_ADMIN_SECURITY_SYSTEM]['Webspaces'] = $webspaceContexts;
         }
 
         return $contexts;
@@ -214,7 +214,7 @@ class SnippetAdmin extends Admin
                 PermissionTypes::EDIT,
             ];
 
-            $contexts['Sulu']['Webspaces'] = $webspaceContexts;
+            $contexts[self::SULU_ADMIN_SECURITY_SYSTEM]['Webspaces'] = $webspaceContexts;
         }
 
         return $contexts;
@@ -223,7 +223,7 @@ class SnippetAdmin extends Admin
     private function getGlobalSnippetsSecurityContext()
     {
         return [
-            'Sulu' => [
+            self::SULU_ADMIN_SECURITY_SYSTEM => [
                 'Global' => [
                     static::SECURITY_CONTEXT => [
                         PermissionTypes::VIEW,

--- a/src/Sulu/Bundle/TagBundle/Admin/TagAdmin.php
+++ b/src/Sulu/Bundle/TagBundle/Admin/TagAdmin.php
@@ -126,7 +126,7 @@ class TagAdmin extends Admin
     public function getSecurityContexts()
     {
         return [
-            'Sulu' => [
+            self::SULU_ADMIN_SECURITY_SYSTEM => [
                 'Settings' => [
                     static::SECURITY_CONTEXT => [
                         PermissionTypes::VIEW,

--- a/src/Sulu/Bundle/WebsiteBundle/Admin/WebsiteAdmin.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Admin/WebsiteAdmin.php
@@ -105,7 +105,7 @@ class WebsiteAdmin extends Admin
         }
 
         return [
-            'Sulu' => [
+            self::SULU_ADMIN_SECURITY_SYSTEM => [
                 'Webspaces' => $webspaceContexts,
             ],
         ];
@@ -114,7 +114,7 @@ class WebsiteAdmin extends Admin
     public function getSecurityContextsWithPlaceholder()
     {
         return [
-            'Sulu' => [
+            self::SULU_ADMIN_SECURITY_SYSTEM => [
                 'Webspaces' => [
                     self::getAnalyticsSecurityContext('#webspace#') => $this->getSecurityContextPermissions(),
                 ],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR is another take on the problem I was trying to solve in #5169.
The PR deprecates the `sulu_security.system` and adds a `SULU_ADMIN_SECURITY_SYSTEM ` constant to make the array returned by the `getSecurityContexts()` method of the `Admin` classes more understandable.

#### Why?

Because setting the `sulu_security.system` in the admin context currently breaks permission related things in the admin. We cannot remove the option because somebody might use it in the website context.