### PR TITLE
Extend sulu event from new event class

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,12 @@
 
 ## dev-master
 
+### Event classes changed
+
+The Sulu `Event` classes extend now from the new `Symfony\Contracts\EventDispatcher\Event`
+class instead of the deprecated `Symfony\Component\EventDispatcher\Event`.
+If you have code depending on the old class you need to update it.
+
 ### DoctrineCacheBundle removed
 
 The doctrine cache bundle requirement has been removed from sulu. The DoctrineCacheBundle is

--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,7 @@
         "symfony/dependency-injection": "^4.4",
         "symfony/dom-crawler": "^4.4",
         "symfony/event-dispatcher": "^4.4",
+        "symfony/event-dispatcher-contracts": "^1.0 || ^2.0",
         "symfony/expression-language": "^4.4",
         "symfony/filesystem": "^4.4",
         "symfony/finder": "^4.4",

--- a/src/Sulu/Bundle/CategoryBundle/Event/CategoryDeleteEvent.php
+++ b/src/Sulu/Bundle/CategoryBundle/Event/CategoryDeleteEvent.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\CategoryBundle\Event;
 
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * An object of this class is thrown along with the category.delete event.

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Events/PreRenderEvent.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Events/PreRenderEvent.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\PreviewBundle\Preview\Events;
 
 use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * This event is thrown right before a preview will be rendered.

--- a/src/Sulu/Bundle/SearchBundle/Search/Event/StructureMetadataLoadEvent.php
+++ b/src/Sulu/Bundle/SearchBundle/Search/Event/StructureMetadataLoadEvent.php
@@ -13,7 +13,7 @@ namespace Sulu\Bundle\SearchBundle\Search\Event;
 
 use Massive\Bundle\SearchBundle\Search\Metadata\IndexMetadata;
 use Sulu\Component\Content\Compat\StructureInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Event which is fired when the Sulu Structure metadata driver

--- a/src/Sulu/Bundle/TagBundle/Event/TagDeleteEvent.php
+++ b/src/Sulu/Bundle/TagBundle/Event/TagDeleteEvent.php
@@ -13,7 +13,7 @@ namespace Sulu\Bundle\TagBundle\Event;
 
 use Sulu\Bundle\TagBundle\Entity\Tag;
 use Sulu\Bundle\TagBundle\Tag\TagInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * An object of this class is thrown along with the tag.delete event.

--- a/src/Sulu/Bundle/TagBundle/Event/TagMergeEvent.php
+++ b/src/Sulu/Bundle/TagBundle/Event/TagMergeEvent.php
@@ -13,7 +13,7 @@ namespace Sulu\Bundle\TagBundle\Event;
 
 use Sulu\Bundle\TagBundle\Entity\Tag;
 use Sulu\Bundle\TagBundle\Tag\TagInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * An object of this class is thrown along with the tag.merge event.

--- a/src/Sulu/Component/Content/Mapper/Event/ContentNodeDeleteEvent.php
+++ b/src/Sulu/Component/Content/Mapper/Event/ContentNodeDeleteEvent.php
@@ -15,8 +15,8 @@ use PHPCR\NodeInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\Util\SuluNodeHelper;
-use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\Validator\Mapping\MetadataInterface;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * This event is thrown when a node is deleted.

--- a/src/Sulu/Component/Content/Mapper/Event/ContentNodeEvent.php
+++ b/src/Sulu/Component/Content/Mapper/Event/ContentNodeEvent.php
@@ -13,7 +13,7 @@ namespace Sulu\Component\Content\Mapper\Event;
 
 use PHPCR\NodeInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * An instance of this class is thrown along with the sulu.content.node.save event.

--- a/src/Sulu/Component/Content/Mapper/Event/ContentNodeOrderEvent.php
+++ b/src/Sulu/Component/Content/Mapper/Event/ContentNodeOrderEvent.php
@@ -12,7 +12,7 @@
 namespace Sulu\Component\Content\Mapper\Event;
 
 use PHPCR\NodeInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Event class for the ContentEvents::NODE_ORDER event.

--- a/src/Sulu/Component/DocumentManager/Event/AbstractEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/AbstractEvent.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Component\DocumentManager\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 abstract class AbstractEvent extends Event
 {

--- a/src/Sulu/Component/DocumentManager/EventDispatcher/DebugEventDispatcher.php
+++ b/src/Sulu/Component/DocumentManager/EventDispatcher/DebugEventDispatcher.php
@@ -13,7 +13,6 @@ namespace Sulu\Component\DocumentManager\EventDispatcher;
 
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Stopwatch\Stopwatch;
 
@@ -44,7 +43,7 @@ class DebugEventDispatcher extends EventDispatcher
         $this->logger = $logger ?: new NullLogger();
     }
 
-    protected function doDispatch($listeners, $eventName, Event $event)
+    protected function doDispatch($listeners, $eventName, $event)
     {
         $eventStopwatch = $this->stopwatch->start($eventName, 'section');
 

--- a/src/Sulu/Component/Rest/ListBuilder/Event/ListBuilderCreateEvent.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Event/ListBuilderCreateEvent.php
@@ -12,7 +12,7 @@
 namespace Sulu\Component\Rest\ListBuilder\Event;
 
 use Sulu\Component\Rest\ListBuilder\ListBuilderInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * An object of this class is emitted along with the listbuilder.create event.

--- a/src/Sulu/Component/Security/Event/PermissionUpdateEvent.php
+++ b/src/Sulu/Component/Security/Event/PermissionUpdateEvent.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Component\Security\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * This event is dispatched when the permissions of an object have been updated.


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | part of https://github.com/sulu/sulu/pull/4798
| License | MIT
| Documentation PR | -

#### What's in this PR?

Extend sulu event from new event class. ~~This is no BC Break as the new class does extend the old one in symfony 4.3 and 4.4.~~

#### Why?

The Symfony Component Event was deprecated in 4.3 and moved the event contracts.

