### PR TITLE
Add svg support by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "ext-simplexml": "*",
         "aferrandini/urlizer": "^1.0",
         "antishov/doctrine-extensions-bundle": "^1.2.2",
+        "contao/imagine-svg": "^0.2.2",
         "dantleech/phpcr-migrations-bundle": "^1.0",
         "doctrine/annotations": "^1.2",
         "doctrine/common": "^2.7.1",
@@ -105,7 +106,6 @@
         "twig/twig": "^1.41 || ^2.10 || ^3.0"
     },
     "require-dev": {
-        "contao/imagine-svg": "^0.2.2",
         "google/cloud-storage": "^1.0",
         "handcraftedinthealps/zendsearch": "^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.3",
@@ -163,7 +163,6 @@
     "suggest": {
         "ext-fileinfo": "* - Needed to recognize file types of uploaded files",
         "ext-zip": "* - Needed by the download commands for the admin build and its translations",
-        "contao/imagine-svg": "^0.2.2 - Rendering raw svg formats for svg uploads",
         "rokka/imagine-vips": "^0.9.2 - Rendering formats by using the libvips",
         "handcraftedinthealps/zendsearch": "To use the PHP based Zend Search library (based on Lucene)",
         "league/flysystem": "^1.0 - Needed for remote media-storages",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "ext-simplexml": "*",
         "aferrandini/urlizer": "^1.0",
         "antishov/doctrine-extensions-bundle": "^1.2.2",
-        "contao/imagine-svg": "^0.2.2",
+        "contao/imagine-svg": "^0.2.2 || ^1.0",
         "dantleech/phpcr-migrations-bundle": "^1.0",
         "doctrine/annotations": "^1.2",
         "doctrine/common": "^2.7.1",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Add svg support by default.

#### Why?

I think we should provide the svg support by default, its just something which will be forget in many projects to be added. As the svg library doesn't have big [requirements](https://github.com/contao/imagine-svg/blob/master/composer.json) I think we should install it by default. Also there will be a stable 1.0 release soon: https://github.com/contao/imagine-svg/issues/22

/cc @sulu/core-team what do you think?

#### To Do

- [ ] Create a documentation PR
