### PR TITLE
Allow access to current request in RequestAnalyzer

### DIFF
--- a/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
+++ b/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
@@ -62,9 +62,14 @@ class RequestAnalyzer implements RequestAnalyzerInterface
         }
     }
 
+    public function getCurrentRequest()
+    {
+        return $this->requestStack->getCurrentRequest();
+    }
+
     public function getAttribute($name, $default = null)
     {
-        $request = $this->requestStack->getCurrentRequest();
+        $request = $this->getCurrentRequest();
 
         if (null === $request) {
             return $default;

--- a/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzerInterface.php
+++ b/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzerInterface.php
@@ -141,4 +141,11 @@ interface RequestAnalyzerInterface
      * @param mixed|null $default
      */
     public function getAttribute($name, $default = null);
+
+    /**
+     * Returns the current request.
+     *
+     * @return Request|null
+     */
+    public function getCurrentRequest();
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

It is not really a new feature or bug fix rather a small improvment for developers. This PR adds the method `getCurrentRequest` to the `Sulu\Component\Webspace\Analyzer\RequestAnalyzer` as a handy method to access the current request.

#### Why?

In my current project I often need access to the current request and the Sulu attributes of the request. I use the latter for convenience instead of writing the same logic over and over again. But this means that I will have to inject the `RequestStack` in my class as well. I personally like to have as few constructor arguments as possible. So instead of injecting both services, I propose to add the `getCurrentRequest` method to the `RequestAnalyzer` in order to make life a little bit easier for developers :-)

#### BC Breaks/Deprecations

None that I can think of.
