### PR TITLE
Add routerAttributesToBlacklist to TabViewBuilder

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilder.php
@@ -22,7 +22,7 @@ class FormOverlayListViewBuilder implements FormOverlayListViewBuilderInterface
         ListViewBuilderTrait::addToolbarActionsToView insteadof FormViewBuilderTrait;
         ListViewBuilderTrait::addRequestParametersToView insteadof FormViewBuilderTrait;
     }
-    use TabViewBuilderTrait;
+    use TabViewChildBuilderTrait;
 
     const TYPE = 'sulu_admin.form_overlay_list';
 

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilder.php
@@ -15,7 +15,7 @@ class FormViewBuilder implements FormViewBuilderInterface
 {
     use ViewBuilderTrait;
     use FormViewBuilderTrait;
-    use TabViewBuilderTrait;
+    use TabViewChildBuilderTrait;
 
     const TYPE = 'sulu_admin.form';
 

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilder.php
@@ -15,7 +15,7 @@ class ListViewBuilder implements ListViewBuilderInterface
 {
     use ViewBuilderTrait;
     use ListViewBuilderTrait;
-    use TabViewBuilderTrait;
+    use TabViewChildBuilderTrait;
 
     const TYPE = 'sulu_admin.list';
 

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/PreviewFormViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/PreviewFormViewBuilder.php
@@ -15,7 +15,7 @@ class PreviewFormViewBuilder implements PreviewFormViewBuilderInterface
 {
     use ViewBuilderTrait;
     use FormViewBuilderTrait;
-    use TabViewBuilderTrait;
+    use TabViewChildBuilderTrait;
 
     const TYPE = 'sulu_admin.preview_form';
 

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ResourceTabViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ResourceTabViewBuilder.php
@@ -55,19 +55,6 @@ class ResourceTabViewBuilder implements ResourceTabViewBuilderInterface
         return $this;
     }
 
-    public function addRouterAttributesToBlacklist(
-        array $routerAttributesToBlacklist
-    ): TabViewBuilderInterface {
-        $oldRouterAttributesToBlacklist = $this->view->getOption('routerAttributesToBlacklist');
-        $newRouterAttributesToBlacklist = $oldRouterAttributesToBlacklist
-            ? array_merge($oldRouterAttributesToBlacklist, $routerAttributesToBlacklist)
-            : $routerAttributesToBlacklist;
-
-        $this->view->setOption('routerAttributesToBlacklist', $newRouterAttributesToBlacklist);
-
-        return $this;
-    }
-
     public function setTitleProperty(string $titleProperty): ResourceTabViewBuilderInterface
     {
         $this->view->setOption('titleProperty', $titleProperty);

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ResourceTabViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ResourceTabViewBuilder.php
@@ -56,7 +56,7 @@ class ResourceTabViewBuilder implements ResourceTabViewBuilderInterface
 
     public function addRouterAttributesToBlacklist(
         array $routerAttributesToBlacklist
-    ): ResourceTabViewBuilderInterface {
+    ): TabViewBuilderInterface {
         $oldRouterAttributesToBlacklist = $this->view->getOption('routerAttributesToBlacklist');
         $newRouterAttributesToBlacklist = $oldRouterAttributesToBlacklist
             ? array_merge($oldRouterAttributesToBlacklist, $routerAttributesToBlacklist)

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ResourceTabViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ResourceTabViewBuilder.php
@@ -62,6 +62,13 @@ class ResourceTabViewBuilder implements ResourceTabViewBuilderInterface
         return $this;
     }
 
+    public function addRouterAttributesToBlacklist(array $routerAttributesToBlacklist): ResourceTabViewBuilderInterface
+    {
+        $this->addRouterAttributesToBlacklistToView($routerAttributesToBlacklist);
+
+        return $this;
+    }
+
     public function getView(): View
     {
         if (!$this->view->getOption('resourceKey')) {

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ResourceTabViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ResourceTabViewBuilder.php
@@ -15,6 +15,7 @@ class ResourceTabViewBuilder implements ResourceTabViewBuilderInterface
 {
     use ViewBuilderTrait;
     use FormViewBuilderTrait;
+    use TabViewBuilderTrait;
 
     const TYPE = 'sulu_admin.resource_tabs';
 

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ResourceTabViewBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ResourceTabViewBuilderInterface.php
@@ -27,10 +27,10 @@ interface ResourceTabViewBuilderInterface extends ViewBuilderInterface
      */
     public function addRouterAttributesToBackView(array $routerAttributesToBackView): self;
 
-    public function setTitleProperty(string $titleProperty): self;
-
     /**
      * @param string[] $routerAttributesToBlacklist
      */
     public function addRouterAttributesToBlacklist(array $routerAttributesToBlacklist): self;
+
+    public function setTitleProperty(string $titleProperty): self;
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ResourceTabViewBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ResourceTabViewBuilderInterface.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Bundle\AdminBundle\Admin\View;
 
-interface ResourceTabViewBuilderInterface extends ViewBuilderInterface
+interface ResourceTabViewBuilderInterface extends TabViewBuilderInterface
 {
     public function setResourceKey(string $resourceKey): self;
 
@@ -26,11 +26,6 @@ interface ResourceTabViewBuilderInterface extends ViewBuilderInterface
      * @param string[] $routerAttributesToBackView
      */
     public function addRouterAttributesToBackView(array $routerAttributesToBackView): self;
-
-    /**
-     * @param string[] $routerAttributesToBlacklist
-     */
-    public function addRouterAttributesToBlacklist(array $routerAttributesToBlacklist): self;
 
     public function setTitleProperty(string $titleProperty): self;
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ResourceTabViewBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ResourceTabViewBuilderInterface.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Bundle\AdminBundle\Admin\View;
 
-interface ResourceTabViewBuilderInterface extends TabViewBuilderInterface
+interface ResourceTabViewBuilderInterface extends ViewBuilderInterface
 {
     public function setResourceKey(string $resourceKey): self;
 
@@ -28,4 +28,9 @@ interface ResourceTabViewBuilderInterface extends TabViewBuilderInterface
     public function addRouterAttributesToBackView(array $routerAttributesToBackView): self;
 
     public function setTitleProperty(string $titleProperty): self;
+
+    /**
+     * @param string[] $routerAttributesToBlacklist
+     */
+    public function addRouterAttributesToBlacklist(array $routerAttributesToBlacklist): self;
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/TabViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/TabViewBuilder.php
@@ -26,4 +26,17 @@ class TabViewBuilder implements TabViewBuilderInterface
     {
         return clone $this->view;
     }
+
+    public function addRouterAttributesToBlacklist(
+        array $routerAttributesToBlacklist
+    ): TabViewBuilderInterface {
+        $oldRouterAttributesToBlacklist = $this->view->getOption('routerAttributesToBlacklist');
+        $newRouterAttributesToBlacklist = $oldRouterAttributesToBlacklist
+            ? array_merge($oldRouterAttributesToBlacklist, $routerAttributesToBlacklist)
+            : $routerAttributesToBlacklist;
+
+        $this->view->setOption('routerAttributesToBlacklist', $newRouterAttributesToBlacklist);
+
+        return $this;
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/TabViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/TabViewBuilder.php
@@ -27,4 +27,11 @@ class TabViewBuilder implements TabViewBuilderInterface
     {
         return clone $this->view;
     }
+
+    public function addRouterAttributesToBlacklist(array $routerAttributesToBlacklist): TabViewBuilderInterface
+    {
+        $this->addRouterAttributesToBlacklistToView($routerAttributesToBlacklist);
+
+        return $this;
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/TabViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/TabViewBuilder.php
@@ -27,17 +27,4 @@ class TabViewBuilder implements TabViewBuilderInterface
     {
         return clone $this->view;
     }
-
-    public function addRouterAttributesToBlacklist(
-        array $routerAttributesToBlacklist
-    ): TabViewBuilderInterface {
-        $oldRouterAttributesToBlacklist = $this->view->getOption('routerAttributesToBlacklist');
-        $newRouterAttributesToBlacklist = $oldRouterAttributesToBlacklist
-            ? array_merge($oldRouterAttributesToBlacklist, $routerAttributesToBlacklist)
-            : $routerAttributesToBlacklist;
-
-        $this->view->setOption('routerAttributesToBlacklist', $newRouterAttributesToBlacklist);
-
-        return $this;
-    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/TabViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/TabViewBuilder.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\AdminBundle\Admin\View;
 class TabViewBuilder implements TabViewBuilderInterface
 {
     use ViewBuilderTrait;
+    use TabViewBuilderTrait;
 
     const TYPE = 'sulu_admin.tabs';
 

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/TabViewBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/TabViewBuilderInterface.php
@@ -13,4 +13,8 @@ namespace Sulu\Bundle\AdminBundle\Admin\View;
 
 interface TabViewBuilderInterface extends ViewBuilderInterface
 {
+    /**
+     * @param string[] $routerAttributesToBlacklist
+     */
+    public function addRouterAttributesToBlacklist(array $routerAttributesToBlacklist): self;
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/TabViewBuilderTrait.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/TabViewBuilderTrait.php
@@ -13,23 +13,65 @@ namespace Sulu\Bundle\AdminBundle\Admin\View;
 
 trait TabViewBuilderTrait
 {
+    use TabViewChildBuilderTrait {
+        setTabTitleToView as parentSetTabTitleToView;
+        setTabConditionToView as parentSetTabConditionToView;
+        setTabOrderToView as parentSetTabOrderToView;
+        setTabPriorityToView as parentSetTabPriorityToView;
+    }
+
+    /**
+     * @deprecated since Sulu 2.1 and will be removed in Sulu 3.0
+     * @see TabViewChildBuilderTrait::setTabTitleToView()
+     */
     private function setTabTitleToView(View $view, string $tabTitle): void
     {
-        $view->setOption('tabTitle', $tabTitle);
+        @trigger_error('The method TabViewBuilderTrait::setTabTitleToView() is deprecated since Sulu 2.1. Use TabViewChildBuilderTrait::setTabTitleToView() instead.', E_USER_DEPRECATED);
+
+        $this->parentSetTabTitleToView($view, $tabTitle);
     }
 
+    /**
+     * @deprecated since Sulu 2.1 and will be removed in Sulu 3.0
+     * @see TabViewChildBuilderTrait::setTabConditionToView()
+     */
     private function setTabConditionToView(View $view, string $tabCondition): void
     {
-        $view->setOption('tabCondition', $tabCondition);
+        @trigger_error('The method TabViewBuilderTrait::setTabConditionToView() is deprecated since Sulu 2.1. Use TabViewChildBuilderTrait::setTabConditionToView() instead.', E_USER_DEPRECATED);
+
+        $this->parentSetTabConditionToView($view, $tabCondition);
     }
 
+    /**
+     * @deprecated since Sulu 2.1 and will be removed in Sulu 3.0
+     * @see TabViewChildBuilderTrait::setTabOrderToView()
+     */
     private function setTabOrderToView(View $view, int $tabOrder): void
     {
-        $view->setOption('tabOrder', $tabOrder);
+        @trigger_error('The method TabViewBuilderTrait::setTabOrderToView() is deprecated since Sulu 2.1. Use TabViewChildBuilderTrait::setTabOrderToView() instead.', E_USER_DEPRECATED);
+
+        $this->parentSetTabOrderToView($view, $tabOrder);
     }
 
+    /**
+     * @deprecated since Sulu 2.1 and will be removed in Sulu 3.0
+     * @see TabViewChildBuilderTrait::setTabPriorityToView()
+     */
     private function setTabPriorityToView(View $view, int $tabPriority): void
     {
-        $view->setOption('tabPriority', $tabPriority);
+        @trigger_error('The method TabViewBuilderTrait::setTabPriorityToView() is deprecated since Sulu 2.1. Use TabViewChildBuilderTrait::setTabPriorityToView() instead.', E_USER_DEPRECATED);
+
+        $this->parentSetTabPriorityToView($view, $tabPriority);
+    }
+
+    public function addRouterAttributesToBlacklist(array $routerAttributesToBlacklist): ViewBuilderInterface {
+        $oldRouterAttributesToBlacklist = $this->view->getOption('routerAttributesToBlacklist');
+        $newRouterAttributesToBlacklist = $oldRouterAttributesToBlacklist
+            ? array_merge($oldRouterAttributesToBlacklist, $routerAttributesToBlacklist)
+            : $routerAttributesToBlacklist;
+
+        $this->view->setOption('routerAttributesToBlacklist', $newRouterAttributesToBlacklist);
+
+        return $this;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/TabViewBuilderTrait.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/TabViewBuilderTrait.php
@@ -64,7 +64,8 @@ trait TabViewBuilderTrait
         $this->parentSetTabPriorityToView($view, $tabPriority);
     }
 
-    public function addRouterAttributesToBlacklist(array $routerAttributesToBlacklist): ViewBuilderInterface {
+    public function addRouterAttributesToBlacklist(array $routerAttributesToBlacklist): ViewBuilderInterface
+    {
         $oldRouterAttributesToBlacklist = $this->view->getOption('routerAttributesToBlacklist');
         $newRouterAttributesToBlacklist = $oldRouterAttributesToBlacklist
             ? array_merge($oldRouterAttributesToBlacklist, $routerAttributesToBlacklist)

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/TabViewBuilderTrait.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/TabViewBuilderTrait.php
@@ -64,7 +64,7 @@ trait TabViewBuilderTrait
         $this->parentSetTabPriorityToView($view, $tabPriority);
     }
 
-    public function addRouterAttributesToBlacklist(array $routerAttributesToBlacklist): ViewBuilderInterface
+    public function addRouterAttributesToBlacklistToView(array $routerAttributesToBlacklist): void
     {
         $oldRouterAttributesToBlacklist = $this->view->getOption('routerAttributesToBlacklist');
         $newRouterAttributesToBlacklist = $oldRouterAttributesToBlacklist
@@ -72,7 +72,5 @@ trait TabViewBuilderTrait
             : $routerAttributesToBlacklist;
 
         $this->view->setOption('routerAttributesToBlacklist', $newRouterAttributesToBlacklist);
-
-        return $this;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/TabViewChildBuilderTrait.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/TabViewChildBuilderTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Admin\View;
+
+trait TabViewChildBuilderTrait
+{
+    private function setTabTitleToView(View $view, string $tabTitle): void
+    {
+        $view->setOption('tabTitle', $tabTitle);
+    }
+
+    private function setTabConditionToView(View $view, string $tabCondition): void
+    {
+        $view->setOption('tabCondition', $tabCondition);
+    }
+
+    private function setTabOrderToView(View $view, int $tabOrder): void
+    {
+        $view->setOption('tabOrder', $tabOrder);
+    }
+
+    private function setTabPriorityToView(View $view, int $tabPriority): void
+    {
+        $view->setOption('tabPriority', $tabPriority);
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ResourceTabViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ResourceTabViewBuilderTest.php
@@ -43,6 +43,7 @@ class ResourceTabViewBuilderTest extends TestCase
                 'sulu_category.list',
                 null,
                 ['webspace'],
+                null,
                 'title',
             ],
             [
@@ -52,6 +53,7 @@ class ResourceTabViewBuilderTest extends TestCase
                 null,
                 null,
                 ['sortColumn', 'sortOrder'],
+                ['page', 'limit'],
                 null,
             ],
             [
@@ -61,6 +63,7 @@ class ResourceTabViewBuilderTest extends TestCase
                 'sulu_category.list',
                 ['webspace'],
                 null,
+                null,
                 'title',
             ],
             [
@@ -69,6 +72,7 @@ class ResourceTabViewBuilderTest extends TestCase
                 'categories',
                 'sulu_category.list',
                 ['webspace', 'active' => 'id'],
+                null,
                 ['sortColumn', 'sortOrder'],
                 'title',
             ],
@@ -84,7 +88,8 @@ class ResourceTabViewBuilderTest extends TestCase
         string $resourceKey,
         ?string $backView,
         ?array $routerAttributesToBackView,
-        ?array $routerAttributesToBlacklist,
+        ?array $routerAttributesToBlacklist1,
+        ?array $routerAttributesToBlacklist2,
         ?string $titleProperty
     ) {
         $viewBuilder = (new ResourceTabViewBuilder($name, $path))
@@ -102,6 +107,18 @@ class ResourceTabViewBuilderTest extends TestCase
             $viewBuilder->setTitleProperty($titleProperty);
         }
 
+        $expectedRouterAttributesToBlacklist = [];
+
+        if ($routerAttributesToBlacklist1) {
+            $viewBuilder->addRouterAttributesToBlacklist($routerAttributesToBlacklist1);
+            $expectedRouterAttributesToBlacklist = array_merge($expectedRouterAttributesToBlacklist, $routerAttributesToBlacklist1 ?? []);
+        }
+
+        if ($routerAttributesToBlacklist2) {
+            $viewBuilder->addRouterAttributesToBlacklist($routerAttributesToBlacklist2);
+            $expectedRouterAttributesToBlacklist = array_merge($expectedRouterAttributesToBlacklist, $routerAttributesToBlacklist2 ?? []);
+        }
+
         $view = $viewBuilder->getView();
 
         $this->assertSame($name, $view->getName());
@@ -111,6 +128,10 @@ class ResourceTabViewBuilderTest extends TestCase
         $this->assertSame($routerAttributesToBackView, $view->getOption('routerAttributesToBackView'));
         $this->assertSame($titleProperty, $view->getOption('titleProperty'));
         $this->assertSame('sulu_admin.resource_tabs', $view->getType());
+        $this->assertSame(
+            $view->getOption('routerAttributesToBlacklist'),
+            !empty($expectedRouterAttributesToBlacklist) ? $expectedRouterAttributesToBlacklist : null
+        );
     }
 
     public function testBuildFormWithParent()

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/TabViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/TabViewBuilderTest.php
@@ -29,10 +29,26 @@ class TabViewBuilderTest extends TestCase
             [
                 'sulu_category.add_form',
                 '/categories/add',
+                ['webspace'],
+                null,
             ],
             [
                 'sulu_tag.edit_form',
                 '/tags/:id',
+                ['sortColumn', 'sortOrder'],
+                ['page', 'limit'],
+            ],
+            [
+                'sulu_category.add_form',
+                '/categories/add',
+                null,
+                null,
+            ],
+            [
+                'sulu_category.add_form',
+                '/categories/add',
+                null,
+                ['sortColumn', 'sortOrder'],
             ],
         ];
     }
@@ -42,14 +58,33 @@ class TabViewBuilderTest extends TestCase
      */
     public function testBuildTabView(
         string $name,
-        string $path
+        string $path,
+        ?array $routerAttributesToBlacklist1,
+        ?array $routerAttributesToBlacklist2
     ) {
-        $viewBuilder = (new TabViewBuilder($name, $path));
+        $viewBuilder = new TabViewBuilder($name, $path);
+
+        $expectedRouterAttributesToBlacklist = [];
+
+        if ($routerAttributesToBlacklist1) {
+            $viewBuilder->addRouterAttributesToBlacklist($routerAttributesToBlacklist1);
+            $expectedRouterAttributesToBlacklist = array_merge($expectedRouterAttributesToBlacklist, $routerAttributesToBlacklist1 ?? []);
+        }
+
+        if ($routerAttributesToBlacklist2) {
+            $viewBuilder->addRouterAttributesToBlacklist($routerAttributesToBlacklist2);
+            $expectedRouterAttributesToBlacklist = array_merge($expectedRouterAttributesToBlacklist, $routerAttributesToBlacklist2 ?? []);
+        }
+
         $view = $viewBuilder->getView();
 
         $this->assertSame($name, $view->getName());
         $this->assertSame($path, $view->getPath());
         $this->assertSame('sulu_admin.tabs', $view->getType());
+        $this->assertSame(
+            $view->getOption('routerAttributesToBlacklist'),
+            !empty($expectedRouterAttributesToBlacklist) ? $expectedRouterAttributesToBlacklist : null
+        );
     }
 
     public function testBuildFormWithParent()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add method `addRouterAttributesToBlacklist` to `TabViewBuilderInterface`.

#### Why?

Because it's missing in `TabViewBuilder`

#### Example Usage

~~~php
(new TabViewBuilder(...))->addRouterAttributesToBlacklist(['sortColumn', 'sortOrder']);
~~~

#### BC Breaks/Deprecations

A method has been added to `TabViewBuilderInterface`