### PR TITLE
Make sure ContentMapperSubscriber runs before the RemoveSubscriber

### DIFF
--- a/src/Sulu/Component/Content/Document/Subscriber/Compat/ContentMapperSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/Compat/ContentMapperSubscriber.php
@@ -87,7 +87,7 @@ class ContentMapperSubscriber implements EventSubscriberInterface
     {
         return [
             Events::REMOVE => [
-                ['handlePreRemove', 500],
+                ['handlePreRemove', 550],
                 ['handlePostRemove', -100],
             ],
             Events::PERSIST => 'handlePersist',

--- a/src/Sulu/Component/Content/Document/Subscriber/Compat/ContentMapperSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/Compat/ContentMapperSubscriber.php
@@ -87,7 +87,7 @@ class ContentMapperSubscriber implements EventSubscriberInterface
     {
         return [
             Events::REMOVE => [
-                ['handlePreRemove', 550],
+                ['handlePreRemove', 510],
                 ['handlePostRemove', -100],
             ],
             Events::PERSIST => 'handlePersist',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5376
| License | MIT

#### What's in this PR?

project/vendor/sulu/sulu/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/RemoveSubscriber.php:46 is set to 500 as well. So I change this weight to 550 and it runs before the PHPCR node is set to "removed".

#### Why?

See #5376
