### PR TITLE
Add position name to serialized contact

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Api/Contact.php
+++ b/src/Sulu/Bundle/ContactBundle/Api/Contact.php
@@ -227,7 +227,7 @@ class Contact extends ApiWrapper
     /**
      * Get position.
      *
-     * @return string
+     * @return int
      *
      * @VirtualProperty
      * @SerializedName("position")
@@ -242,6 +242,26 @@ class Contact extends ApiWrapper
         }
 
         return $position->getId();
+    }
+
+    /**
+     * Get position.
+     *
+     * @return string
+     *
+     * @VirtualProperty
+     * @SerializedName("positionName")
+     * @Groups({"fullContact"})
+     */
+    public function getPositionName()
+    {
+        $position = $this->entity->getPosition();
+
+        if (!$position) {
+            return null;
+        }
+
+        return $position->getPosition();
     }
 
     /**

--- a/src/Sulu/Bundle/ContactBundle/Entity/Contact.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/Contact.php
@@ -51,7 +51,7 @@ class Contact extends ApiEntity implements ContactInterface, AuditableInterface
     protected $lastName;
 
     /**
-     * @var string
+     * @var ContactTitle
      */
     protected $title;
 

--- a/src/Sulu/Bundle/ContactBundle/Entity/ContactRepository.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/ContactRepository.php
@@ -448,6 +448,8 @@ class ContactRepository extends EntityRepository implements DataProviderReposito
             ->addSelect('tags')
             ->addSelect('categories')
             ->addSelect('translations')
+            ->addSelect('accountContacts')
+            ->addSelect('position')
             ->leftJoin($alias . '.emails', 'emails')
             ->leftJoin('emails.emailType', 'emailType')
             ->leftJoin($alias . '.phones', 'phones')
@@ -458,6 +460,8 @@ class ContactRepository extends EntityRepository implements DataProviderReposito
             ->leftJoin('urls.urlType', 'urlType')
             ->leftJoin($alias . '.tags', 'tags')
             ->leftJoin($alias . '.categories', 'categories')
-            ->leftJoin('categories.translations', 'translations');
+            ->leftJoin('categories.translations', 'translations')
+            ->leftJoin($alias . '.accountContacts', 'accountContacts')
+            ->leftJoin('accountContacts.position', 'position');
     }
 }

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
@@ -430,6 +430,7 @@ class ContactControllerTest extends SuluTestCase
         $this->assertEquals('Mustermann', $response->lastName);
         $this->assertEquals($title->getId(), $response->title);
         $this->assertEquals($position->getId(), $response->position);
+        $this->assertEquals($position->getPosition(), $response->positionName);
         $this->assertEquals('erika.mustermann@muster.at', $response->contactDetails->emails[0]->email);
         $this->assertEquals('erika.mustermann@muster.de', $response->contactDetails->emails[1]->email);
         $this->assertEquals('123456789', $response->contactDetails->phones[0]->phone);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5358
| Related issues/PRs | replaces #4895
| License | MIT

#### What's in this PR?

This PR adds a `positionName` property to the serialized representation of the contact entity. This serializer representation is returned by the `ContactAccountSelection` and by the `contacts` smart-content data-provider.

The PR also adjusts the `ContactRepository` to join the respective tables to prevent the lazy-loading of entities during serialization. I tested the adjustments and did not notice any additional queries in the Symfony profiler.

#### Why?

See #5358