### PR TITLE
Add DateTime content type

### DIFF
--- a/config/templates/pages/example.xml
+++ b/config/templates/pages/example.xml
@@ -196,6 +196,13 @@
             </meta>
         </property>
 
+        <property name="datetime" type="datetime">
+            <meta>
+                <title lang="en">Date with Time</title>
+                <title lang="de">Datum mit Zeit</title>
+            </meta>
+        </property>
+
         <property name="email" type="email">
             <meta>
                 <title lang="en">Email</title>

--- a/src/Sulu/Bundle/PageBundle/Content/Types/Date.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/Date.php
@@ -20,7 +20,7 @@ use Sulu\Component\Content\SimpleContentType;
  */
 class Date extends SimpleContentType
 {
-    const FORMAT = 'Y-m-d\TH:i:s';
+    const FORMAT = 'Y-m-d';
 
     public function __construct()
     {

--- a/src/Sulu/Bundle/PageBundle/Content/Types/Date.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/Date.php
@@ -20,6 +20,8 @@ use Sulu\Component\Content\SimpleContentType;
  */
 class Date extends SimpleContentType
 {
+    const FORMAT = 'Y-m-d\TH:i:s';
+
     public function __construct()
     {
         parent::__construct('Date');
@@ -35,7 +37,7 @@ class Date extends SimpleContentType
     ) {
         $value = $property->getValue();
         if (null != $value) {
-            $value = \DateTime::createFromFormat('Y-m-d', $value);
+            $value = \DateTime::createFromFormat(static::FORMAT, $value);
 
             $node->setProperty($property->getName(), $value);
         } else {
@@ -51,7 +53,7 @@ class Date extends SimpleContentType
             $propertyValue = $node->getPropertyValue($property->getName());
 
             if ($propertyValue instanceof \DateTime) {
-                $value = $propertyValue->format('Y-m-d');
+                $value = $propertyValue->format(static::FORMAT);
             }
         }
 

--- a/src/Sulu/Bundle/PageBundle/Content/Types/Date.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/Date.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\PageBundle\Content\Types;
 
 use PHPCR\NodeInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
-use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Content\SimpleContentType;
 
 /**
@@ -59,13 +58,5 @@ class Date extends SimpleContentType
         $property->setValue($value);
 
         return $value;
-    }
-
-    public function getDefaultParams(PropertyInterface $property = null)
-    {
-        return [
-            'display_options' => new PropertyParameter('display_options', [], 'collection'),
-            'placeholder' => new PropertyParameter('placeholder', null),
-        ];
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Content/Types/DateTime.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/DateTime.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PageBundle\Content\Types;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\Content\Compat\PropertyInterface;
+use Sulu\Component\Content\Compat\PropertyParameter;
+use Sulu\Component\Content\SimpleContentType;
+
+/**
+ * ContentType for DateTime.
+ */
+class DateTime extends SimpleContentType
+{
+    const format = 'Y-m-d\TH:i:s';
+
+    public function __construct()
+    {
+        parent::__construct('DateTime');
+    }
+
+    public function write(
+        NodeInterface $node,
+        PropertyInterface $property,
+        $userId,
+        $webspaceKey,
+        $languageCode,
+        $segmentKey
+    ) {
+        $value = $property->getValue();
+        if (null != $value) {
+            $value = \DateTime::createFromFormat(self::format, $value);
+            $new = new \DateTime();
+            $format = $new->format(self::format);
+            $node->setProperty($property->getName(), $value);
+        } else {
+            $this->remove($node, $property, $webspaceKey, $languageCode, $segmentKey);
+        }
+    }
+
+    public function read(NodeInterface $node, PropertyInterface $property, $webspaceKey, $languageCode, $segmentKey)
+    {
+        $value = '';
+        if ($node->hasProperty($property->getName())) {
+            /** @var \DateTime $propertyValue */
+            $propertyValue = $node->getPropertyValue($property->getName());
+
+            if ($propertyValue instanceof \DateTime) {
+                $value = $propertyValue->format(self::format);
+            }
+        }
+
+        $property->setValue($value);
+
+        return $value;
+    }
+
+    public function getDefaultParams(PropertyInterface $property = null)
+    {
+        return [
+            'display_options' => new PropertyParameter('display_options', [], 'collection'),
+            'placeholder' => new PropertyParameter('placeholder', null),
+        ];
+    }
+}

--- a/src/Sulu/Bundle/PageBundle/Content/Types/DateTime.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/DateTime.php
@@ -36,6 +36,7 @@ class DateTime extends SimpleContentType
         $segmentKey
     ) {
         $value = $property->getValue();
+
         if (null != $value) {
             $value = \DateTime::createFromFormat(static::FORMAT, $value);
 
@@ -60,5 +61,16 @@ class DateTime extends SimpleContentType
         $property->setValue($value);
 
         return $value;
+    }
+
+    public function getContentData(PropertyInterface $property)
+    {
+        $value = $property->getValue();
+
+        if (!empty($value)) {
+            return \DateTime::createFromFormat(static::FORMAT, $value);
+        }
+
+        return null;
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Content/Types/DateTime.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/DateTime.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\PageBundle\Content\Types;
 
 use PHPCR\NodeInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
-use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Content\SimpleContentType;
 
 /**
@@ -39,8 +38,7 @@ class DateTime extends SimpleContentType
         $value = $property->getValue();
         if (null != $value) {
             $value = \DateTime::createFromFormat(self::format, $value);
-            $new = new \DateTime();
-            $format = $new->format(self::format);
+
             $node->setProperty($property->getName(), $value);
         } else {
             $this->remove($node, $property, $webspaceKey, $languageCode, $segmentKey);
@@ -62,13 +60,5 @@ class DateTime extends SimpleContentType
         $property->setValue($value);
 
         return $value;
-    }
-
-    public function getDefaultParams(PropertyInterface $property = null)
-    {
-        return [
-            'display_options' => new PropertyParameter('display_options', [], 'collection'),
-            'placeholder' => new PropertyParameter('placeholder', null),
-        ];
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Content/Types/DateTime.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/DateTime.php
@@ -20,7 +20,7 @@ use Sulu\Component\Content\SimpleContentType;
  */
 class DateTime extends SimpleContentType
 {
-    const format = 'Y-m-d\TH:i:s';
+    const FORMAT = 'Y-m-d\TH:i:s';
 
     public function __construct()
     {
@@ -37,7 +37,7 @@ class DateTime extends SimpleContentType
     ) {
         $value = $property->getValue();
         if (null != $value) {
-            $value = \DateTime::createFromFormat(self::format, $value);
+            $value = \DateTime::createFromFormat(static::FORMAT, $value);
 
             $node->setProperty($property->getName(), $value);
         } else {
@@ -53,7 +53,7 @@ class DateTime extends SimpleContentType
             $propertyValue = $node->getPropertyValue($property->getName());
 
             if ($propertyValue instanceof \DateTime) {
-                $value = $propertyValue->format(self::format);
+                $value = $propertyValue->format(static::FORMAT);
             }
         }
 

--- a/src/Sulu/Bundle/PageBundle/Resources/config/content_types.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/content_types.xml
@@ -39,6 +39,10 @@
             <tag name="sulu.content.type" alias="date"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
         </service>
+        <service id="sulu.content.type.datetime" class="Sulu\Bundle\PageBundle\Content\Types\DateTime">
+            <tag name="sulu.content.type" alias="datetime"/>
+            <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
+        </service>
         <service id="sulu.content.type.time" class="Sulu\Bundle\PageBundle\Content\Types\Time">
             <tag name="sulu.content.type" alias="time"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/DateTimeTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/DateTimeTest.php
@@ -93,4 +93,26 @@ class DateTimeTest extends TestCase
 
         $dateTime->write($node->reveal(), $property->reveal(), 1, $webspaceKey, $locale, null);
     }
+
+    public function testGetContentData()
+    {
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getValue()->shouldBeCalled()->willReturn('2020-07-02T11:30:00');
+
+        $dateTime = new DateTime();
+        $result = $dateTime->getContentData($property->reveal());
+
+        $this->assertInstanceOf(\DateTime::class, $result);
+        $this->assertSame('2020-07-02T11:30:00', $result->format('Y-m-d\TH:i:s'));
+    }
+
+    public function testGetContentDataEmpty()
+    {
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getValue()->shouldBeCalled()->willReturn('');
+
+        $dateTime = new DateTime();
+
+        $this->assertNull($dateTime->getContentData($property->reveal()));
+    }
 }

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/DateTimeTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/DateTimeTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PageBundle\Tests\Unit\Content\Types;
+
+use PHPCR\ItemInterface;
+use PHPCR\NodeInterface;
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\PageBundle\Content\Types\DateTime;
+use Sulu\Component\Content\Compat\PropertyInterface;
+
+class DateTimeTest extends TestCase
+{
+    public function testRead()
+    {
+        $webspaceKey = 'sulu_io';
+        $locale = 'de';
+        $dateValue = new \DateTime('2020-07-02T11:30:00');
+
+        $node = $this->prophesize(NodeInterface::class);
+        $node->hasProperty('test')->willReturn(true);
+        $node->getPropertyValue('test')->willReturn($dateValue);
+
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getName()->willReturn('test');
+        $property->setValue('2020-07-02T11:30:00')->shouldBeCalled();
+
+        $dateTime = new DateTime();
+
+        $dateTime->read($node->reveal(), $property->reveal(), $webspaceKey, $locale, null);
+    }
+
+    public function testReadPropertyNotExists()
+    {
+        $webspaceKey = 'sulu_io';
+        $locale = 'de';
+
+        $node = $this->prophesize(NodeInterface::class);
+        $node->hasProperty('test')->willReturn(false);
+        $node->getPropertyValue('test')->shouldNotBeCalled();
+
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getName()->willReturn('test');
+        $property->setValue('')->shouldBeCalled();
+
+        $dateTime = new DateTime();
+
+        $dateTime->read($node->reveal(), $property->reveal(), $webspaceKey, $locale, null);
+    }
+
+    public function testWrite()
+    {
+        $webspaceKey = 'sulu_io';
+        $locale = 'de';
+
+        $node = $this->prophesize(NodeInterface::class);
+        $node->setProperty('test', new \DateTime('2020-07-02T11:30:00'))->shouldBeCalled();
+
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getValue()->willReturn('2020-07-02T11:30:00');
+        $property->getName()->willReturn('test');
+
+        $dateTime = new DateTime();
+
+        $dateTime->write($node->reveal(), $property->reveal(), 1, $webspaceKey, $locale, null);
+    }
+
+    public function testWriteNull()
+    {
+        $webspaceKey = 'sulu_io';
+        $locale = 'de';
+
+        $nodeItem = $this->prophesize(ItemInterface::class);
+        $nodeItem->remove()->shouldBeCalled($nodeItem->reveal());
+
+        $node = $this->prophesize(NodeInterface::class);
+        $node->hasProperty('test')->willReturn(true);
+        $node->getProperty('test')->willReturn($nodeItem->reveal());
+
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getValue()->willReturn(null);
+        $property->getName()->willReturn('test');
+
+        $dateTime = new DateTime();
+
+        $dateTime->write($node->reveal(), $property->reveal(), 1, $webspaceKey, $locale, null);
+    }
+}

--- a/templates/pages/example.html.twig
+++ b/templates/pages/example.html.twig
@@ -32,6 +32,7 @@
     <p>{{ content.color }}</p>
     <p>{{ content.time }}</p>
     <p>{{ content.date }}</p>
+    <p>{{ content.datetime }}</p>
     <p>{{ content.email }}</p>
     <p>{{ content.link }}</p>
 
@@ -57,9 +58,13 @@
         <p>{{ content.single_account_selection.name }}</p>
     {% endif %}
 
+    <p>{{ content.account_selection | map(account => account.name) | join(', ') }}</p>
+
     {% if content.single_contact_selection %}
         <p>{{ content.single_contact_selection.fullName }}</p>
     {% endif %}
+
+    <p>{{ content.contact_selection | map(contact => contact.fullName) | join(', ') }}</p>
 
     <p>{{ content.contact_account_selection | map(contact => contact.name ?? contact.fullName) | join(', ') }}</p>
     <p>{{ content.text_area }}</p>

--- a/templates/pages/example.html.twig
+++ b/templates/pages/example.html.twig
@@ -25,14 +25,14 @@
         </p>
     {% endif %}
 
-    <p>{{ content.tag_selection | join(', ') }}</p>
+    <p>{{ content.tag_selection|join(', ') }}</p>
     <p>{{ content.single_select }}</p>
-    <p>{{ content.select | join(', ') }}</p>
+    <p>{{ content.select|join(', ') }}</p>
     <p>{{ content.checkbox }}</p>
     <p>{{ content.color }}</p>
     <p>{{ content.time }}</p>
     <p>{{ content.date }}</p>
-    <p>{{ content.datetime }}</p>
+    <p>{{ content.datetime  ? content.datetime.format('Y-m-d H:i') : '' }}</p>
     <p>{{ content.email }}</p>
     <p>{{ content.link }}</p>
 
@@ -40,11 +40,11 @@
         <p>{{ sulu_content_load(content.single_page_selection).content.title }}</p>
     {% endif %}
 
-    <p>{{ content.page_selection | map(page => page.title) | join(', ') }}</p>
-    <p>{{ content.teaser_selection | map(teaser => teaser.title) | join(', ') }}</p>
-    <p>{{ content.smart_content | map(page => page.title) | join(', ') }}</p>
-    <p>{{ content.snippet_selection | map(snippet => snippet.title) | join(', ') }}</p>
-    <p>{{ content.category_selection | map(category => category.name) | join(', ') }}</p>
+    <p>{{ content.page_selection|map(page => page.title)|join(', ') }}</p>
+    <p>{{ content.teaser_selection|map(teaser => teaser.title)|join(', ') }}</p>
+    <p>{{ content.smart_content|map(page => page.title)|join(', ') }}</p>
+    <p>{{ content.snippet_selection|map(snippet => snippet.title)|join(', ') }}</p>
+    <p>{{ content.category_selection|map(category => category.name)|join(', ') }}</p>
 
     {% if content.single_media_selection %}
         <img src="{{ content.single_media_selection.thumbnails['sulu-260x'] }}" />
@@ -58,14 +58,14 @@
         <p>{{ content.single_account_selection.name }}</p>
     {% endif %}
 
-    <p>{{ content.account_selection | map(account => account.name) | join(', ') }}</p>
+    <p>{{ content.account_selection|map(account => account.name)|join(', ') }}</p>
 
     {% if content.single_contact_selection %}
         <p>{{ content.single_contact_selection.fullName }}</p>
     {% endif %}
 
-    <p>{{ content.contact_selection | map(contact => contact.fullName) | join(', ') }}</p>
+    <p>{{ content.contact_selection|map(contact => contact.fullName)|join(', ') }}</p>
 
-    <p>{{ content.contact_account_selection | map(contact => contact.name ?? contact.fullName) | join(', ') }}</p>
+    <p>{{ content.contact_account_selection|map(contact => contact.name ?? contact.fullName)|join(', ') }}</p>
     <p>{{ content.text_area }}</p>
 {% endblock %}


### PR DESCRIPTION
Added datetime content type and configuration.

| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | no
| Related issues/PRs | no
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/533

#### What's in this PR?

Adds DateTime content type.

#### Why?

There was a Time and a Date content type but no datetime content type. 

#### Example Usage

in config/templates/pages/{yourpagename}.xml inside <properties> : 
```
        <property name="my_datetime" type="datetime">
            <meta>
                <title lang="en">DateTime</title>
                <title lang="de">DateTime Duits</title>
            </meta>
        </property>

```

#### To Do

fix failed tests?
