### PR TITLE
Handle non ajax logout request

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -94,7 +94,9 @@
             <argument type="service" id="session"/>
         </service>
 
-        <service id="sulu_security.logout_success_handler" class="Sulu\Bundle\SecurityBundle\Security\LogoutSuccessHandler" />
+        <service id="sulu_security.logout_success_handler" class="Sulu\Bundle\SecurityBundle\Security\LogoutSuccessHandler">
+            <argument type="service" id="router"/>
+        </service>
 
         <service id="sulu_security.mask_converter" class="%sulu_security.mask_converter.class%" public="true">
             <argument>%permissions%</argument>

--- a/src/Sulu/Bundle/SecurityBundle/Security/LogoutSuccessHandler.php
+++ b/src/Sulu/Bundle/SecurityBundle/Security/LogoutSuccessHandler.php
@@ -12,14 +12,32 @@
 namespace Sulu\Bundle\SecurityBundle\Security;
 
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Http\Logout\LogoutSuccessHandlerInterface;
 
 class LogoutSuccessHandler implements LogoutSuccessHandlerInterface
 {
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    public function __construct(RouterInterface $router)
+    {
+        $this->router = $router;
+    }
+
     public function onLogoutSuccess(Request $request)
     {
-        return new JsonResponse(null, Response::HTTP_OK);
+        if ($request->isXmlHttpRequest()) {
+            $response = new JsonResponse(null, Response::HTTP_OK);
+        } else {
+            $response = new RedirectResponse($this->router->generate('sulu_admin'));
+        }
+
+        return $response;
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| BC breaks? | no

#### What's in this PR?
Handle logout for normal http requests

#### Why?
Sometime we may need to call the logout action from pages that don't use ajax to do it.
