### PR TITLE
Fix custom url serialization without creator or changer

### DIFF
--- a/src/Sulu/Bundle/CustomUrlBundle/EventListener/CustomUrlSerializeEventSubscriber.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/EventListener/CustomUrlSerializeEventSubscriber.php
@@ -86,7 +86,7 @@ class CustomUrlSerializeEventSubscriber implements EventSubscriberInterface
         );
 
         $creatorFullName = null;
-        $creator = $customUrl->getCreator()
+        $creator = $customUrl->getCreator();
         if ($creator) {
             $creatorFullName = $this->userManager->getFullNameByUserId($creator);
         }

--- a/src/Sulu/Bundle/CustomUrlBundle/EventListener/CustomUrlSerializeEventSubscriber.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/EventListener/CustomUrlSerializeEventSubscriber.php
@@ -86,7 +86,8 @@ class CustomUrlSerializeEventSubscriber implements EventSubscriberInterface
         );
 
         $creatorFullName = null;
-        if ($creator = $customUrl->getCreator()) {
+        $creator = $customUrl->getCreator()
+        if ($creator) {
             $creatorFullName = $this->userManager->getFullNameByUserId($creator);
         }
 
@@ -96,7 +97,8 @@ class CustomUrlSerializeEventSubscriber implements EventSubscriberInterface
         );
 
         $changerFullName = null;
-        if ($changer = $customUrl->getChanger()) {
+        $changer = $customUrl->getChanger();
+        if ($changer) {
             $changerFullName = $this->userManager->getFullNameByUserId($changer);
         }
         $visitor->visitProperty(

--- a/src/Sulu/Bundle/CustomUrlBundle/EventListener/CustomUrlSerializeEventSubscriber.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/EventListener/CustomUrlSerializeEventSubscriber.php
@@ -85,12 +85,20 @@ class CustomUrlSerializeEventSubscriber implements EventSubscriberInterface
             $customUrlProperty
         );
 
-        $creatorFullName = $this->userManager->getFullNameByUserId($customUrl->getCreator());
+        $creatorFullName = null;
+        if ($creator = $customUrl->getCreator()) {
+            $creatorFullName = $this->userManager->getFullNameByUserId($creator);
+        }
+
         $visitor->visitProperty(
             new StaticPropertyMetadata('', 'creatorFullName', $creatorFullName),
             $creatorFullName
         );
-        $changerFullName = $this->userManager->getFullNameByUserId($customUrl->getChanger());
+
+        $changerFullName = null;
+        if ($changer = $customUrl->getChanger()) {
+            $changerFullName = $this->userManager->getFullNameByUserId($changer);
+        }
         $visitor->visitProperty(
             new StaticPropertyMetadata('', 'changerFullName', $changerFullName),
             $changerFullName


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | part of #4798 
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix custom url serialization without creator or changer.

#### Why?

Some tests did fail because of this on symfony 5 branch but for performance I would avoid try to load a creator fullname and so I thought its good to backport it to the 2.0 branch.
