### PR TITLE
Fix sorting of smart content when used with doctrine

### DIFF
--- a/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
+++ b/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
@@ -31,7 +31,7 @@ trait DataProviderRepositoryTrait
         $this->appendJoins($queryBuilder, $alias, $locale);
 
         if (isset($filters['sortBy'])) {
-            $sortMethod = isset($filters['sortMethod']) ? $filters['sortMethod'] : 'asc';
+            $sortMethod = $filters['sortMethod'] ?? 'asc';
             $this->appendSortBy($filters['sortBy'], $sortMethod, $queryBuilder, $alias, $locale);
         }
 

--- a/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
+++ b/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
@@ -30,8 +30,8 @@ trait DataProviderRepositoryTrait
             ->orderBy($alias . '.id', 'ASC');
         $this->appendJoins($queryBuilder, $alias, $locale);
 
-        if (array_key_exists('sortBy', $filters)) {
-            $sortMethod = array_key_exists('sortMethod', $filters) ? $filters['sortMethod'] : 'asc';
+        if (isset($filters['sortBy'])) {
+            $sortMethod = isset($filters['sortMethod']) ? $filters['sortMethod'] : 'asc';
             $this->appendSortBy($filters['sortBy'], $sortMethod, $queryBuilder, $alias, $locale);
         }
 

--- a/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
@@ -101,4 +101,64 @@ class DataProviderRepositoryTraitTest extends TestCase
         // this makes problems if also a limit is used
         $queryBuilder->distinct()->shouldBeCalled();
     }
+
+    public function testFindByFiltersWithSorting()
+    {
+        $query = $this->prophesize(Query::class);
+
+        $query = $this->prophesize(Query::class);
+        $query->setParameter(Argument::cetera())->willReturn($query);
+        $query->setFirstResult(0)->willReturn($query);
+        $query->setMaxResults(Argument::any())->willReturn($query);
+        $query->getScalarResult()->willReturn([]);
+        $query->getResult()->willReturn([]);
+        $queryBuilder = $this->prophesize(QueryBuilder::class);
+        $queryBuilder->addSelect(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->select(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->where(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->orderBy(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->distinct(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->getAllAliases()->willReturn([]);
+        $queryBuilder->getQuery()->willReturn($query);
+        $this->dataProviderRepositoryTrait->method('createQueryBuilder')->willReturn($queryBuilder->reveal());
+        $this->dataProviderRepositoryTrait->findByFilters(
+            ['sortBy' => 'test', 'sortMethod' => 'asc'],
+            1,
+            5,
+            null,
+            'de'
+        );
+
+        $queryBuilder->orderBy('test', 'asc')->shouldBeCalled();
+    }
+
+    public function testFindByFiltersWithoutSorting()
+    {
+        $query = $this->prophesize(Query::class);
+
+        $query = $this->prophesize(Query::class);
+        $query->setParameter(Argument::cetera())->willReturn($query);
+        $query->setFirstResult(0)->willReturn($query);
+        $query->setMaxResults(Argument::any())->willReturn($query);
+        $query->getScalarResult()->willReturn([]);
+        $query->getResult()->willReturn([]);
+        $queryBuilder = $this->prophesize(QueryBuilder::class);
+        $queryBuilder->addSelect(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->select(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->where(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->orderBy(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->distinct(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->getAllAliases()->willReturn([]);
+        $queryBuilder->getQuery()->willReturn($query);
+        $this->dataProviderRepositoryTrait->method('createQueryBuilder')->willReturn($queryBuilder->reveal());
+        $this->dataProviderRepositoryTrait->findByFilters(
+            ['sortBy' => null, 'sortMethod' => 'asc'],
+            1,
+            5,
+            null,
+            'de'
+        );
+
+        $queryBuilder->orderBy(null, 'asc')->shouldNotBeCalled();
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes a bug that occured when the `DataProviderRepositoryTrait` without any sorting. This can be reproduced by using the following property in an XML file:

```xml
<property name="accounts" type="smart_content">
    <meta>
        <title lang="en">Accounts</title>
    </meta>
    <params>
        <param name="provider" value="accounts"/>
    </params>
</property>
```

The following error should appear without this fix:

```
Notice: Trying to access array offset on value of type null
```