### PR TITLE
Get ride of usage of kernel.root_dir

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Tests/Application/config/config.yml
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Application/config/config.yml
@@ -8,7 +8,7 @@ sulu_media:
         response_headers:
             Expires: "+1 month"
     image_format_files:
-        - "%kernel.root_dir%/config/image-formats.xml"
+        - "%kernel.project_dir%/config/image-formats.xml"
     ffmpeg:
         ffmpeg_binary: '/usr/local/bin/ffmpeg'
         ffprobe_binary: '/usr/local/bin/ffmprobe'

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/DependencyInjection/SuluMediaExtensionTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/DependencyInjection/SuluMediaExtensionTest.php
@@ -39,7 +39,6 @@ class SuluMediaExtensionTest extends AbstractExtensionTestCase
     public function testLoad()
     {
         $this->executableFinder->find(Argument::any())->willReturn(true);
-        $this->container->setParameter('kernel.root_dir', __DIR__);
         $this->container->setParameter('kernel.bundles', []);
 
         $this->load(

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/config.yml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/config.yml
@@ -3,7 +3,7 @@ sulu_core:
         structure:
              paths:
                  internal:
-                     path: "%kernel.root_dir%/../../src/Sulu/Bundle/CoreBundle/Content/templates"
+                     path: "%kernel.project_dir%/../../src/Sulu/Bundle/CoreBundle/Content/templates"
                      type: "page"
 
 services:

--- a/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
+++ b/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
@@ -113,7 +113,8 @@ class SuluTestKernel extends SuluKernel
     public function getProjectDir()
     {
         if (null === $this->projectDir) {
-            $this->projectDir = $this->rootDir;
+            $r = new \ReflectionObject($this);
+            $this->projectDir = \dirname($r->getFileName());
         }
 
         return $this->projectDir;

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
@@ -16,7 +16,7 @@ doctrine:
             gedmo_tree:
                 type: xml
                 prefix: Gedmo\Tree\Entity
-                dir: '%kernel.root_dir%/../../../../../../vendor/gedmo/doctrine-extensions/lib/Gedmo/Tree/Entity'
+                dir: '%kernel.project_dir%/../../../../../../vendor/gedmo/doctrine-extensions/lib/Gedmo/Tree/Entity'
                 alias: GedmoTree
                 is_bundle: false
     dbal:


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | https://github.com/sulu/sulu/pull/4798
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Get ride of usage of kernel.root_dir.

#### Why?

The kernel.root_dir is deprecated, as the test SuluTestKernel did use it as project_dir I copied there logic the from Symfony 4.4 https://github.com/symfony/symfony/blob/3aa7f0c5bfc108161bce6e2e8bf74fe696f49af2/src/Symfony/Component/HttpKernel/Kernel.php#L346-L347 to avoid breaking TestKernels.

