### PR TITLE
Fix texts for DateTimeFieldFilterType

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
@@ -13,6 +13,7 @@ import Popover from '../Popover';
 import './datePicker.scss';
 
 type Props = {|
+    className?: string,
     disabled: boolean,
     id?: string,
     inputRef?: (ref: ?ElementRef<'input'>) => void,
@@ -175,7 +176,7 @@ class DatePicker extends React.Component<Props> {
     };
 
     render() {
-        const {disabled, options, placeholder, valid} = this.props;
+        const {className, disabled, options, placeholder, valid} = this.props;
 
         const fieldOptions = {
             closeOnSelect: true,
@@ -192,7 +193,7 @@ class DatePicker extends React.Component<Props> {
         };
 
         return (
-            <div>
+            <div className={className}>
                 <div ref={this.setInputRef} />
                 <Popover
                     anchorElement={this.inputRef}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/tests/DatePicker.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/tests/DatePicker.test.js
@@ -14,7 +14,7 @@ beforeEach(() => {
 
 test('DatePicker should render', () => {
     const onChange = jest.fn();
-    const datePicker = mount(<DatePicker onChange={onChange} value={null} />);
+    const datePicker = mount(<DatePicker className="date-picker" onChange={onChange} value={null} />);
 
     expect(datePicker.render()).toMatchSnapshot();
     expect(datePicker.find('DateTime').render()).toMatchSnapshot();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/tests/__snapshots__/DatePicker.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/tests/__snapshots__/DatePicker.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DatePicker should render 1`] = `
-<div>
+<div
+  class="date-picker"
+>
   <div>
     <label
       class="input default left"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/DateTimeFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/DateTimeFieldFilterType.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import type {ElementRef} from 'react';
 import DatePicker from '../../../components/DatePicker';
+import {translate} from '../../../utils/Translator';
 import AbstractFieldFilterType from './AbstractFieldFilterType';
 import dateTimeFieldFilterTypeStyles from './dateTimeFieldFilterType.scss';
 
@@ -58,6 +59,14 @@ class DateTimeFieldFilterType extends AbstractFieldFilterType<?{from?: Date, to?
 
         if (!from && !to) {
             return Promise.resolve(null);
+        }
+
+        if (from && !to) {
+            return Promise.resolve(translate('sulu_admin.from') + ' ' + formatDate(from));
+        }
+
+        if (!from && to) {
+            return Promise.resolve(translate('sulu_admin.until') + ' ' + formatDate(to));
         }
 
         return Promise.resolve(formatDate(from) + ' - ' + formatDate(to));

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/DateTimeFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/DateTimeFieldFilterType.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import React, {Fragment} from 'react';
 import type {ElementRef} from 'react';
 import DatePicker from '../../../components/DatePicker';
 import {translate} from '../../../utils/Translator';
@@ -39,14 +39,21 @@ class DateTimeFieldFilterType extends AbstractFieldFilterType<?{from?: Date, to?
         const {value} = this;
 
         return (
-            <div className={dateTimeFieldFilterTypeStyles.dateTimeFieldFilterType}>
+            <Fragment>
+                <label className={dateTimeFieldFilterTypeStyles.label}>{translate('sulu_admin.from')}</label>
                 <DatePicker
+                    className={dateTimeFieldFilterTypeStyles.date}
                     inputRef={this.setFromInputRef}
                     onChange={this.handleFromChange}
                     value={value ? value.from : undefined}
                 />
-                <DatePicker onChange={this.handleToChange} value={value ? value.to : undefined} />
-            </div>
+                <label className={dateTimeFieldFilterTypeStyles.label}>{translate('sulu_admin.until')}</label>
+                <DatePicker
+                    className={dateTimeFieldFilterTypeStyles.date}
+                    onChange={this.handleToChange}
+                    value={value ? value.to : undefined}
+                />
+            </Fragment>
         );
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/dateTimeFieldFilterType.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/dateTimeFieldFilterType.scss
@@ -1,7 +1,13 @@
-.date-time-field-filter-type {
-    height: 70px;
+@import '../../../containers/Application/colors.scss';
 
-    > :not(:last-child) {
-        margin-bottom: 10px;
-    }
+$labelColor: $scorpion;
+
+.label {
+    display: block;
+    color: $labelColor;
+    margin-bottom: 5px;
+}
+
+.date {
+    margin-bottom: 10px;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/DateTimeFieldFilterType.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/DateTimeFieldFilterType.test.js
@@ -2,6 +2,10 @@
 import {mount} from 'enzyme';
 import DateTimeFieldFilterType from '../../fieldFilterTypes/DateTimeFieldFilterType';
 
+jest.mock('../../../../utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
+
 test('Render with value of undefined', () => {
     const dateTimeFieldFilterType = new DateTimeFieldFilterType(jest.fn(), {}, undefined);
     expect(mount(dateTimeFieldFilterType.getFormNode()).render()).toMatchSnapshot();
@@ -82,6 +86,8 @@ test('Call onChange handler with to value and existing value', () => {
 test.each([
     [{from: new Date('2018-03-07'), to: new Date('2018-08-02')}, '03/07/2018 - 08/02/2018'],
     [{from: new Date('2017-11-07'), to: new Date('2017-12-11')}, '11/07/2017 - 12/11/2017'],
+    [{from: new Date('1990-11-07')}, 'sulu_admin.from 11/07/1990'],
+    [{to: new Date('1992-12-04')}, 'sulu_admin.until 12/04/1992'],
     [undefined, null],
     [{}, null],
 ])('Return value node with value "%s"', (value, expectedValueNode) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/DateTimeFieldFilterType.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/DateTimeFieldFilterType.test.js
@@ -1,4 +1,5 @@
 // @flow
+import React from 'react';
 import {mount} from 'enzyme';
 import DateTimeFieldFilterType from '../../fieldFilterTypes/DateTimeFieldFilterType';
 
@@ -8,7 +9,7 @@ jest.mock('../../../../utils/Translator', () => ({
 
 test('Render with value of undefined', () => {
     const dateTimeFieldFilterType = new DateTimeFieldFilterType(jest.fn(), {}, undefined);
-    expect(mount(dateTimeFieldFilterType.getFormNode()).render()).toMatchSnapshot();
+    expect(mount(<div>{dateTimeFieldFilterType.getFormNode()}</div>).render()).toMatchSnapshot();
 });
 
 test.each([
@@ -20,7 +21,7 @@ test.each([
         {},
         {from, to}
     );
-    expect(mount(dateTimeFieldFilterType.getFormNode()).render()).toMatchSnapshot();
+    expect(mount(<div>{dateTimeFieldFilterType.getFormNode()}</div>).render()).toMatchSnapshot();
 });
 
 test('Render with value set by setValue', () => {
@@ -32,7 +33,7 @@ test('Render with value set by setValue', () => {
 
     dateTimeFieldFilterType.setValue({from: new Date('2017-06-03'), to: new Date('2018-03-06')});
 
-    expect(mount(dateTimeFieldFilterType.getFormNode()).render()).toMatchSnapshot();
+    expect(mount(<div>{dateTimeFieldFilterType.getFormNode()}</div>).render()).toMatchSnapshot();
 });
 
 test('Call onChange handler with only from value', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/__snapshots__/DateTimeFieldFilterType.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/__snapshots__/DateTimeFieldFilterType.test.js.snap
@@ -1,10 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Render with from and to value 1`] = `
-<div
-  class="dateTimeFieldFilterType"
->
-  <div>
+<div>
+  <label
+    class="label"
+  >
+    sulu_admin.from
+  </label>
+  <div
+    class="date"
+  >
     <div>
       <label
         class="input default left"
@@ -27,7 +32,14 @@ exports[`Render with from and to value 1`] = `
       </label>
     </div>
   </div>
-  <div>
+  <label
+    class="label"
+  >
+    sulu_admin.until
+  </label>
+  <div
+    class="date"
+  >
     <div>
       <label
         class="input default left"
@@ -54,10 +66,15 @@ exports[`Render with from and to value 1`] = `
 `;
 
 exports[`Render with from and to value 2`] = `
-<div
-  class="dateTimeFieldFilterType"
->
-  <div>
+<div>
+  <label
+    class="label"
+  >
+    sulu_admin.from
+  </label>
+  <div
+    class="date"
+  >
     <div>
       <label
         class="input default left"
@@ -80,7 +97,14 @@ exports[`Render with from and to value 2`] = `
       </label>
     </div>
   </div>
-  <div>
+  <label
+    class="label"
+  >
+    sulu_admin.until
+  </label>
+  <div
+    class="date"
+  >
     <div>
       <label
         class="input default left"
@@ -107,10 +131,15 @@ exports[`Render with from and to value 2`] = `
 `;
 
 exports[`Render with value of undefined 1`] = `
-<div
-  class="dateTimeFieldFilterType"
->
-  <div>
+<div>
+  <label
+    class="label"
+  >
+    sulu_admin.from
+  </label>
+  <div
+    class="date"
+  >
     <div>
       <label
         class="input default left"
@@ -133,7 +162,14 @@ exports[`Render with value of undefined 1`] = `
       </label>
     </div>
   </div>
-  <div>
+  <label
+    class="label"
+  >
+    sulu_admin.until
+  </label>
+  <div
+    class="date"
+  >
     <div>
       <label
         class="input default left"
@@ -160,10 +196,15 @@ exports[`Render with value of undefined 1`] = `
 `;
 
 exports[`Render with value set by setValue 1`] = `
-<div
-  class="dateTimeFieldFilterType"
->
-  <div>
+<div>
+  <label
+    class="label"
+  >
+    sulu_admin.from
+  </label>
+  <div
+    class="date"
+  >
     <div>
       <label
         class="input default left"
@@ -186,7 +227,14 @@ exports[`Render with value set by setValue 1`] = `
       </label>
     </div>
   </div>
-  <div>
+  <label
+    class="label"
+  >
+    sulu_admin.until
+  </label>
+  <div
+    class="date"
+  >
     <div>
       <label
         class="input default left"

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -147,5 +147,7 @@
     "sulu_admin.no_options_available": "Keine Optionen verfügbar",
     "sulu_admin.form_contains_invalid_values": "Das Formular beinhaltet ungültige Werte",
     "sulu_admin.form_save_server_error": "Beim Speichern des Formulars ist ein Fehler aufgetreten",
-    "sulu_admin.form_used_by": "Dieses Formular wird momentan benutzt von"
+    "sulu_admin.form_used_by": "Dieses Formular wird momentan benutzt von",
+    "sulu_admin.from": "ab",
+    "sulu_admin.until": "bis"
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -147,5 +147,7 @@
     "sulu_admin.no_options_available": "No options available",
     "sulu_admin.form_contains_invalid_values": "The form contains invalid values",
     "sulu_admin.form_save_server_error": "There was an error when trying to save the form",
-    "sulu_admin.form_used_by": "This form is currently used by"
+    "sulu_admin.form_used_by": "This form is currently used by",
+    "sulu_admin.from": "from",
+    "sulu_admin.until": "until"
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #5035 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds labels to the fields in the `ArrowMenu` and updates the texts being shown on the blue `Chip` when only one of both fields is filled.

#### Why?

Because this improves the UX.