### PR TITLE
Remove old controller reference syntax

### DIFF
--- a/config/templates/pages/example.xml
+++ b/config/templates/pages/example.xml
@@ -6,7 +6,7 @@
     <key>example</key>
 
     <view>pages/example</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>604800</cacheLifetime>
 
     <meta>

--- a/config/templates/pages/homepage.xml
+++ b/config/templates/pages/homepage.xml
@@ -6,7 +6,7 @@
     <key>homepage</key>
 
     <view>pages/homepage</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>86400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/default.xml
@@ -8,7 +8,7 @@
     <key>default</key>
 
     <view>ClientWebsiteBundle:templates:animals</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Application/config/templates/pages/default.xml
@@ -8,7 +8,7 @@
     <key>default</key>
 
     <view>ClientWebsiteBundle:templates:default</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Application/config/templates/pages/default.xml
@@ -8,7 +8,7 @@
     <key>default</key>
 
     <view>ClientWebsiteBundle:templates:animals</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/ContactBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Application/config/templates/pages/default.xml
@@ -8,7 +8,7 @@
     <key>default</key>
 
     <view>ClientWebsiteBundle:templates:animals</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/CoreBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/CoreBundle/Tests/Application/config/templates/pages/default.xml
@@ -8,7 +8,7 @@
     <key>default</key>
 
     <view>ClientWebsiteBundle:templates:animals</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Application/config/templates/pages/default.xml
@@ -7,7 +7,7 @@
     <key>default</key>
 
     <view>ClientWebsiteBundle:templates:default</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Application/config/templates/pages/overview.xml
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Application/config/templates/pages/overview.xml
@@ -7,7 +7,7 @@
     <key>overview</key>
 
     <view>ClientWebsiteBundle:templates:overview</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/MediaBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Application/config/templates/pages/default.xml
@@ -7,7 +7,7 @@
     <key>default</key>
 
     <view>ClientWebsiteBundle:templates:default</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/MediaBundle/Tests/Application/config/templates/pages/images.xml
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Application/config/templates/pages/images.xml
@@ -7,7 +7,7 @@
     <key>images</key>
 
     <view>ClientWebsiteBundle:templates:default</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/MediaBundle/Tests/Application/config/templates/pages/overview.xml
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Application/config/templates/pages/overview.xml
@@ -7,7 +7,7 @@
     <key>overview</key>
 
     <view>ClientWebsiteBundle:templates:default</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/MediaBundle/Tests/Fixtures/DefaultStructureCache.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Fixtures/DefaultStructureCache.php
@@ -24,7 +24,7 @@ class DefaultStructureCache extends \Sulu\Component\Content\Metadata
 {
     public function __construct()
     {
-        parent::__construct('default', 'ClientWebsiteBundle:templates:default.html.twig', 'SuluWebsiteBundle:Default:index', '2400');
+        parent::__construct('default', 'ClientWebsiteBundle:templates:default.html.twig', 'Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction', '2400');
 
         $prop1 = new Property(
             'title',

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/article.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/article.xml
@@ -6,7 +6,7 @@
     <key>article</key>
 
     <view>default</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <properties>

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/block.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/block.xml
@@ -6,7 +6,7 @@
     <key>block</key>
 
     <view>default</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <properties>

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/blocks.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/blocks.xml
@@ -7,7 +7,7 @@
     <key>blocks</key>
 
     <view>ClientWebsiteBundle:templates:default</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/complex.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/complex.xml
@@ -8,7 +8,7 @@
     <key>complex</key>
 
     <view>ClientWebsiteBundle:templates:animals</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/default.xml
@@ -4,13 +4,13 @@
           xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template.xsd">
 
     <key>default</key>
-    
+
     <meta>
         <title lang="en">Standard page</title>
     </meta>
 
     <view>default</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <properties>

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/html5.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/html5.xml
@@ -6,7 +6,7 @@
     <key>html5</key>
 
     <view>html5</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <properties>

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/internal_link.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/internal_link.xml
@@ -8,7 +8,7 @@
     <key>internal_link</key>
 
     <view>ClientWebsiteBundle:templates:animals</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/internal_link_page.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/internal_link_page.xml
@@ -8,7 +8,7 @@
     <key>internal_link_page</key>
 
     <view>ClientWebsiteBundle:templates:animals</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/internallinks.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/internallinks.xml
@@ -6,7 +6,7 @@
     <key>internallinks</key>
 
     <view>default</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <properties>

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/invalidhtml.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/invalidhtml.xml
@@ -6,7 +6,7 @@
     <key>invalidhtml</key>
 
     <view>invalidhtml</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <properties>

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/mandatory.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/mandatory.xml
@@ -8,7 +8,7 @@
     <key>mandatory</key>
 
     <view>ClientWebsiteBundle:templates:animals</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/overview.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/overview.xml
@@ -6,7 +6,7 @@
     <key>overview</key>
 
     <view>overview</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <properties>

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/section.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/section.xml
@@ -8,7 +8,7 @@
     <key>section</key>
 
     <view>ClientWebsiteBundle:templates:animals</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/simple.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/simple.xml
@@ -6,7 +6,7 @@
     <key>simple</key>
 
     <view>default</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <properties>

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/singleinternallink.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/singleinternallink.xml
@@ -6,7 +6,7 @@
     <key>singleinternallink</key>
 
     <view>default</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <properties>

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/smartcontent.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/smartcontent.xml
@@ -6,7 +6,7 @@
     <key>smartcontent</key>
 
     <view>smartcontent</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <properties>

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/teasers.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/teasers.xml
@@ -6,7 +6,7 @@
     <key>teasers</key>
 
     <view>::teasers</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <properties>

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/test_page.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/test_page.xml
@@ -8,7 +8,7 @@
     <key>test_page</key>
 
     <view>ClientWebsiteBundle:templates:animals</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/with_snippet.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/with_snippet.xml
@@ -8,7 +8,7 @@
     <key>with_snippet</key>
 
     <view>ClientWebsiteBundle:templates:animals</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/PersistenceBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/PersistenceBundle/Tests/Application/config/templates/pages/default.xml
@@ -8,7 +8,7 @@
     <key>default</key>
 
     <view>ClientWebsiteBundle:templates:animals</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Application/config/templates/pages/default.xml
@@ -6,7 +6,7 @@
     <key>default</key>
 
     <view>::default</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <properties>

--- a/src/Sulu/Bundle/RouteBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Application/config/templates/pages/default.xml
@@ -8,7 +8,7 @@
     <key>default</key>
 
     <view>ClientWebsiteBundle:templates:animals</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/SearchBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Application/config/templates/pages/default.xml
@@ -8,7 +8,7 @@
     <key>default</key>
 
     <view>ClientWebsiteBundle:templates:animals</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Application/config/templates/pages/default.xml
@@ -8,7 +8,7 @@
     <key>default</key>
 
     <view>ClientWebsiteBundle:templates:animals</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Application/config/templates/pages/default.xml
@@ -8,7 +8,7 @@
     <key>hotel_page</key>
 
     <view>ClientWebsiteBundle:templates:default</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Application/config/templates/pages/hotel_page.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Application/config/templates/pages/hotel_page.xml
@@ -8,7 +8,7 @@
     <key>hotel_page</key>
 
     <view>ClientWebsiteBundle:templates:default</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Application/config/templates/pages/overview.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Application/config/templates/pages/overview.xml
@@ -6,7 +6,7 @@
     <key>overview</key>
 
     <view>::overview</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <properties>

--- a/src/Sulu/Bundle/TagBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/TagBundle/Tests/Application/config/templates/pages/default.xml
@@ -8,7 +8,7 @@
     <key>default</key>
 
     <view>ClientWebsiteBundle:templates:animals</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Bundle/TestBundle/Resources/structures/pages/default.xml
+++ b/src/Sulu/Bundle/TestBundle/Resources/structures/pages/default.xml
@@ -8,7 +8,7 @@
     <key>default</key>
 
     <view>ClientWebsiteBundle:templates:default</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <meta>

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Factory/data/apostrophe/apostrophe.xml
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Factory/data/apostrophe/apostrophe.xml
@@ -4,7 +4,7 @@
           xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
     <key>apostrophe</key>
     <view>AppBundle:templates:apostrophe</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>604800</cacheLifetime>
 
     <meta>

--- a/tests/Resources/DataFixtures/Page/template_block.xml
+++ b/tests/Resources/DataFixtures/Page/template_block.xml
@@ -7,7 +7,7 @@
     <key>template_block</key>
 
     <view>ClientWebsiteBundle:Website:complex.html.twig</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>4800</cacheLifetime>
 
     <properties>

--- a/tests/Resources/DataFixtures/Page/template_block_type_without_meta.xml
+++ b/tests/Resources/DataFixtures/Page/template_block_type_without_meta.xml
@@ -7,7 +7,7 @@
     <key>template_block_types</key>
 
     <view>ClientWebsiteBundle:Website:complex.html.twig</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>4800</cacheLifetime>
 
     <properties>

--- a/tests/Resources/DataFixtures/Page/template_block_types.xml
+++ b/tests/Resources/DataFixtures/Page/template_block_types.xml
@@ -7,7 +7,7 @@
     <key>template_block_types</key>
 
     <view>ClientWebsiteBundle:Website:complex.html.twig</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>4800</cacheLifetime>
 
     <properties>

--- a/tests/Resources/DataFixtures/Page/template_with_nested_blocks.xml
+++ b/tests/Resources/DataFixtures/Page/template_with_nested_blocks.xml
@@ -6,7 +6,7 @@
     <key>default</key>
 
     <view>templates/pages/default</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>604800</cacheLifetime>
 
     <meta>

--- a/tests/Resources/DataFixtures/Page/template_with_nested_sections.xml
+++ b/tests/Resources/DataFixtures/Page/template_with_nested_sections.xml
@@ -6,7 +6,7 @@
     <key>default</key>
 
     <view>templates/pages/default</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>604800</cacheLifetime>
 
     <meta>

--- a/tests/Resources/DataFixtures/Page/template_with_schema.xml
+++ b/tests/Resources/DataFixtures/Page/template_with_schema.xml
@@ -6,7 +6,7 @@
     <key>default</key>
 
     <view>templates/pages/default</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>604800</cacheLifetime>
 
     <meta>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes 
| Related issues/PRs | part of #4798
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Remove old controller reference syntax.

#### Why?

The `:` syntax is deprecated and not longer supported in symfony 5. In the skeleton this was fixed before the 2.0 release so there its correctly.
