### PR TITLE
Remove the path attribute from twig templates

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,19 @@
 
 ## dev-master
 
+## Twig path variable deprecated
+
+The `path` variable was deprecated as it was confused with the `url` property by many developers.
+You should disable it via:
+
+```yaml
+# config/packages/sulu_website.yaml
+sulu_website:
+    twig:
+        attributes:
+            path: false
+```
+
 ### Changes in `SchemaMetadata` classes
 
 The metadata classes in the `Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata` namespace have changed significantly.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,7 +2,7 @@
 
 ## dev-master
 
-## Twig path variable deprecated
+### Deprecated path variable in twig
 
 The `path` twig variable was deprecated because it was confused with the `url` property by many new developers.
 The now deprecated variable contains the internal PHPCR path of a page which should not be exposed to the twig template.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,8 +4,9 @@
 
 ## Twig path variable deprecated
 
-The `path` variable was deprecated as it was confused with the `url` property by many developers.
-You should disable it via:
+The `path` twig variable was deprecated because it was confused with the `url` property by many new developers.
+The now deprecated variable contains the internal PHPCR path of a page which should not be exposed to the twig template.
+You should disable the variable in your project via:
 
 ```yaml
 # config/packages/sulu_website.yaml

--- a/config/packages/sulu_website.yaml
+++ b/config/packages/sulu_website.yaml
@@ -2,3 +2,4 @@ sulu_website:
     twig:
         attributes:
             urls: false
+            path: false

--- a/src/Sulu/Bundle/PageBundle/Content/PageSelectionContainer.php
+++ b/src/Sulu/Bundle/PageBundle/Content/PageSelectionContainer.php
@@ -117,7 +117,7 @@ class PageSelectionContainer implements ArrayableInterface
         $this->permission = $permission;
         $this->enabledTwigAttributes = $enabledTwigAttributes;
 
-        if ($enabledTwigAttributes['path']) {
+        if ($enabledTwigAttributes['path'] ?? true) {
             @\trigger_error('Enabling the "path" parameter is deprecated since sulu/sulu 2.3.', \E_USER_DEPRECATED);
         }
     }
@@ -167,7 +167,7 @@ class PageSelectionContainer implements ArrayableInterface
 
             // map pages
             foreach ($pages as $page) {
-                if (!$this->enabledTwigAttributes['path']) {
+                if (!($this->enabledTwigAttributes['path'] ?? true)) {
                     unset($page['path']);
                 }
 

--- a/src/Sulu/Bundle/PageBundle/Content/PageSelectionContainer.php
+++ b/src/Sulu/Bundle/PageBundle/Content/PageSelectionContainer.php
@@ -115,12 +115,11 @@ class PageSelectionContainer implements ArrayableInterface
         $this->params = $params;
         $this->showDrafts = $showDrafts;
         $this->permission = $permission;
+        $this->enabledTwigAttributes = $enabledTwigAttributes;
 
         if ($enabledTwigAttributes['path']) {
-            @trigger_error('Enable the path parameter is deprecated since sulu/sulu 2.1.', E_USER_DEPRECATED);
+            @\trigger_error('Enabling the "path" parameter is deprecated since sulu/sulu 2.3.', \E_USER_DEPRECATED);
         }
-
-        $this->enabledTwigAttributes = $enabledTwigAttributes;
     }
 
     /**

--- a/src/Sulu/Bundle/PageBundle/Content/PageSelectionContainer.php
+++ b/src/Sulu/Bundle/PageBundle/Content/PageSelectionContainer.php
@@ -89,6 +89,11 @@ class PageSelectionContainer implements ArrayableInterface
      */
     private $permission;
 
+    /**
+     * @var array
+     */
+    private $enabledTwigAttributes = [];
+
     public function __construct(
         $ids,
         ContentQueryExecutorInterface $contentQueryExecutor,
@@ -97,7 +102,10 @@ class PageSelectionContainer implements ArrayableInterface
         $webspaceKey,
         $languageCode,
         $showDrafts,
-        $permission = null
+        $permission = null,
+        array $enabledTwigAttributes = [
+            'path' => true,
+        ]
     ) {
         $this->ids = $ids;
         $this->contentQueryExecutor = $contentQueryExecutor;
@@ -107,6 +115,12 @@ class PageSelectionContainer implements ArrayableInterface
         $this->params = $params;
         $this->showDrafts = $showDrafts;
         $this->permission = $permission;
+
+        if ($enabledTwigAttributes['path']) {
+            @trigger_error('Enable the path parameter is deprecated since sulu/sulu 2.1.', E_USER_DEPRECATED);
+        }
+
+        $this->enabledTwigAttributes = $enabledTwigAttributes;
     }
 
     /**
@@ -154,6 +168,10 @@ class PageSelectionContainer implements ArrayableInterface
 
             // map pages
             foreach ($pages as $page) {
+                if (!$this->enabledTwigAttributes['path']) {
+                    unset($page['path']);
+                }
+
                 $map[$page['id']] = $page;
             }
 

--- a/src/Sulu/Bundle/PageBundle/Content/Types/PageSelection.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/PageSelection.php
@@ -53,39 +53,33 @@ class PageSelection extends ComplexContentType implements ContentTypeExportInter
     /**
      * @var array
      */
-<<<<<<< HEAD
     private $permissions;
-=======
+
+    /**
+     * @var array
+     */
     private $enabledTwigAttributes = [];
->>>>>>> e312527aab... Remove the path attribute from twig templates
 
     public function __construct(
         ContentQueryExecutorInterface $contentQueryExecutor,
         ContentQueryBuilderInterface $contentQueryBuilder,
         ReferenceStoreInterface $referenceStore,
         $showDrafts,
-<<<<<<< HEAD
-        $permissions = null
-=======
+        $permissions = null,
         array $enabledTwigAttributes = [
             'path' => true,
         ]
->>>>>>> e312527aab... Remove the path attribute from twig templates
     ) {
         $this->contentQueryExecutor = $contentQueryExecutor;
         $this->contentQueryBuilder = $contentQueryBuilder;
         $this->referenceStore = $referenceStore;
         $this->showDrafts = $showDrafts;
-<<<<<<< HEAD
         $this->permissions = $permissions;
-=======
+        $this->enabledTwigAttributes = $enabledTwigAttributes;
 
         if ($enabledTwigAttributes['path']) {
-            @trigger_error('Enable the path parameter is deprecated since sulu/sulu 2.1.', E_USER_DEPRECATED);
+            @trigger_error('Enabling the "path" parameter is deprecated since sulu/sulu 2.3.', E_USER_DEPRECATED);
         }
-
-        $this->enabledTwigAttributes = $enabledTwigAttributes;
->>>>>>> e312527aab... Remove the path attribute from twig templates
     }
 
     public function read(

--- a/src/Sulu/Bundle/PageBundle/Content/Types/PageSelection.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/PageSelection.php
@@ -78,7 +78,7 @@ class PageSelection extends ComplexContentType implements ContentTypeExportInter
         $this->enabledTwigAttributes = $enabledTwigAttributes;
 
         if ($enabledTwigAttributes['path']) {
-            @trigger_error('Enabling the "path" parameter is deprecated since sulu/sulu 2.3.', E_USER_DEPRECATED);
+            @\trigger_error('Enabling the "path" parameter is deprecated since sulu/sulu 2.3.', \E_USER_DEPRECATED);
         }
     }
 

--- a/src/Sulu/Bundle/PageBundle/Content/Types/PageSelection.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/PageSelection.php
@@ -157,11 +157,8 @@ class PageSelection extends ComplexContentType implements ContentTypeExportInter
             $property->getStructure()->getWebspaceKey(),
             $property->getStructure()->getLanguageCode(),
             $this->showDrafts,
-<<<<<<< HEAD
-            $this->permissions[PermissionTypes::VIEW]
-=======
+            $this->permissions[PermissionTypes::VIEW],
             $this->enabledTwigAttributes
->>>>>>> e312527aab... Remove the path attribute from twig templates
         );
 
         return $container->getData();

--- a/src/Sulu/Bundle/PageBundle/Content/Types/PageSelection.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/PageSelection.php
@@ -77,7 +77,7 @@ class PageSelection extends ComplexContentType implements ContentTypeExportInter
         $this->permissions = $permissions;
         $this->enabledTwigAttributes = $enabledTwigAttributes;
 
-        if ($enabledTwigAttributes['path']) {
+        if ($enabledTwigAttributes['path'] ?? true) {
             @\trigger_error('Enabling the "path" parameter is deprecated since sulu/sulu 2.3.', \E_USER_DEPRECATED);
         }
     }

--- a/src/Sulu/Bundle/PageBundle/Content/Types/PageSelection.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/PageSelection.php
@@ -53,20 +53,39 @@ class PageSelection extends ComplexContentType implements ContentTypeExportInter
     /**
      * @var array
      */
+<<<<<<< HEAD
     private $permissions;
+=======
+    private $enabledTwigAttributes = [];
+>>>>>>> e312527aab... Remove the path attribute from twig templates
 
     public function __construct(
         ContentQueryExecutorInterface $contentQueryExecutor,
         ContentQueryBuilderInterface $contentQueryBuilder,
         ReferenceStoreInterface $referenceStore,
         $showDrafts,
+<<<<<<< HEAD
         $permissions = null
+=======
+        array $enabledTwigAttributes = [
+            'path' => true,
+        ]
+>>>>>>> e312527aab... Remove the path attribute from twig templates
     ) {
         $this->contentQueryExecutor = $contentQueryExecutor;
         $this->contentQueryBuilder = $contentQueryBuilder;
         $this->referenceStore = $referenceStore;
         $this->showDrafts = $showDrafts;
+<<<<<<< HEAD
         $this->permissions = $permissions;
+=======
+
+        if ($enabledTwigAttributes['path']) {
+            @trigger_error('Enable the path parameter is deprecated since sulu/sulu 2.1.', E_USER_DEPRECATED);
+        }
+
+        $this->enabledTwigAttributes = $enabledTwigAttributes;
+>>>>>>> e312527aab... Remove the path attribute from twig templates
     }
 
     public function read(
@@ -144,7 +163,11 @@ class PageSelection extends ComplexContentType implements ContentTypeExportInter
             $property->getStructure()->getWebspaceKey(),
             $property->getStructure()->getLanguageCode(),
             $this->showDrafts,
+<<<<<<< HEAD
             $this->permissions[PermissionTypes::VIEW]
+=======
+            $this->enabledTwigAttributes
+>>>>>>> e312527aab... Remove the path attribute from twig templates
         );
 
         return $container->getData();

--- a/src/Sulu/Bundle/PageBundle/Resources/config/content_types.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/content_types.xml
@@ -9,6 +9,8 @@
             <argument type="service" id="sulu_page.reference_store.content"/>
             <argument>%sulu_document_manager.show_drafts%</argument>
             <argument>%sulu_security.permissions%</argument>
+            <argument>%sulu_website.enabled_twig_attributes%</argument>
+
             <tag name="sulu.content.type" alias="page_selection"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
         </service>

--- a/src/Sulu/Bundle/PageBundle/Resources/config/smart_content.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/smart_content.xml
@@ -43,6 +43,7 @@
             <argument type="expression">container.hasParameter('sulu_audience_targeting.enabled')</argument>
             <argument type="service" id="sulu_admin.form_metadata_provider" on-invalid="null"/>
             <argument type="service" id="security.token_storage" on-invalid="null"/>
+            <argument>%sulu_website.enabled_twig_attributes%</argument>
 
             <tag name="sulu.smart_content.data_provider" alias="pages"/>
         </service>

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/PageSelectionContainerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/PageSelectionContainerTest.php
@@ -103,9 +103,11 @@ class PageSelectionContainerTest extends TestCase
 
     public function testGetDataOrder()
     {
-        $this->executor->execute('default', ['en'], $this->builder, true, -1, null, null, false, null)->willReturn(
-            [['id' => 1], ['id' => 2], ['id' => 3]]
-        );
+        $this->executor->execute('default', ['en'], $this->builder, true, -1, null, null, false, null)->willReturn([
+            ['id' => 1, 'path' => 'phpcr/path/1'],
+            ['id' => 2],
+            ['id' => 3],
+        ]);
 
         $this->container = new PageSelectionContainer(
             [2, 3, 1],
@@ -118,7 +120,7 @@ class PageSelectionContainerTest extends TestCase
         );
 
         $result = $this->container->getData();
-        $this->assertEquals([['id' => 2], ['id' => 3], ['id' => 1]], $result);
+        $this->assertEquals([['id' => 2], ['id' => 3], ['id' => 1, 'path' => 'phpcr/path/1']], $result);
     }
 
     public function testGetDataWithUser()
@@ -143,5 +145,28 @@ class PageSelectionContainerTest extends TestCase
         );
 
         $this->container->getData();
+    }
+
+    public function testGetDataWithoutPathParameter()
+    {
+        $this->executor->execute('default', ['en'], $this->builder, true, -1, null, null, false, null)->willReturn([
+            ['id' => 1, 'path' => 'phpcr/path/1'],
+            ['id' => 2],
+        ]);
+
+        $this->container = new PageSelectionContainer(
+            [1, 2],
+            $this->executor->reveal(),
+            $this->builder->reveal(),
+            [],
+            'default',
+            'en',
+            false,
+            null,
+            ['path' => false]
+        );
+
+        $result = $this->container->getData();
+        $this->assertEquals([['id' => 1], ['id' => 2]], $result);
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/PageSelectionTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/PageSelectionTest.php
@@ -108,9 +108,12 @@ class PageSelectionTest extends TestCase
             ->shouldBeCalled();
         $this->contentQueryExecutor
              ->execute('default', ['en'], $this->contentQueryBuilder->reveal(), true, -1, null, null, false, 64)
-             ->willReturn([]);
+             ->willReturn([['id' => '123-123-123', 'path' => 'phpcr/path/123']]);
 
-        $pageSelection->getContentData($this->property->reveal());
+        $this->assertSame(
+            [['id' => '123-123-123', 'path' => 'phpcr/path/123']],
+            $pageSelection->getContentData($this->property->reveal())
+        );
     }
 
     public function testGetContentDataWithUser()
@@ -147,6 +150,36 @@ class PageSelectionTest extends TestCase
              ->willReturn([]);
 
         $pageSelection->getContentData($this->property->reveal());
+    }
+
+    public function testGetContentDataWithoutPathParameter()
+    {
+        $pageSelection = new PageSelection(
+            $this->contentQueryExecutor->reveal(),
+            $this->contentQueryBuilder->reveal(),
+            $this->referenceStore->reveal(),
+            false,
+            ['view' => 64],
+            ['path' => false]
+        );
+
+        $this->property->getValue()->willReturn(['123-123-123']);
+        $this->property->getParams()->willReturn([]);
+        $structure = $this->prophesize(StructureInterface::class);
+        $structure->getWebspaceKey()->willReturn('default');
+        $structure->getLanguageCode()->willReturn('en');
+        $this->property->getStructure()->willReturn($structure->reveal());
+
+        $this->contentQueryBuilder->init(['ids' => ['123-123-123'], 'properties' => [], 'published' => true])
+            ->shouldBeCalled();
+        $this->contentQueryExecutor
+            ->execute('default', ['en'], $this->contentQueryBuilder->reveal(), true, -1, null, null, false, 64)
+            ->willReturn([['id' => '123-123-123', 'path' => 'phpcr/path/123']]);
+
+        $this->assertSame(
+            [['id' => '123-123-123']],
+            $pageSelection->getContentData($this->property->reveal())
+        );
     }
 
     public function testPreResolve()

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
@@ -51,3 +51,8 @@ jms_serializer:
 swiftmailer:
     url: 'null://localhost'
     spool: { type: 'memory' }
+
+sulu_website:
+    twig:
+        attributes:
+            path: false

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
@@ -55,4 +55,5 @@ swiftmailer:
 sulu_website:
     twig:
         attributes:
+            urls: false
             path: false

--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Configuration.php
@@ -49,7 +49,7 @@ class Configuration implements ConfigurationInterface
                                 ->beforeNormalization()
                                     ->ifTrue(function($v) { return false !== $v; })
                                     ->then(function($v) {
-                                        @\trigger_error('Enable the urls parameter is deprecated since sulu/sulu 2.2.', \E_USER_DEPRECATED);
+                                        @\trigger_error('Enabling the "urls" parameter is deprecated since sulu/sulu 2.2.', \E_USER_DEPRECATED);
 
                                         return $v;
                                     })
@@ -60,7 +60,7 @@ class Configuration implements ConfigurationInterface
                                 ->beforeNormalization()
                                     ->ifTrue(function($v) { return false !== $v; })
                                     ->then(function($v) {
-                                        @trigger_error('Enable the path parameter is deprecated since sulu/sulu 2.1.', E_USER_DEPRECATED);
+                                        @\trigger_error('Enabling the "path" parameter is deprecated since sulu/sulu 2.3.', \E_USER_DEPRECATED);
 
                                         return $v;
                                     })

--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Configuration.php
@@ -55,6 +55,17 @@ class Configuration implements ConfigurationInterface
                                     })
                                 ->end()
                             ->end()
+                            ->booleanNode('path')
+                                ->defaultTrue()
+                                ->beforeNormalization()
+                                    ->ifTrue(function($v) { return false !== $v; })
+                                    ->then(function($v) {
+                                        @trigger_error('Enable the path parameter is deprecated since sulu/sulu 2.1.', E_USER_DEPRECATED);
+
+                                        return $v;
+                                    })
+                                ->end()
+                            ->end()
                         ->end()
                     ->end()
                     ->arrayNode('navigation')

--- a/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationMapper.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationMapper.php
@@ -77,7 +77,7 @@ class NavigationMapper implements NavigationMapperInterface
         $this->enabledTwigAttributes = $enabledTwigAttributes;
 
         if ($enabledTwigAttributes['path']) {
-            @trigger_error('Enabling the "path" parameter is deprecated since sulu/sulu 2.3.', E_USER_DEPRECATED);
+            @\trigger_error('Enabling the "path" parameter is deprecated since sulu/sulu 2.3.', \E_USER_DEPRECATED);
         }
     }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationMapper.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationMapper.php
@@ -52,20 +52,37 @@ class NavigationMapper implements NavigationMapperInterface
      */
     private $permissions;
 
+    /**
+     * @var array
+     */
+    private $enabledTwigAttributes = [];
+
     public function __construct(
         ContentMapperInterface $contentMapper,
         ContentQueryExecutorInterface $contentQueryExecutor,
         ContentQueryBuilderInterface $queryBuilder,
         SessionManagerInterface $sessionManager,
         Stopwatch $stopwatch = null,
-        $permissions = null
+        $permissions = null,
+        array $enabledTwigAttributes = [
+            'path' => true,
+        ]
     ) {
         $this->contentMapper = $contentMapper;
         $this->contentQueryExecutor = $contentQueryExecutor;
         $this->queryBuilder = $queryBuilder;
         $this->sessionManager = $sessionManager;
         $this->stopwatch = $stopwatch;
+<<<<<<< HEAD
         $this->permissions = $permissions;
+=======
+
+        if ($enabledTwigAttributes['path']) {
+            @trigger_error('Enable the path parameter is deprecated since sulu/sulu 2.1.', E_USER_DEPRECATED);
+        }
+
+        $this->enabledTwigAttributes = $enabledTwigAttributes;
+>>>>>>> e312527aab... Remove the path attribute from twig templates
     }
 
     public function getNavigation(
@@ -93,6 +110,7 @@ class NavigationMapper implements NavigationMapperInterface
                 'segmentKey' => $segmentKey,
             ]
         );
+<<<<<<< HEAD
         $result = $this->contentQueryExecutor->execute(
             $webspaceKey,
             [$locale],
@@ -110,6 +128,10 @@ class NavigationMapper implements NavigationMapperInterface
                 $item['children'] = [];
             }
         }
+=======
+        $result = $this->contentQuery->execute($webspaceKey, [$locale], $this->queryBuilder, $flat, $depth);
+        $result = $this->normalizeResult($result);
+>>>>>>> e312527aab... Remove the path attribute from twig templates
 
         if ($this->stopwatch) {
             $this->stopwatch->stop('NavigationMapper::getNavigation');
@@ -131,6 +153,7 @@ class NavigationMapper implements NavigationMapperInterface
             $this->stopwatch->start('NavigationMapper::getRootNavigation.query');
         }
 
+<<<<<<< HEAD
         $this->queryBuilder->init(['context' => $context, 'excerpt' => $loadExcerpt, 'segmentKey' => $segmentKey]);
         $result = $this->contentQueryExecutor->execute(
             $webspaceKey,
@@ -149,6 +172,11 @@ class NavigationMapper implements NavigationMapperInterface
                 $result[$i]['children'] = [];
             }
         }
+=======
+        $this->queryBuilder->init(['context' => $context, 'excerpt' => $loadExcerpt]);
+        $result = $this->contentQuery->execute($webspaceKey, [$locale], $this->queryBuilder, $flat, $depth);
+        $result = $this->normalizeResult($result);
+>>>>>>> e312527aab... Remove the path attribute from twig templates
 
         if ($this->stopwatch) {
             $this->stopwatch->stop('NavigationMapper::getRootNavigation.query');
@@ -269,5 +297,24 @@ class NavigationMapper implements NavigationMapperInterface
 
         // do not show
         return false;
+    }
+
+    private function normalizeResult(array $result)
+    {
+        foreach ($result as $key => $item) {
+            if (isset($item['children'])) {
+                $item['children'] = $this->normalizeResult($item['children']);
+            } else {
+                $item['children'] = [];
+            }
+
+            if (!$this->enabledTwigAttributes['path']) {
+                unset($item['path']);
+            }
+
+            $result[$key] = $item;
+        }
+
+        return $result;
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationMapper.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationMapper.php
@@ -73,16 +73,12 @@ class NavigationMapper implements NavigationMapperInterface
         $this->queryBuilder = $queryBuilder;
         $this->sessionManager = $sessionManager;
         $this->stopwatch = $stopwatch;
-<<<<<<< HEAD
         $this->permissions = $permissions;
-=======
+        $this->enabledTwigAttributes = $enabledTwigAttributes;
 
         if ($enabledTwigAttributes['path']) {
-            @trigger_error('Enable the path parameter is deprecated since sulu/sulu 2.1.', E_USER_DEPRECATED);
+            @trigger_error('Enabling the "path" parameter is deprecated since sulu/sulu 2.3.', E_USER_DEPRECATED);
         }
-
-        $this->enabledTwigAttributes = $enabledTwigAttributes;
->>>>>>> e312527aab... Remove the path attribute from twig templates
     }
 
     public function getNavigation(
@@ -110,7 +106,6 @@ class NavigationMapper implements NavigationMapperInterface
                 'segmentKey' => $segmentKey,
             ]
         );
-<<<<<<< HEAD
         $result = $this->contentQueryExecutor->execute(
             $webspaceKey,
             [$locale],
@@ -123,15 +118,7 @@ class NavigationMapper implements NavigationMapperInterface
             $this->permissions[PermissionTypes::VIEW] ?? null
         );
 
-        foreach ($result as $item) {
-            if (!isset($item['children'])) {
-                $item['children'] = [];
-            }
-        }
-=======
-        $result = $this->contentQuery->execute($webspaceKey, [$locale], $this->queryBuilder, $flat, $depth);
         $result = $this->normalizeResult($result);
->>>>>>> e312527aab... Remove the path attribute from twig templates
 
         if ($this->stopwatch) {
             $this->stopwatch->stop('NavigationMapper::getNavigation');

--- a/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationMapper.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationMapper.php
@@ -140,7 +140,6 @@ class NavigationMapper implements NavigationMapperInterface
             $this->stopwatch->start('NavigationMapper::getRootNavigation.query');
         }
 
-<<<<<<< HEAD
         $this->queryBuilder->init(['context' => $context, 'excerpt' => $loadExcerpt, 'segmentKey' => $segmentKey]);
         $result = $this->contentQueryExecutor->execute(
             $webspaceKey,
@@ -154,16 +153,7 @@ class NavigationMapper implements NavigationMapperInterface
             $this->permissions[PermissionTypes::VIEW] ?? null
         );
 
-        for ($i = 0; $i < \count($result); ++$i) {
-            if (!isset($result[$i]['children'])) {
-                $result[$i]['children'] = [];
-            }
-        }
-=======
-        $this->queryBuilder->init(['context' => $context, 'excerpt' => $loadExcerpt]);
-        $result = $this->contentQuery->execute($webspaceKey, [$locale], $this->queryBuilder, $flat, $depth);
         $result = $this->normalizeResult($result);
->>>>>>> e312527aab... Remove the path attribute from twig templates
 
         if ($this->stopwatch) {
             $this->stopwatch->stop('NavigationMapper::getRootNavigation.query');

--- a/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationMapper.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationMapper.php
@@ -76,7 +76,7 @@ class NavigationMapper implements NavigationMapperInterface
         $this->permissions = $permissions;
         $this->enabledTwigAttributes = $enabledTwigAttributes;
 
-        if ($enabledTwigAttributes['path']) {
+        if ($enabledTwigAttributes['path'] ?? true) {
             @\trigger_error('Enabling the "path" parameter is deprecated since sulu/sulu 2.3.', \E_USER_DEPRECATED);
         }
     }
@@ -285,7 +285,7 @@ class NavigationMapper implements NavigationMapperInterface
                 $item['children'] = [];
             }
 
-            if (!$this->enabledTwigAttributes['path']) {
+            if (!($this->enabledTwigAttributes['path'] ?? true)) {
                 unset($item['path']);
             }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
@@ -35,12 +35,26 @@ class StructureResolver implements StructureResolverInterface
      */
     protected $extensionManager;
 
+    /**
+     * @var bool
+     */
+    private $enabledTwigAttributes = true;
+
     public function __construct(
         ContentTypeManagerInterface $contentTypeManager,
-        ExtensionManagerInterface $structureManager
+        ExtensionManagerInterface $structureManager,
+        array $enabledTwigAttributes = [
+            'path' => true,
+        ]
     ) {
         $this->contentTypeManager = $contentTypeManager;
         $this->extensionManager = $structureManager;
+
+        if ($enabledTwigAttributes['path'] ?? true) {
+            @trigger_error('Enable the path parameter is deprecated since sulu/sulu 2.1.', E_USER_DEPRECATED);
+        }
+
+        $this->enabledTwigAttributes = $enabledTwigAttributes;
     }
 
     public function resolve(StructureInterface $structure, bool $loadExcerpt = true)
@@ -55,8 +69,11 @@ class StructureResolver implements StructureResolverInterface
             'created' => $structure->getCreated(),
             'changed' => $structure->getChanged(),
             'template' => $structure->getKey(),
-            'path' => $structure->getPath(),
         ];
+
+        if ($this->enabledTwigAttributes['path']) {
+            $data['path'] = $structure->getPath();
+        }
 
         $document = $structure->getDocument();
         if ($document instanceof ExtensionBehavior && $loadExcerpt) {

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
@@ -49,12 +49,11 @@ class StructureResolver implements StructureResolverInterface
     ) {
         $this->contentTypeManager = $contentTypeManager;
         $this->extensionManager = $structureManager;
-
-        if ($enabledTwigAttributes['path'] ?? true) {
-            @trigger_error('Enable the path parameter is deprecated since sulu/sulu 2.1.', E_USER_DEPRECATED);
-        }
-
         $this->enabledTwigAttributes = $enabledTwigAttributes;
+
+        if ($enabledTwigAttributes['path']) {
+            @\trigger_error('Enabling the "path" parameter is deprecated since sulu/sulu 2.3.', \E_USER_DEPRECATED);
+        }
     }
 
     public function resolve(StructureInterface $structure, bool $loadExcerpt = true)

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
@@ -51,7 +51,7 @@ class StructureResolver implements StructureResolverInterface
         $this->extensionManager = $structureManager;
         $this->enabledTwigAttributes = $enabledTwigAttributes;
 
-        if ($enabledTwigAttributes['path']) {
+        if ($enabledTwigAttributes['path'] ?? true) {
             @\trigger_error('Enabling the "path" parameter is deprecated since sulu/sulu 2.3.', \E_USER_DEPRECATED);
         }
     }
@@ -70,7 +70,7 @@ class StructureResolver implements StructureResolverInterface
             'template' => $structure->getKey(),
         ];
 
-        if ($this->enabledTwigAttributes['path']) {
+        if ($this->enabledTwigAttributes['path'] ?? true) {
             $data['path'] = $structure->getPath();
         }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -94,6 +94,7 @@
             <argument type="service" id="sulu.phpcr.session"/>
             <argument type="service" id="debug.stopwatch" on-invalid="null"/>
             <argument>%sulu_security.permissions%</argument>
+            <argument>%sulu_website.enabled_twig_attributes%</argument>
         </service>
 
         <!-- sitemap generator -->
@@ -196,6 +197,7 @@
         <service id="sulu_website.resolver.structure" class="%sulu_website.resolver.structure.class%" public="true">
             <argument type="service" id="sulu.content.type_manager" />
             <argument type="service" id="sulu_page.extension.manager"/>
+            <argument>%sulu_website.enabled_twig_attributes%</argument>
         </service>
 
         <service id="sulu_website.resolver.request_analyzer" class="%sulu_website.resolver.request_analyzer.class%">

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Navigation/NavigationMapperTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Navigation/NavigationMapperTest.php
@@ -272,7 +272,11 @@ class NavigationMapperTest extends SuluTestCase
 
         $main = $this->navigationMapper->getRootNavigation('sulu_io', 'en', 1);
         $this->assertEquals(2, \count($main));
+        $this->assertEquals('/news', $main[0]['url']);
+        $this->assertEquals('/news', $main[0]['path']);
         $this->assertEquals(0, \count($main[0]['children']));
+        $this->assertEquals('/products', $main[1]['url']);
+        $this->assertEquals('/products', $main[1]['path']);
         $this->assertEquals(0, \count($main[1]['children']));
 
         $main = $this->navigationMapper->getRootNavigation('sulu_io', 'en', null);
@@ -283,6 +287,26 @@ class NavigationMapperTest extends SuluTestCase
         $this->assertEquals(0, \count($main[0]['children'][1]['children']));
         $this->assertEquals(0, \count($main[1]['children'][0]['children']));
         $this->assertEquals(0, \count($main[1]['children'][1]['children']));
+    }
+
+    public function testMainNavigationWithoutPathParameter()
+    {
+        $navigationMapper = new NavigationMapper(
+            $this->contentMapper,
+            new ContentQueryExecutor($this->sessionManager, $this->contentMapper, null),
+            new NavigationQueryBuilder($this->structureManager, $this->extensionManager, $this->languageNamespace),
+            $this->sessionManager,
+            null,
+            ['view' => 64],
+            ['path' => false]
+        );
+
+        $main = $navigationMapper->getRootNavigation('sulu_io', 'en', 1);
+        $this->assertEquals(2, \count($main));
+        $this->assertEquals('/news', $main[0]['url']);
+        $this->assertArrayNotHasKey('path', $main[0]);
+        $this->assertEquals('/products', $main[1]['url']);
+        $this->assertArrayNotHasKey('path', $main[1]);
     }
 
     public function testMainNavigationWithSegment()
@@ -351,10 +375,40 @@ class NavigationMapperTest extends SuluTestCase
         $this->assertEquals($this->data['news/news-1']->getUuid(), $main[0]['id']);
         $this->assertEquals('News-1', $main[0]['title']);
         $this->assertEquals('/news/news-1', $main[0]['url']);
+        $this->assertEquals('/news/news-1', $main[0]['path']);
 
         $this->assertEquals($this->data['news/news-2']->getUuid(), $main[1]['id']);
         $this->assertEquals('News-2', $main[1]['title']);
         $this->assertEquals('/news/news-2', $main[1]['url']);
+        $this->assertEquals('/news/news-2', $main[1]['path']);
+    }
+
+    public function testNavigationWithoutPathParameter()
+    {
+        $navigationMapper = new NavigationMapper(
+            $this->contentMapper,
+            new ContentQueryExecutor($this->sessionManager, $this->contentMapper, null),
+            new NavigationQueryBuilder($this->structureManager, $this->extensionManager, $this->languageNamespace),
+            $this->sessionManager,
+            null,
+            ['view' => 64],
+            ['path' => false]
+        );
+
+        $main = $navigationMapper->getNavigation($this->data['news']->getUuid(), 'sulu_io', 'en', 1);
+        $this->assertEquals(2, \count($main));
+        $this->assertEquals(0, \count($main[0]['children']));
+        $this->assertEquals(0, \count($main[1]['children']));
+
+        $this->assertEquals($this->data['news/news-1']->getUuid(), $main[0]['id']);
+        $this->assertEquals('News-1', $main[0]['title']);
+        $this->assertEquals('/news/news-1', $main[0]['url']);
+        $this->assertArrayNotHasKey('path', $main[0]);
+
+        $this->assertEquals($this->data['news/news-2']->getUuid(), $main[1]['id']);
+        $this->assertEquals('News-2', $main[1]['title']);
+        $this->assertEquals('/news/news-2', $main[1]['url']);
+        $this->assertArrayNotHasKey('path', $main[0]);
     }
 
     public function testMainNavigationFlat()

--- a/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
+++ b/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
@@ -100,6 +100,11 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
      */
     private $tokenStorage;
 
+    /**
+     * @var array
+     */
+    private $enabledTwigAttributes = [];
+
     public function __construct(
         ContentQueryBuilderInterface $contentQueryBuilder,
         ContentQueryExecutorInterface $contentQueryExecutor,
@@ -111,7 +116,10 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
         $permissions,
         bool $hasAudienceTargeting = false,
         FormMetadataProvider $formMetadataProvider = null,
-        TokenStorageInterface $tokenStorage = null
+        TokenStorageInterface $tokenStorage = null,
+        array $enabledTwigAttributes = [
+            'path' => true,
+        ]
     ) {
         $this->contentQueryBuilder = $contentQueryBuilder;
         $this->contentQueryExecutor = $contentQueryExecutor;
@@ -128,6 +136,12 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
         if (!$formMetadataProvider) {
             @\trigger_error('The usage of the "PageDataProvider" without setting the "FormMetadataProvider" is deprecated. Please inject the "FormMetadataProvider".', \E_USER_DEPRECATED);
         }
+
+        if ($enabledTwigAttributes['path']) {
+            @trigger_error('Enable the path parameter is deprecated since sulu/sulu 2.1.', E_USER_DEPRECATED);
+        }
+
+        $this->enabledTwigAttributes = $enabledTwigAttributes;
     }
 
     public function getConfiguration()
@@ -210,7 +224,13 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
             return;
         }
 
+<<<<<<< HEAD
         return new DatasourceItem($result[0]['id'], $result[0]['title'], '/' . \ltrim($result[0]['path'], '/'));
+=======
+        $url = $result[0]['url'] ?? null;
+
+        return new DatasourceItem($result[0]['id'], $result[0]['title'], $url);
+>>>>>>> e312527aab... Remove the path attribute from twig templates
     }
 
     public function resolveDataItems(
@@ -400,6 +420,10 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
         return \array_map(
             function($item) use ($locale) {
                 $this->referenceStore->add($item['id']);
+
+                if (!$this->enabledTwigAttributes['path']) {
+                    unset($item['path']);
+                }
 
                 return new ArrayAccessItem($item['id'], $item, $this->getResource($item['id'], $locale));
             },

--- a/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
+++ b/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
@@ -139,7 +139,7 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
         }
 
         if ($enabledTwigAttributes['path']) {
-            @trigger_error('Enabling the "path" parameter is deprecated since sulu/sulu 2.3.', E_USER_DEPRECATED);
+            @\trigger_error('Enabling the "path" parameter is deprecated since sulu/sulu 2.3.', \E_USER_DEPRECATED);
         }
     }
 

--- a/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
+++ b/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
@@ -223,13 +223,9 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
             return;
         }
 
-<<<<<<< HEAD
-        return new DatasourceItem($result[0]['id'], $result[0]['title'], '/' . \ltrim($result[0]['path'], '/'));
-=======
         $url = $result[0]['url'] ?? null;
 
         return new DatasourceItem($result[0]['id'], $result[0]['title'], $url);
->>>>>>> e312527aab... Remove the path attribute from twig templates
     }
 
     public function resolveDataItems(

--- a/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
+++ b/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
@@ -223,9 +223,7 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
             return;
         }
 
-        $url = $result[0]['url'] ?? null;
-
-        return new DatasourceItem($result[0]['id'], $result[0]['title'], $url);
+        return new DatasourceItem($result[0]['id'], $result[0]['title'], $result[0]['url'] ?? null);
     }
 
     public function resolveDataItems(

--- a/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
+++ b/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
@@ -132,16 +132,15 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
         $this->hasAudienceTargeting = $hasAudienceTargeting;
         $this->formMetadataProvider = $formMetadataProvider;
         $this->tokenStorage = $tokenStorage;
+        $this->enabledTwigAttributes = $enabledTwigAttributes;
 
         if (!$formMetadataProvider) {
             @\trigger_error('The usage of the "PageDataProvider" without setting the "FormMetadataProvider" is deprecated. Please inject the "FormMetadataProvider".', \E_USER_DEPRECATED);
         }
 
         if ($enabledTwigAttributes['path']) {
-            @trigger_error('Enable the path parameter is deprecated since sulu/sulu 2.1.', E_USER_DEPRECATED);
+            @trigger_error('Enabling the "path" parameter is deprecated since sulu/sulu 2.3.', E_USER_DEPRECATED);
         }
-
-        $this->enabledTwigAttributes = $enabledTwigAttributes;
     }
 
     public function getConfiguration()

--- a/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
+++ b/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
@@ -138,7 +138,7 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
             @\trigger_error('The usage of the "PageDataProvider" without setting the "FormMetadataProvider" is deprecated. Please inject the "FormMetadataProvider".', \E_USER_DEPRECATED);
         }
 
-        if ($enabledTwigAttributes['path']) {
+        if ($enabledTwigAttributes['path'] ?? true) {
             @\trigger_error('Enabling the "path" parameter is deprecated since sulu/sulu 2.3.', \E_USER_DEPRECATED);
         }
     }
@@ -414,7 +414,7 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
             function($item) use ($locale) {
                 $this->referenceStore->add($item['id']);
 
-                if (!$this->enabledTwigAttributes['path']) {
+                if (!($this->enabledTwigAttributes['path'] ?? true)) {
                     unset($item['path']);
                 }
 

--- a/src/Sulu/Component/Content/Tests/Unit/SmartContent/PageDataProviderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/SmartContent/PageDataProviderTest.php
@@ -549,7 +549,7 @@ class PageDataProviderTest extends TestCase
 
     public function testResolveDatasource()
     {
-        $data = ['id' => '123-123-123', 'title' => 'My-Page', 'path' => '/my-page'];
+        $data = ['id' => '123-123-123', 'title' => 'My-Page', 'path' => null];
 
         $provider = new PageDataProvider(
             $this->getContentQueryBuilder(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4128
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Remove the path attribute from twig templates.

#### Why?

The `path` get mostly be confused by the `url` and so should be removed from the twig side. This effects the StructureResolver (page data) and the ContentMapper (smart content, page selection, navigation). 

#### Example Usage

~~~php
sulu_website:
    twig:
        attributes:
            path: false
~~~

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
