### PR TITLE
Add BC Layer between symfony 4.3 exception controller and 4.4 error controller

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,26 @@
 
 ## dev-master
 
+### Import of dev error routes changed
+
+The `config/routes/packages/dev/sulu_website.yaml` need to be changed to import the correct error routes based on your symfony version:
+
+**before**
+
+```yaml
+_portal_errors:
+    resource: "@SuluWebsiteBundle/Resources/config/routing_error.yml"
+    type: portal
+```
+
+**after**
+
+```yaml
+_portal_errors:
+    resource: "@SuluWebsiteBundle/Resources/config/routing_error.php"
+    type: portal
+```
+
 ### DoctrineCacheBundle removed
 
 The doctrine cache bundle requirement has been removed from sulu. The DoctrineCacheBundle is

--- a/config/routes/dev/sulu_website.yaml
+++ b/config/routes/dev/sulu_website.yaml
@@ -1,3 +1,3 @@
 _portal_errors:
-    resource: "@SuluWebsiteBundle/Resources/config/routing_error.yml"
+    resource: "@SuluWebsiteBundle/Resources/config/routing_error.php"
     type: portal

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/error_controller.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/error_controller.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <!-- error controller -->
+        <service id="sulu_website.error_controller"
+                 class="Sulu\Bundle\WebsiteBundle\Controller\ErrorController"
+                 public="true">
+            <argument type="service" id="sulu_website.resolver.template_attribute" />
+            <argument type="service" id="twig" />
+            <argument type="service" id="error_renderer" on-invalid="ignore"/>
+            <argument>%kernel.debug%</argument>
+
+            <tag name="sulu.context" context="website"/>
+        </service>
+    </services>
+</container>

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/exception_controller.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/exception_controller.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="sulu_website.exception.controller.class">Sulu\Bundle\WebsiteBundle\Controller\ExceptionController</parameter>
+    </parameters>
+
+    <services>
+        <!-- @deprecated exception controller use "sulu_website.exception_controller" instead -->
+        <service id="sulu_website.exception_controller"
+                 decorates="twig.controller.exception"
+                 class="Sulu\Bundle\WebsiteBundle\Controller\ExceptionController">
+            <deprecated>The "%service_id%" service is deprecated since sulu/sulu 2.1 and will be removed in 3.0 use "sulu_website.exception_controller" instead.</deprecated>
+
+            <argument type="service" id="sulu_website.exception_controller.inner"/>
+            <argument type="service" id="sulu_core.webspace.request_analyzer"/>
+            <argument type="service" id="sulu_website.resolver.parameter" />
+            <argument type="service" id="twig" />
+            <argument>%kernel.debug%</argument>
+
+            <tag name="sulu.context" context="website"/>
+        </service>
+
+        <service id="sulu_website.exception.controller" alias="twig.controller.exception" public="true" />
+    </services>
+</container>

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/routing_error.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/routing_error.php
@@ -1,0 +1,14 @@
+<?php
+
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+use Symfony\Component\HttpKernel\Controller\ErrorController;
+
+return function (RoutingConfigurator $routes) {
+    if (class_exists(ErrorController::class)) {
+        $routes->import('@FrameworkBundle/Resources/config/routing/errors.xml')
+            ->prefix('/_error');
+    } else {
+        $routes->import('@TwigBundle/Resources/config/routing/errors.xml')
+            ->prefix('/_error');
+    }
+};

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/routing_error.yml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/routing_error.yml
@@ -1,3 +1,0 @@
-_errors:
-    resource: "@TwigBundle/Resources/config/routing/errors.xml"
-    prefix:   /_error

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -18,7 +18,6 @@
         <parameter key="sulu_website.twig.seo.class">Sulu\Bundle\WebsiteBundle\Twig\Seo\SeoTwigExtension</parameter>
         <parameter key="sulu_website.twig.util.class">Sulu\Bundle\WebsiteBundle\Twig\Core\UtilTwigExtension</parameter>
         <parameter key="sulu_website.routing.portal_loader.class">Sulu\Bundle\WebsiteBundle\Routing\PortalLoader</parameter>
-        <parameter key="sulu_website.exception.controller.class">Sulu\Bundle\WebsiteBundle\Controller\ExceptionController</parameter>
         <parameter key="sulu_website.resolver.request_analyzer.class">Sulu\Bundle\WebsiteBundle\Resolver\RequestAnalyzerResolver</parameter>
         <parameter key="sulu_website.resolver.structure.class">Sulu\Bundle\WebsiteBundle\Resolver\StructureResolver</parameter>
         <parameter key="sulu_website.resolver.parameter.class">Sulu\Bundle\WebsiteBundle\Resolver\ParameterResolver</parameter>
@@ -224,21 +223,6 @@
             <argument type="service" id="sulu_core.webspace.request_analyzer" />
             <tag name="kernel.event_listener" event="kernel.request" method="onRequest" priority="31" />
         </service>
-
-        <!-- exception controller -->
-        <service id="sulu_website.exception_controller"
-                 decorates="twig.controller.exception"
-                 class="Sulu\Bundle\WebsiteBundle\Controller\ExceptionController">
-            <argument type="service" id="sulu_website.exception_controller.inner"/>
-            <argument type="service" id="sulu_core.webspace.request_analyzer"/>
-            <argument type="service" id="sulu_website.resolver.parameter" />
-            <argument type="service" id="twig" />
-            <argument>%kernel.debug%</argument>
-
-            <tag name="sulu.context" context="website"/>
-        </service>
-
-        <service id="sulu_website.exception.controller" alias="twig.controller.exception" public="true" />
 
         <!-- cache clearer -->
         <service id="sulu_website.http_cache.clearer" class="Sulu\Bundle\WebsiteBundle\Cache\CacheClearer" public="true">


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes 
| Related issues/PRs | part of  #4798
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Adds a new ErrorController based on the new `error_renderer` component of symfony.

#### Why?

The TwigBundle ExceptionController will be removed in Symfony 5.

#### BC Breaks/Deprecations

Describe BC breaks/deprecations here. (remove this section if not needed)

#### To Do

- [ ] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md
