### PR TITLE
Hide elements without permission on website

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,16 @@
 
 ## dev-master
 
+### Deprecation of SecuredEntityRepositoryTrait
+
+The `SecuredEntityRepositoryTrait` was deprecated, use the `AccessControlQueryEnhancer` service instead. The following
+classes stopped using the `SecuredEntityRepositoryTrait`, so the `addAccessControl` method won't be available anymore on
+them, consider this if you have extended one of these classes:
+
+- `DoctrineListBuilder`
+- `CollectionRepository`
+- `MediaRepository`
+
 ### Role Entity changed for anonymous roles
 
 Sulu needs to handle anonymous users, so we need additional anonymous roles.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,16 +2,6 @@
 
 ## dev-master
 
-### Deprecation of SecuredEntityRepositoryTrait
-
-The `SecuredEntityRepositoryTrait` was deprecated, use the `AccessControlQueryEnhancer` service instead. The following
-classes stopped using the `SecuredEntityRepositoryTrait`, so the `addAccessControl` method won't be available anymore on
-them, consider this if you have extended one of these classes:
-
-- `DoctrineListBuilder`
-- `CollectionRepository`
-- `MediaRepository`
-
 ### Role Entity changed for anonymous roles
 
 Sulu needs to handle anonymous users, so we need additional anonymous roles.

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
@@ -60,6 +60,7 @@
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="sulu.content.resource_locator.strategy_pool"/>
             <argument type="service" id="sulu_document_manager.namespace_registry" />
+            <argument type="service" id="sulu_security.access_control_manager" />
         </service>
 
         <!-- content type manager -->

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
@@ -61,6 +61,7 @@
             <argument type="service" id="sulu.content.resource_locator.strategy_pool"/>
             <argument type="service" id="sulu_document_manager.namespace_registry" />
             <argument type="service" id="sulu_security.access_control_manager" />
+            <argument>%sulu_security.permissions%</argument>
         </service>
 
         <!-- content type manager -->
@@ -170,6 +171,7 @@
             <argument type="service" id="sulu.phpcr.session"/>
             <argument type="service" id="sulu.content.mapper"/>
             <argument type="service" id="debug.stopwatch" on-invalid="null"/>
+            <argument type="service" id="security.token_storage" on-invalid="null"/>
         </service>
 
         <!-- cache warmer for structures -->

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/rest.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/rest.xml
@@ -24,6 +24,7 @@
             <argument type="service" id="sulu_core.list_builder_filter_type_registry"/>
             <argument type="service" id="event_dispatcher"/>
             <argument>%sulu_security.permissions%</argument>
+            <argument type="service" id="sulu_security.access_control_query_enhancer"/>
         </service>
         <service
             id="Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilderFactoryInterface"

--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
@@ -91,6 +91,11 @@ class CollectionManager implements CollectionManagerInterface
      */
     private $collectionPreviewFormat;
 
+    /**
+     * @var array
+     */
+    private $permissions;
+
     public function __construct(
         CollectionRepositoryInterface $collectionRepository,
         MediaRepositoryInterface $mediaRepository,
@@ -98,7 +103,8 @@ class CollectionManager implements CollectionManagerInterface
         UserRepositoryInterface $userRepository,
         EntityManager $em,
         TokenStorageInterface $tokenStorage = null,
-        $collectionPreviewFormat
+        $collectionPreviewFormat,
+        $permissions
     ) {
         $this->collectionRepository = $collectionRepository;
         $this->mediaRepository = $mediaRepository;
@@ -107,6 +113,7 @@ class CollectionManager implements CollectionManagerInterface
         $this->em = $em;
         $this->tokenStorage = $tokenStorage;
         $this->collectionPreviewFormat = $collectionPreviewFormat;
+        $this->permissions = $permissions;
     }
 
     public function getById(

--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
@@ -92,11 +92,6 @@ class CollectionManager implements CollectionManagerInterface
      */
     private $collectionPreviewFormat;
 
-    /**
-     * @var array
-     */
-    private $permissions;
-
     public function __construct(
         CollectionRepositoryInterface $collectionRepository,
         MediaRepositoryInterface $mediaRepository,
@@ -104,8 +99,7 @@ class CollectionManager implements CollectionManagerInterface
         UserRepositoryInterface $userRepository,
         EntityManager $em,
         TokenStorageInterface $tokenStorage = null,
-        $collectionPreviewFormat,
-        $permissions
+        $collectionPreviewFormat
     ) {
         $this->collectionRepository = $collectionRepository;
         $this->mediaRepository = $mediaRepository;
@@ -114,11 +108,18 @@ class CollectionManager implements CollectionManagerInterface
         $this->em = $em;
         $this->tokenStorage = $tokenStorage;
         $this->collectionPreviewFormat = $collectionPreviewFormat;
-        $this->permissions = $permissions;
     }
 
-    public function getById($id, $locale, $depth = 0, $breadcrumb = false, $filter = [], $sortBy = [], $children = false)
-    {
+    public function getById(
+        $id,
+        $locale,
+        $depth = 0,
+        $breadcrumb = false,
+        $filter = [],
+        $sortBy = [],
+        $children = false,
+        $permission = null
+    ) {
         $collectionEntity = $this->collectionRepository->findCollectionById($id);
         if (null === $collectionEntity) {
             throw new CollectionNotFoundException($id);
@@ -132,7 +133,7 @@ class CollectionManager implements CollectionManagerInterface
                 $collectionEntity,
                 $sortBy,
                 $this->getCurrentUser(),
-                $this->permissions[PermissionTypes::VIEW]
+                $permission
             );
         }
 
@@ -193,8 +194,16 @@ class CollectionManager implements CollectionManagerInterface
         return $result;
     }
 
-    public function getTree($locale, $offset, $limit, $search, $depth = 0, $sortBy = [], $systemCollections = true)
-    {
+    public function getTree(
+        $locale,
+        $offset,
+        $limit,
+        $search,
+        $depth = 0,
+        $sortBy = [],
+        $systemCollections = true,
+        $permission = null
+    ) {
         $filter = [
             'offset' => $offset,
             'limit' => $limit,
@@ -210,7 +219,7 @@ class CollectionManager implements CollectionManagerInterface
             null,
             $sortBy,
             $this->getCurrentUser(),
-            $this->permissions[PermissionTypes::VIEW]
+            $permission
         );
 
         $collections = [];

--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
@@ -29,7 +29,6 @@ use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineJoinDescrip
 use Sulu\Component\Rest\ListBuilder\FieldDescriptorInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authentication\UserRepositoryInterface;
-use Sulu\Component\Security\Authorization\PermissionTypes;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**

--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManagerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManagerInterface.php
@@ -31,10 +31,19 @@ interface CollectionManagerInterface
      * @param bool $breadcrumb if true breadcrumb will be appended
      * @param array $filter array of criteria
      * @param array $sortBy fields to sort by
+     * @param int $permission
      *
      * @return Collection
      */
-    public function getById($id, $locale, $depth = 0, $breadcrumb = false, $filter = [], $sortBy = []);
+    public function getById(
+        $id,
+        $locale,
+        $depth = 0,
+        $breadcrumb = false,
+        $filter = [],
+        $sortBy = []
+        /* $permission = null */
+    );
 
     /**
      * Returns collections with a given parent and/or a given depth-level
@@ -80,10 +89,20 @@ interface CollectionManagerInterface
      * @param int $depth maximum depth for query
      * @param array $sortBy
      * @param bool $systemCollections Whether or not system collectino should be included in the result
+     * @param int $permission
      *
      * @return \Sulu\Bundle\MediaBundle\Api\Collection[]
      */
-    public function getTree($locale, $offset, $limit, $search, $depth = 0, $sortBy = [], $systemCollections = true);
+    public function getTree(
+        $locale,
+        $offset,
+        $limit,
+        $search,
+        $depth = 0,
+        $sortBy = [],
+        $systemCollections = true
+        /* $permission = null */
+    );
 
     /**
      * Returns a collection count.

--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManagerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManagerInterface.php
@@ -31,7 +31,6 @@ interface CollectionManagerInterface
      * @param bool $breadcrumb if true breadcrumb will be appended
      * @param array $filter array of criteria
      * @param array $sortBy fields to sort by
-     * @param int $permission
      *
      * @return Collection
      */
@@ -89,7 +88,6 @@ interface CollectionManagerInterface
      * @param int $depth maximum depth for query
      * @param array $sortBy
      * @param bool $systemCollections Whether or not system collectino should be included in the result
-     * @param int $permission
      *
      * @return \Sulu\Bundle\MediaBundle\Api\Collection[]
      */

--- a/src/Sulu/Bundle/MediaBundle/Content/MediaSelectionContainer.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/MediaSelectionContainer.php
@@ -14,7 +14,6 @@ namespace Sulu\Bundle\MediaBundle\Content;
 use JMS\Serializer\Annotation\Exclude;
 use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
-use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Util\ArrayableInterface;
 
 /**
@@ -66,15 +65,6 @@ class MediaSelectionContainer implements ArrayableInterface
     private $mediaManager;
 
     /**
-     * @Exclude
-     *
-     * @var ?UserInterface
-     */
-    private $user;
-
-    /**
-     * @Exclude
-     *
      * @var ?int
      */
     private $permission;
@@ -86,7 +76,7 @@ class MediaSelectionContainer implements ArrayableInterface
         $locale,
         $types,
         $mediaManager,
-        UserInterface $user = null
+        $permission = null
     ) {
         $this->config = $config;
         $this->displayOption = $displayOption;
@@ -94,7 +84,7 @@ class MediaSelectionContainer implements ArrayableInterface
         $this->locale = $locale;
         $this->types = $types;
         $this->mediaManager = $mediaManager;
-        $this->user = $user;
+        $this->permission = $permission;
     }
 
     /**
@@ -119,7 +109,7 @@ class MediaSelectionContainer implements ArrayableInterface
     private function loadData($locale)
     {
         if (!empty($this->ids)) {
-            return $this->mediaManager->getByIds($this->ids, $locale, $this->user);
+            return $this->mediaManager->getByIds($this->ids, $locale, $this->permission);
         } else {
             return [];
         }

--- a/src/Sulu/Bundle/MediaBundle/Content/MediaSelectionContainer.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/MediaSelectionContainer.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\MediaBundle\Content;
 use JMS\Serializer\Annotation\Exclude;
 use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
+use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Util\ArrayableInterface;
 
 /**
@@ -64,14 +65,38 @@ class MediaSelectionContainer implements ArrayableInterface
      */
     private $mediaManager;
 
-    public function __construct($config, $displayOption, $ids, $locale, $types, $mediaManager)
-    {
+    /**
+     * @Exclude
+     *
+     * @var UserInterface
+     */
+    private $user;
+
+    /**
+     * @Exclude
+     *
+     * @var int
+     */
+    private $permission;
+
+    public function __construct(
+        $config,
+        $displayOption,
+        $ids,
+        $locale,
+        $types,
+        $mediaManager,
+        UserInterface $user = null,
+        $permission = null
+    ) {
         $this->config = $config;
         $this->displayOption = $displayOption;
         $this->ids = $ids;
         $this->locale = $locale;
         $this->types = $types;
         $this->mediaManager = $mediaManager;
+        $this->user = $user;
+        $this->permission = $permission;
     }
 
     /**
@@ -96,7 +121,7 @@ class MediaSelectionContainer implements ArrayableInterface
     private function loadData($locale)
     {
         if (!empty($this->ids)) {
-            return $this->mediaManager->getByIds($this->ids, $locale);
+            return $this->mediaManager->getByIds($this->ids, $locale, $this->user, $this->permission);
         } else {
             return [];
         }

--- a/src/Sulu/Bundle/MediaBundle/Content/MediaSelectionContainer.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/MediaSelectionContainer.php
@@ -86,8 +86,7 @@ class MediaSelectionContainer implements ArrayableInterface
         $locale,
         $types,
         $mediaManager,
-        UserInterface $user = null,
-        $permission = null
+        UserInterface $user = null
     ) {
         $this->config = $config;
         $this->displayOption = $displayOption;
@@ -96,7 +95,6 @@ class MediaSelectionContainer implements ArrayableInterface
         $this->types = $types;
         $this->mediaManager = $mediaManager;
         $this->user = $user;
-        $this->permission = $permission;
     }
 
     /**
@@ -121,7 +119,7 @@ class MediaSelectionContainer implements ArrayableInterface
     private function loadData($locale)
     {
         if (!empty($this->ids)) {
-            return $this->mediaManager->getByIds($this->ids, $locale, $this->user, $this->permission);
+            return $this->mediaManager->getByIds($this->ids, $locale, $this->user);
         } else {
             return [];
         }

--- a/src/Sulu/Bundle/MediaBundle/Content/MediaSelectionContainer.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/MediaSelectionContainer.php
@@ -68,14 +68,14 @@ class MediaSelectionContainer implements ArrayableInterface
     /**
      * @Exclude
      *
-     * @var UserInterface
+     * @var ?UserInterface
      */
     private $user;
 
     /**
      * @Exclude
      *
-     * @var int
+     * @var ?int
      */
     private $permission;
 

--- a/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
@@ -20,7 +20,9 @@ use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Content\ComplexContentType;
 use Sulu\Component\Content\ContentTypeExportInterface;
 use Sulu\Component\Content\PreResolvableContentTypeInterface;
+use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Util\ArrayableInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
  * content type for image selection.
@@ -37,10 +39,26 @@ class MediaSelectionContentType extends ComplexContentType implements ContentTyp
      */
     private $referenceStore;
 
-    public function __construct(MediaManagerInterface $mediaManager, ReferenceStoreInterface $referenceStore)
-    {
+    /**
+     * @var TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    /**
+     * @var array
+     */
+    private $permissions;
+
+    public function __construct(
+        MediaManagerInterface $mediaManager,
+        ReferenceStoreInterface $referenceStore,
+        TokenStorageInterface $tokenStorage = null,
+        array $permissions = null
+    ) {
         $this->mediaManager = $mediaManager;
         $this->referenceStore = $referenceStore;
+        $this->tokenStorage = $tokenStorage;
+        $this->permissions = $permissions;
     }
 
     public function getDefaultParams(PropertyInterface $property = null)
@@ -120,7 +138,9 @@ class MediaSelectionContentType extends ComplexContentType implements ContentTyp
             isset($data['ids']) ? $data['ids'] : [],
             $property->getStructure()->getLanguageCode(),
             $types,
-            $this->mediaManager
+            $this->mediaManager,
+            $this->getUser(),
+            $this->permissions[PermissionTypes::VIEW]
         );
 
         return $container->getData();
@@ -167,5 +187,20 @@ class MediaSelectionContentType extends ComplexContentType implements ContentTyp
         foreach ($data['ids'] as $id) {
             $this->referenceStore->add($id);
         }
+    }
+
+    private function getUser()
+    {
+        if (!$this->tokenStorage) {
+            return null;
+        }
+
+        $user = $this->tokenStorage->getToken()->getUser();
+
+        if (\is_object($user)) {
+            return $user;
+        }
+
+        return null;
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
@@ -40,7 +40,7 @@ class MediaSelectionContentType extends ComplexContentType implements ContentTyp
     private $referenceStore;
 
     /**
-     * @var TokenStorageInterface
+     * @var ?TokenStorageInterface
      */
     private $tokenStorage;
 

--- a/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
@@ -20,7 +20,7 @@ use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Content\ComplexContentType;
 use Sulu\Component\Content\ContentTypeExportInterface;
 use Sulu\Component\Content\PreResolvableContentTypeInterface;
-use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Util\ArrayableInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
@@ -44,14 +44,21 @@ class MediaSelectionContentType extends ComplexContentType implements ContentTyp
      */
     private $tokenStorage;
 
+    /**
+     * @var ?array
+     */
+    private $permissions;
+
     public function __construct(
         MediaManagerInterface $mediaManager,
         ReferenceStoreInterface $referenceStore,
-        TokenStorageInterface $tokenStorage = null
+        TokenStorageInterface $tokenStorage = null,
+        $permissions = null
     ) {
         $this->mediaManager = $mediaManager;
         $this->referenceStore = $referenceStore;
         $this->tokenStorage = $tokenStorage;
+        $this->permissions = $permissions;
     }
 
     public function getDefaultParams(PropertyInterface $property = null)
@@ -132,7 +139,7 @@ class MediaSelectionContentType extends ComplexContentType implements ContentTyp
             $property->getStructure()->getLanguageCode(),
             $types,
             $this->mediaManager,
-            $this->getUser()
+            $this->permissions[PermissionTypes::VIEW]
         );
 
         return $container->getData();
@@ -179,20 +186,5 @@ class MediaSelectionContentType extends ComplexContentType implements ContentTyp
         foreach ($data['ids'] as $id) {
             $this->referenceStore->add($id);
         }
-    }
-
-    private function getUser(): ?UserInterface
-    {
-        if (!$this->tokenStorage) {
-            return null;
-        }
-
-        $user = $this->tokenStorage->getToken()->getUser();
-
-        if ($user instanceof UserInterface) {
-            return $user;
-        }
-
-        return null;
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
@@ -20,7 +20,7 @@ use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Content\ComplexContentType;
 use Sulu\Component\Content\ContentTypeExportInterface;
 use Sulu\Component\Content\PreResolvableContentTypeInterface;
-use Sulu\Component\Security\Authorization\PermissionTypes;
+use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Util\ArrayableInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
@@ -44,21 +44,14 @@ class MediaSelectionContentType extends ComplexContentType implements ContentTyp
      */
     private $tokenStorage;
 
-    /**
-     * @var array
-     */
-    private $permissions;
-
     public function __construct(
         MediaManagerInterface $mediaManager,
         ReferenceStoreInterface $referenceStore,
-        TokenStorageInterface $tokenStorage = null,
-        array $permissions = null
+        TokenStorageInterface $tokenStorage = null
     ) {
         $this->mediaManager = $mediaManager;
         $this->referenceStore = $referenceStore;
         $this->tokenStorage = $tokenStorage;
-        $this->permissions = $permissions;
     }
 
     public function getDefaultParams(PropertyInterface $property = null)
@@ -139,8 +132,7 @@ class MediaSelectionContentType extends ComplexContentType implements ContentTyp
             $property->getStructure()->getLanguageCode(),
             $types,
             $this->mediaManager,
-            $this->getUser(),
-            $this->permissions[PermissionTypes::VIEW]
+            $this->getUser()
         );
 
         return $container->getData();
@@ -189,7 +181,7 @@ class MediaSelectionContentType extends ComplexContentType implements ContentTyp
         }
     }
 
-    private function getUser()
+    private function getUser(): ?UserInterface
     {
         if (!$this->tokenStorage) {
             return null;
@@ -197,7 +189,7 @@ class MediaSelectionContentType extends ComplexContentType implements ContentTyp
 
         $user = $this->tokenStorage->getToken()->getUser();
 
-        if (\is_object($user)) {
+        if ($user instanceof UserInterface) {
             return $user;
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
@@ -84,6 +84,11 @@ class CollectionController extends AbstractRestController implements ClassResour
      */
     private $defaultCollectionType;
 
+    /**
+     * @var array
+     */
+    private $permissions;
+
     public function __construct(
         ViewHandlerInterface $viewHandler,
         TokenStorageInterface $tokenStorage,
@@ -92,7 +97,8 @@ class CollectionController extends AbstractRestController implements ClassResour
         TranslatorInterface $translator,
         SystemCollectionManagerInterface $systemCollectionManager,
         CollectionManagerInterface $collectionManager,
-        array $defaultCollectionType
+        array $defaultCollectionType,
+        array $permissions
     ) {
         parent::__construct($viewHandler, $tokenStorage);
 
@@ -102,6 +108,7 @@ class CollectionController extends AbstractRestController implements ClassResour
         $this->systemCollectionManager = $systemCollectionManager;
         $this->collectionManager = $collectionManager;
         $this->defaultCollectionType = $defaultCollectionType;
+        $this->permissions = $permissions;
     }
 
     /**
@@ -153,7 +160,8 @@ class CollectionController extends AbstractRestController implements ClassResour
                         $breadcrumb,
                         $filter,
                         null !== $sortBy ? [$sortBy => $sortOrder] : [],
-                        $children
+                        $children,
+                        $this->permissions[PermissionTypes::VIEW]
                     );
 
                     if (SystemCollectionManagerInterface::COLLECTION_TYPE === $collection->getType()->getKey()) {
@@ -217,7 +225,8 @@ class CollectionController extends AbstractRestController implements ClassResour
                     $search,
                     $depth,
                     null !== $sortBy ? [$sortBy => $sortOrder] : [],
-                    $this->securityChecker->hasPermission('sulu.media.system_collections', 'view')
+                    $this->securityChecker->hasPermission('sulu.media.system_collections', 'view'),
+                    $this->permissions[PermissionTypes::VIEW]
                 );
             }
 

--- a/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
@@ -16,9 +16,9 @@ use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
+use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancer;
 use Sulu\Component\Media\SystemCollections\SystemCollectionManagerInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
-use Sulu\Component\Security\Authorization\AccessControl\SecuredEntityRepositoryTrait;
 
 /**
  * CollectionRepository.
@@ -28,7 +28,10 @@ use Sulu\Component\Security\Authorization\AccessControl\SecuredEntityRepositoryT
  */
 class CollectionRepository extends NestedTreeRepository implements CollectionRepositoryInterface
 {
-    use SecuredEntityRepositoryTrait;
+    /**
+     * @var AccessControlQueryEnhancer
+     */
+    private $accessControlQueryEnhancer;
 
     public function findCollectionById($id)
     {
@@ -93,7 +96,13 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
         $queryBuilder->addOrderBy('collection.id', 'ASC');
 
         if (null !== $user && null != $permission) {
-            $this->addAccessControl($queryBuilder, $user, $permission, Collection::class, 'collection');
+            $this->accessControlQueryEnhancer->enhance(
+                $queryBuilder,
+                $user,
+                $permission,
+                Collection::class,
+                'collection'
+            );
         }
 
         return $queryBuilder->getQuery()->getResult();
@@ -346,5 +355,10 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
         }
 
         return $queryBuilder->getQuery();
+    }
+
+    public function setAccessControlQueryEnhancer(AccessControlQueryEnhancer $accessControlQueryEnhancer)
+    {
+        $this->accessControlQueryEnhancer = $accessControlQueryEnhancer;
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
@@ -95,7 +95,7 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
 
         $queryBuilder->addOrderBy('collection.id', 'ASC');
 
-        if (null !== $user && null != $permission) {
+        if (null != $permission) {
             $this->accessControlQueryEnhancer->enhance(
                 $queryBuilder,
                 $user,

--- a/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
@@ -19,6 +19,7 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancer;
 use Sulu\Component\Media\SystemCollections\SystemCollectionManagerInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Component\Security\Authorization\AccessControl\SecuredEntityRepositoryTrait;
 
 /**
  * CollectionRepository.
@@ -28,6 +29,8 @@ use Sulu\Component\Security\Authentication\UserInterface;
  */
 class CollectionRepository extends NestedTreeRepository implements CollectionRepositoryInterface
 {
+    use SecuredEntityRepositoryTrait;
+
     /**
      * @var AccessControlQueryEnhancer
      */
@@ -96,13 +99,23 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
         $queryBuilder->addOrderBy('collection.id', 'ASC');
 
         if (null != $permission) {
-            $this->accessControlQueryEnhancer->enhance(
-                $queryBuilder,
-                $user,
-                $permission,
-                Collection::class,
-                'collection'
-            );
+            if ($this->accessControlQueryEnhancer) {
+                $this->accessControlQueryEnhancer->enhance(
+                    $queryBuilder,
+                    $user,
+                    $permission,
+                    Collection::class,
+                    'collection'
+                );
+            } else {
+                $this->addAccessControl(
+                    $queryBuilder,
+                    $user,
+                    $permission,
+                    Collection::class,
+                    'collection'
+                );
+            }
         }
 
         return $queryBuilder->getQuery()->getResult();

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
@@ -51,7 +51,7 @@ class MediaDataProviderRepository implements DataProviderRepositoryInterface
     private $collectionEntityName;
 
     /**
-     * @var AccessControlQueryEnhancer
+     * @var ?AccessControlQueryEnhancer
      */
     private $accessControlQueryEnhancer;
 
@@ -60,7 +60,7 @@ class MediaDataProviderRepository implements DataProviderRepositoryInterface
         MediaManagerInterface $mediaManager,
         $mediaEntityName,
         $collectionEntityName,
-        AccessControlQueryEnhancer $accessControlQueryEnhancer
+        AccessControlQueryEnhancer $accessControlQueryEnhancer = null
     ) {
         $this->entityManager = $entityManager;
         $this->mediaEntityName = $mediaEntityName;

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
@@ -189,7 +189,7 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
 
         $queryBuilder->addOrderBy($orderBy, $orderSort);
 
-        if (null !== $user && null !== $permission) {
+        if (null !== $permission) {
             $this->accessControlQueryEnhancer->enhance($queryBuilder, $user, $permission, Collection::class, 'collection');
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
@@ -19,6 +19,7 @@ use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancer;
 use Sulu\Component\Media\SystemCollections\SystemCollectionManagerInterface;
 use Sulu\Component\Persistence\Repository\ORM\EntityRepository;
 use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Component\Security\Authorization\AccessControl\SecuredEntityRepositoryTrait;
 
 /**
  * MediaRepository.
@@ -28,6 +29,8 @@ use Sulu\Component\Security\Authentication\UserInterface;
  */
 class MediaRepository extends EntityRepository implements MediaRepositoryInterface
 {
+    use SecuredEntityRepositoryTrait;
+
     /**
      * @var ?AccessControlQueryEnhancer
      */
@@ -190,7 +193,23 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
         $queryBuilder->addOrderBy($orderBy, $orderSort);
 
         if (null !== $permission && $this->accessControlQueryEnhancer) {
-            $this->accessControlQueryEnhancer->enhance($queryBuilder, $user, $permission, Collection::class, 'collection');
+            if ($this->accessControlQueryEnhancer) {
+                $this->accessControlQueryEnhancer->enhance(
+                    $queryBuilder,
+                    $user,
+                    $permission,
+                    Collection::class,
+                    'collection'
+                );
+            } else {
+                $this->addAccessControl(
+                    $queryBuilder,
+                    $user,
+                    $permission,
+                    Collection::class,
+                    'collection'
+                );
+            }
         }
 
         return $queryBuilder->getQuery()->getResult();

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
@@ -29,7 +29,7 @@ use Sulu\Component\Security\Authentication\UserInterface;
 class MediaRepository extends EntityRepository implements MediaRepositoryInterface
 {
     /**
-     * @var AccessControlQueryEnhancer
+     * @var ?AccessControlQueryEnhancer
      */
     private $accessControlQueryEnhancer;
 
@@ -189,7 +189,7 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
 
         $queryBuilder->addOrderBy($orderBy, $orderSort);
 
-        if (null !== $permission) {
+        if (null !== $permission && $this->accessControlQueryEnhancer) {
             $this->accessControlQueryEnhancer->enhance($queryBuilder, $user, $permission, Collection::class, 'collection');
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
@@ -15,10 +15,10 @@ use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\Tools\Pagination\Paginator;
+use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancer;
 use Sulu\Component\Media\SystemCollections\SystemCollectionManagerInterface;
 use Sulu\Component\Persistence\Repository\ORM\EntityRepository;
 use Sulu\Component\Security\Authentication\UserInterface;
-use Sulu\Component\Security\Authorization\AccessControl\SecuredEntityRepositoryTrait;
 
 /**
  * MediaRepository.
@@ -28,7 +28,10 @@ use Sulu\Component\Security\Authorization\AccessControl\SecuredEntityRepositoryT
  */
 class MediaRepository extends EntityRepository implements MediaRepositoryInterface
 {
-    use SecuredEntityRepositoryTrait;
+    /**
+     * @var AccessControlQueryEnhancer
+     */
+    private $accessControlQueryEnhancer;
 
     public function findMediaById($id, $asArray = false)
     {
@@ -187,7 +190,7 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
         $queryBuilder->addOrderBy($orderBy, $orderSort);
 
         if (null !== $user && null !== $permission) {
-            $this->addAccessControl($queryBuilder, $user, $permission, Collection::class, 'collection');
+            $this->accessControlQueryEnhancer->enhance($queryBuilder, $user, $permission, Collection::class, 'collection');
         }
 
         return $queryBuilder->getQuery()->getResult();
@@ -421,5 +424,10 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
         );
 
         return $subQuery->getScalarResult();
+    }
+
+    public function setAccessControlQueryEnhancer(AccessControlQueryEnhancer $accessControlQueryEnhancer)
+    {
+        $this->accessControlQueryEnhancer = $accessControlQueryEnhancer;
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -212,10 +212,16 @@ class MediaManager implements MediaManagerInterface
         return $mediaEntity;
     }
 
-    public function getByIds(array $ids, $locale)
+    public function getByIds(array $ids, $locale, UserInterface $user = null, $permission = null)
     {
         $media = [];
-        $mediaEntities = $this->mediaRepository->findMedia(['pagination' => false, 'ids' => $ids]);
+        $mediaEntities = $this->mediaRepository->findMedia(
+            ['pagination' => false, 'ids' => $ids],
+            null,
+            null,
+            $user,
+            $permission
+        );
         $this->count = \count($mediaEntities);
         foreach ($mediaEntities as $mediaEntity) {
             $media[\array_search($mediaEntity->getId(), $ids)] = $this->addFormatsAndUrl(

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -212,7 +212,7 @@ class MediaManager implements MediaManagerInterface
         return $mediaEntity;
     }
 
-    public function getByIds(array $ids, $locale, UserInterface $user = null, $permission = null)
+    public function getByIds(array $ids, $locale, UserInterface $user = null)
     {
         $media = [];
         $mediaEntities = $this->mediaRepository->findMedia(
@@ -220,7 +220,7 @@ class MediaManager implements MediaManagerInterface
             null,
             null,
             $user,
-            $permission
+            $this->permissions[PermissionTypes::VIEW]
         );
         $this->count = \count($mediaEntities);
         foreach ($mediaEntities as $mediaEntity) {

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -131,11 +131,6 @@ class MediaManager implements MediaManagerInterface
     private $pathCleaner;
 
     /**
-     * @var array
-     */
-    private $permissions;
-
-    /**
      * @var string
      */
     private $downloadPath;
@@ -151,7 +146,6 @@ class MediaManager implements MediaManagerInterface
     public $count;
 
     /**
-     * @param array $permissions
      * @param string $downloadPath
      * @param string $maxFileSize
      */
@@ -170,7 +164,6 @@ class MediaManager implements MediaManagerInterface
         TokenStorageInterface $tokenStorage = null,
         SecurityCheckerInterface $securityChecker = null,
         FFProbe $ffprobe = null,
-        $permissions,
         $downloadPath,
         $maxFileSize,
         TargetGroupRepositoryInterface $targetGroupRepository = null
@@ -190,7 +183,6 @@ class MediaManager implements MediaManagerInterface
         $this->tokenStorage = $tokenStorage;
         $this->securityChecker = $securityChecker;
         $this->ffprobe = $ffprobe;
-        $this->permissions = $permissions;
         $this->downloadPath = $downloadPath;
         $this->maxFileSize = $maxFileSize;
     }
@@ -212,15 +204,15 @@ class MediaManager implements MediaManagerInterface
         return $mediaEntity;
     }
 
-    public function getByIds(array $ids, $locale, UserInterface $user = null)
+    public function getByIds(array $ids, $locale, $permission = null)
     {
         $media = [];
         $mediaEntities = $this->mediaRepository->findMedia(
             ['pagination' => false, 'ids' => $ids],
             null,
             null,
-            $user,
-            $this->permissions[PermissionTypes::VIEW]
+            $this->getCurrentUser(),
+            $permission
         );
         $this->count = \count($mediaEntities);
         foreach ($mediaEntities as $mediaEntity) {
@@ -234,7 +226,7 @@ class MediaManager implements MediaManagerInterface
         return \array_values($media);
     }
 
-    public function get($locale, $filter = [], $limit = null, $offset = null)
+    public function get($locale, $filter = [], $limit = null, $offset = null, $permission = null)
     {
         $media = [];
         $mediaEntities = $this->mediaRepository->findMedia(
@@ -242,7 +234,7 @@ class MediaManager implements MediaManagerInterface
             $limit,
             $offset,
             $this->getCurrentUser(),
-            $this->permissions[PermissionTypes::VIEW]
+            $permission
         );
         $this->count = $this->mediaRepository->count($filter);
 

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -141,6 +141,11 @@ class MediaManager implements MediaManagerInterface
     private $ffprobe;
 
     /**
+     * @var array
+     */
+    private $permissions;
+
+    /**
      * @var int
      */
     public $count;
@@ -164,6 +169,7 @@ class MediaManager implements MediaManagerInterface
         TokenStorageInterface $tokenStorage = null,
         SecurityCheckerInterface $securityChecker = null,
         FFProbe $ffprobe = null,
+        $permissions,
         $downloadPath,
         $maxFileSize,
         TargetGroupRepositoryInterface $targetGroupRepository = null
@@ -183,6 +189,7 @@ class MediaManager implements MediaManagerInterface
         $this->tokenStorage = $tokenStorage;
         $this->securityChecker = $securityChecker;
         $this->ffprobe = $ffprobe;
+        $this->permissions = $permissions;
         $this->downloadPath = $downloadPath;
         $this->maxFileSize = $maxFileSize;
     }

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManagerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManagerInterface.php
@@ -30,7 +30,7 @@ interface MediaManagerInterface
      *
      * @return Media[]
      */
-    public function get($locale, $filter = [], $limit = null, $offset = null);
+    public function get($locale, $filter = [], $limit = null, $offset = null /* $permission = null */);
 
     /**
      * Return the count of the last get.
@@ -65,7 +65,7 @@ interface MediaManagerInterface
      *
      * @return Media[]
      */
-    public function getByIds(array $ids, $locale /* UserInterface $user = null */);
+    public function getByIds(array $ids, $locale /* $permission = null */);
 
     /**
      * Creates a new media or overrides an existing one.

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManagerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManagerInterface.php
@@ -30,7 +30,7 @@ interface MediaManagerInterface
      *
      * @return Media[]
      */
-    public function get($locale, $filter = [], $limit = null, $offset = null /* $permission = null */);
+    public function get($locale, $filter = [], $limit = null, $offset = null/*, $permission = null */);
 
     /**
      * Return the count of the last get.
@@ -65,7 +65,7 @@ interface MediaManagerInterface
      *
      * @return Media[]
      */
-    public function getByIds(array $ids, $locale /* $permission = null */);
+    public function getByIds(array $ids, $locale/*, $permission = null */);
 
     /**
      * Creates a new media or overrides an existing one.

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManagerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManagerInterface.php
@@ -65,7 +65,7 @@ interface MediaManagerInterface
      *
      * @return Media[]
      */
-    public function getByIds(array $ids, $locale /* UserInterface $user = null, $permission = null */);
+    public function getByIds(array $ids, $locale /* UserInterface $user = null */);
 
     /**
      * Creates a new media or overrides an existing one.

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManagerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManagerInterface.php
@@ -65,7 +65,7 @@ interface MediaManagerInterface
      *
      * @return Media[]
      */
-    public function getByIds(array $ids, $locale);
+    public function getByIds(array $ids, $locale /* UserInterface $user = null, $permission = null */);
 
     /**
      * Creates a new media or overrides an existing one.

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -235,7 +235,6 @@
             <argument type="service" id="security.token_storage" on-invalid="null" />
             <argument type="service" id="sulu_security.security_checker" on-invalid="null" />
             <argument type="service" id="sulu_media.ffprobe" on-invalid="null" />
-            <argument>%sulu_security.permissions%</argument>
             <argument type="string">%sulu_media.media_manager.media_download_path%</argument>
             <argument>%sulu_media.media.max_file_size%</argument>
             <argument type="service" id="sulu.repository.target_group" on-invalid="null"/>
@@ -276,6 +275,7 @@
             <argument type="service" id="sulu_media.media_manager"/>
             <argument type="service" id="sulu_media.reference_store.media"/>
             <argument type="service" id="security.token_storage" on-invalid="null"/>
+            <argument>%sulu_security.permissions%</argument>
 
             <tag name="sulu.content.type" alias="media_selection"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
@@ -338,6 +338,7 @@
             <argument type="service" id="sulu_core.array_serializer"/>
             <argument type="service" id="request_stack"/>
             <argument type="service" id="sulu_media.reference_store.media"/>
+            <argument type="service" id="security.token_storage" on-invalid="null"/>
 
             <tag name="sulu.smart_content.data_provider" alias="media"/>
         </service>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -98,6 +98,7 @@
             <argument type="service" id="sulu_media.system_collections.manager" />
             <argument type="service" id="sulu_media.collection_manager" />
             <argument>%sulu_media.collection.type.default%</argument>
+            <argument>%sulu_security.permissions%</argument>
 
             <tag name="sulu.context" context="admin"/>
         </service>
@@ -297,7 +298,6 @@
             <argument type="service" id="doctrine.orm.entity_manager" />
             <argument type="service" id="security.token_storage" on-invalid="null"/>
             <argument type="string">%sulu_media.collection.previews.format%</argument>
-            <argument>%sulu_security.permissions%</argument>
         </service>
 
         <service id="sulu_media.twig_extension.disposition_type" class="%sulu_media.twig_extension.disposition_type.class%">

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -137,6 +137,9 @@
         <service id="sulu_media.collection_repository" class="%sulu_media.collection_repository.class%" public="true">
             <factory service="doctrine.orm.entity_manager" method="getRepository"/>
             <argument>%sulu_media.collection_entity%</argument>
+            <call method="setAccessControlQueryEnhancer">
+                <argument type="service" id="sulu_security.access_control_query_enhancer" />
+            </call>
         </service>
         <service id="sulu_media.file_version_meta_repository"
                  class="Sulu\Bundle\MediaBundle\Entity\FileVersionMetaRepository">

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -274,6 +274,8 @@
         <service id="sulu_media.type.media_selection" class="%sulu_media.media_selection.class%">
             <argument type="service" id="sulu_media.media_manager"/>
             <argument type="service" id="sulu_media.reference_store.media"/>
+            <argument type="service" id="security.token_storage" on-invalid="null"/>
+            <argument>%sulu_security.permissions%</argument>
 
             <tag name="sulu.content.type" alias="media_selection"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -275,7 +275,6 @@
             <argument type="service" id="sulu_media.media_manager"/>
             <argument type="service" id="sulu_media.reference_store.media"/>
             <argument type="service" id="security.token_storage" on-invalid="null"/>
-            <argument>%sulu_security.permissions%</argument>
 
             <tag name="sulu.content.type" alias="media_selection"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -284,6 +284,7 @@
         <service id="sulu_media.type.single_media_selection" class="Sulu\Bundle\MediaBundle\Content\Types\SingleMediaSelection">
             <argument type="service" id="sulu_media.media_manager"/>
             <argument type="service" id="sulu_media.reference_store.media"/>
+            <argument type="service" id="sulu_security.security_checker" on-invalid="null"/>
 
             <tag name="sulu.content.type" alias="single_media_selection"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -235,6 +235,7 @@
             <argument type="service" id="security.token_storage" on-invalid="null" />
             <argument type="service" id="sulu_security.security_checker" on-invalid="null" />
             <argument type="service" id="sulu_media.ffprobe" on-invalid="null" />
+            <argument>%sulu_security.permissions%</argument>
             <argument type="string">%sulu_media.media_manager.media_download_path%</argument>
             <argument>%sulu_media.media.max_file_size%</argument>
             <argument type="service" id="sulu.repository.target_group" on-invalid="null"/>
@@ -298,6 +299,7 @@
             <argument type="service" id="doctrine.orm.entity_manager" />
             <argument type="service" id="security.token_storage" on-invalid="null"/>
             <argument type="string">%sulu_media.collection.previews.format%</argument>
+            <argument type="string">%sulu_security.permissions%</argument>
         </service>
 
         <service id="sulu_media.twig_extension.disposition_type" class="%sulu_media.twig_extension.disposition_type.class%">

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -327,6 +327,7 @@
             <argument type="service" id="sulu_media.media_manager"/>
             <argument type="string">%sulu.model.media.class%</argument>
             <argument type="string">%sulu_media.collection_entity%</argument>
+            <argument type="service" id="sulu_security.access_control_query_enhancer"/>
         </service>
 
         <service id="sulu_media.smart_content.data_provider.media" class="Sulu\Component\Media\SmartContent\MediaDataProvider">

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -299,7 +299,7 @@
             <argument type="service" id="doctrine.orm.entity_manager" />
             <argument type="service" id="security.token_storage" on-invalid="null"/>
             <argument type="string">%sulu_media.collection.previews.format%</argument>
-            <argument type="string">%sulu_security.permissions%</argument>
+            <argument>%sulu_security.permissions%</argument>
         </service>
 
         <service id="sulu_media.twig_extension.disposition_type" class="%sulu_media.twig_extension.disposition_type.class%">

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
@@ -181,17 +181,17 @@ class MediaManagerTest extends TestCase
     /**
      * @dataProvider provideGetByIds
      */
-    public function testGetByIds($ids, $user, $permission, $media, $result)
+    public function testGetByIds($ids, $user, $media, $result)
     {
         $this->mediaRepository->findMedia(
             ['pagination' => false, 'ids' => $ids],
             null,
             null,
             $user,
-            $permission
+            64
         )->willReturn($media);
         $this->formatManager->getFormats(Argument::cetera())->willReturn(null);
-        $medias = $this->mediaManager->getByIds($ids, 'en', $user, $permission);
+        $medias = $this->mediaManager->getByIds($ids, 'en', $user);
 
         for ($i = 0; $i < \count($medias); ++$i) {
             $this->assertEquals($result[$i]->getId(), $medias[$i]->getId());
@@ -461,9 +461,9 @@ class MediaManagerTest extends TestCase
         $user = $this->prophesize(SuluUserInterface::class);
 
         return [
-            [[1, 2, 3], null, 64, [$media1, $media2, $media3], [$media1, $media2, $media3]],
-            [[2, 1, 3], $user->reveal(), 32, [$media1, $media2, $media3], [$media2, $media1, $media3]],
-            [[4, 1, 2], null, 16, [$media1, $media2], [$media1, $media2]],
+            [[1, 2, 3], null, [$media1, $media2, $media3], [$media1, $media2, $media3]],
+            [[2, 1, 3], $user->reveal(), [$media1, $media2, $media3], [$media2, $media1, $media3]],
+            [[4, 1, 2], null, [$media1, $media2], [$media1, $media2]],
         ];
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
@@ -169,9 +169,6 @@ class MediaManagerTest extends TestCase
             $this->tokenStorage->reveal(),
             $this->securityChecker->reveal(),
             $this->ffprobe->reveal(),
-            [
-                'view' => 64,
-            ],
             '/download/{id}/media/{slug}',
             0,
             $this->targetGroupRepository->reveal()
@@ -183,15 +180,19 @@ class MediaManagerTest extends TestCase
      */
     public function testGetByIds($ids, $user, $media, $result)
     {
+        $token = $this->prophesize(TokenInterface::class);
+        $token->getUser()->willReturn($user);
+        $this->tokenStorage->getToken()->willReturn($token->reveal());
+
         $this->mediaRepository->findMedia(
             ['pagination' => false, 'ids' => $ids],
             null,
             null,
             $user,
-            64
+            null
         )->willReturn($media);
         $this->formatManager->getFormats(Argument::cetera())->willReturn(null);
-        $medias = $this->mediaManager->getByIds($ids, 'en', $user);
+        $medias = $this->mediaManager->getByIds($ids, 'en');
 
         for ($i = 0; $i < \count($medias); ++$i) {
             $this->assertEquals($result[$i]->getId(), $medias[$i]->getId());
@@ -217,7 +218,7 @@ class MediaManagerTest extends TestCase
         $this->mediaRepository->findMedia([], null, null, null, 64)->willReturn([])->shouldBeCalled();
         $this->mediaRepository->count(Argument::cetera())->shouldBeCalled();
 
-        $this->mediaManager->get('de', [], null, null);
+        $this->mediaManager->get('de', [], null, null, 64);
     }
 
     public function testGetWithSuluUser()
@@ -230,7 +231,7 @@ class MediaManagerTest extends TestCase
         $this->mediaRepository->findMedia([], null, null, $user->reveal(), 64)->willReturn([])->shouldBeCalled();
         $this->mediaRepository->count(Argument::cetera())->shouldBeCalled();
 
-        $this->mediaManager->get('de', [], null, null);
+        $this->mediaManager->get('de', [], null, null, 64);
     }
 
     public function testDeleteWithSecurity()

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
@@ -169,6 +169,7 @@ class MediaManagerTest extends TestCase
             $this->tokenStorage->reveal(),
             $this->securityChecker->reveal(),
             $this->ffprobe->reveal(),
+            [],
             '/download/{id}/media/{slug}',
             0,
             $this->targetGroupRepository->reveal()

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
@@ -181,11 +181,17 @@ class MediaManagerTest extends TestCase
     /**
      * @dataProvider provideGetByIds
      */
-    public function testGetByIds($ids, $media, $result)
+    public function testGetByIds($ids, $user, $permission, $media, $result)
     {
-        $this->mediaRepository->findMedia(Argument::any())->willReturn($media);
+        $this->mediaRepository->findMedia(
+            ['pagination' => false, 'ids' => $ids],
+            null,
+            null,
+            $user,
+            $permission
+        )->willReturn($media);
         $this->formatManager->getFormats(Argument::cetera())->willReturn(null);
-        $medias = $this->mediaManager->getByIds($ids, 'en');
+        $medias = $this->mediaManager->getByIds($ids, 'en', $user, $permission);
 
         for ($i = 0; $i < \count($medias); ++$i) {
             $this->assertEquals($result[$i]->getId(), $medias[$i]->getId());
@@ -452,10 +458,12 @@ class MediaManagerTest extends TestCase
         $media2 = $this->createMedia(2);
         $media3 = $this->createMedia(3);
 
+        $user = $this->prophesize(SuluUserInterface::class);
+
         return [
-            [[1, 2, 3], [$media1, $media2, $media3], [$media1, $media2, $media3]],
-            [[2, 1, 3], [$media1, $media2, $media3], [$media2, $media1, $media3]],
-            [[4, 1, 2], [$media1, $media2], [$media1, $media2]],
+            [[1, 2, 3], null, 64, [$media1, $media2, $media3], [$media1, $media2, $media3]],
+            [[2, 1, 3], $user->reveal(), 32, [$media1, $media2, $media3], [$media2, $media1, $media3]],
+            [[4, 1, 2], null, 16, [$media1, $media2], [$media1, $media2]],
         ];
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/MediaSelectionContentTypeTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/MediaSelectionContentTypeTest.php
@@ -388,7 +388,7 @@ class MediaSelectionContentTypeTest extends TestCase
         $token->getUser()->willReturn($user->reveal());
         $this->tokenStorage->getToken()->willReturn($token->reveal());
 
-        $this->mediaManager->getByIds([1, 2, 3], null, $user->reveal(), 64)->shouldBeCalled();
+        $this->mediaManager->getByIds([1, 2, 3], null, $user->reveal())->shouldBeCalled();
 
         $result = $this->mediaSelection->getContentData($property->reveal());
     }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/MediaSelectionContentTypeTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/MediaSelectionContentTypeTest.php
@@ -17,6 +17,10 @@ use Sulu\Bundle\MediaBundle\Content\Types\MediaSelectionContentType;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
+use Sulu\Component\Content\Compat\StructureInterface;
+use Sulu\Component\Security\Authentication\UserInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class MediaSelectionContentTypeTest extends TestCase
 {
@@ -39,10 +43,13 @@ class MediaSelectionContentTypeTest extends TestCase
     {
         $this->mediaManager = $this->prophesize(MediaManagerInterface::class);
         $this->mediaReferenceStore = $this->prophesize(ReferenceStoreInterface::class);
+        $this->tokenStorage = $this->prophesize(TokenStorageInterface::class);
 
         $this->mediaSelection = new MediaSelectionContentType(
             $this->mediaManager->reveal(),
-            $this->mediaReferenceStore->reveal()
+            $this->mediaReferenceStore->reveal(),
+            $this->tokenStorage->reveal(),
+            ['view' => 64]
         );
     }
 
@@ -365,6 +372,25 @@ class MediaSelectionContentTypeTest extends TestCase
         );
 
         $this->mediaSelection->read($node, $property, 'test', 'en', 's');
+    }
+
+    public function testGetContentData()
+    {
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getValue()->willReturn(['ids' => [1, 2, 3]]);
+        $property->getParams()->willReturn([]);
+
+        $structure = $this->prophesize(StructureInterface::class);
+        $property->getStructure()->willReturn($structure->reveal());
+
+        $token = $this->prophesize(TokenInterface::class);
+        $user = $this->prophesize(UserInterface::class);
+        $token->getUser()->willReturn($user->reveal());
+        $this->tokenStorage->getToken()->willReturn($token->reveal());
+
+        $this->mediaManager->getByIds([1, 2, 3], null, $user->reveal(), 64)->shouldBeCalled();
+
+        $result = $this->mediaSelection->getContentData($property->reveal());
     }
 
     public function testPreResolve()

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/MediaSelectionContentTypeTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/MediaSelectionContentTypeTest.php
@@ -18,9 +18,7 @@ use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
-use Sulu\Component\Security\Authentication\UserInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class MediaSelectionContentTypeTest extends TestCase
 {
@@ -383,12 +381,7 @@ class MediaSelectionContentTypeTest extends TestCase
         $structure = $this->prophesize(StructureInterface::class);
         $property->getStructure()->willReturn($structure->reveal());
 
-        $token = $this->prophesize(TokenInterface::class);
-        $user = $this->prophesize(UserInterface::class);
-        $token->getUser()->willReturn($user->reveal());
-        $this->tokenStorage->getToken()->willReturn($token->reveal());
-
-        $this->mediaManager->getByIds([1, 2, 3], null, $user->reveal())->shouldBeCalled();
+        $this->mediaManager->getByIds([1, 2, 3], null, 64)->shouldBeCalled();
 
         $result = $this->mediaSelection->getContentData($property->reveal());
     }

--- a/src/Sulu/Bundle/PageBundle/Content/PageSelectionContainer.php
+++ b/src/Sulu/Bundle/PageBundle/Content/PageSelectionContainer.php
@@ -15,6 +15,7 @@ use JMS\Serializer\Annotation\Exclude;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Content\Query\ContentQueryBuilderInterface;
 use Sulu\Component\Content\Query\ContentQueryExecutorInterface;
+use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Util\ArrayableInterface;
 
 /**
@@ -84,6 +85,11 @@ class PageSelectionContainer implements ArrayableInterface
      */
     private $showDrafts;
 
+    /**
+     * @var UserInterface
+     */
+    private $user;
+
     public function __construct(
         $ids,
         ContentQueryExecutorInterface $contentQueryExecutor,
@@ -91,7 +97,8 @@ class PageSelectionContainer implements ArrayableInterface
         $params,
         $webspaceKey,
         $languageCode,
-        $showDrafts
+        $showDrafts,
+        UserInterface $user = null
     ) {
         $this->ids = $ids;
         $this->contentQueryExecutor = $contentQueryExecutor;
@@ -100,6 +107,7 @@ class PageSelectionContainer implements ArrayableInterface
         $this->languageCode = $languageCode;
         $this->params = $params;
         $this->showDrafts = $showDrafts;
+        $this->user = $user;
     }
 
     /**
@@ -133,7 +141,13 @@ class PageSelectionContainer implements ArrayableInterface
             $pages = $this->contentQueryExecutor->execute(
                 $this->webspaceKey,
                 [$this->languageCode],
-                $this->contentQueryBuilder
+                $this->contentQueryBuilder,
+                true,
+                -1,
+                null,
+                null,
+                false,
+                $this->user
             );
 
             // init vars

--- a/src/Sulu/Bundle/PageBundle/Content/PageSelectionContainer.php
+++ b/src/Sulu/Bundle/PageBundle/Content/PageSelectionContainer.php
@@ -86,9 +86,9 @@ class PageSelectionContainer implements ArrayableInterface
     private $showDrafts;
 
     /**
-     * @var UserInterface
+     * @var array
      */
-    private $user;
+    private $permission;
 
     public function __construct(
         $ids,
@@ -98,7 +98,7 @@ class PageSelectionContainer implements ArrayableInterface
         $webspaceKey,
         $languageCode,
         $showDrafts,
-        UserInterface $user = null
+        $permission = null
     ) {
         $this->ids = $ids;
         $this->contentQueryExecutor = $contentQueryExecutor;
@@ -107,7 +107,7 @@ class PageSelectionContainer implements ArrayableInterface
         $this->languageCode = $languageCode;
         $this->params = $params;
         $this->showDrafts = $showDrafts;
-        $this->user = $user;
+        $this->permission = $permission;
     }
 
     /**
@@ -147,7 +147,7 @@ class PageSelectionContainer implements ArrayableInterface
                 null,
                 null,
                 false,
-                $this->user
+                $this->permission
             );
 
             // init vars

--- a/src/Sulu/Bundle/PageBundle/Content/PageSelectionContainer.php
+++ b/src/Sulu/Bundle/PageBundle/Content/PageSelectionContainer.php
@@ -15,7 +15,6 @@ use JMS\Serializer\Annotation\Exclude;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Content\Query\ContentQueryBuilderInterface;
 use Sulu\Component\Content\Query\ContentQueryExecutorInterface;
-use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Util\ArrayableInterface;
 
 /**

--- a/src/Sulu/Bundle/PageBundle/Content/Types/PageSelection.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/PageSelection.php
@@ -193,7 +193,7 @@ class PageSelection extends ComplexContentType implements ContentTypeExportInter
 
         $user = $this->tokenStorage->getToken()->getUser();
 
-        if (\is_object($user)) {
+        if ($user instanceof UserInterface) {
             return $user;
         }
 

--- a/src/Sulu/Bundle/PageBundle/Content/Types/PageSelection.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/PageSelection.php
@@ -23,6 +23,7 @@ use Sulu\Component\Content\PreResolvableContentTypeInterface;
 use Sulu\Component\Content\Query\ContentQueryBuilderInterface;
 use Sulu\Component\Content\Query\ContentQueryExecutorInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Util\ArrayableInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
@@ -52,22 +53,22 @@ class PageSelection extends ComplexContentType implements ContentTypeExportInter
     private $showDrafts;
 
     /**
-     * @var ?TokenStorageInterface
+     * @var array
      */
-    private $tokenStorage;
+    private $permissions;
 
     public function __construct(
         ContentQueryExecutorInterface $contentQueryExecutor,
         ContentQueryBuilderInterface $contentQueryBuilder,
         ReferenceStoreInterface $referenceStore,
         $showDrafts,
-        TokenStorageInterface $tokenStorage = null
+        $permissions = null
     ) {
         $this->contentQueryExecutor = $contentQueryExecutor;
         $this->contentQueryBuilder = $contentQueryBuilder;
         $this->referenceStore = $referenceStore;
         $this->showDrafts = $showDrafts;
-        $this->tokenStorage = $tokenStorage;
+        $this->permissions = $permissions;
     }
 
     public function read(
@@ -145,7 +146,7 @@ class PageSelection extends ComplexContentType implements ContentTypeExportInter
             $property->getStructure()->getWebspaceKey(),
             $property->getStructure()->getLanguageCode(),
             $this->showDrafts,
-            $this->getUser()
+            $this->permissions[PermissionTypes::VIEW]
         );
 
         return $container->getData();
@@ -183,20 +184,5 @@ class PageSelection extends ComplexContentType implements ContentTypeExportInter
         foreach ($uuids as $uuid) {
             $this->referenceStore->add($uuid);
         }
-    }
-
-    private function getUser(): ?UserInterface
-    {
-        if (!$this->tokenStorage) {
-            return null;
-        }
-
-        $user = $this->tokenStorage->getToken()->getUser();
-
-        if ($user instanceof UserInterface) {
-            return $user;
-        }
-
-        return null;
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Content/Types/PageSelection.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/PageSelection.php
@@ -22,10 +22,8 @@ use Sulu\Component\Content\ContentTypeExportInterface;
 use Sulu\Component\Content\PreResolvableContentTypeInterface;
 use Sulu\Component\Content\Query\ContentQueryBuilderInterface;
 use Sulu\Component\Content\Query\ContentQueryExecutorInterface;
-use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Util\ArrayableInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
  * content type for internal links selection.

--- a/src/Sulu/Bundle/PageBundle/Content/Types/SinglePageSelection.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/SinglePageSelection.php
@@ -12,10 +12,15 @@
 namespace Sulu\Bundle\PageBundle\Content\Types;
 
 use PHPCR\NodeInterface;
+use Sulu\Bundle\PageBundle\Admin\PageAdmin;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
+use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
 use Sulu\Component\Content\PreResolvableContentTypeInterface;
 use Sulu\Component\Content\SimpleContentType;
+use Sulu\Component\Security\Authorization\PermissionTypes;
+use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
+use Sulu\Component\Security\Authorization\SecurityCondition;
 
 /**
  * ContentType for SinglePageSelection.
@@ -27,11 +32,19 @@ class SinglePageSelection extends SimpleContentType implements PreResolvableCont
      */
     private $referenceStore;
 
-    public function __construct(ReferenceStoreInterface $referenceStore)
-    {
+    /**
+     * @var ?SecurityCheckerInterface
+     */
+    private $securityChecker;
+
+    public function __construct(
+        ReferenceStoreInterface $referenceStore,
+        SecurityCheckerInterface $securityChecker = null
+    ) {
         parent::__construct('SinglePageSelection', '');
 
         $this->referenceStore = $referenceStore;
+        $this->securityChecker = $securityChecker;
     }
 
     public function write(
@@ -66,6 +79,25 @@ class SinglePageSelection extends SimpleContentType implements PreResolvableCont
         $property->setValue($value);
 
         return $value;
+    }
+
+    public function getContentData(PropertyInterface $property)
+    {
+        if ($this->securityChecker
+            && !$this->securityChecker->hasPermission(
+                new SecurityCondition(
+                    PageAdmin::SECURITY_CONTEXT_PREFIX . $property->getStructure()->getWebspaceKey(),
+                    $property->getStructure()->getLanguageCode(),
+                    SecurityBehavior::class,
+                    $property->getValue()
+                ),
+                PermissionTypes::VIEW
+            )
+        ) {
+            return null;
+        }
+
+        return parent::getContentData($property);
     }
 
     public function preResolve(PropertyInterface $property)

--- a/src/Sulu/Bundle/PageBundle/Repository/NodeRepository.php
+++ b/src/Sulu/Bundle/PageBundle/Repository/NodeRepository.php
@@ -288,8 +288,7 @@ class NodeRepository implements NodeRepositoryInterface
                 [],
                 $webspaceKey,
                 $languageCode,
-                true,
-                $this->getUser()
+                true
             );
 
             $result = $container->getData();
@@ -416,8 +415,7 @@ class NodeRepository implements NodeRepositoryInterface
             -1,
             $limit,
             null,
-            false,
-            $this->getUser()
+            false
         );
 
         if ($api) {

--- a/src/Sulu/Bundle/PageBundle/Repository/NodeRepository.php
+++ b/src/Sulu/Bundle/PageBundle/Repository/NodeRepository.php
@@ -24,6 +24,7 @@ use Sulu\Component\Content\Repository\ContentRepository;
 use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
 use Sulu\Component\Rest\Exception\RestException;
+use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authorization\AccessControl\AccessControlManagerInterface;
 use Sulu\Component\Security\Authorization\SecurityCondition;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
@@ -287,7 +288,8 @@ class NodeRepository implements NodeRepositoryInterface
                 [],
                 $webspaceKey,
                 $languageCode,
-                true
+                true,
+                $this->getUser()
             );
 
             $result = $container->getData();
@@ -412,7 +414,10 @@ class NodeRepository implements NodeRepositoryInterface
             $this->queryBuilder,
             true,
             -1,
-            $limit
+            $limit,
+            null,
+            false,
+            $this->getUser()
         );
 
         if ($api) {
@@ -714,5 +719,20 @@ class NodeRepository implements NodeRepositoryInterface
         }
 
         return $this->prepareNode($structure, $webspaceKey, $srcLocale);
+    }
+
+    private function getUser(): ?UserInterface
+    {
+        if (!$this->tokenStorage) {
+            return null;
+        }
+
+        $user = $this->tokenStorage->getToken()->getUser();
+
+        if (\is_object($user)) {
+            return $user;
+        }
+
+        return null;
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Repository/NodeRepository.php
+++ b/src/Sulu/Bundle/PageBundle/Repository/NodeRepository.php
@@ -729,7 +729,7 @@ class NodeRepository implements NodeRepositoryInterface
 
         $user = $this->tokenStorage->getToken()->getUser();
 
-        if (\is_object($user)) {
+        if ($user instanceof UserInterface) {
             return $user;
         }
 

--- a/src/Sulu/Bundle/PageBundle/Resources/config/content_types.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/content_types.xml
@@ -15,6 +15,7 @@
 
         <service id="sulu.content.type.single_page_selection" class="Sulu\Bundle\PageBundle\Content\Types\SinglePageSelection">
             <argument type="service" id="sulu_page.reference_store.content"/>
+            <argument type="service" id="sulu_security.security_checker" on-invalid="null"/>
 
             <tag name="sulu.content.type" alias="single_page_selection"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />

--- a/src/Sulu/Bundle/PageBundle/Resources/config/content_types.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/content_types.xml
@@ -8,7 +8,7 @@
             <argument type="service" id="sulu_page.smart_content.data_provider.content.query_builder"/>
             <argument type="service" id="sulu_page.reference_store.content"/>
             <argument>%sulu_document_manager.show_drafts%</argument>
-            <argument type="service" id="security.token_storage" on-invalid="null"/>
+            <argument>%sulu_security.permissions%</argument>
             <tag name="sulu.content.type" alias="page_selection"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
         </service>

--- a/src/Sulu/Bundle/PageBundle/Resources/config/content_types.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/content_types.xml
@@ -8,6 +8,7 @@
             <argument type="service" id="sulu_page.smart_content.data_provider.content.query_builder"/>
             <argument type="service" id="sulu_page.reference_store.content"/>
             <argument>%sulu_document_manager.show_drafts%</argument>
+            <argument type="service" id="security.token_storage" on-invalid="null"/>
             <tag name="sulu.content.type" alias="page_selection"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
         </service>

--- a/src/Sulu/Bundle/PageBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/services.xml
@@ -196,8 +196,8 @@
                  class="Sulu\Bundle\PageBundle\Sitemap\PagesSitemapProvider">
             <argument type="service" id="sulu_page.content_repository"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
-            <argument type="service" id="sulu_security.access_control_manager"/>
             <argument>%kernel.environment%</argument>
+            <argument type="service" id="sulu_security.access_control_manager"/>
 
             <tag name="sulu.sitemap.provider"/>
         </service>

--- a/src/Sulu/Bundle/PageBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/services.xml
@@ -196,6 +196,7 @@
                  class="Sulu\Bundle\PageBundle\Sitemap\PagesSitemapProvider">
             <argument type="service" id="sulu_page.content_repository"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
+            <argument type="service" id="sulu_security.access_control_manager"/>
             <argument>%kernel.environment%</argument>
 
             <tag name="sulu.sitemap.provider"/>

--- a/src/Sulu/Bundle/PageBundle/Resources/config/smart_content.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/smart_content.xml
@@ -56,6 +56,7 @@
             <argument type="service" id="sulu_category.reference_store.category"/>
             <argument type="service" id="sulu_audience_targeting.target_group_store" on-invalid="null"/>
             <argument type="service" id="sulu_core.webspace.request_analyzer" />
+            <argument type="service" id="security.token_storage" on-invalid="null" />
 
             <tag name="sulu.content.type" alias="smart_content"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
@@ -68,6 +69,7 @@
             <argument type="service" id="fos_rest.view_handler"/>
             <argument type="service" id="sulu_tag.tag_manager"/>
             <argument type="service" id="sulu_page.smart_content.data_provider_pool"/>
+            <argument type="service" id="security.token_storage" on-invalid="null"/>
 
             <tag name="sulu.context" context="admin"/>
         </service>

--- a/src/Sulu/Bundle/PageBundle/Resources/config/smart_content.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/smart_content.xml
@@ -41,6 +41,7 @@
             <argument type="service" id="sulu_document_manager.default_session"/>
             <argument type="service" id="sulu_page.reference_store.content"/>
             <argument>%sulu_document_manager.show_drafts%</argument>
+            <argument>%sulu_security.permissions%</argument>
 
             <tag name="sulu.smart_content.data_provider" alias="pages"/>
         </service>

--- a/src/Sulu/Bundle/PageBundle/Resources/config/smart_content.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/smart_content.xml
@@ -57,7 +57,6 @@
             <argument type="service" id="sulu_category.reference_store.category"/>
             <argument type="service" id="sulu_audience_targeting.target_group_store" on-invalid="null"/>
             <argument type="service" id="sulu_core.webspace.request_analyzer" />
-            <argument type="service" id="security.token_storage" on-invalid="null" />
 
             <tag name="sulu.content.type" alias="smart_content"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />

--- a/src/Sulu/Bundle/PageBundle/Sitemap/PagesSitemapProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Sitemap/PagesSitemapProvider.php
@@ -40,25 +40,25 @@ class PagesSitemapProvider extends AbstractSitemapProvider
     private $webspaceManager;
 
     /**
-     * @var AccessControlManagerInterface
-     */
-    private $accessControlManager;
-
-    /**
      * @var string
      */
     private $environment;
 
+    /**
+     * @var ?AccessControlManagerInterface
+     */
+    private $accessControlManager;
+
     public function __construct(
         ContentRepositoryInterface $contentRepository,
         WebspaceManagerInterface $webspaceManager,
-        AccessControlManagerInterface $accessControlManager,
-        string $environment
+        string $environment,
+        AccessControlManagerInterface $accessControlManager = null
     ) {
         $this->contentRepository = $contentRepository;
         $this->webspaceManager = $webspaceManager;
-        $this->accessControlManager = $accessControlManager;
         $this->environment = $environment;
+        $this->accessControlManager = $accessControlManager;
     }
 
     public function build($page, $scheme, $host)
@@ -94,15 +94,17 @@ class PagesSitemapProvider extends AbstractSitemapProvider
                     continue;
                 }
 
-                $userPermissions = $this->accessControlManager->getUserPermissionByArray(
-                    $contentPage->getLocale(),
-                    PageAdmin::SECURITY_CONTEXT_PREFIX . $contentPage->getWebspaceKey(),
-                    $contentPage->getPermissions(),
-                    null
-                );
+                if ($this->accessControlManager) {
+                    $userPermissions = $this->accessControlManager->getUserPermissionByArray(
+                        $contentPage->getLocale(),
+                        PageAdmin::SECURITY_CONTEXT_PREFIX . $contentPage->getWebspaceKey(),
+                        $contentPage->getPermissions(),
+                        null
+                    );
 
-                if (isset($userPermissions['view']) && !$userPermissions['view']) {
-                    continue;
+                    if (isset($userPermissions['view']) && !$userPermissions['view']) {
+                        continue;
+                    }
                 }
 
                 $sitemapUrl = $this->generateSitemapUrl($contentPage, $portalInformation, $host, $scheme);

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/SmartContentItemControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/SmartContentItemControllerTest.php
@@ -13,14 +13,10 @@ namespace Sulu\Bundle\PageBundle\Tests\Functional\Controller;
 
 use Doctrine\ORM\EntityManager;
 use PHPCR\SessionInterface;
-use Sulu\Bundle\ContactBundle\Entity\Contact;
-use Sulu\Bundle\ContactBundle\Entity\Email;
-use Sulu\Bundle\ContactBundle\Entity\EmailType;
 use Sulu\Bundle\PageBundle\Document\PageDocument;
 use Sulu\Bundle\PageBundle\Form\Type\PageDocumentType;
 use Sulu\Bundle\SecurityBundle\Entity\Permission;
 use Sulu\Bundle\SecurityBundle\Entity\Role;
-use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\SecurityBundle\Entity\UserRole;
 use Sulu\Bundle\TagBundle\Tag\TagInterface;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
@@ -111,55 +107,30 @@ class SmartContentItemControllerTest extends SuluTestCase
     {
         $this->purgeDatabase();
 
-        $contact = new Contact();
-        $contact->setFirstName('Max');
-        $contact->setLastName('Mustermann');
-        $this->em->persist($contact);
-        $this->em->flush();
-
-        $emailType = new EmailType();
-        $emailType->setName('Private');
-        $this->em->persist($emailType);
-        $this->em->flush();
-
-        $email = new Email();
-        $email->setEmail('max.mustermann@muster.at');
-        $email->setEmailType($emailType);
-        $this->em->persist($email);
-        $this->em->flush();
+        $user = $this->getContainer()->get('test_user_provider')->getUser();
 
         $role1 = new Role();
         $role1->setName('Role1');
         $role1->setSystem('Sulu');
         $this->em->persist($role1);
-        $this->em->flush();
-
-        $user = new User();
-        $user->setUsername('admin');
-        $user->setPassword('securepassword');
-        $user->setSalt('salt');
-        $user->setLocale('de');
-        $user->setContact($contact);
-        $this->em->persist($user);
-        $this->em->flush();
 
         $userRole1 = new UserRole();
         $userRole1->setRole($role1);
         $userRole1->setUser($user);
         $userRole1->setLocale(\json_encode(['de', 'en']));
+        $user->addUserRole($userRole1);
         $this->em->persist($userRole1);
-        $this->em->flush();
 
         $permission1 = new Permission();
         $permission1->setPermissions(122);
         $permission1->setRole($role1);
-        $permission1->setContext('Context 1');
+        $permission1->setContext('sulu.webspaces.sulu_io');
         $this->em->persist($permission1);
-        $this->em->flush();
 
         $this->tag1 = $this->getContainer()->get('sulu.repository.tag')->createNew();
         $this->tag1->setName('tag1');
         $this->em->persist($this->tag1);
+
         $this->em->flush();
     }
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/SmartContent/QueryBuilderTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/SmartContent/QueryBuilderTest.php
@@ -32,6 +32,7 @@ use Sulu\Component\Content\SmartContent\QueryBuilder;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
+use Sulu\Component\Security\Authentication\RoleInterface;
 use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
 use Sulu\Component\Webspace\Webspace;
 use Symfony\Component\HttpFoundation\Request;
@@ -93,6 +94,11 @@ class QueryBuilderTest extends SuluTestCase
      */
     private $audienceTargetGroupRepository;
 
+    /**
+     * @var RoleInterface
+     */
+    private $anonymousRole;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -112,6 +118,15 @@ class QueryBuilderTest extends SuluTestCase
 
         $em = $this->getContainer()->get('doctrine')->getManager();
         $user = $em->getRepository('Sulu\Bundle\SecurityBundle\Entity\User')->findOneByUsername('test');
+
+        $this->anonymousRole = $this->getContainer()->get('sulu.repository.role')->createNew();
+        $this->anonymousRole->setName('Anonymous');
+        $this->anonymousRole->setAnonymous(true);
+        $this->anonymousRole->setSystem('sulu_io');
+        $em->persist($this->anonymousRole);
+        $em->flush();
+
+        $this->getContainer()->get('sulu_security.system_store')->setSystem('sulu_io');
 
         $this->tag1 = $this->tagRepository->createNew();
         $this->tag1->setName('test1');

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/PageSelectionContainerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/PageSelectionContainerTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\PageBundle\Content\PageSelectionContainer;
 use Sulu\Component\Content\Query\ContentQueryBuilder;
 use Sulu\Component\Content\Query\ContentQueryExecutor;
+use Sulu\Component\Security\Authentication\UserInterface;
 
 class PageSelectionContainerTest extends TestCase
 {
@@ -52,7 +53,7 @@ class PageSelectionContainerTest extends TestCase
         );
 
         $this->builder->init(['ids' => [2, 3, 1], 'properties' => [], 'published' => false])->shouldBeCalled();
-        $this->executor->execute('default', ['en'], $this->builder)->willReturn(
+        $this->executor->execute('default', ['en'], $this->builder, true, -1, null, null, false, null)->willReturn(
             [['id' => 1], ['id' => 2], ['id' => 3]]
         );
 
@@ -72,7 +73,7 @@ class PageSelectionContainerTest extends TestCase
         );
 
         $this->builder->init(['ids' => [2, 3, 1], 'properties' => [], 'published' => true])->shouldBeCalled();
-        $this->executor->execute('default', ['en'], $this->builder)->willReturn(
+        $this->executor->execute('default', ['en'], $this->builder, true, -1, null, null, false, null)->willReturn(
             [['id' => 1], ['id' => 2], ['id' => 3]]
         );
 
@@ -81,7 +82,7 @@ class PageSelectionContainerTest extends TestCase
 
     public function testGetDataOrder()
     {
-        $this->executor->execute('default', ['en'], $this->builder)->willReturn(
+        $this->executor->execute('default', ['en'], $this->builder, true, -1, null, null, false, null)->willReturn(
             [['id' => 1], ['id' => 2], ['id' => 3]]
         );
 
@@ -97,5 +98,29 @@ class PageSelectionContainerTest extends TestCase
 
         $result = $this->container->getData();
         $this->assertEquals([['id' => 2], ['id' => 3], ['id' => 1]], $result);
+    }
+
+    public function testGetDataWithUser()
+    {
+        $user = $this->prophesize(UserInterface::class);
+
+        $this->container = new PageSelectionContainer(
+            [2, 3, 1],
+            $this->executor->reveal(),
+            $this->builder->reveal(),
+            [],
+            'default',
+            'en',
+            true,
+            $user->reveal()
+        );
+
+        $this->builder->init(['ids' => [2, 3, 1], 'properties' => [], 'published' => false])->shouldBeCalled();
+        $this->executor
+             ->execute('default', ['en'], $this->builder, true, -1, null, null, false, $user->reveal())
+             ->willReturn([['id' => 1], ['id' => 2], ['id' => 3]]
+        );
+
+        $this->container->getData();
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/PageSelectionContainerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/PageSelectionContainerTest.php
@@ -60,6 +60,27 @@ class PageSelectionContainerTest extends TestCase
         $this->container->getData();
     }
 
+    public function testGetDataWithPermissions()
+    {
+        $this->container = new PageSelectionContainer(
+            [2, 3, 1],
+            $this->executor->reveal(),
+            $this->builder->reveal(),
+            [],
+            'default',
+            'en',
+            true,
+            64
+        );
+
+        $this->builder->init(['ids' => [2, 3, 1], 'properties' => [], 'published' => false])->shouldBeCalled();
+        $this->executor->execute('default', ['en'], $this->builder, true, -1, null, null, false, 64)->willReturn(
+            [['id' => 1], ['id' => 2], ['id' => 3]]
+        );
+
+        $this->container->getData();
+    }
+
     public function testGetDataOnlyPublished()
     {
         $this->container = new PageSelectionContainer(

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/PageSelectionTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/PageSelectionTest.php
@@ -22,9 +22,6 @@ use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Content\Query\ContentQueryBuilderInterface;
 use Sulu\Component\Content\Query\ContentQueryExecutorInterface;
-use Sulu\Component\Security\Authentication\UserInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class PageSelectionTest extends TestCase
 {

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/PageSelectionTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/PageSelectionTest.php
@@ -96,7 +96,8 @@ class PageSelectionTest extends TestCase
             $this->contentQueryExecutor->reveal(),
             $this->contentQueryBuilder->reveal(),
             $this->referenceStore->reveal(),
-            false
+            false,
+            ['view' => 64]
         );
 
         $this->property->getValue()->willReturn(['123-123-123']);
@@ -109,7 +110,7 @@ class PageSelectionTest extends TestCase
         $this->contentQueryBuilder->init(['ids' => ['123-123-123'], 'properties' => [], 'published' => true])
             ->shouldBeCalled();
         $this->contentQueryExecutor
-             ->execute('default', ['en'], $this->contentQueryBuilder->reveal(), true, -1, null, null, false, null)
+             ->execute('default', ['en'], $this->contentQueryBuilder->reveal(), true, -1, null, null, false, 64)
              ->willReturn([]);
 
         $pageSelection->getContentData($this->property->reveal());
@@ -117,13 +118,12 @@ class PageSelectionTest extends TestCase
 
     public function testGetContentDataWithUser()
     {
-        $tokenStorage = $this->prophesize(TokenStorageInterface::class);
         $pageSelection = new PageSelection(
             $this->contentQueryExecutor->reveal(),
             $this->contentQueryBuilder->reveal(),
             $this->referenceStore->reveal(),
             false,
-            $tokenStorage->reveal()
+            ['view' => 64]
         );
 
         $this->property->getValue()->willReturn(['123-123-123']);
@@ -132,11 +132,6 @@ class PageSelectionTest extends TestCase
         $structure->getWebspaceKey()->willReturn('default');
         $structure->getLanguageCode()->willReturn('en');
         $this->property->getStructure()->willReturn($structure->reveal());
-
-        $user = $this->prophesize(UserInterface::class);
-        $token = $this->prophesize(TokenInterface::class);
-        $token->getUser()->willReturn($user->reveal());
-        $tokenStorage->getToken()->willReturn($token->reveal());
 
         $this->contentQueryBuilder->init(['ids' => ['123-123-123'], 'properties' => [], 'published' => true])
             ->shouldBeCalled();
@@ -150,7 +145,7 @@ class PageSelectionTest extends TestCase
                  null,
                  null,
                  false,
-                 $user->reveal()
+                 64
              )
              ->willReturn([]);
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Sitemap/PagesSitemapProviderTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Sitemap/PagesSitemapProviderTest.php
@@ -91,8 +91,8 @@ class PagesSitemapProviderTest extends TestCase
         $this->sitemapProvider = new PagesSitemapProvider(
             $this->contentRepository->reveal(),
             $this->webspaceManager->reveal(),
-            $this->accessControlManager->reveal(),
-            'test'
+            'test',
+            $this->accessControlManager->reveal()
         );
     }
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Sitemap/PagesSitemapProviderTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Sitemap/PagesSitemapProviderTest.php
@@ -19,6 +19,7 @@ use Sulu\Component\Content\Repository\Content;
 use Sulu\Component\Content\Repository\ContentRepositoryInterface;
 use Sulu\Component\Content\Repository\Mapping\MappingBuilder;
 use Sulu\Component\Localization\Localization;
+use Sulu\Component\Security\Authorization\AccessControl\AccessControlManagerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\PortalInformation;
 use Sulu\Component\Webspace\Webspace;
@@ -34,6 +35,11 @@ class PagesSitemapProviderTest extends TestCase
      * @var WebspaceManagerInterface
      */
     private $webspaceManager;
+
+    /**
+     * @var AccessControlManagerInterface
+     */
+    private $accessControlManager;
 
     /**
      * @var PagesSitemapProvider
@@ -69,6 +75,7 @@ class PagesSitemapProviderTest extends TestCase
     {
         $this->contentRepository = $this->prophesize(ContentRepositoryInterface::class);
         $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $this->accessControlManager = $this->prophesize(AccessControlManagerInterface::class);
 
         $this->webspace = $this->prophesize(Webspace::class);
         $this->portalInformation = $this->prophesize(PortalInformation::class);
@@ -84,6 +91,7 @@ class PagesSitemapProviderTest extends TestCase
         $this->sitemapProvider = new PagesSitemapProvider(
             $this->contentRepository->reveal(),
             $this->webspaceManager->reveal(),
+            $this->accessControlManager->reveal(),
             'test'
         );
     }
@@ -114,6 +122,9 @@ class PagesSitemapProviderTest extends TestCase
                 ->getMapping()
         )->willReturn($pages);
 
+        $this->accessControlManager->getUserPermissionByArray('de', 'sulu.webspaces.sulu_io', [], null)
+            ->shouldBeCalledTimes(3);
+
         $result = $this->sitemapProvider->build(1, 'http', 'localhost');
 
         $this->assertCount(3, $result);
@@ -121,6 +132,46 @@ class PagesSitemapProviderTest extends TestCase
             $this->assertEquals('http://localhost' . $pages[$i]->getUrl(), $result[$i]->getLoc());
             $this->assertEquals(new \DateTime($pages[$i]->getData()['changed']), $result[$i]->getLastMod());
         }
+    }
+
+    public function testBuildWithPermissions()
+    {
+        $localization = new Localization('de');
+        $this->webspace->getDefaultLocalization()->willReturn($localization);
+        $this->portalInformation->getLocalization()->willReturn($localization);
+
+        $this->webspaceManager->findPortalInformationsByHostIncludingSubdomains('localhost', 'test')
+            ->willReturn([$this->portalInformation->reveal()]);
+
+        /** @var Content[] $pages */
+        $pages = [
+            $this->createContent('/test-1', false, RedirectType::NONE, [], 'de', [1 => ['view' => true]]),
+            $this->createContent('/test-2', false, RedirectType::NONE, [], 'de', [1 => ['view' => false]]),
+            $this->createContent('/test-3', false, RedirectType::NONE, [], 'de', [1 => ['view' => true]]),
+        ];
+
+        $this->contentRepository->findAllByPortal(
+            'de',
+            $this->portalKey,
+            MappingBuilder::create()
+                ->addProperties(['changed', 'seo-hideInSitemap'])
+                ->setResolveUrl(true)
+                ->setHydrateGhost(false)
+                ->getMapping()
+        )->willReturn($pages);
+
+        $this->accessControlManager
+            ->getUserPermissionByArray('de', 'sulu.webspaces.sulu_io', [1 => ['view' => true]], null)
+            ->willReturn(['view' => true]);
+
+        $this->accessControlManager
+            ->getUserPermissionByArray('de', 'sulu.webspaces.sulu_io', [1 => ['view' => false]], null)
+            ->willReturn(['view' => false]);
+
+        $result = $this->sitemapProvider->build(1, 'http', 'localhost');
+
+        $this->assertEquals('http://localhost/test-1', $result[0]->getLoc());
+        $this->assertEquals('http://localhost/test-3', $result[1]->getLoc());
     }
 
     public function testBuildMultipleLocales()
@@ -260,12 +311,17 @@ class PagesSitemapProviderTest extends TestCase
      * @param string $url
      * @param bool $hideInSitemap
      * @param int $redirectTarget
-     * @param array $urls
      *
      * @return Content
      */
-    public function createContent($url, $hideInSitemap = false, $redirectTarget = RedirectType::NONE, $urls = [], $locale = 'de')
-    {
+    public function createContent(
+        $url,
+        $hideInSitemap = false,
+        $redirectTarget = RedirectType::NONE,
+        $urls = [],
+        $locale = 'de',
+        $permissions = []
+    ) {
         $content = new Content(
             $locale,
             $this->portalKey,
@@ -276,7 +332,7 @@ class PagesSitemapProviderTest extends TestCase
             false,
             'default',
             ['seo-hideInSitemap' => $hideInSitemap, 'changed' => (new \DateTime())->format('c')],
-            []
+            $permissions
         );
         $content->setUrl($url);
         $content->setUrls($urls);

--- a/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/PersistenceExtensionTrait.php
+++ b/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/PersistenceExtensionTrait.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\PersistenceBundle\DependencyInjection;
 
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepositoryInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -84,7 +85,10 @@ trait PersistenceExtensionTrait
         ]);
 
         $repositoryReflectionClass = new \ReflectionClass($repositoryClass);
-        if ($repositoryReflectionClass->hasMethod('setAccessControlQueryEnhancer')) {
+        if (
+            $repositoryReflectionClass->hasMethod('setAccessControlQueryEnhancer')
+            && !$repositoryReflectionClass->implementsInterface(ServiceEntityRepositoryInterface::class)
+        ) {
             $definition->addMethodCall(
                 'setAccessControlQueryEnhancer',
                 [new Reference('sulu_security.access_control_query_enhancer')]

--- a/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/PersistenceExtensionTrait.php
+++ b/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/PersistenceExtensionTrait.php
@@ -83,6 +83,14 @@ trait PersistenceExtensionTrait
             $this->getClassMetadataDefinition($services['model']),
         ]);
 
+        $repositoryReflectionClass = new \ReflectionClass($repositoryClass);
+        if ($repositoryReflectionClass->hasMethod('setAccessControlQueryEnhancer')) {
+            $definition->addMethodCall(
+                'setAccessControlQueryEnhancer',
+                [new Reference('sulu_security.access_control_query_enhancer')]
+            );
+        }
+
         return $definition;
     }
 

--- a/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
+++ b/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
@@ -13,13 +13,25 @@ namespace Sulu\Bundle\SecurityBundle\AccessControl;
 
 use Doctrine\ORM\QueryBuilder;
 use Sulu\Bundle\SecurityBundle\Entity\AccessControl;
+use Sulu\Bundle\SecurityBundle\System\SystemStoreInterface;
+use Sulu\Component\Security\Authentication\RoleInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 
 class AccessControlQueryEnhancer
 {
+    /**
+     * @var SystemStoreInterface
+     */
+    private $systemStore;
+
+    public function __construct(SystemStoreInterface $systemStore)
+    {
+        $this->systemStore = $systemStore;
+    }
+
     public function enhance(
         QueryBuilder $queryBuilder,
-        UserInterface $user,
+        UserInterface $user = null,
         int $permission,
         string $entityClass,
         string $entityAlias
@@ -30,20 +42,25 @@ class AccessControlQueryEnhancer
             'WITH',
             'accessControl.entityClass = :entityClass AND accessControl.entityId = ' . $entityAlias . '.id'
         );
-        $queryBuilder->leftJoin('accessControl.role', 'role');
+        $queryBuilder->leftJoin('accessControl.role', 'role', 'WITH', 'role.system = :system');
         $queryBuilder->andWhere(
             'BIT_AND(accessControl.permissions, :permission) = :permission OR accessControl.permissions IS NULL'
         );
 
-        // TODO use anonymous user
         $roleIds = [];
-        foreach ($user->getRoleObjects() as $role) {
-            $roleIds[] = $role->getId();
+        if ($user) {
+            $roleIds = \array_map(function(RoleInterface $role) {
+                return $role->getId();
+            }, $user->getRoleObjects());
+        } else {
+            $anonymousRole = $this->systemStore->getAnonymousRole();
+            $roleIds = $anonymousRole ? [$anonymousRole->getId()] : [];
         }
 
         $queryBuilder->andWhere('role.id IN(:roleIds) OR role.id IS NULL');
         $queryBuilder->setParameter('roleIds', $roleIds);
         $queryBuilder->setParameter('entityClass', $entityClass);
         $queryBuilder->setParameter('permission', $permission);
+        $queryBuilder->setParameter('system', $this->systemStore->getSystem());
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
+++ b/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\AccessControl;
+
+use Doctrine\ORM\QueryBuilder;
+use Sulu\Bundle\SecurityBundle\Entity\AccessControl;
+use Sulu\Component\Security\Authentication\UserInterface;
+
+class AccessControlQueryEnhancer
+{
+    public function enhance(
+        QueryBuilder $queryBuilder,
+        UserInterface $user,
+        int $permission,
+        string $entityClass,
+        string $entityAlias
+    ) {
+        $queryBuilder->leftJoin(
+            AccessControl::class,
+            'accessControl',
+            'WITH',
+            'accessControl.entityClass = :entityClass AND accessControl.entityId = ' . $entityAlias . '.id'
+        );
+        $queryBuilder->leftJoin('accessControl.role', 'role');
+        $queryBuilder->andWhere(
+            'BIT_AND(accessControl.permissions, :permission) = :permission OR accessControl.permissions IS NULL'
+        );
+
+        // TODO use anonymous user
+        $roleIds = [];
+        foreach ($user->getRoleObjects() as $role) {
+            $roleIds[] = $role->getId();
+        }
+
+        $queryBuilder->andWhere('role.id IN(:roleIds) OR role.id IS NULL');
+        $queryBuilder->setParameter('roleIds', $roleIds);
+        $queryBuilder->setParameter('entityClass', $entityClass);
+        $queryBuilder->setParameter('permission', $permission);
+    }
+}

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -321,6 +321,8 @@
         <service
             id="sulu_security.access_control_query_enhancer"
             class="Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancer"
-        />
+        >
+            <argument type="service" id="sulu_security.system_store" />
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -132,7 +132,6 @@
             <argument type="service" id="sulu_document_manager.document_manager"/>
             <argument type="service" id="sulu.repository.role"/>
             <argument>%permissions%</argument>
-            <tag name="sulu.context" context="admin"/>
             <tag name="sulu.access_control"/>
         </service>
 
@@ -141,7 +140,6 @@
             <argument type="service" id="sulu.repository.role"/>
             <argument type="service" id="sulu.repository.access_control"/>
             <argument type="service" id="sulu_security.mask_converter"/>
-            <tag name="sulu.context" context="admin"/>
             <tag name="sulu.access_control"/>
         </service>
 

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -317,5 +317,10 @@
             <tag name="kernel.event_subscriber"/>
             <tag name="sulu.context" context="admin"/>
         </service>
+
+        <service
+            id="sulu_security.access_control_query_enhancer"
+            class="Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancer"
+        />
     </services>
 </container>

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -124,7 +124,9 @@
             <argument type="service" id="sulu.repository.role"/>
         </service>
 
-        <service id="sulu_security.system_store" class="Sulu\Bundle\SecurityBundle\System\SystemStore" />
+        <service id="sulu_security.system_store" class="Sulu\Bundle\SecurityBundle\System\SystemStore">
+            <argument type="service" id="sulu.repository.role"/>
+        </service>
 
         <service id="sulu_security.phpcr_access_control_provider" class="%sulu_security.phpcr_access_control_provider.class%">
             <argument type="service" id="sulu_document_manager.document_manager"/>

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -121,6 +121,7 @@
             <argument type="service" id="sulu_security.mask_converter"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="sulu_security.system_store"/>
+            <argument type="service" id="sulu.repository.role"/>
         </service>
 
         <service id="sulu_security.system_store" class="Sulu\Bundle\SecurityBundle\System\SystemStore" />

--- a/src/Sulu/Bundle/SecurityBundle/System/SystemStore.php
+++ b/src/Sulu/Bundle/SecurityBundle/System/SystemStore.php
@@ -11,12 +11,30 @@
 
 namespace Sulu\Bundle\SecurityBundle\System;
 
+use Sulu\Component\Security\Authentication\RoleInterface;
+use Sulu\Component\Security\Authentication\RoleRepositoryInterface;
+
 class SystemStore implements SystemStoreInterface
 {
+    /**
+     * @var RoleRepositoryInterface
+     */
+    private $roleRepository;
+
     /**
      * @var string
      */
     private $system;
+
+    /**
+     * @var ?RoleInterface
+     */
+    private $anonymousRole;
+
+    public function __construct(RoleRepositoryInterface $roleRepository)
+    {
+        $this->roleRepository = $roleRepository;
+    }
 
     public function getSystem(): ?string
     {
@@ -26,5 +44,17 @@ class SystemStore implements SystemStoreInterface
     public function setSystem(string $system): void
     {
         $this->system = $system;
+        $this->anonymousRole = null;
+    }
+
+    public function getAnonymousRole(): ?RoleInterface
+    {
+        if (!$this->anonymousRole) {
+            $anonymousRoles = $this->roleRepository->findAllRoles(['anonymous' => true, 'system' => $this->system]);
+
+            $this->anonymousRole = $anonymousRoles[0] ?? null;
+        }
+
+        return $this->anonymousRole;
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/System/SystemStoreInterface.php
+++ b/src/Sulu/Bundle/SecurityBundle/System/SystemStoreInterface.php
@@ -11,9 +11,13 @@
 
 namespace Sulu\Bundle\SecurityBundle\System;
 
+use Sulu\Component\Security\Authentication\RoleInterface;
+
 interface SystemStoreInterface
 {
     public function getSystem(): ?string;
 
     public function setSystem(string $system): void;
+
+    public function getAnonymousRole(): ?RoleInterface;
 }

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Twig/SnippetTwigExtensionTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Twig/SnippetTwigExtensionTest.php
@@ -23,6 +23,7 @@ use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class SnippetTwigExtensionTest extends SuluTestCase
 {
@@ -92,6 +93,9 @@ class SnippetTwigExtensionTest extends SuluTestCase
             $this->requestAnalyzer,
             $this->structureResolver
         );
+
+        $user = $this->getContainer()->get('test_user_provider')->getUser();
+        $this->getContainer()->get('security.token_storage')->setToken(new UsernamePasswordToken($user, '', 'test'));
     }
 
     public function testLoadSnippetNotExists()

--- a/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationMapper.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationMapper.php
@@ -17,7 +17,6 @@ use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\Content\Query\ContentQueryBuilderInterface;
 use Sulu\Component\Content\Query\ContentQueryExecutorInterface;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
-use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Symfony\Component\Stopwatch\Stopwatch;
 

--- a/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationMapper.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationMapper.php
@@ -18,6 +18,7 @@ use Sulu\Component\Content\Query\ContentQueryBuilderInterface;
 use Sulu\Component\Content\Query\ContentQueryExecutorInterface;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Component\Security\Authorization\PermissionTypes;
 use Symfony\Component\Stopwatch\Stopwatch;
 
 class NavigationMapper implements NavigationMapperInterface
@@ -47,18 +48,25 @@ class NavigationMapper implements NavigationMapperInterface
      */
     private $stopwatch;
 
+    /**
+     * @var array
+     */
+    private $permissions;
+
     public function __construct(
         ContentMapperInterface $contentMapper,
         ContentQueryExecutorInterface $contentQueryExecutor,
         ContentQueryBuilderInterface $queryBuilder,
         SessionManagerInterface $sessionManager,
-        Stopwatch $stopwatch = null
+        Stopwatch $stopwatch = null,
+        $permissions = null
     ) {
         $this->contentMapper = $contentMapper;
         $this->contentQueryExecutor = $contentQueryExecutor;
         $this->queryBuilder = $queryBuilder;
         $this->sessionManager = $sessionManager;
         $this->stopwatch = $stopwatch;
+        $this->permissions = $permissions;
     }
 
     public function getNavigation(
@@ -69,8 +77,7 @@ class NavigationMapper implements NavigationMapperInterface
         $flat = false,
         $context = null,
         $loadExcerpt = false,
-        $segmentKey = null,
-        ?UserInterface $user = null
+        $segmentKey = null
     ) {
         if ($this->stopwatch) {
             $this->stopwatch->start('NavigationMapper::getNavigation');
@@ -96,7 +103,7 @@ class NavigationMapper implements NavigationMapperInterface
             null,
             null,
             false,
-            $user
+            $this->permissions[PermissionTypes::VIEW] ?? null
         );
 
         foreach ($result as $item) {
@@ -119,8 +126,7 @@ class NavigationMapper implements NavigationMapperInterface
         $flat = false,
         $context = null,
         $loadExcerpt = false,
-        $segmentKey = null,
-        ?UserInterface $user = null
+        $segmentKey = null
     ) {
         if ($this->stopwatch) {
             $this->stopwatch->start('NavigationMapper::getRootNavigation.query');
@@ -136,7 +142,7 @@ class NavigationMapper implements NavigationMapperInterface
             null,
             null,
             false,
-            $user
+            $this->permissions[PermissionTypes::VIEW] ?? null
         );
 
         for ($i = 0; $i < \count($result); ++$i) {

--- a/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationMapperInterface.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationMapperInterface.php
@@ -11,6 +11,8 @@
 
 namespace Sulu\Bundle\WebsiteBundle\Navigation;
 
+use Sulu\Component\Security\Authentication\UserInterface;
+
 /**
  * generates frontend navigation.
  */
@@ -36,7 +38,9 @@ interface NavigationMapperInterface
         $depth = 1,
         $flat = false,
         $context = null,
-        $loadExcerpt = false
+        $loadExcerpt = false,
+        $segmentKey = null,
+        ?UserInterface $user = null
     );
 
     /**
@@ -57,7 +61,9 @@ interface NavigationMapperInterface
         $depth = 1,
         $flat = false,
         $context = null,
-        $loadExcerpt = false
+        $loadExcerpt = false,
+        $segmentKey = null,
+        ?UserInterface $user = null
     );
 
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationMapperInterface.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationMapperInterface.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Bundle\WebsiteBundle\Navigation;
 
-use Sulu\Component\Security\Authentication\UserInterface;
-
 /**
  * generates frontend navigation.
  */
@@ -39,8 +37,7 @@ interface NavigationMapperInterface
         $flat = false,
         $context = null,
         $loadExcerpt = false,
-        $segmentKey = null,
-        ?UserInterface $user = null
+        $segmentKey = null
     );
 
     /**
@@ -62,8 +59,7 @@ interface NavigationMapperInterface
         $flat = false,
         $context = null,
         $loadExcerpt = false,
-        $segmentKey = null,
-        ?UserInterface $user = null
+        $segmentKey = null
     );
 
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -122,6 +122,7 @@
             <argument type="service" id="sulu.content.mapper"/>
             <argument type="service" id="sulu_website.navigation_mapper"/>
             <argument type="service" id="sulu_core.webspace.request_analyzer" on-invalid="ignore"/>
+            <argument type="service" id="security.token_storage" on-invalid="ignore"/>
         </service>
         <service id="sulu_website.twig.navigation.memoized" class="%sulu_website.twig.navigation.memoized.class%">
             <argument type="service" id="sulu_website.twig.navigation"/>

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -122,8 +122,8 @@
         <service id="sulu_website.twig.navigation" class="%sulu_website.twig.navigation.class%">
             <argument type="service" id="sulu.content.mapper"/>
             <argument type="service" id="sulu_website.navigation_mapper"/>
-            <argument type="service" id="sulu_core.webspace.request_analyzer" on-invalid="ignore"/>
-            <argument type="service" id="security.token_storage" on-invalid="ignore"/>
+            <argument type="service" id="sulu_core.webspace.request_analyzer" on-invalid="null"/>
+            <argument type="service" id="security.token_storage" on-invalid="null"/>
         </service>
         <service id="sulu_website.twig.navigation.memoized" class="%sulu_website.twig.navigation.memoized.class%">
             <argument type="service" id="sulu_website.twig.navigation"/>

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -93,6 +93,7 @@
             <argument type="service" id="sulu_website.navigation_mapper.query_builder"/>
             <argument type="service" id="sulu.phpcr.session"/>
             <argument type="service" id="debug.stopwatch" on-invalid="null"/>
+            <argument>%sulu_security.permissions%</argument>
         </service>
 
         <!-- sitemap generator -->

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/SitemapControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/SitemapControllerTest.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\WebsiteBundle\Tests\Functional\Controller;
 
+use Sulu\Bundle\SecurityBundle\Entity\Permission;
 use Sulu\Bundle\TestBundle\Testing\WebsiteTestCase;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
@@ -24,7 +25,26 @@ class SitemapControllerTest extends WebsiteTestCase
     public function setUp(): void
     {
         $this->client = $this->createWebsiteClient();
+        $this->purgeDatabase();
         $this->initPhpcr();
+
+        $this->getContainer()->get('sulu_security.system_store')->setSystem('sulu_io');
+
+        $em = $this->getContainer()->get('doctrine.orm.entity_manager');
+
+        $this->anonymousRole = $this->getContainer()->get('sulu.repository.role')->createNew();
+        $this->anonymousRole->setName('Anonymous');
+        $this->anonymousRole->setAnonymous(true);
+        $this->anonymousRole->setSystem('sulu_io');
+
+        $permission = new Permission();
+        $permission->setPermissions(122);
+        $permission->setRole($this->anonymousRole);
+        $permission->setContext('sulu.webspaces.sulu_io');
+
+        $em->persist($permission);
+        $em->persist($this->anonymousRole);
+        $em->flush();
     }
 
     public function testIndexSingleLanguage()

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Navigation/NavigationMapperTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Navigation/NavigationMapperTest.php
@@ -112,6 +112,8 @@ class NavigationMapperTest extends SuluTestCase
         $this->languageNamespace = 'i18n';
         $this->homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
+        $this->user = $this->getContainer()->get('test_user_provider')->getUser();
+
         $this->getContainer()->get('sulu_security.system_store')->setSystem('sulu_io');
 
         $entityManager = $this->getContainer()->get('doctrine.orm.entity_manager');
@@ -142,8 +144,6 @@ class NavigationMapperTest extends SuluTestCase
             null,
             ['view' => 64]
         );
-
-        $this->user = $this->getContainer()->get('test_user_provider')->getUser();
     }
 
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Navigation/NavigationMapperTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Navigation/NavigationMapperTest.php
@@ -32,6 +32,7 @@ use Sulu\Component\Content\Query\ContentQueryExecutor;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
 use Sulu\Component\Security\Authentication\RoleInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class NavigationMapperTest extends SuluTestCase
 {
@@ -127,6 +128,9 @@ class NavigationMapperTest extends SuluTestCase
             new NavigationQueryBuilder($this->structureManager, $this->extensionManager, $this->languageNamespace),
             $this->sessionManager
         );
+
+        $user = $this->getContainer()->get('test_user_provider')->getUser();
+        $this->getContainer()->get('security.token_storage')->setToken(new UsernamePasswordToken($user, '', 'test'));
     }
 
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Navigation/NavigationMapperTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Navigation/NavigationMapperTest.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\WebsiteBundle\Tests\Functional\Navigation;
 
 use PHPCR\NodeInterface;
 use Sulu\Bundle\PageBundle\Document\PageDocument;
-use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\SecurityBundle\Entity\UserRole;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Bundle\WebsiteBundle\Navigation\NavigationMapper;

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapGeneratorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapGeneratorTest.php
@@ -104,6 +104,8 @@ class SitemapGeneratorTest extends SuluTestCase
         $this->languageNamespace = $this->getContainer()->getParameter('sulu.content.language.namespace');
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
 
+        $this->getContainer()->get('sulu_security.system_store')->setSystem('sulu_io');
+
         $this->prepareTestData('en');
         $this->prepareTestData('en_us');
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapGeneratorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapGeneratorTest.php
@@ -9,12 +9,14 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\WebsiteBundle\Sitemap;
+namespace Sulu\Bundle\WebsiteBundle\Tests\Unit\Sitemap;
 
 use PHPCR\NodeInterface;
 use PHPCR\SessionInterface;
 use Sulu\Bundle\PageBundle\Document\PageDocument;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapContentQueryBuilder;
+use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapGenerator;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\Structure;
 use Sulu\Component\Content\Compat\StructureInterface;
@@ -34,6 +36,7 @@ use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Navigation;
 use Sulu\Component\Webspace\NavigationContext;
 use Sulu\Component\Webspace\Webspace;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class SitemapGeneratorTest extends SuluTestCase
 {
@@ -125,6 +128,9 @@ class SitemapGeneratorTest extends SuluTestCase
             $this->webspaceManager,
             new SitemapContentQueryBuilder($this->structureManager, $this->extensionManager, $this->languageNamespace)
         );
+
+        $user = $this->getContainer()->get('test_user_provider')->getUser();
+        $this->getContainer()->get('security.token_storage')->setToken(new UsernamePasswordToken($user, '', 'test'));
     }
 
     protected function prepareWebspaceManager()

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtension.php
@@ -41,7 +41,7 @@ class NavigationTwigExtension extends AbstractExtension implements NavigationTwi
     private $requestAnalyzer;
 
     /**
-     * @var TokenStorageInterface
+     * @var ?TokenStorageInterface
      */
     private $tokenStorage;
 
@@ -212,7 +212,7 @@ class NavigationTwigExtension extends AbstractExtension implements NavigationTwi
 
         $user = $this->tokenStorage->getToken()->getUser();
 
-        if (\is_object($user)) {
+        if ($user instanceof UserInterface) {
             return $user;
         }
 

--- a/src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
+++ b/src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
@@ -202,7 +202,7 @@ class AccountDataProviderTest extends TestCase
     ) {
         $mock = $this->prophesize(DataProviderRepositoryInterface::class);
 
-        $mock->findByFilters($filters, $page, $pageSize, $limit, 'en', $options)->willReturn($result);
+        $mock->findByFilters($filters, $page, $pageSize, $limit, 'en', $options, null)->willReturn($result);
 
         return $mock->reveal();
     }

--- a/src/Sulu/Component/Contact/Tests/Unit/SmartContent/ContactDataProviderTest.php
+++ b/src/Sulu/Component/Contact/Tests/Unit/SmartContent/ContactDataProviderTest.php
@@ -227,7 +227,7 @@ class ContactDataProviderTest extends TestCase
     ) {
         $mock = $this->prophesize(DataProviderRepositoryInterface::class);
 
-        $mock->findByFilters($filters, $page, $pageSize, $limit, 'en', $options)->willReturn($result);
+        $mock->findByFilters($filters, $page, $pageSize, $limit, 'en', $options, null)->willReturn($result);
 
         return $mock->reveal();
     }

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -690,7 +690,7 @@ class ContentMapper implements ContentMapperInterface
         }
 
         if ($document instanceof SecurityBehavior && $permission) {
-            $permissionKey = array_search($permission, $this->permissions);
+            $permissionKey = \array_search($permission, $this->permissions);
             $permissions = $this->accessControlManager->getUserPermissionByArray(
                 $document->getLocale(),
                 PageAdmin::SECURITY_CONTEXT_PREFIX . $document->getWebspaceName(),

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -19,6 +19,7 @@ use PHPCR\Query\QueryInterface;
 use PHPCR\Query\QueryResultInterface;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\PropertyEncoder;
+use Sulu\Bundle\PageBundle\Admin\PageAdmin;
 use Sulu\Bundle\PageBundle\Document\BasePageDocument;
 use Sulu\Bundle\PageBundle\Document\HomeDocument;
 use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
@@ -34,6 +35,7 @@ use Sulu\Component\Content\Document\Behavior\LocalizedAuthorBehavior;
 use Sulu\Component\Content\Document\Behavior\OrderBehavior;
 use Sulu\Component\Content\Document\Behavior\RedirectTypeBehavior;
 use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
+use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
 use Sulu\Component\Content\Document\Behavior\ShadowLocaleBehavior;
 use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\Content\Document\Behavior\WorkflowStageBehavior;
@@ -56,6 +58,8 @@ use Sulu\Component\DocumentManager\DocumentManager;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 use Sulu\Component\DocumentManager\NamespaceRegistry;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
+use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Component\Security\Authorization\AccessControl\AccessControlManagerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -132,6 +136,11 @@ class ContentMapper implements ContentMapperInterface
      */
     private $namespaceRegistry;
 
+    /**
+     * @var AccessControlManagerInterface
+     */
+    private $accessControlManager;
+
     public function __construct(
         DocumentManager $documentManager,
         WebspaceManagerInterface $webspaceManager,
@@ -144,7 +153,8 @@ class ContentMapper implements ContentMapperInterface
         SessionManagerInterface $sessionManager,
         EventDispatcherInterface $eventDispatcher,
         ResourceLocatorStrategyPoolInterface $resourceLocatorStrategyPool,
-        NamespaceRegistry $namespaceRegistry
+        NamespaceRegistry $namespaceRegistry,
+        AccessControlManagerInterface $accessControlManager
     ) {
         $this->contentTypeManager = $contentTypeManager;
         $this->structureManager = $structureManager;
@@ -157,6 +167,7 @@ class ContentMapper implements ContentMapperInterface
         $this->encoder = $encoder;
         $this->namespaceRegistry = $namespaceRegistry;
         $this->resourceLocatorStrategyPool = $resourceLocatorStrategyPool;
+        $this->accessControlManager = $accessControlManager;
 
         // deprecated
         $this->eventDispatcher = $eventDispatcher;
@@ -614,7 +625,8 @@ class ContentMapper implements ContentMapperInterface
         $locales,
         $fields,
         $maxDepth,
-        $onlyPublished = true
+        $onlyPublished = true,
+        ?UserInterface $user = null
     ) {
         $rootDepth = \substr_count($this->sessionManager->getContentPath($webspaceKey), '/');
 
@@ -624,7 +636,7 @@ class ContentMapper implements ContentMapperInterface
                 $pageDepth = \substr_count($row->getPath('page'), '/') - $rootDepth;
 
                 if (null === $maxDepth || $maxDepth < 0 || ($maxDepth > 0 && $pageDepth <= $maxDepth)) {
-                    $item = $this->rowToArray($row, $locale, $webspaceKey, $fields, $onlyPublished);
+                    $item = $this->rowToArray($row, $locale, $webspaceKey, $fields, $onlyPublished, $user);
 
                     if (false === $item || \in_array($item, $result)) {
                         continue;
@@ -641,8 +653,14 @@ class ContentMapper implements ContentMapperInterface
     /**
      * converts a query row to an array.
      */
-    private function rowToArray(Row $row, $locale, $webspaceKey, $fields, $onlyPublished = true)
-    {
+    private function rowToArray(
+        Row $row,
+        $locale,
+        $webspaceKey,
+        $fields,
+        $onlyPublished = true,
+        ?UserInterface $user = null
+    ) {
         // reset cache
         $this->initializeExtensionCache();
         $templateName = $this->encoder->localizedSystemName('template', $locale);
@@ -660,6 +678,19 @@ class ContentMapper implements ContentMapperInterface
 
         if (!$node->hasProperty($templateName) && !$node->hasProperty('template')) {
             return false;
+        }
+
+        if ($document instanceof SecurityBehavior) {
+            $permissions = $this->accessControlManager->getUserPermissionByArray(
+                $document->getLocale(),
+                PageAdmin::SECURITY_CONTEXT_PREFIX . $document->getWebspaceName(),
+                $document->getPermissions(),
+                $user
+            );
+
+            if (isset($permissions['view']) && !$permissions['view']) {
+                return false;
+            }
         }
 
         $redirectType = null;

--- a/src/Sulu/Component/Content/Query/ContentQueryExecutor.php
+++ b/src/Sulu/Component/Content/Query/ContentQueryExecutor.php
@@ -14,6 +14,7 @@ namespace Sulu\Component\Content\Query;
 use Jackalope\Query\Row;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
+use Sulu\Component\Security\Authentication\UserInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
 
 /**
@@ -54,7 +55,8 @@ class ContentQueryExecutor implements ContentQueryExecutorInterface
         $depth = -1,
         $limit = null,
         $offset = null,
-        $moveUp = false
+        $moveUp = false,
+        ?UserInterface $user = null
     ) {
         if ($this->stopwatch) {
             $this->stopwatch->start('ContentQuery::execute.build-query');
@@ -106,7 +108,8 @@ class ContentQueryExecutor implements ContentQueryExecutorInterface
             $locales,
             $fields,
             $depth,
-            $contentQueryBuilder->getPublished()
+            $contentQueryBuilder->getPublished(),
+            $user
         );
 
         if ($this->stopwatch) {

--- a/src/Sulu/Component/Content/Query/ContentQueryExecutorInterface.php
+++ b/src/Sulu/Component/Content/Query/ContentQueryExecutorInterface.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Component\Content\Query;
 
-use Sulu\Component\Security\Authentication\UserInterface;
-
 /**
  * Interface for content query.
  */

--- a/src/Sulu/Component/Content/Query/ContentQueryExecutorInterface.php
+++ b/src/Sulu/Component/Content/Query/ContentQueryExecutorInterface.php
@@ -28,6 +28,7 @@ interface ContentQueryExecutorInterface
      * @param int $limit
      * @param int $offset
      * @param bool $moveUp
+     * @param ?int $permission
      *
      * @return array
      */
@@ -39,7 +40,7 @@ interface ContentQueryExecutorInterface
         $depth = -1,
         $limit = null,
         $offset = null,
-        $moveUp = false
-        /* ?UserInterface $user = null */
+        $moveUp = false,
+        $permission = null
     );
 }

--- a/src/Sulu/Component/Content/Query/ContentQueryExecutorInterface.php
+++ b/src/Sulu/Component/Content/Query/ContentQueryExecutorInterface.php
@@ -11,6 +11,8 @@
 
 namespace Sulu\Component\Content\Query;
 
+use Sulu\Component\Security\Authentication\UserInterface;
+
 /**
  * Interface for content query.
  */
@@ -38,5 +40,6 @@ interface ContentQueryExecutorInterface
         $limit = null,
         $offset = null,
         $moveUp = false
+        /* ?UserInterface $user = null */
     );
 }

--- a/src/Sulu/Component/Content/Repository/ContentRepository.php
+++ b/src/Sulu/Component/Content/Repository/ContentRepository.php
@@ -431,11 +431,6 @@ class ContentRepository implements ContentRepositoryInterface
     private function resolveResultPermissions(array $result, UserInterface $user = null)
     {
         $permissions = [];
-        if (null === $user) {
-            return $permissions;
-        }
-
-        // TODO recognize system automatically
         $systemRoleIds = $this->roleRepository->findRoleIdsBySystem($this->systemStore->getSystem());
 
         foreach ($result as $index => $row) {

--- a/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
+++ b/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
@@ -22,7 +22,6 @@ use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Content\Query\ContentQueryBuilderInterface;
 use Sulu\Component\Content\Query\ContentQueryExecutorInterface;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
-use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\SmartContent\ArrayAccessItem;
 use Sulu\Component\SmartContent\Configuration\Builder;

--- a/src/Sulu/Component/Content/Tests/Unit/Block/BlockContentTypeTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Block/BlockContentTypeTest.php
@@ -83,13 +83,13 @@ class BlockContentTypeTest extends TestCase
         $this->contentTypeValueMap = [
             ['text_line', new TextLine('not in use')],
             ['text_area', new TextArea('not in use')],
-            ['internal_link', new SinglePageSelection(new ReferenceStore(), 'not in use')],
+            ['internal_link', new SinglePageSelection(new ReferenceStore())],
             ['block', $this->blockContentType],
         ];
 
         $this->contentTypeManager->get('text_line')->willReturn(new TextLine('not in use'));
         $this->contentTypeManager->get('text_area')->willReturn(new TextArea('not in use'));
-        $this->contentTypeManager->get('internal_link')->willReturn(new SinglePageSelection(new ReferenceStore(), 'not in use'));
+        $this->contentTypeManager->get('internal_link')->willReturn(new SinglePageSelection(new ReferenceStore()));
         $this->contentTypeManager->get('block')->willReturn($this->blockContentType);
     }
 

--- a/src/Sulu/Component/Content/Tests/Unit/Repository/ContentRepositoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Repository/ContentRepositoryTest.php
@@ -189,7 +189,7 @@ class ContentRepositoryTest extends TestCase
         $this->nodeHelper->extractWebspaceFromPath('/cmf/sulu_io/contents')->willReturn('sulu_io');
 
         $node = $this->prophesize(NodeInterface::class);
-        $node->getProperties('sec:*')->willReturn([]);
+        $node->getProperties('sec:role-*')->willReturn([]);
         $row->getNode()->willReturn($node->reveal());
 
         $row->getValues()->willReturn(

--- a/src/Sulu/Component/Content/Tests/Unit/SmartContent/Orm/BaseDataProviderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/SmartContent/Orm/BaseDataProviderTest.php
@@ -22,6 +22,8 @@ use Sulu\Component\SmartContent\DataProviderResult;
 use Sulu\Component\SmartContent\Orm\BaseDataProvider;
 use Sulu\Component\SmartContent\Orm\DataProviderRepositoryInterface;
 use Sulu\Component\SmartContent\ResourceItemInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class BaseDataProviderTest extends TestCase
 {
@@ -344,10 +346,15 @@ class BaseDataProviderTest extends TestCase
 
         $serializer = $this->prophesize(ArraySerializerInterface::class);
 
+        $tokenStorage = $this->prophesize(TokenStorageInterface::class);
+        $token = $this->prophesize(TokenInterface::class);
+        $token->getUser()->willReturn($user->reveal());
+        $tokenStorage->getToken()->willReturn($token->reveal());
+
         /** @var BaseDataProvider $provider */
         $provider = $this->getMockForAbstractClass(
             BaseDataProvider::class,
-            [$repository->reveal(), $serializer->reveal()]
+            [$repository->reveal(), $serializer->reveal(), null, $tokenStorage->reveal()]
         );
 
         $result = $provider->resolveResourceItems(
@@ -356,8 +363,7 @@ class BaseDataProviderTest extends TestCase
             ['locale' => 'en', 'webspace' => 'sulu_io'],
             -1,
             1,
-            null,
-            $user->reveal()
+            null
         );
     }
 

--- a/src/Sulu/Component/Content/Tests/Unit/SmartContent/PageDataProviderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/SmartContent/PageDataProviderTest.php
@@ -27,7 +27,6 @@ use Sulu\Component\Content\Query\ContentQueryExecutorInterface;
 use Sulu\Component\Content\SmartContent\ContentDataItem;
 use Sulu\Component\Content\SmartContent\PageDataProvider;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
-use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\SmartContent\Configuration\ProviderConfigurationInterface;
 use Sulu\Component\SmartContent\DataProviderResult;
 use Sulu\Component\SmartContent\DatasourceItem;

--- a/src/Sulu/Component/Content/Tests/Unit/SmartContent/PageDataProviderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/SmartContent/PageDataProviderTest.php
@@ -57,7 +57,7 @@ class PageDataProviderTest extends TestCase
      *
      * @return ContentQueryExecutorInterface
      */
-    private function getContentQueryExecutor($limit = -1, $page = 1, $result = [], $user = null)
+    private function getContentQueryExecutor($limit = -1, $page = 1, $result = [], $permission = 64)
     {
         $mock = $this->prophesize(ContentQueryExecutorInterface::class);
 
@@ -70,7 +70,7 @@ class PageDataProviderTest extends TestCase
             ($limit > -1 ? $limit + 1 : null),
             ($limit > -1 ? $limit * ($page - 1) : null),
             false,
-            $user
+            $permission
         )->willReturn($result);
 
         return $mock->reveal();
@@ -124,7 +124,8 @@ class PageDataProviderTest extends TestCase
             $this->getProxyFactory(),
             $this->getSession(),
             new ReferenceStore(),
-            false
+            false,
+            ['view' => 64]
         );
 
         $configuration = $provider->getConfiguration();
@@ -141,7 +142,8 @@ class PageDataProviderTest extends TestCase
             $this->getProxyFactory(),
             $this->getSession(),
             new ReferenceStore(),
-            false
+            false,
+            ['view' => 64]
         );
 
         $parameter = $provider->getDefaultPropertyParameter();
@@ -162,7 +164,8 @@ class PageDataProviderTest extends TestCase
             $this->getProxyFactory(),
             $this->getSession(),
             new ReferenceStore(),
-            false
+            false,
+            ['view' => 64]
         );
 
         $result = $provider->resolveDataItems(
@@ -194,7 +197,8 @@ class PageDataProviderTest extends TestCase
             $this->getProxyFactory(),
             $this->getSession(),
             new ReferenceStore(),
-            true
+            true,
+            ['view' => 64]
         );
 
         $result = $provider->resolveDataItems(
@@ -236,7 +240,8 @@ class PageDataProviderTest extends TestCase
             $this->getProxyFactory(),
             $this->getSession(),
             new ReferenceStore(),
-            true
+            true,
+            ['view' => 64]
         );
 
         $result = $provider->resolveDataItems(
@@ -284,7 +289,8 @@ class PageDataProviderTest extends TestCase
             $this->getProxyFactory(),
             $this->getSession(),
             new ReferenceStore(),
-            false
+            false,
+            ['view' => 64]
         );
 
         $result = $provider->resolveDataItems(
@@ -333,7 +339,8 @@ class PageDataProviderTest extends TestCase
             $this->getProxyFactory(),
             $this->getSession(),
             $referenceStore,
-            true
+            true,
+            ['view' => 64]
         );
 
         $result = $provider->resolveResourceItems(
@@ -355,49 +362,6 @@ class PageDataProviderTest extends TestCase
         $this->assertEquals($document2->reveal(), $items[1]->getResource()->getWrappedValueHolderValue());
         $this->assertTrue($result->getHasNextPage());
         $this->assertEquals(['123-123-123', '123-123-456'], $referenceStore->getAll());
-    }
-
-    public function testResolveResourceItemsWithUser()
-    {
-        $data = [
-            ['id' => '123-123-123', 'title' => 'My-Page', 'path' => '/my-page'],
-        ];
-
-        $document1 = $this->prophesize(BasePageDocument::class);
-
-        $user = $this->prophesize(UserInterface::class);
-
-        $referenceStore = new ReferenceStore();
-        $provider = new PageDataProvider(
-            $this->getContentQueryBuilder(
-                [
-                    'config' => ['dataSource' => '123-123-123', 'excluded' => ['123-123-123']],
-                    'properties' => ['my-properties' => true],
-                    'excluded' => ['123-123-123'],
-                    'published' => false,
-                ]
-            ),
-            $this->getContentQueryExecutor(2, 1, $data, $user->reveal()),
-            $this->getDocumentManager(['123-123-123' => $document1->reveal()]),
-            $this->getProxyFactory(),
-            $this->getSession(),
-            $referenceStore,
-            true
-        );
-
-        $result = $provider->resolveResourceItems(
-            ['dataSource' => '123-123-123', 'excluded' => ['123-123-123']],
-            ['properties' => new PropertyParameter('properties', ['my-properties' => true], 'collection')],
-            ['webspaceKey' => 'sulu_io', 'locale' => 'en'],
-            5,
-            1,
-            2,
-            $user->reveal()
-        );
-
-        $this->assertInstanceOf(DataProviderResult::class, $result);
-        $items = $result->getItems();
-        $this->assertEquals($data[0]['id'], $items[0]->getId());
     }
 
     public function testResolveDataItemsNoPagination()
@@ -428,7 +392,8 @@ class PageDataProviderTest extends TestCase
             $this->getProxyFactory(),
             $this->getSession(),
             new ReferenceStore(),
-            true
+            true,
+            ['view' => 64]
         );
 
         $result = $provider->resolveDataItems(
@@ -461,7 +426,8 @@ class PageDataProviderTest extends TestCase
             $this->getProxyFactory(),
             $this->getSession(true),
             new ReferenceStore(),
-            true
+            true,
+            ['view' => 64]
         );
 
         $result = $provider->resolveDataItems(
@@ -483,12 +449,13 @@ class PageDataProviderTest extends TestCase
             $this->getContentQueryBuilder(
                 ['ids' => [$data['id']], 'properties' => ['my-properties' => true], 'published' => false]
             ),
-            $this->getContentQueryExecutor(0, 1, [$data]),
+            $this->getContentQueryExecutor(0, 1, [$data], null),
             $this->getDocumentManager([$data['id'] => $data]),
             $this->getProxyFactory(),
             $this->getSession(),
             new ReferenceStore(),
-            false
+            false,
+            ['view' => 64]
         );
 
         $result = $provider->resolveDatasource(
@@ -546,7 +513,8 @@ class PageDataProviderTest extends TestCase
             $this->getProxyFactory(),
             $this->getSession(),
             $referenceStore,
-            true
+            true,
+            ['view' => 64]
         );
 
         $result = $provider->resolveResourceItems(
@@ -586,7 +554,8 @@ class PageDataProviderTest extends TestCase
             $this->getProxyFactory(),
             $this->getSession(),
             $referenceStore,
-            true
+            true,
+            ['view' => 64]
         );
 
         $result = $provider->resolveResourceItems(

--- a/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
+++ b/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
@@ -15,7 +15,6 @@ use Sulu\Bundle\MediaBundle\Admin\MediaAdmin;
 use Sulu\Bundle\MediaBundle\Collection\Manager\CollectionManagerInterface;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
-use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Serializer\ArraySerializerInterface;
 use Sulu\Component\SmartContent\DataProviderResult;
 use Sulu\Component\SmartContent\DatasourceItem;
@@ -115,8 +114,7 @@ class MediaDataProvider extends BaseDataProvider
         array $options = [],
         $limit = null,
         $page = 1,
-        $pageSize = null,
-        UserInterface $user = null
+        $pageSize = null
     ) {
         if (($filters['dataSource'] ?? null) === null) {
             return new DataProviderResult([], false);

--- a/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
+++ b/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
@@ -15,6 +15,7 @@ use Sulu\Bundle\MediaBundle\Admin\MediaAdmin;
 use Sulu\Bundle\MediaBundle\Collection\Manager\CollectionManagerInterface;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
+use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Serializer\ArraySerializerInterface;
 use Sulu\Component\SmartContent\DataProviderResult;
 use Sulu\Component\SmartContent\DatasourceItem;
@@ -112,13 +113,14 @@ class MediaDataProvider extends BaseDataProvider
         array $options = [],
         $limit = null,
         $page = 1,
-        $pageSize = null
+        $pageSize = null,
+        UserInterface $user = null
     ) {
         if (($filters['dataSource'] ?? null) === null) {
             return new DataProviderResult([], false);
         }
 
-        return parent::resolveResourceItems($filters, $propertyParameter, $options, $limit, $page, $pageSize);
+        return parent::resolveResourceItems($filters, $propertyParameter, $options, $limit, $page, $pageSize, $user);
     }
 
     protected function getOptions(

--- a/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
+++ b/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
@@ -22,6 +22,7 @@ use Sulu\Component\SmartContent\DatasourceItem;
 use Sulu\Component\SmartContent\Orm\BaseDataProvider;
 use Sulu\Component\SmartContent\Orm\DataProviderRepositoryInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
  * Media DataProvider for SmartContent.
@@ -43,9 +44,10 @@ class MediaDataProvider extends BaseDataProvider
         CollectionManagerInterface $collectionManager,
         ArraySerializerInterface $serializer,
         RequestStack $requestStack,
-        ReferenceStoreInterface $referenceStore
+        ReferenceStoreInterface $referenceStore,
+        TokenStorageInterface $tokenStorage = null
     ) {
-        parent::__construct($repository, $serializer, $referenceStore);
+        parent::__construct($repository, $serializer, $referenceStore, $tokenStorage);
 
         $this->configuration = self::createConfigurationBuilder()
             ->enableTags()
@@ -120,7 +122,7 @@ class MediaDataProvider extends BaseDataProvider
             return new DataProviderResult([], false);
         }
 
-        return parent::resolveResourceItems($filters, $propertyParameter, $options, $limit, $page, $pageSize, $user);
+        return parent::resolveResourceItems($filters, $propertyParameter, $options, $limit, $page, $pageSize);
     }
 
     protected function getOptions(

--- a/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
+++ b/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
@@ -29,6 +29,8 @@ use Sulu\Component\SmartContent\DataProviderResult;
 use Sulu\Component\SmartContent\DatasourceItem;
 use Sulu\Component\SmartContent\Orm\DataProviderRepositoryInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class MediaDataProviderTest extends TestCase
 {
@@ -181,6 +183,12 @@ class MediaDataProviderTest extends TestCase
         $collectionManager = $this->prophesize(CollectionManagerInterface::class);
         $requestStack = $this->prophesize(RequestStack::class);
         $referenceStore = $this->prophesize(ReferenceStoreInterface::class);
+        $tokenStorage = $this->prophesize(TokenStorageInterface::class);
+
+        $token = $this->prophesize(TokenInterface::class);
+        $token->getUser()->willReturn($user);
+        $tokenStorage->getToken()->willReturn($token->reveal());
+
         $provider = new MediaDataProvider(
             $this->getRepository(
                 $filters,
@@ -194,7 +202,8 @@ class MediaDataProviderTest extends TestCase
             $collectionManager->reveal(),
             $serializer->reveal(),
             $requestStack->reveal(),
-            $referenceStore->reveal()
+            $referenceStore->reveal(),
+            $tokenStorage->reveal()
         );
 
         $result = $provider->resolveResourceItems(

--- a/src/Sulu/Component/Rest/AbstractRestController.php
+++ b/src/Sulu/Component/Rest/AbstractRestController.php
@@ -13,7 +13,6 @@ namespace Sulu\Component\Rest;
 
 use FOS\RestBundle\Controller\ControllerTrait;
 use FOS\RestBundle\View\ViewHandlerInterface;
-use Sulu\Component\Security\Authentication\UserInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
@@ -50,7 +49,7 @@ abstract class AbstractRestController
         }
 
         $user = $token->getUser();
-        if (!($user instanceof UserInterface)) {
+        if (!\is_object($user)) {
             // e.g. anonymous authentication
             return null;
         }

--- a/src/Sulu/Component/Rest/AbstractRestController.php
+++ b/src/Sulu/Component/Rest/AbstractRestController.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\Rest;
 
 use FOS\RestBundle\Controller\ControllerTrait;
 use FOS\RestBundle\View\ViewHandlerInterface;
+use Sulu\Component\Security\Authentication\UserInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
@@ -49,7 +50,7 @@ abstract class AbstractRestController
         }
 
         $user = $token->getUser();
-        if (!\is_object($user)) {
+        if (!($user instanceof UserInterface)) {
             // e.g. anonymous authentication
             return null;
         }

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilderFactory.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilderFactory.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\Rest\ListBuilder\Doctrine;
 
 use Doctrine\ORM\EntityManager;
+use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancer;
 use Sulu\Component\Rest\ListBuilder\Filter\FilterTypeRegistry;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -40,16 +41,23 @@ class DoctrineListBuilderFactory implements DoctrineListBuilderFactoryInterface
      */
     private $permissions;
 
+    /**
+     * @var AccessControlQueryEnhancer
+     */
+    private $accessControlQueryEnhancer;
+
     public function __construct(
         EntityManager $em,
         FilterTypeRegistry $filterTypeRegistry,
         EventDispatcherInterface $eventDispatcher,
-        array $permissions
+        array $permissions,
+        AccessControlQueryEnhancer $accessControlQueryEnhancer
     ) {
         $this->em = $em;
         $this->filterTypeRegistry = $filterTypeRegistry;
         $this->eventDispatcher = $eventDispatcher;
         $this->permissions = $permissions;
+        $this->accessControlQueryEnhancer = $accessControlQueryEnhancer;
     }
 
     /**
@@ -66,7 +74,8 @@ class DoctrineListBuilderFactory implements DoctrineListBuilderFactoryInterface
             $entityName,
             $this->filterTypeRegistry,
             $this->eventDispatcher,
-            $this->permissions
+            $this->permissions,
+            $this->accessControlQueryEnhancer
         );
     }
 }

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\Query\Expr\Select;
 use Doctrine\ORM\QueryBuilder;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancer;
 use Sulu\Bundle\SecurityBundle\Entity\AccessControl;
 use Sulu\Bundle\SecurityBundle\Entity\Role;
 use Sulu\Bundle\SecurityBundle\Entity\User;
@@ -126,7 +127,8 @@ class DoctrineListBuilderTest extends TestCase
             self::$entityName,
             $this->filterTypeRegistry->reveal(),
             $this->eventDispatcher->reveal(),
-            [PermissionTypes::VIEW => 64]
+            [PermissionTypes::VIEW => 64],
+            new AccessControlQueryEnhancer()
         );
         $this->doctrineListBuilder->limit(10);
         $this->queryBuilder->setFirstResult(Argument::any())->willReturn($this->queryBuilder->reveal());

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -21,6 +21,7 @@ use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancer;
 use Sulu\Bundle\SecurityBundle\Entity\AccessControl;
 use Sulu\Bundle\SecurityBundle\Entity\Role;
 use Sulu\Bundle\SecurityBundle\Entity\User;
+use Sulu\Bundle\SecurityBundle\System\SystemStoreInterface;
 use Sulu\Bundle\TestBundle\Testing\ReadObjectAttributeTrait;
 use Sulu\Component\Rest\Exception\InvalidSearchException;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilder;
@@ -122,13 +123,16 @@ class DoctrineListBuilderTest extends TestCase
 
         $this->eventDispatcher = $this->prophesize(EventDispatcherInterface::class);
 
+        $this->systemStore = $this->prophesize(SystemStoreInterface::class);
+        $this->systemStore->getSystem()->willReturn('Sulu');
+
         $this->doctrineListBuilder = new DoctrineListBuilder(
             $this->entityManager->reveal(),
             self::$entityName,
             $this->filterTypeRegistry->reveal(),
             $this->eventDispatcher->reveal(),
             [PermissionTypes::VIEW => 64],
-            new AccessControlQueryEnhancer()
+            new AccessControlQueryEnhancer($this->systemStore->reveal())
         );
         $this->doctrineListBuilder->limit(10);
         $this->queryBuilder->setFirstResult(Argument::any())->willReturn($this->queryBuilder->reveal());
@@ -1109,7 +1113,7 @@ class DoctrineListBuilderTest extends TestCase
             'WITH',
             'accessControl.entityClass = :entityClass AND accessControl.entityId = SuluCoreBundle_Example.id'
         )->shouldBeCalled();
-        $this->queryBuilder->leftJoin('accessControl.role', 'role')->shouldBeCalled();
+        $this->queryBuilder->leftJoin('accessControl.role', 'role', 'WITH', 'role.system = :system')->shouldBeCalled();
         $this->queryBuilder->andWhere(
             'BIT_AND(accessControl.permissions, :permission) = :permission OR accessControl.permissions IS NULL'
         )->shouldBeCalled();
@@ -1117,6 +1121,7 @@ class DoctrineListBuilderTest extends TestCase
         $this->queryBuilder->setParameter('roleIds', [1])->shouldBeCalled();
         $this->queryBuilder->setParameter('entityClass', self::$entityName)->shouldBeCalled();
         $this->queryBuilder->setParameter('permission', 64)->shouldBeCalled();
+        $this->queryBuilder->setParameter('system', 'Sulu')->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -1147,7 +1152,7 @@ class DoctrineListBuilderTest extends TestCase
             'WITH',
             'accessControl.entityClass = :entityClass AND accessControl.entityId = stdClass.id'
         )->shouldBeCalled();
-        $this->queryBuilder->leftJoin('accessControl.role', 'role')->shouldBeCalled();
+        $this->queryBuilder->leftJoin('accessControl.role', 'role', 'WITH', 'role.system = :system')->shouldBeCalled();
         $this->queryBuilder->andWhere(
             'BIT_AND(accessControl.permissions, :permission) = :permission OR accessControl.permissions IS NULL'
         )->shouldBeCalled();
@@ -1155,6 +1160,7 @@ class DoctrineListBuilderTest extends TestCase
         $this->queryBuilder->setParameter('roleIds', [1])->shouldBeCalled();
         $this->queryBuilder->setParameter('entityClass', \stdClass::class)->shouldBeCalled();
         $this->queryBuilder->setParameter('permission', 64)->shouldBeCalled();
+        $this->queryBuilder->setParameter('system', 'Sulu')->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -1192,7 +1198,7 @@ class DoctrineListBuilderTest extends TestCase
             'WITH',
             'accessControl.entityClass = :entityClass AND accessControl.entityId = stdClass.id'
         )->shouldBeCalled();
-        $this->queryBuilder->leftJoin('accessControl.role', 'role')->shouldBeCalled();
+        $this->queryBuilder->leftJoin('accessControl.role', 'role', 'WITH', 'role.system = :system')->shouldBeCalled();
         $this->queryBuilder->andWhere(
             'BIT_AND(accessControl.permissions, :permission) = :permission OR accessControl.permissions IS NULL'
         )->shouldBeCalled();
@@ -1200,6 +1206,7 @@ class DoctrineListBuilderTest extends TestCase
         $this->queryBuilder->setParameter('roleIds', [1])->shouldBeCalled();
         $this->queryBuilder->setParameter('entityClass', \stdClass::class)->shouldBeCalled();
         $this->queryBuilder->setParameter('permission', 64)->shouldBeCalled();
+        $this->queryBuilder->setParameter('system', 'Sulu')->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }

--- a/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
@@ -276,7 +276,9 @@ class AccessControlManager implements AccessControlManagerInterface
     private function getRolesForLocale(?UserInterface $user, ?string $locale)
     {
         if (!\is_object($user)) {
-            return [$this->systemStore->getAnonymousRole()];
+            $anonymousRole = $this->systemStore->getAnonymousRole();
+
+            return $anonymousRole ? [$anonymousRole] : [];
         }
 
         $roles = [];

--- a/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
@@ -85,7 +85,7 @@ class AccessControlManager implements AccessControlManagerInterface
 
     public function getUserPermissions(SecurityCondition $securityCondition, $user)
     {
-        if (!\is_object($user)) {
+        if (!($user instanceof UserInterface)) {
             $user = null;
         }
 
@@ -279,7 +279,7 @@ class AccessControlManager implements AccessControlManagerInterface
 
     private function getRolesForLocale(?UserInterface $user, ?string $locale)
     {
-        if (!\is_object($user)) {
+        if (!($user instanceof UserInterface)) {
             $anonymousRole = $this->systemStore->getAnonymousRole();
 
             return $anonymousRole ? [$anonymousRole] : [];

--- a/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
@@ -85,6 +85,10 @@ class AccessControlManager implements AccessControlManagerInterface
 
     public function getUserPermissions(SecurityCondition $securityCondition, $user)
     {
+        if (!\is_object($user)) {
+            $user = null;
+        }
+
         $system = $this->systemStore->getSystem();
         $locale = $securityCondition->getLocale();
 

--- a/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\Security\Authorization\AccessControl;
 
 use Sulu\Bundle\SecurityBundle\Entity\UserRole;
 use Sulu\Bundle\SecurityBundle\System\SystemStoreInterface;
+use Sulu\Component\Security\Authentication\RoleInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authorization\MaskConverterInterface;
 use Sulu\Component\Security\Authorization\SecurityCondition;
@@ -90,14 +91,18 @@ class AccessControlManager implements AccessControlManagerInterface
         }
 
         $system = $this->systemStore->getSystem();
+        $locale = $securityCondition->getLocale();
 
-        $objectPermissions = $this->getUserObjectPermission($securityCondition, $user, $system);
+        $objectPermissions = $this->getUserObjectPermission(
+            $securityCondition,
+            $this->getRolesForLocale($user, $locale),
+            $system
+        );
         $checkPermissionType = empty($objectPermissions);
 
-        $securityContextPermissions = $this->getUserSecurityContextPermissions(
-            $securityCondition->getLocale(),
+        $securityContextPermissions = $this->getRolesSecurityContextPermissions(
             $securityCondition->getSecurityContext(),
-            $user,
+            $this->getRolesForLocale($user, $locale),
             $checkPermissionType,
             $system
         );
@@ -117,13 +122,16 @@ class AccessControlManager implements AccessControlManagerInterface
     ) {
         $system = $this->systemStore->getSystem();
 
-        $objectPermissions = $this->getUserObjectPermissionByArray($objectPermissionsByRole, $user, $system);
+        $objectPermissions = $this->getRolesObjectPermissionsByArray(
+            $objectPermissionsByRole,
+            $this->getRolesForLocale($user, $locale),
+            $system
+        );
         $checkPermissionType = empty($objectPermissions);
 
-        $securityContextPermissions = $this->getUserSecurityContextPermissions(
-            $locale,
+        $securityContextPermissions = $this->getRolesSecurityContextPermissions(
             $securityContext,
-            $user,
+            $this->getRolesForLocale($user, $locale),
             $checkPermissionType,
             $system
         );
@@ -149,11 +157,11 @@ class AccessControlManager implements AccessControlManagerInterface
      * Returns the permissions for the given object for the given user.
      *
      * @param SecurityCondition $securityCondition The condition to check
-     * @param UserInterface $user The user for the check
+     * @param RoleInterface[] $roles The role for which the security should be checked
      *
      * @return array
      */
-    private function getUserObjectPermission(SecurityCondition $securityCondition, UserInterface $user, $system)
+    private function getUserObjectPermission(SecurityCondition $securityCondition, array $roles, $system)
     {
         $permissions = $this->getPermissions(
             $securityCondition->getObjectType(),
@@ -161,25 +169,24 @@ class AccessControlManager implements AccessControlManagerInterface
             $system
         );
 
-        return $this->getUserObjectPermissionByArray($permissions, $user, $system);
+        return $this->getRolesObjectPermissionsByArray($permissions, $roles, $system);
     }
 
     /**
      * Returns the permissions for the given permission array and the given user.
      *
      * @param array $permissions Object permissions
-     * @param UserInterface $user The user for the check
+     * @param RoleInterface[] $roles The role for which the security should be checked
      *
      * @return array
      */
-    private function getUserObjectPermissionByArray($permissions, UserInterface $user, $system)
+    private function getRolesObjectPermissionsByArray($permissions, array $roles, $system)
     {
         if (empty($permissions)) {
             return null;
         }
 
         $userPermission = [];
-        $roles = $user->getRoleObjects();
         foreach ($roles as $role) {
             $roleId = $role->getId();
             if (!isset($permissions[$roleId])) {
@@ -199,34 +206,35 @@ class AccessControlManager implements AccessControlManagerInterface
     /**
      * Returns the permissions for the given security context for the given user.
      *
-     * @param string $locale
      * @param string $securityContext
-     * @param UserInterface $user The user for which the security is checked
+     * @param RoleInterface[] $roles The role for which the security should be checked
      * @param bool $checkPermissionType Flag to show if the permission type should also be checked. If set to false
      *                                  it will only check if the user has access to the context in the given locale
      *
      * @return array
      */
-    private function getUserSecurityContextPermissions(
-        $locale,
+    private function getRolesSecurityContextPermissions(
         $securityContext,
-        UserInterface $user,
+        array $roles,
         $checkPermissionType,
         $system
     ) {
+        if (empty($roles)) {
+            return $this->maskConverter->convertPermissionsToArray(0);
+        }
+
         $userPermissions = [];
 
-        foreach ($user->getUserRoles() as $userRole) {
-            if ($userRole->getRole()->getSystem() !== $system) {
+        foreach ($roles as $role) {
+            if ($role->getSystem() !== $system) {
                 continue;
             }
 
             $userPermissions = $this->cumulatePermissions(
                 $userPermissions,
-                $this->getUserRoleSecurityContextPermission(
-                    $locale,
+                $this->getRoleSecurityContextPermissions(
                     $securityContext,
-                    $userRole,
+                    $role,
                     $checkPermissionType
                 )
             );
@@ -238,31 +246,23 @@ class AccessControlManager implements AccessControlManagerInterface
     /**
      * Returns the permissions for the given security context for the given user role.
      *
-     * @param string $locale
      * @param string $securityContext
-     * @param UserRole $userRole The user role for which the security is checked
+     * @param RoleInterface $role The role for which the security is checked
      * @param bool $checkPermissionType Flag to show if the permission type should also be checked
      *
      * @return array
      */
-    private function getUserRoleSecurityContextPermission(
-        $locale,
+    private function getRoleSecurityContextPermissions(
         $securityContext,
-        UserRole $userRole,
+        RoleInterface $role,
         $checkPermissionType
     ) {
-        $userPermission = $this->maskConverter->convertPermissionsToArray(0);
+        $userPermission = [];
 
-        foreach ($userRole->getRole()->getPermissions() as $permission) {
+        foreach ($role->getPermissions() as $permission) {
             $hasContext = $permission->getContext() == $securityContext;
 
             if (!$hasContext) {
-                continue;
-            }
-
-            $hasLocale = null == $locale || \in_array($locale, $userRole->getLocales());
-
-            if (!$hasLocale) {
                 continue;
             }
 
@@ -276,6 +276,21 @@ class AccessControlManager implements AccessControlManagerInterface
         }
 
         return $userPermission;
+    }
+
+    private function getRolesForLocale(UserInterface $user, ?string $locale)
+    {
+        $roles = [];
+
+        foreach ($user->getUserRoles() as $userRole) {
+            if ($locale != null && !\in_array($locale, $userRole->getLocales())) {
+                continue;
+            }
+
+            $roles[] = $userRole->getRole();
+        }
+
+        return $roles;
     }
 
     /**

--- a/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
@@ -13,7 +13,6 @@ namespace Sulu\Component\Security\Authorization\AccessControl;
 
 use Sulu\Bundle\SecurityBundle\System\SystemStoreInterface;
 use Sulu\Component\Security\Authentication\RoleInterface;
-use Sulu\Component\Security\Authentication\RoleRepositoryInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authorization\MaskConverterInterface;
 use Sulu\Component\Security\Authorization\SecurityCondition;
@@ -47,21 +46,14 @@ class AccessControlManager implements AccessControlManagerInterface
      */
     private $systemStore;
 
-    /**
-     * @var RoleRepositoryInterface
-     */
-    private $roleRepository;
-
     public function __construct(
         MaskConverterInterface $maskConverter,
         EventDispatcherInterface $eventDispatcher,
-        SystemStoreInterface $systemStore,
-        RoleRepositoryInterface $roleRepository
+        SystemStoreInterface $systemStore
     ) {
         $this->maskConverter = $maskConverter;
         $this->eventDispatcher = $eventDispatcher;
         $this->systemStore = $systemStore;
-        $this->roleRepository = $roleRepository;
     }
 
     public function setPermissions($type, $identifier, $permissions)
@@ -98,14 +90,14 @@ class AccessControlManager implements AccessControlManagerInterface
 
         $objectPermissions = $this->getUserObjectPermission(
             $securityCondition,
-            $this->getRolesForLocale($user, $locale, $system),
+            $this->getRolesForLocale($user, $locale),
             $system
         );
         $checkPermissionType = empty($objectPermissions);
 
         $securityContextPermissions = $this->getRolesSecurityContextPermissions(
             $securityCondition->getSecurityContext(),
-            $this->getRolesForLocale($user, $locale, $system),
+            $this->getRolesForLocale($user, $locale),
             $checkPermissionType,
             $system
         );
@@ -127,14 +119,14 @@ class AccessControlManager implements AccessControlManagerInterface
 
         $objectPermissions = $this->getRolesObjectPermissionsByArray(
             $objectPermissionsByRole,
-            $this->getRolesForLocale($user, $locale, $system),
+            $this->getRolesForLocale($user, $locale),
             $system
         );
         $checkPermissionType = empty($objectPermissions);
 
         $securityContextPermissions = $this->getRolesSecurityContextPermissions(
             $securityContext,
-            $this->getRolesForLocale($user, $locale, $system),
+            $this->getRolesForLocale($user, $locale),
             $checkPermissionType,
             $system
         );
@@ -281,10 +273,10 @@ class AccessControlManager implements AccessControlManagerInterface
         return $userPermission;
     }
 
-    private function getRolesForLocale(?UserInterface $user, ?string $locale, string $system)
+    private function getRolesForLocale(?UserInterface $user, ?string $locale)
     {
         if (!\is_object($user)) {
-            return $this->roleRepository->findAllRoles(['anonymous' => true, 'system' => $system]);
+            return [$this->systemStore->getAnonymousRole()];
         }
 
         $roles = [];

--- a/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManagerInterface.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManagerInterface.php
@@ -42,7 +42,7 @@ interface AccessControlManagerInterface
      * Returns the permissions regarding an object and its security context for a given user.
      *
      * @param SecurityCondition $securityCondition The condition to check
-     * @param UserInterface $user The user for which the security is returned
+     * @param ?UserInterface $user The user for which the security is returned
      *
      * @return mixed[]
      */
@@ -54,9 +54,9 @@ interface AccessControlManagerInterface
      * @param string $locale
      * @param string $securityContext
      * @param mixed[] $objectPermissionsByRole
-     * @param UserInterface $user The user for which the security is returned
+     * @param ?UserInterface $user The user for which the security is returned
      *
      * @return mixed[]
      */
-    public function getUserPermissionByArray($locale, $securityContext, $objectPermissionsByRole, UserInterface $user);
+    public function getUserPermissionByArray($locale, $securityContext, $objectPermissionsByRole, $user);
 }

--- a/src/Sulu/Component/Security/Authorization/AccessControl/SecuredEntityRepositoryTrait.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/SecuredEntityRepositoryTrait.php
@@ -12,11 +12,14 @@
 namespace Sulu\Component\Security\Authorization\AccessControl;
 
 use Doctrine\ORM\QueryBuilder;
+use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancer;
 use Sulu\Bundle\SecurityBundle\Entity\AccessControl;
 use Sulu\Component\Security\Authentication\UserInterface;
 
 /**
  * This trait adds functionality to add filtering for access control to doctrine query builders.
+ *
+ * @deprecated Will be removed with 3.0, use the Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancer instead.
  */
 trait SecuredEntityRepositoryTrait
 {
@@ -36,6 +39,15 @@ trait SecuredEntityRepositoryTrait
         $entityClass,
         $entityAlias
     ) {
+        @\trigger_error(
+            \sprintf(
+                'The "%s" is deprecated since Sulu 2.2. Use the "%s" service instead.',
+                __TRAIT__,
+                AccessControlQueryEnhancer::class
+            ),
+            \E_USER_DEPRECATED
+        );
+
         $queryBuilder->leftJoin(
             AccessControl::class,
             'accessControl',

--- a/src/Sulu/Component/SmartContent/ContentType.php
+++ b/src/Sulu/Component/SmartContent/ContentType.php
@@ -20,6 +20,7 @@ use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Content\ComplexContentType;
 use Sulu\Component\Content\ContentTypeExportInterface;
+use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\SmartContent\Exception\PageOutOfBoundsException;
 use Sulu\Component\Tag\Request\TagRequestHandlerInterface;
 use Sulu\Component\Util\ArrayableInterface;
@@ -455,7 +456,7 @@ class ContentType extends ComplexContentType implements ContentTypeExportInterfa
         }
     }
 
-    private function getUser()
+    private function getUser(): ?UserInterface
     {
         if (!$this->tokenStorage) {
             return null;
@@ -463,7 +464,7 @@ class ContentType extends ComplexContentType implements ContentTypeExportInterfa
 
         $user = $this->tokenStorage->getToken()->getUser();
 
-        if (\is_object($user)) {
+        if ($user instanceof UserInterface) {
             return $user;
         }
 

--- a/src/Sulu/Component/SmartContent/ContentType.php
+++ b/src/Sulu/Component/SmartContent/ContentType.php
@@ -20,13 +20,11 @@ use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Content\ComplexContentType;
 use Sulu\Component\Content\ContentTypeExportInterface;
-use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\SmartContent\Exception\PageOutOfBoundsException;
 use Sulu\Component\Tag\Request\TagRequestHandlerInterface;
 use Sulu\Component\Util\ArrayableInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
  * Content type for smart selection.
@@ -85,11 +83,6 @@ class ContentType extends ComplexContentType implements ContentTypeExportInterfa
      */
     private $requestAnalyzer;
 
-    /**
-     * @var TokenStorageInterface|null
-     */
-    private $tokenStorage;
-
     public function __construct(
         DataProviderPoolInterface $dataProviderPool,
         TagManagerInterface $tagManager,
@@ -99,8 +92,7 @@ class ContentType extends ComplexContentType implements ContentTypeExportInterfa
         ReferenceStoreInterface $tagReferenceStore,
         ReferenceStoreInterface $categoryReferenceStore,
         TargetGroupStoreInterface $targetGroupStore = null,
-        RequestAnalyzerInterface $requestAnalyzer,
-        TokenStorageInterface $tokenStorage = null
+        RequestAnalyzerInterface $requestAnalyzer
     ) {
         $this->dataProviderPool = $dataProviderPool;
         $this->tagManager = $tagManager;
@@ -111,7 +103,6 @@ class ContentType extends ComplexContentType implements ContentTypeExportInterfa
         $this->categoryReferenceStore = $categoryReferenceStore;
         $this->targetGroupStore = $targetGroupStore;
         $this->requestAnalyzer = $requestAnalyzer;
-        $this->tokenStorage = $tokenStorage;
     }
 
     public function read(
@@ -300,8 +291,7 @@ class ContentType extends ComplexContentType implements ContentTypeExportInterfa
                 $options,
                 (!empty($limit) ? \intval($limit) : null),
                 $page,
-                $pageSize,
-                $this->getUser()
+                $pageSize
             );
 
             if ($page > 1 && 0 === \count($data->getItems())) {
@@ -313,9 +303,7 @@ class ContentType extends ComplexContentType implements ContentTypeExportInterfa
                 $params,
                 $options,
                 (!empty($limit) ? \intval($limit) : null),
-                1,
-                null,
-                $this->getUser()
+                1
             );
         }
 
@@ -454,20 +442,5 @@ class ContentType extends ComplexContentType implements ContentTypeExportInterfa
 
             $value[$key] = $ids;
         }
-    }
-
-    private function getUser(): ?UserInterface
-    {
-        if (!$this->tokenStorage) {
-            return null;
-        }
-
-        $user = $this->tokenStorage->getToken()->getUser();
-
-        if ($user instanceof UserInterface) {
-            return $user;
-        }
-
-        return null;
     }
 }

--- a/src/Sulu/Component/SmartContent/DataProviderInterface.php
+++ b/src/Sulu/Component/SmartContent/DataProviderInterface.php
@@ -53,7 +53,6 @@ interface DataProviderInterface
         $limit = null,
         $page = 1,
         $pageSize = null
-        /* ?UserInterface $user */
     );
 
     /**
@@ -75,7 +74,6 @@ interface DataProviderInterface
         $limit = null,
         $page = 1,
         $pageSize = null
-        /* UserInterface $user = null */
     );
 
     /**
@@ -87,5 +85,5 @@ interface DataProviderInterface
      *
      * @return DatasourceItemInterface
      */
-    public function resolveDatasource($datasource, array $propertyParameter, array $options /* ?UserInterface $user */);
+    public function resolveDatasource($datasource, array $propertyParameter, array $options);
 }

--- a/src/Sulu/Component/SmartContent/DataProviderInterface.php
+++ b/src/Sulu/Component/SmartContent/DataProviderInterface.php
@@ -12,7 +12,6 @@
 namespace Sulu\Component\SmartContent;
 
 use Sulu\Component\Content\Compat\PropertyParameter;
-use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\SmartContent\Configuration\ProviderConfigurationInterface;
 
 /**

--- a/src/Sulu/Component/SmartContent/DataProviderInterface.php
+++ b/src/Sulu/Component/SmartContent/DataProviderInterface.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\SmartContent;
 
 use Sulu\Component\Content\Compat\PropertyParameter;
+use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\SmartContent\Configuration\ProviderConfigurationInterface;
 
 /**
@@ -52,6 +53,7 @@ interface DataProviderInterface
         $limit = null,
         $page = 1,
         $pageSize = null
+        /* ?UserInterface $user */
     );
 
     /**
@@ -73,6 +75,7 @@ interface DataProviderInterface
         $limit = null,
         $page = 1,
         $pageSize = null
+        /* UserInterface $user = null */
     );
 
     /**
@@ -84,5 +87,5 @@ interface DataProviderInterface
      *
      * @return DatasourceItemInterface
      */
-    public function resolveDatasource($datasource, array $propertyParameter, array $options);
+    public function resolveDatasource($datasource, array $propertyParameter, array $options /* ?UserInterface $user */);
 }

--- a/src/Sulu/Component/SmartContent/Orm/BaseDataProvider.php
+++ b/src/Sulu/Component/SmartContent/Orm/BaseDataProvider.php
@@ -14,6 +14,7 @@ namespace Sulu\Component\SmartContent\Orm;
 use JMS\Serializer\SerializationContext;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
+use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Serializer\ArraySerializerInterface;
 use Sulu\Component\SmartContent\ArrayAccessItem;
 use Sulu\Component\SmartContent\Configuration\Builder;
@@ -110,7 +111,8 @@ abstract class BaseDataProvider implements DataProviderInterface
         array $options = [],
         $limit = null,
         $page = 1,
-        $pageSize = null
+        $pageSize = null,
+        UserInterface $user = null
     ) {
         list($result, $hasNextPage) = $this->resolveFilters(
             $filters,
@@ -118,7 +120,8 @@ abstract class BaseDataProvider implements DataProviderInterface
             $limit,
             $page,
             $pageSize,
-            $this->getOptions($propertyParameter, $options)
+            $this->getOptions($propertyParameter, $options),
+            $user
         );
 
         return new DataProviderResult($this->decorateResourceItems($result, $options['locale']), $hasNextPage);
@@ -133,9 +136,10 @@ abstract class BaseDataProvider implements DataProviderInterface
         $limit = null,
         $page = 1,
         $pageSize = null,
-        $options = []
+        $options = [],
+        UserInterface $user = null
     ) {
-        $result = $this->repository->findByFilters($filters, $page, $pageSize, $limit, $locale, $options);
+        $result = $this->repository->findByFilters($filters, $page, $pageSize, $limit, $locale, $options, $user);
 
         $hasNextPage = false;
         if (null !== $pageSize && \count($result) > $pageSize) {

--- a/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryInterface.php
+++ b/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryInterface.php
@@ -29,5 +29,5 @@ interface DataProviderRepositoryInterface
      *
      * @return object[]
      */
-    public function findByFilters($filters, $page, $pageSize, $limit, $locale, $options = []);
+    public function findByFilters($filters, $page, $pageSize, $limit, $locale, $options = []/*, ?UserInterface $user*/);
 }

--- a/templates/pages/homepage.html.twig
+++ b/templates/pages/homepage.html.twig
@@ -10,4 +10,8 @@
             </li>
         {% endfor %}
     </ul>
+
+    {% for media in content.media %}
+        <img src="{{ media.thumbnails['sulu-260x'] }}" />
+    {% endfor %}
 {% endblock %}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4051
| Related issues/PRs | #5406 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR will hide elements for which the currently logged in user does not have any permissions.

#### Why?

Because that is the reason you apply security in the first place.

#### BC Breaks/Deprecations

TODO

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
- [x] Hide navigation items without sufficient permission
- [x] Hide pages from smart content without sufficient permissions
- [x] Hide pages from a selection field without sufficient permissions
- [x] Hide pages from a single selection field without sufficient permissions
- [x] Hide entities from smart content without sufficient permissions
- [x] Hide entities from a selection field without sufficient permissions
- [x] Hide entities from a single selection field without sufficient permissions
- [ ] Check for better solution than copying `getUser` function
- [x] Adjust `AccessControlManager` to fallback to anonymous role if no user is passed
- [x] Make sure the `MediaDataProvider` uses the collection to check permissions
- [x] Hide pages on sitemap not visible to anonymous users
- [x] `DataProviderRepositoryTrait` should also work without a user
- [ ] `DataProviderRepositoryTrait` could work only with `QueryBuilder` instead of returning the end result to be more flexible and reuse a known interface (not implementable now for BC reasons, but create an issue?)
- [x] Deprecate `SecuredEntityRepositoryTrait` and create a `AccessControlQueryEnhancer` service instead
- [x] Inject the `AccessControlQueryEnhancer` service into the `MediaDataRepository` so that it is available to the `DataProviderRepositoryTrait`
- [x] Lazily load anonymous role for current system in `SystemStore` to avoid multiple queries