### PR TITLE
Add possibility to include search fields as indexed

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureProvider.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureProvider.php
@@ -159,7 +159,7 @@ class StructureProvider implements ProviderInterface
                                         '[' . $componentProperty->getName() . ']'
                                     ),
                                     'aggregate' => true,
-                                    'indexed' => false,
+                                    'indexed' => isset($tagAttributes['index']) && 'indexed' === $tagAttributes['index'],
                                 ]
                             );
                         }
@@ -386,7 +386,7 @@ EOT;
                     'type' => isset($tagAttributes['type']) ? $tagAttributes['type'] : 'string',
                     'field' => $this->getContentField($property),
                     'aggregate' => true,
-                    'indexed' => false,
+                    'indexed' => isset($tagAttributes['index']) && 'indexed' === $tagAttributes['index'],
                 ]
             );
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

The PR makes it possible to include fields as `indexed`, not just as part of the aggregate.

#### Why?

If a field is (additionally) indexed by itself, it can be used in a search query with higher priority.

#### Example Usage

The XML would look something like this:

```xml
<property name="search_keywords" type="text_line" mandatory="false">
    <meta>
        <title lang="de">Suchpriorisierung für folgende Schlüsselwörter</title>
    </meta>
    <params>
        <param name="search_keywords" value="true"/>
    </params>
    <tag name="sulu.search.field" index="indexed"/>
</property>
```

The query something like this

> search_keywords:("test")^2

For more
https://github.com/sulu/sulu/issues/5290