### PR TITLE
Filter out obsolete entries when changing value of Select field

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Select.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Select.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import {computed} from 'mobx';
 import MultiSelectComponent from '../../../components/MultiSelect';
 import type {FieldTypeProps} from '../../../types';
 
@@ -38,24 +39,32 @@ export default class Select extends React.Component<Props> {
         }
     }
 
-    handleChange = (value: Array<string | number>) => {
-        const {onChange, onFinish} = this.props;
-
-        onChange(value.length > 0 ? value : undefined);
-        onFinish();
-    };
-
-    render() {
-        const {schemaOptions, disabled, value} = this.props;
-        const {values} = schemaOptions;
+    @computed get values() {
+        const {values} = this.props.schemaOptions;
 
         if (!values || !Array.isArray(values.value)) {
             throw new Error('The "values" option has to be set for the Select FieldType');
         }
 
+        return values.value;
+    }
+
+    handleChange = (value: Array<string | number>) => {
+        const {onChange, onFinish} = this.props;
+
+        const allowedValues = this.values.map((value) => value.name);
+        const filteredValue = value.filter((v) => allowedValues.includes(v));
+
+        onChange(filteredValue.length > 0 ? filteredValue : undefined);
+        onFinish();
+    };
+
+    render() {
+        const {disabled, value} = this.props;
+
         return (
             <MultiSelectComponent disabled={!!disabled} onChange={this.handleChange} values={value || []}>
-                {values.value.map(({name: value, title}) => {
+                {this.values.map(({name: value, title}) => {
                     if (typeof value !== 'string' && typeof value !== 'number') {
                         throw new Error('The children of "values" must only contain values of type string or number!');
                     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Select.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Select.test.js
@@ -144,6 +144,42 @@ test('Should call onChange with undefined if value is changed to an empty array'
     expect(finishSpy).toBeCalledWith();
 });
 
+test('Should call onChange with allowed values only if value contains old values', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+    const changeSpy = jest.fn();
+    const finishSpy = jest.fn();
+    const schemaOptions = {
+        values: {
+            name: 'values',
+            value: [
+                {
+                    name: 'mr',
+                    title: 'Mister',
+                },
+                {
+                    name: 'ms',
+                    title: 'Miss',
+                },
+            ],
+        },
+    };
+
+    const select = shallow(
+        <Select
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            onChange={changeSpy}
+            onFinish={finishSpy}
+            schemaOptions={schemaOptions}
+        />
+    );
+
+    select.simulate('change', ['mr', 'removed-value']);
+
+    expect(changeSpy).toBeCalledWith(['mr']);
+    expect(finishSpy).toBeCalledWith();
+});
+
 test('Should call onFinish callback on every onChange', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
     const finishSpy = jest.fn();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | maybe
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5388
| License | MIT

#### What's in this PR?

This PR adjusts the `Select` field to filter out invalid entries when the selection is changed.

#### Why?

Because the current value might contain entries which are not valid (see #5388). For example, this happens if a selected value is removed from the template of a page. 
