### PR TITLE
Invalidate System collections cache in warmUp

### DIFF
--- a/src/Sulu/Component/Media/SystemCollections/SystemCollectionManager.php
+++ b/src/Sulu/Component/Media/SystemCollections/SystemCollectionManager.php
@@ -76,6 +76,9 @@ class SystemCollectionManager implements SystemCollectionManagerInterface
 
     public function warmUp()
     {
+        if ($this->cache->isFresh()) {
+            $this->cache->invalidate();
+        }
         $this->getSystemCollections();
     }
 

--- a/src/Sulu/Component/Media/SystemCollections/SystemCollectionManager.php
+++ b/src/Sulu/Component/Media/SystemCollections/SystemCollectionManager.php
@@ -76,9 +76,7 @@ class SystemCollectionManager implements SystemCollectionManagerInterface
 
     public function warmUp()
     {
-        if ($this->cache->isFresh()) {
-            $this->cache->invalidate();
-        }
+        $this->cache->invalidate();
         $this->getSystemCollections();
     }
 

--- a/src/Sulu/Component/Media/Tests/Unit/SystemCollections/SystemCollectionManagerTest.php
+++ b/src/Sulu/Component/Media/Tests/Unit/SystemCollections/SystemCollectionManagerTest.php
@@ -345,17 +345,29 @@ class SystemCollectionManagerTest extends TestCase
         $collectionManager = $this->getCollectionManager($existingCollections, $notExistingCollections);
 
         $entityManager = $this->prophesize(EntityManagerInterface::class);
-        $cache = $this->prophesize(CacheInterface::class);
-        $cache->isFresh()->shouldBeCalled()->willReturn(false);
-        $cache->write($data)->shouldBeCalled();
-        $cache->read()->shouldBeCalled()->willReturn($data);
+        $cache = $this->createMock(CacheInterface::class);
+
+        $cache
+            ->expects($this->exactly(2))
+            ->method('isFresh')
+            ->willReturnOnConsecutiveCalls(false, false);
+
+        $cache
+            ->expects($this->once())
+            ->method('write')
+            ->with($data);
+
+        $cache
+            ->expects($this->once())
+            ->method('read')
+            ->willReturn($data);
 
         $manager = new SystemCollectionManager(
             $config,
             $collectionManager->reveal(),
             $entityManager->reveal(),
             $tokenStorage->reveal(),
-            $cache->reveal(),
+            $cache,
             'en'
         );
 
@@ -371,17 +383,33 @@ class SystemCollectionManagerTest extends TestCase
         $collectionManager = $this->getCollectionManager($existingCollections, $notExistingCollections, false);
 
         $entityManager = $this->prophesize(EntityManagerInterface::class);
-        $cache = $this->prophesize(CacheInterface::class);
-        $cache->isFresh()->shouldBeCalled()->willReturn(true);
-        $cache->write($data)->shouldNotBeCalled();
-        $cache->read()->shouldBeCalled()->willReturn($data);
+        $cache = $this->createMock(CacheInterface::class);
+
+        $cache
+            ->expects($this->exactly(2))
+            ->method('isFresh')
+            ->willReturnOnConsecutiveCalls(true, false);
+
+        $cache
+            ->expects($this->once())
+            ->method('invalidate');
+
+        $cache
+            ->expects($this->once())
+            ->method('write')
+            ->with($data);
+
+        $cache
+            ->expects($this->once())
+            ->method('read')
+            ->willReturn($data);
 
         $manager = new SystemCollectionManager(
             $config,
             $collectionManager->reveal(),
             $entityManager->reveal(),
             $tokenStorage->reveal(),
-            $cache->reveal(),
+            $cache,
             'en'
         );
 

--- a/src/Sulu/Component/Media/Tests/Unit/SystemCollections/SystemCollectionManagerTest.php
+++ b/src/Sulu/Component/Media/Tests/Unit/SystemCollections/SystemCollectionManagerTest.php
@@ -339,77 +339,24 @@ class SystemCollectionManagerTest extends TestCase
     /**
      * @dataProvider configProvider
      */
-    public function testWarmUpNotFresh($config, $existingCollections, $notExistingCollections, $data)
+    public function testWarmUp($config, $existingCollections, $notExistingCollections, $data)
     {
         $tokenStorage = $this->getTokenStorage();
         $collectionManager = $this->getCollectionManager($existingCollections, $notExistingCollections);
 
         $entityManager = $this->prophesize(EntityManagerInterface::class);
-        $cache = $this->createMock(CacheInterface::class);
-
-        $cache
-            ->expects($this->exactly(2))
-            ->method('isFresh')
-            ->willReturnOnConsecutiveCalls(false, false);
-
-        $cache
-            ->expects($this->once())
-            ->method('write')
-            ->with($data);
-
-        $cache
-            ->expects($this->once())
-            ->method('read')
-            ->willReturn($data);
+        $cache = $this->prophesize(CacheInterface::class);
+        $cache->invalidate()->shouldBeCalled();
+        $cache->isFresh()->shouldBeCalled()->willReturn(false);
+        $cache->write($data)->shouldBeCalled();
+        $cache->read()->shouldBeCalled()->willReturn($data);
 
         $manager = new SystemCollectionManager(
             $config,
             $collectionManager->reveal(),
             $entityManager->reveal(),
             $tokenStorage->reveal(),
-            $cache,
-            'en'
-        );
-
-        $manager->warmUp();
-    }
-
-    /**
-     * @dataProvider configProvider
-     */
-    public function testWarmUpFresh($config, $existingCollections, $notExistingCollections, $data)
-    {
-        $tokenStorage = $this->getTokenStorage();
-        $collectionManager = $this->getCollectionManager($existingCollections, $notExistingCollections, false);
-
-        $entityManager = $this->prophesize(EntityManagerInterface::class);
-        $cache = $this->createMock(CacheInterface::class);
-
-        $cache
-            ->expects($this->exactly(2))
-            ->method('isFresh')
-            ->willReturnOnConsecutiveCalls(true, false);
-
-        $cache
-            ->expects($this->once())
-            ->method('invalidate');
-
-        $cache
-            ->expects($this->once())
-            ->method('write')
-            ->with($data);
-
-        $cache
-            ->expects($this->once())
-            ->method('read')
-            ->willReturn($data);
-
-        $manager = new SystemCollectionManager(
-            $config,
-            $collectionManager->reveal(),
-            $entityManager->reveal(),
-            $tokenStorage->reveal(),
-            $cache,
+            $cache->reveal(),
             'en'
         );
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes  #5245 
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Invalidate media cache file on warmup.

I have changed test to use PHPUnit without `prophesize`. I think it's more clear . WDT?

#### BC Breaks/Deprecations

No BC Breaks
