### PR TITLE
Add Pages Security Check in ContentRouteProvider

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/website.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/website.xml
@@ -21,6 +21,7 @@
             <argument type="service" id="sulu.content.structure_manager"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="sulu_core.webspace.request_analyzer"/>
+            <argument type="service" id="sulu_security.security_checker" on-invalid="null"/>
 
             <tag name="sulu.context" context="website"/>
         </service>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes 
| Related issues/PRs | that the permissions are written to live workspace #5439 is needed
| License | MIT
| Documentation PR | -

#### What's in this PR?

Add Pages Security Check in ContentRouteProvider.

#### Why?

We want to disallow specific user to access specific pages on the website.

#### Example Usage

1. Add System to Webspace
2. Activate Security for the Project
3. Run `bin/console sulu:security:init`
4. Disallow Anonymous user for a specific page

#### BC Breaks/Deprecations

-

#### To Do

- [ ] ~~Create a documentation PR~~
- [ ] ~~Add breaking changes to UPGRADE.md~~
