### PR TITLE
Fix block types select width and overflowing form width in Firefox

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/block.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/block.scss
@@ -47,7 +47,7 @@ $blockHandleWidth: 20px;
 }
 
 .types {
-    width: 150px;
+    min-width: 120px;
 }
 
 .icons {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/block.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/block.scss
@@ -47,7 +47,7 @@ $blockHandleWidth: 20px;
 }
 
 .types {
-    width: 120px;
+    width: 150px;
 }
 
 .icons {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/application.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/application.scss
@@ -52,11 +52,11 @@
     width: 0;
     max-width: 100%;
     height: 100vh;
-    flex-basis: $viewMinWidth;
     flex-grow: 1;
     flex-shrink: 0;
     display: flex;
     flex-direction: column;
+    min-width: $viewMinWidth;
 }
 
 .sidebar {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/field.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/field.scss
@@ -13,8 +13,8 @@ $exceptionBorderColor: $persianRed;
 
 .field {
     flex: 1;
-    width: 100%;
     max-width: 100%;
+    width: 100%;
 }
 
 .field-exception {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/field.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/field.scss
@@ -14,6 +14,7 @@ $exceptionBorderColor: $persianRed;
 .field {
     flex: 1;
     width: 100%;
+    max-width: 100%;
 }
 
 .field-exception {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Set the width of the types select field to 150px to also show longer block names

<img width="1182" alt="Bildschirmfoto 2020-07-11 um 23 17 06" src="https://user-images.githubusercontent.com/1748788/87233974-e58a1d00-c3cc-11ea-8bba-24d96546eb3c.png">

<img width="1185" alt="Bildschirmfoto 2020-07-11 um 23 16 49" src="https://user-images.githubusercontent.com/1748788/87233973-e4f18680-c3cc-11ea-9490-66c54fc5ae58.png">

#### Why?

To show longer block names in full length



