### PR TITLE
Fix clearing of preview cache

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/EventSubscriber/CacheCommandSubscriber.php
+++ b/src/Sulu/Bundle/PreviewBundle/EventSubscriber/CacheCommandSubscriber.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PreviewBundle\EventSubscriber;
+
+use Sulu\Bundle\PreviewBundle\Preview\Renderer\KernelFactoryInterface;
+use Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand;
+use Symfony\Bundle\FrameworkBundle\Command\CacheWarmupCommand;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class CacheCommandSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var KernelFactoryInterface
+     */
+    private $kernelFactory;
+
+    /**
+     * @var string
+     */
+    private $environment;
+
+    /**
+     * Needed for testing.
+     *
+     * @see Sulu\Bundle\PreviewBundle\Tests\Unit\EventSubscriber\CacheCommandSubscriberTest
+     *
+     * @var Application|null
+     */
+    private $application;
+
+    public function __construct(
+        KernelFactoryInterface $kernelFactory,
+        string $environment
+    ) {
+        $this->kernelFactory = $kernelFactory;
+        $this->environment = $environment;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            ConsoleEvents::COMMAND => [
+                ['onCommand', 0],
+            ],
+        ];
+    }
+
+    public function onCommand(ConsoleCommandEvent $event)
+    {
+        if (!in_array($event->getCommand()->getName(), [
+            CacheClearCommand::getDefaultName(),
+            CacheWarmupCommand::getDefaultName(),
+        ])) {
+            return;
+        }
+
+        $previewKernel = $this->kernelFactory->create($this->environment);
+
+        $application = $this->application ?: new Application($previewKernel);
+        $application->run($event->getInput(), $event->getOutput());
+    }
+}

--- a/src/Sulu/Bundle/PreviewBundle/EventSubscriber/CacheCommandSubscriber.php
+++ b/src/Sulu/Bundle/PreviewBundle/EventSubscriber/CacheCommandSubscriber.php
@@ -32,10 +32,6 @@ class CacheCommandSubscriber implements EventSubscriberInterface
     private $environment;
 
     /**
-     * Needed for testing.
-     *
-     * @see Sulu\Bundle\PreviewBundle\Tests\Unit\EventSubscriber\CacheCommandSubscriberTest
-     *
      * @var Application|null
      */
     private $application;
@@ -70,5 +66,17 @@ class CacheCommandSubscriber implements EventSubscriberInterface
 
         $application = $this->application ?: new Application($previewKernel);
         $application->run($event->getInput(), $event->getOutput());
+    }
+
+    /**
+     * @internal
+     *
+     * Needed for testing
+     *
+     * @see Sulu\Bundle\PreviewBundle\Tests\Unit\EventSubscriber\CacheCommandSubscriberTest
+     */
+    public function setApplication(Application $application): void
+    {
+        $this->application = $application;
     }
 }

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/services.xml
@@ -17,6 +17,14 @@
             <tag name="sulu.context" context="admin"/>
         </service>
 
+        <service id="sulu_preview.cache_command_subscriber" class="Sulu\Bundle\PreviewBundle\EventSubscriber\CacheCommandSubscriber">
+            <argument type="service" id="sulu_preview.preview.kernel_factory"/>
+            <argument type="string">%kernel.environment%</argument>
+
+            <tag name="kernel.event_subscriber"/>
+            <tag name="sulu.context" context="admin"/>
+        </service>
+
         <!-- preview -->
         <service id="sulu_preview.preview.kernel_factory"
                  class="Sulu\Bundle\PreviewBundle\Preview\Renderer\WebsiteKernelFactory"/>

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/EventSubscriber/CacheCommandSubscriberTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/EventSubscriber/CacheCommandSubscriberTest.php
@@ -51,11 +51,7 @@ class CacheCommandSubscriberTest extends TestCase
         $this->kernelFactory = $this->prophesize(KernelFactoryInterface::class);
         $this->cacheCommandSubscriber = new CacheCommandSubscriber($this->kernelFactory->reveal(), 'test');
 
-        $reflectionClass = new \ReflectionClass($this->cacheCommandSubscriber);
-        $reflectionProperty = $reflectionClass->getProperty('application');
-        $reflectionProperty->setAccessible('public');
-
-        $reflectionProperty->setValue($this->cacheCommandSubscriber, $this->application->reveal());
+        $this->cacheCommandSubscriber->setApplication($this->application->reveal());
     }
 
     public function testEventCacheClear(): void

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/EventSubscriber/CacheCommandSubscriberTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/EventSubscriber/CacheCommandSubscriberTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PreviewBundle\Tests\Unit\EventSubscriber;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Sulu\Bundle\PreviewBundle\EventSubscriber\CacheCommandSubscriber;
+use Sulu\Bundle\PreviewBundle\Preview\Renderer\KernelFactoryInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class CacheCommandSubscriberTest extends TestCase
+{
+    /**
+     * @var KernelFactoryInterface
+     */
+    private $kernelFactory;
+
+    /**
+     * @var CacheCommandSubscriber
+     */
+    private $cacheCommandSubscriber;
+
+    /**
+     * @var KernelInterface
+     */
+    private $previewKernel;
+
+    /**
+     * @var Application
+     */
+    private $application;
+
+    public function setUp(): void
+    {
+        $this->application = $this->prophesize(Application::class);
+        $this->previewKernel = $this->prophesize(KernelInterface::class);
+        $this->kernelFactory = $this->prophesize(KernelFactoryInterface::class);
+        $this->cacheCommandSubscriber = new CacheCommandSubscriber($this->kernelFactory->reveal(), 'test');
+
+        $reflectionClass = new \ReflectionClass($this->cacheCommandSubscriber);
+        $reflectionProperty = $reflectionClass->getProperty('application');
+        $reflectionProperty->setAccessible('public');
+
+        $reflectionProperty->setValue($this->cacheCommandSubscriber, $this->application->reveal());
+    }
+
+    public function testEventCacheClear(): void
+    {
+        $command = $this->prophesize(Command::class);
+        $command->getName()->willReturn('cache:clear');
+
+        $this->kernelFactory->create(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn($this->previewKernel->reveal());
+
+        $this->application->run(Argument::any(), Argument::any())
+            ->shouldBeCalled();
+
+        $this->runCommand($command->reveal());
+    }
+
+    public function testEventCacheWarmup(): void
+    {
+        $command = $this->prophesize(Command::class);
+        $command->getName()->willReturn('cache:warmup');
+
+        $this->kernelFactory->create(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn($this->previewKernel->reveal());
+
+        $this->application->run(Argument::any(), Argument::any())
+            ->shouldBeCalled();
+
+        $this->runCommand($command->reveal());
+    }
+
+    public function testEventOtherCommand(): void
+    {
+        $command = $this->prophesize(Command::class);
+        $command->getName()->willReturn('other:command');
+
+        $this->kernelFactory->create(Argument::any())
+            ->shouldNotBeCalled();
+
+        $this->application->run(Argument::any(), Argument::any())
+            ->shouldNotBeCalled();
+
+        $this->runCommand($command->reveal());
+    }
+
+    private function runCommand(Command $command): void
+    {
+        $input = $this->prophesize(InputInterface::class);
+        $output = $this->prophesize(OutputInterface::class);
+
+        $event = new ConsoleCommandEvent($command, $input->reveal(), $output->reveal());
+
+        $this->cacheCommandSubscriber->onCommand($event);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4369
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix clearing of preview cache.

#### Why?

Currently the preview cache is not cleared when running `bin/console cache:clear` and so changes in twig files has no effect under `prod`. 

#### Example Usage

1. Change env to `.prod`
2. Open page with preview
3. Change `.html.twig`  preview
4. Run bin/console cache:clear
5. Preview should show changes

