### PR TITLE
Fix copy language with different template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* release/1.6
+    * BUGFIX      #5240  [Content]                 Fix copy language with different template
+
 * 1.6.32 (2020-03-26)
     * FEATURE     #5062  [MediaBundle]             Added download counter to list view of medias.
     * BUGFIX      #5109  [WebsiteBundle]           Fix disabled request analyzer for esi requests

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -472,6 +472,7 @@ class ContentMapper implements ContentMapperInterface
             );
             $destDocument->setLocale($destLocale);
             $destDocument->setTitle($document->getTitle());
+            $destDocument->setStructureType($document->getStructureType());
             $destDocument->getStructure()->bind($document->getStructure()->toArray());
 
             if ($document instanceof WorkflowStageBehavior) {

--- a/src/Sulu/Component/Content/Tests/Functional/Mapper/ContentMapperTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/Mapper/ContentMapperTest.php
@@ -1445,6 +1445,39 @@ class ContentMapperTest extends SuluTestCase
         );
     }
 
+    public function testLanguageCopyStructureType()
+    {
+        $data = [
+            'title' => 'Page-1',
+            'url' => '/page-1',
+            'ext' => [
+                'test1' => [
+                    'a' => 'That´s a test',
+                    'b' => 'That´s a second test',
+                ],
+            ],
+        ];
+
+        $deData = $this->save($data, 'overview', 'sulu_io', 'de', 1, true, null);
+        $enData = $this->save($data, 'default', 'sulu_io', 'en', 1, true, $deData->getUuid());
+
+        $this->mapper->copyLanguage($deData->getUuid(), 1, 'sulu_io', 'de', 'en');
+
+        $result = $this->mapper->load($enData->getUuid(), 'sulu_io', 'en');
+
+        $this->assertEquals('Page-1', $result->title);
+        $this->assertEquals('/page-1', $result->url);
+        $this->assertEquals(
+            [
+                'a' => 'That´s a test',
+                'b' => 'That´s a second test',
+            ],
+            $result->getExt()['test1']
+        );
+
+        $this->assertEquals('overview', $result->getDocument()->getStructureType());
+    }
+
     public function testLanguageCopyPublishedDocument()
     {
         $data = $this->prepareSinglePageTestData(WorkflowStage::PUBLISHED);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4422
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix copy language with different template

#### Why?

If you copy the template should also be the same as from the source language.

