### PR TITLE
Throw meaningful error when value of MediaSelection field does not match expected format

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {observer} from 'mobx-react';
 import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import userStore from 'sulu-admin-bundle/stores/userStore';
-import {observable} from 'mobx';
+import {isArrayLike, observable} from 'mobx';
 import {
     convertDisplayOptionsFromParams,
     convertMediaTypesFromParams,
@@ -25,8 +25,11 @@ class MediaSelection extends React.Component<FieldTypeProps<Value>> {
             } = {},
         } = schemaOptions;
 
-        if (value !== undefined && value !== null && (typeof value !== 'object' || !Array.isArray(value.ids))) {
-            throw new Error('The "MediaSelection" field expects an object with an "ids" property as value.');
+        if (value !== undefined && value !== null && (typeof value !== 'object' || !isArrayLike(value.ids))) {
+            throw new Error(
+                'The "MediaSelection" field expects an object with an "ids" property and '
+                + 'an optional "displayOption" property as value.'
+            );
         }
 
         if (!defaultDisplayOption) {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
@@ -25,7 +25,7 @@ class MediaSelection extends React.Component<FieldTypeProps<Value>> {
             } = {},
         } = schemaOptions;
 
-        if (value !== undefined && (typeof value !== 'object' || !Array.isArray(value.ids))) {
+        if (value != null && (typeof value !== 'object' || !Array.isArray(value.ids))) {
             throw new Error('The "MediaSelection" field expects an object with an "ids" property as value.');
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
@@ -25,6 +25,10 @@ class MediaSelection extends React.Component<FieldTypeProps<Value>> {
             } = {},
         } = schemaOptions;
 
+        if (value !== undefined && (typeof value !== 'object' || !Array.isArray(value.ids))) {
+            throw new Error('The "MediaSelection" field expects an object with an "ids" property as value.');
+        }
+
         if (!defaultDisplayOption) {
             return;
         }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
@@ -25,7 +25,7 @@ class MediaSelection extends React.Component<FieldTypeProps<Value>> {
             } = {},
         } = schemaOptions;
 
-        if (value != null && (typeof value !== 'object' || !Array.isArray(value.ids))) {
+        if (value !== undefined && value !== null && (typeof value !== 'object' || !Array.isArray(value.ids))) {
             throw new Error('The "MediaSelection" field expects an object with an "ids" property as value.');
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/MediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/MediaSelection.test.js
@@ -209,6 +209,40 @@ test('Should throw an error if displayOptions schemaOption is given but not an a
     )).toThrow(/"displayOptions"/);
 });
 
+test('Should throw an error if given value is not an object', () => {
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            new ResourceStore('test', undefined, {locale: observable.box('en')}),
+            'test'
+        )
+    );
+
+    expect(() => shallow(
+        <MediaSelection
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            value={true}
+        />
+    )).toThrow(/expects an object/);
+});
+
+test('Should throw an error if given value does not have an ids property', () => {
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            new ResourceStore('test', undefined, {locale: observable.box('en')}),
+            'test'
+        )
+    );
+
+    expect(() => shallow(
+        <MediaSelection
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            value={{unrelatedProperty: 123}}
+        />
+    )).toThrow(/"ids" property/);
+});
+
 test('Should throw an error if displayOptions schemaOption is given but not an array', () => {
     const formInspector = new FormInspector(
         new ResourceFormStore(

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/MediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/MediaSelection.test.js
@@ -221,7 +221,7 @@ test('Should throw an error if given value is not an object', () => {
         <MediaSelection
             {...fieldTypeDefaultProps}
             formInspector={formInspector}
-            value={true}
+            value={(true: any)}
         />
     )).toThrow(/expects an object/);
 });
@@ -238,7 +238,7 @@ test('Should throw an error if given value does not have an ids property', () =>
         <MediaSelection
             {...fieldTypeDefaultProps}
             formInspector={formInspector}
-            value={{unrelatedProperty: 123}}
+            value={({unrelatedProperty: 123}: any)}
         />
     )).toThrow(/"ids" property/);
 });


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5253
| License | MIT

#### What's in this PR?

This PR adjusts the `MediaSelection` field to throw an error with a meaningful message if the given value does not match the expected format.

#### Why?

Because it is a frequent mistake to pass an array of ids to the field. This leads to a cryptic error message at the moment.

#### How to test?

Adjust the `read()` method of the `MediaSelectionContentType` to match this:
```
    public function read(
        NodeInterface $node,
        PropertyInterface $property,
        $webspaceKey,
        $languageCode,
        $segmentKey
    ) {
        $data = json_decode($node->getPropertyValueWithDefault($property->getName(), '{"ids": []}'), true);
        
        $property->setValue(isset($data['ids']) ? [] : null);
    }
```

Then open the `Create Page` form, assign a media, save the page and see a meaningful error in the console of your browser.