### PR TITLE
Add smart-content migration for sortBy

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version202005250917.php
+++ b/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version202005250917.php
@@ -16,7 +16,7 @@ use PHPCR\SessionInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-class Version202005191116 implements VersionInterface, ContainerAwareInterface
+class Version202005250917 implements VersionInterface, ContainerAwareInterface
 {
     use ContainerAwareTrait;
 
@@ -45,7 +45,7 @@ class Version202005191116 implements VersionInterface, ContainerAwareInterface
     {
         $queryManager = $session->getWorkspace()->getQueryManager();
 
-        $query = 'SELECT * FROM [nt:unstructured] WHERE ([jcr:mixinTypes] = "sulu:snippet")';
+        $query = 'SELECT * FROM [nt:unstructured] WHERE ([jcr:mixinTypes] = "sulu:snippet" or [jcr:mixinTypes] = "sulu:page")';
         $rows = $queryManager->createQuery($query, 'JCR-SQL2')->execute();
 
         foreach ($rows as $row) {
@@ -54,11 +54,10 @@ class Version202005191116 implements VersionInterface, ContainerAwareInterface
             foreach ($node->getProperties() as $property) {
                 if (\is_string($property->getValue())) {
                     $propertyValue = json_decode($property->getValue(), true);
-                    if (\is_array($propertyValue) && \array_key_exists('items', $propertyValue)) {
-                        foreach ($propertyValue['items'] as &$item) {
-                            if (isset($item['type']) && 'content' === $item['type']) {
-                                $item['type'] = 'pages';
-                            }
+                    if (\is_array($propertyValue) && \array_key_exists('presentAs', $propertyValue) &&
+                        \array_key_exists('limitResult', $propertyValue) && \array_key_exists('sortBy', $propertyValue)) {
+                        if (is_array($propertyValue['sortBy'])) {
+                            $propertyValue['sortBy'] = \count($propertyValue['sortBy']) > 0 ? $propertyValue['sortBy'][0] : null;
                         }
 
                         $property->setValue(json_encode($propertyValue));
@@ -72,7 +71,7 @@ class Version202005191116 implements VersionInterface, ContainerAwareInterface
     {
         $queryManager = $session->getWorkspace()->getQueryManager();
 
-        $query = 'SELECT * FROM [nt:unstructured] WHERE ([jcr:mixinTypes] = "sulu:snippet")';
+        $query = 'SELECT * FROM [nt:unstructured] WHERE ([jcr:mixinTypes] = "sulu:snippet" or [jcr:mixinTypes] = "sulu:page")';
         $rows = $queryManager->createQuery($query, 'JCR-SQL2')->execute();
 
         foreach ($rows as $row) {
@@ -81,11 +80,10 @@ class Version202005191116 implements VersionInterface, ContainerAwareInterface
             foreach ($node->getProperties() as $property) {
                 if (\is_string($property->getValue())) {
                     $propertyValue = json_decode($property->getValue(), true);
-                    if (\is_array($propertyValue) && \array_key_exists('items', $propertyValue)) {
-                        foreach ($propertyValue['items'] as &$item) {
-                            if (isset($item['type']) && 'pages' === $item['type']) {
-                                $item['type'] = 'content';
-                            }
+                    if (\is_array($propertyValue) && \array_key_exists('presentAs', $propertyValue) &&
+                        \array_key_exists('limitResult', $propertyValue) && \array_key_exists('sortBy', $propertyValue)) {
+                        if (is_array($propertyValue['sortBy'])) {
+                            $propertyValue['sortBy'] = [$propertyValue['sortBy']];
                         }
 
                         $property->setValue(json_encode($propertyValue));

--- a/src/Sulu/Bundle/PageBundle/Teaser/PageTeaserProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Teaser/PageTeaserProvider.php
@@ -121,7 +121,7 @@ class PageTeaserProvider implements TeaserProviderInterface
     {
         $images = json_decode($document->getField($field)->getValue(), true);
 
-        if (!array_key_exists('ids', $images) || 0 === count($images['ids'])) {
+        if (!$images || !array_key_exists('ids', $images) || 0 === count($images['ids'])) {
             return;
         }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Adds missing migration for `sortBy` property in snippets and pages.