### PR TITLE
Avoid setting id properties on block values

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -136,18 +136,12 @@ class BlockCollection extends React.Component<Props> {
     render() {
         const {disabled, renderBlockContent, types, value} = this.props;
 
-        const identifiedValues = value.map((block, index) => {
-            return {
-                ...block,
-                __id: this.generatedBlockIds[index],
-            };
-        });
-
         return (
             <section className={blockCollectionStyles.blockCollection}>
                 <SortableBlockList
                     disabled={disabled}
                     expandedBlocks={this.expandedBlocks}
+                    generatedBlockIds={this.generatedBlockIds}
                     lockAxis="y"
                     onCollapse={this.handleCollapse}
                     onExpand={this.handleExpand}
@@ -157,7 +151,7 @@ class BlockCollection extends React.Component<Props> {
                     renderBlockContent={renderBlockContent}
                     types={types}
                     useDragHandle={true}
-                    value={identifiedValues}
+                    value={value}
                 />
                 <Button
                     disabled={disabled || this.hasMaximumReached()}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -53,7 +53,9 @@ class BlockCollection extends React.Component<Props> {
         );
         if (minOccurs && value.length < minOccurs) {
             expandedBlocks.push(...new Array(minOccurs - value.length).fill(true));
-            generatedBlockIds.push(...new Array(minOccurs - value.length).map(() => ++BlockCollection.idCounter));
+            generatedBlockIds.push(
+                ...new Array(minOccurs - value.length).fill(false).map(() => ++BlockCollection.idCounter)
+            );
 
             onChange([
                 ...value,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -30,6 +30,7 @@ class BlockCollection extends React.Component<Props> {
         value: [],
     };
 
+    @observable generatedBlockIds: Array<number> = [];
     @observable expandedBlocks: Array<boolean> = [];
 
     constructor(props: Props) {
@@ -40,15 +41,20 @@ class BlockCollection extends React.Component<Props> {
 
     fillArrays() {
         const {defaultType, onChange, minOccurs, value} = this.props;
-        const {expandedBlocks} = this;
+        const {expandedBlocks, generatedBlockIds} = this;
 
         if (!value) {
             return;
         }
 
         expandedBlocks.push(...new Array(value.length - expandedBlocks.length).fill(false));
+        generatedBlockIds.push(
+            ...new Array(value.length - generatedBlockIds.length).fill(false).map(() => ++BlockCollection.idCounter)
+        );
         if (minOccurs && value.length < minOccurs) {
             expandedBlocks.push(...new Array(minOccurs - value.length).fill(true));
+            generatedBlockIds.push(...new Array(minOccurs - value.length).map(() => ++BlockCollection.idCounter));
+
             onChange([
                 ...value,
                 ...Array.from(
@@ -68,6 +74,7 @@ class BlockCollection extends React.Component<Props> {
 
         if (value) {
             this.expandedBlocks.push(true);
+            this.generatedBlockIds.push(++BlockCollection.idCounter);
 
             onChange([...value, {type: defaultType}]);
         }
@@ -82,6 +89,7 @@ class BlockCollection extends React.Component<Props> {
 
         if (value) {
             this.expandedBlocks.splice(index, 1);
+            this.generatedBlockIds.splice(index, 1);
             onChange(value.filter((element, arrayIndex) => arrayIndex != index));
         }
     };
@@ -90,6 +98,7 @@ class BlockCollection extends React.Component<Props> {
         const {onChange, onSortEnd, value} = this.props;
 
         this.expandedBlocks = arrayMove(this.expandedBlocks, oldIndex, newIndex);
+        this.generatedBlockIds = arrayMove(this.generatedBlockIds, oldIndex, newIndex);
         onChange(arrayMove(value, oldIndex, newIndex));
 
         if (onSortEnd) {
@@ -127,12 +136,11 @@ class BlockCollection extends React.Component<Props> {
     render() {
         const {disabled, renderBlockContent, types, value} = this.props;
 
-        const identifiedValues = value.map((block) => {
-            if (!block.__id) {
-                block.__id = ++BlockCollection.idCounter;
-            }
-
-            return block;
+        const identifiedValues = value.map((block, index) => {
+            return {
+                ...block,
+                __id: this.generatedBlockIds[index],
+            };
         });
 
         return (

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlockList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlockList.js
@@ -11,6 +11,7 @@ type Props = {|
     blockTypes: Array<string>,
     disabled: boolean,
     expandedBlocks: Array<boolean>,
+    generatedBlockIds: Array<number>,
     onCollapse: (index: number) => void,
     onExpand: (index: number) => void,
     onRemove: (index: number) => void,
@@ -50,7 +51,7 @@ class SortableBlockList extends React.Component<Props> {
     };
 
     render() {
-        const {disabled, expandedBlocks, onRemove, renderBlockContent, types, value} = this.props;
+        const {disabled, expandedBlocks, generatedBlockIds, onRemove, renderBlockContent, types, value} = this.props;
 
         const sortableBlockListClass = classNames(
             sortableBlockListStyles.sortableBlockList,
@@ -66,7 +67,7 @@ class SortableBlockList extends React.Component<Props> {
                         activeType={block.type}
                         expanded={!disabled && expandedBlocks[index]}
                         index={index}
-                        key={block.__id}
+                        key={generatedBlockIds[index]}
                         onCollapse={this.handleCollapse}
                         onExpand={this.handleExpand}
                         onRemove={onRemove ? this.handleRemove : undefined}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -1,6 +1,5 @@
 // @flow
-import React from 'react';
-import {observable} from 'mobx';
+import React from 'react'; import {observable} from 'mobx';
 import {mount, render, shallow} from 'enzyme';
 import BlockCollection from '../BlockCollection';
 import SortableBlockList from '../SortableBlockList';
@@ -241,6 +240,7 @@ test('Should allow to reorder blocks by using drag and drop', () => {
     blockCollection.find('Block').at(0).simulate('click');
 
     expect(blockCollection.instance().expandedBlocks.toJS()).toEqual([true, false, false]);
+    expect(blockCollection.instance().generatedBlockIds.toJS()).toEqual([1, 2, 3]);
 
     blockCollection.find(SortableBlockList).prop('onSortEnd')({newIndex: 2, oldIndex: 0});
     expect(changeSpy).toBeCalledWith([
@@ -251,6 +251,7 @@ test('Should allow to reorder blocks by using drag and drop', () => {
     expect(sortEndSpy).toBeCalledWith(0, 2);
 
     expect(blockCollection.instance().expandedBlocks.toJS()).toEqual([false, false, true]);
+    expect(blockCollection.instance().generatedBlockIds.toJS()).toEqual([2, 3, 1]);
 });
 
 test('Should allow to add a new block', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -1,5 +1,6 @@
 // @flow
-import React from 'react'; import {observable} from 'mobx';
+import React from 'react';
+import {observable} from 'mobx';
 import {mount, render, shallow} from 'enzyme';
 import BlockCollection from '../BlockCollection';
 import SortableBlockList from '../SortableBlockList';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/types.js
@@ -2,7 +2,6 @@
 import type {Node} from 'react';
 
 export type BlockEntry = {
-    __id?: number,
     type: string,
 };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
@@ -542,13 +542,11 @@ test('Call onChange on componentDidUpdate when type not longer exist', () => {
 
     expect(changeSpy).toBeCalledWith([
         {
-            __id: 11,
             text1: 'Test 1',
             text2: 'Test 2',
             type: 'new',
         },
         {
-            __id: 12,
             text1: 'Test 3',
             text2: 'Test 4',
             type: 'new',
@@ -837,7 +835,7 @@ test ('Should set nested properties in handleBlockChange and call onChange with 
             },
         },
     };
-    const value = [{__id: 1, type: 'default'}];
+    const value = [{type: 'default'}];
     formInspector.getSchemaEntryByPath.mockReturnValue({types});
 
     const changeSpy = jest.fn();
@@ -858,11 +856,11 @@ test ('Should set nested properties in handleBlockChange and call onChange with 
     fieldBlocks.find('Block').simulate('click');
     fieldBlocks.find('FieldRenderer').prop('onChange')(0, 'options/test1', 'value1');
 
-    const expectedArray1 = [{__id: 1, type: 'default', options: {test1: 'value1'}}];
+    const expectedArray1 = [{type: 'default', options: {test1: 'value1'}}];
     expect(changeSpy).toBeCalledWith(expectedArray1);
 
     fieldBlocks.find('FieldRenderer').prop('onChange')(0, 'options/test2/test3', 'value2');
-    const expectedArray2 = [{__id: 1, type: 'default', options: {test1: 'value1', test2: {test3: 'value2'}}}];
+    const expectedArray2 = [{type: 'default', options: {test1: 'value1', test2: {test3: 'value2'}}}];
     expect(changeSpy).toBeCalledWith(expectedArray2);
 });
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5185 
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR avoids sending the internal `__id` from the blocks to the server. This sometimes introduced some problems, see e.g. #5185.
#### BC Breaks/Deprecations

Describe BC breaks/deprecations here. (remove this section if not needed)

#### To Do

- [x] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md
- [x] Remove the `__id` property completely by removing the `SortableBlockList` component and integrate it into the `BlockCollection`
