### PR TITLE
Fix error when sulu link has no href attribute

### DIFF
--- a/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
@@ -40,7 +40,9 @@ class LinkTag implements TagInterface
         $result = [];
         foreach ($attributesByTag as $tag => $attributes) {
             $provider = $this->getValue($attributes, 'provider', self::DEFAULT_PROVIDER);
-            if (!array_key_exists($provider . '-' . $attributes['href'], $contents)) {
+            if (!isset($attributes['href'])
+                || !array_key_exists($provider . '-' . $attributes['href'], $contents)
+            ) {
                 $result[$tag] = $this->getContent($attributes);
 
                 continue;
@@ -80,7 +82,9 @@ class LinkTag implements TagInterface
         $result = [];
         foreach ($attributesByTag as $tag => $attributes) {
             $provider = $this->getValue($attributes, 'provider', self::DEFAULT_PROVIDER);
-            if (!array_key_exists($provider . '-' . $attributes['href'], $items)) {
+            if (!isset($attributes['href'])
+                || !array_key_exists($provider . '-' . $attributes['href'], $items)
+            ) {
                 $result[$tag] = self::VALIDATE_REMOVED;
             } elseif (!$items[$provider . '-' . $attributes['href']]->isPublished()) {
                 $result[$tag] = self::VALIDATE_UNPUBLISHED;
@@ -108,7 +112,9 @@ class LinkTag implements TagInterface
                 $hrefsByType[$provider] = [];
             }
 
-            $hrefsByType[$provider][] = $attributes['href'];
+            if (isset($attributes['href'])) {
+                $hrefsByType[$provider][] = $attributes['href'];
+            }
         }
 
         $result = [];

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
@@ -300,7 +300,7 @@ class LinkTagTest extends TestCase
 
     public function testParseAllValidationState()
     {
-        $this->providers['article']->preload(['123-123-123'], 'de', true)
+        $this->providers['article']->preload(['123-123-123', '456-789-123'], 'de', true)
             ->willReturn(
                 [
                     new LinkItem('123-123-123', 'Page-Title 1', '/de/test-1', true),
@@ -308,7 +308,8 @@ class LinkTagTest extends TestCase
             );
 
         $tag1 = '<sulu-link href="123-123-123" title="Test-Title" target="_blank" provider="article" sulu-validation-state="unpublished">Test-Content</sulu-link>';
-        $tag2 = '<sulu-link href="123-123-123" title="Test-Title" target="_blank" provider="article" sulu-validation-state="removed">Test-Content</sulu-link>';
+        $tag2 = '<sulu-link href="456-789-123" title="Test-Title" target="_blank" provider="article" sulu-validation-state="removed">Test-Content</sulu-link>';
+        $tag3 = '<sulu-link provider="article" sulu-validation-state="removed">Test-Content</sulu-link>';
 
         $result = $this->linkTag->parseAll(
             [
@@ -321,11 +322,16 @@ class LinkTagTest extends TestCase
                     'validation-state' => 'unpublished',
                 ],
                 $tag2 => [
-                    'href' => '123-123-123',
+                    'href' => '456-789-123',
                     'title' => 'Test-Title',
                     'target' => '_blank',
                     'content' => 'Test-Content',
                     'provider' => 'article',
+                    'validation-state' => 'removed',
+                ],
+                $tag3 => [
+                    'provider' => 'article',
+                    'content' => 'Test-Content',
                     'validation-state' => 'removed',
                 ],
             ],
@@ -335,7 +341,8 @@ class LinkTagTest extends TestCase
         $this->assertEquals(
             [
                 $tag1 => '<a href="/de/test-1" title="Test-Title" target="_blank">Test-Content</a>',
-                $tag2 => '<a href="/de/test-1" title="Test-Title" target="_blank">Test-Content</a>',
+                $tag2 => 'Test-Content',
+                $tag3 => 'Test-Content',
             ],
             $result
         );


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5286
| Related issues/PRs |
| License | MIT
| Documentation PR | -

#### What's in this PR?

Check if href attribute is set if not ignore it and mark link as not validate.

#### Why?

It should not crash if an invalid sulu-link without href is in the text editor. Seems like the new ckeditor does remove an empty href tag.

#### TODO

 - [x] Add Test
