### PR TITLE
Add conflict for doctrine/inflector breaking our media API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
         "phpdocumentor/reflection-docblock": "~3.1"
     },
     "conflict": {
+        "doctrine/inflector": "1.4.0",
         "symfony/symfony": "3.4.12 || 3.4.16 || 3.4.17",
         "jackalope/jackalope": "1.2.8 || 1.3.0 || 1.3.1 || 1.3.6",
         "phpcr/phpcr-utils": "1.2.0 - 1.2.10 || 1.3.0 - 1.3.2"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5283 
| Related issues/PRs | https://github.com/doctrine/inflector/pull/142
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds a conflict for `doctrine/inflector`, because the current version breaks our media API.
#### Why?

Which problem does the PR fix? (remove this section if you linked an issue above)