### PR TITLE
Fix setting image crops for downscaled images

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/ImageRectangleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/ImageRectangleSelection.js
@@ -23,10 +23,18 @@ class ImageRectangleSelection extends React.Component<Props> {
     image: Image;
     @observable imageLoaded = false;
 
-    naturalHorizontalToScaled = (h: number) => h * this.imageResizedWidth / this.image.naturalWidth;
-    scaledHorizontalToNatural = (h: number) => h * this.image.naturalWidth / this.imageResizedWidth;
-    naturalVerticalToScaled = (v: number) => v * this.imageResizedHeight / this.image.naturalHeight;
-    scaledVerticalToNatural = (v: number) => v * this.image.naturalHeight / this.imageResizedHeight;
+    naturalHorizontalToScaled = (h: number) => {
+        return Math.max(h * this.scaledImageWidth / this.image.naturalWidth, 0);
+    };
+    scaledHorizontalToNatural = (h: number) => {
+        return Math.min(h * this.image.naturalWidth / this.scaledImageWidth, this.image.naturalWidth);
+    };
+    naturalVerticalToScaled = (v: number) => {
+        return Math.max(v * this.scaledImageHeight / this.image.naturalHeight, 0);
+    };
+    scaledVerticalToNatural = (v: number) => {
+        return Math.min(v * this.image.naturalHeight / this.scaledImageHeight, this.image.naturalHeight);
+    };
 
     naturalDataToScaled(data: SelectionData): SelectionData {
         return {
@@ -55,23 +63,23 @@ class ImageRectangleSelection extends React.Component<Props> {
         this.image.src = this.props.image;
     }
 
-    @computed get imageResizedHeight(): number {
-        if (this.imageTouchesHorizontalBorders()) {
+    @computed get scaledImageHeight(): number {
+        if (this.imageFillsContainerHeight()) {
             return Math.min(this.image.naturalHeight, this.props.containerHeight);
         } else {
-            return this.imageResizedWidth * this.image.naturalHeight / this.image.naturalWidth;
+            return this.scaledImageWidth * this.image.naturalHeight / this.image.naturalWidth;
         }
     }
 
-    @computed get imageResizedWidth(): number {
-        if (this.imageTouchesHorizontalBorders()) {
-            return this.imageResizedHeight * this.image.naturalWidth / this.image.naturalHeight;
+    @computed get scaledImageWidth(): number {
+        if (this.imageFillsContainerHeight()) {
+            return this.scaledImageHeight * this.image.naturalWidth / this.image.naturalHeight;
         } else {
             return Math.min(this.image.naturalWidth, this.props.containerWidth);
         }
     }
 
-    imageTouchesHorizontalBorders() {
+    imageFillsContainerHeight() {
         const imageHeightToWidth = this.image.naturalHeight / this.image.naturalWidth;
         const containerHeightToWidth = this.props.containerHeight / this.props.containerWidth;
         return imageHeightToWidth > containerHeightToWidth;
@@ -82,11 +90,11 @@ class ImageRectangleSelection extends React.Component<Props> {
         onChange(data ? this.scaledDataToNatural(data) : undefined);
     };
 
-    @computed get minDimensions() {
+    @computed get scaledMinDimensions() {
         const {minHeight, minWidth, containerHeight, containerWidth} = this.props;
 
-        let height = minHeight;
-        let width = minWidth;
+        let height = minHeight ? this.naturalVerticalToScaled(minHeight) : undefined;
+        let width = minWidth ? this.naturalHorizontalToScaled(minWidth) : undefined;
 
         if (height && height > containerHeight) {
             height = containerHeight;
@@ -101,12 +109,12 @@ class ImageRectangleSelection extends React.Component<Props> {
         return {width, height};
     }
 
-    @computed get minWidth() {
-        return this.minDimensions.width;
+    @computed get scaledMinWidth() {
+        return this.scaledMinDimensions.width;
     }
 
-    @computed get minHeight() {
-        return this.minDimensions.height;
+    @computed get scaledMinHeight() {
+        return this.scaledMinDimensions.height;
     }
 
     render() {
@@ -118,16 +126,16 @@ class ImageRectangleSelection extends React.Component<Props> {
 
         return (
             <RectangleSelection
-                minHeight={this.minHeight}
-                minWidth={this.minWidth}
+                minHeight={this.scaledMinHeight}
+                minWidth={this.scaledMinWidth}
                 onChange={this.handleRectangleSelectionChange}
                 round={false}
                 value={value}
             >
                 <img
-                    height={this.imageResizedHeight}
+                    height={this.scaledImageHeight}
                     src={this.props.image}
-                    width={this.imageResizedWidth}
+                    width={this.scaledImageWidth}
                 />
             </RectangleSelection>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/tests/ImageRectangleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/tests/ImageRectangleSelection.test.js
@@ -103,12 +103,67 @@ test('The component should pass a value of undefined', () => {
     expect(changeSpy).toBeCalledWith(undefined);
 });
 
+test('The component should scale the value based on the image height and container height', () => {
+    const changeSpy = jest.fn();
+
+    const view = mount(
+        <ImageRectangleSelection
+            containerHeight={360}
+            containerWidth={640}
+            image="//:0"
+            onChange={changeSpy}
+            value={undefined}
+        />
+    );
+
+    const onImageLoad = view.instance().image.onload;
+    view.instance().image = {
+        naturalWidth: 1920,
+        naturalHeight: 1080,
+    };
+    onImageLoad();
+    view.update();
+
+    view.find('RectangleSelection').prop('onChange')({width: 320, height: 180, top: 0, left: 320});
+
+    expect(changeSpy).toBeCalledWith({width: 960, height: 540, top: 0, left: 960});
+});
+
+test('The component should not scale the value to exceed the natural image width', () => {
+    const changeSpy = jest.fn();
+
+    const view = mount(
+        <ImageRectangleSelection
+            // window.innerHeight = 798
+            containerHeight={369}
+            // window.innerWidth = 1440
+            containerWidth={1000}
+            image="//:0"
+            onChange={changeSpy}
+            value={undefined}
+        />
+    );
+
+    const onImageLoad = view.instance().image.onload;
+    view.instance().image = {
+        naturalWidth: 4896,
+        naturalHeight: 3264,
+    };
+    onImageLoad();
+    view.update();
+
+    view.find('RectangleSelection').prop('onChange')({width: 554, height: 200, top: 0, left: 0});
+
+    expect(changeSpy).toBeCalledWith({width: 4896, height: 1769.1056910569105, top: 0, left: 0});
+});
+
 test.each([
-    [300, 600, 360, 640, 300, 600],
-    [200, 200, 300, 400, 200, 200],
-    [800, 800, 300, 400, 300, 300],
-    [800, 1000, 200, 400, 200, 250],
-    [1000, 800, 200, 400, 200, 160],
+    [300, 600, 360, 640, 100, 200],
+    [200, 200, 400, 480, 50, 50],
+    [600, 300, 180, 480, 100, 50],
+    [800, 1000, 400, 240, 100, 125],
+    [1000, 800, 400, 240, 125, 100],
+    [500, 500, 1600, 2000, 500, 500],
 ])(
     'The component should render with minHeight %s, minWidth %s, containerHeight %s and containerWidth %s',
     (minHeight, minWidth, containerHeight, containerWidth, expectedMinHeight, expectedMinWidth) => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes https://github.com/sulu/sulu/issues/5372#issuecomment-660098831
| License | MIT

#### What's in this PR?

This PR fixes two issues that occur when setting crops for images that are downscaled significantly in the crop overlay. I will add comments in the respective places that explain the issues.

The issues can be tested with the following parameters:
![87789391-438c8980-c83f-11ea-808d-5ddfa41105b5](https://user-images.githubusercontent.com/13310795/87914741-669e7f80-ca71-11ea-80f2-ff5aa4cc3ec3.jpeg)

```xml
<format key="image_element">
    <meta>
        <title lang="nl">Afbeelding element</title>
    </meta>
    
    <scale x="1280"/>
</format>
```

```
window.innerWidth = 1440
window.innerHeight = 798
```
