### PR TITLE
Fix partial portal matching for url for specified language

### DIFF
--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
@@ -330,11 +330,17 @@ class WebspaceCollectionBuilder
             $country = $url->getCountry();
             $locale = $language . ($country ? '_' . $country : '');
 
+            $replacers = [
+                ReplacerInterface::REPLACER_LANGUAGE => $language,
+                ReplacerInterface::REPLACER_COUNTRY => $country,
+                ReplacerInterface::REPLACER_LOCALIZATION => $locale,
+            ];
+
             $this->buildUrlFullMatch(
                 $portal,
                 $environment,
                 $segments,
-                [],
+                $replacers,
                 $urlAddress,
                 $portal->getLocalization($locale),
                 $urlAnalyticsKey,
@@ -363,14 +369,15 @@ class WebspaceCollectionBuilder
                     $url
                 );
             }
-            $this->buildUrlPartialMatch(
-                $portal,
-                $environment,
-                $urlAddress,
-                $urlAnalyticsKey,
-                $url
-            );
         }
+
+        $this->buildUrlPartialMatch(
+            $portal,
+            $environment,
+            $urlAddress,
+            $urlAnalyticsKey,
+            $url
+        );
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
@@ -249,4 +249,29 @@ class WebspaceCollectionBuilderTest extends WebspaceTestCase
         $this->assertEquals('sulu.lo/*', $prod->getCustomUrls()[0]->getUrl());
         $this->assertEquals('*.sulu.lo', $prod->getCustomUrls()[1]->getUrl());
     }
+
+    public function testLanguageSpecificPartial()
+    {
+        $webspaceCollectionBuilder = new WebspaceCollectionBuilder(
+            $this->loader,
+            new Replacer(),
+            $this->getResourceDirectory() . '/DataFixtures/Webspace/language-specific'
+        );
+
+        $webspaceCollection = $webspaceCollectionBuilder->build();
+
+        $portalInformations = $webspaceCollection->getPortalInformations('dev');
+
+        $this->assertSame([
+            'austria.sulu.io/de',
+            'austria.sulu.io',
+            'usa.sulu.io/en',
+            'usa.sulu.io',
+        ], array_keys($portalInformations));
+
+        $this->assertSame($portalInformations['austria.sulu.io/de']->getPriority(), 10);
+        $this->assertSame($portalInformations['austria.sulu.io']->getPriority(), 9);
+        $this->assertSame($portalInformations['usa.sulu.io/en']->getPriority(), 10);
+        $this->assertSame($portalInformations['usa.sulu.io']->getPriority(), 9);
+    }
 }

--- a/tests/Resources/DataFixtures/Webspace/language-specific/sulu.io.xml
+++ b/tests/Resources/DataFixtures/Webspace/language-specific/sulu.io.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<webspace xmlns="http://schemas.sulu.io/webspace/webspace"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.1.xsd">
+
+    <name>sulu.io</name>
+    <key>sulu_io</key>
+
+    <localizations>
+        <localization language="en" country="us" default="true"/>
+        <localization language="de" country="at"/>
+    </localizations>
+
+    <theme>default</theme>
+
+    <default-templates>
+        <default-template type="page">default</default-template>
+        <default-template type="homepage">overview</default-template>
+    </default-templates>
+
+    <templates>
+        <template type="error">ClientWebsiteBundle:views:error.html.twig</template>
+        <template type="error-404">ClientWebsiteBundle:views:error404.html.twig</template>
+    </templates>
+
+    <navigation>
+        <contexts>
+            <context key="main">
+                <meta>
+                    <title lang="de">Hauptnavigation</title>
+                    <title lang="en">Mainnavigation</title>
+                </meta>
+            </context>
+        </contexts>
+    </navigation>
+
+    <resource-locator>
+        <strategy>tree_leaf_edit</strategy>
+    </resource-locator>
+
+    <portals>
+        <portal>
+            <name>sulu.io</name>
+            <key>sulu_io</key>
+
+            <environments>
+                <environment type="prod">
+                    <urls>
+                        <url language="de" country="at">austria.sulu.io/{language}</url>
+                        <url language="en" country="us">usa.sulu.io/{language}</url>
+                    </urls>
+                </environment>
+                <environment type="stage">
+                    <urls>
+                        <url language="de" country="at">austria.sulu.io/{language}</url>
+                        <url language="en" country="us">usa.sulu.io/{language}</url>
+                    </urls>
+                </environment>
+                <environment type="dev">
+                    <urls>
+                        <url language="de" country="at">austria.sulu.io/{language}</url>
+                        <url language="en" country="us">usa.sulu.io/{language}</url>
+                    </urls>
+                </environment>
+            </environments>
+        </portal>
+    </portals>
+</webspace>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix partial portal matching for url for specified language.

#### Why?

When have the following portal:

```xml
<url language="en" country="uk">uk.mydomain.com/{language}</url>
<url language="de" country="at">austria.mydomain.com/{language}</url>
```

The partial portal mapping does not work this means `/`is not redirected to `/en` and `/sitemap.xml` will not work.

In the project they had the following url `austria.mydomai.com/de` but as we can not just replace `de` i suggested to use `{language}` placeholder but that doesn't currently work so it need to replaced correctly also there and that the partial map work the logic need to be moved out of if else.

#### Example Usage

~~~xml
<url language="en" country="uk">uk.mydomain.com/{language}</url>
<url language="de" country="at">austria.mydomain.com/{language}</url>
~~~

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
