### PR TITLE
Add better typing for router attributes

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/Login.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/Login.js
@@ -78,8 +78,8 @@ class Login extends React.Component<Props> {
 
         const {forgotPasswordToken} = router.attributes;
 
-        if (!forgotPasswordToken) {
-            throw new Error('The "forgotPasswordToken" is not set. This should not happen and is likely a bug.');
+        if (typeof forgotPasswordToken !== 'string') {
+            throw new Error('The "forgotPasswordToken" router attribute must be a string!');
         }
 
         userStore.resetPassword(password, forgotPasswordToken)

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -11,7 +11,7 @@ import Route from './Route';
 export default class Router {
     history: Object;
     @observable route: Route;
-    @observable attributes: Object = {};
+    @observable attributes: AttributeMap = {};
     @observable bindings: Map<string, IObservableValue<*>> = new Map();
     bindingDefaults: Map<string, ?string | number | boolean> = new Map();
     attributesHistory: {[string]: Array<AttributeMap>} = {};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/types.js
@@ -11,7 +11,7 @@ export type RouteConfig = {|
     type: string,
 |};
 
-export type AttributeMap = {[string]: any };
+export type AttributeMap = {[string]: ?mixed};
 
 export type RouteMap = {[string]: Route};
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/updateUserStoreContentLocaleFromRouterAttributes.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/updateUserStoreContentLocaleFromRouterAttributes.js
@@ -13,7 +13,16 @@ const updateUserStoreContentLocaleFromRouterAttributes: UpdateRouteHook = functi
     }
 
     if (newAttributes.locale) {
-        userStore.updateContentLocale(newAttributes.locale);
+        const locale = typeof newAttributes.locale.get === 'function'
+            // $FlowFixMe
+            ? newAttributes.locale.get()
+            : newAttributes.locale;
+
+        if (typeof locale !== 'string') {
+            throw new Error('The "locale" router attribute must be a string if given!');
+        }
+
+        userStore.updateContentLocale(locale);
     }
 
     return true;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -19,7 +19,8 @@ import formToolbarActionRegistry from './registries/formToolbarActionRegistry';
 import AbstractFormToolbarAction from './toolbarActions/AbstractFormToolbarAction';
 import formStyles from './form.scss';
 
-type Props = ViewProps & {
+type Props = {
+    ...ViewProps,
     locales: Array<string>,
     resourceStore: ResourceStore,
     title?: string,
@@ -91,6 +92,10 @@ class Form extends React.Component<Props> {
             },
         } = router;
         const {id} = attributes;
+
+        if (id !== undefined && typeof id !== 'string' && typeof id !== 'number') {
+            throw new Error('The "id" router attribute must be a string or a number if given!');
+        }
 
         if (!resourceStore) {
             throw new Error(

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteToolbarAction.js
@@ -129,7 +129,7 @@ export default class DeleteToolbarAction extends AbstractFormToolbarAction {
                 const attributeKey = routerAttributesToBackView[key];
                 const attributeName = isNaN(key) ? key : routerAttributesToBackView[key];
 
-                if (typeof attributeKey !== 'string') {
+                if (typeof attributeKey !== 'string' || typeof attributeName !== 'string') {
                     throw new Error('The value of the "router_attributes_to_back_view" option must be a string!');
                 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
@@ -10,7 +10,8 @@ import ResourceStore from '../../stores/ResourceStore';
 import {Route} from '../../services/Router';
 import resourceTabsStyles from './resourceTabs.scss';
 
-type Props = ViewProps & {
+type Props = {
+    ...ViewProps,
     locales?: Array<string>,
     titleProperty?: string,
 };
@@ -43,6 +44,10 @@ class ResourceTabs extends React.Component<Props> {
         if (this.locales) {
             options.locale = observable.box();
             router.bind('locale', options.locale);
+        }
+
+        if (id !== undefined && typeof id !== 'string' && typeof id !== 'number') {
+            throw new Error('The "id" router attribute must be a string or a number if given!');
         }
 
         this.resourceStore = new ResourceStore(resourceKey, id, options);

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/PageList.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/PageList.js
@@ -21,7 +21,8 @@ function getUserSettingsKeyForWebspace(webspace: string) {
     return [USER_SETTINGS_KEY, webspace].join('_');
 }
 
-type Props = ViewProps & {
+type Props = {
+    ...ViewProps,
     webspace: Webspace,
     webspaceKey: IObservableValue<string>,
 };
@@ -37,6 +38,10 @@ class PageList extends React.Component<Props> {
     webspaceKeyDisposer: () => void;
 
     static getDerivedRouteAttributes(route: Route, attributes: AttributeMap) {
+        if (typeof attributes.webspace !== 'string') {
+            throw new Error('The "webspace" router attribute must be a string!');
+        }
+
         return {
             active: ListStore.getActiveSetting(PAGES_RESOURCE_KEY, getUserSettingsKeyForWebspace(attributes.webspace)),
         };
@@ -96,6 +101,10 @@ class PageList extends React.Component<Props> {
                 webspace,
             },
         } = router;
+
+        if (typeof webspace !== 'string') {
+            throw new Error('The "webspace" router attribute must be a string!');
+        }
 
         const observableOptions = {};
         const requestParameters = {webspace};

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageTabs/PageTabs.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageTabs/PageTabs.js
@@ -18,6 +18,10 @@ class PageTabs extends React.Component<ViewProps> {
             },
         } = this.props;
 
+        if (typeof webspace !== 'string') {
+            throw new Error('The "webspace" router attribute must be a string!');
+        }
+
         return (
             <ResourceTabs
                 {...props}

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
@@ -58,6 +58,14 @@ class Preview extends React.Component<Props> {
             },
         } = this.props;
 
+        if (webspace !== undefined && typeof webspace !== 'string') {
+            throw new Error('The "webspace" router attribute must be a string if set!');
+        }
+
+        if (locale !== undefined && typeof locale !== 'string') {
+            throw new Error('The "webspace" router attribute must be a string if set!');
+        }
+
         if (Preview.audienceTargeting) {
             const targetGroupsStore = new ResourceListStore('target_groups');
             this.targetGroupsStore = targetGroupsStore;

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
@@ -63,7 +63,7 @@ class Preview extends React.Component<Props> {
         }
 
         if (locale !== undefined && typeof locale !== 'string') {
-            throw new Error('The "webspace" router attribute must be a string if set!');
+            throw new Error('The "locale" router attribute must be a string if set!');
         }
 
         if (Preview.audienceTargeting) {

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/stores/PreviewStore.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/stores/PreviewStore.js
@@ -18,13 +18,13 @@ export default class PreviewStore {
 
     resourceKey: string;
     id: ?string | number;
-    locale: string;
+    locale: ?string;
     @observable webspace: string;
     @observable targetGroup: number = -1;
 
     @observable token: ?string;
 
-    constructor(resourceKey: string, id: ?string | number, locale: string, webspace: string) {
+    constructor(resourceKey: string, id: ?string | number, locale: ?string, webspace: string) {
         this.resourceKey = resourceKey;
         this.id = id;
         this.locale = locale;

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/SnippetAreas.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/SnippetAreas.js
@@ -27,6 +27,10 @@ class SnippetAreas extends React.Component<ViewProps> {
             },
         } = router;
 
+        if (typeof webspace !== 'string') {
+            throw new Error('The "webspace" router attribute must be a string!');
+        }
+
         this.snippetAreaStore = new SnippetAreaStore(webspace);
         this.cacheClearToolbarAction = new CacheClearToolbarAction();
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR removes the `any` type from the router attributes, which allows flow to warn us if router attributes are not used in a safe manner.

#### Why?

To avoid errors [like in this PR](https://github.com/sulu/sulu/pull/5277#discussion_r435861926).