### PR TITLE
Run preview cache clear command only when App\Kernel exists

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/EventSubscriber/CacheCommandSubscriber.php
+++ b/src/Sulu/Bundle/PreviewBundle/EventSubscriber/CacheCommandSubscriber.php
@@ -62,6 +62,13 @@ class CacheCommandSubscriber implements EventSubscriberInterface
             return;
         }
 
+        // avoid to clear cache for preview if no \App\Kernel exists
+        // this can happens in test kernels of bundles
+        // this can be removed when https://github.com/sulu/sulu/issues/4782 is fixed
+        if (!class_exists(\App\Kernel::class)) {
+            return;
+        }
+
         $previewKernel = $this->kernelFactory->create($this->environment);
 
         $application = $this->application ?: new Application($previewKernel);

--- a/src/Sulu/Bundle/PreviewBundle/EventSubscriber/CacheCommandSubscriber.php
+++ b/src/Sulu/Bundle/PreviewBundle/EventSubscriber/CacheCommandSubscriber.php
@@ -63,7 +63,7 @@ class CacheCommandSubscriber implements EventSubscriberInterface
         }
 
         // avoid to clear cache for preview if no \App\Kernel exists
-        // this can happens in test kernels of bundles
+        // can cause an error in test kernels of bundles
         // this can be removed when https://github.com/sulu/sulu/issues/4782 is fixed
         if (!class_exists(\App\Kernel::class)) {
             return;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | #4782
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Aslong the PreviewKernel extends from App\Kernel we need to check in this listener if `App\Kernel` exist and only then allow to clear also the preview cache.

This lines can be removed when https://github.com/sulu/sulu/issues/4782 is fixed.

#### Why?

Currently all bundles with use of `cache:warmup` to generate data for phpstan crash because they don't have a App\Kernel in it.