### PR TITLE
Fix portal route matching

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -142,6 +142,8 @@
 
         <!-- portal loader -->
         <service id="sulu_website.routing.portal_loader" class="%sulu_website.routing.portal_loader.class%">
+            <argument type="service" id="sulu_core.webspace.webspace_manager"/>
+
             <tag name="routing.loader"/>
         </service>
 

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/PortalLoader.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/PortalLoader.php
@@ -42,8 +42,13 @@ class PortalLoader extends Loader
 
         $prefixes = [];
         foreach ($this->webspaceManager->getPortalInformations() as $portalInformation) {
-            // cast null to string as prefix can be empty string
-            $prefixes[] = preg_quote((string) $portalInformation->getPrefix());
+            if (!$portalInformation->getPrefix()) {
+                $prefixes[] = '(^$)?';
+                
+                continue;
+            }
+
+            $prefixes[] = preg_quote($portalInformation->getPrefix());
         }
 
         foreach ($importedRoutes as $importedRouteName => $importedRoute) {

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/PortalLoader.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/PortalLoader.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\WebsiteBundle\Routing;
 
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Symfony\Component\Config\Loader\Loader;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
@@ -22,6 +23,16 @@ use Symfony\Component\Routing\RouteCollection;
  */
 class PortalLoader extends Loader
 {
+    /**
+     * @var WebspaceManagerInterface
+     */
+    private $webspaceManager;
+
+    public function __construct(WebspaceManagerInterface $webspaceManager)
+    {
+        $this->webspaceManager = $webspaceManager;
+    }
+
     public function load($resource, $type = null)
     {
         $collection = new RouteCollection();
@@ -29,25 +40,24 @@ class PortalLoader extends Loader
         /** @var Route[] $importedRoutes */
         $importedRoutes = $this->import($resource, null);
 
-        $condition = \sprintf(
-            'request.get("_sulu").getAttribute("portalInformation") !== null && request.get("_sulu").getAttribute("portalInformation").getType() === %s',
-            RequestAnalyzerInterface::MATCH_TYPE_FULL
-        );
+        $prefixes = [];
+        foreach ($this->webspaceManager->getPortalInformations() as $portalInformation) {
+            // cast null to string as prefix can be empty string
+            $prefixes[] = preg_quote((string) $portalInformation->getPrefix());
+        }
 
         foreach ($importedRoutes as $importedRouteName => $importedRoute) {
-            $importedCondition = $importedRoute->getCondition();
-
             $collection->add(
                 $importedRouteName,
                 new PortalRoute(
                     '{prefix}' . $importedRoute->getPath(),
                     $importedRoute->getDefaults(),
-                    \array_merge(['prefix' => '.*', 'host' => '.+'], $importedRoute->getRequirements()),
+                    \array_merge(['prefix' => implode('|', $prefixes)], $importedRoute->getRequirements()),
                     $importedRoute->getOptions(),
                     (!empty($importedRoute->getHost()) ? $importedRoute->getHost() : '{host}'),
                     $importedRoute->getSchemes(),
                     $importedRoute->getMethods(),
-                    $condition . (!empty($importedCondition) ? ' and (' . $importedCondition . ')' : '')
+                    $importedRoute->getCondition()
                 )
             );
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5489
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix portal route matching.

#### Why?

Currently routes e.g.: `/_profiler/search`  does also match our search, only routes with a specific portal prefix should match.

#### To Do

- [ ] Add Tests
