### PR TITLE
Set max-height for Dialog component to prevent hidden controls

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/dialog.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/dialog.scss
@@ -1,4 +1,5 @@
 @import '../../containers/Application/colors.scss';
+@import './variables.scss';
 
 $contentBackgroundColor: $concrete;
 $footerBackgroundColor: $white;
@@ -33,6 +34,7 @@ $transitionDuration: 300ms;
     transition: opacity $transitionDuration;
     z-index: 1;
     pointer-events: none;
+    max-height: calc(100vh - $dialogMarginVertical);
 
     & > * {
         pointer-events: auto;
@@ -64,10 +66,12 @@ $transitionDuration: 300ms;
         font-size: 22px;
         font-weight: bold;
         text-align: center;
-        padding: 30px;
+        height: $dialogHeaderHeight;
+        line-height: $dialogHeaderHeight;
     }
 
     article {
+        max-height: $dialogContentMaxHeight;
         color: $contentColor;
         font-size: 12px;
         line-height: 22px;
@@ -83,9 +87,11 @@ $transitionDuration: 300ms;
     footer {
         background: $footerBackgroundColor;
         border-top: 1px solid $footerBorderColor;
-        padding: 30px;
+        height: $dialogFooterHeight;
+        padding: 0 30px;
         display: flex;
         justify-content: space-between;
+        align-items: center;
         flex-direction: row-reverse;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/variables.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/variables.scss
@@ -1,0 +1,4 @@
+$dialogHeaderHeight: 85px;
+$dialogFooterHeight: 90px;
+$dialogMarginVertical: 100px;
+$dialogContentMaxHeight: calc(100vh - $dialogHeaderHeight - $dialogFooterHeight - $dialogMarginVertical);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5377
| License | MIT

#### What's in this PR?

This PR sets a `max-height` to the `Dialog` component. The height handling is implemented similar to the existing height handling of the `Overlay` component. 

#### Why?

Because the `Dialog` might overflow the screen and therefore hide the control buttons if there is a lot of content. If this happens, the user cannot close the dialog via the user interface anymore. See #5377
