### PR TITLE
Allow to use SetUnpublishedToolbarAction for unlocalized entities

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SetUnpublishedToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SetUnpublishedToolbarAction.test.js
@@ -176,15 +176,6 @@ test('Return no dialog if no id is set', () => {
     expect(setUnpublishedToolbarAction.getNode()).toEqual(null);
 });
 
-test('Throw error if no locale is given', () => {
-    const setUnpublishedToolbarAction = createSetUnpublishedToolbarAction();
-    setUnpublishedToolbarAction.resourceFormStore.resourceStore.id = 3;
-    // $FlowFixMe
-    setUnpublishedToolbarAction.resourceFormStore.resourceStore.locale = undefined;
-
-    expect(() => setUnpublishedToolbarAction.getNode()).toThrow('locale');
-});
-
 test('Close dialog when onClose from unpublish dialog is called', () => {
     const setUnpublishedToolbarAction = createSetUnpublishedToolbarAction();
     setUnpublishedToolbarAction.resourceFormStore.resourceStore.id = 3;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SetUnpublishedToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SetUnpublishedToolbarAction.js
@@ -46,16 +46,11 @@ export default class SetUnpublishedToolbarAction extends AbstractFormToolbarActi
         const {
             resourceFormStore: {
                 id,
-                locale,
             },
         } = this;
 
         if (!id) {
             return null;
-        }
-
-        if (!locale) {
-            throw new Error('The SetUnpublishedToolbarAction only works with locale!');
         }
 
         return (


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adjusts the `SetUnpublishedToolbarAction` to not throw an error if the resource store of the form does not have a locale.

#### Why?

Because right now, the `SetUnpublishedToolbarAction` cannot be used for unlocalized entities.
