### PR TITLE
Fix category medias typehint

### DIFF
--- a/src/Sulu/Bundle/CategoryBundle/Entity/CategoryTranslationInterface.php
+++ b/src/Sulu/Bundle/CategoryBundle/Entity/CategoryTranslationInterface.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\CategoryBundle\Entity;
 
 use Doctrine\Common\Collections\Collection;
-use Sulu\Bundle\MediaBundle\Entity\Media;
+use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
 use Sulu\Component\Persistence\Model\AuditableInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 
@@ -56,14 +56,14 @@ interface CategoryTranslationInterface extends AuditableInterface
     /**
      * Get description.
      *
-     * @return Media[]
+     * @return MediaInterface[]
      */
     public function getMedias();
 
     /**
      * Set images.
      *
-     * @param Media[] $images
+     * @param MediaInterface[] $images
      *
      * @return CategoryTranslationInterface
      */


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix category medias typehint.

#### Why?

We should use the MediaInterface instead directly the Media entity in typehints.
