### PR TITLE
Remove navigation context from homepage

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Resources/config/forms/page_settings.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/forms/page_settings.xml
@@ -52,7 +52,7 @@
             name="navContexts"
             type="page_settings_navigation_select"
             colspan="6"
-            visibleCondition="shadowOn == false"
+            visibleCondition="shadowOn == false &amp;&amp; path != ''"
         >
             <meta>
                 <title>sulu_page.show_page_in</title>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | related to #1527
| License | MIT
| Documentation PR | -

#### What's in this PR?

Remove navigation context from homepage.

#### Why?

Currently the homepage is never shown so we should hide that option from the settings tab for the homepage.
