### PR TITLE
Fix composer 2 compatibility for php 7.3 and lower

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "ext-dom": "*",
         "ext-json": "*",
         "ext-simplexml": "*",
+        "composer/package-versions-deprecated": "^1.8",
         "dantleech/phpcr-migrations-bundle": "^1.0",
         "doctrine/annotations": "^1.2",
         "doctrine/common": "^2.7.1",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Require https://github.com/composer/package-versions-deprecated

#### Why?

Fix composer 2 compatibility for php 7.3 and lower. Think require it will make the developers which use sulu the least problems.

Alternative require https://github.com/sulu/skeleton/pull/60 and add it here only as dev dependency.

This is needed as following https://github.com/Ocramius/PackageVersions/pull/133 was not backported to supported PHP Versions of Ocramius/PackageVersions.

We currently targeting `release/2.0` branch as the bridge package does only support `php 7` and our `1.6` still supports PHP 5: https://github.com/composer/package-versions-deprecated/blob/c8c9aa8a14cc3d3bec86d0a8c3fa52ea79936855/composer.json#L17.
