### PR TITLE
Fix SuluCollector compatibility

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
@@ -24,7 +24,7 @@ class SuluCollector extends DataCollector
         return $this->data[$key];
     }
 
-    public function collect(Request $request, Response $response, \Exception $exception = null)
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null)
     {
         if (!$request->attributes->has('_sulu')) {
             return;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | part of https://github.com/sulu/sulu/pull/4798
| License | MIT
| Documentation PR | -

#### What's in this PR?

Update symfony/http-kernel and fix SuluCollector compatibility.

#### Why?

PHP 7.2 and 7.3 does not support override a function with less specified type. (Covariance and Contravariance in PHP)[https://www.php.net/manual/en/language.oop5.variance.php]. So to get around this error we would need to upgrade http-kernel to 4.4. EDIT: update was done in #5238 