### PR TITLE
Add metadataOptions to FormMetadataProvider evaluations

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
@@ -50,10 +50,10 @@ class FormMetadataProvider implements MetadataProviderInterface
         }
 
         if ($form instanceof FormMetadata) {
-            $this->evaluateFormItemExpressions($form->getItems());
+            $this->evaluateFormItemExpressions($form->getItems(), $metadataOptions);
         } elseif ($form instanceof TypedFormMetadata) {
             foreach ($form->getForms() as $formType) {
-                $this->evaluateFormItemExpressions($formType->getItems());
+                $this->evaluateFormItemExpressions($formType->getItems(), $metadataOptions);
             }
 
             if (\array_key_exists('tags', $metadataOptions)) {
@@ -108,21 +108,21 @@ class FormMetadataProvider implements MetadataProviderInterface
     /**
      * @param ItemMetadata[] $items
      */
-    private function evaluateFormItemExpressions(array $items)
+    private function evaluateFormItemExpressions(array $items, array $metadataOptions)
     {
         foreach ($items as $item) {
             if ($item instanceof SectionMetadata) {
-                $this->evaluateFormItemExpressions($item->getItems());
+                $this->evaluateFormItemExpressions($item->getItems(), $metadataOptions);
             }
 
             if ($item instanceof FieldMetadata) {
                 foreach ($item->getTypes() as $type) {
-                    $this->evaluateFormItemExpressions($type->getItems());
+                    $this->evaluateFormItemExpressions($type->getItems(), $metadataOptions);
                 }
 
                 foreach ($item->getOptions() as $option) {
                     if (OptionMetadata::TYPE_EXPRESSION === $option->getType()) {
-                        $option->setValue($this->expressionLanguage->evaluate($option->getValue()));
+                        $option->setValue($this->expressionLanguage->evaluate($option->getValue(), $metadataOptions));
                     }
                 }
             }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/forms/form_with_webspace_expression_param.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/forms/form_with_webspace_expression_param.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<form xmlns="http://schemas.sulu.io/template/template"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd"
+>
+    <key>form_with_webspace_expression_param</key>
+
+    <properties>
+        <property name="name" type="text_line">
+            <params>
+                <param name="id" type="expression" value="webspace" />
+            </params>
+        </property>
+    </properties>
+</form>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
@@ -44,6 +44,18 @@ class FormMetadataProviderTest extends KernelTestCase
         $this->assertCount(2, \array_keys($schema));
     }
 
+    public function testGetMetadataWithExpressions()
+    {
+        $form = $this->formMetadataProvider->getMetadata(
+            'form_with_webspace_expression_param',
+            'en',
+            ['webspace' => 'sulu_io']
+        );
+        $this->assertInstanceOf(FormMetadata::class, $form);
+
+        $this->assertEquals('sulu_io', $form->getItems()['name']->getOptions()['id']->getValue());
+    }
+
     public function testGetMetadataFromStructureLoader()
     {
         $typedForm = $this->formMetadataProvider->getMetadata('page', 'en');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR allows to use the `metadataOptions` passed to the `AdminController::metadataAction` as variables in the a parameter expression.

#### Why?

Because that might be useful in certain situations. It was actually implemented for #5277, but it turned out that we can't use it there. Would be a shame to just withdraw it, therefore I am creating a separate PR.

#### Example Usage

Call of metadata URL like `/admin/metadata/form/page?webspace=sulu-blog` could use the `webspace` variable containing a value of `sulu-blog` like in the following metadata definition:

~~~xml
<?xml version="1.0" ?>
<form xmlns="http://schemas.sulu.io/template/template"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd"
>
    <key>form_with_webspace_expression_param</key>

     <properties>
        <property name="name" type="text_line">
            <params>
                <param name="id" type="expression" value="webspace" />
            </params>
        </property>
    </properties>
</form>
~~~

#### BC Breaks/Deprecations

None.

#### To Do

- [x] ~~Create a documentation PR~~ (There is currently no place to document this)