### PR TITLE
Add missing service definition for SingleCategorySelection

### DIFF
--- a/config/templates/pages/example.xml
+++ b/config/templates/pages/example.xml
@@ -252,6 +252,13 @@
             </meta>
         </property>
 
+        <property name="single_category_selection" type="single_category_selection">
+            <meta>
+                <title lang="en">Single Category Selection</title>
+                <title lang="de">Einzelkategorien</title>
+            </meta>
+        </property>
+
         <property name="single_media_selection" type="single_media_selection">
             <meta>
                 <title lang="en">Single Media Selection</title>

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/services.xml
@@ -28,6 +28,15 @@
             <argument type="service" id="sulu_category.category_manager"/>
         </service>
 
+        <service
+            id="sulu_category.content.type.single_category_selection"
+            class="Sulu\Bundle\CategoryBundle\Content\Types\SingleCategorySelection"
+        >
+            <tag name="sulu.content.type" alias="single_category_selection"/>
+            <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
+            <argument type="service" id="sulu_category.category_manager"/>
+        </service>
+
         <service id="sulu_category.category_request_handler" class="Sulu\Component\Category\Request\CategoryRequestHandler">
             <argument type="service" id="request_stack"/>
         </service>

--- a/templates/pages/example.html.twig
+++ b/templates/pages/example.html.twig
@@ -44,6 +44,7 @@
     <p>{{ content.smart_content | map(page => page.title) | join(', ') }}</p>
     <p>{{ content.snippet_selection | map(snippet => snippet.title) | join(', ') }}</p>
     <p>{{ content.category_selection | map(category => category.name) | join(', ') }}</p>
+    <p>{{ content.single_category_selection ? content.single_category_selection.name : ''}}
 
     {% if content.single_media_selection %}
         <img src="{{ content.single_media_selection.thumbnails['sulu-260x'] }}" />


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5295 
| Related issues/PRs | #5106 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds the missing service for the `SingleCategorySelection` field type.

#### Why?

Because otherwise the content type cannot be used.

#### Example Usage

~~~xml
<property name="single_category" type="single_category_selection" />
~~~