### PR TITLE
Write permissions of pages also to live workspace

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Resources/config/document.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/document.xml
@@ -96,6 +96,7 @@
         <service id="sulu_document_manager.document.subscriber.security"
                  class="Sulu\Component\Content\Document\Subscriber\SecuritySubscriber">
             <argument>%sulu_security.permissions%</argument>
+            <argument type="service" id="sulu_document_manager.live_session"/>
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR will also write security information of pages on the live workspaces.

#### Why?

Because we need that information in the live workspace, in order to implement security for pages on the website. That is a prerequisite for #5439 and #5446.