### PR TITLE
Use in test same container class name as in other env

### DIFF
--- a/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
+++ b/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
@@ -129,14 +129,4 @@ class SuluTestKernel extends SuluKernel
             ));
         });
     }
-
-    /**
-     * {@inheritdoc}
-     *
-     * Add the Sulu environment to the container name
-     */
-    protected function getContainerClass()
-    {
-        return $this->name . \ucfirst($this->getContext()) . \ucfirst($this->environment) . ($this->debug ? 'Debug' : '') . 'ProjectContainer';
-    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | https://github.com/sulu/sulu/pull/5184
| License | MIT
| Documentation PR | -

#### What's in this PR?

Use in test same container class name as in other env.

#### Why?

Was forgot in https://github.com/sulu/sulu/pull/5184

#### BC Breaks/Deprecations

If used for phpstan he need to configure phpstan to the new path, but that was also the case for projects.
