### PR TITLE
Fix API for saving target groups

### DIFF
--- a/src/Sulu/Bundle/AudienceTargetingBundle/Controller/TargetGroupController.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Controller/TargetGroupController.php
@@ -274,6 +274,7 @@ class TargetGroupController extends AbstractRestController implements ClassResou
             $this->targetGroupRepository->getClassName(),
             'json'
         );
+        $this->entityManager->clear();
 
         return $result;
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR fixes the API for saving target groups by clearing the entity manager after deserializing the target group entity from the data passed to the API. **This is not a great solution and we should probably not merge this.**

This fixes the `TargetGroupControllerTest::testPutWithRemoveRoleAndWebspaces` test that is failing at the moment. I figured that the error happens when the `jms/serializer-bundle` package is updated from `3.6` to `3.7`. Somehow, after this update, the entity which is deserialized in the `TargetGroupController` is detected as `STATE_MANAGED` by doctrine. Because of this, the `$this->getEntityManager()->merge($targetGroup);` does not do anything.
