### PR TITLE
Fix mobx regression causing error in development build

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
@@ -1,6 +1,6 @@
 // @flow
 import {observer} from 'mobx-react';
-import {action, computed} from 'mobx';
+import {action, computed, toJS} from 'mobx';
 import React, {Fragment} from 'react';
 import ToolbarComponent from '../../components/Toolbar';
 import Snackbar from '../../components/Snackbar';
@@ -153,7 +153,11 @@ class Toolbar extends React.Component<ToolbarProps> {
                     <ToolbarComponent.Controls>
                         {iconsConfig.length > 0 &&
                             <ToolbarComponent.Icons>
-                                {iconsConfig.map((icon) => icon)}
+                                {iconsConfig.map((icon) => {
+                                    // TODO this creates a deep copy and has a performance impact.
+                                    // Would be better to return functional components in withToolbar.
+                                    return toJS(icon);
+                                })}
                             </ToolbarComponent.Icons>
                         }
                         {!!localeConfig &&

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/types.js
@@ -36,7 +36,7 @@ export type ToolbarConfig = {
     backButton?: Button,
     disableAll?: boolean,
     errors?: Array<string>,
-    icons?: Array<Node>,
+    icons?: Array<Node>, // TODO would be better to be typed as Array<React.ComponentType>
     items?: Array<ToolbarItemConfig<*>>,
     locale?: Select<string>,
     showSuccess?: IObservableValue<boolean>,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | mobxjs/mobx#2430, webpack/webpack#11312
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds a `toJS` to the JSX passed via a mobx store, because since mobx 4.15.5 the internals of react also seem to be tracked by mobx, and causes an error when react tries to change those later. See also mobxjs/mobx#2430 for more details.

#### Example Usage

1. Make a development build using `npm run watch`
2. Open an existing page in Sulu
3. Before this PR the screen will turn blank and an error is shown in the dev tools