### PR TITLE
Show publish indicator on list

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/PublishIndicator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/PublishIndicator.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
-import publishIndicatorStyles from './publishIndicator.scss';
 import classNames from 'classnames';
+import publishIndicatorStyles from './publishIndicator.scss';
 
 type Props = {
     containerClass?: string,
@@ -20,7 +20,7 @@ export default class PublishIndicator extends React.Component<Props> {
 
         const className = classNames(
             publishIndicatorStyles.publishIndicator,
-            containerClass,
+            containerClass
         );
 
         return (

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/PublishIndicator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/PublishIndicator.js
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import publishIndicatorStyles from './publishIndicator.scss';
 
 type Props = {
-    containerClass?: string,
+    className?: string,
     draft: boolean,
     published: boolean,
 };
@@ -16,15 +16,15 @@ export default class PublishIndicator extends React.Component<Props> {
     };
 
     render() {
-        const {containerClass, draft, published} = this.props;
+        const {className, draft, published} = this.props;
 
-        const className = classNames(
+        const containerClass = classNames(
             publishIndicatorStyles.publishIndicator,
-            containerClass
+            className
         );
 
         return (
-            <div className={className}>
+            <div className={containerClass}>
                 {published && <span className={publishIndicatorStyles.published} />}
                 {draft && <span className={publishIndicatorStyles.draft} />}
             </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/PublishIndicator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/PublishIndicator.js
@@ -1,8 +1,10 @@
 // @flow
 import React from 'react';
 import publishIndicatorStyles from './publishIndicator.scss';
+import classNames from 'classnames';
 
 type Props = {
+    containerClass?: string,
     draft: boolean,
     published: boolean,
 };
@@ -14,10 +16,15 @@ export default class PublishIndicator extends React.Component<Props> {
     };
 
     render() {
-        const {draft, published} = this.props;
+        const {containerClass, draft, published} = this.props;
+
+        const className = classNames(
+            publishIndicatorStyles.publishIndicator,
+            containerClass,
+        );
 
         return (
-            <div className={publishIndicatorStyles.publishIndicator}>
+            <div className={className}>
                 {published && <span className={publishIndicatorStyles.published} />}
                 {draft && <span className={publishIndicatorStyles.draft} />}
             </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/PublishIndicator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/PublishIndicator.js
@@ -18,6 +18,10 @@ export default class PublishIndicator extends React.Component<Props> {
     render() {
         const {className, draft, published} = this.props;
 
+        if (!draft && !published) {
+            return null;
+        }
+
         const containerClass = classNames(
             publishIndicatorStyles.publishIndicator,
             className

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/AbstractTableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/AbstractTableAdapter.js
@@ -45,21 +45,25 @@ export default class AbstractTableAdapter extends AbstractAdapter {
                     indicators.push(
                         <GhostIndicator
                             className={abstractTableAdapterStyles.ghostIndicator}
+                            key="ghost"
                             locale={item.ghostLocale}
                         />
                     );
                 } else {
-                    const draft = item.publishedState === undefined ? false : !item.publishedState;
-                    const published = item.published === undefined ? false : !!item.published;
+                    if (item.publishedState !== undefined || item.published !== undefined) {
+                        const draft = !item.publishedState;
+                        const published = !!item.published;
 
-                    if (draft || !published) {
-                        indicators.push(
-                            <PublishIndicator
-                                className={abstractTableAdapterStyles.publishIndicator}
-                                draft={draft}
-                                published={published}
-                            />
-                        );
+                        if (draft || !published) {
+                            indicators.push(
+                                <PublishIndicator
+                                    className={abstractTableAdapterStyles.publishIndicator}
+                                    draft={draft}
+                                    key="publish"
+                                    published={published}
+                                />
+                            );
+                        }
                     }
                 }
             }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/AbstractTableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/AbstractTableAdapter.js
@@ -41,7 +41,9 @@ export default class AbstractTableAdapter extends AbstractAdapter {
 
             return (
                 <Table.Cell key={item.id + schemaKey}>
-                    {index === 0 && !item.ghostLocale && (item.hasOwnProperty('publishedState') || item.hasOwnProperty('published')) && !item.publishedState &&
+                    {index === 0 && !item.ghostLocale
+                        && (item.hasOwnProperty('publishedState') || item.hasOwnProperty('published'))
+                        && !item.publishedState &&
                         <PublishIndicator
                             containerClass={abstractTableAdapterStyles.publishIndicator}
                             draft={item.publishedState === undefined ? false : !item.publishedState}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/AbstractTableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/AbstractTableAdapter.js
@@ -2,6 +2,7 @@
 import {computed} from 'mobx';
 import React from 'react';
 import GhostIndicator from '../../../components/GhostIndicator';
+import PublishIndicator from '../../../components/PublishIndicator';
 import Table from '../../../components/Table';
 import listFieldTransformerRegistry from '../registries/listFieldTransformerRegistry';
 import type {Schema} from '../types';
@@ -40,6 +41,13 @@ export default class AbstractTableAdapter extends AbstractAdapter {
 
             return (
                 <Table.Cell key={item.id + schemaKey}>
+                    {index === 0 && !item.ghostLocale && (item.hasOwnProperty('publishedState') || item.hasOwnProperty('published')) && !item.publishedState &&
+                        <PublishIndicator
+                            containerClass={abstractTableAdapterStyles.publishIndicator}
+                            draft={item.publishedState === undefined ? false : !item.publishedState}
+                            published={item.published === undefined ? false : !!item.published}
+                        />
+                    }
                     {index === 0 && item.ghostLocale &&
                         <GhostIndicator
                             className={abstractTableAdapterStyles.ghostIndicator}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/AbstractTableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/AbstractTableAdapter.js
@@ -39,23 +39,34 @@ export default class AbstractTableAdapter extends AbstractAdapter {
             const transformer = listFieldTransformerRegistry.get(this.schema[schemaKey].type);
             const value = transformer.transform(item[schemaKey]);
 
-            return (
-                <Table.Cell key={item.id + schemaKey}>
-                    {index === 0 && !item.ghostLocale
-                        && (item.hasOwnProperty('publishedState') || item.hasOwnProperty('published'))
-                        && !item.publishedState &&
-                        <PublishIndicator
-                            containerClass={abstractTableAdapterStyles.publishIndicator}
-                            draft={item.publishedState === undefined ? false : !item.publishedState}
-                            published={item.published === undefined ? false : !!item.published}
-                        />
-                    }
-                    {index === 0 && item.ghostLocale &&
+            const indicators = [];
+            if (index === 0) {
+                if (item.ghostLocale) {
+                    indicators.push(
                         <GhostIndicator
                             className={abstractTableAdapterStyles.ghostIndicator}
                             locale={item.ghostLocale}
                         />
+                    );
+                } else {
+                    const draft = item.publishedState === undefined ? false : !item.publishedState;
+                    const published = item.published === undefined ? false : !!item.published;
+
+                    if (draft || !published) {
+                        indicators.push(
+                            <PublishIndicator
+                                className={abstractTableAdapterStyles.publishIndicator}
+                                draft={draft}
+                                published={published}
+                            />
+                        );
                     }
+                }
+            }
+
+            return (
+                <Table.Cell key={item.id + schemaKey}>
+                    {indicators}
                     {value}
                 </Table.Cell>
             );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
@@ -11,7 +11,6 @@ import FullLoadingStrategy from '../loadingStrategies/FullLoadingStrategy';
 import ColumnStructureStrategy from '../structureStrategies/ColumnStructureStrategy';
 import AbstractAdapter from './AbstractAdapter';
 import columnListAdapterStyles from './columnListAdapter.scss';
-import abstractTableAdapterStyles from './abstractTableAdapter.scss';
 
 @observer
 class ColumnListAdapter extends AbstractAdapter {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
@@ -11,6 +11,7 @@ import FullLoadingStrategy from '../loadingStrategies/FullLoadingStrategy';
 import ColumnStructureStrategy from '../structureStrategies/ColumnStructureStrategy';
 import AbstractAdapter from './AbstractAdapter';
 import columnListAdapterStyles from './columnListAdapter.scss';
+import abstractTableAdapterStyles from './abstractTableAdapter.scss';
 
 @observer
 class ColumnListAdapter extends AbstractAdapter {
@@ -94,11 +95,19 @@ class ColumnListAdapter extends AbstractAdapter {
             indicators.push(<Icon key="shadow" name="su-shadow-page" />);
         }
 
-        const draft = item.publishedState === undefined ? false : !item.publishedState;
-        const published = item.published === undefined ? false : !!item.published;
+        if (item.publishedState !== undefined || item.published !== undefined) {
+            const draft = !item.publishedState;
+            const published = !!item.published;
 
-        if (draft || !published) {
-            indicators.push(<PublishIndicator draft={draft} key="publish" published={published} />);
+            if (draft || !published) {
+                indicators.push(
+                    <PublishIndicator
+                        draft={draft}
+                        key="publish"
+                        published={published}
+                    />
+                );
+            }
         }
 
         return indicators;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/abstractTableAdapter.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/abstractTableAdapter.scss
@@ -1,7 +1,4 @@
-.publish-indicator {
-    margin-right: 5px;
-}
-
+.publish-indicator,
 .ghost-indicator {
     margin-right: 5px;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/abstractTableAdapter.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/abstractTableAdapter.scss
@@ -1,3 +1,7 @@
+.publish-indicator {
+    margin-right: 5px;
+}
+
 .ghost-indicator {
     margin-right: 5px;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
@@ -68,6 +68,84 @@ test('Render data with schema', () => {
     expect(tableAdapter).toMatchSnapshot();
 });
 
+test('Render different kind of data with schema', () => {
+    const data = [
+        {
+            id: 1,
+            title: 'Page 1',
+            published: '2017-08-23',
+            publishedState: true,
+        },
+        {
+            id: 2,
+            title: 'Page 2',
+            publishedState: true,
+            published: null,
+        },
+        {
+            id: 3,
+            title: 'Page 3',
+            publishedState: false,
+            published: '2017-08-23',
+        },
+        {
+            id: 4,
+            title: 'Page 4',
+            publishedState: false,
+            published: null,
+        },
+        {
+            id: 5,
+            title: 'Page 5',
+            published: '2017-08-23',
+            publishedState: true,
+            ghostLocale: 'de',
+        },
+        {
+            id: 6,
+            title: 'Page 6',
+            publishedState: true,
+            published: null,
+            ghostLocale: 'de',
+        },
+        {
+            id: 7,
+            title: 'Page 7',
+            publishedState: false,
+            published: '2017-08-23',
+            ghostLocale: 'de',
+        },
+        {
+            id: 8,
+            title: 'Page 8',
+            publishedState: false,
+            published: null,
+            ghostLocale: 'de',
+        },
+    ];
+
+    const schema = {
+        title: {
+            type: 'string',
+            sortable: true,
+            visibility: 'yes',
+            label: 'Title',
+        },
+    };
+
+    const tableAdapter = render(
+        <TableAdapter
+            {...listAdapterDefaultProps}
+            data={data}
+            page={1}
+            pageCount={1}
+            schema={schema}
+        />
+    );
+
+    expect(tableAdapter).toMatchSnapshot();
+});
+
 test('Render data with skin', () => {
     const data = [];
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
@@ -31,47 +31,6 @@ test('Render data with schema', () => {
     const data = [
         {
             id: 1,
-            title: 'Title 1',
-            description: 'Description 1',
-        },
-        {
-            id: 2,
-            title: 'Title 2',
-            description: 'Description 2',
-            ghostLocale: 'en',
-        },
-    ];
-    const schema = {
-        title: {
-            type: 'string',
-            sortable: true,
-            visibility: 'no',
-            label: 'Title',
-        },
-        description: {
-            type: 'string',
-            sortable: true,
-            visibility: 'yes',
-            label: 'Description',
-        },
-    };
-    const tableAdapter = render(
-        <TableAdapter
-            {...listAdapterDefaultProps}
-            data={data}
-            page={2}
-            pageCount={5}
-            schema={schema}
-        />
-    );
-
-    expect(tableAdapter).toMatchSnapshot();
-});
-
-test('Render different kind of data with schema', () => {
-    const data = [
-        {
-            id: 1,
             title: 'Page 1',
             published: '2017-08-23',
             publishedState: true,
@@ -137,8 +96,8 @@ test('Render different kind of data with schema', () => {
         <TableAdapter
             {...listAdapterDefaultProps}
             data={data}
-            page={1}
-            pageCount={1}
+            page={2}
+            pageCount={5}
             schema={schema}
         />
     );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
@@ -78,6 +78,114 @@ test('Render data with schema', () => {
     expect(treeListAdapter).toMatchSnapshot();
 });
 
+test('Render different kind of data with schema', () => {
+    const data = [
+        {
+            data: {
+                id: 1,
+                title: 'Page 1',
+                published: '2017-08-23',
+                publishedState: true,
+            },
+            children: [],
+            hasChildren: true,
+        },
+        {
+            data: {
+                id: 2,
+                title: 'Page 2',
+                publishedState: true,
+                published: null,
+            },
+            children: [],
+            hasChildren: true,
+        },
+        {
+            data: {
+                id: 3,
+                title: 'Page 3',
+                publishedState: false,
+                published: '2017-08-23',
+            },
+            children: [],
+            hasChildren: true,
+        },
+        {
+            data: {
+                id: 4,
+                title: 'Page 4',
+                publishedState: false,
+                published: null,
+            },
+            children: [],
+            hasChildren: true,
+        },
+        {
+            data: {
+                id: 5,
+                title: 'Page 5',
+                published: '2017-08-23',
+                publishedState: true,
+                ghostLocale: 'de',
+            },
+            children: [],
+            hasChildren: true,
+        },
+        {
+            data: {
+                id: 6,
+                title: 'Page 6',
+                publishedState: true,
+                published: null,
+                ghostLocale: 'de',
+            },
+            children: [],
+            hasChildren: true,
+        },
+        {
+            data: {
+                id: 7,
+                title: 'Page 7',
+                publishedState: false,
+                published: '2017-08-23',
+                ghostLocale: 'de',
+            },
+            children: [],
+            hasChildren: true,
+        },
+        {
+            data: {
+                id: 8,
+                title: 'Page 8',
+                publishedState: false,
+                published: null,
+                ghostLocale: 'de',
+            },
+            children: [],
+            hasChildren: true,
+        },
+    ];
+
+    const schema = {
+        title: {
+            type: 'string',
+            sortable: true,
+            visibility: 'yes',
+            label: 'Title',
+        },
+    };
+
+    const treeTableAdapter = render(
+        <TreeTableAdapter
+            {...listAdapterDefaultProps}
+            data={data}
+            schema={schema}
+        />
+    );
+
+    expect(treeTableAdapter).toMatchSnapshot();
+});
+
 test('Render data without header', () => {
     const test1 = {
         data: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
@@ -28,57 +28,6 @@ jest.mock('../../registries/listFieldTransformerRegistry', () => ({
 }));
 
 test('Render data with schema', () => {
-    const test1 = {
-        data: {
-            id: 2,
-            title: 'Test1',
-        },
-        children: [],
-        hasChildren: false,
-    };
-    const test2 = {
-        data: {
-            ghostLocale: 'en',
-            id: 3,
-            title: 'Test2',
-        },
-        children: [],
-        hasChildren: true,
-    };
-    const test3 = {
-        data: {
-            id: 6,
-            title: 'Test3',
-        },
-        children: [],
-        hasChildren: true,
-    };
-
-    const data = [
-        test1,
-        test2,
-        test3,
-    ];
-    const schema = {
-        title: {
-            label: 'Title',
-            sortable: true,
-            type: 'string',
-            visibility: 'yes',
-        },
-    };
-    const treeListAdapter = render(
-        <TreeTableAdapter
-            {...listAdapterDefaultProps}
-            data={data}
-            schema={schema}
-        />
-    );
-
-    expect(treeListAdapter).toMatchSnapshot();
-});
-
-test('Render different kind of data with schema', () => {
     const data = [
         {
             data: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/ColumnListAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/ColumnListAdapter.test.js.snap
@@ -82,13 +82,6 @@ exports[`Render data with disabled items 1`] = `
               </div>
             </span>
             <span
-              class="indicator"
-            >
-              <div
-                class="publishIndicator"
-              />
-            </span>
-            <span
               class="children"
             >
               <span
@@ -144,13 +137,6 @@ exports[`Render data with disabled items 1`] = `
                   Page 1.1
                 </div>
               </div>
-            </span>
-            <span
-              class="indicator"
-            >
-              <div
-                class="publishIndicator"
-              />
             </span>
             <span
               class="children"
@@ -242,13 +228,6 @@ exports[`Render data with loading column 1`] = `
               </div>
             </span>
             <span
-              class="indicator"
-            >
-              <div
-                class="publishIndicator"
-              />
-            </span>
-            <span
               class="children"
             >
               <span
@@ -292,13 +271,6 @@ exports[`Render data with loading column 1`] = `
                   Page 2
                 </div>
               </div>
-            </span>
-            <span
-              class="indicator"
-            >
-              <div
-                class="publishIndicator"
-              />
             </span>
             <span
               class="children"
@@ -383,13 +355,6 @@ exports[`Render data with name as fallback for title 1`] = `
                   Page 1
                 </div>
               </div>
-            </span>
-            <span
-              class="indicator"
-            >
-              <div
-                class="publishIndicator"
-              />
             </span>
             <span
               class="children"
@@ -484,13 +449,6 @@ exports[`Render data with selection 1`] = `
               </div>
             </span>
             <span
-              class="indicator"
-            >
-              <div
-                class="publishIndicator"
-              />
-            </span>
-            <span
               class="children"
             >
               <span
@@ -579,13 +537,6 @@ exports[`Render data without edit button 1`] = `
                   Page 1
                 </div>
               </div>
-            </span>
-            <span
-              class="indicator"
-            >
-              <div
-                class="publishIndicator"
-              />
             </span>
             <span
               class="children"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TableAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TableAdapter.test.js.snap
@@ -42,9 +42,6 @@ exports[`Render column with ascending sort icon 1`] = `
             <div
               class="cellContent"
             >
-              <div
-                class="publishIndicator publishIndicator"
-              />
               Title 1
             </div>
           </td>
@@ -202,9 +199,6 @@ exports[`Render column with descending sort icon 1`] = `
             <div
               class="cellContent"
             >
-              <div
-                class="publishIndicator publishIndicator"
-              />
               Title 1
             </div>
           </td>
@@ -358,9 +352,6 @@ exports[`Render data with all different visibility types schema 1`] = `
             <div
               class="cellContent"
             >
-              <div
-                class="publishIndicator publishIndicator"
-              />
               Description 1
             </div>
           </td>
@@ -381,9 +372,6 @@ exports[`Render data with all different visibility types schema 1`] = `
             <div
               class="cellContent"
             >
-              <div
-                class="publishIndicator publishIndicator"
-              />
               Description 2
             </div>
           </td>
@@ -599,9 +587,6 @@ exports[`Render data with pencil button and given actions when onItemEdit callba
             <div
               class="cellContent"
             >
-              <div
-                class="publishIndicator publishIndicator"
-              />
               Description 1
             </div>
           </td>
@@ -657,9 +642,6 @@ exports[`Render data with pencil button and given actions when onItemEdit callba
             <div
               class="cellContent"
             >
-              <div
-                class="publishIndicator publishIndicator"
-              />
               Description 2
             </div>
           </td>
@@ -821,9 +803,6 @@ exports[`Render data with pencil button when onItemEdit callback is passed 1`] =
             <div
               class="cellContent"
             >
-              <div
-                class="publishIndicator publishIndicator"
-              />
               Description 1
             </div>
           </td>
@@ -851,9 +830,6 @@ exports[`Render data with pencil button when onItemEdit callback is passed 1`] =
             <div
               class="cellContent"
             >
-              <div
-                class="publishIndicator publishIndicator"
-              />
               Description 2
             </div>
           </td>
@@ -1004,9 +980,6 @@ exports[`Render data with schema 1`] = `
             <div
               class="cellContent"
             >
-              <div
-                class="publishIndicator publishIndicator"
-              />
               Page 2
             </div>
           </td>
@@ -1303,9 +1276,6 @@ exports[`Render data with schema and selections 1`] = `
             <div
               class="cellContent"
             >
-              <div
-                class="publishIndicator publishIndicator"
-              />
               Description 1
             </div>
           </td>
@@ -1340,9 +1310,6 @@ exports[`Render data with schema and selections 1`] = `
             <div
               class="cellContent"
             >
-              <div
-                class="publishIndicator publishIndicator"
-              />
               Description 2
             </div>
           </td>
@@ -1383,9 +1350,6 @@ exports[`Render data with schema and selections 1`] = `
             <div
               class="cellContent"
             >
-              <div
-                class="publishIndicator publishIndicator"
-              />
               Description 3
             </div>
           </td>
@@ -1523,9 +1487,6 @@ exports[`Render data with schema in different order 1`] = `
             <div
               class="cellContent"
             >
-              <div
-                class="publishIndicator publishIndicator"
-              />
               Description 1
             </div>
           </td>
@@ -1539,9 +1500,6 @@ exports[`Render data with schema in different order 1`] = `
             <div
               class="cellContent"
             >
-              <div
-                class="publishIndicator publishIndicator"
-              />
               Description 2
             </div>
           </td>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TableAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TableAdapter.test.js.snap
@@ -1746,3 +1746,269 @@ exports[`Render data with skin 1`] = `
   </nav>
 </section>
 `;
+
+exports[`Render different kind of data with schema 1`] = `
+<section>
+  <div
+    class="tableContainer dark"
+  >
+    <table
+      class="table"
+    >
+      <thead
+        class="header"
+      >
+        <tr>
+          <th
+            class="headerCell clickable"
+          >
+            <button>
+              Title
+            </button>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          class="row"
+        >
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              Page 1
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="row"
+        >
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              Page 2
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="row"
+        >
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              <div
+                class="publishIndicator publishIndicator"
+              >
+                <span
+                  class="published"
+                />
+                <span
+                  class="draft"
+                />
+              </div>
+              Page 3
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="row"
+        >
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              <div
+                class="publishIndicator publishIndicator"
+              >
+                <span
+                  class="draft"
+                />
+              </div>
+              Page 4
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="row"
+        >
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              <span
+                class="ghostIndicator ghostIndicator"
+              >
+                de
+              </span>
+              Page 5
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="row"
+        >
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              <span
+                class="ghostIndicator ghostIndicator"
+              >
+                de
+              </span>
+              Page 6
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="row"
+        >
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              <span
+                class="ghostIndicator ghostIndicator"
+              >
+                de
+              </span>
+              Page 7
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="row"
+        >
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              <span
+                class="ghostIndicator ghostIndicator"
+              >
+                de
+              </span>
+              Page 8
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <nav
+    class="pagination"
+  >
+    <span
+      class="display"
+    >
+      :
+    </span>
+    <span>
+      <div
+        class="select"
+      >
+        <button
+          class="displayValue dark"
+          type="button"
+        >
+          <div
+            aria-label="10"
+            class="croppedText"
+            title="10"
+          >
+            <div
+              aria-hidden="true"
+              class="front"
+            >
+              1
+            </div>
+            <div
+              aria-hidden="true"
+              class="back"
+            >
+              <span>
+                0
+              </span>
+            </div>
+            <div
+              class="whole"
+            >
+              10
+            </div>
+          </div>
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down toggle"
+          />
+        </button>
+      </div>
+    </span>
+    <div
+      class="loader"
+    />
+    <span>
+      Page:
+    </span>
+    <span
+      class="inputContainer"
+    >
+      <label
+        class="input dark center"
+      >
+        <input
+          inputmode="numeric"
+          type="text"
+          value="1"
+        />
+      </label>
+    </span>
+    <span
+      class="display"
+    >
+      of 1
+    </span>
+    <div
+      class="buttonGroup"
+    >
+      <button
+        class="button icon button"
+        disabled=""
+        type="button"
+      >
+        <span
+          aria-label="su-angle-left"
+          class="su-angle-left buttonIcon"
+        />
+      </button>
+      <button
+        class="button icon button"
+        disabled=""
+        type="button"
+      >
+        <span
+          aria-label="su-angle-right"
+          class="su-angle-right buttonIcon"
+        />
+      </button>
+    </div>
+  </nav>
+</section>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TableAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TableAdapter.test.js.snap
@@ -42,6 +42,9 @@ exports[`Render column with ascending sort icon 1`] = `
             <div
               class="cellContent"
             >
+              <div
+                class="publishIndicator publishIndicator"
+              />
               Title 1
             </div>
           </td>
@@ -199,6 +202,9 @@ exports[`Render column with descending sort icon 1`] = `
             <div
               class="cellContent"
             >
+              <div
+                class="publishIndicator publishIndicator"
+              />
               Title 1
             </div>
           </td>
@@ -352,6 +358,9 @@ exports[`Render data with all different visibility types schema 1`] = `
             <div
               class="cellContent"
             >
+              <div
+                class="publishIndicator publishIndicator"
+              />
               Description 1
             </div>
           </td>
@@ -372,6 +381,9 @@ exports[`Render data with all different visibility types schema 1`] = `
             <div
               class="cellContent"
             >
+              <div
+                class="publishIndicator publishIndicator"
+              />
               Description 2
             </div>
           </td>
@@ -587,6 +599,9 @@ exports[`Render data with pencil button and given actions when onItemEdit callba
             <div
               class="cellContent"
             >
+              <div
+                class="publishIndicator publishIndicator"
+              />
               Description 1
             </div>
           </td>
@@ -642,6 +657,9 @@ exports[`Render data with pencil button and given actions when onItemEdit callba
             <div
               class="cellContent"
             >
+              <div
+                class="publishIndicator publishIndicator"
+              />
               Description 2
             </div>
           </td>
@@ -803,6 +821,9 @@ exports[`Render data with pencil button when onItemEdit callback is passed 1`] =
             <div
               class="cellContent"
             >
+              <div
+                class="publishIndicator publishIndicator"
+              />
               Description 1
             </div>
           </td>
@@ -830,6 +851,9 @@ exports[`Render data with pencil button when onItemEdit callback is passed 1`] =
             <div
               class="cellContent"
             >
+              <div
+                class="publishIndicator publishIndicator"
+              />
               Description 2
             </div>
           </td>
@@ -952,7 +976,7 @@ exports[`Render data with schema 1`] = `
             class="headerCell clickable"
           >
             <button>
-              Description
+              Title
             </button>
           </th>
         </tr>
@@ -967,7 +991,66 @@ exports[`Render data with schema 1`] = `
             <div
               class="cellContent"
             >
-              Description 1
+              Page 1
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="row"
+        >
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              <div
+                class="publishIndicator publishIndicator"
+              />
+              Page 2
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="row"
+        >
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              <div
+                class="publishIndicator publishIndicator"
+              >
+                <span
+                  class="published"
+                />
+                <span
+                  class="draft"
+                />
+              </div>
+              Page 3
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="row"
+        >
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              <div
+                class="publishIndicator publishIndicator"
+              >
+                <span
+                  class="draft"
+                />
+              </div>
+              Page 4
             </div>
           </td>
         </tr>
@@ -983,9 +1066,63 @@ exports[`Render data with schema 1`] = `
               <span
                 class="ghostIndicator ghostIndicator"
               >
-                en
+                de
               </span>
-              Description 2
+              Page 5
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="row"
+        >
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              <span
+                class="ghostIndicator ghostIndicator"
+              >
+                de
+              </span>
+              Page 6
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="row"
+        >
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              <span
+                class="ghostIndicator ghostIndicator"
+              >
+                de
+              </span>
+              Page 7
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="row"
+        >
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              <span
+                class="ghostIndicator ghostIndicator"
+              >
+                de
+              </span>
+              Page 8
             </div>
           </td>
         </tr>
@@ -1166,6 +1303,9 @@ exports[`Render data with schema and selections 1`] = `
             <div
               class="cellContent"
             >
+              <div
+                class="publishIndicator publishIndicator"
+              />
               Description 1
             </div>
           </td>
@@ -1200,6 +1340,9 @@ exports[`Render data with schema and selections 1`] = `
             <div
               class="cellContent"
             >
+              <div
+                class="publishIndicator publishIndicator"
+              />
               Description 2
             </div>
           </td>
@@ -1240,6 +1383,9 @@ exports[`Render data with schema and selections 1`] = `
             <div
               class="cellContent"
             >
+              <div
+                class="publishIndicator publishIndicator"
+              />
               Description 3
             </div>
           </td>
@@ -1377,6 +1523,9 @@ exports[`Render data with schema in different order 1`] = `
             <div
               class="cellContent"
             >
+              <div
+                class="publishIndicator publishIndicator"
+              />
               Description 1
             </div>
           </td>
@@ -1390,6 +1539,9 @@ exports[`Render data with schema in different order 1`] = `
             <div
               class="cellContent"
             >
+              <div
+                class="publishIndicator publishIndicator"
+              />
               Description 2
             </div>
           </td>
@@ -1735,272 +1887,6 @@ exports[`Render data with skin 1`] = `
       </button>
       <button
         class="button icon button"
-        type="button"
-      >
-        <span
-          aria-label="su-angle-right"
-          class="su-angle-right buttonIcon"
-        />
-      </button>
-    </div>
-  </nav>
-</section>
-`;
-
-exports[`Render different kind of data with schema 1`] = `
-<section>
-  <div
-    class="tableContainer dark"
-  >
-    <table
-      class="table"
-    >
-      <thead
-        class="header"
-      >
-        <tr>
-          <th
-            class="headerCell clickable"
-          >
-            <button>
-              Title
-            </button>
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr
-          class="row"
-        >
-          <td
-            class="cell"
-          >
-            <div
-              class="cellContent"
-            >
-              Page 1
-            </div>
-          </td>
-        </tr>
-        <tr
-          class="row"
-        >
-          <td
-            class="cell"
-          >
-            <div
-              class="cellContent"
-            >
-              Page 2
-            </div>
-          </td>
-        </tr>
-        <tr
-          class="row"
-        >
-          <td
-            class="cell"
-          >
-            <div
-              class="cellContent"
-            >
-              <div
-                class="publishIndicator publishIndicator"
-              >
-                <span
-                  class="published"
-                />
-                <span
-                  class="draft"
-                />
-              </div>
-              Page 3
-            </div>
-          </td>
-        </tr>
-        <tr
-          class="row"
-        >
-          <td
-            class="cell"
-          >
-            <div
-              class="cellContent"
-            >
-              <div
-                class="publishIndicator publishIndicator"
-              >
-                <span
-                  class="draft"
-                />
-              </div>
-              Page 4
-            </div>
-          </td>
-        </tr>
-        <tr
-          class="row"
-        >
-          <td
-            class="cell"
-          >
-            <div
-              class="cellContent"
-            >
-              <span
-                class="ghostIndicator ghostIndicator"
-              >
-                de
-              </span>
-              Page 5
-            </div>
-          </td>
-        </tr>
-        <tr
-          class="row"
-        >
-          <td
-            class="cell"
-          >
-            <div
-              class="cellContent"
-            >
-              <span
-                class="ghostIndicator ghostIndicator"
-              >
-                de
-              </span>
-              Page 6
-            </div>
-          </td>
-        </tr>
-        <tr
-          class="row"
-        >
-          <td
-            class="cell"
-          >
-            <div
-              class="cellContent"
-            >
-              <span
-                class="ghostIndicator ghostIndicator"
-              >
-                de
-              </span>
-              Page 7
-            </div>
-          </td>
-        </tr>
-        <tr
-          class="row"
-        >
-          <td
-            class="cell"
-          >
-            <div
-              class="cellContent"
-            >
-              <span
-                class="ghostIndicator ghostIndicator"
-              >
-                de
-              </span>
-              Page 8
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-  <nav
-    class="pagination"
-  >
-    <span
-      class="display"
-    >
-      :
-    </span>
-    <span>
-      <div
-        class="select"
-      >
-        <button
-          class="displayValue dark"
-          type="button"
-        >
-          <div
-            aria-label="10"
-            class="croppedText"
-            title="10"
-          >
-            <div
-              aria-hidden="true"
-              class="front"
-            >
-              1
-            </div>
-            <div
-              aria-hidden="true"
-              class="back"
-            >
-              <span>
-                0
-              </span>
-            </div>
-            <div
-              class="whole"
-            >
-              10
-            </div>
-          </div>
-          <span
-            aria-label="su-angle-down"
-            class="su-angle-down toggle"
-          />
-        </button>
-      </div>
-    </span>
-    <div
-      class="loader"
-    />
-    <span>
-      Page:
-    </span>
-    <span
-      class="inputContainer"
-    >
-      <label
-        class="input dark center"
-      >
-        <input
-          inputmode="numeric"
-          type="text"
-          value="1"
-        />
-      </label>
-    </span>
-    <span
-      class="display"
-    >
-      of 1
-    </span>
-    <div
-      class="buttonGroup"
-    >
-      <button
-        class="button icon button"
-        disabled=""
-        type="button"
-      >
-        <span
-          aria-label="su-angle-left"
-          class="su-angle-left buttonIcon"
-        />
-      </button>
-      <button
-        class="button icon button"
-        disabled=""
         type="button"
       >
         <span

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TreeTableAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TreeTableAdapter.test.js.snap
@@ -501,3 +501,250 @@ exports[`Render data without header 1`] = `
   </table>
 </div>
 `;
+
+exports[`Render different kind of data with schema 1`] = `
+<div
+  class="tableContainer dark"
+>
+  <table
+    class="table"
+  >
+    <thead
+      class="header"
+    >
+      <tr>
+        <th
+          class="headerCell clickable"
+        >
+          <button>
+            Title
+          </button>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        class="row"
+      >
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            <span
+              class="toggleIcon"
+            >
+              <span
+                aria-label="su-angle-right"
+                class="su-angle-right clickable"
+                role="button"
+                tabindex="0"
+              />
+            </span>
+            Page 1
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            <span
+              class="toggleIcon"
+            >
+              <span
+                aria-label="su-angle-right"
+                class="su-angle-right clickable"
+                role="button"
+                tabindex="0"
+              />
+            </span>
+            Page 2
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            <span
+              class="toggleIcon"
+            >
+              <span
+                aria-label="su-angle-right"
+                class="su-angle-right clickable"
+                role="button"
+                tabindex="0"
+              />
+            </span>
+            <div
+              class="publishIndicator publishIndicator"
+            >
+              <span
+                class="published"
+              />
+              <span
+                class="draft"
+              />
+            </div>
+            Page 3
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            <span
+              class="toggleIcon"
+            >
+              <span
+                aria-label="su-angle-right"
+                class="su-angle-right clickable"
+                role="button"
+                tabindex="0"
+              />
+            </span>
+            <div
+              class="publishIndicator publishIndicator"
+            >
+              <span
+                class="draft"
+              />
+            </div>
+            Page 4
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            <span
+              class="toggleIcon"
+            >
+              <span
+                aria-label="su-angle-right"
+                class="su-angle-right clickable"
+                role="button"
+                tabindex="0"
+              />
+            </span>
+            <span
+              class="ghostIndicator ghostIndicator"
+            >
+              de
+            </span>
+            Page 5
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            <span
+              class="toggleIcon"
+            >
+              <span
+                aria-label="su-angle-right"
+                class="su-angle-right clickable"
+                role="button"
+                tabindex="0"
+              />
+            </span>
+            <span
+              class="ghostIndicator ghostIndicator"
+            >
+              de
+            </span>
+            Page 6
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            <span
+              class="toggleIcon"
+            >
+              <span
+                aria-label="su-angle-right"
+                class="su-angle-right clickable"
+                role="button"
+                tabindex="0"
+              />
+            </span>
+            <span
+              class="ghostIndicator ghostIndicator"
+            >
+              de
+            </span>
+            Page 7
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            <span
+              class="toggleIcon"
+            >
+              <span
+                aria-label="su-angle-right"
+                class="su-angle-right clickable"
+                role="button"
+                tabindex="0"
+              />
+            </span>
+            <span
+              class="ghostIndicator ghostIndicator"
+            >
+              de
+            </span>
+            Page 8
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TreeTableAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TreeTableAdapter.test.js.snap
@@ -53,7 +53,11 @@ exports[`Render data with pencil button when onItemEdit callback is passed 1`] =
         >
           <div
             class="cellContent"
-          />
+          >
+            <div
+              class="publishIndicator publishIndicator"
+            />
+          </div>
         </td>
       </tr>
     </tbody>
@@ -114,7 +118,11 @@ exports[`Render data with plus button when onItemAdd callback is passed 1`] = `
         >
           <div
             class="cellContent"
-          />
+          >
+            <div
+              class="publishIndicator publishIndicator"
+            />
+          </div>
         </td>
       </tr>
     </tbody>
@@ -123,386 +131,6 @@ exports[`Render data with plus button when onItemAdd callback is passed 1`] = `
 `;
 
 exports[`Render data with schema 1`] = `
-<div
-  class="tableContainer dark"
->
-  <table
-    class="table"
-  >
-    <thead
-      class="header"
-    >
-      <tr>
-        <th
-          class="headerCell clickable"
-        >
-          <button>
-            Title
-          </button>
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr
-        class="row"
-      >
-        <td
-          class="cell"
-        >
-          <div
-            class="cellContent"
-          >
-            Test1
-          </div>
-        </td>
-      </tr>
-      <tr
-        class="row"
-      >
-        <td
-          class="cell"
-        >
-          <div
-            class="cellContent"
-          >
-            <span
-              class="toggleIcon"
-            >
-              <span
-                aria-label="su-angle-right"
-                class="su-angle-right clickable"
-                role="button"
-                tabindex="0"
-              />
-            </span>
-            <span
-              class="ghostIndicator ghostIndicator"
-            >
-              en
-            </span>
-            Test2
-          </div>
-        </td>
-      </tr>
-      <tr
-        class="row"
-      >
-        <td
-          class="cell"
-        >
-          <div
-            class="cellContent"
-          >
-            <span
-              class="toggleIcon"
-            >
-              <span
-                aria-label="su-angle-right"
-                class="su-angle-right clickable"
-                role="button"
-                tabindex="0"
-              />
-            </span>
-            Test3
-          </div>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-`;
-
-exports[`Render data with schema and selections 1`] = `
-<div
-  class="tableContainer dark"
->
-  <table
-    class="table"
-  >
-    <thead
-      class="header"
-    >
-      <tr>
-        <th
-          class="headerCell clickable"
-        >
-          <button>
-            Title
-          </button>
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr
-        class="row"
-      >
-        <td
-          class="cell"
-        >
-          <div
-            class="cellContent"
-          >
-            Test1
-          </div>
-        </td>
-      </tr>
-      <tr
-        class="row"
-      >
-        <td
-          class="cell"
-        >
-          <div
-            class="cellContent"
-          >
-            <span
-              class="toggleIcon"
-            >
-              <span
-                aria-label="su-angle-right"
-                class="su-angle-right clickable"
-                role="button"
-                tabindex="0"
-              />
-            </span>
-            Test2
-          </div>
-        </td>
-      </tr>
-      <tr
-        class="row"
-      >
-        <td
-          class="cell"
-        >
-          <div
-            class="cellContent"
-          >
-            <span
-              class="toggleIcon"
-            >
-              <span
-                aria-label="su-angle-right"
-                class="su-angle-right clickable"
-                role="button"
-                tabindex="0"
-              />
-            </span>
-            Test3
-          </div>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-`;
-
-exports[`Render data with two columns 1`] = `
-<div
-  class="tableContainer dark"
->
-  <table
-    class="table"
-  >
-    <thead
-      class="header"
-    >
-      <tr>
-        <th
-          class="headerCell clickable"
-        >
-          <button>
-            Title
-          </button>
-        </th>
-        <th
-          class="headerCell clickable"
-        >
-          <button>
-            Title2
-          </button>
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr
-        class="row"
-      >
-        <td
-          class="cell"
-        >
-          <div
-            class="cellContent"
-          >
-            Test1
-          </div>
-        </td>
-        <td
-          class="cell"
-        >
-          <div
-            class="cellContent"
-          >
-            Title2 - Test1
-          </div>
-        </td>
-      </tr>
-      <tr
-        class="row"
-      >
-        <td
-          class="cell"
-        >
-          <div
-            class="cellContent"
-          >
-            <span
-              class="toggleIcon"
-            >
-              <span
-                aria-label="su-angle-right"
-                class="su-angle-right clickable"
-                role="button"
-                tabindex="0"
-              />
-            </span>
-            Test2
-          </div>
-        </td>
-        <td
-          class="cell"
-        >
-          <div
-            class="cellContent"
-          >
-            Title2 - Test2
-          </div>
-        </td>
-      </tr>
-      <tr
-        class="row"
-      >
-        <td
-          class="cell"
-        >
-          <div
-            class="cellContent"
-          >
-            <span
-              class="toggleIcon"
-            >
-              <span
-                aria-label="su-angle-right"
-                class="su-angle-right clickable"
-                role="button"
-                tabindex="0"
-              />
-            </span>
-            Test3
-          </div>
-        </td>
-        <td
-          class="cell"
-        >
-          <div
-            class="cellContent"
-          >
-            Title2 - Test3
-          </div>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-`;
-
-exports[`Render data without header 1`] = `
-<div
-  class="tableContainer dark"
->
-  <table
-    class="table"
-  >
-    <tbody>
-      <tr
-        class="row"
-      >
-        <td
-          class="cell"
-        >
-          <div
-            class="cellContent"
-          >
-            Test1
-          </div>
-        </td>
-      </tr>
-      <tr
-        class="row"
-      >
-        <td
-          class="cell"
-        >
-          <div
-            class="cellContent"
-          >
-            <span
-              class="toggleIcon"
-            >
-              <span
-                aria-label="su-angle-right"
-                class="su-angle-right clickable"
-                role="button"
-                tabindex="0"
-              />
-            </span>
-            Test2
-          </div>
-        </td>
-      </tr>
-      <tr
-        class="row"
-      >
-        <td
-          class="cell"
-        >
-          <div
-            class="cellContent"
-          >
-            <span
-              class="toggleIcon"
-            >
-              <span
-                aria-label="su-angle-down"
-                class="su-angle-down clickable"
-                role="button"
-                tabindex="0"
-              />
-            </span>
-            Test3
-          </div>
-        </td>
-      </tr>
-      <tr
-        class="row"
-      >
-        <td
-          class="cell"
-        >
-          <div
-            class="cellContent"
-            style="padding-left:25px"
-          >
-            Test4
-          </div>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-`;
-
-exports[`Render different kind of data with schema 1`] = `
 <div
   class="tableContainer dark"
 >
@@ -565,6 +193,9 @@ exports[`Render different kind of data with schema 1`] = `
                 tabindex="0"
               />
             </span>
+            <div
+              class="publishIndicator publishIndicator"
+            />
             Page 2
           </div>
         </td>
@@ -741,6 +372,326 @@ exports[`Render different kind of data with schema 1`] = `
               de
             </span>
             Page 8
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Render data with schema and selections 1`] = `
+<div
+  class="tableContainer dark"
+>
+  <table
+    class="table"
+  >
+    <thead
+      class="header"
+    >
+      <tr>
+        <th
+          class="headerCell clickable"
+        >
+          <button>
+            Title
+          </button>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        class="row"
+      >
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            <div
+              class="publishIndicator publishIndicator"
+            />
+            Test1
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            <span
+              class="toggleIcon"
+            >
+              <span
+                aria-label="su-angle-right"
+                class="su-angle-right clickable"
+                role="button"
+                tabindex="0"
+              />
+            </span>
+            <div
+              class="publishIndicator publishIndicator"
+            />
+            Test2
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            <span
+              class="toggleIcon"
+            >
+              <span
+                aria-label="su-angle-right"
+                class="su-angle-right clickable"
+                role="button"
+                tabindex="0"
+              />
+            </span>
+            <div
+              class="publishIndicator publishIndicator"
+            />
+            Test3
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Render data with two columns 1`] = `
+<div
+  class="tableContainer dark"
+>
+  <table
+    class="table"
+  >
+    <thead
+      class="header"
+    >
+      <tr>
+        <th
+          class="headerCell clickable"
+        >
+          <button>
+            Title
+          </button>
+        </th>
+        <th
+          class="headerCell clickable"
+        >
+          <button>
+            Title2
+          </button>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        class="row"
+      >
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            <div
+              class="publishIndicator publishIndicator"
+            />
+            Test1
+          </div>
+        </td>
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            Title2 - Test1
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            <span
+              class="toggleIcon"
+            >
+              <span
+                aria-label="su-angle-right"
+                class="su-angle-right clickable"
+                role="button"
+                tabindex="0"
+              />
+            </span>
+            <div
+              class="publishIndicator publishIndicator"
+            />
+            Test2
+          </div>
+        </td>
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            Title2 - Test2
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            <span
+              class="toggleIcon"
+            >
+              <span
+                aria-label="su-angle-right"
+                class="su-angle-right clickable"
+                role="button"
+                tabindex="0"
+              />
+            </span>
+            <div
+              class="publishIndicator publishIndicator"
+            />
+            Test3
+          </div>
+        </td>
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            Title2 - Test3
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Render data without header 1`] = `
+<div
+  class="tableContainer dark"
+>
+  <table
+    class="table"
+  >
+    <tbody>
+      <tr
+        class="row"
+      >
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            <div
+              class="publishIndicator publishIndicator"
+            />
+            Test1
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            <span
+              class="toggleIcon"
+            >
+              <span
+                aria-label="su-angle-right"
+                class="su-angle-right clickable"
+                role="button"
+                tabindex="0"
+              />
+            </span>
+            <div
+              class="publishIndicator publishIndicator"
+            />
+            Test2
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            <span
+              class="toggleIcon"
+            >
+              <span
+                aria-label="su-angle-down"
+                class="su-angle-down clickable"
+                role="button"
+                tabindex="0"
+              />
+            </span>
+            <div
+              class="publishIndicator publishIndicator"
+            />
+            Test3
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+            style="padding-left:25px"
+          >
+            <div
+              class="publishIndicator publishIndicator"
+            />
+            Test4
           </div>
         </td>
       </tr>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TreeTableAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TreeTableAdapter.test.js.snap
@@ -53,11 +53,7 @@ exports[`Render data with pencil button when onItemEdit callback is passed 1`] =
         >
           <div
             class="cellContent"
-          >
-            <div
-              class="publishIndicator publishIndicator"
-            />
-          </div>
+          />
         </td>
       </tr>
     </tbody>
@@ -118,11 +114,7 @@ exports[`Render data with plus button when onItemAdd callback is passed 1`] = `
         >
           <div
             class="cellContent"
-          >
-            <div
-              class="publishIndicator publishIndicator"
-            />
-          </div>
+          />
         </td>
       </tr>
     </tbody>
@@ -193,9 +185,6 @@ exports[`Render data with schema 1`] = `
                 tabindex="0"
               />
             </span>
-            <div
-              class="publishIndicator publishIndicator"
-            />
             Page 2
           </div>
         </td>
@@ -410,9 +399,6 @@ exports[`Render data with schema and selections 1`] = `
           <div
             class="cellContent"
           >
-            <div
-              class="publishIndicator publishIndicator"
-            />
             Test1
           </div>
         </td>
@@ -436,9 +422,6 @@ exports[`Render data with schema and selections 1`] = `
                 tabindex="0"
               />
             </span>
-            <div
-              class="publishIndicator publishIndicator"
-            />
             Test2
           </div>
         </td>
@@ -462,9 +445,6 @@ exports[`Render data with schema and selections 1`] = `
                 tabindex="0"
               />
             </span>
-            <div
-              class="publishIndicator publishIndicator"
-            />
             Test3
           </div>
         </td>
@@ -511,9 +491,6 @@ exports[`Render data with two columns 1`] = `
           <div
             class="cellContent"
           >
-            <div
-              class="publishIndicator publishIndicator"
-            />
             Test1
           </div>
         </td>
@@ -546,9 +523,6 @@ exports[`Render data with two columns 1`] = `
                 tabindex="0"
               />
             </span>
-            <div
-              class="publishIndicator publishIndicator"
-            />
             Test2
           </div>
         </td>
@@ -581,9 +555,6 @@ exports[`Render data with two columns 1`] = `
                 tabindex="0"
               />
             </span>
-            <div
-              class="publishIndicator publishIndicator"
-            />
             Test3
           </div>
         </td>
@@ -619,9 +590,6 @@ exports[`Render data without header 1`] = `
           <div
             class="cellContent"
           >
-            <div
-              class="publishIndicator publishIndicator"
-            />
             Test1
           </div>
         </td>
@@ -645,9 +613,6 @@ exports[`Render data without header 1`] = `
                 tabindex="0"
               />
             </span>
-            <div
-              class="publishIndicator publishIndicator"
-            />
             Test2
           </div>
         </td>
@@ -671,9 +636,6 @@ exports[`Render data without header 1`] = `
                 tabindex="0"
               />
             </span>
-            <div
-              class="publishIndicator publishIndicator"
-            />
             Test3
           </div>
         </td>
@@ -688,9 +650,6 @@ exports[`Render data without header 1`] = `
             class="cellContent"
             style="padding-left:25px"
           >
-            <div
-              class="publishIndicator publishIndicator"
-            />
             Test4
           </div>
         </td>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
@@ -372,6 +372,9 @@ exports[`Should render the list with a title 1`] = `
                 <div
                   class="cellContent"
                 >
+                  <div
+                    class="publishIndicator publishIndicator"
+                  />
                   Description 1
                 </div>
               </td>
@@ -406,6 +409,9 @@ exports[`Should render the list with a title 1`] = `
                 <div
                   class="cellContent"
                 >
+                  <div
+                    class="publishIndicator publishIndicator"
+                  />
                   Description 2
                 </div>
               </td>
@@ -635,6 +641,9 @@ exports[`Should render the list with the correct resourceKey 1`] = `
                 <div
                   class="cellContent"
                 >
+                  <div
+                    class="publishIndicator publishIndicator"
+                  />
                   Description 1
                 </div>
               </td>
@@ -669,6 +678,9 @@ exports[`Should render the list with the correct resourceKey 1`] = `
                 <div
                   class="cellContent"
                 >
+                  <div
+                    class="publishIndicator publishIndicator"
+                  />
                   Description 2
                 </div>
               </td>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
@@ -372,9 +372,6 @@ exports[`Should render the list with a title 1`] = `
                 <div
                   class="cellContent"
                 >
-                  <div
-                    class="publishIndicator publishIndicator"
-                  />
                   Description 1
                 </div>
               </td>
@@ -409,9 +406,6 @@ exports[`Should render the list with a title 1`] = `
                 <div
                   class="cellContent"
                 >
-                  <div
-                    class="publishIndicator publishIndicator"
-                  />
                   Description 2
                 </div>
               </td>
@@ -641,9 +635,6 @@ exports[`Should render the list with the correct resourceKey 1`] = `
                 <div
                   class="cellContent"
                 >
-                  <div
-                    class="publishIndicator publishIndicator"
-                  />
                   Description 1
                 </div>
               </td>
@@ -678,9 +669,6 @@ exports[`Should render the list with the correct resourceKey 1`] = `
                 <div
                   class="cellContent"
                 >
-                  <div
-                    class="publishIndicator publishIndicator"
-                  />
                   Description 2
                 </div>
               </td>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5225
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Show publish indicator on list

#### Why?

Because it's displayed in the `column_list` adapter, but not in the `table` and `tree_table` adapters.
