### PR TITLE
Avoid setting form to dirty in autocomplete selection when creating a new page

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -485,7 +485,7 @@ class Selection extends React.Component<Props> {
             return;
         }
 
-        if (!equals(toJS(value), toJS(selectedIds))) {
+        if (!equals(toJS(value) || [], toJS(selectedIds))) {
             onChange(selectedIds);
             onFinish();
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -1452,6 +1452,42 @@ test('Should call onChange and onFinish callback when content of selectionStore 
     expect(finishSpy).toBeCalledWith();
 });
 
+test('Should not call onChange and onFinish callback when content of selectionStore is empty and undefined', () => {
+    const changeSpy = jest.fn();
+    const finishSpy = jest.fn();
+
+    const fieldOptions = {
+        default_type: 'auto_complete',
+        resource_key: 'pages',
+        types: {
+            auto_complete: {
+                allow_add: true,
+                display_property: 'name',
+                filter_parameter: 'names',
+                id_property: 'uuid',
+                search_properties: ['name'],
+            },
+        },
+    };
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('snippets'), 'pages'));
+
+    const selection = mount(
+        <Selection
+            {...fieldTypeDefaultProps}
+            fieldTypeOptions={fieldOptions}
+            formInspector={formInspector}
+            onChange={changeSpy}
+            onFinish={finishSpy}
+        />
+    );
+
+    selection.instance().autoCompleteSelectionStore.dataLoading = false;
+    selection.instance().autoCompleteSelectionStore.items = [];
+
+    expect(changeSpy).not.toBeCalled();
+    expect(finishSpy).not.toBeCalled();
+});
+
 test('Should pass allowAdd prop to MultiAutoComplete component', () => {
     const value = [1, 6, 8];
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #5219 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR makes sure that an empty array and `undefined` are handled the same in the `auto_complete` type of the `selection` field type.

#### Why?

When creating a new page with the given `example` template, there will be a message asking if you want to leave the form before the user is redirected to the edit form.