### PR TITLE
Update usage of new kernel event classes

### DIFF
--- a/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/DeviceDetectorSubscriber.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/DeviceDetectorSubscriber.php
@@ -13,7 +13,7 @@ namespace Sulu\Bundle\AudienceTargetingBundle\EventListener;
 
 use DeviceDetector\DeviceDetector;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 class DeviceDetectorSubscriber implements EventSubscriberInterface
@@ -37,7 +37,7 @@ class DeviceDetectorSubscriber implements EventSubscriberInterface
         ];
     }
 
-    public function setUserAgent(GetResponseEvent $event)
+    public function setUserAgent(RequestEvent $event)
     {
         $this->deviceDetector->setUserAgent($event->getRequest()->headers->get('User-Agent'));
         $this->deviceDetector->parse();

--- a/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/TargetGroupSubscriber.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/TargetGroupSubscriber.php
@@ -18,8 +18,8 @@ use Sulu\Bundle\AudienceTargetingBundle\TargetGroup\TargetGroupStoreInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Twig\Environment;
 
@@ -149,7 +149,7 @@ class TargetGroupSubscriber implements EventSubscriberInterface
      * Evaluates the cookie holding the target group information. This has only an effect if there is no cache used,
      * since in that case the cache already did it.
      */
-    public function setTargetGroup(GetResponseEvent $event)
+    public function setTargetGroup(RequestEvent $event)
     {
         $request = $event->getRequest();
 
@@ -187,7 +187,7 @@ class TargetGroupSubscriber implements EventSubscriberInterface
     /**
      * Adds the vary header on the response, so that the cache takes the target group into account.
      */
-    public function addVaryHeader(FilterResponseEvent $event)
+    public function addVaryHeader(ResponseEvent $event)
     {
         $request = $event->getRequest();
         $response = $event->getResponse();
@@ -201,7 +201,7 @@ class TargetGroupSubscriber implements EventSubscriberInterface
      * Adds the SetCookie header for the target group, if the user context has changed. In addition to that a second
      * cookie without a lifetime is set, whose expiration marks a new session.
      */
-    public function addSetCookieHeader(FilterResponseEvent $event)
+    public function addSetCookieHeader(ResponseEvent $event)
     {
         if (!$this->targetGroupStore->hasChangedTargetGroup()
             || $event->getRequest()->getPathInfo() === $this->targetGroupUrl
@@ -230,7 +230,7 @@ class TargetGroupSubscriber implements EventSubscriberInterface
     /**
      * Adds a script for triggering an ajax request, which updates the target group on every hit.
      */
-    public function addTargetGroupHitScript(FilterResponseEvent $event)
+    public function addTargetGroupHitScript(ResponseEvent $event)
     {
         $request = $event->getRequest();
         $response = $event->getResponse();

--- a/src/Sulu/Bundle/MarkupBundle/Listener/MarkupListener.php
+++ b/src/Sulu/Bundle/MarkupBundle/Listener/MarkupListener.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\MarkupBundle\Listener;
 
 use Sulu\Bundle\MarkupBundle\Markup\MarkupParserInterface;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 
 /**
  * Parses content of response and set the replaced html as new content.
@@ -35,7 +35,7 @@ class MarkupListener
     /**
      * Parses content of response and set the replaced html as new content.
      */
-    public function replaceMarkup(FilterResponseEvent $event)
+    public function replaceMarkup(ResponseEvent $event)
     {
         $request = $event->getRequest();
         $response = $event->getResponse();

--- a/src/Sulu/Bundle/SecurityBundle/EventListener/SuluSecurityListener.php
+++ b/src/Sulu/Bundle/SecurityBundle/EventListener/SuluSecurityListener.php
@@ -16,7 +16,7 @@ use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Sulu\Component\Security\Authorization\SecurityCondition;
 use Sulu\Component\Security\SecuredControllerInterface;
-use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
@@ -39,7 +39,7 @@ class SuluSecurityListener
      *
      * @throws AccessDeniedException
      */
-    public function onKernelController(FilterControllerEvent $event)
+    public function onKernelController(ControllerEvent $event)
     {
         $controller = $event->getController();
         $action = '__invoke';

--- a/src/Sulu/Bundle/SecurityBundle/EventListener/UserLocaleListener.php
+++ b/src/Sulu/Bundle/SecurityBundle/EventListener/UserLocaleListener.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\SecurityBundle\EventListener;
 
 use Sulu\Component\Security\Authentication\UserInterface;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -50,7 +50,7 @@ class UserLocaleListener
     /**
      * Sets the locale of the current User to the request, if a User is logged in.
      */
-    public function copyUserLocaleToRequest(GetResponseEvent $event)
+    public function copyUserLocaleToRequest(RequestEvent $event)
     {
         $token = $this->tokenStorage->getToken();
         if (!$token) {

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
@@ -14,7 +14,7 @@ namespace Sulu\Bundle\WebsiteBundle\EventListener;
 use Sulu\Bundle\WebsiteBundle\Entity\Analytics;
 use Sulu\Bundle\WebsiteBundle\Entity\AnalyticsRepository;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Twig\Environment;
 
 /**
@@ -86,7 +86,7 @@ class AppendAnalyticsListener
     /**
      * Appends analytics scripts into body.
      */
-    public function onResponse(FilterResponseEvent $event)
+    public function onResponse(ResponseEvent $event)
     {
         if ($this->preview) {
             return;

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/RedirectExceptionSubscriber.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/RedirectExceptionSubscriber.php
@@ -19,7 +19,7 @@ use Sulu\Component\Webspace\Url\ReplacerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
@@ -75,9 +75,9 @@ class RedirectExceptionSubscriber implements EventSubscriberInterface
     /**
      * Redirect trailing slashes or ".html".
      */
-    public function redirectTrailingSlashOrHtml(GetResponseForExceptionEvent $event)
+    public function redirectTrailingSlashOrHtml(ExceptionEvent $event)
     {
-        if (!$event->getException() instanceof NotFoundHttpException) {
+        if (!$event->getThrowable() instanceof NotFoundHttpException) {
             return;
         }
 
@@ -106,9 +106,9 @@ class RedirectExceptionSubscriber implements EventSubscriberInterface
     /**
      * Redirect partial and redirect matches.
      */
-    public function redirectPartialMatch(GetResponseForExceptionEvent $event)
+    public function redirectPartialMatch(ExceptionEvent $event)
     {
-        if (!$event->getException() instanceof NotFoundHttpException) {
+        if (!$event->getThrowable() instanceof NotFoundHttpException) {
             return;
         }
 

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/RouterListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/RouterListener.php
@@ -14,7 +14,7 @@ namespace Sulu\Bundle\WebsiteBundle\EventListener;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\EventListener\RouterListener as BaseRouterListener;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -47,7 +47,7 @@ class RouterListener implements EventSubscriberInterface
      * Analyzes the request before passing the event to the default RouterListener from symfony and validates the result
      * afterwards.
      */
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(RequestEvent $event)
     {
         $request = $event->getRequest();
 

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/TranslatorListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/TranslatorListener.php
@@ -14,7 +14,7 @@ namespace Sulu\Bundle\WebsiteBundle\EventListener;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Translation\Translator;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
@@ -31,7 +31,7 @@ class TranslatorListener implements EventSubscriberInterface
         $this->translator = $translator;
     }
 
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(RequestEvent $event)
     {
         $attributes = $event->getRequest()->attributes->get('_sulu');
 

--- a/src/Sulu/Bundle/WebsiteBundle/EventSubscriber/GeneratorEventSubscriber.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventSubscriber/GeneratorEventSubscriber.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\WebsiteBundle\EventSubscriber;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -40,7 +40,7 @@ class GeneratorEventSubscriber implements EventSubscriberInterface
         ];
     }
 
-    public function onResponse(FilterResponseEvent $event)
+    public function onResponse(ResponseEvent $event)
     {
         $event->getResponse()->headers->set('X-Generator', 'Sulu/' . $this->version);
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/RequestListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/RequestListener.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\WebsiteBundle\Routing;
 
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Routing\RouterInterface;
 
 class RequestListener
@@ -33,7 +33,7 @@ class RequestListener
         $this->requestAnalyzer = $requestAnalyzer;
     }
 
-    public function onRequest(GetResponseEvent $event)
+    public function onRequest(RequestEvent $event)
     {
         $context = $this->router->getContext();
         $portalInformation = $this->requestAnalyzer->getPortalInformation();

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListenerTest.php
@@ -22,7 +22,8 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
@@ -50,17 +51,15 @@ class AppendAnalyticsListenerTest extends TestCase
             'prod'
         );
 
-        $event = $this->prophesize(FilterResponseEvent::class);
         $request = $this->prophesize(Request::class);
-        $event->getRequest()->willReturn($request->reveal());
         $request->getRequestFormat()->willReturn($format);
         $response = $this->prophesize(Response::class);
         $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/plain']);
         $response->getContent()->shouldNotBeCalled();
         $requestAnalyzer->getPortalInformation()->shouldNotBeCalled();
-        $event->getResponse()->willReturn($response->reveal());
+        $event = $this->createResponseEvent($request->reveal(), $response->reveal());
 
-        $listener->onResponse($event->reveal());
+        $listener->onResponse($event);
 
         $engine->render(Argument::any(), Argument::any())->shouldNotBeCalled();
         $response->setContent(Argument::any())->shouldNotBeCalled();
@@ -78,17 +77,15 @@ class AppendAnalyticsListenerTest extends TestCase
             'prod'
         );
 
-        $event = $this->prophesize(FilterResponseEvent::class);
         $request = $this->prophesize(Request::class);
-        $event->getRequest()->willReturn($request->reveal());
         $request->getRequestFormat()->willReturn('html');
         $response = $this->prophesize(BinaryFileResponse::class);
         $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/html']);
         $response->getContent()->willReturn(false)->shouldBeCalled();
         $requestAnalyzer->getPortalInformation()->shouldNotBeCalled();
-        $event->getResponse()->willReturn($response->reveal());
+        $event = $this->createResponseEvent($request->reveal(), $response->reveal());
 
-        $listener->onResponse($event->reveal());
+        $listener->onResponse($event);
 
         $engine->render(Argument::any(), Argument::any())->shouldNotBeCalled();
         $response->setContent(Argument::any())->shouldNotBeCalled();
@@ -118,13 +115,11 @@ class AppendAnalyticsListenerTest extends TestCase
             'prod'
         );
 
-        $event = $this->prophesize(FilterResponseEvent::class);
         $request = $this->prophesize(Request::class);
-        $event->getRequest()->willReturn($request->reveal());
         $request->getRequestFormat()->willReturn('html');
         $response = $this->prophesize(Response::class);
         $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/html']);
-        $event->getResponse()->willReturn($response->reveal());
+        $event = $this->createResponseEvent($request->reveal(), $response->reveal());
 
         $loader = $this->prophesize(FilesystemLoader::class);
         $engine->getLoader()->shouldBeCalled()->willReturn($loader->reveal());
@@ -149,7 +144,7 @@ class AppendAnalyticsListenerTest extends TestCase
         $response->setContent(
             '<html><head><title>Test</title><script>var i = 0;</script></head><body><h1>Title</h1></body></html>'
         )->shouldBeCalled();
-        $listener->onResponse($event->reveal());
+        $listener->onResponse($event);
     }
 
     public function testAppendWildcard()
@@ -176,15 +171,13 @@ class AppendAnalyticsListenerTest extends TestCase
             'prod'
         );
 
-        $event = $this->prophesize(FilterResponseEvent::class);
         $request = $this->prophesize(Request::class);
-        $event->getRequest()->willReturn($request->reveal());
         $request->getRequestFormat()->willReturn('html');
         $request->getHost()->willReturn('1.sulu.lo');
         $request->getRequestUri()->willReturn('/2');
         $response = $this->prophesize(Response::class);
         $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/html']);
-        $event->getResponse()->willReturn($response->reveal());
+        $event = $this->createResponseEvent($request->reveal(), $response->reveal());
 
         $loader = $this->prophesize(FilesystemLoader::class);
         $engine->getLoader()->shouldBeCalled()->willReturn($loader->reveal());
@@ -210,7 +203,7 @@ class AppendAnalyticsListenerTest extends TestCase
             '<html><head><title>Test</title><script>var i = 0;</script></head><body><h1>Title</h1></body></html>'
         )->shouldBeCalled();
 
-        $listener->onResponse($event->reveal());
+        $listener->onResponse($event);
     }
 
     public function testAppendGoogleTagManager()
@@ -237,13 +230,11 @@ class AppendAnalyticsListenerTest extends TestCase
             'prod'
         );
 
-        $event = $this->prophesize(FilterResponseEvent::class);
         $request = $this->prophesize(Request::class);
-        $event->getRequest()->willReturn($request->reveal());
         $request->getRequestFormat()->willReturn('html');
         $response = $this->prophesize(Response::class);
         $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/html']);
-        $event->getResponse()->willReturn($response->reveal());
+        $event = $this->createResponseEvent($request->reveal(), $response->reveal());
 
         $loader = $this->prophesize(FilesystemLoader::class);
         $engine->getLoader()->shouldBeCalled()->willReturn($loader->reveal());
@@ -269,7 +260,7 @@ class AppendAnalyticsListenerTest extends TestCase
         $response->setContent(
             '<html><head><script>var i = 0;</script><title>Test</title></head><body class="test"><noscript><div>Blabla</div></noscript><h1>Title</h1></body></html>'
         )->shouldBeCalled();
-        $listener->onResponse($event->reveal());
+        $listener->onResponse($event);
     }
 
     public function testAppendPiwik()
@@ -296,13 +287,11 @@ class AppendAnalyticsListenerTest extends TestCase
             'prod'
         );
 
-        $event = $this->prophesize(FilterResponseEvent::class);
         $request = $this->prophesize(Request::class);
-        $event->getRequest()->willReturn($request->reveal());
         $request->getRequestFormat()->willReturn('html');
         $response = $this->prophesize(Response::class);
         $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/html']);
-        $event->getResponse()->willReturn($response->reveal());
+        $event = $this->createResponseEvent($request->reveal(), $response->reveal());
 
         $loader = $this->prophesize(FilesystemLoader::class);
         $engine->getLoader()->shouldBeCalled()->willReturn($loader->reveal());
@@ -328,7 +317,7 @@ class AppendAnalyticsListenerTest extends TestCase
         $response->setContent(
             '<html><head><title>Test</title><script>var i = 0;</script></head><body class="test"><noscript><div>Blabla</div></noscript><h1>Title</h1></body></html>'
         )->shouldBeCalled();
-        $listener->onResponse($event->reveal());
+        $listener->onResponse($event);
     }
 
     public function testAppendCustom()
@@ -355,13 +344,11 @@ class AppendAnalyticsListenerTest extends TestCase
             'prod'
         );
 
-        $event = $this->prophesize(FilterResponseEvent::class);
         $request = $this->prophesize(Request::class);
-        $event->getRequest()->willReturn($request->reveal());
         $request->getRequestFormat()->willReturn('html');
         $response = $this->prophesize(Response::class);
         $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/html']);
-        $event->getResponse()->willReturn($response->reveal());
+        $event = $this->createResponseEvent($request->reveal(), $response->reveal());
 
         $loader = $this->prophesize(FilesystemLoader::class);
         $engine->getLoader()->shouldBeCalled()->willReturn($loader->reveal());
@@ -387,7 +374,7 @@ class AppendAnalyticsListenerTest extends TestCase
         $response->setContent(
             '<html><head maybe-a-attribute-here="true"><script>var nice_var = false;</script><title>Test</title></head><body><header><h1>Title</h1></header></body></html>'
         )->shouldBeCalled();
-        $listener->onResponse($event->reveal());
+        $listener->onResponse($event);
     }
 
     public function testAppendPreview()
@@ -405,10 +392,24 @@ class AppendAnalyticsListenerTest extends TestCase
             true
         );
 
-        $event = $this->prophesize(FilterResponseEvent::class);
-        $event->getRequest()->shouldNotBeCalled();
-        $event->getResponse()->shouldNotBeCalled();
+        $request = $this->prophesize(Request::class);
+        $request->getRequestFormat()->shouldNotBeCalled();
+        $response = $this->prophesize(Response::class);
+        $response->getContent()->shouldNotBeCalled();
+        $event = $this->createResponseEvent($request->reveal(), $response->reveal());
 
-        $listener->onResponse($event->reveal());
+        $listener->onResponse($event);
+    }
+
+    private function createResponseEvent(Request $request, Response $response): ResponseEvent
+    {
+        $kernel = $this->prophesize(HttpKernelInterface::class);
+
+        return new ResponseEvent(
+            $kernel->reveal(),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            $response
+        );
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | https://github.com/sulu/sulu/pull/4798
| License | MIT
| Documentation PR | -

#### What's in this PR?

Update usage of new kernel event classes.

#### Why?

The old classes are deprecated since symfony 4.3 so and the new classes extends from the old one so you have on the event classes access to the same.

#### BC Breaks/Deprecations

Describe BC breaks/deprecations here. (remove this section if not needed)

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
