### PR TITLE
Fix PageTreeRoute component

### DIFF
--- a/src/Sulu/Bundle/RouteBundle/Resources/js/containers/Form/fields/PageTreeRoute.js
+++ b/src/Sulu/Bundle/RouteBundle/Resources/js/containers/Form/fields/PageTreeRoute.js
@@ -64,7 +64,7 @@ class PageTreeRoute extends Component<Props> {
         const {onFinish} = this.props;
 
         const uuid = (value && value.toString()) || null;
-        const path = (page && page.path) || null;
+        const path = (page && page.url) || null;
 
         this.handleChange({
             ...this.props.value,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

New articles are currently created with the path of the parent page instead of the url. Thus new articles for parent-pages could be created, but the smart-content never listed them correctly, if the url was changed.