### PR TITLE
Use permissions of parents when creating new collections or pages

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
@@ -29,7 +29,6 @@ use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineJoinDescrip
 use Sulu\Component\Rest\ListBuilder\FieldDescriptorInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authentication\UserRepositoryInterface;
-use Sulu\Component\Security\Authorization\AccessControl\AccessControlManager;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
@@ -97,16 +96,6 @@ class CollectionManager implements CollectionManagerInterface
      */
     private $permissions;
 
-    /**
-     * @var AccessControlManager
-     */
-    private $accessControlManager;
-
-    /**
-     * @var string
-     */
-    private $collectionClass;
-
     public function __construct(
         CollectionRepositoryInterface $collectionRepository,
         MediaRepositoryInterface $mediaRepository,
@@ -115,9 +104,7 @@ class CollectionManager implements CollectionManagerInterface
         EntityManager $em,
         TokenStorageInterface $tokenStorage = null,
         $collectionPreviewFormat,
-        $permissions,
-        AccessControlManager $accessControlManager,
-        string $collectionClass
+        $permissions
     ) {
         $this->collectionRepository = $collectionRepository;
         $this->mediaRepository = $mediaRepository;
@@ -127,8 +114,6 @@ class CollectionManager implements CollectionManagerInterface
         $this->tokenStorage = $tokenStorage;
         $this->collectionPreviewFormat = $collectionPreviewFormat;
         $this->permissions = $permissions;
-        $this->accessControlManager = $accessControlManager;
-        $this->collectionClass = $collectionClass;
     }
 
     public function getById(
@@ -445,16 +430,6 @@ class CollectionManager implements CollectionManagerInterface
 
         $this->em->persist($collectionEntity);
         $this->em->flush();
-
-        $parentCollection = $collectionEntity->getParent();
-
-        if ($parentCollection) {
-            $this->accessControlManager->setPermissions(
-                $this->collectionClass,
-                $collection->getId(),
-                $this->accessControlManager->getPermissions($this->collectionClass, $parentCollection->getId())
-            );
-        }
 
         return $collection;
     }

--- a/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
@@ -122,7 +122,7 @@ class CollectionController extends AbstractRestController implements ClassResour
 
             @\trigger_error(
                 \sprintf(
-                    'Omitting the "collectionClass" argument is deprecated and will not longer work in Sulu 3.0.',
+                    'Omitting the "collectionClass" argument is deprecated and will not longer work in Sulu 3.0.'
                 ),
                 \E_USER_DEPRECATED
             );

--- a/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
@@ -16,6 +16,7 @@ use HandcraftedInTheAlps\RestRoutingBundle\Routing\ClassResourceInterface;
 use Sulu\Bundle\MediaBundle\Api\Collection;
 use Sulu\Bundle\MediaBundle\Api\RootCollection;
 use Sulu\Bundle\MediaBundle\Collection\Manager\CollectionManagerInterface;
+use Sulu\Bundle\MediaBundle\Entity\Collection as CollectionEntity;
 use Sulu\Bundle\MediaBundle\Media\Exception\CollectionNotFoundException;
 use Sulu\Bundle\MediaBundle\Media\Exception\MediaException;
 use Sulu\Component\Media\SystemCollections\SystemCollectionManagerInterface;
@@ -103,7 +104,7 @@ class CollectionController extends AbstractRestController implements ClassResour
         CollectionManagerInterface $collectionManager,
         array $defaultCollectionType,
         array $permissions,
-        string $collectionClass
+        string $collectionClass = null
     ) {
         parent::__construct($viewHandler, $tokenStorage);
 
@@ -115,6 +116,17 @@ class CollectionController extends AbstractRestController implements ClassResour
         $this->defaultCollectionType = $defaultCollectionType;
         $this->permissions = $permissions;
         $this->collectionClass = $collectionClass;
+
+        if (!$this->collectionClass) {
+            $this->collectionClass = CollectionEntity::class;
+
+            @\trigger_error(
+                \sprintf(
+                    'Omitting the "collectionClass" argument is deprecated and will not longer work in Sulu 3.0.',
+                ),
+                \E_USER_DEPRECATED
+            );
+        }
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
@@ -16,7 +16,6 @@ use HandcraftedInTheAlps\RestRoutingBundle\Routing\ClassResourceInterface;
 use Sulu\Bundle\MediaBundle\Api\Collection;
 use Sulu\Bundle\MediaBundle\Api\RootCollection;
 use Sulu\Bundle\MediaBundle\Collection\Manager\CollectionManagerInterface;
-use Sulu\Bundle\MediaBundle\Entity\Collection as CollectionEntity;
 use Sulu\Bundle\MediaBundle\Media\Exception\CollectionNotFoundException;
 use Sulu\Bundle\MediaBundle\Media\Exception\MediaException;
 use Sulu\Component\Media\SystemCollections\SystemCollectionManagerInterface;
@@ -89,6 +88,11 @@ class CollectionController extends AbstractRestController implements ClassResour
      */
     private $permissions;
 
+    /**
+     * @var string
+     */
+    private $collectionClass;
+
     public function __construct(
         ViewHandlerInterface $viewHandler,
         TokenStorageInterface $tokenStorage,
@@ -98,7 +102,8 @@ class CollectionController extends AbstractRestController implements ClassResour
         SystemCollectionManagerInterface $systemCollectionManager,
         CollectionManagerInterface $collectionManager,
         array $defaultCollectionType,
-        array $permissions
+        array $permissions,
+        string $collectionClass
     ) {
         parent::__construct($viewHandler, $tokenStorage);
 
@@ -109,6 +114,7 @@ class CollectionController extends AbstractRestController implements ClassResour
         $this->collectionManager = $collectionManager;
         $this->defaultCollectionType = $defaultCollectionType;
         $this->permissions = $permissions;
+        $this->collectionClass = $collectionClass;
     }
 
     /**
@@ -428,7 +434,7 @@ class CollectionController extends AbstractRestController implements ClassResour
 
     public function getSecuredClass()
     {
-        return CollectionEntity::class;
+        return $this->collectionClass;
     }
 
     public function getSecuredObjectId(Request $request)

--- a/src/Sulu/Bundle/MediaBundle/Entity/Collection.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/Collection.php
@@ -14,12 +14,13 @@ namespace Sulu\Bundle\MediaBundle\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection as DoctrineCollection;
 use JMS\Serializer\Annotation\Exclude;
+use Sulu\Bundle\SecurityBundle\Entity\PermissionInheritanceInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 
 /**
  * Collection.
  */
-class Collection implements CollectionInterface
+class Collection implements CollectionInterface, PermissionInheritanceInterface
 {
     /**
      * @var int
@@ -369,6 +370,13 @@ class Collection implements CollectionInterface
     public function getParent()
     {
         return $this->parent;
+    }
+
+    public function getParentId()
+    {
+        if ($this->parent) {
+            return $this->parent->getId();
+        }
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -99,6 +99,7 @@
             <argument type="service" id="sulu_media.collection_manager" />
             <argument>%sulu_media.collection.type.default%</argument>
             <argument>%sulu_security.permissions%</argument>
+            <argument>%sulu.model.collection.class%</argument>
 
             <tag name="sulu.context" context="admin"/>
         </service>
@@ -304,6 +305,8 @@
             <argument type="service" id="security.token_storage" on-invalid="null"/>
             <argument type="string">%sulu_media.collection.previews.format%</argument>
             <argument>%sulu_security.permissions%</argument>
+            <argument type="service" id="sulu_security.access_control_manager" />
+            <argument>%sulu.model.collection.class%</argument>
         </service>
 
         <service id="sulu_media.twig_extension.disposition_type" class="%sulu_media.twig_extension.disposition_type.class%">

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -305,8 +305,6 @@
             <argument type="service" id="security.token_storage" on-invalid="null"/>
             <argument type="string">%sulu_media.collection.previews.format%</argument>
             <argument>%sulu_security.permissions%</argument>
-            <argument type="service" id="sulu_security.access_control_manager" />
-            <argument>%sulu.model.collection.class%</argument>
         </service>
 
         <service id="sulu_media.twig_extension.disposition_type" class="%sulu_media.twig_extension.disposition_type.class%">

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/CollectionRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/CollectionRepositoryTest.php
@@ -211,17 +211,15 @@ class CollectionRepositoryTest extends SuluTestCase
 
         $this->assertCount(10, $ids);
 
-        $this->assertSame([
-            $this->collections[2]->getId(),
-            $this->collections[3]->getId(),
-            $this->collections[4]->getId(),
-            $this->collections[5]->getId(),
-            $this->collections[6]->getId(),
-            $this->collections[7]->getId(),
-            $this->collections[8]->getId(),
-            $this->collections[9]->getId(),
-            $this->collections[10]->getId(),
-            $this->collections[11]->getId(),
-        ], $ids);
+        $this->assertContains($this->collections[2]->getId(), $ids);
+        $this->assertContains($this->collections[3]->getId(), $ids);
+        $this->assertContains($this->collections[4]->getId(), $ids);
+        $this->assertContains($this->collections[5]->getId(), $ids);
+        $this->assertContains($this->collections[6]->getId(), $ids);
+        $this->assertContains($this->collections[7]->getId(), $ids);
+        $this->assertContains($this->collections[8]->getId(), $ids);
+        $this->assertContains($this->collections[9]->getId(), $ids);
+        $this->assertContains($this->collections[10]->getId(), $ids);
+        $this->assertContains($this->collections[11]->getId(), $ids);
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Collection/CollectionManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Collection/CollectionManagerTest.php
@@ -212,6 +212,8 @@ class CollectionManagerTest extends TestCase
         $permissions = [5 => ['view' => true]];
         $this->accessControlManager->getPermissions(Collection::class, 1)->willReturn($permissions);
 
+        $this->accessControlManager->setPermissions(Collection::class, null, $permissions)->shouldBeCalled();
+
         $this->collectionManager->save(
             [
                 'locale' => 'de',
@@ -219,7 +221,5 @@ class CollectionManagerTest extends TestCase
                 'title' => 'Test',
             ]
         );
-
-        $this->accessControlManager->setPermissions(Collection::class, null, $permissions)->shouldBeCalled();
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Collection/CollectionManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Collection/CollectionManagerTest.php
@@ -23,7 +23,6 @@ use Sulu\Bundle\MediaBundle\Entity\CollectionRepository;
 use Sulu\Bundle\MediaBundle\Entity\MediaRepository;
 use Sulu\Bundle\MediaBundle\Media\FormatManager\FormatManagerInterface;
 use Sulu\Component\Security\Authentication\UserRepositoryInterface;
-use Sulu\Component\Security\Authorization\AccessControl\AccessControlManager;
 
 class CollectionManagerTest extends TestCase
 {

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Collection/CollectionManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Collection/CollectionManagerTest.php
@@ -57,11 +57,6 @@ class CollectionManagerTest extends TestCase
      */
     private $collectionManager;
 
-    /**
-     * @var AccessControlManager
-     */
-    private $accessControlManager;
-
     public function setUp(): void
     {
         $this->collectionRepository = $this->prophesize(CollectionRepository::class);
@@ -69,7 +64,6 @@ class CollectionManagerTest extends TestCase
         $this->formatManager = $this->prophesize(FormatManagerInterface::class);
         $this->userRepository = $this->prophesize(UserRepositoryInterface::class);
         $this->entityManager = $this->prophesize(EntityManager::class);
-        $this->accessControlManager = $this->prophesize(AccessControlManager::class);
 
         $this->collectionManager = new CollectionManager(
             $this->collectionRepository->reveal(),
@@ -79,9 +73,7 @@ class CollectionManagerTest extends TestCase
             $this->entityManager->reveal(),
             null,
             'sulu-50x50',
-            ['view' => 64],
-            $this->accessControlManager->reveal(),
-            Collection::class
+            ['view' => 64]
         );
     }
 
@@ -199,27 +191,5 @@ class CollectionManagerTest extends TestCase
 
         $this->entityManager->persist($collectionEntity)->shouldBeCalled();
         $this->entityManager->flush()->shouldBeCalled();
-    }
-
-    public function testSaveWithParentPermissions()
-    {
-        $collectionEntity = $this->createEntity(1, 'de');
-        $this->collectionRepository->findCollectionById(1)->willReturn($collectionEntity);
-        $this->collectionRepository->countMedia($collectionEntity)->willReturn(0);
-        $this->collectionRepository->countSubCollections($collectionEntity)->willReturn(0);
-        $this->mediaRepository->findMedia(Argument::cetera())->willReturn([]);
-
-        $permissions = [5 => ['view' => true]];
-        $this->accessControlManager->getPermissions(Collection::class, 1)->willReturn($permissions);
-
-        $this->accessControlManager->setPermissions(Collection::class, null, $permissions)->shouldBeCalled();
-
-        $this->collectionManager->save(
-            [
-                'locale' => 'de',
-                'parent' => 1,
-                'title' => 'Test',
-            ]
-        );
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Resources/config/document.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/document.xml
@@ -97,6 +97,8 @@
                  class="Sulu\Component\Content\Document\Subscriber\SecuritySubscriber">
             <argument>%sulu_security.permissions%</argument>
             <argument type="service" id="sulu_document_manager.live_session"/>
+            <argument type="service" id="sulu_document_manager.property_encoder" />
+            <argument type="service" id="sulu_security.access_control_manager" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 

--- a/src/Sulu/Bundle/SecurityBundle/Entity/PermissionInheritanceInterface.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/PermissionInheritanceInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\Entity;
+
+interface PermissionInheritanceInterface
+{
+    /**
+     * @return string|int
+     */
+    public function getId();
+
+    /**
+     * @return ?string|int
+     */
+    public function getParentId();
+}

--- a/src/Sulu/Bundle/SecurityBundle/EventListener/PermissionInheritanceSubscriber.php
+++ b/src/Sulu/Bundle/SecurityBundle/EventListener/PermissionInheritanceSubscriber.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\EventListener;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\ORM\Events;
+use Sulu\Bundle\SecurityBundle\Entity\PermissionInheritanceInterface;
+use Sulu\Component\Security\Authorization\AccessControl\AccessControlManagerInterface;
+
+class PermissionInheritanceSubscriber implements EventSubscriber
+{
+    /**
+     * @var AccessControlManagerInterface
+     */
+    private $accessControlManager;
+
+    public function __construct(AccessControlManagerInterface $accessControlManager)
+    {
+        $this->accessControlManager = $accessControlManager;
+    }
+
+    public function getSubscribedEvents()
+    {
+        $events = [
+            Events::postPersist,
+        ];
+
+        return $events;
+    }
+
+    public function postPersist(LifecycleEventArgs $event)
+    {
+        $entity = $event->getEntity();
+
+        if (!$entity instanceof PermissionInheritanceInterface) {
+            return;
+        }
+
+        $parentId = $entity->getParentId();
+        if (!$parentId) {
+            return;
+        }
+
+        $entityClass = \get_class($entity);
+
+        $this->accessControlManager->setPermissions(
+            $entityClass,
+            $entity->getId(),
+            $this->accessControlManager->getPermissions($entityClass, $parentId)
+        );
+    }
+}

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -323,5 +323,13 @@
             <argument type="service" id="sulu_security.system_store" />
             <argument type="service" id="doctrine.orm.entity_manager" />
         </service>
+
+        <service
+            id="sulu_security.permission_inheritance_subscriber"
+            class="Sulu\Bundle\SecurityBundle\EventListener\PermissionInheritanceSubscriber"
+        >
+            <argument type="service" id="sulu_security.access_control_manager" />
+            <tag name="doctrine.event_subscriber"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
@@ -85,6 +85,7 @@ class TestUserProvider implements UserProviderInterface
             $contact->setFirstName('Max');
             $contact->setLastName('Mustermann');
             $this->entityManager->persist($contact);
+            $this->entityManager->flush();
 
             $user = $this->userRepository->createNew();
             $user->setContact($contact);

--- a/src/Sulu/Component/Security/Authorization/AccessControl/PhpcrAccessControlProvider.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/PhpcrAccessControlProvider.php
@@ -69,6 +69,10 @@ class PhpcrAccessControlProvider implements AccessControlProviderInterface
             return [];
         }
 
+        if (!($document instanceof SecurityBehavior)) {
+            return [];
+        }
+
         $documentPermissions = $document->getPermissions();
 
         if (!$documentPermissions) {

--- a/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/PhpcrAccessControlProviderTest.php
+++ b/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/PhpcrAccessControlProviderTest.php
@@ -131,6 +131,15 @@ class PhpcrAccessControlProviderTest extends TestCase
         $this->assertEquals([], $this->phpcrAccessControlProvider->getPermissions('Acme\Document', '1'));
     }
 
+    public function testGetPermissionsForUnsecuredDocument()
+    {
+        $document = $this->prophesize(WebspaceBehavior::class);
+
+        $this->documentManager->find('1', null, ['rehydrate' => false])->willReturn($document);
+
+        $this->assertEquals([], $this->phpcrAccessControlProvider->getPermissions('Acme\Document', '1'));
+    }
+
     /**
      * @dataProvider provideSupport
      */


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | needs #5457 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR uses the parent permissions when a new page or media collection is created. 

#### Why?

This way we can make sure that a page being created under a restricted page is no publicly visible by accident.
#### To Do

- [x] Implement for pages
