### PR TITLE
Implement handling of resource_store_properties_to_request param in SingleSelection field

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/tests/SingleListOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/tests/SingleListOverlay.test.js
@@ -29,6 +29,7 @@ jest.mock('../../../containers/List/stores/ListStore', () => jest.fn(
         });
 
         this.clear = jest.fn();
+        this.reset = jest.fn();
         this.clearSelection = jest.fn();
         this.destroy = jest.fn();
     }
@@ -61,6 +62,66 @@ test('Should instantiate the ListStore with locale, excluded-ids, options and me
     expect(singleListOverlay.instance().listStore.observableOptions.excludedIds.get()).toEqual(['id-1', 'id-2']);
     expect(singleListOverlay.instance().listStore.options).toBe(options);
     expect(singleListOverlay.instance().listStore.metadataOptions).toBe(metadataOptions);
+});
+
+test('Should update options of ListStore if the options prop is changed', () => {
+    const oldOptions = {key: 'value-1'};
+
+    const singleListOverlay = shallow(
+        <SingleListOverlay
+            adapter="table"
+            excludedIds={['id-1', 'id-2']}
+            listKey="snippets_list"
+            locale={observable.box('en')}
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+            open={false}
+            options={oldOptions}
+            resourceKey="snippets"
+            title="Selection"
+        />
+    );
+    singleListOverlay.instance().listStore.selectionIds = [12, 14];
+
+    expect(singleListOverlay.instance().listStore.reset).not.toBeCalled();
+    expect(singleListOverlay.instance().listStore.options).toEqual(oldOptions);
+
+    const newOptions = {key: 'value-2'};
+    singleListOverlay.setProps({
+        options: newOptions,
+    });
+
+    expect(singleListOverlay.instance().listStore.reset).toBeCalled();
+    expect(singleListOverlay.instance().listStore.initialSelectionIds).toEqual([12, 14]);
+    expect(singleListOverlay.instance().listStore.options).toEqual(newOptions);
+});
+
+test('Should not update options of ListStore if new value of options prop is equal to old value', () => {
+    const oldOptions = {key: 'value-1'};
+
+    const singleListOverlay = shallow(
+        <SingleListOverlay
+            adapter="table"
+            excludedIds={['id-1', 'id-2']}
+            listKey="snippets_list"
+            locale={observable.box('en')}
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+            open={false}
+            options={oldOptions}
+            resourceKey="snippets"
+            title="Selection"
+        />
+    );
+
+    expect(singleListOverlay.instance().listStore.reset).not.toBeCalled();
+
+    const newOldOptions = {key: 'value-1'};
+    singleListOverlay.setProps({
+        options: newOldOptions,
+    });
+
+    expect(singleListOverlay.instance().listStore.reset).not.toBeCalled();
 });
 
 test('Should instantiate the ListStore without locale, excluded-ids, options and metadataOptions', () => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | maybe
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/541

#### What's in this PR?

The PR implements the handling of the `resource_store_properties_to_request` schema-option for the `SingleSelection` field.

The functionality is implemented for the `list_overlay` type of the field and behaves the same as the `resource_store_properties_to_request` schema-option of the `Selection` field.

#### Why?

Because there was a request in our Slack channel for this some time ago. Also, the `Selection` field already implements this functionality.

#### Example Usage

~~~xml
<property name="testParameter" type="text_line" mandatory="true">
    <meta>
        <title lang="en">Test Parameter</title>
        <title lang="de">Test Parameter</title>
    </meta>
</property>

<property name="single_contact_selection" type="single_contact_selection">
    <meta>
        <title lang="en">Single Contact Selection</title>
        <title lang="de">Kontakt</title>
    </meta>

    <params>
        <param name="resource_store_properties_to_request" type="collection">
            <param name="parameterKey" value="testParameter" />
        </param>
    </params>
</property>
~~~
