### PR TITLE
Add request-parameters to selection-field-filter-type

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/SelectionFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/SelectionFieldFilterType.js
@@ -30,7 +30,7 @@ class SelectionFieldFilterType extends AbstractFieldFilterType<?Array<string | n
     ) {
         super(onChange, parameters, value);
 
-        this.selectionStore = new MultiSelectionStore(this.resourceKey, []);
+        this.selectionStore = new MultiSelectionStore(this.resourceKey, [], null, 'ids', this.requestParameters);
 
         this.selectionStoreDisposer = autorun(() => {
             const {onChange, selectionStore} = this;
@@ -61,7 +61,7 @@ class SelectionFieldFilterType extends AbstractFieldFilterType<?Array<string | n
         this.valueDisposer();
     }
 
-    @computed get resourceKey() {
+    @computed get resourceKey(): string {
         const {parameters} = this;
 
         if (!parameters) {
@@ -77,7 +77,23 @@ class SelectionFieldFilterType extends AbstractFieldFilterType<?Array<string | n
         return resourceKey;
     }
 
-    @computed get displayProperty() {
+    @computed get requestParameters(): {[string]: mixed} {
+        const {parameters} = this;
+
+        if (!parameters) {
+            throw new Error('The "SelectionFieldFilterType" needs some parameters to work!');
+        }
+
+        const {requestParameters = {}} = parameters;
+
+        if (typeof requestParameters !== 'object') {
+            throw new Error('The "requestParameters" parameter must be an object!');
+        }
+
+        return requestParameters;
+    }
+
+    @computed get displayProperty(): string {
         const {parameters} = this;
 
         if (!parameters) {
@@ -126,6 +142,7 @@ class SelectionFieldFilterType extends AbstractFieldFilterType<?Array<string | n
                     <ResourceCheckboxGroup
                         displayProperty={this.displayProperty}
                         onChange={this.handleSelectChange}
+                        requestParameters={this.requestParameters}
                         resourceKey={this.resourceKey}
                         values={this.selectValue}
                     />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/SelectionFieldFilterType.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/SelectionFieldFilterType.test.js
@@ -18,6 +18,8 @@ test.each([
     [undefined, 'parameters'],
     [{}, 'resourceKey'],
     [{resourceKey: 35}, 'resourceKey'],
+    [{requestParameters: ''}, 'requestParameters'],
+    [{requestParameters: []}, 'requestParameters'],
 ])('Throw error if "%s" is passed as a parameter', (parameters, errorMessage) => {
     expect(() => new SelectionFieldFilterType(jest.fn(), parameters, undefined)).toThrow(errorMessage);
 });
@@ -25,7 +27,7 @@ test.each([
 test('Pass correct props to MultiAutoComplete', () => {
     const selectionFieldFilterType = new SelectionFieldFilterType(
         jest.fn(),
-        {displayProperty: 'name', resourceKey: 'accounts'},
+        {displayProperty: 'name', resourceKey: 'accounts', requestParameters: {limit: '99'}},
         undefined
     );
 
@@ -40,7 +42,7 @@ test('Pass correct props to MultiAutoComplete', () => {
 test('Pass correct props to Select', () => {
     const selectionFieldFilterType = new SelectionFieldFilterType(
         jest.fn(),
-        {displayProperty: 'name', resourceKey: 'accounts', type: 'select'},
+        {displayProperty: 'name', resourceKey: 'accounts', type: 'select', requestParameters: {limit: '99'}},
         [4, 6]
     );
 
@@ -49,6 +51,7 @@ test('Pass correct props to Select', () => {
     expect(selectionFieldFilterTypeForm.find('ResourceCheckboxGroup').props()).toEqual(expect.objectContaining({
         displayProperty: 'name',
         resourceKey: 'accounts',
+        requestParameters: {limit: '99'},
         values: [4, 6],
     }));
 });


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR adds `requestParameters` to the SelectionFieldFilterType to allow passing parameters to the api.

#### Why?

Is needed to set the limit of the APIs when loading the entities

#### Example Usage

~~~xml
<property name="eventId" visibility="never">
    <field-name>eventId</field-name>
    <entity-name>App\Entity\Show</entity-name>

    <filter type="selection">
        <params>
            <param name="displayProperty" value="title"/>
            <param name="resourceKey" value="events"/>
            <param name="type" value="select"/>
            <param name="requestParameters" type="collection">
                <param name="limit" value="99"/>
            </param>
        </params>
    </filter>
</property>
~~~
