### PR TITLE
Activate babel cacheDirectory

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -70,6 +70,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                         options: {
                             ...babelConfig,
                             cacheDirectory: true,
+                            cacheCompression: false,
                         },
                     },
                 },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,7 +67,10 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                     exclude: /node_modules\/(?!(sulu-(.*)-bundle|@ckeditor|lodash-es)\/)/,
                     use: {
                         loader: 'babel-loader',
-                        options: babelConfig,
+                        options: {
+                            ...babelConfig,
+                            cacheDirectory: true,
+                        },
                     },
                 },
                 {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Activate cacheDirectory for the webpack [babel-loader](https://webpack.js.org/loaders/babel-loader/).

#### Why?

Performance Improvements for multiple builds:

*Without cache active:*

```bash
59.18 real        86.69 user         5.81 sys
```

*With cache active:*

```bash
26.96 real        37.32 user         3.66 sys
```

I'm targeting master branch as I'm not sure if it could have any side effects in our setup. 

#### Example Usage

~~~bash
# stop time for npm run build command
time npm run build
~~~

