### PR TITLE
Remove urlizer requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "ext-dom": "*",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "aferrandini/urlizer": "^1.0",
         "antishov/doctrine-extensions-bundle": "^1.2.2",
         "contao/imagine-svg": "^0.2.2 || ^1.0",
         "dantleech/phpcr-migrations-bundle": "^1.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | #5353
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Remove requirement to urlizer.

#### Why?

The urlizer was removed in #5353 but seems in a merge commit a conflict was false resolved.

