### PR TITLE
Add command for regeneration formats

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateCommand.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
-class FormatCacheRegenerateFormats extends Command
+class FormatCacheRegenerateCommand extends Command
 {
     protected static $defaultName = 'sulu:media:regenerate-formats';
 

--- a/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateFormats.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateFormats.php
@@ -73,7 +73,7 @@ class FormatCacheRegenerateFormats extends Command
 
         $progressBar = $ui->createProgressBar(\count($files));
 
-        $ui->writeln('Starting to regenerate: ' . \count($files) .' images');
+        $ui->writeln('Starting to regenerate: ' . \count($files) . ' images');
         $ui->writeln('');
 
         /** @var SplFileInfo $file */

--- a/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateFormats.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateFormats.php
@@ -53,8 +53,7 @@ class FormatCacheRegenerateFormats extends Command
 
     protected function configure()
     {
-        $this->setDescription('Loops over sulu image cache, and regenerates the existing images')
-        ;
+        $this->setDescription('Loops over sulu image cache, and regenerates the existing images');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateFormats.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateFormats.php
@@ -12,18 +12,45 @@
 namespace Sulu\Bundle\MediaBundle\Command;
 
 use Sulu\Bundle\MediaBundle\Media\FormatCache\FormatCacheClearerInterface;
+use Sulu\Bundle\MediaBundle\Media\FormatManager\FormatManagerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 
 class FormatCacheRegenerateFormats extends Command
 {
     protected static $defaultName = 'sulu:media:regenerate:formats';
 
-    public function __construct()
-    {
+    /**
+     * @var Filesystem
+     */
+    private $fileSystem;
+
+    /**
+     * @var FormatManagerInterface
+     */
+    private $formatManager;
+
+    /**
+     * @var string
+     */
+    private $localFormatCachePath;
+
+    public function __construct(
+        Filesystem $filesystem,
+        FormatManagerInterface $formatManager,
+        string $localFormatCachePath
+    ) {
         parent::__construct();
+
+        $this->fileSystem = $filesystem;
+        $this->formatManager = $formatManager;
+        $this->localFormatCachePath = $localFormatCachePath;
     }
 
     protected function configure()
@@ -34,8 +61,52 @@ class FormatCacheRegenerateFormats extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        dd('dsa');
+        $ui = new SymfonyStyle($input, $output);
+
+        $finder = new Finder();
+        $finder->in(\realpath($this->localFormatCachePath));
+        $files = $finder->files();
+
+        $progressBar = $ui->createProgressBar(\count($files));
+
+        if (!count($files)) {
+            $ui->writeln('No images to regenerate');
+            return 0;
+        }
+
+        $ui->writeln('Starting to regenerate: ' . count($files) .' images');
+        $ui->writeln('');
+
+        /** @var SplFileInfo $file */
+        foreach ($files as $file) {
+            $fileInformation = $this->getFileInformationArrayFromPath($file->getRelativePathname());
+
+            $this->formatManager->returnImage(
+                $fileInformation['id'],
+                $fileInformation['formatKey'],
+                $fileInformation['fileName']
+            );
+
+            $progressBar->advance();
+        }
+
+        $ui->writeln('');
+        $ui->writeln('');
+        $ui->writeln('DONE');
+
+        $progressBar->finish();
 
         return 0;
+    }
+
+    private function getFileInformationArrayFromPath($path): array
+    {
+        $exploded = explode('/', $path);
+
+        return [
+            'id' => $exploded[1],
+            'formatKey' => $exploded[0],
+            'fileName' => $exploded[2]
+        ];
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateFormats.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateFormats.php
@@ -103,7 +103,7 @@ class FormatCacheRegenerateFormats extends Command
     {
         $pathParts = \explode('/', $path);
         $formatKey = \reset($pathParts);
-        $filenameParts = explode('-', \end($pathParts), 2);
+        $filenameParts = \explode('-', \end($pathParts), 2);
         $id = (int) $filenameParts[0];
         $fileName = $filenameParts[1];
 

--- a/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateFormats.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateFormats.php
@@ -11,10 +11,8 @@
 
 namespace Sulu\Bundle\MediaBundle\Command;
 
-use Sulu\Bundle\MediaBundle\Media\FormatCache\FormatCacheClearerInterface;
 use Sulu\Bundle\MediaBundle\Media\FormatManager\FormatManagerInterface;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -68,7 +66,7 @@ class FormatCacheRegenerateFormats extends Command
         $files = $finder->files();
 
         if (!\count($files)) {
-            $ui->writeln(sprintf('No images to regenerate found in "%s".', $this->localFormatCachePath));
+            $ui->writeln(\sprintf('No images to regenerate found in "%s".', $this->localFormatCachePath));
 
             return 0;
         }
@@ -96,7 +94,7 @@ class FormatCacheRegenerateFormats extends Command
         $ui->writeln('');
         $ui->writeln('');
 
-        $ui->success(sprintf('Finished regenerating of "%s" images.', \count($files)));
+        $ui->success(\sprintf('Finished regenerating of "%s" images.', \count($files)));
 
         return 0;
     }
@@ -111,7 +109,7 @@ class FormatCacheRegenerateFormats extends Command
         return [
             'id' => $fileNameParts[0],
             'formatKey' => $directories[0],
-            'fileName' => $fileNameParts[1]
+            'fileName' => $fileNameParts[1],
         ];
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateFormats.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateFormats.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Command;
+
+use Sulu\Bundle\MediaBundle\Media\FormatCache\FormatCacheClearerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class FormatCacheRegenerateFormats extends Command
+{
+    protected static $defaultName = 'sulu:media:regenerate:formats';
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this->setDescription('Loops over sulu image cache, and regenerates the existing images')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        dd('dsa');
+
+        return 0;
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateFormats.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateFormats.php
@@ -101,15 +101,16 @@ class FormatCacheRegenerateFormats extends Command
 
     private function getFileInformationArrayFromPath($path): array
     {
-        $exploded = \explode('/', $path);
-
-        $directories = \explode('/', $path, 2);
-        $fileNameParts = \explode('-', $directories[1], 2);
+        $pathParts = \explode('/', $path);
+        $formatKey = \reset($pathParts);
+        $filenameParts = explode('-', \end($pathParts), 2);
+        $id = (int) $filenameParts[0];
+        $fileName = $filenameParts[1];
 
         return [
-            'id' => $fileNameParts[0],
-            'formatKey' => $directories[0],
-            'fileName' => $fileNameParts[1],
+            'id' => $id,
+            'formatKey' => $formatKey,
+            'fileName' => $fileName,
         ];
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateFormats.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateFormats.php
@@ -24,7 +24,7 @@ use Symfony\Component\Finder\SplFileInfo;
 
 class FormatCacheRegenerateFormats extends Command
 {
-    protected static $defaultName = 'sulu:media:regenerate:formats';
+    protected static $defaultName = 'sulu:media:regenerate-formats';
 
     /**
      * @var Filesystem
@@ -67,14 +67,15 @@ class FormatCacheRegenerateFormats extends Command
         $finder->in(\realpath($this->localFormatCachePath));
         $files = $finder->files();
 
-        $progressBar = $ui->createProgressBar(\count($files));
+        if (!\count($files)) {
+            $ui->writeln(sprintf('No images to regenerate found in "%s".', $this->localFormatCachePath));
 
-        if (!count($files)) {
-            $ui->writeln('No images to regenerate');
             return 0;
         }
 
-        $ui->writeln('Starting to regenerate: ' . count($files) .' images');
+        $progressBar = $ui->createProgressBar(\count($files));
+
+        $ui->writeln('Starting to regenerate: ' . \count($files) .' images');
         $ui->writeln('');
 
         /** @var SplFileInfo $file */
@@ -90,23 +91,27 @@ class FormatCacheRegenerateFormats extends Command
             $progressBar->advance();
         }
 
-        $ui->writeln('');
-        $ui->writeln('');
-        $ui->writeln('DONE');
-
         $progressBar->finish();
+
+        $ui->writeln('');
+        $ui->writeln('');
+
+        $ui->success(sprintf('Finished regenerating of "%s" images.', \count($files)));
 
         return 0;
     }
 
     private function getFileInformationArrayFromPath($path): array
     {
-        $exploded = explode('/', $path);
+        $exploded = \explode('/', $path);
+
+        $directories = \explode('/', $path, 2);
+        $fileNameParts = \explode('-', $directories[1], 2);
 
         return [
-            'id' => $exploded[1],
-            'formatKey' => $exploded[0],
-            'fileName' => $exploded[2]
+            'id' => $fileNameParts[0],
+            'formatKey' => $directories[0],
+            'fileName' => $fileNameParts[1]
         ];
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -391,6 +391,7 @@
         <service id="sulu_media.command.format_cache.regenerate"
                  class="Sulu\Bundle\MediaBundle\Command\FormatCacheRegenerateFormats">
             <argument type="service" id="filesystem"/>
+            <argument type="service" id="sulu_media.format_manager" />
             <argument>%sulu_media.format_cache.path%</argument>
 
             <tag name="console.command"/>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -389,7 +389,7 @@
         </service>
 
         <service id="sulu_media.command.format_cache.regenerate"
-                 class="Sulu\Bundle\MediaBundle\Command\FormatCacheRegenerateFormats">
+                 class="Sulu\Bundle\MediaBundle\Command\FormatCacheRegenerateCommand">
             <argument type="service" id="filesystem"/>
             <argument type="service" id="sulu_media.format_manager" />
             <argument>%sulu_media.format_cache.path%</argument>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -388,6 +388,14 @@
             <tag name="console.command"/>
         </service>
 
+        <service id="sulu_media.command.format_cache.regenerate"
+                 class="Sulu\Bundle\MediaBundle\Command\FormatCacheRegenerateFormats">
+            <argument type="service" id="filesystem"/>
+            <argument>%sulu_media.format_cache.path%</argument>
+
+            <tag name="console.command"/>
+        </service>
+
         <service id="sulu_media.fixtures.collection_types" class="Sulu\Bundle\MediaBundle\DataFixtures\ORM\LoadCollectionTypes">
             <tag name="doctrine.fixture.orm"/>
         </service>

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Command/FormatCacheRegenerateCommandTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Command/FormatCacheRegenerateCommandTest.php
@@ -13,13 +13,13 @@ namespace Sulu\Bundle\MediaBundle\Tests\Unit\Command;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
-use Sulu\Bundle\MediaBundle\Command\FormatCacheRegenerateFormats;
+use Sulu\Bundle\MediaBundle\Command\FormatCacheRegenerateCommand;
 use Sulu\Bundle\MediaBundle\Media\FormatManager\FormatManagerInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
 
-class FormatCacheRegenerateFormatsTest extends TestCase
+class FormatCacheRegenerateCommandTest extends TestCase
 {
     /**
      * @var ObjectProphecy|FormatManagerInterface
@@ -50,7 +50,7 @@ class FormatCacheRegenerateFormatsTest extends TestCase
         $fileSystem = new Filesystem();
 
         $application = new Application();
-        $command = new FormatCacheRegenerateFormats(
+        $command = new FormatCacheRegenerateCommand(
             $fileSystem,
             $this->formatManager->reveal(),
             $localFormatCachePath

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Command/FormatCacheRegenerateFormatsTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Command/FormatCacheRegenerateFormatsTest.php
@@ -42,7 +42,6 @@ class FormatCacheRegenerateFormatsTest extends TestCase
         $this->formatManager->returnImage(3, '400x400-inset', '2020-test-test.svg')
             ->shouldBeCalled();
 
-
         $this->executeCommand(__DIR__ . '/../../Fixtures/regenerate-formats');
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Command/FormatCacheRegenerateFormatsTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Command/FormatCacheRegenerateFormatsTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Command;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\MediaBundle\Command\FormatCacheRegenerateFormats;
+use Sulu\Bundle\MediaBundle\Media\FormatManager\FormatManagerInterface;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+
+class FormatCacheRegenerateFormatsTest extends TestCase
+{
+    /**
+     * @var ObjectProphecy|FormatManagerInterface
+     */
+    private $formatManager;
+
+    public function setUp(): void
+    {
+        $this->formatManager = $this->prophesize(FormatManagerInterface::class);
+    }
+
+    public function testExecute(): void
+    {
+        $this->formatManager->returnImage(1, '50x50', 'test.svg')
+            ->shouldBeCalled();
+
+        $this->formatManager->returnImage(2, '200x', 'test.svg')
+            ->shouldBeCalled();
+
+        $this->formatManager->returnImage(3, '400x400-inset', '2020-test-test.svg')
+            ->shouldBeCalled();
+
+
+        $this->executeCommand(__DIR__ . '/../../Fixtures/regenerate-formats');
+    }
+
+    private function executeCommand(string $localFormatCachePath): void
+    {
+        $fileSystem = new Filesystem();
+
+        $application = new Application();
+        $command = new FormatCacheRegenerateFormats(
+            $fileSystem,
+            $this->formatManager->reveal(),
+            $localFormatCachePath
+        );
+        $command->setApplication($application);
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([]);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | Kinda
| New feature? | Yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

In this PR i added a command which iterates over the current image cache and refreshes it.

You can use this command instead of `rm -rf public/media/uploads` to regenerate/refresh image cache.

#### Why?

This because removing the image cache `rm -rf public/uploads/media` is a bad idea. 
When you do this, you create a giant load on your server because it start alot of PHP-fpm processes for cutting out the images. 

We've expierenced a problem where OOMKILLER jumped in to shoot mysql and elastic and the website went down.
I was discussing this with @alexander-schranz in slack and he asked me to create a PR for this command.
https://sulu-io.slack.com/archives/C0430GGCV/p1593690512302700 

#### Example Usage

```
php bin/console sulu:media:regenerate-formats
```
![Screenshot from 2020-07-06 21-59-44](https://user-images.githubusercontent.com/8653367/86636004-184ea280-bfd4-11ea-91d0-dbfe4969e241.png)


