### PR TITLE
Add all available permissions to anonymous roles

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -298,6 +298,29 @@ class PageAdmin extends Admin
 
     public function getSecurityContexts()
     {
+        $webspaceSecuritySystemContexts = [];
+
+        /** @var Webspace $webspace */
+        foreach ($this->webspaceManager->getWebspaceCollection() as $webspace) {
+            $security = $webspace->getSecurity();
+            if (!$security) {
+                continue;
+            }
+
+            $system = $security->getSystem();
+            if (!$system) {
+                continue;
+            }
+
+            $webspaceSecuritySystemContexts[$system] = [
+                static::SECURITY_CONTEXT_GROUP => [
+                    static::SECURITY_CONTEXT_PREFIX . $webspace->getKey() => [
+                        PermissionTypes::VIEW,
+                    ],
+                ],
+            ];
+        }
+
         $webspaceContexts = [];
         foreach ($this->webspaceManager->getWebspaceCollection() as $webspace) {
             /* @var Webspace $webspace */
@@ -317,32 +340,11 @@ class PageAdmin extends Admin
                     'Webspaces' => $webspaceContexts,
                 ],
             ],
-            $this->getWebspaceSecuritySystemContexts()
+            $webspaceSecuritySystemContexts
         );
     }
 
     public function getSecurityContextsWithPlaceholder()
-    {
-        return \array_merge(
-            [
-                static::SULU_ADMIN_SECURITY_SYSTEM => [
-                    static::SECURITY_CONTEXT_GROUP => [
-                        static::SECURITY_CONTEXT_PREFIX . '#webspace#' => [
-                            PermissionTypes::VIEW,
-                            PermissionTypes::ADD,
-                            PermissionTypes::EDIT,
-                            PermissionTypes::DELETE,
-                            PermissionTypes::LIVE,
-                            PermissionTypes::SECURITY,
-                        ],
-                    ],
-                ],
-            ],
-            $this->getWebspaceSecuritySystemContexts()
-        );
-    }
-
-    private function getWebspaceSecuritySystemContexts(): array
     {
         $webspaceSecuritySystemContexts = [];
 
@@ -367,7 +369,23 @@ class PageAdmin extends Admin
             ];
         }
 
-        return $webspaceSecuritySystemContexts;
+        return \array_merge(
+            [
+                static::SULU_ADMIN_SECURITY_SYSTEM => [
+                    static::SECURITY_CONTEXT_GROUP => [
+                        static::SECURITY_CONTEXT_PREFIX . '#webspace#' => [
+                            PermissionTypes::VIEW,
+                            PermissionTypes::ADD,
+                            PermissionTypes::EDIT,
+                            PermissionTypes::DELETE,
+                            PermissionTypes::LIVE,
+                            PermissionTypes::SECURITY,
+                        ],
+                    ],
+                ],
+            ],
+            $webspaceSecuritySystemContexts
+        );
     }
 
     public function getConfigKey(): ?string

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Admin/PageAdminTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Admin/PageAdminTest.php
@@ -182,7 +182,7 @@ class PageAdminTest extends TestCase
                 ],
                 'webspace-security-system-2' => [
                     'Webspaces' => [
-                        'sulu.webspaces.#webspace#' => ['view'],
+                        'sulu.webspaces.webspace-key-2' => ['view'],
                     ],
                 ],
             ],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds all available permissions from a anonymous role to the anonymous role of this system.

#### Why?

Because the security system is implemented in a way, that it does not grant access, if it does not have any permissions on the given security context, even if the object under investigation has added security for the given role.

Because of that it might also make sense to make the anonymous roles editable in the UI, because if e.g. a new webspace is added, the anonymous role will lack the permissions for that webspace. Also somebody might want to disallow an entire webspace only for the anonymous role. That would be quite cumbersome to do without this feature, as every page would have to be adjusted accordingly. But I guess that's a topic for a separate PR.