### PR TITLE
Add conflict for broken phpstan version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -137,6 +137,7 @@
         "jackalope/jackalope-jackrabbit": "< 1.3.0",
         "phpcr/phpcr-utils": "1.2.0 - 1.2.10 || 1.3.0 - 1.3.2",
         "phpdocumentor/reflection-docblock": "5.0.0",
+        "phpstan/phpstan": "0.12.26",
         "symfony/doctrine-bridge": "< 3.4.0",
         "symfony/http-foundation": "4.3.4"
     },


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | phpstan/phpstan#3406, phpstan/phpstan#3404
| License | MIT
| Documentation PR | ---

#### What's in this PR?

Add a conflict for phpstan, because it shows some errors that are not any errors.