### PR TITLE
Change service definition for DefaultController

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/SuluWebsiteExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/SuluWebsiteExtension.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\WebsiteBundle\DependencyInjection;
 
+use Sulu\Bundle\WebsiteBundle\Controller\DefaultController;
 use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapProviderInterface;
 use Sulu\Component\HttpKernel\SuluKernel;
 use Symfony\Component\Config\FileLocator;
@@ -120,6 +121,10 @@ class SuluWebsiteExtension extends Extension implements PrependExtensionInterfac
 
             // default local provider
             $container->setAlias('sulu_website.default_locale.provider', $config['default_locale']['provider_service_id']);
+
+            // add alias for default controller
+            $container->setAlias(DefaultController::class, 'sulu_website.default_controller')
+                ->setPublic(true);
         }
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -34,7 +34,10 @@
                  public="true">
             <argument type="service" id="router"/>
         </service>
-        <service id="sulu_website.default_controller" class="Sulu\Bundle\WebsiteBundle\Controller\DefaultController">
+
+        <service id="sulu_website.default_controller"
+                 class="Sulu\Bundle\WebsiteBundle\Controller\DefaultController"
+                 public="true">
             <tag name="container.service_subscriber" />
             <tag name="controller.service_arguments" />
             <tag name="sulu.context" context="website" />
@@ -42,7 +45,6 @@
                 <argument type="service" id="Psr\Container\ContainerInterface" />
             </call>
         </service>
-        <service id="Sulu\Bundle\WebsiteBundle\Controller\DefaultController" alias="sulu_website.default_controller"/>
 
         <service id="sulu_website.sitemap_controller"
                  class="Sulu\Bundle\WebsiteBundle\Controller\SitemapController"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | part of #4798, https://github.com/symfony/symfony/issues/36495 
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Change service definition for DefaultController.

#### Why?

~~Not sure why but the alias does not longer work and the controller does not get the container correctly set. So at current state only switch alias and id did work supporting symfony 5.~~

As shown in the linked symfony issue we need to make the service and alias public that it works in symfony 5.

#### To Do

- [ ] ~~Create a documentation PR~~
- [ ] ~~Add breaking changes to UPGRADE.md~~
