### PR TITLE
Use interface of CategoryTranslation for CategoryTranslationMedia

### DIFF
--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/CategoryTranslationMedia.orm.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/CategoryTranslationMedia.orm.xml
@@ -14,7 +14,7 @@
             </options>
         </field>
 
-        <many-to-one field="categoryTranslation" target-entity="Sulu\Bundle\CategoryBundle\Entity\CategoryTranslation" inversed-by="medias">
+        <many-to-one field="categoryTranslation" target-entity="Sulu\Bundle\CategoryBundle\Entity\CategoryTranslationInterface" inversed-by="medias">
             <join-columns>
                 <join-column name="idCategoryTranslations" referenced-column-name="id" on-delete="CASCADE" nullable="false"/>
             </join-columns>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

When overwriting the `CategoryTranslation` Entity, an error is thrown after the execution of `bin/adminconsole doctrine:schema:validate`.

```
[FAIL] The entity-class Sulu\Bundle\CategoryBundle\Entity\CategoryTranslationMedia mapping is invalid:
 * The association Sulu\Bundle\CategoryBundle\Entity\CategoryTranslationMedia#categoryTranslation refers to the inverse side field Sulu\Bundle\CategoryBundle\Entity\CategoryTranslation#medias which does not exist.
```

#### Why?

This PR fixes the `target-entity` of the `CategoryTranslationMedia.orm.xml` file to prevent this error.
