### PR TITLE
Fix ckeditor z-index dropdown problem

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
@@ -25,6 +25,10 @@ $textEditorUnpublishedLinkColor: $gold;
         --ck-font-size-base: $textEditorFontSize;
         --ck-icon-size: $textEditorFontSize;
 
+        /* z-index */
+        /* set it to auto instead of 1 to fix problem with overlapping components https://github.com/sulu/sulu/issues/5375 */
+        --ck-z-default: auto;
+
         /* shadows */
         --ck-color-shadow-inner: none;
         --ck-color-shadow-drop: none;
@@ -97,8 +101,6 @@ $textEditorUnpublishedLinkColor: $gold;
     }
 
     .ck.ck-editor {
-        z-index: 0;
-
         .ck.ck-toolbar__separator {
             background: none;
             width: $textEditorButtonMinSize;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5375
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix ckeditor z-index dropdown problem.

#### Why?

If we set it to z-index 0 the ckeditor is under the select if we set it to 1 we  have other issues with overlays. If we don't set it the ckeditor dropdown icons are over the overlay. The solution with creating a new rendering layer with transform seems to fix this issue.

#### TODO

 - [ ] see https://github.com/sulu/sulu/issues/5375#issuecomment-651788783