### PR TITLE
Fix phpstan error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -115,6 +115,7 @@
         "phpstan/phpstan": "^0.12",
         "phpstan/phpstan-symfony": "^0.12",
         "phpunit/phpunit": "^8.0",
+        "psr/event-dispatcher": "^1.0",
         "superbalist/flysystem-google-storage": "^7.1",
         "symfony/browser-kit": "^4.3",
         "symfony/debug": "^4.3",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR introduces `psr/event-dispatcher` as a dev dependency.

#### Why?

Because in version 1 of [`symfony/event-dispatcher-contracts`](https://github.com/symfony/event-dispatcher-contracts/blob/v1.1.7/EventDispatcherInterface.php#L16) this dependency is optional and will not be installed. And then extending from it will make phpstan fail.