### PR TITLE
Fix EventDispatcher Test compatibility

### DIFF
--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ChildrenCollectionTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ChildrenCollectionTest.php
@@ -46,6 +46,8 @@ class ChildrenCollectionTest extends TestCase
 
         $this->dispatcher->dispatch(Argument::type('Sulu\Component\DocumentManager\Event\HydrateEvent'), Events::HYDRATE)->will(function($args) {
             $args[0]->setDocument(new \stdClass());
+
+            return $args[0];
         });
 
         $results = [];

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/QueryResultCollectionTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/QueryResultCollectionTest.php
@@ -58,6 +58,8 @@ class QueryResultCollectionTest extends TestCase
 
         $this->dispatcher->dispatch(Argument::type('Sulu\Component\DocumentManager\Event\HydrateEvent'), Events::HYDRATE)->will(function($args) {
             $args[0]->setDocument(new \stdClass());
+
+            return $args[0];
         });
 
         $results = [];

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ReferrerCollectionTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ReferrerCollectionTest.php
@@ -50,6 +50,8 @@ class ReferrerCollectionTest extends TestCase
 
         $this->dispatcher->dispatch(Argument::type('Sulu\Component\DocumentManager\Event\HydrateEvent'), Events::HYDRATE)->will(function($args) {
             $args[0]->setDocument(new \stdClass());
+
+            return $args[0];
         });
 
         $results = [];

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Metadata/BaseMetadataFactoryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Metadata/BaseMetadataFactoryTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\DocumentManager\tests\Unit\Metadata;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Sulu\Component\DocumentManager\DocumentStrategyInterface;
 use Sulu\Component\DocumentManager\Exception\MetadataNotFoundException;
 use Sulu\Component\DocumentManager\Metadata;
@@ -24,6 +25,9 @@ class BaseMetadataFactoryTest extends TestCase
     {
         $this->strategy = $this->prophesize(DocumentStrategyInterface::class);
         $this->dispatcher = $this->prophesize(EventDispatcherInterface::class);
+        $this->dispatcher
+            ->dispatch(Argument::any(), Argument::any())
+            ->willReturnArgument(0);
         $this->factory = new BaseMetadataFactory(
             $this->dispatcher->reveal(),
             [

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/ProxyFactoryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/ProxyFactoryTest.php
@@ -136,7 +136,7 @@ class ProxyFactoryTest extends TestCase
                 }
             ),
             'sulu_document_manager.hydrate'
-        )->shouldBeCalled();
+        )->shouldBeCalled()->willReturnArgument(0);
 
         // hydrate
         $proxy->getTitle();
@@ -158,7 +158,7 @@ class ProxyFactoryTest extends TestCase
                 }
             ),
             Events::HYDRATE
-        )->shouldBeCalled();
+        )->shouldBeCalled()->willReturnArgument(0);
 
         $this->assertEquals('Hello', $proxy->getTitle());
     }

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Query/QueryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Query/QueryTest.php
@@ -74,6 +74,8 @@ class QueryTest extends TestCase
         $resultCollection = $this->prophesize(QueryResultCollection::class);
         $this->dispatcher->dispatch(new QueryExecuteEvent($this->query), Events::QUERY_EXECUTE)->will(function($args) use ($resultCollection) {
             $args[0]->setResult($resultCollection->reveal());
+
+            return $args[0];
         });
 
         $result = $this->query->execute();

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
@@ -93,6 +93,8 @@ class FindSubscriberTest extends TestCase
             ->dispatch(Argument::type(HydrateEvent::class), Events::HYDRATE)
             ->will(function($args) {
                 $args[0]->setDocument(new \stdClass());
+
+                return $args[0];
             });
 
         $event = new FindEvent($path, $locale, $options);

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RefreshSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RefreshSubscriberTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Comonent\DocumentManager\tests\Unit\Subscriber\Phpcr;
 
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Sulu\Component\DocumentManager\DocumentRegistry;
 use Sulu\Component\DocumentManager\Event\HydrateEvent;
 use Sulu\Component\DocumentManager\Event\RefreshEvent;
@@ -60,8 +61,11 @@ class RefreshSubscriberTest extends TestCase
         $node->revert()->shouldBeCalled();
         $this->documentRegistry->getLocaleForDocument($document)->willReturn('fr');
 
-        $event = new HydrateEvent($node->reveal(), 'fr');
-        $this->eventDispatcher->dispatch($event, Events::REFRESH);
+        $this->eventDispatcher->dispatch(Argument::that(function(HydrateEvent $event) use ($node) {
+            return $node->reveal() === $event->getNode()
+                && 'fr' === $event->getLocale();
+        }), Events::HYDRATE)
+            ->willReturnArgument(0);
 
         $this->refreshSubscriber->refreshDocument($refreshEvent->reveal());
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | part of #4798 
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix EventDispatcher Test compatibility.

#### Why?

In Symfony 5.0 the dispatch function must return an object.
