### PR TITLE
Store values from image crop as integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* release/1.6
+    * BUGFIX      #5418  [MediaBundle]             Store values from image crop as integers
+
 * 1.6.35 (2020-07-30)
     * BUGFIX      #5435  [ContactBundle]           Fix type of tag names for serialization of contacts
 

--- a/src/Sulu/Bundle/MediaBundle/Entity/FormatOptions.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/FormatOptions.php
@@ -53,9 +53,9 @@ class FormatOptions
      *
      * @return FormatOptions
      */
-    public function setCropX($cropX): self
+    public function setCropX($cropX)
     {
-        $this->cropX = (int) $cropX;
+        $this->cropX = (int) \round($cropX);
 
         return $this;
     }
@@ -65,7 +65,7 @@ class FormatOptions
      *
      * @return int
      */
-    public function getCropX(): int
+    public function getCropX()
     {
         return $this->cropX;
     }
@@ -77,9 +77,9 @@ class FormatOptions
      *
      * @return FormatOptions
      */
-    public function setCropY($cropY): self
+    public function setCropY($cropY)
     {
-        $this->cropY = (int) $cropY;
+        $this->cropY = (int) \round($cropY);
 
         return $this;
     }
@@ -89,7 +89,7 @@ class FormatOptions
      *
      * @return int
      */
-    public function getCropY(): int
+    public function getCropY()
     {
         return $this->cropY;
     }
@@ -101,9 +101,9 @@ class FormatOptions
      *
      * @return FormatOptions
      */
-    public function setCropWidth($cropWidth): self
+    public function setCropWidth($cropWidth)
     {
-        $this->cropWidth = (int) $cropWidth;
+        $this->cropWidth = (int) \round($cropWidth);
 
         return $this;
     }
@@ -113,7 +113,7 @@ class FormatOptions
      *
      * @return int
      */
-    public function getCropWidth(): int
+    public function getCropWidth()
     {
         return $this->cropWidth;
     }
@@ -125,9 +125,9 @@ class FormatOptions
      *
      * @return FormatOptions
      */
-    public function setCropHeight($cropHeight): self
+    public function setCropHeight($cropHeight)
     {
-        $this->cropHeight = (int) $cropHeight;
+        $this->cropHeight = (int) \round($cropHeight);
 
         return $this;
     }
@@ -137,7 +137,7 @@ class FormatOptions
      *
      * @return int
      */
-    public function getCropHeight(): int
+    public function getCropHeight()
     {
         return $this->cropHeight;
     }
@@ -149,7 +149,7 @@ class FormatOptions
      *
      * @return FormatOptions
      */
-    public function setFormatKey(string $formatKey): self
+    public function setFormatKey($formatKey)
     {
         $this->formatKey = $formatKey;
 
@@ -161,7 +161,7 @@ class FormatOptions
      *
      * @return string
      */
-    public function getFormatKey(): string
+    public function getFormatKey()
     {
         return $this->formatKey;
     }
@@ -171,7 +171,7 @@ class FormatOptions
      *
      * @return FormatOptions
      */
-    public function setFileVersion(FileVersion $fileVersion): self
+    public function setFileVersion(FileVersion $fileVersion)
     {
         $this->fileVersion = $fileVersion;
 
@@ -183,7 +183,7 @@ class FormatOptions
      *
      * @return FileVersion
      */
-    public function getFileVersion(): FileVersion
+    public function getFileVersion()
     {
         return $this->fileVersion;
     }

--- a/src/Sulu/Bundle/MediaBundle/Entity/FormatOptions.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/FormatOptions.php
@@ -55,7 +55,7 @@ class FormatOptions
      */
     public function setCropX($cropX): self
     {
-        $this->cropX = (int)$cropX;
+        $this->cropX = (int) $cropX;
 
         return $this;
     }
@@ -79,7 +79,7 @@ class FormatOptions
      */
     public function setCropY($cropY): self
     {
-        $this->cropY = (int)$cropY;
+        $this->cropY = (int) $cropY;
 
         return $this;
     }
@@ -103,7 +103,7 @@ class FormatOptions
      */
     public function setCropWidth($cropWidth): self
     {
-        $this->cropWidth = (int)$cropWidth;
+        $this->cropWidth = (int) $cropWidth;
 
         return $this;
     }
@@ -127,7 +127,7 @@ class FormatOptions
      */
     public function setCropHeight($cropHeight): self
     {
-        $this->cropHeight = (int)$cropHeight;
+        $this->cropHeight = (int) $cropHeight;
 
         return $this;
     }

--- a/src/Sulu/Bundle/MediaBundle/Entity/FormatOptions.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/FormatOptions.php
@@ -53,9 +53,9 @@ class FormatOptions
      *
      * @return FormatOptions
      */
-    public function setCropX($cropX)
+    public function setCropX($cropX): self
     {
-        $this->cropX = $cropX;
+        $this->cropX = (int)$cropX;
 
         return $this;
     }
@@ -65,7 +65,7 @@ class FormatOptions
      *
      * @return int
      */
-    public function getCropX()
+    public function getCropX(): int
     {
         return $this->cropX;
     }
@@ -77,9 +77,9 @@ class FormatOptions
      *
      * @return FormatOptions
      */
-    public function setCropY($cropY)
+    public function setCropY($cropY): self
     {
-        $this->cropY = $cropY;
+        $this->cropY = (int)$cropY;
 
         return $this;
     }
@@ -89,7 +89,7 @@ class FormatOptions
      *
      * @return int
      */
-    public function getCropY()
+    public function getCropY(): int
     {
         return $this->cropY;
     }
@@ -101,9 +101,9 @@ class FormatOptions
      *
      * @return FormatOptions
      */
-    public function setCropWidth($cropWidth)
+    public function setCropWidth($cropWidth): self
     {
-        $this->cropWidth = $cropWidth;
+        $this->cropWidth = (int)$cropWidth;
 
         return $this;
     }
@@ -113,7 +113,7 @@ class FormatOptions
      *
      * @return int
      */
-    public function getCropWidth()
+    public function getCropWidth(): int
     {
         return $this->cropWidth;
     }
@@ -125,9 +125,9 @@ class FormatOptions
      *
      * @return FormatOptions
      */
-    public function setCropHeight($cropHeight)
+    public function setCropHeight($cropHeight): self
     {
-        $this->cropHeight = $cropHeight;
+        $this->cropHeight = (int)$cropHeight;
 
         return $this;
     }
@@ -137,7 +137,7 @@ class FormatOptions
      *
      * @return int
      */
-    public function getCropHeight()
+    public function getCropHeight(): int
     {
         return $this->cropHeight;
     }
@@ -149,7 +149,7 @@ class FormatOptions
      *
      * @return FormatOptions
      */
-    public function setFormatKey($formatKey)
+    public function setFormatKey(string $formatKey): self
     {
         $this->formatKey = $formatKey;
 
@@ -161,7 +161,7 @@ class FormatOptions
      *
      * @return string
      */
-    public function getFormatKey()
+    public function getFormatKey(): string
     {
         return $this->formatKey;
     }
@@ -171,7 +171,7 @@ class FormatOptions
      *
      * @return FormatOptions
      */
-    public function setFileVersion(FileVersion $fileVersion)
+    public function setFileVersion(FileVersion $fileVersion): self
     {
         $this->fileVersion = $fileVersion;
 
@@ -183,7 +183,7 @@ class FormatOptions
      *
      * @return FileVersion
      */
-    public function getFileVersion()
+    public function getFileVersion(): FileVersion
     {
         return $this->fileVersion;
     }

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatOptions/FormatOptionsManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatOptions/FormatOptionsManager.php
@@ -121,8 +121,8 @@ class FormatOptionsManager implements FormatOptionsManagerInterface
         if (!isset($formatOptions)) {
             $formatOptions = new FormatOptions();
             $formatOptions->setFileVersion($fileVersion);
-            $fileVersion->addFormatOptions($formatOptions);
             $formatOptions->setFormatKey($formatKey);
+            $fileVersion->addFormatOptions($formatOptions);
         }
 
         $formatOptions = $this->setDataOnEntity($formatOptions, $data);

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/FormatControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/FormatControllerTest.php
@@ -212,6 +212,52 @@ class FormatControllerTest extends SuluTestCase
         $this->assertEquals(100, $response->{'small-inset'}->options->cropHeight);
     }
 
+    public function testPutWithFormatOptionsAsDecimal()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request(
+            'PUT',
+            \sprintf('/api/media/%d/formats/small-inset', $this->media->getId()),
+            [
+                'locale' => 'de',
+                'options' => [
+                    'cropX' => 10.05,
+                    'cropY' => 14.75,
+                    'cropWidth' => 100.1,
+                    'cropHeight' => 99.6,
+                ],
+            ]
+        );
+
+        $response = \json_decode($client->getResponse()->getContent());
+        $this->assertHttpStatusCode(200, $client->getResponse());
+
+        $this->assertEquals(10, $response->options->cropX);
+        $this->assertEquals(15, $response->options->cropY);
+        $this->assertEquals(100, $response->options->cropWidth);
+        $this->assertEquals(100, $response->options->cropHeight);
+
+        // Test if the options have really been persisted
+
+        $client->request(
+            'GET',
+            \sprintf('/api/media/%d/formats', $this->media->getId()),
+            [
+                'locale' => 'de',
+            ]
+        );
+
+        $response = \json_decode($client->getResponse()->getContent());
+        $this->assertHttpStatusCode(200, $client->getResponse());
+
+        $this->assertNotNull($response->{'small-inset'});
+        $this->assertEquals(10, $response->{'small-inset'}->options->cropX);
+        $this->assertEquals(15, $response->{'small-inset'}->options->cropY);
+        $this->assertEquals(100, $response->{'small-inset'}->options->cropWidth);
+        $this->assertEquals(100, $response->{'small-inset'}->options->cropHeight);
+    }
+
     public function testPutWithEmptyFormatOptions()
     {
         $client = $this->createAuthenticatedClient();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5409
| License | MIT

#### What's in this PR?

I added type casts and return types to the FormatOptions Entity Object.
As JS could provide FLOATs this might be a good place to make sure SULU and it's DB is working with INTs in the end.

By doing this I figured that

`$fileVersion->addFormatOptions($formatOptions);`

relies on

`$formatOptions->setFormatKey($formatKey);`

is already called or the array key will be NULL
No clue how this ever could have been able to run but probably the array of format options is never used.

#### Possible BC break
PHPStorm tells me that return self is PHP > 7 and the 1.6 still supports 5.5

#### Why?

JS might provide FLOATS and at least PGSQL will not save the crop then.
