### PR TITLE
Fix format regenerate command on windows

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateCommand.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateCommand.php
@@ -100,7 +100,7 @@ class FormatCacheRegenerateCommand extends Command
 
     private function getFileInformationArrayFromPath($path): array
     {
-        $pathParts = \explode('/', $path);
+        $pathParts = \explode(\DIRECTORY_SEPARATOR, $path);
         $formatKey = \reset($pathParts);
         $filenameParts = \explode('-', \end($pathParts), 2);
         $id = (int) $filenameParts[0];


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | #5393 
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix format regenerate command on windows.

#### Why?

The command didn't use the directory seperator so it failed on windows. Appveyor did fail but did not notice that because we currently have a failing appveyor because of the audience targeting / jms serializer bug.
