### PR TITLE
Rename sulu_content_path in sulu_content_url

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,12 @@
 # Upgrade
 
+## unreleased
+
+### The `sulu_content_path` and `sulu_content_root_path` are deprecated
+
+The `sulu_content_path` and `sulu_content_root_path` are deprecated use instead the
+new `sulu_content_url` and `sulu_content_root_url` twig extension.
+
 ## 2.1.0-RC1
 
 ### Deprecated ExceptionController changed to ErrorController

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Extension/seo.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Extension/seo.html.twig
@@ -29,7 +29,7 @@
 {% set seoCanonical = seo.canonicalUrl|default() %}
 
 {%- if not seoCanonical and shadowBaseLocale and urls[shadowBaseLocale]|default() %}
-    {% set seoCanonical = sulu_content_path(urls[shadowBaseLocale], null, shadowBaseLocale) %}
+    {% set seoCanonical = sulu_content_url(urls[shadowBaseLocale], null, shadowBaseLocale) %}
 {%- endif -%}
 
 {#- render blocks -#}
@@ -63,9 +63,9 @@
     {%- if urls|length > 1 -%}
         {%- for locale, url in urls -%}
             {%- if defaultLocale == locale -%}
-                <link rel="alternate" href="{{ sulu_content_path(url, null, locale) }}" hreflang="x-default"/>
+                <link rel="alternate" href="{{ sulu_content_url(url, null, locale) }}" hreflang="x-default"/>
             {%- endif -%}
-            <link rel="alternate" href="{{ sulu_content_path(url, null, locale) }}" hreflang="{{ locale|replace({'_': '-'}) }}"/>
+            <link rel="alternate" href="{{ sulu_content_url(url, null, locale) }}" hreflang="{{ locale|replace({'_': '-'}) }}"/>
         {%- endfor -%}
     {%- endif -%}
 {%- endblock -%}

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/ContentPathTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/ContentPathTwigExtensionTest.php
@@ -80,7 +80,7 @@ class ContentPathTwigExtensionTest extends TestCase
         );
     }
 
-    public function testGetContentPath()
+    public function testLegacyGetContentPath()
     {
         $this->requestAnalyzer->getAttribute('host')->willReturn('www.sulu.io');
         $this->requestAnalyzer->getAttribute('port')->willReturn(80);
@@ -96,7 +96,55 @@ class ContentPathTwigExtensionTest extends TestCase
         $this->assertEquals('www.sulu.io/de/test', $this->extension->getContentPath('/test'));
     }
 
-    public function testGetContentPathWithPort()
+    public function testLegacyGetContentRootPath()
+    {
+        $this->requestAnalyzer->getAttribute('host')->willReturn('www.sulu.io');
+        $this->requestAnalyzer->getAttribute('port')->willReturn(80);
+        $this->webspaceManager->findUrlByResourceLocator(
+            '/',
+            $this->environment,
+            'de',
+            'sulu_io',
+            'www.sulu.io',
+            'http'
+        )->willReturn('www.sulu.io/de')->shouldBeCalledTimes(1);
+
+        $this->assertEquals('www.sulu.io/de', $this->extension->getContentRootPath());
+    }
+
+    public function testGetContentRootUrl()
+    {
+        $this->requestAnalyzer->getAttribute('host')->willReturn('www.sulu.io');
+        $this->requestAnalyzer->getAttribute('port')->willReturn(80);
+        $this->webspaceManager->findUrlByResourceLocator(
+            '/',
+            $this->environment,
+            'de',
+            'sulu_io',
+            'www.sulu.io',
+            'http'
+        )->willReturn('www.sulu.io/de')->shouldBeCalledTimes(1);
+
+        $this->assertEquals('www.sulu.io/de', $this->extension->getContentRootUrl());
+    }
+
+    public function testGetContentUrl()
+    {
+        $this->requestAnalyzer->getAttribute('host')->willReturn('www.sulu.io');
+        $this->requestAnalyzer->getAttribute('port')->willReturn(80);
+        $this->webspaceManager->findUrlByResourceLocator(
+            '/test',
+            $this->environment,
+            'de',
+            'sulu_io',
+            'www.sulu.io',
+            'http'
+        )->willReturn('www.sulu.io/de/test')->shouldBeCalledTimes(1);
+
+        $this->assertEquals('www.sulu.io/de/test', $this->extension->getContentUrl('/test'));
+    }
+
+    public function testGetContentUrlWithPort()
     {
         $this->requestAnalyzer->getAttribute('host')->willReturn('www.sulu.io');
         $this->requestAnalyzer->getAttribute('port')->willReturn(8000);
@@ -109,10 +157,10 @@ class ContentPathTwigExtensionTest extends TestCase
             'http'
         )->willReturn('www.sulu.io/de/test')->shouldBeCalledTimes(1);
 
-        $this->assertEquals('www.sulu.io:8000/de/test', $this->extension->getContentPath('/test'));
+        $this->assertEquals('www.sulu.io:8000/de/test', $this->extension->getContentUrl('/test'));
     }
 
-    public function testGetContentPathWithHttpsPort()
+    public function testGetContentUrlWithHttpsPort()
     {
         $this->requestAnalyzer->getAttribute('host')->willReturn('www.sulu.io');
         $this->requestAnalyzer->getAttribute('scheme')->willReturn('https');
@@ -126,10 +174,10 @@ class ContentPathTwigExtensionTest extends TestCase
             'https'
         )->willReturn('www.sulu.io/de/test')->shouldBeCalledTimes(1);
 
-        $this->assertEquals('www.sulu.io:444/de/test', $this->extension->getContentPath('/test'));
+        $this->assertEquals('www.sulu.io:444/de/test', $this->extension->getContentUrl('/test'));
     }
 
-    public function testGetContentPathWithDefaultHttpsPort()
+    public function testGetContentUrlWithDefaultHttpsPort()
     {
         $this->requestAnalyzer->getAttribute('host')->willReturn('www.sulu.io');
         $this->requestAnalyzer->getAttribute('scheme')->willReturn('https');
@@ -143,10 +191,10 @@ class ContentPathTwigExtensionTest extends TestCase
             'https'
         )->willReturn('www.sulu.io/de/test')->shouldBeCalledTimes(1);
 
-        $this->assertEquals('www.sulu.io/de/test', $this->extension->getContentPath('/test'));
+        $this->assertEquals('www.sulu.io/de/test', $this->extension->getContentUrl('/test'));
     }
 
-    public function testGetContentPathWithLocaleForDifferentDomain()
+    public function testGetContentUrlWithLocaleForDifferentDomain()
     {
         $this->requestAnalyzer->getAttribute('host')->willReturn('en.sulu.io');
         $this->requestAnalyzer->getAttribute('port')->willReturn(80);
@@ -159,10 +207,10 @@ class ContentPathTwigExtensionTest extends TestCase
             'http'
         )->willReturn('de.sulu.io/test');
         $this->suluWebspace->hasDomain('en.sulu.io', 'prod', 'de')->willReturn(false);
-        $this->assertEquals('de.sulu.io/test', $this->extension->getContentPath('/test', null, 'de'));
+        $this->assertEquals('de.sulu.io/test', $this->extension->getContentUrl('/test', null, 'de'));
     }
 
-    public function testGetContentPathWithWebspaceKey()
+    public function testGetContentUrlWithWebspaceKey()
     {
         $this->requestAnalyzer->getAttribute('host')->willReturn('www.test.io');
         $this->requestAnalyzer->getAttribute('port')->willReturn(80);
@@ -175,10 +223,10 @@ class ContentPathTwigExtensionTest extends TestCase
             'http'
         )->willReturn('www.sulu.io/de/test')->shouldBeCalledTimes(1);
 
-        $this->assertEquals('www.sulu.io/de/test', $this->extension->getContentPath('/test', 'test_io'));
+        $this->assertEquals('www.sulu.io/de/test', $this->extension->getContentUrl('/test', 'test_io'));
     }
 
-    public function testGetContentPathWithWebspaceKeyNotFoundForDomain()
+    public function testGetContentUrlWithWebspaceKeyNotFoundForDomain()
     {
         $this->requestAnalyzer->getAttribute('host')->willReturn('www.test.io');
         $this->requestAnalyzer->getAttribute('port')->willReturn(80);
@@ -196,10 +244,10 @@ class ContentPathTwigExtensionTest extends TestCase
             'http'
         )->willReturn('www.test.io/de/test')->shouldBeCalledTimes(1);
 
-        $this->assertEquals('www.test.io/de/test', $this->extension->getContentPath('/test', 'test_io'));
+        $this->assertEquals('www.test.io/de/test', $this->extension->getContentUrl('/test', 'test_io'));
     }
 
-    public function testGetContentPathWithWebspaceKeyHostNotWebspace()
+    public function testGetContentUrlWithWebspaceKeyHostNotWebspace()
     {
         $this->requestAnalyzer->getAttribute('host')->willReturn('www.xy.io');
         $this->requestAnalyzer->getAttribute('port')->willReturn(80);
@@ -213,10 +261,10 @@ class ContentPathTwigExtensionTest extends TestCase
             'http'
         )->willReturn('www.test.io/de/test')->shouldBeCalledTimes(1);
 
-        $this->assertEquals('www.test.io/de/test', $this->extension->getContentPath('/test', 'test_io'));
+        $this->assertEquals('www.test.io/de/test', $this->extension->getContentUrl('/test', 'test_io'));
     }
 
-    public function testGetContentPathWithWebspaceKeyAndDomain()
+    public function testGetContentUrlWithWebspaceKeyAndDomain()
     {
         $this->requestAnalyzer->getAttribute('host')->willReturn('www.sulu.io');
         $this->requestAnalyzer->getAttribute('port')->willReturn(80);
@@ -231,11 +279,11 @@ class ContentPathTwigExtensionTest extends TestCase
 
         $this->assertEquals(
             '/test',
-            $this->extension->getContentPath('/test', 'test_io', 'en', 'www.test.io')
+            $this->extension->getContentUrl('/test', 'test_io', 'en', 'www.test.io')
         );
     }
 
-    public function testGetContentPathExternalUrl()
+    public function testGetContentUrlExternalUrl()
     {
         $this->requestAnalyzer->getAttribute('host')->willReturn('www.sulu.io');
         $this->webspaceManager->findUrlByResourceLocator(

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathTwigExtension.php
@@ -49,12 +49,21 @@ class ContentPathTwigExtension extends AbstractExtension implements ContentPathI
     public function getFunctions()
     {
         return [
+            new TwigFunction('sulu_content_url', [$this, 'getContentUrl']),
+            new TwigFunction('sulu_content_root_url', [$this, 'getContentRootUrl']),
             new TwigFunction('sulu_content_path', [$this, 'getContentPath']),
             new TwigFunction('sulu_content_root_path', [$this, 'getContentRootPath']),
         ];
     }
 
     public function getContentPath($route, $webspaceKey = null, $locale = null, $domain = null, $scheme = null, $withoutDomain = true)
+    {
+        @trigger_error('The usage of the "sulu_content_path" is deprecated since sulu/sulu 2.1 use "sulu_content_url" instead.', E_USER_DEPRECATED);
+
+        return $this->getContentUrl($route, $webspaceKey, $locale, $domain, $scheme, $withoutDomain);
+    }
+
+    public function getContentUrl($route, $webspaceKey = null, $locale = null, $domain = null, $scheme = null, $withoutDomain = true)
     {
         // if the request analyzer null or a route is passed which is relative or inclusive a domain nothing should be
         // done (this is important for external-links in navigations)
@@ -106,6 +115,13 @@ class ContentPathTwigExtension extends AbstractExtension implements ContentPathI
 
     public function getContentRootPath($full = false)
     {
-        return $this->getContentPath('/');
+        @trigger_error('The usage of the "sulu_content_root_path" is deprecated since sulu/sulu 2.1 use "sulu_content_root_url" instead.', E_USER_DEPRECATED);
+
+        return $this->getContentUrl('/');
+    }
+
+    public function getContentRootUrl($webspaceKey = null, $locale = null, $domain = null, $scheme = null, $withoutDomain = true)
+    {
+        return $this->getContentUrl('/', $webspaceKey, $locale, $domain, $scheme, $withoutDomain);
     }
 }

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -23,12 +23,12 @@
             <nav>
                 <ul>
                     <li>
-                        <a href="{{ sulu_content_root_path() }}">Homepage</a>
+                        <a href="{{ sulu_content_root_url() }}">Homepage</a>
                     </li>
 
                     {% for item in sulu_navigation_root_tree('main') %}
                         <li>
-                            <a href="{{ sulu_content_path(item.url, item.webspaceKey) }}"
+                            <a href="{{ sulu_content_url(item.url, item.webspaceKey) }}"
                                title="{{ item.title }}">{{ item.title }}</a>
                         </li>
                     {% endfor %}

--- a/templates/pages/homepage.html.twig
+++ b/templates/pages/homepage.html.twig
@@ -6,7 +6,7 @@
     <ul>
         {% for page in content.pages  %}
             <li>
-                <a href="{{sulu_content_path(page.url)}}">{{ page.title }}</a>
+                <a href="{{sulu_content_url(page.url)}}">{{ page.title }}</a>
             </li>
         {% endfor %}
     </ul>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Explain the contents of the PR.

#### Why?

Since sulu [1.2](https://github.com/sulu/sulu/blob/master/UPGRADE.md#sulu_content_path) the `sulu_content_path` does return the full url. To be similar to [Symfony Url Twig Extension](https://symfony.com/doc/4.4/reference/twig_reference.html#url) which does also return the full path I would rename the function to _url instead of _path.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
