### PR TITLE
Fix filtering of snippets when choosing snippet areas

### DIFF
--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/SnippetAreas.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/SnippetAreas.js
@@ -126,7 +126,7 @@ class SnippetAreas extends React.Component<ViewProps> {
                     onClose={this.handleListOverlayClose}
                     onConfirm={this.handleListOverlayConfirm}
                     open={!!this.openedAreaKey}
-                    options={{type: this.openedAreaKey}}
+                    options={{types: this.openedAreaKey}}
                     resourceKey="snippets"
                     title={translate('sulu_snippet.selection_overlay_title')}
                 />

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/SnippetAreas.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/SnippetAreas.js
@@ -126,7 +126,7 @@ class SnippetAreas extends React.Component<ViewProps> {
                     onClose={this.handleListOverlayClose}
                     onConfirm={this.handleListOverlayConfirm}
                     open={!!this.openedAreaKey}
-                    options={{types: this.openedAreaKey}}
+                    options={{areas: this.openedAreaKey}}
                     resourceKey="snippets"
                     title={translate('sulu_snippet.selection_overlay_title')}
                 />

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/SnippetAreas.test.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/SnippetAreas.test.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {mount, render} from 'enzyme';
+import {shallow, mount, render} from 'enzyme';
 import {Router} from 'sulu-admin-bundle/services';
 import {findWithHighOrderFunction} from 'sulu-admin-bundle/utils/TestHelper';
 
@@ -23,7 +23,7 @@ beforeEach(() => {
     jest.resetModules();
 });
 
-test('Render snippet areas with loading icon', () => {
+test('Show loader when loading snippet areas', () => {
     const SnippetAreas = require('../SnippetAreas').default;
     const SnippetAreaStore = require('../stores/SnippetAreaStore');
 
@@ -37,8 +37,8 @@ test('Render snippet areas with loading icon', () => {
         this.loading = true;
     });
 
-    expect(render(<SnippetAreas route={router.route} router={router} />)).toMatchSnapshot();
-    expect(SnippetAreaStore).toBeCalledWith('sulu');
+    const snippetAreas = shallow(<SnippetAreas route={router.route} router={router} />);
+    expect(snippetAreas.find('Loader')).toHaveLength(1);
 });
 
 test('Render snippet areas with data as table', () => {
@@ -103,6 +103,7 @@ test('Close after clicking add without choosing a snippet', () => {
     expect(snippetAreas.find(SingleListOverlay).prop('open')).toEqual(false);
     snippetAreas.find('Button[className="addButton"] button').simulate('click');
     expect(snippetAreas.find(SingleListOverlay).prop('open')).toEqual(true);
+    expect(snippetAreas.find(SingleListOverlay).prop('options')).toEqual({types: 'default'});
 
     snippetAreas.find(SingleListOverlay).prop('onClose')();
     snippetAreas.update();

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/SnippetAreas.test.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/SnippetAreas.test.js
@@ -103,7 +103,7 @@ test('Close after clicking add without choosing a snippet', () => {
     expect(snippetAreas.find(SingleListOverlay).prop('open')).toEqual(false);
     snippetAreas.find('Button[className="addButton"] button').simulate('click');
     expect(snippetAreas.find(SingleListOverlay).prop('open')).toEqual(true);
-    expect(snippetAreas.find(SingleListOverlay).prop('options')).toEqual({types: 'default'});
+    expect(snippetAreas.find(SingleListOverlay).prop('options')).toEqual({areas: 'default'});
 
     snippetAreas.find(SingleListOverlay).prop('onClose')();
     snippetAreas.update();

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/__snapshots__/SnippetAreas.test.js.snap
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/__snapshots__/SnippetAreas.test.js.snap
@@ -97,17 +97,3 @@ exports[`Render snippet areas with data as table 1`] = `
   </table>
 </div>
 `;
-
-exports[`Render snippet areas with loading icon 1`] = `
-<div
-  class="spinner"
-  style="width:40px;height:40px"
->
-  <div
-    class="doubleBounce1"
-  />
-  <div
-    class="doubleBounce2"
-  />
-</div>
-`;

--- a/src/Sulu/Bundle/SnippetBundle/Snippet/DefaultSnippetManager.php
+++ b/src/Sulu/Bundle/SnippetBundle/Snippet/DefaultSnippetManager.php
@@ -162,6 +162,17 @@ class DefaultSnippetManager implements DefaultSnippetManagerInterface
         return $this->settingsManager->loadString($webspaceKey, 'snippets-' . $area['key']);
     }
 
+    public function getTypeForArea(string $area): ?string
+    {
+        $area = $this->areas->get($area);
+
+        if (!$area) {
+            return null;
+        }
+
+        return $area['template'];
+    }
+
     /**
      * Check template.
      *

--- a/src/Sulu/Bundle/SnippetBundle/Snippet/DefaultSnippetManagerInterface.php
+++ b/src/Sulu/Bundle/SnippetBundle/Snippet/DefaultSnippetManagerInterface.php
@@ -90,4 +90,6 @@ interface DefaultSnippetManagerInterface
      * @return Webspace[]
      */
     public function loadWebspaces($uuid);
+
+    public function getTypeForArea(string $area): ?string;
 }

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Application/config/templates/snippets/car.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Application/config/templates/snippets/car.xml
@@ -7,6 +7,15 @@
 
     <key>car</key>
 
+    <areas>
+        <area key="car">
+            <meta>
+                <title lang="en">Car</title>
+                <title lang="de">Auto</title>
+            </meta>
+        </area>
+    </areas>
+
     <properties>
         <property name="title" type="text_line" mandatory="true">
             <meta>

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Application/config/templates/snippets/hotel.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Application/config/templates/snippets/hotel.xml
@@ -12,6 +12,22 @@
         <title lang="fr">Hôtel</title>
     </meta>
 
+    <areas>
+        <area key="golf_hotel">
+            <meta>
+                <title lang="en">Golf hotel</title>
+                <title lang="de">Golfhotel</title>
+            </meta>
+        </area>
+
+        <area key="sport_hotel">
+            <meta>
+                <title lang="en">Sport hotel</title>
+                <title lang="de">Sporthotel</title>
+            </meta>
+        </area>
+    </areas>
+
     <properties>
         <property name="title" type="text_line" mandatory="true">
             <meta>

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetAreaControllerTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetAreaControllerTest.php
@@ -41,15 +41,19 @@ class SnippetAreaControllerTest extends BaseFunctionalTestCase
         $response = \json_decode($client->getResponse()->getContent(), true);
 
         $data = $response['_embedded']['areas'];
-        $this->assertEquals(2, $response['total']);
+        $this->assertEquals(3, $response['total']);
         $this->assertEquals('car', $data[0]['template']);
         $this->assertEquals('Car', $data[0]['title']);
         $this->assertEquals(null, $data[0]['defaultTitle']);
         $this->assertEquals(null, $data[0]['defaultUuid']);
         $this->assertEquals('hotel', $data[1]['template']);
-        $this->assertEquals('Hotel', $data[1]['title']);
+        $this->assertEquals('Golf hotel', $data[1]['title']);
         $this->assertEquals(null, $data[1]['defaultTitle']);
         $this->assertEquals(null, $data[1]['defaultUuid']);
+        $this->assertEquals('hotel', $data[2]['template']);
+        $this->assertEquals('Sport hotel', $data[2]['title']);
+        $this->assertEquals(null, $data[2]['defaultTitle']);
+        $this->assertEquals(null, $data[2]['defaultUuid']);
     }
 
     public function testPutDefault()
@@ -76,15 +80,19 @@ class SnippetAreaControllerTest extends BaseFunctionalTestCase
         $response = \json_decode($client->getResponse()->getContent(), true);
         $data = $response['_embedded']['areas'];
 
-        $this->assertEquals(2, $response['total']);
+        $this->assertEquals(3, $response['total']);
         $this->assertEquals('car', $data[0]['template']);
         $this->assertEquals('Car', $data[0]['title']);
         $this->assertEquals($this->car1->getTitle(), $data[0]['defaultTitle']);
         $this->assertEquals($this->car1->getUuid(), $data[0]['defaultUuid']);
         $this->assertEquals('hotel', $data[1]['template']);
-        $this->assertEquals('Hotel', $data[1]['title']);
+        $this->assertEquals('Golf hotel', $data[1]['title']);
         $this->assertEquals(null, $data[1]['defaultTitle']);
         $this->assertEquals(null, $data[1]['defaultUuid']);
+        $this->assertEquals('hotel', $data[2]['template']);
+        $this->assertEquals('Sport hotel', $data[2]['title']);
+        $this->assertEquals(null, $data[2]['defaultTitle']);
+        $this->assertEquals(null, $data[2]['defaultUuid']);
     }
 
     /**
@@ -114,14 +122,18 @@ class SnippetAreaControllerTest extends BaseFunctionalTestCase
         $response = \json_decode($client->getResponse()->getContent(), true);
         $data = $response['_embedded']['areas'];
 
-        $this->assertEquals(2, $response['total']);
+        $this->assertEquals(3, $response['total']);
         $this->assertEquals('car', $data[0]['template']);
         $this->assertEquals('Car', $data[0]['title']);
         $this->assertEquals(null, $data[0]['defaultTitle']);
         $this->assertEquals(null, $data[0]['defaultUuid']);
         $this->assertEquals('hotel', $data[1]['template']);
-        $this->assertEquals('Hotel', $data[1]['title']);
+        $this->assertEquals('Golf hotel', $data[1]['title']);
         $this->assertEquals(null, $data[1]['defaultTitle']);
         $this->assertEquals(null, $data[1]['defaultUuid']);
+        $this->assertEquals('hotel', $data[2]['template']);
+        $this->assertEquals('Sport hotel', $data[2]['title']);
+        $this->assertEquals(null, $data[2]['defaultTitle']);
+        $this->assertEquals(null, $data[2]['defaultUuid']);
     }
 }

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
@@ -182,6 +182,24 @@ class SnippetControllerTest extends SuluTestCase
             ],
             [
                 [
+                    'areas' => 'car',
+                ],
+                4,
+            ],
+            [
+                [
+                    'areas' => 'golf_hotel',
+                ],
+                2,
+            ],
+            [
+                [
+                    'areas' => 'sport_hotel',
+                ],
+                2,
+            ],
+            [
+                [
                     'types' => 'hotel',
                 ],
                 2,
@@ -213,7 +231,7 @@ class SnippetControllerTest extends SuluTestCase
     /**
      * @dataProvider provideIndex
      */
-    public function testIndex($params, $expectedNbResults)
+    public function testIndex($params, $expectedResultCount)
     {
         $params = \array_merge([
             'locale' => 'de',
@@ -226,7 +244,7 @@ class SnippetControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $response);
 
         $result = \json_decode($response->getContent(), true);
-        $this->assertCount($expectedNbResults, $result['_embedded']['snippets']);
+        $this->assertCount($expectedResultCount, $result['_embedded']['snippets']);
 
         foreach ($result['_embedded']['snippets'] as $snippet) {
             // check if all snippets have a title, even if it is a ghost page
@@ -460,7 +478,7 @@ class SnippetControllerTest extends SuluTestCase
         $this->documentManager->persist($page, 'de', ['parent_path' => '/cmf/sulu_io/contents']);
         $this->documentManager->flush();
 
-        $this->defaultSnippetManager->save('sulu_io', 'hotel', $this->hotel1->getUuid(), 'en');
+        $this->defaultSnippetManager->save('sulu_io', 'sport_hotel', $this->hotel1->getUuid(), 'en');
 
         $this->client->request('DELETE', '/api/snippets/' . $this->hotel1->getUuid());
         $response = $this->client->getResponse();

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/DefaultSnippetManagerTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/DefaultSnippetManagerTest.php
@@ -321,4 +321,24 @@ class DefaultSnippetManagerTest extends TestCase
         $this->assertEquals([$webspace2], $manager->loadWebspaces('456'));
         $this->assertEquals([], $manager->loadWebspaces('321-321-321'));
     }
+
+    public function testGetTypeForArea()
+    {
+        $settingsManager = $this->prophesize(SettingsManagerInterface::class);
+        $documentManager = $this->prophesize(DocumentManagerInterface::class);
+        $webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $registry = $this->prophesize(DocumentRegistry::class);
+
+        $manager = new DefaultSnippetManager(
+            $settingsManager->reveal(),
+            $documentManager->reveal(),
+            $webspaceManager->reveal(),
+            $registry->reveal(),
+            $this->defaultTypes
+        );
+
+        $this->assertEquals('test', $manager->getTypeForArea('test_homepage'));
+        $this->assertEquals('test', $manager->getTypeForArea('testCase'));
+        $this->assertEquals('test', $manager->getTypeForArea('test'));
+    }
 }

--- a/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
@@ -87,13 +87,15 @@ class TestUserProvider implements UserProviderInterface
             $this->entityManager->persist($contact);
 
             $user = $this->userRepository->createNew();
-            $this->setCredentials($user);
-            $user->setLocale('en');
             $user->setContact($contact);
             $this->entityManager->persist($user);
-        } else {
-            $this->setCredentials($user);
         }
+
+        $user->setUsername(self::TEST_USER_USERNAME);
+        $user->setSalt('');
+        $encoder = $this->userPasswordEncoderFactory->getEncoder($user);
+        $user->setPassword($encoder->encodePassword('test', $user->getSalt()));
+        $user->setLocale('en');
 
         $this->entityManager->flush();
 
@@ -163,9 +165,5 @@ class TestUserProvider implements UserProviderInterface
      */
     private function setCredentials(UserInterface $user)
     {
-        $user->setUsername(self::TEST_USER_USERNAME);
-        $user->setSalt('');
-        $encoder = $this->userPasswordEncoderFactory->getEncoder($user);
-        $user->setPassword($encoder->encodePassword('test', $user->getSalt()));
     }
 }

--- a/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
@@ -159,11 +159,4 @@ class TestUserProvider implements UserProviderInterface
     {
         return $this->userProvider->supportsClass($class);
     }
-
-    /**
-     * Sets the standard credentials for the user.
-     */
-    private function setCredentials(UserInterface $user)
-    {
-    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5311 
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes the name of the query parameter used for filtering snippet areas.