### PR TITLE
Introduce SaveWithFormDialogToolbarAction to show forms on save

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,27 @@
 
 ## dev-master
 
+### Deprecation of passing action string to submit form functions
+
+Passing an `action` string to the `submit` function of the `Form` react component is deprecated, instead an `options`
+object is passed now, which is more flexible. The old way still works, but will log a warning and will be removed
+in the next major release.
+
+This change affects the following JavaScript code:
+- `Form` container
+- `Form` view
+- `FormInspector`
+- `SaveHandler` registered in the `FormInspector`
+
+To avoid using the deprecation rewrite your code as shown in the next code snippet:
+
+```javascript
+// Before
+form.submit('publish');
+// After
+form.submit({action: 'publish'});
+```
+
 ### Role Entity changed for anonymous roles
 
 Sulu needs to handle anonymous users, so we need additional anonymous roles.

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/SaveWithFormDialogToolbarAction.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/SaveWithFormDialogToolbarAction.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Admin\View;
+
+class SaveWithFormDialogToolbarAction extends ToolbarAction
+{
+    public function __construct(string $title, string $formKey)
+    {
+        parent::__construct(
+            'sulu_admin.save_with_form_dialog',
+            [
+                'formKey' => $formKey,
+                'title' => $title,
+            ]
+        );
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/SaveWithFormDialogToolbarAction.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/SaveWithFormDialogToolbarAction.php
@@ -13,11 +13,12 @@ namespace Sulu\Bundle\AdminBundle\Admin\View;
 
 class SaveWithFormDialogToolbarAction extends ToolbarAction
 {
-    public function __construct(string $title, string $formKey)
+    public function __construct(string $title, string $formKey, string $condition = 'true')
     {
         parent::__construct(
             'sulu_admin.save_with_form_dialog',
             [
+                'condition' => $condition,
                 'formKey' => $formKey,
                 'title' => $title,
             ]

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -155,6 +155,13 @@
             <tag name="jms_serializer.event_subscriber"/>
         </service>
 
+        <service id="sulu_admin.save_with_form_dialog_toolbar_action_subscriber"
+            class="Sulu\Bundle\AdminBundle\Serializer\Subscriber\SaveWithFormDialogToolbarActionSubscriber"
+        >
+            <argument type="service" id="translator"/>
+            <tag name="jms_serializer.event_subscriber"/>
+        </service>
+
         <service id="sulu_admin.toggler_toolbar_action_subscriber"
             class="Sulu\Bundle\AdminBundle\Serializer\Subscriber\TogglerToolbarActionSubscriber"
         >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
@@ -15,7 +15,7 @@ import MissingTypeDialog from './MissingTypeDialog';
 type Props = {|
     onError?: (errors: Object) => void,
     onMissingTypeCancel?: () => void,
-    onSubmit: (action: ?string) => ?Promise<Object>,
+    onSubmit: (action: ?string | {[string]: any}) => ?Promise<Object>,
     onSuccess?: () => void,
     router?: Router,
     store: FormStoreInterface,
@@ -67,16 +67,23 @@ class Form extends React.Component<Props> {
     }
 
     /** @public */
-    @action submit = (action: ?string) => {
+    @action submit = (options: ?string | {[string]: any}) => {
+        if (typeof options === 'string') {
+            log.warn(
+                'Passing a string to the "submit" method is deprecated since 2.2 and will be removed. ' +
+                'Pass an object with an "action" property instead.'
+            );
+        }
+
         const {onError, onSubmit, store} = this.props;
 
         this.showAllErrors = true;
 
         if (store.validate()) {
-            const submitPromise = onSubmit(action);
+            const submitPromise = onSubmit(options);
             if (submitPromise) {
                 return submitPromise.then((response) => {
-                    this.formInspector.triggerSaveHandler(action);
+                    this.formInspector.triggerSaveHandler(options);
                     return response;
                 });
             }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/FormInspector.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/FormInspector.js
@@ -1,6 +1,7 @@
 // @flow
 import {computed} from 'mobx';
 import type {IObservableValue} from 'mobx';
+import log from 'loglevel';
 import type {FinishFieldHandler, FormStoreInterface, SaveHandler} from './types';
 
 export default class FormInspector {
@@ -56,8 +57,15 @@ export default class FormInspector {
         this.saveHandlers.push(saveHandler);
     }
 
-    triggerSaveHandler(action: ?string) {
-        this.saveHandlers.forEach((saveHandler) => saveHandler(action));
+    triggerSaveHandler(options: ?string | {[string]: any}) {
+        if (typeof options === 'string') {
+            log.warn(
+                'Passing a string to the "submit" method is deprecated since 2.2 and will be removed. ' +
+                'Pass an object with an "action" property instead.'
+            );
+        }
+
+        this.saveHandlers.forEach((saveHandler) => saveHandler(options));
     }
 
     addFinishFieldHandler(finishFieldHandler: FinishFieldHandler) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -90,7 +90,7 @@ export type Schema = {[string]: SchemaEntry};
 
 export type FinishFieldHandler = (dataPath: string, schemaPath: string) => void;
 
-export type SaveHandler = (action: ?string) => void;
+export type SaveHandler = (action: ?string | {[string]: any}) => void;
 
 export type ConditionDataProvider = (
     data: {[string]: any},

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -96,6 +96,7 @@ import Form, {
     DeleteToolbarAction as FormDeleteToolbarAction,
     DropdownToolbarAction as FormDropdownToolbarAction,
     SaveToolbarAction as FormSaveToolbarAction,
+    SaveWithFormDialogToolbarAction as FormSaveWithFormDialogToolbarAction,
     SaveWithPublishingToolbarAction as FormSaveWithPublishingToolbarAction,
     SetUnpublishedToolbarAction as FormSetUnpublishedToolbarAction,
     TypeToolbarAction as FormTypeToolbarAction,
@@ -290,6 +291,7 @@ function registerFormToolbarActions() {
     formToolbarActionRegistry.add('sulu_admin.dropdown', FormDropdownToolbarAction);
     formToolbarActionRegistry.add('sulu_admin.save_with_publishing', FormSaveWithPublishingToolbarAction);
     formToolbarActionRegistry.add('sulu_admin.save', FormSaveToolbarAction);
+    formToolbarActionRegistry.add('sulu_admin.save_with_form_dialog', FormSaveWithFormDialogToolbarAction);
     formToolbarActionRegistry.add('sulu_admin.set_unpublished', FormSetUnpublishedToolbarAction);
     formToolbarActionRegistry.add('sulu_admin.type', FormTypeToolbarAction);
     formToolbarActionRegistry.add('sulu_admin.toggler', FormTogglerToolbarAction);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -260,7 +260,7 @@ class Form extends React.Component<Props> {
     };
 
     @action componentDidMount() {
-        const {router} = this.props;
+        const {resourceStore: parentResourceStore, router} = this.props;
         const {
             route: {
                 options: {
@@ -292,7 +292,8 @@ class Form extends React.Component<Props> {
                 this,
                 router,
                 this.locales,
-                toolbarAction.options
+                toolbarAction.options,
+                parentResourceStore
             ));
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -5,6 +5,7 @@ import type {IObservableValue} from 'mobx';
 import {action, computed, toJS, isObservableArray, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import equals from 'fast-deep-equal';
+import log from 'loglevel';
 import Dialog from '../../components/Dialog';
 import PublishIndicator from '../../components/PublishIndicator';
 import {default as FormContainer, ResourceFormStore, resourceFormStoreFactory} from '../../containers/Form';
@@ -315,21 +316,39 @@ class Form extends React.Component<Props> {
         if (this.hasOwnResourceStore) {
             this.resourceStore.destroy();
         }
+
+        this.toolbarActions.forEach((toolbarAction) => toolbarAction.destroy());
     }
 
     @action showSuccessSnackbar = () => {
         this.showSuccess.set(true);
     };
 
-    @action submit = (action: ?string) => {
+    @action submit = (options: ?string | {[string]: any}) => {
+        if (typeof options === 'string') {
+            log.warn(
+                'Passing a string to the "submit" method is deprecated since 2.2 and will be removed. ' +
+                'Pass an object with an "action" property instead.'
+            );
+        }
+
         if (!this.form) {
             throw new Error('The form ref has not been set! This should not happen and is likely a bug.');
         }
-        this.form.submit(action);
+        this.form.submit(options);
     };
 
-    handleSubmit = (actionParameter: ?string) => {
-        return this.save({action: actionParameter});
+    handleSubmit = (options: ?string | {[string]: any}) => {
+        if (typeof options === 'string') {
+            log.warn(
+                'Passing a string to the "submit" method is deprecated since 2.2 and will be removed. ' +
+                'Pass an object with an "action" property instead.'
+            );
+
+            options = {action: options};
+        }
+
+        return this.save(options);
     };
 
     handleSuccess = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/index.js
@@ -7,6 +7,7 @@ import DeleteDraftToolbarAction from './toolbarActions/DeleteDraftToolbarAction'
 import DeleteToolbarAction from './toolbarActions/DeleteToolbarAction';
 import DropdownToolbarAction from './toolbarActions/DropdownToolbarAction';
 import SaveWithPublishingToolbarAction from './toolbarActions/SaveWithPublishingToolbarAction';
+import SaveWithFormDialogToolbarAction from './toolbarActions/SaveWithFormDialogToolbarAction';
 import SaveToolbarAction from './toolbarActions/SaveToolbarAction';
 import SetUnpublishedToolbarAction from './toolbarActions/SetUnpublishedToolbarAction';
 import TypeToolbarAction from './toolbarActions/TypeToolbarAction';
@@ -23,6 +24,7 @@ export {
     DropdownToolbarAction,
     SaveWithPublishingToolbarAction,
     SaveToolbarAction,
+    SaveWithFormDialogToolbarAction,
     SetUnpublishedToolbarAction,
     TypeToolbarAction,
     TogglerToolbarAction,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -426,7 +426,8 @@ test('Should add items defined in ToolbarActions to Toolbar with options', () =>
         form.instance(),
         router,
         undefined,
-        {test1: 'value1'}
+        {test1: 'value1'},
+        resourceStore
     );
 
     expect(DeleteToolbarAction).toBeCalledWith(
@@ -434,7 +435,8 @@ test('Should add items defined in ToolbarActions to Toolbar with options', () =>
         form.instance(),
         router,
         undefined,
-        {test2: 'value2'}
+        {test2: 'value2'},
+        resourceStore
     );
 
     expect(EditToolbarAction).toBeCalledWith(
@@ -442,7 +444,8 @@ test('Should add items defined in ToolbarActions to Toolbar with options', () =>
         form.instance(),
         router,
         undefined,
-        {}
+        {},
+        resourceStore
     );
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -1127,7 +1127,7 @@ test('Should save form when submitted', () => {
     resourceStore.destroy = jest.fn();
 
     return Promise.all([schemaTypesPromise, schemaPromise, jsonSchemaPromise]).then(() => {
-        form.find('Form').at(1).instance().submit('publish');
+        form.find('Form').at(1).instance().submit({action: 'publish'});
         expect(resourceStore.destroy).not.toBeCalled();
         expect(ResourceRequester.put).toBeCalledWith(
             'snippets',
@@ -1390,7 +1390,7 @@ test('Should show warning when form is submitted but already changed on the serv
     resourceStore.destroy = jest.fn();
 
     return Promise.all([schemaTypesPromise, schemaPromise, jsonSchemaPromise]).then(() => {
-        form.find('Form').at(1).instance().submit('publish');
+        form.find('Form').at(1).instance().submit({action: 'publish'});
         expect(resourceStore.destroy).not.toBeCalled();
         expect(ResourceRequester.put).toBeCalledWith(
             'snippets',
@@ -1461,7 +1461,7 @@ test('Should show warning when form is submitted but already changed on the serv
     resourceStore.destroy = jest.fn();
 
     return Promise.all([schemaTypesPromise, schemaPromise, jsonSchemaPromise]).then(() => {
-        form.find('Form').at(1).instance().submit('publish');
+        form.find('Form').at(1).instance().submit({action: 'publish'});
         expect(resourceStore.destroy).not.toBeCalled();
         expect(ResourceRequester.put).toBeCalledWith(
             'snippets',
@@ -2045,16 +2045,44 @@ test('Should pass options to Form metadata with mixed routerAttribuesToFormMetad
 });
 
 test('Should destroy the store on unmount', () => {
+    const formToolbarActionRegistry = require('../registries/formToolbarActionRegistry');
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
     const resourceStore = new ResourceStore('snippets', 12, {locale: observable.box()});
     resourceStore.destroy = jest.fn();
+
+    const SaveToolbarAction = jest.fn(function() {
+        this.getNode = jest.fn();
+        this.destroy = jest.fn();
+    });
+
+    const DeleteToolbarAction = jest.fn(function() {
+        this.getNode = jest.fn();
+        this.destroy = jest.fn();
+    });
+
+    formToolbarActionRegistry.get.mockImplementation((name) => {
+        switch (name) {
+            case 'save':
+                return SaveToolbarAction;
+            case 'delete':
+                return DeleteToolbarAction;
+        }
+    });
+
     const route = {
         options: {
             formKey: 'snippets',
             locales: [],
             resourceKey: 'snippets',
-            toolbarActions: [],
+            toolbarActions: [
+                {
+                    type: 'save',
+                },
+                {
+                    type: 'delete',
+                },
+            ],
         },
     };
     const router = {
@@ -2073,9 +2101,13 @@ test('Should destroy the store on unmount', () => {
     const resourceFormStore = form.instance().resourceFormStore;
     resourceFormStore.destroy = jest.fn();
 
+    const toolbarActions = form.instance().toolbarActions;
+
     form.unmount();
     expect(resourceFormStore.destroy).toBeCalled();
     expect(resourceStore.destroy).not.toBeCalled();
+    expect(toolbarActions[0].destroy).toBeCalled();
+    expect(toolbarActions[1].destroy).toBeCalled();
 });
 
 test('Should destroy the own resourceStore if existing on unmount', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/CopyLocaleToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/CopyLocaleToolbarAction.test.js
@@ -77,7 +77,7 @@ function createCopyLocaleToolbarAction(locales, options = {}) {
         router,
     });
 
-    return new CopyLocaleToolbarAction(formStore, form, router, locales, options);
+    return new CopyLocaleToolbarAction(formStore, form, router, locales, options, resourceStore);
 }
 
 test('Return enabled item config', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteDraftToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteDraftToolbarAction.test.js
@@ -78,7 +78,7 @@ function createDeleteDraftToolbarAction(options = {}) {
         router,
     });
 
-    return new DeleteDraftToolbarAction(formStore, form, router, [], options);
+    return new DeleteDraftToolbarAction(formStore, form, router, [], options, resourceStore);
 }
 
 test('Return enabled item config', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteToolbarAction.test.js
@@ -63,7 +63,7 @@ function createDeleteToolbarAction(options = {}) {
         route: router.route,
         router,
     });
-    return new DeleteToolbarAction(resourceFormStore, form, router, [], options);
+    return new DeleteToolbarAction(resourceFormStore, form, router, [], options, resourceStore);
 }
 
 test('Return item config with correct disabled, loading, icon, type and value and return closed dialog', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DropdownToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DropdownToolbarAction.test.js
@@ -50,7 +50,7 @@ function createDropdownToolbarAction(options = {}) {
         router,
     });
 
-    return new DropdownToolbarAction(resourceFormStore, form, router, [], options);
+    return new DropdownToolbarAction(resourceFormStore, form, router, [], options, resourceStore);
 }
 
 test('Return item config with an option for every action in array and skip undefined button', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveToolbarAction.test.js
@@ -45,7 +45,7 @@ function createSaveToolbarAction() {
         router,
     });
 
-    return new SaveToolbarAction(resourceFormStore, form, router, [], {});
+    return new SaveToolbarAction(resourceFormStore, form, router, [], {}, resourceStore);
 }
 
 test('Return item config with correct disabled, loading, icon, type and value', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithFormDialogToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithFormDialogToolbarAction.test.js
@@ -91,14 +91,48 @@ test('Return item config with loading button when saving flag is set', () => {
 });
 
 test('Throw error if no formKey is passed', () => {
-    expect(() => createSaveWithFormDialogToolbarAction({})).toThrow(/"formKey"/);
+    const saveWithFormDialogToolbarAction = createSaveWithFormDialogToolbarAction({title: 'Test'});
+
+    const toolbarItemConfig = saveWithFormDialogToolbarAction.getToolbarItemConfig();
+    if (!toolbarItemConfig) {
+        throw new Error('The toolbarItemConfig should be a value!');
+    }
+
+    const clickHandler = toolbarItemConfig.onClick;
+    if (!clickHandler) {
+        throw new Error('A onClick callback should be registered on the copy locale option');
+    }
+
+    clickHandler();
+
+    expect(() => saveWithFormDialogToolbarAction.getNode()).toThrow(/"formKey"/);
 });
 
 test('Destroy store when being destroyed', () => {
-    const saveWithFormDialogToolbarAction = createSaveWithFormDialogToolbarAction({formKey: 'test'});
+    const saveWithFormDialogToolbarAction = createSaveWithFormDialogToolbarAction({formKey: 'test', title: 'Test'});
+
+    const toolbarItemConfig = saveWithFormDialogToolbarAction.getToolbarItemConfig();
+    if (!toolbarItemConfig) {
+        throw new Error('The toolbarItemConfig should be a value!');
+    }
+
+    const clickHandler = toolbarItemConfig.onClick;
+    if (!clickHandler) {
+        throw new Error('A onClick callback should be registered on the copy locale option');
+    }
+
+    clickHandler();
+
+    saveWithFormDialogToolbarAction.getNode();
     saveWithFormDialogToolbarAction.destroy();
 
-    expect(saveWithFormDialogToolbarAction.dialogFormStore.destroy).toBeCalledWith();
+    const dialogFormStore = saveWithFormDialogToolbarAction.dialogFormStore;
+
+    if (!dialogFormStore) {
+        throw new Error('The dialogFormStore should have been initialized');
+    }
+
+    expect(dialogFormStore.destroy).toBeCalledWith();
 });
 
 test('Close dialog when cancel button of dialog is clicked', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithFormDialogToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithFormDialogToolbarAction.test.js
@@ -1,0 +1,181 @@
+// @flow
+import mockReact from 'react';
+import {mount} from 'enzyme';
+import FormContainer, {ResourceFormStore} from '../../../../containers/Form';
+import Router from '../../../../services/Router';
+import ResourceStore from '../../../../stores/ResourceStore';
+import Form from '../../../../views/Form';
+import SaveWithFormDialogToolbarAction from '../../toolbarActions/SaveWithFormDialogToolbarAction';
+
+jest.mock('../../../../utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
+
+jest.mock('../../../../containers/Form/Form', () => class extends mockReact.Component<*> {
+    submit = jest.fn();
+
+    render() {
+        return null;
+    }
+});
+
+jest.mock('../../../../containers/Form/stores/ResourceFormStore', () => class {
+    resourceStore;
+    constructor(resourceStore) {
+        this.resourceStore = resourceStore;
+    }
+
+    get dirty() {
+        return this.resourceStore.dirty;
+    }
+
+    get saving() {
+        return this.resourceStore.saving;
+    }
+});
+
+jest.mock('../../../../containers/Form/stores/memoryFormStoreFactory', () => ({
+    createFromFormKey: jest.fn(() => ({destroy: jest.fn()})),
+}));
+
+jest.mock('../../../../services/Router', () => jest.fn());
+
+jest.mock('../../../../views/Form', () => jest.fn(function() {
+    this.submit = jest.fn();
+}));
+
+function createSaveWithFormDialogToolbarAction(options: {[string]: any}) {
+    const locales = [];
+    const resourceStore = new ResourceStore('test');
+    const formStore = new ResourceFormStore(resourceStore, 'test');
+    const router = new Router({});
+    const form = new Form({
+        locales,
+        resourceStore,
+        route: router.route,
+        router,
+    });
+
+    return new SaveWithFormDialogToolbarAction(formStore, form, router, locales, options);
+}
+
+test('Return item config with correct disabled, loading, icon, type and value', () => {
+    const saveWithFormDialogToolbarAction = createSaveWithFormDialogToolbarAction({formKey: 'test'});
+    saveWithFormDialogToolbarAction.resourceFormStore.resourceStore.saving = false;
+
+    expect(saveWithFormDialogToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        disabled: true,
+        label: 'sulu_admin.save',
+        loading: false,
+        icon: 'su-save',
+        type: 'button',
+    }));
+});
+
+test('Return item config with enabled button when dirty flag is set', () => {
+    const saveWithFormDialogToolbarAction = createSaveWithFormDialogToolbarAction({formKey: 'test'});
+    saveWithFormDialogToolbarAction.resourceFormStore.resourceStore.dirty = true;
+
+    expect(saveWithFormDialogToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        disabled: false,
+    }));
+});
+
+test('Return item config with loading button when saving flag is set', () => {
+    const saveWithFormDialogToolbarAction = createSaveWithFormDialogToolbarAction({formKey: 'test'});
+    saveWithFormDialogToolbarAction.resourceFormStore.resourceStore.saving = true;
+
+    expect(saveWithFormDialogToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        loading: true,
+    }));
+});
+
+test('Throw error if no formKey is passed', () => {
+    expect(() => createSaveWithFormDialogToolbarAction({})).toThrow(/"formKey"/);
+});
+
+test('Destroy store when being destroyed', () => {
+    const saveWithFormDialogToolbarAction = createSaveWithFormDialogToolbarAction({formKey: 'test'});
+    saveWithFormDialogToolbarAction.destroy();
+
+    expect(saveWithFormDialogToolbarAction.dialogFormStore.destroy).toBeCalledWith();
+});
+
+test('Close dialog when cancel button of dialog is clicked', () => {
+    const saveWithFormDialogToolbarAction = createSaveWithFormDialogToolbarAction({formKey: 'test', title: 'Test'});
+
+    const toolbarItemConfig = saveWithFormDialogToolbarAction.getToolbarItemConfig();
+    if (!toolbarItemConfig) {
+        throw new Error('The toolbarItemConfig should be a value!');
+    }
+
+    const clickHandler = toolbarItemConfig.onClick;
+    if (!clickHandler) {
+        throw new Error('A onClick callback should be registered on the copy locale option');
+    }
+
+    let element = mount(saveWithFormDialogToolbarAction.getNode()).at(0);
+    expect(element.instance().props).toEqual(expect.objectContaining({
+        open: false,
+    }));
+
+    clickHandler();
+    element = mount(saveWithFormDialogToolbarAction.getNode()).at(0);
+    expect(element.instance().props).toEqual(expect.objectContaining({
+        open: true,
+    }));
+
+    element.find('Dialog').prop('onCancel')();
+    element = mount(saveWithFormDialogToolbarAction.getNode()).at(0);
+    expect(element.instance().props).toEqual(expect.objectContaining({
+        open: false,
+    }));
+
+    const dialogForm = saveWithFormDialogToolbarAction.dialogForm;
+    if (!dialogForm) {
+        throw new Error('The dialogForm should be defined');
+    }
+
+    expect(dialogForm.submit).not.toBeCalled();
+});
+
+test('Submit form with passed form data dialog when confirm button of dialog is clicked', () => {
+    const saveWithFormDialogToolbarAction = createSaveWithFormDialogToolbarAction({formKey: 'test', title: 'Test'});
+
+    const toolbarItemConfig = saveWithFormDialogToolbarAction.getToolbarItemConfig();
+    if (!toolbarItemConfig) {
+        throw new Error('The toolbarItemConfig should be a value!');
+    }
+
+    const clickHandler = toolbarItemConfig.onClick;
+    if (!clickHandler) {
+        throw new Error('A onClick callback should be registered on the copy locale option');
+    }
+
+    let element = mount(saveWithFormDialogToolbarAction.getNode()).at(0);
+    expect(element.instance().props).toEqual(expect.objectContaining({
+        open: false,
+    }));
+
+    clickHandler();
+    element = mount(saveWithFormDialogToolbarAction.getNode()).at(0);
+    expect(element.instance().props).toEqual(expect.objectContaining({
+        open: true,
+    }));
+
+    // $FlowFixMe
+    saveWithFormDialogToolbarAction.dialogFormStore.data = {test: 'Test'};
+
+    element.find(FormContainer).prop('onSubmit')();
+    element = mount(saveWithFormDialogToolbarAction.getNode()).at(0);
+
+    const dialogForm = saveWithFormDialogToolbarAction.dialogForm;
+    if (!dialogForm) {
+        throw new Error('The dialogForm should be defined');
+    }
+
+    expect(saveWithFormDialogToolbarAction.form.submit).toBeCalledWith({test: 'Test'});
+    expect(element.instance().props).toEqual(expect.objectContaining({
+        open: false,
+    }));
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithFormDialogToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithFormDialogToolbarAction.test.js
@@ -56,7 +56,7 @@ function createSaveWithFormDialogToolbarAction(options: {[string]: any}) {
         router,
     });
 
-    return new SaveWithFormDialogToolbarAction(formStore, form, router, locales, options);
+    return new SaveWithFormDialogToolbarAction(formStore, form, router, locales, options, resourceStore);
 }
 
 test('Return item config with correct disabled, loading, icon, type and value', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithFormDialogToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithFormDialogToolbarAction.test.js
@@ -91,48 +91,14 @@ test('Return item config with loading button when saving flag is set', () => {
 });
 
 test('Throw error if no formKey is passed', () => {
-    const saveWithFormDialogToolbarAction = createSaveWithFormDialogToolbarAction({title: 'Test'});
-
-    const toolbarItemConfig = saveWithFormDialogToolbarAction.getToolbarItemConfig();
-    if (!toolbarItemConfig) {
-        throw new Error('The toolbarItemConfig should be a value!');
-    }
-
-    const clickHandler = toolbarItemConfig.onClick;
-    if (!clickHandler) {
-        throw new Error('A onClick callback should be registered on the copy locale option');
-    }
-
-    clickHandler();
-
-    expect(() => saveWithFormDialogToolbarAction.getNode()).toThrow(/"formKey"/);
+    expect(() => createSaveWithFormDialogToolbarAction({})).toThrow(/"formKey"/);
 });
 
 test('Destroy store when being destroyed', () => {
-    const saveWithFormDialogToolbarAction = createSaveWithFormDialogToolbarAction({formKey: 'test', title: 'Test'});
-
-    const toolbarItemConfig = saveWithFormDialogToolbarAction.getToolbarItemConfig();
-    if (!toolbarItemConfig) {
-        throw new Error('The toolbarItemConfig should be a value!');
-    }
-
-    const clickHandler = toolbarItemConfig.onClick;
-    if (!clickHandler) {
-        throw new Error('A onClick callback should be registered on the copy locale option');
-    }
-
-    clickHandler();
-
-    saveWithFormDialogToolbarAction.getNode();
+    const saveWithFormDialogToolbarAction = createSaveWithFormDialogToolbarAction({formKey: 'test'});
     saveWithFormDialogToolbarAction.destroy();
 
-    const dialogFormStore = saveWithFormDialogToolbarAction.dialogFormStore;
-
-    if (!dialogFormStore) {
-        throw new Error('The dialogFormStore should have been initialized');
-    }
-
-    expect(dialogFormStore.destroy).toBeCalledWith();
+    expect(saveWithFormDialogToolbarAction.dialogFormStore.destroy).toBeCalledWith();
 });
 
 test('Close dialog when cancel button of dialog is clicked', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithFormDialogToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithFormDialogToolbarAction.test.js
@@ -60,7 +60,7 @@ function createSaveWithFormDialogToolbarAction(options: {[string]: any}) {
 }
 
 test('Return item config with correct disabled, loading, icon, type and value', () => {
-    const saveWithFormDialogToolbarAction = createSaveWithFormDialogToolbarAction({formKey: 'test'});
+    const saveWithFormDialogToolbarAction = createSaveWithFormDialogToolbarAction({condition: 'true', formKey: 'test'});
     saveWithFormDialogToolbarAction.resourceFormStore.resourceStore.saving = false;
 
     expect(saveWithFormDialogToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
@@ -73,7 +73,7 @@ test('Return item config with correct disabled, loading, icon, type and value', 
 });
 
 test('Return item config with enabled button when dirty flag is set', () => {
-    const saveWithFormDialogToolbarAction = createSaveWithFormDialogToolbarAction({formKey: 'test'});
+    const saveWithFormDialogToolbarAction = createSaveWithFormDialogToolbarAction({condition: 'true', formKey: 'test'});
     saveWithFormDialogToolbarAction.resourceFormStore.resourceStore.dirty = true;
 
     expect(saveWithFormDialogToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
@@ -82,7 +82,7 @@ test('Return item config with enabled button when dirty flag is set', () => {
 });
 
 test('Return item config with loading button when saving flag is set', () => {
-    const saveWithFormDialogToolbarAction = createSaveWithFormDialogToolbarAction({formKey: 'test'});
+    const saveWithFormDialogToolbarAction = createSaveWithFormDialogToolbarAction({condition: 'true', formKey: 'test'});
     saveWithFormDialogToolbarAction.resourceFormStore.resourceStore.saving = true;
 
     expect(saveWithFormDialogToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
@@ -102,7 +102,9 @@ test('Destroy store when being destroyed', () => {
 });
 
 test('Close dialog when cancel button of dialog is clicked', () => {
-    const saveWithFormDialogToolbarAction = createSaveWithFormDialogToolbarAction({formKey: 'test', title: 'Test'});
+    const saveWithFormDialogToolbarAction = createSaveWithFormDialogToolbarAction(
+        {condition: 'true', formKey: 'test', title: 'Test'}
+    );
 
     const toolbarItemConfig = saveWithFormDialogToolbarAction.getToolbarItemConfig();
     if (!toolbarItemConfig) {
@@ -140,7 +142,18 @@ test('Close dialog when cancel button of dialog is clicked', () => {
 });
 
 test('Submit form with passed form data dialog when confirm button of dialog is clicked', () => {
-    const saveWithFormDialogToolbarAction = createSaveWithFormDialogToolbarAction({formKey: 'test', title: 'Test'});
+    const saveWithFormDialogToolbarAction = createSaveWithFormDialogToolbarAction(
+        {condition: 'title == "test1" && __parent.title == "test2"', formKey: 'test', title: 'Test'}
+    );
+
+    // $FlowFixMe
+    saveWithFormDialogToolbarAction.resourceFormStore.data = {
+        title: 'test1',
+    };
+
+    saveWithFormDialogToolbarAction.parentResourceStore.data = {
+        title: 'test2',
+    };
 
     const toolbarItemConfig = saveWithFormDialogToolbarAction.getToolbarItemConfig();
     if (!toolbarItemConfig) {
@@ -178,4 +191,24 @@ test('Submit form with passed form data dialog when confirm button of dialog is 
     expect(element.instance().props).toEqual(expect.objectContaining({
         open: false,
     }));
+});
+
+test('Submit form without form data dialog when condition does not evaluate to true', () => {
+    const saveWithFormDialogToolbarAction = createSaveWithFormDialogToolbarAction(
+        {condition: 'false', formKey: 'test', title: 'Test'}
+    );
+
+    const toolbarItemConfig = saveWithFormDialogToolbarAction.getToolbarItemConfig();
+    if (!toolbarItemConfig) {
+        throw new Error('The toolbarItemConfig should be a value!');
+    }
+
+    const clickHandler = toolbarItemConfig.onClick;
+    if (!clickHandler) {
+        throw new Error('A onClick callback should be registered on the copy locale option');
+    }
+
+    clickHandler();
+
+    expect(saveWithFormDialogToolbarAction.form.submit).toBeCalledWith();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithPublishingToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithPublishingToolbarAction.test.js
@@ -297,7 +297,7 @@ test('Submit form with draft action when draft option is clicked', () => {
 
     toolbarItemConfig.options[0].onClick();
 
-    expect(publishableSaveToolbarAction.form.submit).toBeCalledWith('draft');
+    expect(publishableSaveToolbarAction.form.submit).toBeCalledWith({action: 'draft'});
 });
 
 test('Submit form with publish action when draft option is clicked', () => {
@@ -314,7 +314,7 @@ test('Submit form with publish action when draft option is clicked', () => {
 
     toolbarItemConfig.options[1].onClick();
 
-    expect(publishableSaveToolbarAction.form.submit).toBeCalledWith('publish');
+    expect(publishableSaveToolbarAction.form.submit).toBeCalledWith({action: 'publish'});
 });
 
 test('Return item config with loading button when saving flag is set', () => {
@@ -340,7 +340,7 @@ test('Submit form with draft action when draft option is clicked', () => {
 
     toolbarItemConfig.options[0].onClick();
 
-    expect(publishableSaveToolbarAction.form.submit).toBeCalledWith('draft');
+    expect(publishableSaveToolbarAction.form.submit).toBeCalledWith({action: 'draft'});
 });
 
 test('Submit form with publish action when draft option is clicked', () => {
@@ -357,5 +357,5 @@ test('Submit form with publish action when draft option is clicked', () => {
 
     toolbarItemConfig.options[1].onClick();
 
-    expect(publishableSaveToolbarAction.form.submit).toBeCalledWith('publish');
+    expect(publishableSaveToolbarAction.form.submit).toBeCalledWith({action: 'publish'});
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithPublishingToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithPublishingToolbarAction.test.js
@@ -56,7 +56,7 @@ function createSaveWithPublishingToolbarAction(options = {}) {
         router,
     });
 
-    return new SaveWithPublishingToolbarAction(resourceFormStore, form, router, [], options);
+    return new SaveWithPublishingToolbarAction(resourceFormStore, form, router, [], options, resourceStore);
 }
 
 test('Return item config with correct disabled, loading, icon, type and value', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SetUnpublishedToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SetUnpublishedToolbarAction.test.js
@@ -78,7 +78,7 @@ function createSetUnpublishedToolbarAction(options = {}) {
         router,
     });
 
-    return new SetUnpublishedToolbarAction(formStore, form, router, [], options);
+    return new SetUnpublishedToolbarAction(formStore, form, router, [], options, resourceStore);
 }
 
 test('Return enabled item config', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TogglerToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TogglerToolbarAction.test.js
@@ -68,7 +68,7 @@ function createTogglerToolbarAction(resourceKey, options: {[key: string]: mixed}
         router,
     });
 
-    return new TogglerToolbarAction(resourceFormStore, form, router, [], options);
+    return new TogglerToolbarAction(resourceFormStore, form, router, [], options, resourceStore);
 }
 
 test('Return item config with correct type, label, loading and value', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TypeToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TypeToolbarAction.test.js
@@ -47,7 +47,7 @@ function createTypeToolbarAction(options = {}) {
         router,
     });
 
-    return new TypeToolbarAction(resourceFormStore, form, router, [], options);
+    return new TypeToolbarAction(resourceFormStore, form, router, [], options, resourceStore);
 }
 
 test('Return item config with correct disabled, loading, options, icon, type and value ', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/AbstractFormToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/AbstractFormToolbarAction.js
@@ -1,5 +1,6 @@
 // @flow
 import type {Node} from 'react';
+import ResourceStore from '../../../stores/ResourceStore';
 import {ResourceFormStore} from '../../../containers/Form';
 import type {ToolbarItemConfig} from '../../../containers/Toolbar/types';
 import Router from '../../../services/Router';
@@ -11,19 +12,22 @@ export default class AbstractFormToolbarAction {
     router: Router;
     locales: ?Array<string>;
     options: {[key: string]: mixed};
+    parentResourceStore: ResourceStore;
 
     constructor(
         resourceFormStore: ResourceFormStore,
         form: Form,
         router: Router,
         locales: ?Array<string>,
-        options: {[key: string]: mixed}
+        options: {[key: string]: mixed},
+        parentResourceStore: ResourceStore
     ) {
         this.resourceFormStore = resourceFormStore;
         this.form = form;
         this.router = router;
         this.locales = locales;
         this.options = options;
+        this.parentResourceStore = parentResourceStore;
     }
 
     setLocales(locales: Array<string>) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/AbstractFormToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/AbstractFormToolbarAction.js
@@ -37,4 +37,8 @@ export default class AbstractFormToolbarAction {
     getToolbarItemConfig(): ?ToolbarItemConfig<*> {
         throw new Error('The getToolbarItemConfig method must be implemented by the sub class!');
     }
+
+    destroy() {
+
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/CopyLocaleToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/CopyLocaleToolbarAction.js
@@ -8,8 +8,9 @@ import Dialog from '../../../components/Dialog';
 import ResourceRequester from '../../../services/ResourceRequester';
 import {translate} from '../../../utils/Translator';
 import {ResourceFormStore} from '../../../containers/Form';
-import Form from '../Form';
 import Router from '../../../services/Router';
+import ResourceStore from '../../../stores/ResourceStore';
+import Form from '../Form';
 import copyLocaleActionStyles from './copyLocaleAction.scss';
 import AbstractFormToolbarAction from './AbstractFormToolbarAction';
 
@@ -23,7 +24,8 @@ export default class CopyLocaleToolbarAction extends AbstractFormToolbarAction {
         form: Form,
         router: Router,
         locales: ?Array<string>,
-        options: {[key: string]: mixed}
+        options: {[key: string]: mixed},
+        parentResourceStore: ResourceStore
     ) {
         const {
             display_condition: displayCondition,
@@ -42,7 +44,7 @@ export default class CopyLocaleToolbarAction extends AbstractFormToolbarAction {
             }
         }
 
-        super(resourceFormStore, form, router, locales, options);
+        super(resourceFormStore, form, router, locales, options, parentResourceStore);
     }
 
     getNode() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteDraftToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteDraftToolbarAction.js
@@ -9,6 +9,7 @@ import {translate} from '../../../utils/Translator';
 import {ResourceFormStore} from '../../../containers/Form';
 import Form from '../Form';
 import Router from '../../../services/Router';
+import ResourceStore from '../../../stores/ResourceStore';
 import AbstractFormToolbarAction from './AbstractFormToolbarAction';
 
 export default class DeleteDraftToolbarAction extends AbstractFormToolbarAction {
@@ -20,7 +21,8 @@ export default class DeleteDraftToolbarAction extends AbstractFormToolbarAction 
         form: Form,
         router: Router,
         locales: ?Array<string>,
-        options: {[key: string]: mixed}
+        options: {[key: string]: mixed},
+        parentResourceStore: ResourceStore
     ) {
         const {
             display_condition: displayCondition,
@@ -39,7 +41,7 @@ export default class DeleteDraftToolbarAction extends AbstractFormToolbarAction 
             }
         }
 
-        super(resourceFormStore, form, router, locales, options);
+        super(resourceFormStore, form, router, locales, options, parentResourceStore);
     }
 
     getNode() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteToolbarAction.js
@@ -6,8 +6,9 @@ import log from 'loglevel';
 import Dialog from '../../../components/Dialog';
 import {translate} from '../../../utils/Translator';
 import {ResourceFormStore} from '../../../containers/Form';
-import Form from '../Form';
 import Router from '../../../services/Router';
+import ResourceStore from '../../../stores/ResourceStore';
+import Form from '../Form';
 import AbstractFormToolbarAction from './AbstractFormToolbarAction';
 
 export default class DeleteToolbarAction extends AbstractFormToolbarAction {
@@ -26,7 +27,8 @@ export default class DeleteToolbarAction extends AbstractFormToolbarAction {
         form: Form,
         router: Router,
         locales: ?Array<string>,
-        options: {[key: string]: mixed}
+        options: {[key: string]: mixed},
+        parentResourceStore: ResourceStore
     ) {
         const {
             display_condition: displayCondition,
@@ -45,7 +47,7 @@ export default class DeleteToolbarAction extends AbstractFormToolbarAction {
             }
         }
 
-        super(resourceFormStore, form, router, locales, options);
+        super(resourceFormStore, form, router, locales, options, parentResourceStore);
     }
 
     getNode() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DropdownToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DropdownToolbarAction.js
@@ -3,6 +3,7 @@ import React, {Fragment} from 'react';
 import {ResourceFormStore} from '../../../containers/Form';
 import type {DropdownOption} from '../../../components/Toolbar/types';
 import Router from '../../../services/Router';
+import ResourceStore from '../../../stores/ResourceStore';
 import formToolbarActionRegistry from '../registries/formToolbarActionRegistry';
 import Form from '../Form';
 import AbstractFormToolbarAction from './AbstractFormToolbarAction';
@@ -15,14 +16,16 @@ export default class DropdownToolbarAction extends AbstractFormToolbarAction {
         form: Form,
         router: Router,
         locales: ?Array<string>,
-        options: {[key: string]: mixed}
+        options: {[key: string]: mixed},
+        parentResourceStore: ResourceStore
     ) {
         super(
             resourceFormStore,
             form,
             router,
             locales,
-            options
+            options,
+            parentResourceStore
         );
 
         const {toolbarActions} = this.options;
@@ -52,7 +55,8 @@ export default class DropdownToolbarAction extends AbstractFormToolbarAction {
                     this.form,
                     router,
                     this.locales,
-                    ((options: any): {[key: string]: mixed})
+                    ((options: any): {[key: string]: mixed}),
+                    parentResourceStore
                 );
             });
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveWithFormDialogToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveWithFormDialogToolbarAction.js
@@ -1,0 +1,99 @@
+// @flow
+import React from 'react';
+import type {ElementRef} from 'react';
+import {action, observable} from 'mobx';
+import Dialog from '../../../components/Dialog';
+import {default as FormContainer, memoryFormStoreFactory, ResourceFormStore} from '../../../containers/Form';
+import type {FormStoreInterface} from '../../../containers/Form';
+import Router from '../../../services/Router';
+import {translate} from '../../../utils/Translator';
+import Form from '../Form';
+import AbstractFormToolbarAction from './AbstractFormToolbarAction';
+
+export default class SaveWithFormDialogToolbarAction extends AbstractFormToolbarAction {
+    @observable showDialog: boolean = false;
+    dialogForm: ?FormContainer;
+    dialogFormStore: FormStoreInterface;
+
+    constructor(
+        resourceFormStore: ResourceFormStore,
+        form: Form,
+        router: Router,
+        locales: ?Array<string>,
+        options: {[key: string]: mixed}
+    ) {
+        super(resourceFormStore, form, router, locales, options);
+
+        const {formKey} = options;
+
+        if (typeof formKey !== 'string') {
+            throw new Error('The "formKey" option of the SaveWithFormDialogToolbarAction must be a string!');
+        }
+
+        this.dialogFormStore = memoryFormStoreFactory.createFromFormKey(formKey);
+    }
+
+    handleConfirm = () => {
+        if (!this.dialogForm) {
+            throw new Error('The dialog form was not initialized. This should not happen and is likely a bug.');
+        }
+
+        this.dialogForm.submit();
+    };
+
+    @action handleCancel = () => {
+        this.showDialog = false;
+    };
+
+    @action handleSubmit = () => {
+        this.form.submit(this.dialogFormStore.data);
+        this.showDialog = false;
+    };
+
+    setDialogFormRef = (dialogForm: ?ElementRef<typeof FormContainer>) => {
+        this.dialogForm = dialogForm;
+    };
+
+    getNode() {
+        const {title} = this.options;
+
+        if (typeof title !== 'string') {
+            throw new Error('The "title" option of the SaveWithFormDialogToolbarAction must be a string!');
+        }
+
+        return (
+            <Dialog
+                cancelText={translate('sulu_admin.cancel')}
+                confirmText={translate('sulu_admin.ok')}
+                key="sulu_admin.save_with_form_dialog"
+                onCancel={this.handleCancel}
+                onConfirm={this.handleConfirm}
+                open={this.showDialog}
+                title={title}
+            >
+                <FormContainer
+                    onSubmit={this.handleSubmit}
+                    ref={this.setDialogFormRef}
+                    store={this.dialogFormStore}
+                />
+            </Dialog>
+        );
+    }
+
+    getToolbarItemConfig() {
+        return {
+            disabled: !this.resourceFormStore.dirty,
+            icon: 'su-save',
+            label: translate('sulu_admin.save'),
+            loading: this.resourceFormStore.saving,
+            onClick: action(() => {
+                this.showDialog = true;
+            }),
+            type: 'button',
+        };
+    }
+
+    destroy() {
+        this.dialogFormStore.destroy();
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveWithFormDialogToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveWithFormDialogToolbarAction.js
@@ -6,6 +6,7 @@ import Dialog from '../../../components/Dialog';
 import {default as FormContainer, memoryFormStoreFactory, ResourceFormStore} from '../../../containers/Form';
 import type {FormStoreInterface} from '../../../containers/Form';
 import Router from '../../../services/Router';
+import ResourceStore from '../../../stores/ResourceStore';
 import {translate} from '../../../utils/Translator';
 import Form from '../Form';
 import AbstractFormToolbarAction from './AbstractFormToolbarAction';
@@ -20,9 +21,10 @@ export default class SaveWithFormDialogToolbarAction extends AbstractFormToolbar
         form: Form,
         router: Router,
         locales: ?Array<string>,
-        options: {[key: string]: mixed}
+        options: {[key: string]: mixed},
+        parentResourceStore: ResourceStore
     ) {
-        super(resourceFormStore, form, router, locales, options);
+        super(resourceFormStore, form, router, locales, options, parentResourceStore);
 
         const {formKey} = options;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveWithFormDialogToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveWithFormDialogToolbarAction.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import type {ElementRef} from 'react';
 import {action, observable} from 'mobx';
+import jexl from 'jexl';
 import Dialog from '../../../components/Dialog';
 import {default as FormContainer, memoryFormStoreFactory, ResourceFormStore} from '../../../containers/Form';
 import type {FormStoreInterface} from '../../../containers/Form';
@@ -89,7 +90,16 @@ export default class SaveWithFormDialogToolbarAction extends AbstractFormToolbar
             label: translate('sulu_admin.save'),
             loading: this.resourceFormStore.saving,
             onClick: action(() => {
-                this.showDialog = true;
+                if (
+                    jexl.evalSync(
+                        this.options.condition,
+                        {...this.resourceFormStore.data, __parent: this.parentResourceStore.data}
+                    )
+                ) {
+                    this.showDialog = true;
+                } else {
+                    this.form.submit();
+                }
             }),
             type: 'button',
         };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveWithPublishingToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveWithPublishingToolbarAction.js
@@ -3,6 +3,7 @@ import jexl from 'jexl';
 import log from 'loglevel';
 import {translate} from '../../../utils/Translator';
 import {ResourceFormStore} from '../../../containers/Form';
+import ResourceStore from '../../../stores/ResourceStore';
 import Form from '../Form';
 import Router from '../../../services/Router';
 import AbstractFormToolbarAction from './AbstractFormToolbarAction';
@@ -13,7 +14,8 @@ export default class SaveWithPublishingToolbarAction extends AbstractFormToolbar
         form: Form,
         router: Router,
         locales: ?Array<string>,
-        options: {[key: string]: mixed}
+        options: {[key: string]: mixed},
+        parentResourceStore: ResourceStore
     ) {
         const {
             publish_display_condition: publishDisplayCondition,
@@ -46,7 +48,7 @@ export default class SaveWithPublishingToolbarAction extends AbstractFormToolbar
             }
         }
 
-        super(resourceFormStore, form, router, locales, options);
+        super(resourceFormStore, form, router, locales, options, parentResourceStore);
     }
 
     getToolbarItemConfig() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveWithPublishingToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveWithPublishingToolbarAction.js
@@ -70,7 +70,7 @@ export default class SaveWithPublishingToolbarAction extends AbstractFormToolbar
                 label: translate('sulu_admin.save_draft'),
                 disabled: !dirty,
                 onClick: () => {
-                    this.form.submit('draft');
+                    this.form.submit({action: 'draft'});
                 },
             });
         }
@@ -80,7 +80,7 @@ export default class SaveWithPublishingToolbarAction extends AbstractFormToolbar
                 label: translate('sulu_admin.save_publish'),
                 disabled: !dirty,
                 onClick: () => {
-                    this.form.submit('publish');
+                    this.form.submit({action: 'publish'});
                 },
             });
         }
@@ -91,7 +91,7 @@ export default class SaveWithPublishingToolbarAction extends AbstractFormToolbar
                 // TODO do not hardcode "publishedState" but use metadata instead
                 disabled: dirty || data.publishedState === undefined || !!data.publishedState,
                 onClick: () => {
-                    this.form.submit('publish');
+                    this.form.submit({action: 'publish'});
                 },
             });
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SetUnpublishedToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SetUnpublishedToolbarAction.js
@@ -5,6 +5,7 @@ import jexl from 'jexl';
 import log from 'loglevel';
 import Dialog from '../../../components/Dialog';
 import ResourceRequester from '../../../services/ResourceRequester';
+import ResourceStore from '../../../stores/ResourceStore';
 import {translate} from '../../../utils/Translator';
 import {ResourceFormStore} from '../../../containers/Form';
 import Form from '../Form';
@@ -20,7 +21,8 @@ export default class SetUnpublishedToolbarAction extends AbstractFormToolbarActi
         form: Form,
         router: Router,
         locales: ?Array<string>,
-        options: {[key: string]: mixed}
+        options: {[key: string]: mixed},
+        parentResourceStore: ResourceStore
     ) {
         const {
             display_condition: displayCondition,
@@ -39,7 +41,7 @@ export default class SetUnpublishedToolbarAction extends AbstractFormToolbarActi
             }
         }
 
-        super(resourceFormStore, form, router, locales, options);
+        super(resourceFormStore, form, router, locales, options, parentResourceStore);
     }
 
     getNode() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -290,6 +290,8 @@ class List extends React.Component<Props> {
 
     componentWillUnmount() {
         this.listStore.destroy();
+
+        this.toolbarActions.forEach((toolbarAction) => toolbarAction.destroy());
     }
 
     addItem = (parentId: ?string | number) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
@@ -725,6 +725,20 @@ test('Should throw an error when no listKey is defined in the route options', ()
 });
 
 test('Should destroy the store on unmount', () => {
+    const listToolbarActionRegistry = require('../registries/listToolbarActionRegistry').default;
+
+    listToolbarActionRegistry.add('sulu_admin.add', jest.fn(function() {
+        this.getNode = jest.fn();
+        this.setLocales = jest.fn();
+        this.destroy = jest.fn();
+    }));
+
+    listToolbarActionRegistry.add('sulu_admin.delete', jest.fn(function() {
+        this.getNode = jest.fn();
+        this.setLocales = jest.fn();
+        this.destroy = jest.fn();
+    }));
+
     const List = require('../List').default;
     const router = {
         bind: jest.fn(),
@@ -734,6 +748,14 @@ test('Should destroy the store on unmount', () => {
                 listKey: 'snippets',
                 locales: ['de', 'en'],
                 resourceKey: 'snippets',
+                toolbarActions: [
+                    {
+                        type: 'sulu_admin.add',
+                    },
+                    {
+                        type: 'sulu_admin.delete',
+                    },
+                ],
             },
         },
     };
@@ -754,9 +776,13 @@ test('Should destroy the store on unmount', () => {
     expect(router.bind).toBeCalledWith('limit', listStore.limit, 10);
     expect(router.bind).toBeCalledWith('filter', listStore.filterOptions, {});
 
+    const toolbarActions = list.instance().toolbarActions;
+
     list.unmount();
 
     expect(listStore.destroy).toBeCalled();
+    expect(toolbarActions[0].destroy).toBeCalledWith();
+    expect(toolbarActions[1].destroy).toBeCalledWith();
 });
 
 test('Should navigate to defined route on back button click', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/AbstractListToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/AbstractListToolbarAction.js
@@ -41,4 +41,8 @@ export default class AbstractListToolbarAction {
     getToolbarItemConfig(): ?ToolbarItemConfig<*> {
         throw new Error('The getToolbarItemConfig method must be implemented by the sub class!');
     }
+
+    destroy() {
+
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Serializer/Subscriber/SaveWithFormDialogToolbarActionSubscriber.php
+++ b/src/Sulu/Bundle/AdminBundle/Serializer/Subscriber/SaveWithFormDialogToolbarActionSubscriber.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Serializer\Subscriber;
+
+use JMS\Serializer\EventDispatcher\Events;
+use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
+use JMS\Serializer\EventDispatcher\ObjectEvent;
+use Sulu\Bundle\AdminBundle\Admin\View\SaveWithFormDialogToolbarAction;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class SaveWithFormDialogToolbarActionSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            [
+                'event' => Events::POST_SERIALIZE,
+                'format' => 'json',
+                'method' => 'onPostSerialize',
+                'class' => SaveWithFormDialogToolbarAction::class,
+            ],
+        ];
+    }
+
+    public function onPostSerialize(ObjectEvent $event)
+    {
+        $dropdownToolbarAction = $event->getObject();
+        $visitor = $event->getVisitor();
+
+        $options = $dropdownToolbarAction->getOptions();
+        $options['title'] = $this->translator->trans($options['title'], [], 'admin');
+        $serializedOptions = $visitor->visitArray($options, [], $event->getContext());
+        $visitor->setData('options', $serializedOptions);
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Admin/View/SaveWithFormDialogToolbarActionTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Admin/View/SaveWithFormDialogToolbarActionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Functional\Admin\View;
+
+use Sulu\Bundle\AdminBundle\Admin\View\SaveWithFormDialogToolbarAction;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+
+class SaveWithFormDialogToolbarActionTest extends SuluTestCase
+{
+    public function testSerializer()
+    {
+        $saveWithFormDialogToolbarAction = new SaveWithFormDialogToolbarAction('title', 'form');
+
+        $this->assertEquals(
+            '{"type":"sulu_admin.save_with_form_dialog","options":{"formKey":"form","title":"title"}}',
+            $this->getContainer()->get('jms_serializer')->serialize($saveWithFormDialogToolbarAction, 'json')
+        );
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Admin/View/SaveWithFormDialogToolbarActionTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Admin/View/SaveWithFormDialogToolbarActionTest.php
@@ -18,10 +18,10 @@ class SaveWithFormDialogToolbarActionTest extends SuluTestCase
 {
     public function testSerializer()
     {
-        $saveWithFormDialogToolbarAction = new SaveWithFormDialogToolbarAction('title', 'form');
+        $saveWithFormDialogToolbarAction = new SaveWithFormDialogToolbarAction('sulu_admin.save', 'form');
 
         $this->assertEquals(
-            '{"type":"sulu_admin.save_with_form_dialog","options":{"formKey":"form","title":"title"}}',
+            '{"type":"sulu_admin.save_with_form_dialog","options":{"formKey":"form","title":"Save"}}',
             $this->getContainer()->get('jms_serializer')->serialize($saveWithFormDialogToolbarAction, 'json')
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Admin/View/SaveWithFormDialogToolbarActionTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Admin/View/SaveWithFormDialogToolbarActionTest.php
@@ -21,7 +21,17 @@ class SaveWithFormDialogToolbarActionTest extends SuluTestCase
         $saveWithFormDialogToolbarAction = new SaveWithFormDialogToolbarAction('sulu_admin.save', 'form');
 
         $this->assertEquals(
-            '{"type":"sulu_admin.save_with_form_dialog","options":{"formKey":"form","title":"Save"}}',
+            '{"type":"sulu_admin.save_with_form_dialog","options":{"condition":"true","formKey":"form","title":"Save"}}',
+            $this->getContainer()->get('jms_serializer')->serialize($saveWithFormDialogToolbarAction, 'json')
+        );
+    }
+
+    public function testSerializerWithCondition()
+    {
+        $saveWithFormDialogToolbarAction = new SaveWithFormDialogToolbarAction('sulu_admin.save', 'form', 'flag');
+
+        $this->assertEquals(
+            '{"type":"sulu_admin.save_with_form_dialog","options":{"condition":"flag","formKey":"form","title":"Save"}}',
             $this->getContainer()->get('jms_serializer')->serialize($saveWithFormDialogToolbarAction, 'json')
         );
     }

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/tests/toolbarActions/EnableUserToolbarAction.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/tests/toolbarActions/EnableUserToolbarAction.test.js
@@ -67,7 +67,7 @@ function createEnableUserToolbarAction() {
         router,
     });
 
-    return new EnableUserToolbarAction(resourceFormStore, form, router, [], {});
+    return new EnableUserToolbarAction(resourceFormStore, form, router, [], {}, resourceStore);
 }
 
 test('Return item config with correct disabled, loading, icon, type and label', () => {


### PR DESCRIPTION
| Q | A 
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | prerequesite of #5457
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR introduces a new `SaveWithFormDialogToolbarAction`, which shows a form when a user hits the save button. The form is displayed in a dialog, and whatever the user chooses is appended to the save request.

#### Why?

Because we need this functionality for #5457.

#### Example Usage

See the [`PageAdmin` in the other PR](https://github.com/sulu/sulu/pull/5457/files#diff-35e269d96646ae05db89f97f6115d238). Use e.g. `tag_details` instead of `permission_inheritance`, as the latter does not exist in this PR.

#### BC Breaks/Deprecations

The form submit now does not take a single `action` string anymore, but an `options` object instead. The old way still works, but is deprecated and logs a warning.