### PR TITLE
Fix behaviour of crops when minimum dimensions are bigger than selectable area

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/ImageRectangleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/ImageRectangleSelection.js
@@ -23,10 +23,18 @@ class ImageRectangleSelection extends React.Component<Props> {
     image: Image;
     @observable imageLoaded = false;
 
-    naturalHorizontalToScaled = (h: number) => h * this.imageResizedWidth / this.image.naturalWidth;
-    scaledHorizontalToNatural = (h: number) => h * this.image.naturalWidth / this.imageResizedWidth;
-    naturalVerticalToScaled = (v: number) => v * this.imageResizedHeight / this.image.naturalHeight;
-    scaledVerticalToNatural = (v: number) => v * this.image.naturalHeight / this.imageResizedHeight;
+    naturalHorizontalToScaled = (h: number) => {
+        return Math.max(h * this.scaledImageWidth / this.image.naturalWidth, 0);
+    };
+    scaledHorizontalToNatural = (h: number) => {
+        return Math.min(h * this.image.naturalWidth / this.scaledImageWidth, this.image.naturalWidth);
+    };
+    naturalVerticalToScaled = (v: number) => {
+        return Math.max(v * this.scaledImageHeight / this.image.naturalHeight, 0);
+    };
+    scaledVerticalToNatural = (v: number) => {
+        return Math.min(v * this.image.naturalHeight / this.scaledImageHeight, this.image.naturalHeight);
+    };
 
     naturalDataToScaled(data: SelectionData): SelectionData {
         return {
@@ -55,23 +63,23 @@ class ImageRectangleSelection extends React.Component<Props> {
         this.image.src = this.props.image;
     }
 
-    @computed get imageResizedHeight(): number {
-        if (this.imageTouchesHorizontalBorders()) {
+    @computed get scaledImageHeight(): number {
+        if (this.imageFillsContainerHeight()) {
             return Math.min(this.image.naturalHeight, this.props.containerHeight);
         } else {
-            return this.imageResizedWidth * this.image.naturalHeight / this.image.naturalWidth;
+            return this.scaledImageWidth * this.image.naturalHeight / this.image.naturalWidth;
         }
     }
 
-    @computed get imageResizedWidth(): number {
-        if (this.imageTouchesHorizontalBorders()) {
-            return this.imageResizedHeight * this.image.naturalWidth / this.image.naturalHeight;
+    @computed get scaledImageWidth(): number {
+        if (this.imageFillsContainerHeight()) {
+            return this.scaledImageHeight * this.image.naturalWidth / this.image.naturalHeight;
         } else {
             return Math.min(this.image.naturalWidth, this.props.containerWidth);
         }
     }
 
-    imageTouchesHorizontalBorders() {
+    imageFillsContainerHeight() {
         const imageHeightToWidth = this.image.naturalHeight / this.image.naturalWidth;
         const containerHeightToWidth = this.props.containerHeight / this.props.containerWidth;
         return imageHeightToWidth > containerHeightToWidth;
@@ -82,11 +90,11 @@ class ImageRectangleSelection extends React.Component<Props> {
         onChange(data ? this.scaledDataToNatural(data) : undefined);
     };
 
-    @computed get minDimensions() {
+    @computed get scaledMinDimensions() {
         const {minHeight, minWidth, containerHeight, containerWidth} = this.props;
 
-        let height = minHeight;
-        let width = minWidth;
+        let height = minHeight ? this.naturalVerticalToScaled(minHeight) : undefined;
+        let width = minWidth ? this.naturalHorizontalToScaled(minWidth) : undefined;
 
         if (height && height > containerHeight) {
             height = containerHeight;
@@ -101,12 +109,12 @@ class ImageRectangleSelection extends React.Component<Props> {
         return {width, height};
     }
 
-    @computed get minWidth() {
-        return this.minDimensions.width;
+    @computed get scaledMinWidth() {
+        return this.scaledMinDimensions.width;
     }
 
-    @computed get minHeight() {
-        return this.minDimensions.height;
+    @computed get scaledMinHeight() {
+        return this.scaledMinDimensions.height;
     }
 
     render() {
@@ -118,16 +126,16 @@ class ImageRectangleSelection extends React.Component<Props> {
 
         return (
             <RectangleSelection
-                minHeight={this.minHeight}
-                minWidth={this.minWidth}
+                minHeight={this.scaledMinHeight}
+                minWidth={this.scaledMinWidth}
                 onChange={this.handleRectangleSelectionChange}
                 round={false}
                 value={value}
             >
                 <img
-                    height={this.imageResizedHeight}
+                    height={this.scaledImageHeight}
                     src={this.props.image}
-                    width={this.imageResizedWidth}
+                    width={this.scaledImageWidth}
                 />
             </RectangleSelection>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/tests/ImageRectangleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/tests/ImageRectangleSelection.test.js
@@ -103,12 +103,67 @@ test('The component should pass a value of undefined', () => {
     expect(changeSpy).toBeCalledWith(undefined);
 });
 
+test('The component should scale the value based on the image height and container height', () => {
+    const changeSpy = jest.fn();
+
+    const view = mount(
+        <ImageRectangleSelection
+            containerHeight={360}
+            containerWidth={640}
+            image="//:0"
+            onChange={changeSpy}
+            value={undefined}
+        />
+    );
+
+    const onImageLoad = view.instance().image.onload;
+    view.instance().image = {
+        naturalWidth: 1920,
+        naturalHeight: 1080,
+    };
+    onImageLoad();
+    view.update();
+
+    view.find('RectangleSelection').prop('onChange')({width: 320, height: 180, top: 0, left: 320});
+
+    expect(changeSpy).toBeCalledWith({width: 960, height: 540, top: 0, left: 960});
+});
+
+test('The component should not scale the value to exceed the natural image width', () => {
+    const changeSpy = jest.fn();
+
+    const view = mount(
+        <ImageRectangleSelection
+            // window.innerHeight = 798
+            containerHeight={369}
+            // window.innerWidth = 1440
+            containerWidth={1000}
+            image="//:0"
+            onChange={changeSpy}
+            value={undefined}
+        />
+    );
+
+    const onImageLoad = view.instance().image.onload;
+    view.instance().image = {
+        naturalWidth: 4896,
+        naturalHeight: 3264,
+    };
+    onImageLoad();
+    view.update();
+
+    view.find('RectangleSelection').prop('onChange')({width: 554, height: 200, top: 0, left: 0});
+
+    expect(changeSpy).toBeCalledWith({width: 4896, height: 1769.1056910569105, top: 0, left: 0});
+});
+
 test.each([
-    [300, 600, 360, 640, 300, 600],
-    [200, 200, 300, 400, 200, 200],
-    [800, 800, 300, 400, 300, 300],
-    [800, 1000, 200, 400, 200, 250],
-    [1000, 800, 200, 400, 200, 160],
+    [300, 600, 360, 640, 100, 200],
+    [200, 200, 400, 480, 50, 50],
+    [600, 300, 180, 480, 100, 50],
+    [800, 1000, 400, 240, 100, 125],
+    [1000, 800, 400, 240, 125, 100],
+    [500, 500, 1600, 2000, 500, 500],
 ])(
     'The component should render with minHeight %s, minWidth %s, containerHeight %s and containerWidth %s',
     (minHeight, minWidth, containerHeight, containerWidth, expectedMinHeight, expectedMinWidth) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/RectangleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/RectangleSelection.js
@@ -1,6 +1,7 @@
 // @flow
 import type {Node} from 'react';
 import {observer} from 'mobx-react';
+import {computed} from 'mobx';
 import React from 'react';
 import withContainerSize from '../withContainerSize';
 import type {Normalizer, RectangleChange, SelectionData} from './types';
@@ -27,8 +28,6 @@ class RectangleSelection extends React.Component<Props> {
     static defaultProps = {
         round: true,
     };
-
-    normalizers: Array<Normalizer> = [];
 
     static createNormalizers(props: Props): Array<Normalizer> {
         if (!props.containerWidth || !props.containerHeight) {
@@ -59,14 +58,8 @@ class RectangleSelection extends React.Component<Props> {
         return normalizers;
     }
 
-    constructor(props: Props) {
-        super(props);
-
-        this.normalizers = RectangleSelection.createNormalizers(this.props);
-    }
-
-    componentDidUpdate() {
-        this.normalizers = RectangleSelection.createNormalizers(this.props);
+    @computed get normalizers() {
+        return RectangleSelection.createNormalizers(this.props);
     }
 
     normalize(selection: SelectionData): SelectionData {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/RectangleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/RectangleSelection.js
@@ -35,13 +35,14 @@ class RectangleSelection extends React.Component<Props> {
         }
 
         const normalizers = [];
+
         normalizers.push(new SizeNormalizer(
             props.containerWidth,
             props.containerHeight,
             props.minWidth,
             props.minHeight
         ));
-        normalizers.push(new PositionNormalizer(props.containerWidth, props.containerHeight));
+
         if (props.minWidth && props.minHeight) {
             normalizers.push(new RatioNormalizer(
                 props.containerWidth,
@@ -50,6 +51,8 @@ class RectangleSelection extends React.Component<Props> {
                 props.minHeight
             ));
         }
+
+        normalizers.push(new PositionNormalizer(props.containerWidth, props.containerHeight));
 
         if (props.round) {
             normalizers.push(new RoundingNormalizer());

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Cropper/Cropper.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Cropper/Cropper.php
@@ -32,8 +32,11 @@ class Cropper implements CropperInterface
 
     public function isValid(ImageInterface $image, $x, $y, $width, $height, array $format)
     {
-        return $this->isInsideImage($image, $x, $y, $width, $height)
-            && $this->isNotSmallerThanFormat($width, $height, $format);
+        $isInsideImage = $this->isInsideImage($image, $x, $y, $width, $height);
+        $isNotSmallerThanFormat = $this->isNotSmallerThanFormat($width, $height, $format);
+        $isMaxSizeForImage = $this->isMaxSizeForImage($image, $width, $height);
+
+        return $isInsideImage && ($isNotSmallerThanFormat || $isMaxSizeForImage);
     }
 
     /**
@@ -79,5 +82,17 @@ class Cropper implements CropperInterface
         }
 
         return true;
+    }
+
+    private function isMaxSizeForImage(ImageInterface $image, $width, $height)
+    {
+        if ($width === $image->getSize()->getWidth()) {
+            return true;
+        }
+        if ($height === $image->getSize()->getHeight()) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Cropper/CropperTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Cropper/CropperTest.php
@@ -96,6 +96,23 @@ class CropperTest extends SuluTestCase
         $this->assertTrue($valid);
     }
 
+    public function testValidTooSmallButMaxWidthForImage()
+    {
+        $imagine = $this->createImagine();
+        $imageBox = new Box(60, 100);
+        $image = $imagine->create($imageBox);
+
+        $format = [
+            'scale' => [
+                'x' => 300,
+                'y' => 200,
+            ],
+        ];
+        $valid = $this->cropper->isValid($image, 0, 0, 60, 40, $format);
+
+        $this->assertTrue($valid);
+    }
+
     public function testNotValidTooSmall()
     {
         $imagine = $this->createImagine();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5372, fixes #5385
| License | MIT

#### What's in this PR?

This PR fixes two different issues that occur when defining crops for images:

#### Crop rectangle should change after selecting a format without a defined crop

At the moment, the selected area is not updated to match the ratio of the selected format, when a format that has no defined crop is selected. 

The problem here is that `RectangleSelection` component rendered its content before updating the `normalizers` that are used for determining the selected area in its `componentDidUpdate` method. After the `normalizers` were updated, the component was not rerendered because the `this.normalizers` property is no observable.

#### Incorrect behaviour when minimum dimensions are bigger than selectable area 

Currently, the `RectangleSelection` behaves incorrectly when the minimum dimensions are bigger than the selectable area. This is caused by the order in which the normalizers of are applied. For example, if i want to define the crop for an image with the dimensions `500x500` and a format with the dimensions `2000x1000`, the following will happen:

1. Current crop is set to `{left: 0, top: 0, height: 250, width: 500}`
2. User tries to set crop to `{left: 0, top: 10, height: 250, width: 500}` by moving selection
3. `SizeNormalizer` normalizes this to `{left: 0, top: 10, height: 500, width: 500}`
4. `PositionNormalizer` normalizes this to `{left: 0, top: 0, height: 500, width: 500}`
5. `RatioNormalizer` normalizes this to `{left: 0, top: 0, height: 250, width: 500}`
5. User thinks he cannot move selection towards bottom

This PR adjusts the order of the normalizers to apply the `RatioNormalizer` before the `PositionNormalizer`. This leads to the following behaviour:

1. Current crop is set to `{left: 0, top: 0, height: 250, width: 500}`
2. User tries to set crop to `{left: 0, top: 10, height: 250, width: 500}` by moving selection
3. `SizeNormalizer` normalizes this to `{left: 0, top: 10, height: 500, width: 500}`
4. `RatioNormalizer` normalizes this to `{left: 0, top: 3, height: 250, width: 500}`
5. `PositionNormalizer` normalizes this to `{left: 0, top: 3, height: 250, width: 500}`