### PR TITLE
Fix fuzzy matching in WebsiteSearchController by omiting quotes from query

### DIFF
--- a/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
+++ b/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
@@ -79,8 +79,8 @@ class WebsiteSearchController
             foreach ($queryValues as $queryValue) {
                 if (\strlen($queryValue) > 2) {
                     $queryString .= '+("' . self::escapeDoubleQuotes($queryValue) . '" OR ' .
-                        '"' . \preg_replace('/([^\pL\s\d])/u', '?', $queryValue) . '*" OR ' .
-                        '"' . \preg_replace('/([^\pL\s\d])/u', '', $queryValue) . '~") ';
+                        \preg_replace('/([^\pL\s\d])/u', '?', $queryValue) . '* OR ' .
+                        \preg_replace('/([^\pL\s\d])/u', '', $queryValue) . '~) ';
                 } else {
                     $queryString .= '+("' . self::escapeDoubleQuotes($queryValue) . '") ';
                 }

--- a/src/Sulu/Bundle/SearchBundle/Tests/Application/Kernel.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Application/Kernel.php
@@ -31,5 +31,10 @@ class Kernel extends SuluTestKernel
         parent::registerContainerConfiguration($loader);
 
         $loader->load(__DIR__ . '/config/config.yml');
+
+        $environmentConfig = __DIR__ . '/config/config_' . $this->getEnvironment() . '.yml';
+        if (\file_exists($environmentConfig)) {
+            $loader->load($environmentConfig);
+        }
     }
 }

--- a/src/Sulu/Bundle/SearchBundle/Tests/Application/config/config.yml
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Application/config/config.yml
@@ -1,6 +1,3 @@
-massive_search:
-    adapter: test
-
 sulu_page:
     search:
         mapping:

--- a/src/Sulu/Bundle/SearchBundle/Tests/Application/config/config_test_search_adapter.yml
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Application/config/config_test_search_adapter.yml
@@ -1,0 +1,2 @@
+massive_search:
+    adapter: test

--- a/src/Sulu/Bundle/SearchBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Application/config/routing.yml
@@ -1,6 +1,9 @@
 sulu_media_website:
     resource: "@SuluMediaBundle/Resources/config/routing_website.yml"
 
-sulu_page_api:
+sulu_search_website:
+    resource: "@SuluSearchBundle/Resources/config/routing_website.yml"
+
+sulu_search_api:
     resource: "@SuluSearchBundle/Resources/config/routing.yml"
     prefix: /search

--- a/src/Sulu/Bundle/SearchBundle/Tests/Application/config/webspaces/sulu.io.xml
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Application/config/webspaces/sulu.io.xml
@@ -22,6 +22,10 @@
         <default-template type="homepage">overview</default-template>
     </default-templates>
 
+    <templates>
+        <template type="search">search</template>
+    </templates>
+
     <navigation>
         <contexts>
             <context key="main">
@@ -78,6 +82,15 @@
                     <urls>
                         <url language="de" country="at">sulu.lo</url>
                         <url language="de" country="at">localhost</url>
+                        <url language="de">de.sulu.lo</url>
+                        <url redirect="sulu.lo">sulu-redirect.lo</url>
+                    </urls>
+                </environment>
+                <environment type="test_zend_lucene">
+                    <urls>
+                        <url language="de" country="at">sulu.lo</url>
+                        <url language="de" country="at">localhost</url>
+                        <url language="de">de.sulu.lo</url>
                         <url redirect="sulu.lo">sulu-redirect.lo</url>
                     </urls>
                 </environment>

--- a/src/Sulu/Bundle/SearchBundle/Tests/Application/config/webspaces/sulu.io.xml
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Application/config/webspaces/sulu.io.xml
@@ -86,7 +86,7 @@
                         <url redirect="sulu.lo">sulu-redirect.lo</url>
                     </urls>
                 </environment>
-                <environment type="test_zend_lucene">
+                <environment type="test_search_adapter">
                     <urls>
                         <url language="de" country="at">sulu.lo</url>
                         <url language="de" country="at">localhost</url>

--- a/src/Sulu/Bundle/SearchBundle/Tests/Application/templates/search.html.twig
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Application/templates/search.html.twig
@@ -1,0 +1,11 @@
+<h2>Showing {{ hits|length }} results for "{{ query }}"</h2>
+
+<ul>
+    {% for i, hit in hits %}
+        <li class="search-result">
+            <a href="{{ hit.document.url }}">
+                {{- hit.document.title -}}
+            </a>
+        </li>
+    {% endfor %}
+</ul>

--- a/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/SearchControllerTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/SearchControllerTest.php
@@ -41,6 +41,13 @@ class SearchControllerTest extends SuluTestCase
      */
     private $user;
 
+    protected static function getKernelConfiguration(): array
+    {
+        return [
+            'environment' => 'test_search_adapter',
+        ];
+    }
+
     public function setUp(): void
     {
         parent::setUp();
@@ -73,7 +80,7 @@ class SearchControllerTest extends SuluTestCase
             ],
             [
                 [
-                    'q' => 'Product',
+                    'q' => 'Bike',
                     'indexes' => ['Product'],
                     'locale' => 'fr',
                 ],
@@ -87,7 +94,7 @@ class SearchControllerTest extends SuluTestCase
                                 'id' => null,
                                 'document' => [
                                     'id' => 6,
-                                    'title' => 'Product Xeon',
+                                    'title' => 'Bike Xeon',
                                     'description' => 'To be or not to be, that is the question',
                                     'url' => '/foobar',
                                     'locale' => 'fr',
@@ -98,7 +105,7 @@ class SearchControllerTest extends SuluTestCase
                                     'creatorName' => 'dantleech',
                                     'changerName' => 'dantleech',
                                     'properties' => [
-                                        'title' => 'Product Xeon',
+                                        'title' => 'Bike Xeon',
                                         'body' => 'To be or not to be, that is the question',
                                     ],
                                 ],
@@ -112,6 +119,8 @@ class SearchControllerTest extends SuluTestCase
             [
                 [
                     'q' => 'Xeon',
+                    'indexes' => ['Product'],
+                    'locale' => 'fr',
                     'limit' => 1,
                     'page' => 2,
                 ],
@@ -203,7 +212,7 @@ class SearchControllerTest extends SuluTestCase
     {
         $product = new Product();
         $product->id = 6;
-        $product->title = 'Product Xeon';
+        $product->title = 'Bike Xeon';
         $product->body = 'To be or not to be, that is the question';
         $product->url = '/foobar';
         $product->locale = 'fr';

--- a/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/WebsiteSearchControllerTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/WebsiteSearchControllerTest.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SearchBundle\Tests\Functional\Controller;
+
+use Sulu\Bundle\PageBundle\Document\PageDocument;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Component\Content\Document\WorkflowStage;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\DomCrawler\Crawler;
+
+class WebsiteSearchControllerTest extends SuluTestCase
+{
+    /**
+     * @var KernelBrowser
+     */
+    private $websiteClient;
+
+    protected static function getKernelConfiguration(): array
+    {
+        return [
+            'environment' => 'test_zend_lucene',
+        ];
+    }
+
+    public static function setUpBeforeClass(): void
+    {
+        static::purgeDatabase();
+        static::initPhpcr();
+
+        $searchManager = self::getContainer()->get('massive_search.search_manager');
+        foreach ($searchManager->getIndexNames() as $indexName) {
+            $searchManager->purge($indexName);
+        }
+        $searchManager->flush();
+
+        $documentManager = static::$container->get('sulu_document_manager.document_manager');
+
+        /** @var PageDocument $document1 */
+        $document1 = $documentManager->create('page');
+        $document1->setLocale('de');
+        $document1->setTitle('Hello World');
+        $document1->setResourceSegment('/hello-world');
+        $document1->setStructureType('default');
+        $document1->setExtensionsData(['seo' => [], 'excerpt' => []]);
+        $document1->setWorkflowStage(WorkflowStage::PUBLISHED);
+        $document1->getStructure()->bind([
+            'title' => 'Hello World',
+        ]);
+        $documentManager->persist($document1, 'de', [
+            'parent_path' => '/cmf/sulu_io/contents',
+        ]);
+        $documentManager->publish($document1, 'de');
+        $documentManager->flush();
+
+        /** @var PageDocument $document1 */
+        $document2 = $documentManager->create('page');
+        $document2->setLocale('de');
+        $document2->setTitle('Example Product Page');
+        $document2->setResourceSegment('/example-product-page');
+        $document2->setStructureType('default');
+        $document2->setExtensionsData(['seo' => [], 'excerpt' => []]);
+        $document2->setWorkflowStage(WorkflowStage::PUBLISHED);
+        $document2->getStructure()->bind([
+            'title' => 'Example Product Page',
+        ]);
+        $documentManager->persist($document2, 'de', [
+            'parent_path' => '/cmf/sulu_io/contents',
+        ]);
+        $documentManager->publish($document2, 'de');
+        $documentManager->flush();
+
+        static::ensureKernelShutdown();
+    }
+
+    protected function setUp(): void
+    {
+        $this->websiteClient = static::createWebsiteClient();
+    }
+
+    public function testSearchExactTerm(): void
+    {
+        /** @var Crawler $crawler */
+        $crawler = $this->websiteClient->request('GET', 'http://de.sulu.lo/search?q=Product');
+        $response = $this->websiteClient->getResponse();
+
+        static::assertHttpStatusCode(200, $response);
+        $this->assertSame(1, $crawler->filter('.search-result')->count());
+    }
+
+    public function testSearchExactTermEndingWithSpace(): void
+    {
+        /** @var Crawler $crawler */
+        $crawler = $this->websiteClient->request('GET', 'http://de.sulu.lo/search?q=Product ');
+        $response = $this->websiteClient->getResponse();
+
+        static::assertHttpStatusCode(200, $response);
+        $this->assertSame(1, $crawler->filter('.search-result')->count());
+    }
+
+    public function testSearchIncompleteTerm(): void
+    {
+        /** @var Crawler $crawler */
+        $crawler = $this->websiteClient->request('GET', 'http://de.sulu.lo/search?q=Prod');
+        $response = $this->websiteClient->getResponse();
+
+        static::assertHttpStatusCode(200, $response);
+        $this->assertSame(1, $crawler->filter('.search-result')->count());
+    }
+
+    public function testSearchTermFuzzy(): void
+    {
+        /** @var Crawler $crawler */
+        $crawler = $this->websiteClient->request('GET', 'http://de.sulu.lo/search?q=Prodoct');
+        $response = $this->websiteClient->getResponse();
+
+        static::assertHttpStatusCode(200, $response);
+        $this->assertSame(1, $crawler->filter('.search-result')->count());
+    }
+
+    public function testSearchTermWithSpecialChar(): void
+    {
+        /** @var Crawler $crawler */
+        $crawler = $this->websiteClient->request('GET', 'http://de.sulu.lo/search?q=Prod*?t');
+        $response = $this->websiteClient->getResponse();
+
+        static::assertHttpStatusCode(200, $response);
+        $this->assertSame(1, $crawler->filter('.search-result')->count());
+    }
+}

--- a/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/WebsiteSearchControllerTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/WebsiteSearchControllerTest.php
@@ -24,13 +24,6 @@ class WebsiteSearchControllerTest extends SuluTestCase
      */
     private $websiteClient;
 
-    protected static function getKernelConfiguration(): array
-    {
-        return [
-            'environment' => 'test_zend_lucene',
-        ];
-    }
-
     public static function setUpBeforeClass(): void
     {
         static::purgeDatabase();

--- a/src/Sulu/Bundle/SearchBundle/Tests/Unit/Controller/WebsiteSearchControllerTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Unit/Controller/WebsiteSearchControllerTest.php
@@ -89,7 +89,7 @@ class WebsiteSearchControllerTest extends TestCase
         $this->requestAnalyzer->getWebspace()->willReturn($webspace);
 
         $searchQueryBuilder = $this->prophesize(SearchQueryBuilder::class);
-        $this->searchManager->createSearch('+("Test" OR "Test*" OR "Test~") ')->willReturn(
+        $this->searchManager->createSearch('+("Test" OR Test* OR Test~) ')->willReturn(
             $searchQueryBuilder->reveal()
         );
         $searchQueryBuilder->locale('en')->willReturn($searchQueryBuilder->reveal());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | https://github.com/sulu/SuluHeadlessBundle/pull/37 https://github.com/sulu/sulu/pull/3263
| License | MIT

#### What's in this PR?

This PR adjusts the `WebsiteSearchController` to not add quotes around the query string for the fuzzy matching search terms. 

These removed quotes were introduced in #3263 with the reason `Words containing special characters have led to empty search result.`. I am not sure if this reason was correct because the `preg_replace('/([^\pL\s\d])/u', '?', $queryValue)` should actually remove all special characters.

#### Why?

At the moment, searching for `keywor` creates the following query: `+("keywor" OR "keywor*" OR "keywor~")`
As the fuzzy matching search terms (`"keywor*"`, `"keywor~"`) are enclosed in `"`, the fuzzy characters (`*`. `~`) will be interpreted as literal characters. For example, this means that searching for `keywor` will not include a page with the title `Keyword` in the result.

See: https://github.com/sulu/SuluHeadlessBundle/pull/37
