### PR TITLE
Conflict doctrine/infector 1.4.0 and 2.0.0 version to fix media routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * release/1.6
+    * BUGFIX      #5284  [MediaBundle]             Conflict doctrine/inflector 1.4.0 and 2.0.0 version to fix media routes
     * BUGFIX      #5240  [Content]                 Fix copy language with different template
 
 * 1.6.32 (2020-03-26)

--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
         "phpdocumentor/reflection-docblock": "~3.1"
     },
     "conflict": {
+        "doctrine/inflector": "1.4.0 || 2.0.0",
         "symfony/symfony": "3.4.12 || 3.4.16 || 3.4.17",
         "jackalope/jackalope": "1.2.8 || 1.3.0 || 1.3.1 || 1.3.6",
         "phpcr/phpcr-utils": "1.2.0 - 1.2.10 || 1.3.0 - 1.3.2"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5283
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Conflict doctrine/infector 1.4.0 and 2.0.0 version.

#### Why?

They are not compatible with sulu as they introduced a bug which should be fixed in newer version (https://github.com/doctrine/inflector/pull/142).

