### PR TITLE
Throw proper error message when invalid form XML is loaded

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Exception/InvalidRootTagException.php
+++ b/src/Sulu/Bundle/AdminBundle/Exception/InvalidRootTagException.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Exception;
+
+class InvalidRootTagException extends \Exception
+{
+    /**
+     * @var string
+     */
+    private $resource;
+
+    /**
+     * @var string
+     */
+    private $rootTag;
+
+    public function __construct(string $resource, string $rootTag)
+    {
+        parent::__construct(
+            \sprintf('The resource "%s" does not have a root tag named "%s"', $resource, $rootTag)
+        );
+
+        $this->resource = $resource;
+        $this->rootTag = $rootTag;
+    }
+
+    public function getResource()
+    {
+        return $this->resource;
+    }
+
+    public function getRootTag()
+    {
+        return $this->rootTag;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/FormMetadata/FormXmlLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/FormMetadata/FormXmlLoader.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\AdminBundle\FormMetadata;
 
+use Sulu\Bundle\AdminBundle\Exception\InvalidRootTagException;
 use Sulu\Bundle\AdminBundle\FormMetadata\FormMetadata as ExternalFormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\LocalizedFormMetadataCollection;
@@ -68,6 +69,10 @@ class FormXmlLoader extends AbstractLoader
     {
         // init running vars
         $tags = [];
+
+        if (0 === $xpath->query('/x:form')->count()) {
+            throw new InvalidRootTagException($resource, 'form');
+        }
 
         $form = new ExternalFormMetadata();
         $form->setResource($resource);

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\AdminBundle\Tests\Unit\FormMetadata;
 
 use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Exception\InvalidRootTagException;
 use Sulu\Bundle\AdminBundle\FormMetadata\FormMetadataMapper;
 use Sulu\Bundle\AdminBundle\FormMetadata\FormXmlLoader;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
@@ -375,6 +376,16 @@ class FormXmlLoaderTest extends TestCase
         $this->assertEquals('name', $formMetadata->getItems()['name']->getName());
         $this->assertEquals(8, $formMetadata->getItems()['name']->getColSpan());
         $this->assertCount(1, $formMetadata->getItems()['name']->getItems());
+    }
+
+    public function testLoadFormInvalidRootTag()
+    {
+        $this->expectException(InvalidRootTagException::class);
+        $this->expectExceptionMessageRegExp('/"form"/');
+
+        $this->loader->load(
+            __DIR__ . \DIRECTORY_SEPARATOR . 'data' . \DIRECTORY_SEPARATOR . 'form_invalid_root_tag.xml'
+        );
     }
 
     public function testLoadFormInvalid()

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/data/form_invalid_root_tag.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/data/form_invalid_root_tag.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+<properties xmlns="http://schemas.sulu.io/template/template"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd"
+>
+    <property name="audience_targeting_groups" type="target_group_select" onInvalid="ignore" />
+</properties>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR throws a proper exception when a file with a root tag not suitable for a form is interpreted as a form.

#### Why?

Because when people want to make use of XML Includes, they might want to create a `fragments` folder within `config/forms` and put them there. If they do so, it will result in a cryptic error like this:

```
Notice: Trying to get property 'nodeValue' of non-object
```

That's because the program tries to load the key from the form, but the fragment most often does not even have a `key` under a `form` tag, and that's why the code fails.

In order to make that at least a little bit more understandable, we throw a better error message now.

#### Steps to reproduce

Place a file like this in `config/forms/fragments`, and the cryptic error message should be shown:

```xml
<properties xmlns="http://schemas.sulu.io/template/template" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.1.xsd">
    <property name="test" type="text_line" />
</properties>