### PR TITLE
Correct serialization type of tags for Accounts and Contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* release/1.6
+    * BUGFIX      #5435  [ContactBundle]           Fix type of tag names for serialization of contacts
+
 * 1.6.34 (2020-06-09)
     * BUGFIX      #5323  [SnippetBundle]           Fix /cmf/snippets node not exist in live workspace
     * BUGFIX      #5328  [ContentBundle]           Fix url generation in link-prover with portals

--- a/src/Sulu/Bundle/ContactBundle/Entity/AbstractAccount.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/AbstractAccount.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use JMS\Serializer\Annotation\Accessor;
 use JMS\Serializer\Annotation\Exclude;
+use JMS\Serializer\Annotation\Type;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
 use Sulu\Bundle\TagBundle\Entity\Tag;
@@ -99,6 +100,7 @@ class AbstractAccount extends BaseAccount implements AuditableInterface, Account
     /**
      * @var Collection
      * @Accessor(getter="getTagNameArray")
+     * @Type("array")
      */
     protected $tags;
 

--- a/src/Sulu/Bundle/ContactBundle/Entity/Contact.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/Contact.php
@@ -18,6 +18,7 @@ use JMS\Serializer\Annotation\Exclude;
 use JMS\Serializer\Annotation\Expose;
 use JMS\Serializer\Annotation\Groups;
 use JMS\Serializer\Annotation\SerializedName;
+use JMS\Serializer\Annotation\Type;
 use JMS\Serializer\Annotation\VirtualProperty;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\CoreBundle\Entity\ApiEntity;
@@ -143,6 +144,7 @@ class Contact extends ApiEntity implements ContactInterface, AuditableInterface
      * @var Collection
      * @Accessor(getter="getTagNameArray")
      * @Groups({"fullContact"})
+     * @Type("array")
      */
     protected $tags;
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR sets the type of the `tags` property to `array`.

#### Why?

In a project JMS Serializer was not able to recognize this type correctly, but used `ArrayCollection` instead of `array` as type. And because the type is not set correctly, a function is called with a wrong argument, and a PHP error is thrown because of that. I don't really know why that happens, and it does not occur in the core of Sulu, but this addition fixes that problem for that project.