### PR TITLE
Accept zero as valid latitude and longitude in Location component

### DIFF
--- a/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/LocationOverlay.js
+++ b/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/LocationOverlay.js
@@ -179,7 +179,8 @@ class LocationOverlay extends React.Component<Props> {
         } = this.props;
 
         // enable confirm button if all marker properties are set or no property is set in case of a reset
-        const confirmEnabled = (this.markerLat && this.markerLong) || (!this.markerLat && !this.markerLong);
+        const confirmEnabled = (this.markerLat !== null && this.markerLong !== null)
+            || (this.markerLat === null && this.markerLong === null);
 
         return (
             <Overlay

--- a/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/LocationOverlay.js
+++ b/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/LocationOverlay.js
@@ -64,7 +64,7 @@ class LocationOverlay extends React.Component<Props> {
         const {onConfirm} = this.props;
         const {title, street, number, code, town, country, markerLat, markerLong, mapZoom} = this;
 
-        if (!markerLat || !markerLong) {
+        if (markerLat === null || markerLat === undefined || markerLong === null || markerLong === undefined) {
             onConfirm(null);
 
             return;
@@ -112,10 +112,8 @@ class LocationOverlay extends React.Component<Props> {
     };
 
     @action handleMarkerDragEnd = () => {
-        if (this.markerLong && this.markerLat) {
-            this.mapLong = this.markerLong;
-            this.mapLat = this.markerLat;
-        }
+        this.mapLong = this.markerLong || 0;
+        this.mapLat = this.markerLat || 0;
     };
 
     @action handleResetLocation = () => {

--- a/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/LocationOverlay.test.js
+++ b/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/LocationOverlay.test.js
@@ -393,6 +393,46 @@ test('Should call onConfirm callback when the Overlay is confirmed after marker 
     }));
 });
 
+test('Should call onConfirm callback when the Overlay is confirmed after setting lat and ling to zero', () => {
+    const locationData = {
+        lat: 1,
+        long: 1,
+        zoom: 1,
+        title: 'old-title',
+        street: 'old-street',
+        number: 'old-number',
+        code: 'old-code',
+        town: 'old-town',
+        country: 'old-country',
+    };
+    const confirmSpy = jest.fn();
+
+    const locationOverlay = mount(
+        <LocationOverlay
+            onClose={jest.fn()}
+            onConfirm={confirmSpy}
+            open={true}
+            value={locationData}
+        />
+    );
+
+    locationOverlay.find(Number).at(0).props().onChange(0); // lat
+    locationOverlay.find(Number).at(1).props().onChange(0); // long
+    locationOverlay.find(Overlay).props().onConfirm();
+
+    expect(confirmSpy).toBeCalledWith(expect.objectContaining({
+        lat: 0,
+        long: 0,
+        zoom: 1,
+        title: 'old-title',
+        street: 'old-street',
+        number: 'old-number',
+        code: 'old-code',
+        town: 'old-town',
+        country: 'old-country',
+    }));
+});
+
 test('Should pass correct props to the map, marker and input fields after reset', () => {
     const locationData = {
         code: 'code-123',

--- a/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/LocationOverlay.test.js
+++ b/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/LocationOverlay.test.js
@@ -582,4 +582,19 @@ test('Should enable confirm button if longitude and latitude are both not set or
     locationOverlay.find(Number).at(1).props().onChange(11); // long
     locationOverlay.update();
     expect(locationOverlay.find(Overlay).props().confirmDisabled).toEqual(false);
+
+    locationOverlay.find(Number).at(0).props().onChange(0); // lat
+    locationOverlay.find(Number).at(1).props().onChange(11); // long
+    locationOverlay.update();
+    expect(locationOverlay.find(Overlay).props().confirmDisabled).toEqual(false);
+
+    locationOverlay.find(Number).at(0).props().onChange(11); // lat
+    locationOverlay.find(Number).at(1).props().onChange(0); // long
+    locationOverlay.update();
+    expect(locationOverlay.find(Overlay).props().confirmDisabled).toEqual(false);
+
+    locationOverlay.find(Number).at(0).props().onChange(0); // lat
+    locationOverlay.find(Number).at(1).props().onChange(0); // long
+    locationOverlay.update();
+    expect(locationOverlay.find(Overlay).props().confirmDisabled).toEqual(false);
 });


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5389
| License | MIT

#### What's in this PR?

This PR adjusts the overlay of the `Location` component to accept 0 as valid latitude and valid longitude.
