### PR TITLE
Register deprecated exception controller when decorated service exist

### DIFF
--- a/bin/runtests
+++ b/bin/runtests
@@ -125,7 +125,7 @@ function exec_sf_cmd($cmd, $echo = true, $checkForError = true)
 
 function exec_cmd($cmdLine, $echo = true, $checkForError = true)
 {
-    $process = new Process($cmdLine);
+    $process = Process::fromShellCommandline($cmdLine);
     $process->setTimeout(null);
     $process->run(function ($type, $out) use ($echo) {
         if (!$echo) {

--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/SuluWebsiteExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/SuluWebsiteExtension.php
@@ -128,6 +128,10 @@ class SuluWebsiteExtension extends Extension implements PrependExtensionInterfac
             // add alias for default controller
             $container->setAlias(DefaultController::class, 'sulu_website.default_controller')
                 ->setPublic(true);
+
+            if ($container->hasExtension('twig') && class_exists(ExceptionController::class)) {
+                $loader->load('exception_controller.xml');
+            }
         }
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/SuluWebsiteExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/SuluWebsiteExtension.php
@@ -129,7 +129,7 @@ class SuluWebsiteExtension extends Extension implements PrependExtensionInterfac
             $container->setAlias(DefaultController::class, 'sulu_website.default_controller')
                 ->setPublic(true);
 
-            if ($container->hasExtension('twig') && class_exists(ExceptionController::class)) {
+            if (class_exists(ExceptionController::class)) {
                 $loader->load('exception_controller.xml');
             }
         }

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/exception_controller.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/exception_controller.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="sulu_website.exception.controller.class">Sulu\Bundle\WebsiteBundle\Controller\ExceptionController</parameter>
+    </parameters>
+
+    <services>
+        <!-- exception controller -->
+        <service id="sulu_website.exception_controller"
+                 decorates="twig.controller.exception"
+                 class="Sulu\Bundle\WebsiteBundle\Controller\ExceptionController">
+            <argument type="service" id="sulu_website.exception_controller.inner"/>
+            <argument type="service" id="sulu_core.webspace.request_analyzer"/>
+            <argument type="service" id="sulu_website.resolver.parameter" />
+            <argument type="service" id="twig" />
+            <argument>%kernel.debug%</argument>
+
+            <tag name="sulu.context" context="website"/>
+        </service>
+    </services>
+</container>

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/exception_controller.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/exception_controller.xml
@@ -8,7 +8,6 @@
     </parameters>
 
     <services>
-        <!-- exception controller -->
         <service id="sulu_website.exception_controller"
                  decorates="twig.controller.exception"
                  class="Sulu\Bundle\WebsiteBundle\Controller\ExceptionController">

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -18,7 +18,6 @@
         <parameter key="sulu_website.twig.seo.class">Sulu\Bundle\WebsiteBundle\Twig\Seo\SeoTwigExtension</parameter>
         <parameter key="sulu_website.twig.util.class">Sulu\Bundle\WebsiteBundle\Twig\Core\UtilTwigExtension</parameter>
         <parameter key="sulu_website.routing.portal_loader.class">Sulu\Bundle\WebsiteBundle\Routing\PortalLoader</parameter>
-        <parameter key="sulu_website.exception.controller.class">Sulu\Bundle\WebsiteBundle\Controller\ExceptionController</parameter>
         <parameter key="sulu_website.resolver.request_analyzer.class">Sulu\Bundle\WebsiteBundle\Resolver\RequestAnalyzerResolver</parameter>
         <parameter key="sulu_website.resolver.structure.class">Sulu\Bundle\WebsiteBundle\Resolver\StructureResolver</parameter>
         <parameter key="sulu_website.resolver.parameter.class">Sulu\Bundle\WebsiteBundle\Resolver\ParameterResolver</parameter>
@@ -226,21 +225,6 @@
             <argument type="service" id="sulu_core.webspace.request_analyzer" />
             <tag name="kernel.event_listener" event="kernel.request" method="onRequest" priority="31" />
         </service>
-
-        <!-- exception controller -->
-        <service id="sulu_website.exception_controller"
-                 decorates="twig.controller.exception"
-                 class="Sulu\Bundle\WebsiteBundle\Controller\ExceptionController">
-            <argument type="service" id="sulu_website.exception_controller.inner"/>
-            <argument type="service" id="sulu_core.webspace.request_analyzer"/>
-            <argument type="service" id="sulu_website.resolver.parameter" />
-            <argument type="service" id="twig" />
-            <argument>%kernel.debug%</argument>
-
-            <tag name="sulu.context" context="website"/>
-        </service>
-
-        <service id="sulu_website.exception.controller" alias="twig.controller.exception" public="true" />
 
         <service id="sulu_website.error_controller"
                  decorates="error_controller"

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Controller/ExceptionControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Controller/ExceptionControllerTest.php
@@ -57,6 +57,10 @@ class ExceptionControllerTest extends TestCase
 
     public function setUp(): void
     {
+        if (!class_exists(BaseExceptionController::class)) {
+            $this->markTestSkipped();
+        }
+
         $this->twig = $this->prophesize(Environment::class);
         $this->loader = $this->prophesize(FilesystemLoader::class);
         $this->twig->getLoader()->willReturn($this->loader->reveal());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | #5266, part of #4798 
| License | MIT
| Documentation PR | -

#### What's in this PR?

Register deprecated exception controller when decorated service exist.

#### Why?

Else it will fail on symfony 5 when the parent services dont exist in container build.

#### To Do

- [ ] ~~Create a documentation PR~~
- [ ] ~~Add breaking changes to UPGRADE.md~~
