### PR TITLE
Remove ignoreErrors section from phpstan.neon

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -27,6 +27,3 @@ parameters:
         - %currentWorkingDirectory%/src/Sulu/Bundle/TestBundle/Resources/app/config/config.php
         # The following should be removed at some point
         - %currentWorkingDirectory%/*/Tests/*
-    ignoreErrors:
-        - /Class Imagine\\Vips\\Imagine not found./
-        - /Doctrine\\Bundle\\DoctrineCacheBundle\\DoctrineCacheBundle not found./


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### Why?

Because these errors no longer occur as the behaviour of `class_exists()` was changed in version 0.12.19 of phpstan: https://github.com/phpstan/phpstan/releases/tag/0.12.19