### PR TITLE
Fix export data function of audience-target selection

### DIFF
--- a/src/Sulu/Bundle/AudienceTargetingBundle/Content/Types/AudienceTargetingGroups.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Content/Types/AudienceTargetingGroups.php
@@ -96,7 +96,7 @@ class AudienceTargetingGroups extends ComplexContentType implements ContentTypeE
             return \json_encode($propertyValue);
         }
 
-        return [];
+        return \json_encode([]);
     }
 
     public function importData(

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Content/Types/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Content/Types/AudienceTargetingGroupsTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Content/Types/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Content/Types/AudienceTargetingGroupsTest.php
@@ -118,4 +118,39 @@ class AudienceTargetingGroupsTest extends \PHPUnit_Framework_TestCase
 
         $this->audienceTargetingGroups->remove($node->reveal(), $property->reveal(), 'sulu_io', 'en', null);
     }
+
+    public function testExportData()
+    {
+        $this->assertEquals('[]', $this->audienceTargetingGroups->exportData(null));
+        $this->assertEquals('[]', $this->audienceTargetingGroups->exportData([]));
+        $this->assertEquals('[1]', $this->audienceTargetingGroups->exportData([1]));
+    }
+
+    public function testImportDataEmpty()
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $property = $this->prophesize(PropertyInterface::class);
+
+        $property->getName()->willReturn('test');
+
+        $property->setValue([])->shouldBeCalled();
+        $property->getValue()->willReturn([]);
+        $node->setProperty('test', [])->shouldBeCalled();
+
+        $this->audienceTargetingGroups->importData($node->reveal(), $property->reveal(), '[]', 1, 'sulu_io', 'en');
+    }
+
+    public function testImportData()
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $property = $this->prophesize(PropertyInterface::class);
+
+        $property->getName()->willReturn('test');
+
+        $property->setValue([1, 2])->shouldBeCalled();
+        $property->getValue()->willReturn([1, 2]);
+        $node->setProperty('test', [1, 2])->shouldBeCalled();
+
+        $this->audienceTargetingGroups->importData($node->reveal(), $property->reveal(), '[1, 2]', 1, 'sulu_io', 'en');
+    }
 }

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Export/WebspaceExportTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Export/WebspaceExportTest.php
@@ -465,7 +465,7 @@ class WebspaceExportTest extends SuluTestCase
                         'audience_targeting_groups',
                         'audience_targeting_groups',
                         false,
-                        $extensionData['excerpt']['audience_targeting_groups']
+                        \json_encode($extensionData['excerpt']['audience_targeting_groups'])
                     ),
                 ],
             ];


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the export function of the audience-target selection when the data is empty.

#### Why?

The export requires a string as result.
