### PR TITLE
Add port to urls generated by the WebspaceManager

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentPathTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentPathTwigExtensionTest.php
@@ -83,7 +83,6 @@ class ContentPathTwigExtensionTest extends TestCase
     public function testGetContentPath()
     {
         $this->requestAnalyzer->getAttribute('host')->willReturn('www.sulu.io');
-        $this->requestAnalyzer->getAttribute('port')->willReturn(80);
         $this->webspaceManager->findUrlByResourceLocator(
             '/test',
             $this->environment,
@@ -96,44 +95,10 @@ class ContentPathTwigExtensionTest extends TestCase
         $this->assertEquals('www.sulu.io/de/test', $this->extension->getContentPath('/test'));
     }
 
-    public function testGetContentPathWithPort()
-    {
-        $this->requestAnalyzer->getAttribute('host')->willReturn('www.sulu.io');
-        $this->requestAnalyzer->getAttribute('port')->willReturn(8000);
-        $this->webspaceManager->findUrlByResourceLocator(
-            '/test',
-            $this->environment,
-            'de',
-            'sulu_io',
-            'www.sulu.io',
-            'http'
-        )->willReturn('www.sulu.io/de/test')->shouldBeCalledTimes(1);
-
-        $this->assertEquals('www.sulu.io:8000/de/test', $this->extension->getContentPath('/test'));
-    }
-
-    public function testGetContentPathWithHttpsPort()
+    public function testGetContentPathWithHttps()
     {
         $this->requestAnalyzer->getAttribute('host')->willReturn('www.sulu.io');
         $this->requestAnalyzer->getAttribute('scheme')->willReturn('https');
-        $this->requestAnalyzer->getAttribute('port')->willReturn(444);
-        $this->webspaceManager->findUrlByResourceLocator(
-            '/test',
-            $this->environment,
-            'de',
-            'sulu_io',
-            'www.sulu.io',
-            'https'
-        )->willReturn('www.sulu.io/de/test')->shouldBeCalledTimes(1);
-
-        $this->assertEquals('www.sulu.io:444/de/test', $this->extension->getContentPath('/test'));
-    }
-
-    public function testGetContentPathWithDefaultHttpsPort()
-    {
-        $this->requestAnalyzer->getAttribute('host')->willReturn('www.sulu.io');
-        $this->requestAnalyzer->getAttribute('scheme')->willReturn('https');
-        $this->requestAnalyzer->getAttribute('port')->willReturn(443);
         $this->webspaceManager->findUrlByResourceLocator(
             '/test',
             $this->environment,
@@ -149,7 +114,6 @@ class ContentPathTwigExtensionTest extends TestCase
     public function testGetContentPathWithLocaleForDifferentDomain()
     {
         $this->requestAnalyzer->getAttribute('host')->willReturn('en.sulu.io');
-        $this->requestAnalyzer->getAttribute('port')->willReturn(80);
         $this->webspaceManager->findUrlByResourceLocator(
             '/test',
             $this->environment,
@@ -165,7 +129,6 @@ class ContentPathTwigExtensionTest extends TestCase
     public function testGetContentPathWithWebspaceKey()
     {
         $this->requestAnalyzer->getAttribute('host')->willReturn('www.test.io');
-        $this->requestAnalyzer->getAttribute('port')->willReturn(80);
         $this->webspaceManager->findUrlByResourceLocator(
             '/test',
             $this->environment,
@@ -181,7 +144,6 @@ class ContentPathTwigExtensionTest extends TestCase
     public function testGetContentPathWithWebspaceKeyNotFoundForDomain()
     {
         $this->requestAnalyzer->getAttribute('host')->willReturn('www.test.io');
-        $this->requestAnalyzer->getAttribute('port')->willReturn(80);
 
         // empty webspace object will not contain domain as tested in isFromDomain call
         $webspace = new Webspace();
@@ -202,7 +164,6 @@ class ContentPathTwigExtensionTest extends TestCase
     public function testGetContentPathWithWebspaceKeyHostNotWebspace()
     {
         $this->requestAnalyzer->getAttribute('host')->willReturn('www.xy.io');
-        $this->requestAnalyzer->getAttribute('port')->willReturn(80);
         $this->testWebspace->hasDomain('www.xy.io', $this->environment, 'de')->willReturn(false);
         $this->webspaceManager->findUrlByResourceLocator(
             '/test',
@@ -219,7 +180,6 @@ class ContentPathTwigExtensionTest extends TestCase
     public function testGetContentPathWithWebspaceKeyAndDomain()
     {
         $this->requestAnalyzer->getAttribute('host')->willReturn('www.sulu.io');
-        $this->requestAnalyzer->getAttribute('port')->willReturn(80);
         $this->webspaceManager->findUrlByResourceLocator(
             '/test',
             $this->environment,

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathTwigExtension.php
@@ -83,13 +83,6 @@ class ContentPathTwigExtension extends AbstractExtension implements ContentPathI
             $scheme
         );
 
-        $port = $this->requestAnalyzer->getAttribute('port');
-        if ($url && false !== \strpos($url, $host)) {
-            if (!('http' == $scheme && 80 == $port) && !('https' == $scheme && 443 == $port)) {
-                $url = \str_replace($host, $host . ':' . $port, $url);
-            }
-        }
-
         if (!$withoutDomain && !$url) {
             $url = $this->webspaceManager->findUrlByResourceLocator(
                 $route,

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -461,7 +461,6 @@ class WebspaceManager implements WebspaceManagerInterface
      *
      * @param string $portalUrl
      * @param string $resourceLocator
-     * @param string|null $domain
      * @param string|null $scheme
      *
      * @return string

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Config\Loader\DelegatingLoader;
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 class WebspaceManagerTest extends WebspaceTestCase
@@ -723,6 +724,40 @@ class WebspaceManagerTest extends WebspaceTestCase
         $this->assertEquals(['https://sulu.lo/'], $result);
     }
 
+    public function testFindUrlsByResourceLocatorWithCustomHttpPort()
+    {
+        $request = $this->prophesize(Request::class);
+        $request->getHost()->willReturn('massiveart.lo');
+        $request->getPort()->willReturn(8080);
+        $this->requestStack->getCurrentRequest()->willReturn($request->reveal());
+
+        $result = $this->webspaceManager->findUrlsByResourceLocator('/test', 'dev', 'en_us', 'massiveart', null, 'http');
+
+        $this->assertCount(2, $result);
+        $this->assertContains('http://massiveart.lo:8080/en-us/w/test', $result);
+        $this->assertContains('http://massiveart.lo:8080/en-us/s/test', $result);
+
+        $result = $this->webspaceManager->findUrlsByResourceLocator('/test', 'dev', 'de_at', 'sulu_io', null, 'http');
+        $this->assertEquals(['http://sulu.lo/test'], $result);
+    }
+
+    public function testFindUrlsByResourceLocatorWithCustomHttpsPort()
+    {
+        $request = $this->prophesize(Request::class);
+        $request->getHost()->willReturn('sulu.lo');
+        $request->getPort()->willReturn(4444);
+        $this->requestStack->getCurrentRequest()->willReturn($request->reveal());
+
+        $result = $this->webspaceManager->findUrlsByResourceLocator('/test', 'dev', 'en_us', 'massiveart', null, 'https');
+
+        $this->assertCount(2, $result);
+        $this->assertContains('https://massiveart.lo/en-us/w/test', $result);
+        $this->assertContains('https://massiveart.lo/en-us/s/test', $result);
+
+        $result = $this->webspaceManager->findUrlsByResourceLocator('/test', 'dev', 'de_at', 'sulu_io', null, 'https');
+        $this->assertEquals(['https://sulu.lo:4444/test'], $result);
+    }
+
     public function testFindUrlByResourceLocator()
     {
         $result = $this->webspaceManager->findUrlByResourceLocator('/test', 'dev', 'de_at', 'sulu_io');
@@ -743,6 +778,34 @@ class WebspaceManagerTest extends WebspaceTestCase
             'https'
         );
         $this->assertEquals('https://sulu.lo/test', $result);
+    }
+
+    public function testFindUrlByResourceLocatorWithCustomHttpPort()
+    {
+        $request = $this->prophesize(Request::class);
+        $request->getHost()->willReturn('massiveart.lo');
+        $request->getPort()->willReturn(8080);
+        $this->requestStack->getCurrentRequest()->willReturn($request->reveal());
+
+        $result = $this->webspaceManager->findUrlByResourceLocator('/test', 'dev', 'en_us', 'massiveart', null, 'http');
+        $this->assertEquals('http://massiveart.lo:8080/en-us/s/test', $result);
+
+        $result = $this->webspaceManager->findUrlByResourceLocator('/test', 'dev', 'de_at', 'sulu_io', null, 'http');
+        $this->assertEquals('http://sulu.lo/test', $result);
+    }
+
+    public function testFindUrlByResourceLocatorWithCustomHttpsPort()
+    {
+        $request = $this->prophesize(Request::class);
+        $request->getHost()->willReturn('sulu.lo');
+        $request->getPort()->willReturn(4444);
+        $this->requestStack->getCurrentRequest()->willReturn($request->reveal());
+
+        $result = $this->webspaceManager->findUrlByResourceLocator('/test', 'dev', 'en_us', 'massiveart', null, 'https');
+        $this->assertEquals('https://massiveart.lo/en-us/s/test', $result);
+
+        $result = $this->webspaceManager->findUrlByResourceLocator('/test', 'dev', 'de_at', 'sulu_io', null, 'https');
+        $this->assertEquals('https://sulu.lo:4444/test', $result);
     }
 
     public function testGetPortals()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5364
| License | MIT

#### What's in this PR?

This PR adjusts the `WebspaceManager` to add the port of the current request to generated urls, if the urls match the host of the current request. This fixes the url generation for the following services when serving a website via a non-default port:
* `ContentPathTwigExtension` (port was already added by the service itself before)
* `PageLinkProvider`
* `PagesSitemapProvider`
* `ContentRouteProvider`
* `SitemapTwigExtension`
* `RedirectEnhancer`
* `SeoEnhancer`

#### Why?

Because a lot of developers serve their application via a non-default (eg `8080`) port during development. At the moment, in such a setup, the links generated by the services listed above will not work because they omit the port.
