### PR TITLE
Fix security for webspaces without a system

### DIFF
--- a/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
@@ -85,11 +85,15 @@ class AccessControlManager implements AccessControlManagerInterface
 
     public function getUserPermissions(SecurityCondition $securityCondition, $user)
     {
+        $system = $this->systemStore->getSystem();
+        if (!$system) {
+            return $this->maskConverter->convertPermissionsToArray(127);
+        }
+
         if (!($user instanceof UserInterface)) {
             $user = null;
         }
 
-        $system = $this->systemStore->getSystem();
         $locale = $securityCondition->getLocale();
 
         $objectPermissions = $this->getUserObjectPermission(
@@ -120,6 +124,10 @@ class AccessControlManager implements AccessControlManagerInterface
         $user
     ) {
         $system = $this->systemStore->getSystem();
+
+        if (!$system) {
+            return $this->maskConverter->convertPermissionsToArray(127);
+        }
 
         $objectPermissions = $this->getRolesObjectPermissionsByArray(
             $objectPermissionsByRole,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #5439 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes an issue that was probably introduced by #5439. If a webspace does not have a security system attached (that means no `<security>` tag in the webspace config), no elements are shown in e.g. the navigation or smart content.

#### Why?

Because in #5439 that case was not considered.

#### Example Usage

Use the sulu/skeleton template repository, create a few pages, and assign them to the navigation. The navigation will still be empty, unless this PR is checked out.