### PR TITLE
Added user factory

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Command/CreateUserCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/CreateUserCommand.php
@@ -14,7 +14,6 @@ namespace Sulu\Bundle\SecurityBundle\Command;
 use Sulu\Bundle\SecurityBundle\Entity\UserRepository;
 use Sulu\Bundle\SecurityBundle\Exception\RoleNotFoundException;
 use Sulu\Bundle\SecurityBundle\Factory\UserFactoryInterface;
-use Sulu\Component\Security\Authentication\RoleInterface;
 use Sulu\Component\Security\Authentication\RoleRepositoryInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;

--- a/src/Sulu/Bundle/SecurityBundle/Exception/RoleNotFoundException.php
+++ b/src/Sulu/Bundle/SecurityBundle/Exception/RoleNotFoundException.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\Exception;
+
+class RoleNotFoundException extends \Exception
+{
+    /**
+     * @var string
+     */
+    private $roleName;
+
+    public function __construct(string $roleName)
+    {
+        parent::__construct(sprintf('Role with name %s could not be found.', $roleName));
+
+        $this->roleName = $roleName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRoleName(): string
+    {
+        return $this->roleName;
+    }
+}

--- a/src/Sulu/Bundle/SecurityBundle/Exception/RoleNotFoundException.php
+++ b/src/Sulu/Bundle/SecurityBundle/Exception/RoleNotFoundException.php
@@ -20,14 +20,11 @@ class RoleNotFoundException extends \Exception
 
     public function __construct(string $roleName)
     {
-        parent::__construct(sprintf('Role with name %s could not be found.', $roleName));
+        parent::__construct(\sprintf('Role with name %s could not be found.', $roleName));
 
         $this->roleName = $roleName;
     }
 
-    /**
-     * @return string
-     */
     public function getRoleName(): string
     {
         return $this->roleName;

--- a/src/Sulu/Bundle/SecurityBundle/Factory/UserFactory.php
+++ b/src/Sulu/Bundle/SecurityBundle/Factory/UserFactory.php
@@ -118,6 +118,13 @@ class UserFactory implements UserFactoryInterface
         string $roleName,
         array $locales
     ): UserInterface {
+        /** @var RoleInterface|null $role */
+        $role = $this->roleRepository->findOneBy(['name' => $roleName]);
+
+        if (null === $role) {
+            throw new RoleNotFoundException($roleName);
+        }
+
         $user = $this->userRepository->createNew();
 
         /** @var ContactInterface $contact */
@@ -135,13 +142,6 @@ class UserFactory implements UserFactoryInterface
         $user->setPassword($this->encodePassword($user, $password, $user->getSalt()));
         $user->setLocale($locale);
         $user->setEmail($email);
-
-        /** @var RoleInterface|null $role */
-        $role = $this->roleRepository->findOneBy(['name' => $roleName]);
-
-        if (null === $role) {
-            throw new RoleNotFoundException($roleName);
-        }
 
         $userRole = new UserRole();
         $userRole->setRole($role);

--- a/src/Sulu/Bundle/SecurityBundle/Factory/UserFactory.php
+++ b/src/Sulu/Bundle/SecurityBundle/Factory/UserFactory.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\Factory;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
+use Sulu\Bundle\ContactBundle\Entity\ContactRepositoryInterface;
+use Sulu\Bundle\SecurityBundle\Entity\UserRole;
+use Sulu\Component\Localization\Manager\LocalizationManagerInterface;
+use Sulu\Component\Security\Authentication\RoleInterface;
+use Sulu\Component\Security\Authentication\RoleRepositoryInterface;
+use Sulu\Component\Security\Authentication\SaltGenerator;
+use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Component\Security\Authentication\UserRepositoryInterface;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+use Webmozart\Assert\Assert;
+
+final class UserFactory implements UserFactoryInterface
+{
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    /** @var UserRepositoryInterface */
+    private $userRepository;
+
+    /** @var RoleRepositoryInterface */
+    private $roleRepository;
+
+    /** @var ContactRepositoryInterface */
+    private $contactRepository;
+
+    /** @var LocalizationManagerInterface */
+    private $localizationManager;
+
+    /** @var SaltGenerator */
+    private $saltGenerator;
+
+    /** @var EncoderFactoryInterface */
+    private $encoderFactory;
+
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        UserRepositoryInterface $userRepository,
+        RoleRepositoryInterface $roleRepository,
+        ContactRepositoryInterface $contactRepository,
+        LocalizationManagerInterface $localizationManager,
+        SaltGenerator $saltGenerator,
+        EncoderFactoryInterface $encoderFactory
+    ) {
+        $this->entityManager = $entityManager;
+        $this->userRepository = $userRepository;
+        $this->roleRepository = $roleRepository;
+        $this->contactRepository = $contactRepository;
+        $this->localizationManager = $localizationManager;
+        $this->saltGenerator = $saltGenerator;
+        $this->encoderFactory = $encoderFactory;
+    }
+
+    public function create(
+        string $username,
+        string $firstName,
+        string $lastName,
+        string $email,
+        string $locale,
+        string $password,
+        string $roleName = 'User'
+    ): UserInterface {
+        $existing = $this->userRepository->findOneBy(['username' => $username]);
+        if ($existing instanceof UserInterface) {
+            return $existing;
+        }
+
+        $locales = \array_keys($this->localizationManager->getLocalizations());
+
+        return $this->createUser($firstName, $lastName, $email, $username, $password, $locale, $roleName, $locales);
+    }
+
+    /**
+     * Generates a random salt for the password.
+     */
+    private function generateSalt(): string
+    {
+        return $this->saltGenerator->getRandomSalt();
+    }
+
+    /**
+     * Encodes the given password, for the given password, with he given salt and returns the result.
+     *
+     * @param string $user
+     * @param string $password
+     * @param string $salt
+     */
+    private function encodePassword($user, $password, $salt): string
+    {
+        return $this->encoderFactory->getEncoder($user)->encodePassword($password, $salt);
+    }
+
+    private function createUser(
+        string $firstName,
+        string $lastName,
+        string $email,
+        string $username,
+        string $password,
+        string $locale,
+        string $roleName,
+        array $locales
+    ): UserInterface {
+        $user = $this->userRepository->createNew();
+
+        /** @var ContactInterface $contact */
+        $contact = $this->contactRepository->createNew();
+        $contact->setFirstName($firstName);
+        $contact->setLastName($lastName);
+        $contact->setMainEmail($email);
+
+        $this->entityManager->persist($contact);
+        $this->entityManager->flush();
+
+        $user->setContact($contact);
+        $user->setUsername($username);
+        $user->setSalt($this->generateSalt());
+        $user->setPassword($this->encodePassword($user, $password, $user->getSalt()));
+        $user->setLocale($locale);
+        $user->setEmail($email);
+
+        /** @var RoleInterface|null $role */
+        $role = $this->roleRepository->findOneBy(['name' => $roleName]);
+        Assert::notNull($role);
+
+        $userRole = new UserRole();
+        $userRole->setRole($role);
+        $userRole->setUser($user);
+        $userRole->setLocale(\json_encode($locales)); // set all locales
+        $this->entityManager->persist($userRole);
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/src/Sulu/Bundle/SecurityBundle/Factory/UserFactoryInterface.php
+++ b/src/Sulu/Bundle/SecurityBundle/Factory/UserFactoryInterface.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of Sulu.
  *

--- a/src/Sulu/Bundle/SecurityBundle/Factory/UserFactoryInterface.php
+++ b/src/Sulu/Bundle/SecurityBundle/Factory/UserFactoryInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\Factory;
+
+use Sulu\Component\Security\Authentication\UserInterface;
+
+interface UserFactoryInterface
+{
+    public function create(
+        string $username,
+        string $firstName,
+        string $lastName,
+        string $email,
+        string $locale,
+        string $password,
+        string $roleName = 'User'
+    ): UserInterface;
+}

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/command.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/command.xml
@@ -13,13 +13,9 @@
         </service>
 
         <service id="sulu_security.command.create_user" class="Sulu\Bundle\SecurityBundle\Command\CreateUserCommand">
-            <argument type="service" id="doctrine.orm.entity_manager"/>
             <argument type="service" id="sulu.repository.user"/>
             <argument type="service" id="sulu.repository.role"/>
-            <argument type="service" id="sulu.repository.contact"/>
-            <argument type="service" id="sulu.core.localization_manager"/>
-            <argument type="service" id="sulu_security.salt_generator"/>
-            <argument type="service" id="security.encoder_factory"/>
+            <argument type="service" id="sulu_security.user_factory"/>
             <argument>%sulu_core.locales%</argument>
 
             <tag name="console.command" />

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -288,5 +288,15 @@
         <service id="sulu_security.fixtures.security_types" class="Sulu\Bundle\SecurityBundle\DataFixtures\ORM\LoadSecurityTypes">
             <tag name="doctrine.fixture.orm"/>
         </service>
+
+        <service id="sulu_security.user_factory" class="Sulu\Bundle\SecurityBundle\Factory\UserFactory">
+            <argument type="service" id="doctrine.orm.entity_manager"/>
+            <argument type="service" id="sulu_security.user_repository"/>
+            <argument type="service" id="sulu.repository.role"/>
+            <argument type="service" id="sulu.repository.contact"/>
+            <argument type="service" id="sulu.core.localization_manager"/>
+            <argument type="service" id="sulu_security.salt_generator"/>
+            <argument type="service" id="security.encoder_factory"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/CreateUserCommandTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/CreateUserCommandTest.php
@@ -35,13 +35,9 @@ class CreateUserCommandTest extends SuluTestCase
         $application = new Application($this->getContainer()->get('kernel'));
 
         $this->command = new CreateUserCommand(
-            $this->getContainer()->get('doctrine.orm.entity_manager'),
             $this->getContainer()->get('sulu.repository.user'),
             $this->getContainer()->get('sulu.repository.role'),
-            $this->getContainer()->get('sulu.repository.contact'),
-            $this->getContainer()->get('sulu.core.localization_manager'),
-            $this->getContainer()->get('sulu_security.salt_generator'),
-            $this->getContainer()->get('sulu_security.encoder_factory'),
+            $this->getContainer()->get('sulu_security.user_factory'),
             $this->getContainer()->getParameter('sulu_core.locales')
         );
         $this->command->setApplication($application);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

This adds a user factory. The `CreateUserCommand` uses this factory instead of creating the user itself.

#### Why?

It's easier to override/decorate the factory instead of the command. The factory can also be used in other services. 

#### Example Usage

You could integrate an Ldap login using this.

#### BC Breaks/Deprecations

`CreateUserCommand` has fewer constructor arguments:
```php
UserRepository $userRepository,
RoleRepositoryInterface $roleRepository,
UserFactoryInterface $userFactory,
array $locales
```

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
