### PR TITLE
Show better error messages for invalid list searches

### DIFF
--- a/src/Sulu/Component/Rest/Exception/InvalidSearchException.php
+++ b/src/Sulu/Component/Rest/Exception/InvalidSearchException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Rest\Exception;
+
+class InvalidSearchException extends RestException
+{
+}

--- a/src/Sulu/Component/Rest/Exception/SearchFieldNotFoundException.php
+++ b/src/Sulu/Component/Rest/Exception/SearchFieldNotFoundException.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Rest\Exception;
+
+class SearchFieldNotFoundException extends RestException
+{
+    /**
+     * @var string
+     */
+    private $field;
+
+    public function __construct(string $field)
+    {
+        $this->field = $field;
+
+        parent::__construct(\sprintf('The "%s" field does not exist, but was requested as a search field', $field));
+    }
+}

--- a/src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Component\Rest\ListBuilder;
 
+use Sulu\Component\Rest\Exception\InvalidSearchException;
 use Sulu\Component\Rest\ListBuilder\Expression\ExpressionInterface;
 use Sulu\Component\Rest\ListBuilder\Metadata\AbstractPropertyMetadata;
 use Sulu\Component\Security\Authentication\UserInterface;
@@ -306,6 +307,13 @@ abstract class AbstractListBuilder implements ListBuilderInterface
     {
         $this->expressions[] = $this->createBetweenExpression($fieldDescriptor, $values);
         $this->addFieldDescriptor($fieldDescriptor);
+    }
+
+    public function execute()
+    {
+        if (null !== $this->search && \count($this->searchFields) <= 0) {
+            throw new InvalidSearchException('Searching is not possible, because no search fields have been defined');
+        }
     }
 
     /**

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -187,6 +187,8 @@ class DoctrineListBuilder extends AbstractListBuilder
 
     public function execute()
     {
+        parent::execute();
+
         // emit listbuilder.create event
         $event = new ListBuilderCreateEvent($this);
         $this->eventDispatcher->dispatch($event, ListBuilderEvents::LISTBUILDER_CREATE);

--- a/src/Sulu/Component/Rest/RestHelper.php
+++ b/src/Sulu/Component/Rest/RestHelper.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\Rest;
 
 use Sulu\Component\Persistence\RelationTrait;
+use Sulu\Component\Rest\Exception\SearchFieldNotFoundException;
 use Sulu\Component\Rest\ListBuilder\FieldDescriptorInterface;
 use Sulu\Component\Rest\ListBuilder\ListBuilderInterface;
 use Sulu\Component\Rest\ListBuilder\ListRestHelper;
@@ -64,6 +65,10 @@ class RestHelper implements RestHelperInterface
             }
 
             foreach ($searchFields as $searchField) {
+                if (!isset($fieldDescriptors[$searchField])) {
+                    throw new SearchFieldNotFoundException($searchField);
+                }
+
                 $fieldDescriptor = $fieldDescriptors[$searchField];
 
                 if (FieldDescriptorInterface::SEARCHABILITY_NEVER === $fieldDescriptor->getSearchability()) {

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -21,6 +21,7 @@ use Sulu\Bundle\SecurityBundle\Entity\AccessControl;
 use Sulu\Bundle\SecurityBundle\Entity\Role;
 use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\TestBundle\Testing\ReadObjectAttributeTrait;
+use Sulu\Component\Rest\Exception\InvalidSearchException;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilder;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineConcatenationFieldDescriptor;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescriptor;
@@ -451,6 +452,16 @@ class DoctrineListBuilderTest extends TestCase
         )->shouldBeCalled();
         $this->queryBuilder->setParameter('search', '%val%e%')->shouldBeCalled();
 
+        $this->doctrineListBuilder->execute();
+    }
+
+    public function testSearchWithoutSearchFields()
+    {
+        $this->expectException(InvalidSearchException::class);
+
+        $this->queryBuilder->addOrderBy(Argument::cetera())->shouldNotBeCalled();
+
+        $this->doctrineListBuilder->search('value');
         $this->doctrineListBuilder->execute();
     }
 

--- a/src/Sulu/Component/Rest/Tests/Unit/RestHelperTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/RestHelperTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\Rest\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use Sulu\Component\Rest\Exception\SearchFieldNotFoundException;
 use Sulu\Component\Rest\ListBuilder\FieldDescriptor;
 use Sulu\Component\Rest\ListBuilder\FieldDescriptorInterface;
 use Sulu\Component\Rest\RestHelper;
@@ -143,6 +144,28 @@ class RestHelperTest extends TestCase
         $listBuilder->expects($this->at(0))->method('addSearchField')->with($field1);
         $listBuilder->expects($this->at(1))->method('addSearchField')->with($field2);
         $listBuilder->expects($this->once())->method('search')->with('searchValue');
+
+        $this->restHelper->initializeListBuilder($listBuilder, ['name' => $field1, 'desc' => $field2]);
+    }
+
+    public function testInitializeListBuilderAddSearchWithNonExistingSearchField()
+    {
+        $this->expectException(SearchFieldNotFoundException::class);
+
+        $listBuilder = $this->getMockBuilder('Sulu\Component\Rest\ListBuilder\AbstractListBuilder')
+            ->setMethods(['search'])
+            ->getMockForAbstractClass();
+
+        $field1 = $this->getMockBuilder(FieldDescriptor::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $field2 = $this->getMockBuilder(FieldDescriptor::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->listRestHelper->expects($this->any())->method('getSearchFields')->willReturn(['non-existing']);
+        $this->listRestHelper->expects($this->any())->method('getSearchPattern')->willReturn('searchValue');
 
         $this->restHelper->initializeListBuilder($listBuilder, ['name' => $field1, 'desc' => $field2]);
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5227 
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds better error messages, when invalid list search are triggered.

#### Why?

Because #5227 shows that this irritated people, because the shown error messages were very cryptic.

#### Example Usage

1. Call a URL like this: ` /admin/api/contacts?page=1&limit=10&fields=avatar,firstName,lastName,mainEmail,account,city,mainPhone,id&flat=true&search=Daniel&searchFields=non-existing`

2. Do a search form a list where not a single search field has been defined.