### PR TITLE
Json_decode on userroles returns object

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Entity/UserRole.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/UserRole.php
@@ -92,7 +92,7 @@ class UserRole extends ApiEntity
      */
     public function getLocales()
     {
-        return json_decode($this->locale);
+        return json_decode($this->locale, true);
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | Yes
| New feature? | no
| BC breaks? | Maybe
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fixing the locale deserialization on roles.

#### Why?

The `json_decode` function returns an object contrary to what the documentation of the method describes. 
This breaks in `src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php:242` when the `in_array` function gets an object.

#### BC Breaks/Deprecations

If someone was depending on it being an object (dispite the fact that it says array in the documentation) this could be a problem.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
