### PR TITLE
Include all schema properties in userSchema of ListStore

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
@@ -229,10 +229,6 @@ export default class ListStore {
         }
 
         const schemaSettings = ListStore.getSchemaSetting(this.listKey, this.userSettingsKey) || [];
-        if (!schemaSettings) {
-            return this.schema;
-        }
-
         const userSchema = {};
 
         for (const schemaSettingsEntry of schemaSettings) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
@@ -229,17 +229,27 @@ export default class ListStore {
         }
 
         const schemaSettings = ListStore.getSchemaSetting(this.listKey, this.userSettingsKey) || [];
+        if (!schemaSettings) {
+            return this.schema;
+        }
 
-        const userSchema = {...this.schema};
+        const userSchema = {};
+
         for (const schemaSettingsEntry of schemaSettings) {
-            if (!userSchema.hasOwnProperty(schemaSettingsEntry.schemaKey)) {
+            if (!this.schema.hasOwnProperty(schemaSettingsEntry.schemaKey)) {
                 continue;
             }
 
             userSchema[schemaSettingsEntry.schemaKey] = {
-                ...userSchema[schemaSettingsEntry.schemaKey],
+                ...this.schema[schemaSettingsEntry.schemaKey],
                 visibility: schemaSettingsEntry.visibility,
             };
+        }
+
+        for (const schemaKey of Object.keys(this.schema)) {
+            if (!userSchema.hasOwnProperty(schemaKey)) {
+                userSchema[schemaKey] = this.schema[schemaKey];
+            }
         }
 
         return userSchema;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
@@ -228,20 +228,16 @@ export default class ListStore {
             return {};
         }
 
-        const schemaSettings = ListStore.getSchemaSetting(this.listKey, this.userSettingsKey);
-        const schema = this.schema;
-        if (!schemaSettings) {
-            return schema;
-        }
+        const schemaSettings = ListStore.getSchemaSetting(this.listKey, this.userSettingsKey) || [];
 
-        const userSchema = {};
+        const userSchema = {...this.schema};
         for (const schemaSettingsEntry of schemaSettings) {
-            if (!schema.hasOwnProperty(schemaSettingsEntry.schemaKey)) {
+            if (!userSchema.hasOwnProperty(schemaSettingsEntry.schemaKey)) {
                 continue;
             }
 
             userSchema[schemaSettingsEntry.schemaKey] = {
-                ...schema[schemaSettingsEntry.schemaKey],
+                ...userSchema[schemaSettingsEntry.schemaKey],
                 visibility: schemaSettingsEntry.visibility,
             };
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
@@ -270,8 +270,6 @@ test('The userSchema should include schema properties that are not present in th
     const loadingStrategy = new LoadingStrategy();
     const structureStrategy = new StructureStrategy();
     const page = observable.box(1);
-    const locale = observable.box();
-    const additionalValue = observable.box(5);
 
     const schemaSetting = [
         {
@@ -291,8 +289,6 @@ test('The userSchema should include schema properties that are not present in th
         'list_test',
         {
             page,
-            locale,
-            additionalValue,
         },
         {
             test: 'value',
@@ -353,6 +349,63 @@ test('The userSchema should include schema properties that are not present in th
             },
         }
     );
+    expect((userStore).getPersistentSetting).toBeCalledWith('sulu_admin.list_store.tests.list_test.schema');
+
+    listStore.destroy();
+});
+
+test('The userSchema should reflect the order of the schemaSetting of the user', () => {
+    const loadingStrategy = new LoadingStrategy();
+    const structureStrategy = new StructureStrategy();
+    const page = observable.box(1);
+
+    const schemaSetting = [
+        {
+            'schemaKey': 'title',
+            'visibility': 'no',
+        },
+        {
+            'schemaKey': 'id',
+            'visibility': 'no',
+        },
+    ];
+    userStore.getPersistentSetting.mockReturnValueOnce(schemaSetting);
+
+    const listStore = new ListStore(
+        'tests',
+        'tests',
+        'list_test',
+        {
+            page,
+        },
+        {
+            test: 'value',
+        },
+        {
+            id: 1,
+        }
+    );
+
+    listStore.updateLoadingStrategy(loadingStrategy);
+    listStore.updateStructureStrategy(structureStrategy);
+    listStore.schema = {
+        id: {
+            label: 'ID',
+            name: 'id',
+            sortable: true,
+            type: 'string',
+            visibility: 'no',
+        },
+        title: {
+            label: 'Title',
+            name: 'title',
+            sortable: true,
+            type: 'string',
+            visibility: 'no',
+        },
+    };
+
+    expect(Object.keys(listStore.userSchema)).toEqual(['title', 'id']);
     expect((userStore).getPersistentSetting).toBeCalledWith('sulu_admin.list_store.tests.list_test.schema');
 
     listStore.destroy();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
@@ -266,6 +266,98 @@ test('The user store should be called correctly when changing the schema', () =>
     });
 });
 
+test('The userSchema should include schema properties that are not present in the schemaSetting of the user', () => {
+    const loadingStrategy = new LoadingStrategy();
+    const structureStrategy = new StructureStrategy();
+    const page = observable.box(1);
+    const locale = observable.box();
+    const additionalValue = observable.box(5);
+
+    const schemaSetting = [
+        {
+            'schemaKey': 'id',
+            'visibility': 'no',
+        },
+        {
+            'schemaKey': 'title',
+            'visibility': 'no',
+        },
+    ];
+    userStore.getPersistentSetting.mockReturnValueOnce(schemaSetting);
+
+    const listStore = new ListStore(
+        'tests',
+        'tests',
+        'list_test',
+        {
+            page,
+            locale,
+            additionalValue,
+        },
+        {
+            test: 'value',
+        },
+        {
+            id: 1,
+        }
+    );
+
+    listStore.updateLoadingStrategy(loadingStrategy);
+    listStore.updateStructureStrategy(structureStrategy);
+    listStore.schema = {
+        id: {
+            label: 'ID',
+            name: 'id',
+            sortable: true,
+            type: 'string',
+            visibility: 'no',
+        },
+        title: {
+            label: 'Title',
+            name: 'title',
+            sortable: true,
+            type: 'string',
+            visibility: 'no',
+        },
+        newSchemaProperty: {
+            label: 'New Schema Property',
+            name: 'newSchemaProperty',
+            sortable: true,
+            type: 'string',
+            visibility: 'always',
+        },
+    };
+
+    expect(listStore.userSchema).toEqual(
+        {
+            id: {
+                label: 'ID',
+                name: 'id',
+                sortable: true,
+                type: 'string',
+                visibility: 'no',
+            },
+            title: {
+                label: 'Title',
+                name: 'title',
+                sortable: true,
+                type: 'string',
+                visibility: 'no',
+            },
+            newSchemaProperty: {
+                label: 'New Schema Property',
+                name: 'newSchemaProperty',
+                sortable: true,
+                type: 'string',
+                visibility: 'always',
+            },
+        }
+    );
+    expect((userStore).getPersistentSetting).toBeCalledWith('sulu_admin.list_store.tests.list_test.schema');
+
+    listStore.destroy();
+});
+
 test('The loading strategy should be called with a different resourceKey when a request is sent', () => {
     const loadingStrategy = new LoadingStrategy();
     const structureStrategy = new StructureStrategy();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR fixes the `userSchema` property of the `ListStore` to include all properties of the schema if there are existing `schemaSettings` for the current user. At the moment, the `userSchema` contains only schema properties that were present when the `schemaSettings` were saved.

#### Why?

Because the `userSchema` property is used for rendering the display options of the list. At the moment, if there are existing `schemaSettings` for a user, the user will not see new schema properties in his UI. This is a common problem during development.
