### PR TITLE
Make parent-template available in schema + pass it all the way to rou…

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
@@ -102,7 +102,7 @@ class StructureFormMetadataLoader implements FormMetadataLoaderInterface, CacheW
             $form->setDefaultType($this->defaultTypes[$key]);
         }
 
-        if (isset($metadataOptions['defaultTemplate'])) {
+        if (isset($metadataOptions['defaultTemplate']) && isset($form->getForms()[$metadataOptions['defaultTemplate']])) {
             $form->setDefaultType($metadataOptions['defaultTemplate']);
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
@@ -102,6 +102,10 @@ class StructureFormMetadataLoader implements FormMetadataLoaderInterface, CacheW
             $form->setDefaultType($this->defaultTypes[$key]);
         }
 
+        if (isset($metadataOptions['defaultTemplate'])) {
+            $form->setDefaultType($metadataOptions['defaultTemplate']);
+        }
+
         return $form;
     }
 

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -159,7 +159,7 @@ class PageAdmin extends Admin
         ];
 
         $routerAttributesToFormRequest = ['parentId', 'webspace'];
-        $routerAttributesToFormMetdata = ['webspace'];
+        $routerAttributesToFormMetdata = ['webspace', 'defaultTemplate'];
 
         $previewCondition = 'nodeType == 1';
 

--- a/src/Sulu/Bundle/PageBundle/Resources/config/serializer/Webspace.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/serializer/Webspace.xml
@@ -7,6 +7,6 @@
         <property name="localizations" expose="true" groups="frontend,Default">
             <type><![CDATA[array<Sulu\Component\Localization\Localization>]]></type>
         </property>
-        <property name="defaultTemplates" expose="true" groups="frontend,Default"/>
+        <property name="defaultTemplates" expose="true" groups="frontend,Default" />
     </class>
 </serializer>

--- a/src/Sulu/Bundle/PageBundle/Resources/js/stores/webspaceStore/types.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/stores/webspaceStore/types.js
@@ -5,7 +5,7 @@ export type Webspace = {
     _permissions: {[permission: string]: boolean},
     allLocalizations: Array<LocalizationItem>,
     customUrls: Array<CustomUrl>,
-    defaultTemplates: {[type: string]: string},
+    defaultTemplates: {[type: string]: Array<DefaultTemplate>},
     key: string,
     localizations: Array<Localization>,
     name: string,
@@ -13,6 +13,12 @@ export type Webspace = {
     portalInformation: Array<PortalInformation>,
     resourceLocatorStrategy: ResourceLocatorStrategy,
     urls: Array<Url>,
+};
+
+export type DefaultTemplate = {
+    parentTemplate: string | null,
+    template: string,
+    type: string
 };
 
 export type ResourceLocatorStrategy = {

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/PageList.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/PageList.js
@@ -172,14 +172,19 @@ class PageList extends React.Component<Props> {
             return defaultTemplate.parentTemplate === template;
         });
 
+        let addFormArgs = {
+            parentId: id,
+            locale: this.locale.get(),
+            webspace: router.attributes.webspace,
+        }
+
+        if (defaultTemplate && defaultTemplate.template) {
+            addFormArgs.defaultTemplate = defaultTemplate.template;
+        }
+
         router.navigate(
             'sulu_page.page_add_form',
-            {
-                parentId: id,
-                defaultTemplate: defaultTemplate.template,
-                locale: this.locale.get(),
-                webspace: router.attributes.webspace,
-            }
+            addFormArgs
         );
     };
 

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/PageList.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/PageList.js
@@ -167,13 +167,16 @@ class PageList extends React.Component<Props> {
 
         const key = page.path === '/' ? 'home' : 'page';
         const template = page.template;
-        console.log(template, webspace.defaultTemplates[key]);
+        const defaultTemplates = webspace.defaultTemplates[key];
+        const defaultTemplate = defaultTemplates.find((defaultTemplate) => {
+            return defaultTemplate.parentTemplate === template;
+        });
 
         router.navigate(
             'sulu_page.page_add_form',
             {
                 parentId: id,
-                parentTemplate: template,
+                defaultTemplate: defaultTemplate.template,
                 locale: this.locale.get(),
                 webspace: router.attributes.webspace,
             }

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/PageList.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/PageList.js
@@ -155,10 +155,22 @@ class PageList extends React.Component<Props> {
 
     handleItemAdd = (id: ?string | number) => {
         const {router} = this.props;
+
+        // Find template for id
+        let pageArray = [];
+        this.listStore.data.forEach((pages) => {
+            pageArray = [...pageArray, ...pages];
+        })
+        const page = pageArray.find((page) => {
+            return page.id === id
+        });
+        const template = page.template;
+
         router.navigate(
             'sulu_page.page_add_form',
             {
                 parentId: id,
+                parentTemplate: template,
                 locale: this.locale.get(),
                 webspace: router.attributes.webspace,
             }

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/PageList.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/PageList.js
@@ -154,7 +154,7 @@ class PageList extends React.Component<Props> {
     };
 
     handleItemAdd = (id: ?string | number) => {
-        const {router} = this.props;
+        const {router, webspace} = this.props;
 
         // Find template for id
         let pageArray = [];
@@ -164,7 +164,10 @@ class PageList extends React.Component<Props> {
         const page = pageArray.find((page) => {
             return page.id === id
         });
+
+        const key = page.path === '/' ? 'home' : 'page';
         const template = page.template;
+        console.log(template, webspace.defaultTemplates[key]);
 
         router.navigate(
             'sulu_page.page_add_form',

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapGeneratorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapGeneratorTest.php
@@ -30,6 +30,7 @@ use Sulu\Component\Content\Query\ContentQueryExecutor;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
+use Sulu\Component\Webspace\DefaultTemplate;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Navigation;
 use Sulu\Component\Webspace\NavigationContext;
@@ -144,7 +145,7 @@ class SitemapGeneratorTest extends SuluTestCase
         $this->webspace->setLocalizations([$local1, $local2]);
         $this->webspace->setName('Default');
 
-        $this->webspace->addDefaultTemplate('page', 'default');
+        $this->webspace->addDefaultTemplate(new DefaultTemplate('page', 'default'));
         $this->webspace->setTheme('test');
 
         $this->webspace->setNavigation(

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/StructureSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/StructureSubscriberTest.php
@@ -27,6 +27,7 @@ use Sulu\Component\Content\Mapper\Translation\TranslatedProperty;
 use Sulu\Component\Content\Metadata\PropertyMetadata;
 use Sulu\Component\Content\Metadata\StructureMetadata;
 use Sulu\Component\DocumentManager\Metadata;
+use Sulu\Component\Webspace\DefaultTemplate;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Webspace;
 
@@ -426,7 +427,7 @@ class StructureSubscriberTest extends SubscriberTestCase
         $this->inspector->getMetadata($this->document->reveal())->willReturn($metadata->reveal());
 
         $webspace = new Webspace();
-        $webspace->addDefaultTemplate('page', 'default');
+        $webspace->addDefaultTemplate(new DefaultTemplate('page', 'default'));
 
         $this->webspaceManager->findWebspaceByKey('sulu_io')->willReturn($webspace);
 

--- a/src/Sulu/Component/Webspace/DefaultTemplate.php
+++ b/src/Sulu/Component/Webspace/DefaultTemplate.php
@@ -1,0 +1,34 @@
+<?php
+
+
+namespace Sulu\Component\Webspace;
+
+
+class DefaultTemplate
+{
+    private $type;
+    private $template;
+    private $parentTemplate;
+
+    public function __construct(string $type, string $template, ?string $parentTemplate = null)
+    {
+        $this->type = $type;
+        $this->template = $template;
+        $this->parentTemplate = $parentTemplate;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getTemplate(): string
+    {
+        return $this->template;
+    }
+
+    public function getParentTemplate(): ?string
+    {
+        return $this->parentTemplate;
+    }
+}

--- a/src/Sulu/Component/Webspace/DefaultTemplate.php
+++ b/src/Sulu/Component/Webspace/DefaultTemplate.php
@@ -4,10 +4,24 @@
 namespace Sulu\Component\Webspace;
 
 
-class DefaultTemplate
+use JMS\Serializer\Annotation as Serializer;
+use Sulu\Component\Util\ArrayableInterface;
+
+class DefaultTemplate implements \JsonSerializable, ArrayableInterface
 {
+    /**
+     * @var string
+     */
     private $type;
+
+    /**
+     * @var string
+     */
     private $template;
+
+    /**
+     * @var string|null
+     */
     private $parentTemplate;
 
     public function __construct(string $type, string $template, ?string $parentTemplate = null)

--- a/src/Sulu/Component/Webspace/DefaultTemplate.php
+++ b/src/Sulu/Component/Webspace/DefaultTemplate.php
@@ -11,16 +11,19 @@ class DefaultTemplate implements \JsonSerializable, ArrayableInterface
 {
     /**
      * @var string
+     * @Serializer\Groups({"frontend", "Default"})
      */
     private $type;
 
     /**
      * @var string
+     * @Serializer\Groups({"frontend", "Default"})
      */
     private $template;
 
     /**
      * @var string|null
+     * @Serializer\Groups({"frontend", "Default"})
      */
     private $parentTemplate;
 
@@ -44,5 +47,19 @@ class DefaultTemplate implements \JsonSerializable, ArrayableInterface
     public function getParentTemplate(): ?string
     {
         return $this->parentTemplate;
+    }
+
+    public function toArray($depth = null)
+    {
+        return [
+            'template' => $this->template,
+            'type' => $this->type,
+            'parentTemplate' => $this->parentTemplate
+        ];
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->toArray();
     }
 }

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\Webspace\Loader;
 
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\CustomUrl;
+use Sulu\Component\Webspace\DefaultTemplate;
 use Sulu\Component\Webspace\Environment;
 use Sulu\Component\Webspace\Exception\InvalidWebspaceException;
 use Sulu\Component\Webspace\Loader\Exception\ExpectedDefaultTemplatesNotFound;
@@ -417,9 +418,9 @@ class XmlFileLoader10 extends BaseXmlFileLoader
             $template = $node->nodeValue;
             $type = $node->attributes->getNamedItem('type')->nodeValue;
 
-            $webspace->addDefaultTemplate($type, $template);
+            $webspace->addDefaultTemplate(new DefaultTemplate($type, $template));
             if ('homepage' === $type) {
-                $webspace->addDefaultTemplate('home', $template);
+                $webspace->addDefaultTemplate(new DefaultTemplate('home', $template));
             }
         }
 

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader11.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader11.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Component\Webspace\Loader;
 
+use Sulu\Component\Webspace\DefaultTemplate;
 use Sulu\Component\Webspace\Loader\Exception\ExpectedDefaultTemplatesNotFound;
 use Sulu\Component\Webspace\Webspace;
 
@@ -49,9 +50,14 @@ class XmlFileLoader11 extends XmlFileLoader10
             $template = $node->nodeValue;
             $type = $node->attributes->getNamedItem('type')->nodeValue;
 
-            $webspace->addDefaultTemplate($type, $template);
+            $parentTemplateNode = $node->attributes->getNamedItem('parent-template');
+            if ($parentTemplateNode) {
+                $parentTemplate = $parentTemplateNode->nodeValue;
+            }
+
+            $webspace->addDefaultTemplate(new DefaultTemplate($type, $template, isset($parentTemplate) ? $parentTemplate : null));
             if ('homepage' === $type) {
-                $webspace->addDefaultTemplate('home', $template);
+                $webspace->addDefaultTemplate(new DefaultTemplate('home', $template, isset($parentTemplate) ? $parentTemplate : null));
             }
         }
 

--- a/src/Sulu/Component/Webspace/Loader/schema/webspace/webspace-1.1.xsd
+++ b/src/Sulu/Component/Webspace/Loader/schema/webspace/webspace-1.1.xsd
@@ -128,6 +128,7 @@
         <xs:simpleContent>
             <xs:extension base="xs:string">
                 <xs:attribute name="type" type="xs:string" use="required"/>
+                <xs:attribute name="parent-template" type="xs:string"/>
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>

--- a/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
+++ b/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
@@ -11,6 +11,7 @@ use Sulu\Component\Webspace\CustomUrl;
 use Sulu\Component\Webspace\Webspace;
 use Sulu\Component\Webspace\Navigation;
 use Sulu\Component\Webspace\NavigationContext;
+use Sulu\Component\Webspace\DefaultTemplate;
 
 /**
  * {{ cache_class }}
@@ -69,7 +70,9 @@ class {{ cache_class }} extends {{ base_class }}
 
 {% for type,template in webspace.templates %}        $webspace->addTemplate('{{ type|raw }}', '{{ template }}');
 {% endfor %}
-{% for type,template in webspace.defaultTemplates %}        $webspace->addDefaultTemplate('{{ type }}', '{{ template }}');
+{% for templates in webspace.defaultTemplates %}
+{% for defaultTemplate in templates %}        $webspace->addDefaultTemplate(new DefaultTemplate('{{ defaultTemplate.type }}', '{{ defaultTemplate.template }}', '{{ defaultTemplate.parentTemplate }}'));
+{% endfor %}
 {% endfor %}
 {% for template in webspace.excludedTemplates %}        $webspace->addExcludedTemplate('{{ template }}');
 {% endfor %}

--- a/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\Webspace\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\DefaultTemplate;
 use Sulu\Component\Webspace\Environment;
 use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\Security;
@@ -270,8 +271,8 @@ class WebspaceTest extends TestCase
         $defaultTemplates = ['page' => 'default', 'homepage' => 'overview'];
 
         $webspace = new Webspace();
-        $webspace->addDefaultTemplate('page', 'default');
-        $webspace->addDefaultTemplate('homepage', 'overview');
+        $webspace->addDefaultTemplate(new DefaultTemplate('page', 'default'));
+        $webspace->addDefaultTemplate(new DefaultTemplate('homepage', 'overview'));
         $this->assertEquals($defaultTemplates, $webspace->getDefaultTemplates());
         $this->assertEquals($defaultTemplates['page'], $webspace->getDefaultTemplate('page'));
         $this->assertEquals($defaultTemplates['homepage'], $webspace->getDefaultTemplate('homepage'));

--- a/src/Sulu/Component/Webspace/Webspace.php
+++ b/src/Sulu/Component/Webspace/Webspace.php
@@ -487,12 +487,11 @@ class Webspace implements ArrayableInterface
     /**
      * Add a new default template for given type.
      *
-     * @param string $type
-     * @param string $template
+     * @param DefaultTemplate $defaultTemplate
      */
-    public function addDefaultTemplate($type, $template)
+    public function addDefaultTemplate(DefaultTemplate $defaultTemplate)
     {
-        $this->defaultTemplates[$type] = $template;
+        $this->defaultTemplates[$defaultTemplate->getType()][] = $defaultTemplate;
     }
 
     /**
@@ -505,7 +504,7 @@ class Webspace implements ArrayableInterface
     public function getDefaultTemplate($type)
     {
         if (\array_key_exists($type, $this->defaultTemplates)) {
-            return $this->defaultTemplates[$type];
+            return $this->defaultTemplates[$type][0]->getTemplate();
         }
 
         return;

--- a/src/Sulu/Component/Webspace/Webspace.php
+++ b/src/Sulu/Component/Webspace/Webspace.php
@@ -106,7 +106,7 @@ class Webspace implements ArrayableInterface
     /**
      * Template which is selected by default if no other template is chosen.
      *
-     * @var string[]
+     * @var DefaultTemplate[]
      */
     private $defaultTemplates = [];
 
@@ -513,7 +513,7 @@ class Webspace implements ArrayableInterface
     /**
      * Returns a array of default template.
      *
-     * @return string[]
+     * @return DefaultTemplate[]
      */
     public function getDefaultTemplates()
     {

--- a/src/Sulu/Component/Webspace/Webspace.php
+++ b/src/Sulu/Component/Webspace/Webspace.php
@@ -498,10 +498,11 @@ class Webspace implements ArrayableInterface
      * Returns a error template for given code.
      *
      * @param string $type
+     * @param string $defaultTemplate
      *
      * @return string|null
      */
-    public function getDefaultTemplate($type)
+    public function getDefaultTemplate($type, $defaultTemplate = null)
     {
         if (\array_key_exists($type, $this->defaultTemplates)) {
             return $this->defaultTemplates[$type][0]->getTemplate();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4922
| Related issues/PRs | #4922
| License | MIT
| Documentation PR | sulu/sulu-docs#479

#### What's in this PR?

Option to provide default template to children of a parent page.

#### Why?

An artists page should have artist as a default template, makes a lot more sense than always providing a default "Default".

#### To Do

- [x] Set the page template from the route attributes
- [ ] call store.setType to set the template select value