### PR TITLE
Fix nullable metadata in routeable subscriber

### DIFF
--- a/src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspector.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspector.php
@@ -108,7 +108,7 @@ class DocumentInspector extends BaseDocumentInspector
     /**
      * Return the structure for the given StructureBehavior implementing document.
      *
-     * @return StructureMetadata
+     * @return StructureMetadata|null
      */
     public function getStructureMetadata(StructureBehavior $document)
     {

--- a/src/Sulu/Bundle/RouteBundle/Document/Subscriber/RoutableSubscriber.php
+++ b/src/Sulu/Bundle/RouteBundle/Document/Subscriber/RoutableSubscriber.php
@@ -291,7 +291,7 @@ class RoutableSubscriber implements EventSubscriberInterface
     {
         $metadata = $this->documentInspector->getStructureMetadata($document);
 
-        if ($metadata->hasTag(self::TAG_NAME)) {
+        if ($metadata && $metadata->hasTag(self::TAG_NAME)) {
             return $this->getPropertyName(
                 $locale,
                 $metadata->getPropertyByTagName(self::TAG_NAME)->getName()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix nullable metadata in routeable subscriber.

#### Why?

Metadata can be returning null and should then fallback to the default behaviour.
