### PR TITLE
Allow DateTimeInterface in PublishInterface

### DIFF
--- a/src/Sulu/Component/SmartContent/PublishInterface.php
+++ b/src/Sulu/Component/SmartContent/PublishInterface.php
@@ -19,7 +19,7 @@ interface PublishInterface extends ResourceItemInterface
     /**
      * Returns the date at which the content was published.
      *
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getPublished();
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Allow DateTimeInterface in PublishInterface.

#### Why?

In some cases we use the \DateTimeImmutable which works but phpstan will fail.

#### BC Breaks/Deprecations

No BC Break as it now allows more be returned as before and as it only is a phpdoc the inheritance will not fail.
