### PR TITLE
Fix deprecation in authorizationChecker isGranted

### DIFF
--- a/src/Sulu/Component/Security/Authorization/SecurityChecker.php
+++ b/src/Sulu/Component/Security/Authorization/SecurityChecker.php
@@ -45,13 +45,11 @@ class SecurityChecker extends AbstractSecurityChecker
             return true;
         }
 
-        $attributes = [$permission];
-
         if (is_string($subject)) {
             $subject = new SecurityCondition($subject);
         }
 
-        $granted = $this->authorizationChecker->isGranted($attributes, $subject);
+        $granted = $this->authorizationChecker->isGranted($permission, $subject);
 
         return $granted;
     }

--- a/src/Sulu/Component/Security/Tests/Unit/Authorization/SecurityCheckerTest.php
+++ b/src/Sulu/Component/Security/Tests/Unit/Authorization/SecurityCheckerTest.php
@@ -52,7 +52,7 @@ class SecurityCheckerTest extends TestCase
     public function testIsGrantedContext()
     {
         $this->authorizationChecker->isGranted(
-            ['view'],
+            'view',
             Argument::which('getSecurityContext', 'sulu.media.collection')
         )->willReturn(true);
 
@@ -66,7 +66,7 @@ class SecurityCheckerTest extends TestCase
         $object = new \stdClass();
 
         $this->authorizationChecker->isGranted(
-            ['view'],
+            'view',
             $object
         )->willReturn(true);
 
@@ -91,7 +91,7 @@ class SecurityCheckerTest extends TestCase
         );
 
         $this->authorizationChecker->isGranted(
-            ['view'],
+            'view',
             Argument::which('getSecurityContext', 'sulu.media.collection')
         )->willReturn(false);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes 
| Related issues/PRs | part of #4798 
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix deprecation in authorizationChecker isGranted.

#### Why?

Symfony does not longer allow to give an array to the isGranted function it need to be a single entity [now](https://github.com/symfony/symfony/blob/master/UPGRADE-5.0.md#security). 
