### PR TITLE
Add configuration for additional indexes for website search

### DIFF
--- a/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
+++ b/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
@@ -47,16 +47,23 @@ class WebsiteSearchController
      */
     private $twig;
 
+    /**
+     * @var string[]
+     */
+    private $additionalIndexes;
+
     public function __construct(
         SearchManagerInterface $searchManager,
         RequestAnalyzerInterface $requestAnalyzer,
         ParameterResolverInterface $parameterResolver,
-        Environment $twig
+        Environment $twig,
+        array $additionalIndexes
     ) {
         $this->searchManager = $searchManager;
         $this->requestAnalyzer = $requestAnalyzer;
         $this->parameterResolver = $parameterResolver;
         $this->twig = $twig;
+        $this->additionalIndexes = $additionalIndexes;
     }
 
     /**
@@ -90,7 +97,10 @@ class WebsiteSearchController
         $hits = $this->searchManager
             ->createSearch($queryString)
             ->locale($locale)
-            ->index('page_' . $webspace->getKey() . '_published')
+            ->indexes(array_merge(
+                ['page_' . $webspace->getKey() . '_published'],
+                $this->additionalIndexes
+            ))
             ->execute();
 
         $template = $webspace->getTemplate('search', $request->getRequestFormat());

--- a/src/Sulu/Bundle/SearchBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/SearchBundle/DependencyInjection/Configuration.php
@@ -45,6 +45,15 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->arrayNode('website')
+                    ->children()
+                        ->arrayNode('additional_indexes')
+                            ->prototype('scalar')
+                                ->defaultValue([])
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Sulu/Bundle/SearchBundle/DependencyInjection/SuluSearchExtension.php
+++ b/src/Sulu/Bundle/SearchBundle/DependencyInjection/SuluSearchExtension.php
@@ -93,6 +93,10 @@ class SuluSearchExtension extends Extension implements PrependExtensionInterface
         $config = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('sulu_search.indexes', $config['indexes']);
+        $container->setParameter(
+            'sulu_search.website.additional_indexes',
+            $config['website']['additional_indexes']
+        );
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');

--- a/src/Sulu/Bundle/SearchBundle/Resources/config/search.xml
+++ b/src/Sulu/Bundle/SearchBundle/Resources/config/search.xml
@@ -27,6 +27,8 @@
             <argument type="service" id="sulu_core.webspace.request_analyzer"/>
             <argument type="service" id="sulu_website.resolver.parameter"/>
             <argument type="service" id="twig"/>
+            <argument>%sulu_search.website.additional_indexes%</argument>
+
             <tag name="sulu.context" context="website"/>
         </service>
 

--- a/src/Sulu/Bundle/SearchBundle/Tests/Unit/Controller/WebsiteSearchControllerTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Unit/Controller/WebsiteSearchControllerTest.php
@@ -70,7 +70,8 @@ class WebsiteSearchControllerTest extends TestCase
             $this->searchManager->reveal(),
             $this->requestAnalyzer->reveal(),
             $this->parameterResolver->reveal(),
-            $this->twig->reveal()
+            $this->twig->reveal(),
+            []
         );
     }
 
@@ -93,7 +94,54 @@ class WebsiteSearchControllerTest extends TestCase
             $searchQueryBuilder->reveal()
         );
         $searchQueryBuilder->locale('en')->willReturn($searchQueryBuilder->reveal());
-        $searchQueryBuilder->index('page_sulu_published')->willReturn($searchQueryBuilder->reveal());
+        $searchQueryBuilder->indexes(['page_sulu_published'])->willReturn($searchQueryBuilder->reveal());
+        $searchQueryBuilder->execute()->willReturn([]);
+
+        $this->parameterResolver->resolve(
+            ['query' => 'Test', 'hits' => []],
+            $this->requestAnalyzer->reveal()
+        )->willReturn(['query' => 'Test', 'hits' => []]);
+
+        $this->twigLoader->exists(Argument::any())->willReturn(true);
+
+        $this->twig->render(
+            'search.html.twig',
+            ['query' => 'Test', 'hits' => []]
+        )->willReturn(new Response());
+
+        $this->assertInstanceOf(Response::class, $this->websiteSearchController->queryAction($request));
+    }
+
+    public function testQueryActionWithAdditionalIndexes()
+    {
+        $this->websiteSearchController = new WebsiteSearchController(
+            $this->searchManager->reveal(),
+            $this->requestAnalyzer->reveal(),
+            $this->parameterResolver->reveal(),
+            $this->twig->reveal(),
+            ['examples']
+        );
+
+        $request = new Request(['q' => 'Test']);
+
+        $localization = new Localization();
+        $localization->setLanguage('en');
+
+        $webspace = new Webspace();
+        $webspace->setKey('sulu');
+        $webspace->addTemplate('search', 'search');
+
+        $this->requestAnalyzer->getCurrentLocalization()->willReturn($localization);
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $searchQueryBuilder = $this->prophesize(SearchQueryBuilder::class);
+        $this->searchManager->createSearch('+("Test" OR Test* OR Test~) ')->willReturn(
+            $searchQueryBuilder->reveal()
+        );
+        $searchQueryBuilder->locale('en')->willReturn($searchQueryBuilder->reveal());
+        $searchQueryBuilder->indexes(['page_sulu_published', 'examples_published'])->willReturn(
+            $searchQueryBuilder->reveal()
+        );
         $searchQueryBuilder->execute()->willReturn([]);
 
         $this->parameterResolver->resolve(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

This pull request adds configuration for additional indexes for the website search

#### Why?

Without this, you always have to override the `WebsiteSearchController` to allow searching for documents in different indexes.

#### Example Usage

~~~yaml
# config/packages/sulu_search.yaml

sulu_search:
  website:
    additional_indexes:
      - examples_published
~~~
