### PR TITLE
Don't use spaces on the role identifier

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Entity/Role.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/Role.php
@@ -95,12 +95,12 @@ class Role implements RoleInterface
 
     public function getRole()
     {
-        return 'ROLE_SULU_' . strtoupper($this->name);
+        return 'ROLE_SULU_' . str_replace(" ", "_", strtoupper($this->getName()));
     }
 
     public function getIdentifier()
     {
-        return 'ROLE_SULU_' . strtoupper($this->getName());
+        return 'ROLE_SULU_' . str_replace(" ", "_", strtoupper($this->getName()));
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| BC breaks? | yes

#### Why?

Since we are concatenating with "ROLE_SULU_" the rest of the role should be coherent. 