### PR TITLE
Use defaultWebspace in tests where appropriate

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Resources/js/stores/webspaceStore/tests/webspaceStore.test.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/stores/webspaceStore/tests/webspaceStore.test.js
@@ -1,5 +1,6 @@
 // @flow
 import log from 'loglevel';
+import {defaultWebspace} from 'sulu-admin-bundle/utils/TestHelper';
 import webspaceStore from '../webspaceStore';
 
 jest.mock('loglevel', () => ({
@@ -12,35 +13,23 @@ beforeEach(() => {
 
 test('Has webspace', () => {
     const webspace1 = {
+        ...defaultWebspace,
         _permissions: {
             view: true,
         },
         name: 'sulu',
         key: 'sulu',
-        allLocalizations: [],
-        customUrls: [],
-        defaultTemplates: {},
-        localizations: [],
-        navigations: [],
-        portalInformation: [],
         resourceLocatorStrategy: {inputType: 'leaf'},
-        urls: [],
     };
 
     const webspace2 = {
+        ...defaultWebspace,
         _permissions: {
             view: false,
         },
         name: 'Sulu Blog',
         key: 'sulu_blog',
-        allLocalizations: [],
-        customUrls: [],
-        defaultTemplates: {},
-        localizations: [],
-        navigations: [],
-        portalInformation: [],
         resourceLocatorStrategy: {inputType: 'leaf'},
-        urls: [],
     };
 
     const webspaces = [webspace1, webspace2];
@@ -54,35 +43,23 @@ test('Has webspace', () => {
 
 test('Load granted webspaces', () => {
     const webspace1 = {
+        ...defaultWebspace,
         _permissions: {
             view: true,
         },
         name: 'sulu',
         key: 'sulu',
-        allLocalizations: [],
-        customUrls: [],
-        defaultTemplates: {},
-        localizations: [],
-        navigations: [],
-        portalInformation: [],
         resourceLocatorStrategy: {inputType: 'leaf'},
-        urls: [],
     };
 
     const webspace2 = {
+        ...defaultWebspace,
         _permissions: {
             view: false,
         },
         name: 'Sulu Blog',
         key: 'sulu_blog',
-        allLocalizations: [],
-        customUrls: [],
-        defaultTemplates: {},
-        localizations: [],
-        navigations: [],
-        portalInformation: [],
         resourceLocatorStrategy: {inputType: 'leaf'},
-        urls: [],
     };
 
     const webspaces = [webspace1, webspace2];
@@ -99,35 +76,23 @@ test('Load granted webspaces', () => {
 
 test('Load webspace with given key', () => {
     const webspace1 = {
+        ...defaultWebspace,
         _permissions: {
             view: true,
         },
         name: 'sulu',
         key: 'sulu',
-        allLocalizations: [],
-        customUrls: [],
-        defaultTemplates: {},
-        localizations: [],
-        navigations: [],
-        portalInformation: [],
         resourceLocatorStrategy: {inputType: 'leaf'},
-        urls: [],
     };
 
     const webspace2 = {
+        ...defaultWebspace,
         _permissions: {
             view: false,
         },
         name: 'Sulu Blog',
         key: 'sulu_blog',
-        allLocalizations: [],
-        customUrls: [],
-        defaultTemplates: {},
-        localizations: [],
-        navigations: [],
-        portalInformation: [],
         resourceLocatorStrategy: {inputType: 'leaf'},
-        urls: [],
     };
 
     const webspaces = [webspace1, webspace2];
@@ -144,35 +109,23 @@ test('Load webspace with given key', () => {
 
 test('Get granted webspaces', () => {
     const webspace1 = {
+        ...defaultWebspace,
         _permissions: {
             view: true,
         },
         name: 'sulu',
         key: 'sulu',
-        allLocalizations: [],
-        customUrls: [],
-        defaultTemplates: {},
-        localizations: [],
-        navigations: [],
-        portalInformation: [],
         resourceLocatorStrategy: {inputType: 'leaf'},
-        urls: [],
     };
 
     const webspace2 = {
+        ...defaultWebspace,
         _permissions: {
             view: false,
         },
         name: 'Sulu Blog',
         key: 'sulu_blog',
-        allLocalizations: [],
-        customUrls: [],
-        defaultTemplates: {},
-        localizations: [],
-        navigations: [],
-        portalInformation: [],
         resourceLocatorStrategy: {inputType: 'leaf'},
-        urls: [],
     };
 
     const webspaces = [webspace1, webspace2];
@@ -185,35 +138,23 @@ test('Get granted webspaces', () => {
 
 test('Get webspace with given key', () => {
     const webspace1 = {
+        ...defaultWebspace,
         _permissions: {
             view: true,
         },
         name: 'sulu',
         key: 'sulu',
-        allLocalizations: [],
-        customUrls: [],
-        defaultTemplates: {},
-        localizations: [],
-        navigations: [],
-        portalInformation: [],
         resourceLocatorStrategy: {inputType: 'leaf'},
-        urls: [],
     };
 
     const webspace2 = {
+        ...defaultWebspace,
         _permissions: {
             view: false,
         },
         name: 'Sulu Blog',
         key: 'sulu_blog',
-        allLocalizations: [],
-        customUrls: [],
-        defaultTemplates: {},
-        localizations: [],
-        navigations: [],
-        portalInformation: [],
         resourceLocatorStrategy: {inputType: 'leaf'},
-        urls: [],
     };
 
     const webspaces = [webspace1, webspace2];


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #5277 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

In #5277 the structure of the webspace changes, and therefore the `defaultWebspace` object changed as well. But it was not already used everywhere, so I am introducing that here, in order to make the other PR smaller.