### PR TITLE
Add deep links for smart content

### DIFF
--- a/config/templates/pages/homepage.xml
+++ b/config/templates/pages/homepage.xml
@@ -42,5 +42,41 @@
                 <title lang="de">Seiten</title>
             </meta>
         </property>
+
+        <property name="snippet" type="smart_content">
+            <meta>
+                <title lang="en">Snippets</title>
+            </meta>
+            <params>
+                <param name="provider" value="snippets" />
+            </params>
+        </property>
+
+        <property name="media" type="smart_content">
+            <meta>
+                <title lang="en">Media</title>
+            </meta>
+            <params>
+                <param name="provider" value="media" />
+            </params>
+        </property>
+
+        <property name="accounts" type="smart_content">
+            <meta>
+                <title lang="en">Accounts</title>
+            </meta>
+            <params>
+                <param name="provider" value="accounts" />
+            </params>
+        </property>
+
+        <property name="contacts" type="smart_content">
+            <meta>
+                <title lang="en">Contacts</title>
+            </meta>
+            <params>
+                <param name="provider" value="contacts" />
+            </params>
+        </property>
     </properties>
 </template>

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/serializer/ProviderConfiguration.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/serializer/ProviderConfiguration.xml
@@ -10,5 +10,7 @@
         <property name="sorting" type="array" expose="true" groups="frontend"/>
         <property name="limit" type="boolean" expose="true" groups="frontend"/>
         <property name="presentAs" type="boolean" expose="true" groups="frontend"/>
+        <property name="view" type="string" expose="true" groups="frontend"/>
+        <property name="resultToView" type="array" expose="true" groups="frontend"/>
     </class>
 </serializer>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
@@ -227,7 +227,7 @@ class SmartContent extends React.Component<Props> {
                 defaultValue={this.defaultValue}
                 disabled={!!disabled}
                 fieldLabel={label}
-                onItemClick={this.handleItemClick}
+                onItemClick={this.viewName && this.resultToView ? this.handleItemClick : undefined}
                 presentations={this.presentations}
                 store={this.smartContentStore}
             />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SmartContent.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SmartContent.test.js
@@ -246,6 +246,7 @@ test('Pass correct props to SmartContent component', () => {
     ]);
     expect(smartContent.find('SmartContent').prop('fieldLabel')).toEqual('Test');
     expect(smartContent.find('SmartContent').prop('disabled')).toEqual(true);
+    expect(smartContent.find('SmartContent').prop('onItemClick')).toEqual(undefined);
 });
 
 test('Should not call the onChange and onFinish callbacks if SmartContentStore is still loading', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/SmartContent.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/SmartContent.js
@@ -15,6 +15,7 @@ type Props = {|
     defaultValue: FilterCriteria,
     disabled: boolean,
     fieldLabel: ?string,
+    onItemClick?: (id: number | string, item: ?Object) => void,
     presentations: Array<Presentation>,
     store: SmartContentStore,
 |};
@@ -79,7 +80,7 @@ class SmartContent extends React.Component<Props> {
     };
 
     render() {
-        const {categoryRootKey, defaultValue, disabled, fieldLabel, store} = this.props;
+        const {categoryRootKey, defaultValue, disabled, fieldLabel, onItemClick, store} = this.props;
 
         const presentations = this.props.presentations.reduce((presentations, presentation) => {
             presentations[presentation.name] = presentation.value;
@@ -96,10 +97,11 @@ class SmartContent extends React.Component<Props> {
                         onClick: this.handleFilterClick,
                     }}
                     loading={store.itemsLoading || store.loading}
+                    onItemClick={onItemClick}
                     sortable={false}
                 >
                     {store.items.map((item, index) => (
-                        <MultiItemSelection.Item id={item.id} index={index + 1} key={index}>
+                        <MultiItemSelection.Item id={item.id} index={index + 1} key={index} value={item}>
                             <SmartContentItem item={item} />
                         </MultiItemSelection.Item>
                     ))}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/SmartContent.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/SmartContent.test.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {shallow} from 'enzyme';
+import {mount, shallow} from 'enzyme';
 import {translate} from '../../../utils/Translator';
 import SmartContentStore from '../stores/SmartContentStore';
 import smartContentConfigStore from '../stores/smartContentConfigStore';
@@ -9,9 +9,12 @@ import SmartContent from '../SmartContent';
 jest.mock('../stores/SmartContentStore', () => jest.fn(function() {
     this.items = [];
 }));
+
 jest.mock('../stores/smartContentConfigStore', () => ({
     getConfig: jest.fn().mockReturnValue({}),
 }));
+
+jest.mock('../../MultiListOverlay', () => jest.fn(() => null));
 
 jest.mock('../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
@@ -190,6 +193,30 @@ test('Show items in a SmartContentItem', () => {
     expect(smartContent.find('SmartContentItem')).toHaveLength(2);
     expect(smartContent.find('SmartContentItem').at(0).prop('item')).toEqual({title: 'Homepage'});
     expect(smartContent.find('SmartContentItem').at(1).prop('item')).toEqual({title: 'About us'});
+});
+
+test('Call onItemClick when an item in the SmartContent is clicked', () => {
+    const itemClickSpy = jest.fn();
+    const smartContentStore = new SmartContentStore('content');
+    smartContentStore.items = [
+        {id: 1, title: 'Homepage'},
+        {id: 2, title: 'About us'},
+    ];
+
+    const smartContent = mount(
+        <SmartContent
+            defaultValue={defaultValue}
+            fieldLabel="Test"
+            onItemClick={itemClickSpy}
+            store={smartContentStore}
+        />
+    );
+
+    smartContent.find('MultiItemSelection .content').at(0).simulate('click');
+    expect(itemClickSpy).toHaveBeenLastCalledWith(1, {id: 1, title: 'Homepage'});
+
+    smartContent.find('MultiItemSelection .content').at(1).simulate('click');
+    expect(itemClickSpy).toHaveBeenLastCalledWith(2, {id: 2, title: 'About us'});
 });
 
 test('Pass the loading prop to the MultiItemSelection if items are still loading', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/types.js
@@ -42,8 +42,10 @@ export type SmartContentConfig = {
     datasourceResourceKey?: string,
     limit: boolean,
     presentAs: boolean,
+    resultToView?: {[string]: string},
     sorting: Array<Sorting>,
     tags: boolean,
+    view?: string,
 };
 
 export type SmartContentConfigs = {[key: string]: SmartContentConfig};

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -51,6 +51,24 @@ class AdminControllerTest extends SuluTestCase
         $this->assertEquals('pages', $pageConfig->teaser->pages->resourceKey);
     }
 
+    public function testSmartContentConfig()
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', '/admin/config');
+
+        $this->assertHttpStatusCode(200, $client->getResponse());
+        $response = json_decode($client->getResponse()->getContent());
+
+        $adminConfig = $response->sulu_admin;
+
+        $this->assertObjectHasAttribute('pages', $adminConfig->smartContent);
+        $this->assertEquals('sulu_page.page_edit_form', $adminConfig->smartContent->pages->view);
+        $this->assertEquals(
+            ['id' => 'id', 'webspace' => 'webspace'],
+            (array) $adminConfig->smartContent->pages->resultToView
+        );
+    }
+
     public function testWebspacesConfig()
     {
         $client = $this->createAuthenticatedClient();

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/SmartContentItemControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/SmartContentItemControllerTest.php
@@ -276,6 +276,7 @@ class SmartContentItemControllerTest extends SuluTestCase
                     'publishedState' => false,
                     'url' => '/team/johannes',
                     'published' => null,
+                    'webspace' => 'sulu_io',
                 ],
                 [
                     'id' => $this->daniel->getUuid(),
@@ -283,6 +284,7 @@ class SmartContentItemControllerTest extends SuluTestCase
                     'publishedState' => false,
                     'url' => '/team/daniel',
                     'published' => null,
+                    'webspace' => 'sulu_io',
                 ],
                 [
                     'id' => $this->thomas->getUuid(),
@@ -290,6 +292,7 @@ class SmartContentItemControllerTest extends SuluTestCase
                     'publishedState' => false,
                     'url' => '/team/thomas',
                     'published' => null,
+                    'webspace' => 'sulu_io',
                 ],
             ],
             $result['_embedded']['items']
@@ -324,6 +327,7 @@ class SmartContentItemControllerTest extends SuluTestCase
                     'publishedState' => false,
                     'url' => '/team/daniel',
                     'published' => null,
+                    'webspace' => 'sulu_io',
                 ],
                 [
                     'id' => $this->thomas->getUuid(),
@@ -331,6 +335,7 @@ class SmartContentItemControllerTest extends SuluTestCase
                     'publishedState' => false,
                     'url' => '/team/thomas',
                     'published' => null,
+                    'webspace' => 'sulu_io',
                 ],
             ],
             $result['_embedded']['items']
@@ -369,6 +374,7 @@ class SmartContentItemControllerTest extends SuluTestCase
                     'publishedState' => false,
                     'url' => '/team/thomas',
                     'published' => null,
+                    'webspace' => 'sulu_io',
                 ],
             ],
             $result['_embedded']['items']
@@ -405,6 +411,7 @@ class SmartContentItemControllerTest extends SuluTestCase
                     'publishedState' => false,
                     'url' => '/team/daniel',
                     'published' => null,
+                    'webspace' => 'sulu_io',
                 ],
                 [
                     'id' => $this->thomas->getUuid(),
@@ -412,6 +419,7 @@ class SmartContentItemControllerTest extends SuluTestCase
                     'publishedState' => false,
                     'url' => '/team/thomas',
                     'published' => null,
+                    'webspace' => 'sulu_io',
                 ],
             ],
             $result['_embedded']['items']
@@ -448,6 +456,7 @@ class SmartContentItemControllerTest extends SuluTestCase
                     'publishedState' => false,
                     'url' => '/team/daniel',
                     'published' => null,
+                    'webspace' => 'sulu_io',
                 ],
                 [
                     'id' => $this->thomas->getUuid(),
@@ -455,6 +464,7 @@ class SmartContentItemControllerTest extends SuluTestCase
                     'publishedState' => false,
                     'url' => '/team/thomas',
                     'published' => null,
+                    'webspace' => 'sulu_io',
                 ],
             ],
             $result['_embedded']['items']
@@ -489,6 +499,7 @@ class SmartContentItemControllerTest extends SuluTestCase
                     'publishedState' => false,
                     'url' => '/team/johannes',
                     'published' => null,
+                    'webspace' => 'sulu_io',
                 ],
                 [
                     'id' => $this->daniel->getUuid(),
@@ -496,6 +507,7 @@ class SmartContentItemControllerTest extends SuluTestCase
                     'publishedState' => false,
                     'url' => '/team/daniel',
                     'published' => null,
+                    'webspace' => 'sulu_io',
                 ],
             ],
             $result['_embedded']['items']
@@ -530,6 +542,7 @@ class SmartContentItemControllerTest extends SuluTestCase
                     'publishedState' => false,
                     'url' => '/team/johannes',
                     'published' => null,
+                    'webspace' => 'sulu_io',
                 ],
             ],
             $result['_embedded']['items']

--- a/src/Sulu/Bundle/SnippetBundle/Content/SnippetDataProvider.php
+++ b/src/Sulu/Bundle/SnippetBundle/Content/SnippetDataProvider.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\SnippetBundle\Content;
 
 use ProxyManager\Factory\LazyLoadingValueHolderFactory;
 use ProxyManager\Proxy\LazyLoadingInterface;
+use Sulu\Bundle\SnippetBundle\Admin\SnippetAdmin;
 use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Query\ContentQueryBuilderInterface;
@@ -99,6 +100,7 @@ class SnippetDataProvider implements DataProviderInterface
                         ['column' => 'changed', 'title' => 'sulu_admin.changed'],
                     ]
                 )
+                ->enableView(SnippetAdmin::EDIT_FORM_VIEW, ['id' => 'id'])
                 ->getConfiguration();
         }
 

--- a/src/Sulu/Component/Contact/SmartContent/AccountDataProvider.php
+++ b/src/Sulu/Component/Contact/SmartContent/AccountDataProvider.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Component\Contact\SmartContent;
 
+use Sulu\Bundle\ContactBundle\Admin\ContactAdmin;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Serializer\ArraySerializerInterface;
 use Sulu\Component\SmartContent\Orm\BaseDataProvider;
@@ -31,6 +32,7 @@ class AccountDataProvider extends BaseDataProvider
             ->enableLimit()
             ->enablePagination()
             ->enablePresentAs()
+            ->enableView(ContactAdmin::ACCOUNT_EDIT_FORM_VIEW, ['id' => 'id'])
             ->getConfiguration();
     }
 

--- a/src/Sulu/Component/Contact/SmartContent/ContactDataProvider.php
+++ b/src/Sulu/Component/Contact/SmartContent/ContactDataProvider.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Component\Contact\SmartContent;
 
+use Sulu\Bundle\ContactBundle\Admin\ContactAdmin;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Serializer\ArraySerializerInterface;
 use Sulu\Component\SmartContent\Orm\BaseDataProvider;
@@ -34,6 +35,7 @@ class ContactDataProvider extends BaseDataProvider
             ->enableLimit()
             ->enablePagination()
             ->enablePresentAs()
+            ->enableView(ContactAdmin::CONTACT_EDIT_FORM_VIEW, ['id' => 'id'])
             ->getConfiguration();
     }
 

--- a/src/Sulu/Component/Content/SmartContent/ContentDataItem.php
+++ b/src/Sulu/Component/Content/SmartContent/ContentDataItem.php
@@ -80,6 +80,18 @@ class ContentDataItem extends ArrayAccessItem implements ItemInterface, PublishI
         return $this->get('url');
     }
 
+    /**
+     * Returns the webspace of the content item.
+     *
+     * @return string
+     *
+     * @VirtualProperty
+     */
+    public function getWebspace()
+    {
+        return $this->get('webspaceKey');
+    }
+
     public function getImage()
     {
         return;

--- a/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
+++ b/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
@@ -15,6 +15,7 @@ use PHPCR\ItemNotFoundException;
 use PHPCR\SessionInterface;
 use ProxyManager\Factory\LazyLoadingValueHolderFactory;
 use ProxyManager\Proxy\LazyLoadingInterface;
+use Sulu\Bundle\PageBundle\Admin\PageAdmin;
 use Sulu\Bundle\PageBundle\Document\PageDocument;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
@@ -126,6 +127,7 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
                     ['column' => 'authored', 'title' => 'sulu_admin.authored'],
                 ]
             )
+            ->enableView(PageAdmin::EDIT_FORM_VIEW, ['id' => 'id', 'webspace' => 'webspace'])
             ->getConfiguration();
 
         return $this->configuration;

--- a/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
+++ b/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Component\Media\SmartContent;
 
+use Sulu\Bundle\MediaBundle\Admin\MediaAdmin;
 use Sulu\Bundle\MediaBundle\Collection\Manager\CollectionManagerInterface;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
@@ -58,6 +59,7 @@ class MediaDataProvider extends BaseDataProvider
                     ['column' => 'fileVersionMeta.title', 'title' => 'sulu_admin.title'],
                 ]
             )
+            ->enableView(MediaAdmin::EDIT_FORM_VIEW, ['id' => 'id'])
             ->getConfiguration();
 
         $this->requestStack = $requestStack;

--- a/src/Sulu/Component/SmartContent/Configuration/Builder.php
+++ b/src/Sulu/Component/SmartContent/Configuration/Builder.php
@@ -103,6 +103,14 @@ class Builder implements BuilderInterface
         return $this;
     }
 
+    public function enableView(string $view, array $resultToView)
+    {
+        $this->configuration->setView($view);
+        $this->configuration->setResultToView($resultToView);
+
+        return $this;
+    }
+
     public function getConfiguration(): ProviderConfigurationInterface
     {
         return $this->configuration;

--- a/src/Sulu/Component/SmartContent/Configuration/BuilderInterface.php
+++ b/src/Sulu/Component/SmartContent/Configuration/BuilderInterface.php
@@ -87,6 +87,11 @@ interface BuilderInterface
     public function enableSorting(array $sorting);
 
     /**
+     * Defines where the deep link when clicking on a smart content item should navigate to.
+     */
+    public function enableView(string $view, array $resultToView);
+
+    /**
      * Returns build configuration.
      */
     public function getConfiguration(): ProviderConfigurationInterface;

--- a/src/Sulu/Component/SmartContent/Configuration/ProviderConfiguration.php
+++ b/src/Sulu/Component/SmartContent/Configuration/ProviderConfiguration.php
@@ -68,6 +68,16 @@ class ProviderConfiguration implements ProviderConfigurationInterface
      */
     private $paginated = false;
 
+    /**
+     * @var string
+     */
+    private $view;
+
+    /**
+     * @var string[]
+     */
+    private $resultToView;
+
     public function hasDatasource(): bool
     {
         return null !== $this->datasourceResourceKey && false !== $this->datasourceResourceKey;
@@ -176,5 +186,25 @@ class ProviderConfiguration implements ProviderConfigurationInterface
     public function setPaginated(bool $paginated)
     {
         $this->paginated = $paginated;
+    }
+
+    public function getView(): string
+    {
+        return $this->view;
+    }
+
+    public function setView(string $view)
+    {
+        $this->view = $view;
+    }
+
+    public function getResultToView(): array
+    {
+        return $this->resultToView;
+    }
+
+    public function setResultToView(array $resultToView)
+    {
+        $this->resultToView = $resultToView;
     }
 }

--- a/src/Sulu/Component/SmartContent/Configuration/ProviderConfigurationInterface.php
+++ b/src/Sulu/Component/SmartContent/Configuration/ProviderConfigurationInterface.php
@@ -83,4 +83,16 @@ interface ProviderConfigurationInterface
      * Indicates pagination is possible.
      */
     public function hasPagination(): bool;
+
+    /**
+     * Returns the name of the view to navigate to when a smart content item in the UI is clicked.
+     */
+    public function getView(): string;
+
+    /**
+     * Returns the mapping from smart content item properties to view.
+     *
+     * @return string[]
+     */
+    public function getResultToView(): array;
 }

--- a/src/Sulu/Component/SmartContent/Tests/Unit/BuilderTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/BuilderTest.php
@@ -172,4 +172,16 @@ class BuilderTest extends TestCase
         $this->assertEquals('collections', $configuration->getDatasourceListKey());
         $this->assertEquals('column_list', $configuration->getDatasourceAdapter());
     }
+
+    public function testView()
+    {
+        $builder = Builder::create();
+
+        $this->assertEquals($builder, $builder->enableView('edit_form', ['id' => 'id']));
+
+        $configuration = $builder->getConfiguration();
+
+        $this->assertEquals('edit_form', $configuration->getView());
+        $this->assertEquals(['id' => 'id'], $configuration->getResultToView());
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #5219 
| License | MIT
| Documentation PR | sulu/sulu-docs#511

#### What's in this PR?

This PR adds deep links to the smart content. Therefore the configuration returned by different `DataProvider`s had to be extended, so that the smart content knows where the link should go.

#### Why?

Because it is a useful feature.

#### To Do

- [x] Create a documentation PR
