### PR TITLE
Add link to selected default-snippet in SnippetAreas view

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/BlockCollection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/BlockCollection.test.js.snap
@@ -73,7 +73,7 @@ exports[`Should render a block list 1`] = `
       class="su-plus buttonIcon"
     />
     <span
-      class="text"
+      class="buttonText"
     >
       Add block
     </span>
@@ -155,7 +155,7 @@ exports[`Should render a disabled block list 1`] = `
       class="su-plus buttonIcon"
     />
     <span
-      class="text"
+      class="buttonText"
     >
       Add block
     </span>
@@ -237,7 +237,7 @@ exports[`Should render a fully filled block list without add button if maxOccurs
       class="su-plus buttonIcon"
     />
     <span
-      class="text"
+      class="buttonText"
     >
       Add block
     </span>
@@ -261,7 +261,7 @@ exports[`Should render an empty block list 1`] = `
       class="su-plus buttonIcon"
     />
     <span
-      class="text"
+      class="buttonText"
     >
       Add block
     </span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/Button.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/Button.js
@@ -92,7 +92,7 @@ export default class Button<T> extends React.PureComponent<Props<T>> {
                     <Icon className={iconClass} name={icon} />
                 }
                 {children &&
-                    <span className={buttonStyles.text}>{children}</span>
+                    <span className={buttonStyles.buttonText}>{children}</span>
                 }
                 {showDropdownIcon &&
                     <Icon className={buttonStyles.dropdownIcon} name="su-angle-down" />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/README.md
@@ -46,6 +46,19 @@ const onClick = () => {
 };
 
 <Button
+    skin="text"
+    onClick={onClick}>
+    Click me dude
+</Button>
+```
+
+```javascript
+const onClick = () => {
+    /* do click things */
+    alert('Clicked this nice button, congrats!');
+};
+
+<Button
     skin="icon"
     icon="su-plus"
     onClick={onClick}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/button.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/button.scss
@@ -17,6 +17,9 @@ $secondaryDisabledColor: $silver;
 $linkColor: $black;
 $linkDisabledColor: $silverChalice;
 
+$textColor: $black;
+$textDisabledColor: $silverChalice;
+
 $iconFontSize: 14px;
 $iconBackgroundColorActive: $doveGray;
 $iconBackgroundColorHover: $mercury;
@@ -108,6 +111,28 @@ $iconColorActive: $white;
 
     &:disabled {
         color: $linkDisabledColor;
+    }
+}
+
+.text {
+    padding: 0;
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+    font-size: $fontSize;
+    color: $textColor;
+
+    .button-icon + .text {
+        margin-left: 10px;
+    }
+
+    .dropdown-icon {
+        margin-left: 10px;
+        font-size: $dropdownFontSize;
+    }
+
+    &:disabled {
+        color: $textDisabledColor;
     }
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/button.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/button.scss
@@ -96,11 +96,11 @@ $iconColorActive: $white;
     font-size: $fontSize;
     color: $linkColor;
 
-    .text {
+    .button-text {
         text-decoration: underline;
     }
 
-    .button-icon + .text {
+    .button-icon + .button-text {
         margin-left: 10px;
     }
 
@@ -122,7 +122,7 @@ $iconColorActive: $white;
     font-size: $fontSize;
     color: $textColor;
 
-    .button-icon + .text {
+    .button-icon + .button-text {
         margin-left: 10px;
     }
 
@@ -185,7 +185,7 @@ $iconColorActive: $white;
     background-color: transparent;
     border-color: transparent;
 
-    .text {
+    .button-text {
         opacity: 0;
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/Button.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/Button.test.js
@@ -23,6 +23,10 @@ test('Should render with skin link', () => {
     expect(render(<Button skin="link" />)).toMatchSnapshot();
 });
 
+test('Should render with skin text', () => {
+    expect(render(<Button skin="text" />)).toMatchSnapshot();
+});
+
 test('Should render with skin icon', () => {
     expect(render(<Button skin="icon" />)).toMatchSnapshot();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/__snapshots__/Button.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/__snapshots__/Button.test.js.snap
@@ -10,7 +10,7 @@ exports[`Should render the button with icon 1`] = `
     class="su-plus buttonIcon"
   />
   <span
-    class="text"
+    class="buttonText"
   >
     Add something
   </span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/__snapshots__/Button.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/__snapshots__/Button.test.js.snap
@@ -100,6 +100,13 @@ exports[`Should render with skin secondary and dropdown icon 1`] = `
 </button>
 `;
 
+exports[`Should render with skin text 1`] = `
+<button
+  class="button text"
+  type="button"
+/>
+`;
+
 exports[`should render disabled with skin secondary 1`] = `
 <button
   class="button secondary"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/types.js
@@ -1,3 +1,3 @@
 // @flow
 
-export type ButtonSkin = 'primary' | 'secondary' | 'link' | 'icon';
+export type ButtonSkin = 'primary' | 'secondary' | 'link' | 'text' | 'icon';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ButtonGroup/tests/__snapshots__/ButtonGroup.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ButtonGroup/tests/__snapshots__/ButtonGroup.test.js.snap
@@ -9,7 +9,7 @@ exports[`Should render a button and a dropdown button 1`] = `
     type="button"
   >
     <span
-      class="text"
+      class="buttonText"
     >
       <span
         aria-label="su-th-large"
@@ -38,7 +38,7 @@ exports[`Should render a button with a custom className 1`] = `
     type="button"
   >
     <span
-      class="text"
+      class="buttonText"
     >
       <span
         aria-label="su-th-large"
@@ -58,7 +58,7 @@ exports[`Should render more than two buttons 1`] = `
     type="button"
   >
     <span
-      class="text"
+      class="buttonText"
     >
       <span
         aria-label="su-th-large"
@@ -71,7 +71,7 @@ exports[`Should render more than two buttons 1`] = `
     type="button"
   >
     <span
-      class="text"
+      class="buttonText"
     >
       <span
         aria-label="su-align-justify"
@@ -84,7 +84,7 @@ exports[`Should render more than two buttons 1`] = `
     type="button"
   >
     <span
-      class="text"
+      class="buttonText"
     >
       <span
         aria-label="su-th-large"
@@ -97,7 +97,7 @@ exports[`Should render more than two buttons 1`] = `
     type="button"
   >
     <span
-      class="text"
+      class="buttonText"
     >
       <span
         aria-label="su-align-justify"
@@ -117,7 +117,7 @@ exports[`Should render one button 1`] = `
     type="button"
   >
     <span
-      class="text"
+      class="buttonText"
     >
       <span
         aria-label="su-th-large"
@@ -137,7 +137,7 @@ exports[`Should render one button with a custom className and another one withou
     type="button"
   >
     <span
-      class="text"
+      class="buttonText"
     >
       <span
         aria-label="su-th-large"
@@ -150,7 +150,7 @@ exports[`Should render one button with a custom className and another one withou
     type="button"
   >
     <span
-      class="text"
+      class="buttonText"
     >
       <span
         aria-label="su-align-justify"
@@ -170,7 +170,7 @@ exports[`Should render two buttons 1`] = `
     type="button"
   >
     <span
-      class="text"
+      class="buttonText"
     >
       <span
         aria-label="su-th-large"
@@ -183,7 +183,7 @@ exports[`Should render two buttons 1`] = `
     type="button"
   >
     <span
-      class="text"
+      class="buttonText"
     >
       <span
         aria-label="su-align-justify"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CardCollection/tests/__snapshots__/CardCollection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CardCollection/tests/__snapshots__/CardCollection.test.js.snap
@@ -17,7 +17,7 @@ Array [
         class="su-plus buttonIcon"
       />
       <span
-        class="text"
+        class="buttonText"
       >
         sulu_admin.add
       </span>
@@ -72,7 +72,7 @@ Array [
         class="su-plus buttonIcon"
       />
       <span
-        class="text"
+        class="buttonText"
       >
         sulu_admin.add
       </span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/__snapshots__/Dialog.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/__snapshots__/Dialog.test.js.snap
@@ -29,7 +29,7 @@ Array [
             type="button"
           >
             <span
-              class="text"
+              class="buttonText"
             >
               Confirm
             </span>
@@ -39,7 +39,7 @@ Array [
             type="button"
           >
             <span
-              class="text"
+              class="buttonText"
             >
               Cancel
             </span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DropdownButton/tests/__snapshots__/DropdownButton.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DropdownButton/tests/__snapshots__/DropdownButton.test.js.snap
@@ -10,7 +10,7 @@ exports[`Render dropdown button 1`] = `
     class="su-plus buttonIcon"
   />
   <span
-    class="text"
+    class="buttonText"
   >
     Add
   </span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/FileUploadButton/tests/__snapshots__/FileUploadButton.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/FileUploadButton/tests/__snapshots__/FileUploadButton.test.js.snap
@@ -9,7 +9,7 @@ exports[`Render a FileUploadButton 1`] = `
     type="button"
   >
     <span
-      class="text"
+      class="buttonText"
     >
       Upload something!
     </span>
@@ -37,7 +37,7 @@ exports[`Render a FileUploadButton with other skin and icon 1`] = `
       class="su-image buttonIcon"
     />
     <span
-      class="text"
+      class="buttonText"
     >
       Upload something!
     </span>
@@ -62,7 +62,7 @@ exports[`Render a disabled FileUploadButton 1`] = `
     type="button"
   >
     <span
-      class="text"
+      class="buttonText"
     >
       Upload something!
     </span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/__snapshots__/Actions.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/__snapshots__/Actions.test.js.snap
@@ -9,7 +9,7 @@ exports[`The component should render 1`] = `
     type="button"
   >
     <span
-      class="text"
+      class="buttonText"
     >
       Action 1
     </span>
@@ -19,7 +19,7 @@ exports[`The component should render 1`] = `
     type="button"
   >
     <span
-      class="text"
+      class="buttonText"
     >
       Action 2
     </span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/__snapshots__/Overlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/__snapshots__/Overlay.test.js.snap
@@ -40,7 +40,7 @@ Array [
               type="button"
             >
               <span
-                class="text"
+                class="buttonText"
               >
                 Action 1
               </span>
@@ -50,7 +50,7 @@ Array [
               type="button"
             >
               <span
-                class="text"
+                class="buttonText"
               >
                 Action 2
               </span>
@@ -61,7 +61,7 @@ Array [
             type="button"
           >
             <span
-              class="text"
+              class="buttonText"
             >
               Apply
             </span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/__snapshots__/Application.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/__snapshots__/Application.test.js.snap
@@ -445,7 +445,7 @@ Array [
                 type="button"
               >
                 <span
-                  class="text"
+                  class="buttonText"
                 >
                   sulu_admin.to_login
                 </span>
@@ -456,7 +456,7 @@ Array [
                 type="submit"
               >
                 <span
-                  class="text"
+                  class="buttonText"
                 >
                   sulu_admin.reset_password
                 </span>
@@ -585,7 +585,7 @@ Array [
                 type="button"
               >
                 <span
-                  class="text"
+                  class="buttonText"
                 >
                   sulu_admin.forgot_password
                 </span>
@@ -596,7 +596,7 @@ Array [
                 type="submit"
               >
                 <span
-                  class="text"
+                  class="buttonText"
                 >
                   sulu_admin.login
                 </span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
@@ -223,7 +223,7 @@ exports[`Render block with schema 1`] = `
       class="su-plus buttonIcon"
     />
     <span
-      class="text"
+      class="buttonText"
     >
       sulu_admin.add_block
     </span>
@@ -473,7 +473,7 @@ exports[`Render block with schema and error on fields already being modified 1`]
       class="su-plus buttonIcon"
     />
     <span
-      class="text"
+      class="buttonText"
     >
       sulu_admin.add_block
     </span>
@@ -726,7 +726,7 @@ exports[`Render block with schema and error on fields already being modified 2`]
       class="su-plus buttonIcon"
     />
     <span
-      class="text"
+      class="buttonText"
     >
       sulu_admin.add_block
     </span>
@@ -825,7 +825,7 @@ exports[`Render collapsed blocks with block previews 1`] = `
       class="su-plus buttonIcon"
     />
     <span
-      class="text"
+      class="buttonText"
     >
       sulu_admin.add_block
     </span>
@@ -936,7 +936,7 @@ exports[`Render collapsed blocks with block previews 2`] = `
       class="su-plus buttonIcon"
     />
     <span
-      class="text"
+      class="buttonText"
     >
       sulu_admin.add_block
     </span>
@@ -1047,7 +1047,7 @@ exports[`Render collapsed blocks with block previews without tags 1`] = `
       class="su-plus buttonIcon"
     />
     <span
-      class="text"
+      class="buttonText"
     >
       sulu_admin.add_block
     </span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/GhostDialog.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/GhostDialog.test.js.snap
@@ -80,7 +80,7 @@ Array [
             type="button"
           >
             <span
-              class="text"
+              class="buttonText"
             >
               sulu_admin.yes
             </span>
@@ -90,7 +90,7 @@ Array [
             type="button"
           >
             <span
-              class="text"
+              class="buttonText"
             >
               sulu_admin.no
             </span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/__snapshots__/CardCollection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/__snapshots__/CardCollection.test.js.snap
@@ -68,7 +68,7 @@ Array [
         class="su-plus buttonIcon"
       />
       <span
-        class="text"
+        class="buttonText"
       >
         sulu_admin.add
       </span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/__snapshots__/AdapterSwitch.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/__snapshots__/AdapterSwitch.test.js.snap
@@ -9,7 +9,7 @@ exports[`The component should render with current adapter "folder" 1`] = `
     type="button"
   >
     <span
-      class="text"
+      class="buttonText"
     >
       <span
         aria-label="su-th-large"
@@ -22,7 +22,7 @@ exports[`The component should render with current adapter "folder" 1`] = `
     type="button"
   >
     <span
-      class="text"
+      class="buttonText"
     >
       <span
         aria-label="su-th-large"
@@ -42,7 +42,7 @@ exports[`The component should render with current adapter "table" 1`] = `
     type="button"
   >
     <span
-      class="text"
+      class="buttonText"
     >
       <span
         aria-label="su-th-large"
@@ -55,7 +55,7 @@ exports[`The component should render with current adapter "table" 1`] = `
     type="button"
   >
     <span
-      class="text"
+      class="buttonText"
     >
       <span
         aria-label="su-th-large"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/__snapshots__/FieldFilterItem.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/__snapshots__/FieldFilterItem.test.js.snap
@@ -62,7 +62,7 @@ Array [
                 type="button"
               >
                 <span
-                  class="text"
+                  class="buttonText"
                 >
                   sulu_admin.ok
                 </span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/__snapshots__/ForgotPasswordForm.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/__snapshots__/ForgotPasswordForm.test.js.snap
@@ -44,7 +44,7 @@ Array [
           type="button"
         >
           <span
-            class="text"
+            class="buttonText"
           >
             sulu_admin.to_login
           </span>
@@ -55,7 +55,7 @@ Array [
           type="submit"
         >
           <span
-            class="text"
+            class="buttonText"
           >
             sulu_admin.reset
           </span>
@@ -110,7 +110,7 @@ Array [
           type="button"
         >
           <span
-            class="text"
+            class="buttonText"
           >
             sulu_admin.to_login
           </span>
@@ -121,7 +121,7 @@ Array [
           type="submit"
         >
           <span
-            class="text"
+            class="buttonText"
           >
             sulu_admin.reset
           </span>
@@ -176,7 +176,7 @@ Array [
           type="button"
         >
           <span
-            class="text"
+            class="buttonText"
           >
             sulu_admin.to_login
           </span>
@@ -187,7 +187,7 @@ Array [
           type="submit"
         >
           <span
-            class="text"
+            class="buttonText"
           >
             sulu_admin.reset_resend
           </span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/__snapshots__/Login.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/__snapshots__/Login.test.js.snap
@@ -85,7 +85,7 @@ exports[`Should render the Login component when initialized is true 1`] = `
               type="button"
             >
               <span
-                class="text"
+                class="buttonText"
               >
                 sulu_admin.forgot_password
               </span>
@@ -96,7 +96,7 @@ exports[`Should render the Login component when initialized is true 1`] = `
               type="submit"
             >
               <span
-                class="text"
+                class="buttonText"
               >
                 sulu_admin.login
               </span>
@@ -183,7 +183,7 @@ exports[`Should render the Login with forgot password view 1`] = `
               type="button"
             >
               <span
-                class="text"
+                class="buttonText"
               >
                 sulu_admin.to_login
               </span>
@@ -194,7 +194,7 @@ exports[`Should render the Login with forgot password view 1`] = `
               type="submit"
             >
               <span
-                class="text"
+                class="buttonText"
               >
                 sulu_admin.reset
               </span>
@@ -281,7 +281,7 @@ exports[`Should render the Login with forgot password with success 1`] = `
               type="button"
             >
               <span
-                class="text"
+                class="buttonText"
               >
                 sulu_admin.to_login
               </span>
@@ -292,7 +292,7 @@ exports[`Should render the Login with forgot password with success 1`] = `
               type="submit"
             >
               <span
-                class="text"
+                class="buttonText"
               >
                 sulu_admin.reset_resend
               </span>
@@ -404,7 +404,7 @@ exports[`Should render the Login with reset password view 1`] = `
               type="button"
             >
               <span
-                class="text"
+                class="buttonText"
               >
                 sulu_admin.to_login
               </span>
@@ -415,7 +415,7 @@ exports[`Should render the Login with reset password view 1`] = `
               type="submit"
             >
               <span
-                class="text"
+                class="buttonText"
               >
                 sulu_admin.reset_password
               </span>
@@ -527,7 +527,7 @@ exports[`Should render the LoginForm component with error 1`] = `
               type="button"
             >
               <span
-                class="text"
+                class="buttonText"
               >
                 sulu_admin.forgot_password
               </span>
@@ -538,7 +538,7 @@ exports[`Should render the LoginForm component with error 1`] = `
               type="submit"
             >
               <span
-                class="text"
+                class="buttonText"
               >
                 sulu_admin.login
               </span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/__snapshots__/LoginForm.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/__snapshots__/LoginForm.test.js.snap
@@ -69,7 +69,7 @@ Array [
           type="button"
         >
           <span
-            class="text"
+            class="buttonText"
           >
             sulu_admin.forgot_password
           </span>
@@ -80,7 +80,7 @@ Array [
           type="submit"
         >
           <span
-            class="text"
+            class="buttonText"
           >
             sulu_admin.login
           </span>
@@ -160,7 +160,7 @@ Array [
           type="button"
         >
           <span
-            class="text"
+            class="buttonText"
           >
             sulu_admin.forgot_password
           </span>
@@ -171,7 +171,7 @@ Array [
           type="submit"
         >
           <span
-            class="text"
+            class="buttonText"
           >
             sulu_admin.login
           </span>
@@ -266,7 +266,7 @@ Array [
           type="button"
         >
           <span
-            class="text"
+            class="buttonText"
           >
             sulu_admin.forgot_password
           </span>
@@ -277,7 +277,7 @@ Array [
           type="submit"
         >
           <span
-            class="text"
+            class="buttonText"
           >
             sulu_admin.login
           </span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/__snapshots__/ResetPasswordForm.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/__snapshots__/ResetPasswordForm.test.js.snap
@@ -69,7 +69,7 @@ Array [
           type="button"
         >
           <span
-            class="text"
+            class="buttonText"
           >
             sulu_admin.to_login
           </span>
@@ -80,7 +80,7 @@ Array [
           type="submit"
         >
           <span
-            class="text"
+            class="buttonText"
           >
             sulu_admin.reset_password
           </span>
@@ -160,7 +160,7 @@ Array [
           type="button"
         >
           <span
-            class="text"
+            class="buttonText"
           >
             sulu_admin.to_login
           </span>
@@ -171,7 +171,7 @@ Array [
           type="submit"
         >
           <span
-            class="text"
+            class="buttonText"
           >
             sulu_admin.reset_password
           </span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/__snapshots__/MultiSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/__snapshots__/MultiSelection.test.js.snap
@@ -365,7 +365,7 @@ Array [
             type="button"
           >
             <span
-              class="text"
+              class="buttonText"
             >
               sulu_admin.confirm
             </span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/tests/__snapshots__/ResourceLocatorHistory.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/tests/__snapshots__/ResourceLocatorHistory.test.js.snap
@@ -150,7 +150,7 @@ Array [
             type="button"
           >
             <span
-              class="text"
+              class="buttonText"
             >
               sulu_admin.ok
             </span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceSingleSelect/tests/__snapshots__/EditOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceSingleSelect/tests/__snapshots__/EditOverlay.test.js.snap
@@ -69,7 +69,7 @@ exports[`Render data in EditLines 2`] = `
       class="su-plus buttonIcon"
     />
     <span
-      class="text"
+      class="buttonText"
     >
       sulu_admin.add
     </span>
@@ -146,7 +146,7 @@ exports[`Render data in EditLines with other properties 2`] = `
       class="su-plus buttonIcon"
     />
     <span
-      class="text"
+      class="buttonText"
     >
       sulu_admin.add
     </span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/__snapshots__/FilterOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/__snapshots__/FilterOverlay.test.js.snap
@@ -44,7 +44,7 @@ Array [
                   type="button"
                 >
                   <span
-                    class="text"
+                    class="buttonText"
                   >
                     sulu_admin.choose_data_source
                   </span>
@@ -86,7 +86,7 @@ Array [
                   type="button"
                 >
                   <span
-                    class="text"
+                    class="buttonText"
                   >
                     sulu_admin.choose_categories
                   </span>
@@ -393,7 +393,7 @@ Array [
               type="button"
             >
               <span
-                class="text"
+                class="buttonText"
               >
                 sulu_admin.reset
               </span>
@@ -404,7 +404,7 @@ Array [
             type="button"
           >
             <span
-              class="text"
+              class="buttonText"
             >
               sulu_admin.confirm
             </span>
@@ -456,7 +456,7 @@ Array [
               type="button"
             >
               <span
-                class="text"
+                class="buttonText"
               >
                 sulu_admin.reset
               </span>
@@ -467,7 +467,7 @@ Array [
             type="button"
           >
             <span
-              class="text"
+              class="buttonText"
             >
               sulu_admin.confirm
             </span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/__snapshots__/FormOverlayList.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/__snapshots__/FormOverlayList.test.js.snap
@@ -74,7 +74,7 @@ Array [
             type="button"
           >
             <span
-              class="text"
+              class="buttonText"
             >
               sulu_admin.save
             </span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
@@ -238,7 +238,7 @@ Array [
             type="button"
           >
             <span
-              class="text"
+              class="buttonText"
             >
               Export
             </span>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/__snapshots__/ConditionList.test.js.snap
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/__snapshots__/ConditionList.test.js.snap
@@ -10,7 +10,7 @@ exports[`Render an empty ConditionList 1`] = `
     class="su-plus buttonIcon"
   />
   <span
-    class="text"
+    class="buttonText"
   >
     sulu_audience_targeting.add_condition
   </span>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/__snapshots__/RuleOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/__snapshots__/RuleOverlay.test.js.snap
@@ -131,7 +131,7 @@ Array [
                       class="su-plus buttonIcon"
                     />
                     <span
-                      class="text"
+                      class="buttonText"
                     >
                       sulu_audience_targeting.add_condition
                     </span>
@@ -155,7 +155,7 @@ Array [
             type="button"
           >
             <span
-              class="text"
+              class="buttonText"
             >
               sulu_admin.ok
             </span>

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/components/ContactDetails/tests/__snapshots__/ContactDetails.test.js.snap
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/components/ContactDetails/tests/__snapshots__/ContactDetails.test.js.snap
@@ -344,7 +344,7 @@ exports[`Render ContactDetails with data 1`] = `
           class="su-plus buttonIcon"
         />
         <span
-          class="text"
+          class="buttonText"
         >
           sulu_admin.add
         </span>
@@ -497,7 +497,7 @@ exports[`Render empty ContactDetails 1`] = `
           class="su-plus buttonIcon"
         />
         <span
-          class="text"
+          class="buttonText"
         >
           sulu_admin.add
         </span>
@@ -854,7 +854,7 @@ exports[`Render empty phone and email fields even if other values are set 1`] = 
           class="su-plus buttonIcon"
         />
         <span
-          class="text"
+          class="buttonText"
         >
           sulu_admin.add
         </span>

--- a/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/__snapshots__/LocationOverlay.test.js.snap
+++ b/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/__snapshots__/LocationOverlay.test.js.snap
@@ -423,7 +423,7 @@ Array [
               type="button"
             >
               <span
-                class="text"
+                class="buttonText"
               >
                 sulu_admin.reset
               </span>
@@ -434,7 +434,7 @@ Array [
             type="button"
           >
             <span
-              class="text"
+              class="buttonText"
             >
               sulu_admin.confirm
             </span>
@@ -890,7 +890,7 @@ Array [
               type="button"
             >
               <span
-                class="text"
+                class="buttonText"
               >
                 sulu_admin.reset
               </span>
@@ -901,7 +901,7 @@ Array [
             type="button"
           >
             <span
-              class="text"
+              class="buttonText"
             >
               sulu_admin.confirm
             </span>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
@@ -589,7 +589,7 @@ Array [
               type="button"
             >
               <span
-                class="text"
+                class="buttonText"
               >
                 sulu_media.reset_selection
               </span>
@@ -601,7 +601,7 @@ Array [
             type="button"
           >
             <span
-              class="text"
+              class="buttonText"
             >
               sulu_admin.confirm
             </span>
@@ -1202,7 +1202,7 @@ Array [
               type="button"
             >
               <span
-                class="text"
+                class="buttonText"
               >
                 sulu_media.reset_selection
               </span>
@@ -1213,7 +1213,7 @@ Array [
             type="button"
           >
             <span
-              class="text"
+              class="buttonText"
             >
               sulu_admin.confirm
             </span>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaVersionUpload/tests/__snapshots__/MediaVersionUpload.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaVersionUpload/tests/__snapshots__/MediaVersionUpload.test.js.snap
@@ -51,7 +51,7 @@ Array [
         class="su-focus buttonIcon"
       />
       <span
-        class="text"
+        class="buttonText"
       >
         sulu_media.set_focus_point
       </span>
@@ -65,7 +65,7 @@ Array [
         class="su-cut buttonIcon"
       />
       <span
-        class="text"
+        class="buttonText"
       >
         sulu_media.define_crops
       </span>
@@ -128,7 +128,7 @@ Array [
           class="su-image buttonIcon"
         />
         <span
-          class="text"
+          class="buttonText"
         >
           sulu_media.upload_preview_image
         </span>
@@ -150,7 +150,7 @@ Array [
         class="su-trash-alt buttonIcon"
       />
       <span
-        class="text"
+        class="buttonText"
       >
         sulu_media.delete_preview_image
       </span>
@@ -213,7 +213,7 @@ Array [
           class="su-image buttonIcon"
         />
         <span
-          class="text"
+          class="buttonText"
         >
           sulu_media.upload_preview_image
         </span>
@@ -236,7 +236,7 @@ Array [
         class="su-trash-alt buttonIcon"
       />
       <span
-        class="text"
+        class="buttonText"
       >
         sulu_media.delete_preview_image
       </span>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/tests/__snapshots__/SingleMediaUpload.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/tests/__snapshots__/SingleMediaUpload.test.js.snap
@@ -48,7 +48,7 @@ Array [
         class="su-download buttonIcon"
       />
       <span
-        class="text"
+        class="buttonText"
       >
         sulu_media.download_media
       </span>
@@ -62,7 +62,7 @@ Array [
         class="su-trash-alt buttonIcon"
       />
       <span
-        class="text"
+        class="buttonText"
       >
         sulu_media.delete_media
       </span>
@@ -155,7 +155,7 @@ Array [
         class="su-download buttonIcon"
       />
       <span
-        class="text"
+        class="buttonText"
       >
         sulu_media.download_media
       </span>
@@ -169,7 +169,7 @@ Array [
         class="su-trash-alt buttonIcon"
       />
       <span
-        class="text"
+        class="buttonText"
       >
         sulu_media.delete_media
       </span>
@@ -267,7 +267,7 @@ Array [
         class="su-download buttonIcon"
       />
       <span
-        class="text"
+        class="buttonText"
       >
         sulu_media.download_media
       </span>
@@ -281,7 +281,7 @@ Array [
         class="su-trash-alt buttonIcon"
       />
       <span
-        class="text"
+        class="buttonText"
       >
         sulu_media.delete_media
       </span>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/__snapshots__/MediaOverview.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/__snapshots__/MediaOverview.test.js.snap
@@ -273,7 +273,7 @@ exports[`Render a simple MediaOverview 1`] = `
               type="button"
             >
               <span
-                class="text"
+                class="buttonText"
               >
                 <span
                   aria-label="su-th-large"
@@ -286,7 +286,7 @@ exports[`Render a simple MediaOverview 1`] = `
               type="button"
             >
               <span
-                class="text"
+                class="buttonText"
               >
                 <span
                   aria-label="su-align-justify"

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/TeaserSelection/tests/__snapshots__/Item.test.js.snap
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/TeaserSelection/tests/__snapshots__/Item.test.js.snap
@@ -94,7 +94,7 @@ exports[`Render Item with data as form 1`] = `
       type="button"
     >
       <span
-        class="text"
+        class="buttonText"
       >
         sulu_admin.cancel
       </span>
@@ -104,7 +104,7 @@ exports[`Render Item with data as form 1`] = `
       type="button"
     >
       <span
-        class="text"
+        class="buttonText"
       >
         sulu_admin.reset
       </span>
@@ -114,7 +114,7 @@ exports[`Render Item with data as form 1`] = `
       type="button"
     >
       <span
-        class="text"
+        class="buttonText"
       >
         sulu_admin.apply
       </span>

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/tests/__snapshots__/PageList.test.js.snap
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/tests/__snapshots__/PageList.test.js.snap
@@ -21,7 +21,7 @@ exports[`Render PageList 1`] = `
           type="button"
         >
           <span
-            class="text"
+            class="buttonText"
           >
             <span
               aria-label="su-columns"
@@ -34,7 +34,7 @@ exports[`Render PageList 1`] = `
           type="button"
         >
           <span
-            class="text"
+            class="buttonText"
           >
             <span
               aria-label="su-columns"

--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -176,6 +176,7 @@ class SnippetAdmin extends Admin
             $viewCollection->add(
                 $this->viewBuilderFactory
                     ->createViewBuilder('sulu_snippet.snippet_areas', '/snippet-areas', 'sulu_snippet.snippet_areas')
+                    ->setOption('snippetEditView', static::EDIT_FORM_VIEW)
                     ->setOption('tabTitle', 'sulu_snippet.default_snippets')
                     ->setOption('tabOrder', 3072)
                     ->setParent(PageAdmin::WEBSPACE_TABS_VIEW)

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/SnippetAreas.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/SnippetAreas.js
@@ -35,6 +35,13 @@ class SnippetAreas extends React.Component<ViewProps> {
         this.cacheClearToolbarAction = new CacheClearToolbarAction();
     }
 
+    @action handleSnippetClick = (snippetUuid: string) => {
+        const {router, route} = this.props;
+        const {snippetEditView} = route.options;
+
+        router.navigate(snippetEditView, {id: snippetUuid});
+    };
+
     @action handleAddClick = (areaKey: string) => {
         this.openedAreaKey = areaKey;
     };
@@ -97,9 +104,14 @@ class SnippetAreas extends React.Component<ViewProps> {
                                     <Table.Cell>
                                         {defaultUuid
                                             ? <Fragment>
-                                                <div className={snippetAreasStyles.title}>
+                                                <Button
+                                                    className={snippetAreasStyles.titleButton}
+                                                    onClick={this.handleSnippetClick}
+                                                    skin="link"
+                                                    value={defaultUuid}
+                                                >
                                                     {defaultTitle}
-                                                </div>
+                                                </Button>
                                                 <Button
                                                     className={snippetAreasStyles.deleteButton}
                                                     icon="su-trash-alt"

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/SnippetAreas.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/SnippetAreas.js
@@ -107,7 +107,7 @@ class SnippetAreas extends React.Component<ViewProps> {
                                                 <Button
                                                     className={snippetAreasStyles.titleButton}
                                                     onClick={this.handleSnippetClick}
-                                                    skin="link"
+                                                    skin="text"
                                                     value={defaultUuid}
                                                 >
                                                     {defaultTitle}

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/snippetAreas.scss
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/snippetAreas.scss
@@ -3,6 +3,7 @@
     font-size: 18px;
 }
 
-.title {
+.title-button {
     flex-grow: 1;
+    justify-content: flex-start;
 }

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/SnippetAreas.test.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/SnippetAreas.test.js
@@ -1,15 +1,13 @@
 // @flow
 import React from 'react';
 import {shallow, mount, render} from 'enzyme';
-import Router from 'sulu-admin-bundle/services/Router';
-import Route from 'sulu-admin-bundle/services/Router/Route';
+import {Route, Router} from 'sulu-admin-bundle/services';
 import {findWithHighOrderFunction} from 'sulu-admin-bundle/utils/TestHelper';
 
 jest.mock('sulu-admin-bundle/containers', () => ({
     SingleListOverlay: jest.fn(() => null),
     withToolbar: jest.fn((Component) => Component),
 }));
-jest.mock('sulu-admin-bundle/services/Router/Router', () => jest.fn());
 jest.mock('sulu-admin-bundle/utils', () => ({
     translate: jest.fn((key) =>key),
 }));
@@ -19,7 +17,7 @@ jest.mock('sulu-website-bundle/containers/CacheClearToolbarAction', () => jest.f
     this.getNode = jest.fn();
     this.getToolbarItemConfig = jest.fn();
 }));
-jest.mock('sulu-admin-bundle/services/Router', () => jest.fn(function() {
+jest.mock('sulu-admin-bundle/services/Router/Router', () => jest.fn(function() {
     this.navigate = jest.fn();
     this.attributes = {
         webspace: 'sulu',

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/SnippetAreas.test.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/SnippetAreas.test.js
@@ -1,7 +1,8 @@
 // @flow
 import React from 'react';
 import {shallow, mount, render} from 'enzyme';
-import {Router} from 'sulu-admin-bundle/services';
+import Router from 'sulu-admin-bundle/services/Router';
+import Route from 'sulu-admin-bundle/services/Router/Route';
 import {findWithHighOrderFunction} from 'sulu-admin-bundle/utils/TestHelper';
 
 jest.mock('sulu-admin-bundle/containers', () => ({
@@ -18,6 +19,12 @@ jest.mock('sulu-website-bundle/containers/CacheClearToolbarAction', () => jest.f
     this.getNode = jest.fn();
     this.getToolbarItemConfig = jest.fn();
 }));
+jest.mock('sulu-admin-bundle/services/Router', () => jest.fn(function() {
+    this.navigate = jest.fn();
+    this.attributes = {
+        webspace: 'sulu',
+    };
+}));
 
 beforeEach(() => {
     jest.resetModules();
@@ -27,10 +34,7 @@ test('Show loader when loading snippet areas', () => {
     const SnippetAreas = require('../SnippetAreas').default;
     const SnippetAreaStore = require('../stores/SnippetAreaStore');
 
-    const router = new Router({});
-    router.attributes = {
-        webspace: 'sulu',
-    };
+    const router = new Router();
 
     // $FlowFixMe
     SnippetAreaStore.mockImplementation(function() {
@@ -45,10 +49,7 @@ test('Render snippet areas with data as table', () => {
     const SnippetAreas = require('../SnippetAreas').default;
     const SnippetAreaStore = require('../stores/SnippetAreaStore');
 
-    const router = new Router({});
-    router.attributes = {
-        webspace: 'sulu',
-    };
+    const router = new Router();
 
     // $FlowFixMe
     SnippetAreaStore.mockImplementation(function() {
@@ -77,10 +78,7 @@ test('Close after clicking add without choosing a snippet', () => {
     const SnippetAreaStore = require('../stores/SnippetAreaStore');
     const SingleListOverlay = require('sulu-admin-bundle/containers').SingleListOverlay;
 
-    const router = new Router({});
-    router.attributes = {
-        webspace: 'sulu',
-    };
+    const router = new Router();
 
     // $FlowFixMe
     SnippetAreaStore.mockImplementation(function() {
@@ -117,10 +115,7 @@ test('Save after adding a new snippet area', () => {
     const SnippetAreaStore = require('../stores/SnippetAreaStore');
     const SingleListOverlay = require('sulu-admin-bundle/containers').SingleListOverlay;
 
-    const router = new Router({});
-    router.attributes = {
-        webspace: 'sulu',
-    };
+    const router = new Router();
 
     const savePromise = Promise.resolve();
 
@@ -160,10 +155,7 @@ test('Close after clicking delete and cancel dialog', () => {
     const SnippetAreas = require('../SnippetAreas').default;
     const SnippetAreaStore = require('../stores/SnippetAreaStore');
 
-    const router = new Router({});
-    router.attributes = {
-        webspace: 'sulu',
-    };
+    const router = new Router();
 
     // $FlowFixMe
     SnippetAreaStore.mockImplementation(function() {
@@ -198,10 +190,7 @@ test('Delete after confirming the confirmation dialog', () => {
     const SnippetAreas = require('../SnippetAreas').default;
     const SnippetAreaStore = require('../stores/SnippetAreaStore');
 
-    const router = new Router({});
-    router.attributes = {
-        webspace: 'sulu',
-    };
+    const router = new Router();
 
     const deletePromise = Promise.resolve();
 
@@ -237,6 +226,40 @@ test('Delete after confirming the confirmation dialog', () => {
     });
 });
 
+test('Navigate when selected default snippet is clicked', () => {
+    const SnippetAreas = require('../SnippetAreas').default;
+    const SnippetAreaStore = require('../stores/SnippetAreaStore');
+
+    const route = new Route({
+        name: 'snippet_areas',
+        path: '/snippet-areas',
+        type: 'snippet_areas',
+        options: {
+            snippetEditView: 'sulu_snippet.edit_form',
+        },
+    });
+    const router = new Router();
+
+    // $FlowFixMe
+    SnippetAreaStore.mockImplementation(function() {
+        this.snippetAreas = {
+            default: {
+                defaultTitle: 'Default Snippet',
+                defaultUuid: 'some-uuid',
+                key: 1,
+                title: 'Default',
+            },
+        };
+
+        this.save = jest.fn();
+    });
+
+    const snippetAreas = mount(<SnippetAreas route={route} router={router} />);
+    snippetAreas.find('Button[className="titleButton"] button').simulate('click');
+
+    expect(router.navigate).toBeCalledWith('sulu_snippet.edit_form', {id: 'some-uuid'});
+});
+
 test('Should use CacheClearToolbarAction for cache clearing', () => {
     const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
     const SnippetAreas = require('../SnippetAreas').default;
@@ -244,10 +267,7 @@ test('Should use CacheClearToolbarAction for cache clearing', () => {
     const toolbarFunction = findWithHighOrderFunction(withToolbar, SnippetAreas);
     const CacheClearToolbarAction = require('sulu-website-bundle/containers').CacheClearToolbarAction;
 
-    const router = new Router({});
-    router.attributes = {
-        webspace: 'sulu',
-    };
+    const router = new Router();
 
     // $FlowFixMe
     SnippetAreaStore.mockImplementation(function() {

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/__snapshots__/SnippetAreas.test.js.snap
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/__snapshots__/SnippetAreas.test.js.snap
@@ -77,7 +77,7 @@ exports[`Render snippet areas with data as table 1`] = `
             class="cellContent"
           >
             <button
-              class="button link titleButton"
+              class="button text titleButton"
               type="button"
             >
               <span

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/__snapshots__/SnippetAreas.test.js.snap
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/__snapshots__/SnippetAreas.test.js.snap
@@ -81,7 +81,7 @@ exports[`Render snippet areas with data as table 1`] = `
               type="button"
             >
               <span
-                class="text"
+                class="buttonText"
               >
                 Footer Snippet
               </span>

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/__snapshots__/SnippetAreas.test.js.snap
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/__snapshots__/SnippetAreas.test.js.snap
@@ -76,11 +76,16 @@ exports[`Render snippet areas with data as table 1`] = `
           <div
             class="cellContent"
           >
-            <div
-              class="title"
+            <button
+              class="button link titleButton"
+              type="button"
             >
-              Footer Snippet
-            </div>
+              <span
+                class="text"
+              >
+                Footer Snippet
+              </span>
+            </button>
             <button
               class="button link deleteButton"
               type="button"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | related to #5143
| License | MIT

#### What's in this PR?

This PR adjusts the `SnippetAreas` view to provide a link to to the selected snippet. The `SnippetAreas` view is used to set default snippets for a webspace. 

#### Why?

Because the `Selection`, `SingleSelection`, `SmartContent` and `TeaserSelection` provide a similar link feature. Also, it is quite annoying to search for the name of the selected snippet in the snippet list if there are a lot of snippets 🙂 