### PR TITLE
Add localizations variable to twig

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,33 @@
 
 ## dev-master
 
+### Deprecated urls variable in twig
+
+The `urls` twig variable has been deprecated in favour of the `localizations` variable. So the code should be adapted
+as shown in the following snippet:
+
+```jinja
+{# Before #}
+<ul>
+    {% for locale, url in urls %}
+        <li>
+            <a href="{{ sulu_content_path(url, request.webspaceKey, locale) }}">{{ locale }}</a>
+        </li>
+    {% endfor %}
+</ul>
+
+{# After #}
+<ul>
+    {% for localization in localizations %}
+        <li>
+            <a href="{{ localization.url }}">{{ localization.locale }}</a>
+        </li>
+    {% endfor %}
+</ul>
+```
+
+### HTTP Cache environment handling
+
 The `sulu_http_cache` configuration behaved differently based on the configured environment. Since this behavior was
 causing some configuration to be ignored in the `dev` and `test` environment, it was very hard to understand. Therefore
 we removed this behavior. In order to imitate the old behavior, the `sulu_http_cache` has to be configured

--- a/config/packages/sulu_website.yaml
+++ b/config/packages/sulu_website.yaml
@@ -1,0 +1,4 @@
+sulu_website:
+    twig:
+        attributes:
+            urls: false

--- a/config/webspaces/sulu-blog.xml
+++ b/config/webspaces/sulu-blog.xml
@@ -39,22 +39,22 @@
             <environments>
                 <environment type="prod">
                     <urls>
-                        <url language="en">{host}</url>
+                        <url language="en">{host}/blog</url>
                     </urls>
                 </environment>
                 <environment type="stage">
                     <urls>
-                        <url language="en">{host}</url>
+                        <url language="en">{host}/blog</url>
                     </urls>
                 </environment>
                 <environment type="test">
                     <urls>
-                        <url language="en">{host}</url>
+                        <url language="en">{host}/blog</url>
                     </urls>
                 </environment>
                 <environment type="dev">
                     <urls>
-                        <url language="en">{host}</url>
+                        <url language="en">{host}/blog</url>
                     </urls>
                 </environment>
             </environments>

--- a/config/webspaces/sulu-test.xml
+++ b/config/webspaces/sulu-test.xml
@@ -40,22 +40,22 @@
             <environments>
                 <environment type="prod">
                     <urls>
-                        <url language="en">{host}</url>
+                        <url>{host}/{localization}</url>
                     </urls>
                 </environment>
                 <environment type="stage">
                     <urls>
-                        <url language="en">{host}</url>
+                        <url>{host}/{localization}</url>
                     </urls>
                 </environment>
                 <environment type="test">
                     <urls>
-                        <url language="en">{host}</url>
+                        <url>{host}/{localization}</url>
                     </urls>
                 </environment>
                 <environment type="dev">
                     <urls>
-                        <url language="en">{host}</url>
+                        <url>{host}/{localization}</url>
                     </urls>
                 </environment>
             </environments>

--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Configuration.php
@@ -33,6 +33,22 @@ class Configuration implements ConfigurationInterface
             ->arrayNode('twig')
                 ->addDefaultsIfNotSet()
                 ->children()
+                    ->arrayNode('attributes')
+                        ->addDefaultsIfNotSet()
+                        ->children()
+                            ->booleanNode('urls')
+                                ->defaultTrue()
+                                ->beforeNormalization()
+                                    ->ifTrue(function($v) { return false !== $v; })
+                                    ->then(function($v) {
+                                        @trigger_error('Enable the urls parameter is deprecated since sulu/sulu 2.2.', E_USER_DEPRECATED);
+
+                                        return $v;
+                                    })
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
                     ->arrayNode('navigation')
                         ->addDefaultsIfNotSet()
                         ->children()

--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/SuluWebsiteExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/SuluWebsiteExtension.php
@@ -107,6 +107,10 @@ class SuluWebsiteExtension extends Extension implements PrependExtensionInterfac
             'sulu_website.sitemap.dump_dir',
             $config['sitemap']['dump_dir']
         );
+        $container->setParameter(
+            'sulu_website.enabled_twig_attributes',
+            $config['twig']['attributes']
+        );
         $container->registerForAutoconfiguration(SitemapProviderInterface::class)
             ->addTag('sulu.sitemap.provider');
 

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -215,6 +215,7 @@
         <service id="sulu_website.resolver.parameter" class="%sulu_website.resolver.parameter.class%" public="true">
             <argument type="service" id="sulu_website.resolver.structure"/>
             <argument type="service" id="sulu_website.resolver.request_analyzer"/>
+            <argument type="service" id="sulu_core.webspace.webspace_manager" />
         </service>
 
         <service id="Sulu\Bundle\WebsiteBundle\Resolver\ParameterResolverInterface"

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -216,6 +216,7 @@
             <argument type="service" id="sulu_website.resolver.structure"/>
             <argument type="service" id="sulu_website.resolver.request_analyzer"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager" />
+            <argument>%sulu_website.enabled_twig_attributes%</argument>
         </service>
 
         <service id="Sulu\Bundle\WebsiteBundle\Resolver\ParameterResolverInterface"

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -34,6 +34,16 @@
                     {% endfor %}
                 </ul>
             </nav>
+
+            <nav>
+                <ul>
+                    {% for localization in localizations %}
+                        <li>
+                            <a href="{{ localization.url }}">{{ localization.locale }}</a>
+                        </li>
+                    {% endfor %}
+                </ul>
+            </nav>
         {% endblock %}
     </header>
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #5277 
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

This PR introduces a `localizations` twig parameter, which contains all information the localization and also contains the URL for the current page in that localization.

#### Why?

The new `localizations` parameter should be used instead of the deprecated `urls` parameter. This has been introduced because `urls` doesn't say what other kind of URLs this variable holds. A `Urls` suffix has been avoided, because this variable contains more information than just the URL.

The reason for this was #5277, which introduces segments offering another kind of alternative URL. Having `urls` and `segmentUrls` seemed confusing, and we also needed to pass more information about the segments, so we wanted to make that consistent.

#### Example Usage

~~~jinja
{# Before #}
<ul>
    {% for locale, url in urls %}
        <li>
            <a href="{{ sulu_content_path(url, request.webspaceKey, locale) }}">{{ locale }}</a>
        </li>
    {% endfor %}
</ul>

{# After #}
<ul>
    {% for localization in localizations %}
        <li>
            <a href="{{ localization.url }}">{{ localization.locale }}</a>
        </li>
    {% endfor %}
</ul>
~~~

#### BC Breaks/Deprecations

The `urls` twig variable has been deprecated.

#### To Do

- [ ] Create a documentation PR
- [ ] Create skeleton PR