### PR TITLE
Disable upload toolbar-action inside of system collections

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -244,7 +244,11 @@ export default withToolbar(MediaOverview, function() {
 
     const items = [];
 
-    const {permissions: collectionPermissions = {}} = this.collectionStore;
+    const {
+        permissions: collectionPermissions = {},
+        loading: collectionLoading,
+        locked: collectionLocked,
+    } = this.collectionStore;
 
     const addPermission = collectionPermissions.add !== undefined ? collectionPermissions.add : routeAddPermission;
     const deletePermission = collectionPermissions.delete !== undefined
@@ -254,7 +258,7 @@ export default withToolbar(MediaOverview, function() {
 
     if (addPermission) {
         items.push({
-            disabled: !this.collectionId.get(),
+            disabled: !this.collectionId.get() || collectionLoading || collectionLocked,
             icon: 'su-upload',
             label: translate('sulu_media.upload'),
             onClick: action(() => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adjusts the `MediaOverview` view to disable the upload toolbar-action when a system collection is opened.

#### Why?

Because the dropzone for uploading images does not work inside of system collections. This is quite confusing if you do not know that it is not possible to upload something into a system collection via the administration interface.