### PR TITLE
Fix broken PublishIndicator in SmartContent

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/PublishIndicator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/PublishIndicator.js
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react';
-import classNames from 'classnames';
 import publishIndicatorStyles from './publishIndicator.scss';
 
 type Props = {
@@ -17,16 +16,8 @@ export default class PublishIndicator extends React.Component<Props> {
     render() {
         const {draft, published} = this.props;
 
-        const publishIndicatorClass = classNames(
-            publishIndicatorStyles.publishIndicator,
-            {
-                [publishIndicatorStyles.hasPublished]: published,
-                [publishIndicatorStyles.hasDraft]: draft,
-            }
-        );
-
         return (
-            <div className={publishIndicatorClass}>
+            <div className={publishIndicatorStyles.publishIndicator}>
                 {published && <span className={publishIndicatorStyles.published} />}
                 {draft && <span className={publishIndicatorStyles.draft} />}
             </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/PublishIndicator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/PublishIndicator.js
@@ -1,5 +1,6 @@
 // @flow
-import React, {Fragment} from 'react';
+import React from 'react';
+import classNames from 'classnames';
 import publishIndicatorStyles from './publishIndicator.scss';
 
 type Props = {
@@ -16,11 +17,19 @@ export default class PublishIndicator extends React.Component<Props> {
     render() {
         const {draft, published} = this.props;
 
+        const publishIndicatorClass = classNames(
+            publishIndicatorStyles.publishIndicator,
+            {
+                [publishIndicatorStyles.hasPublished]: published,
+                [publishIndicatorStyles.hasDraft]: draft,
+            }
+        );
+
         return (
-            <Fragment>
+            <div className={publishIndicatorClass}>
                 {published && <span className={publishIndicatorStyles.published} />}
                 {draft && <span className={publishIndicatorStyles.draft} />}
-            </Fragment>
+            </div>
         );
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/README.md
@@ -3,17 +3,23 @@ The `PublishIndicator` is a simple component, which can be used to show the draf
 The `published` state is represented by a green circle.
 
 ```
-<PublishIndicator published={true} />
+<div style={{width: '10px'}}>
+    <PublishIndicator published={true} />
+</div>
 ```
 
 The `draft` state is represented by a yellow circle.
 
 ```
-<PublishIndicator draft={true} />
+<div style={{width: '10px'}}>
+    <PublishIndicator draft={true} />
+</div>
 ```
 
 If something was already published and another draft was saved afterwards, then a yellow and green circle is shown.
 
 ```
-<PublishIndicator draft={true} published={true} />
+<div style={{width: '10px'}}>
+    <PublishIndicator draft={true} published={true} />
+</div>
 ```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/publishIndicator.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/publishIndicator.scss
@@ -7,17 +7,12 @@ $indicatorDimension: 18px;
 $indicatorOverlap: 10px;
 
 .publish-indicator {
-    min-width: $indicatorDimension;
-
-    &.has-published.has-draft {
-        min-width: calc($indicatorDimension * 2 - $indicatorOverlap);
-    }
+    white-space: nowrap;
 }
 
 .published,
 .draft {
-    display: block;
-    float: left;
+    display: inline-block;
     border: 2px $indicatorBorderColor solid;
     border-radius: 50%;
     height: $indicatorDimension;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/publishIndicator.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/publishIndicator.scss
@@ -4,6 +4,15 @@ $indicatorDraftBackgroundColor: $gold;
 $indicatorPublishedBackgroundColor: $mantis;
 $indicatorBorderColor: $white;
 $indicatorDimension: 18px;
+$indicatorOverlap: 10px;
+
+.publish-indicator {
+    min-width: $indicatorDimension;
+
+    &.has-published.has-draft {
+        min-width: calc($indicatorDimension * 2 - $indicatorOverlap);
+    }
+}
 
 .published,
 .draft {
@@ -16,7 +25,7 @@ $indicatorDimension: 18px;
 }
 
 .published + .draft {
-    margin-left: -10px;
+    margin-left: -$indicatorOverlap;
 }
 
 .draft {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/ColumnListAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/ColumnListAdapter.test.js.snap
@@ -83,7 +83,11 @@ exports[`Render data with disabled items 1`] = `
             </span>
             <span
               class="indicator"
-            />
+            >
+              <div
+                class="publishIndicator"
+              />
+            </span>
             <span
               class="children"
             >
@@ -143,7 +147,11 @@ exports[`Render data with disabled items 1`] = `
             </span>
             <span
               class="indicator"
-            />
+            >
+              <div
+                class="publishIndicator"
+              />
+            </span>
             <span
               class="children"
             />
@@ -235,7 +243,11 @@ exports[`Render data with loading column 1`] = `
             </span>
             <span
               class="indicator"
-            />
+            >
+              <div
+                class="publishIndicator"
+              />
+            </span>
             <span
               class="children"
             >
@@ -283,7 +295,11 @@ exports[`Render data with loading column 1`] = `
             </span>
             <span
               class="indicator"
-            />
+            >
+              <div
+                class="publishIndicator"
+              />
+            </span>
             <span
               class="children"
             />
@@ -370,7 +386,11 @@ exports[`Render data with name as fallback for title 1`] = `
             </span>
             <span
               class="indicator"
-            />
+            >
+              <div
+                class="publishIndicator"
+              />
+            </span>
             <span
               class="children"
             />
@@ -465,7 +485,11 @@ exports[`Render data with selection 1`] = `
             </span>
             <span
               class="indicator"
-            />
+            >
+              <div
+                class="publishIndicator"
+              />
+            </span>
             <span
               class="children"
             >
@@ -558,7 +582,11 @@ exports[`Render data without edit button 1`] = `
             </span>
             <span
               class="indicator"
-            />
+            >
+              <div
+                class="publishIndicator"
+              />
+            </span>
             <span
               class="children"
             >
@@ -667,9 +695,13 @@ exports[`Render different kind of data with edit button 1`] = `
             <span
               class="indicator"
             >
-              <span
-                class="draft"
-              />
+              <div
+                class="publishIndicator hasDraft"
+              >
+                <span
+                  class="draft"
+                />
+              </div>
             </span>
             <span
               class="children"
@@ -726,12 +758,16 @@ exports[`Render different kind of data with edit button 1`] = `
             <span
               class="indicator"
             >
-              <span
-                class="published"
-              />
-              <span
-                class="draft"
-              />
+              <div
+                class="publishIndicator hasPublished hasDraft"
+              >
+                <span
+                  class="published"
+                />
+                <span
+                  class="draft"
+                />
+              </div>
             </span>
             <span
               class="children"
@@ -791,12 +827,16 @@ exports[`Render different kind of data with edit button 1`] = `
             <span
               class="indicator"
             >
-              <span
-                class="published"
-              />
-              <span
-                class="draft"
-              />
+              <div
+                class="publishIndicator hasPublished hasDraft"
+              >
+                <span
+                  class="published"
+                />
+                <span
+                  class="draft"
+                />
+              </div>
             </span>
             <span
               class="children"
@@ -1038,12 +1078,16 @@ exports[`Render different kind of data with edit button 1`] = `
             <span
               class="indicator"
             >
-              <span
-                class="published"
-              />
-              <span
-                class="draft"
-              />
+              <div
+                class="publishIndicator hasPublished hasDraft"
+              >
+                <span
+                  class="published"
+                />
+                <span
+                  class="draft"
+                />
+              </div>
             </span>
             <span
               class="children"
@@ -1163,9 +1207,13 @@ exports[`Render different kind of data with edit button 1`] = `
             <span
               class="indicator"
             >
-              <span
-                class="draft"
-              />
+              <div
+                class="publishIndicator hasDraft"
+              >
+                <span
+                  class="draft"
+                />
+              </div>
             </span>
             <span
               class="children"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/ColumnListAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/ColumnListAdapter.test.js.snap
@@ -696,7 +696,7 @@ exports[`Render different kind of data with edit button 1`] = `
               class="indicator"
             >
               <div
-                class="publishIndicator hasDraft"
+                class="publishIndicator"
               >
                 <span
                   class="draft"
@@ -759,7 +759,7 @@ exports[`Render different kind of data with edit button 1`] = `
               class="indicator"
             >
               <div
-                class="publishIndicator hasPublished hasDraft"
+                class="publishIndicator"
               >
                 <span
                   class="published"
@@ -828,7 +828,7 @@ exports[`Render different kind of data with edit button 1`] = `
               class="indicator"
             >
               <div
-                class="publishIndicator hasPublished hasDraft"
+                class="publishIndicator"
               >
                 <span
                   class="published"
@@ -1079,7 +1079,7 @@ exports[`Render different kind of data with edit button 1`] = `
               class="indicator"
             >
               <div
-                class="publishIndicator hasPublished hasDraft"
+                class="publishIndicator"
               >
                 <span
                   class="published"
@@ -1208,7 +1208,7 @@ exports[`Render different kind of data with edit button 1`] = `
               class="indicator"
             >
               <div
-                class="publishIndicator hasDraft"
+                class="publishIndicator"
               >
                 <span
                   class="draft"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/__snapshots__/SmartContentItem.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/__snapshots__/SmartContentItem.test.js.snap
@@ -141,7 +141,7 @@ exports[`Render item with title and draft with published state 1`] = `
       class="publishIndicator"
     >
       <div
-        class="publishIndicator hasPublished hasDraft"
+        class="publishIndicator"
       >
         <span
           class="published"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/__snapshots__/SmartContentItem.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/__snapshots__/SmartContentItem.test.js.snap
@@ -140,12 +140,16 @@ exports[`Render item with title and draft with published state 1`] = `
     <div
       class="publishIndicator"
     >
-      <span
-        class="published"
-      />
-      <span
-        class="draft"
-      />
+      <div
+        class="publishIndicator hasPublished hasDraft"
+      >
+        <span
+          class="published"
+        />
+        <span
+          class="draft"
+        />
+      </div>
     </div>
     <div
       aria-label="Draft and published"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5268 
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adjusts the `PublishIndicator`, so that it does not break over multiple lines.