### PR TITLE
Fix multiple requests when switching between locales for teaser selection

### DIFF
--- a/config/webspaces/sulu-test.xml
+++ b/config/webspaces/sulu-test.xml
@@ -8,6 +8,7 @@
 
     <localizations>
         <localization language="en" default="true"/>
+        <localization language="de"/>
     </localizations>
 
     <default-templates>

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/TeaserSelection/TeaserSelection.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/TeaserSelection/TeaserSelection.js
@@ -64,6 +64,10 @@ class TeaserSelection extends React.Component<Props> {
         })();
     }
 
+    componentWillUnmount() {
+        this.teaserStore.destroy();
+    }
+
     @computed get teaserItems(): Array<TeaserItem> {
         return this.props.value.items.map((teaserItem) => ({
             ...this.teaserStore.findById(teaserItem.type, teaserItem.id),

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/TeaserSelection/tests/TeaserSelection.test.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/TeaserSelection/tests/TeaserSelection.test.js
@@ -741,3 +741,17 @@ test('Call onChange with new values after items are sorted', () => {
         }
     );
 });
+
+test('Call destroy of TeaserStore when unmounted', () => {
+    // $FlowFixMe
+    TeaserStore.mockImplementation(function() {
+        this.destroy = jest.fn();
+    });
+
+    const teaserSelection = mount(<TeaserSelection locale={observable.box('en')} onChange={jest.fn()} />);
+
+    const teaserStore = teaserSelection.instance().teaserStore;
+    teaserSelection.unmount();
+
+    expect(teaserStore.destroy).toBeCalledWith();
+});


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

The `autorun` call of the `TeaserSelection` was not disposed when the component is unmounted.

#### Why?

When switching between the locale on a page with a `teaser_selection` multiple times, you can observe how more and more requests for loading teasers are sent.

There is another bug which makes the teaser being loaded for the old and new language, so there are still two loads currently. This is not fixed in this PR, but also multiple switching should not increase that number anymore.