### PR TITLE
Fix /cmf/snippets node not exist in live workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* release/1.6
+    * BUGFIX      #5323  [SnippetBundle]           Fix /cmf/snippets node not exist in live workspace
+
 * 1.6.33 (2020-05-11)
     * BUGFIX      #5284  [MediaBundle]             Conflict doctrine/inflector 1.4.0 and 2.0.0 version to fix media routes
     * BUGFIX      #5240  [Content]                 Fix copy language with different template

--- a/src/Sulu/Bundle/SnippetBundle/Document/SnippetInitializer.php
+++ b/src/Sulu/Bundle/SnippetBundle/Document/SnippetInitializer.php
@@ -59,7 +59,17 @@ class SnippetInitializer implements InitializerInterface
 
         $output->writeln(\sprintf('  [+] <info>snippet path:</info>: %s ', $snippetPath));
 
-        $session->getRootNode()->addNode(\ltrim($snippetPath, '/'));
+        $currentNode = $session->getRootNode();
+        $pathSegments = \explode('/', \trim($snippetPath, '/'));
+
+        foreach ($pathSegments as $pathSegment) {
+            if (!$currentNode->hasNode($pathSegment)) {
+                $currentNode->addNode($pathSegment);
+            }
+
+            $currentNode = $currentNode->getNode($pathSegment);
+        }
+
         $session->save();
     }
 }

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/snippet.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/snippet.xml
@@ -71,7 +71,7 @@
         </service>
 
         <service id="sulu_snippet.document.snippet_initializer" class="%sulu_snippet.document.snippet_initializer.class%">
-            <argument type="service" id="sulu_document_manager.node_manager" />
+            <argument type="service" id="doctrine_phpcr" />
             <argument type="service" id="sulu_document_manager.path_builder" />
             <tag name="sulu_document_manager.initializer"/>
         </service>

--- a/src/Sulu/Component/Util/SuluNodeHelper.php
+++ b/src/Sulu/Component/Util/SuluNodeHelper.php
@@ -222,7 +222,7 @@ class SuluNodeHelper
                 'Snippet type "%s" not available, available snippet types are: [%s]',
                 $type,
                 \implode(', ', $snippetStructures)
-            ));
+            ), 0, $e);
         }
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix /cmf/snippets node not exist in live workspace.

#### Why?

Currently /cmf/snippets is only created in default workspace which will fail on website  until a new snippet is created.

#### 

Use https://github.com/sulu/sulu/blob/851fc5464886e8cee65e4d2ed523620e16b00a96/config/templates/pages/homepage.xml#L48-L55

and do `bin/console sulu:build dev --destroy` and visit snippet error.
