### PR TITLE
Fix compatibility of tests with PHP 5.5 by removing scalar type hint

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ResettingControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ResettingControllerTest.php
@@ -386,7 +386,7 @@ class ResettingControllerTest extends SuluTestCase
         $this->assertEquals(null, $response);
     }
 
-    protected function getExpectedEmailData(Client $client, User $user, string $token)
+    protected function getExpectedEmailData(Client $client, User $user, $token)
     {
         $sender = $this->getContainer()->getParameter('sulu_security.reset_password.mail.sender');
         $template = $this->getContainer()->getParameter('sulu_security.reset_password.mail.template');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR removes a scalar type hint from the code.

#### Why?

Because scalar type hints do not work in PHP 5.5, which is still supported by Sulu 1.6