### PR TITLE
Add eslint rule to ensure only one statement is written per line

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,6 +43,7 @@
             "error",
             120
         ],
+        "max-statements-per-line": "error",
         "quotes": [
             "error",
             "single"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
@@ -851,8 +851,12 @@ test('Cancel request when a second one is started before finishing the first one
     const loadingStrategy = new LoadingStrategy();
     const structureStrategy = new StructureStrategy();
 
-    loadingStrategy.load.mockReturnValueOnce(new RequestPromise(function(resolve){resolve();}));
-    loadingStrategy.load.mockReturnValueOnce(new RequestPromise(function(resolve){resolve();}));
+    loadingStrategy.load.mockReturnValueOnce(new RequestPromise(function(resolve){
+        resolve();
+    }));
+    loadingStrategy.load.mockReturnValueOnce(new RequestPromise(function(resolve){
+        resolve();
+    }));
 
     listStore.schema = {};
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | --
| License | MIT
| Documentation PR | ---

#### What's in this PR?

I've added a rule to ensure there is only one statement per line.

#### Why?

I've put two lines into a single one by accident and it was not caught by the linter. I've added the rule and almost had no changes to make, so I decided to create a PR.