### PR TITLE
Warn when a page or collection with permissions is moved

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/__snapshots__/List.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/__snapshots__/List.test.js.snap
@@ -21,6 +21,7 @@ exports[`Do not render Loader instead of Adapter if no page count is given 1`] =
         />
       </div>
       <input
+        placeholder="sulu_admin.list_search_placeholder"
         type="text"
         value=""
       />
@@ -60,6 +61,7 @@ exports[`Render Loader instead of Adapter if nothing was loaded yet 1`] = `
         />
       </div>
       <input
+        placeholder="sulu_admin.list_search_placeholder"
         type="text"
         value=""
       />
@@ -98,6 +100,7 @@ exports[`Render permission hint if permissions are missing 1`] = `
       class="su-lock"
     />
   </div>
+  sulu_admin.no_permissions
 </div>
 `;
 
@@ -125,6 +128,7 @@ exports[`Render the adapter in disabled state 1`] = `
         />
       </div>
       <input
+        placeholder="sulu_admin.list_search_placeholder"
         type="text"
         value=""
       />
@@ -201,6 +205,7 @@ exports[`Render the adapter with filters 1`] = `
         />
       </div>
       <input
+        placeholder="sulu_admin.list_search_placeholder"
         type="text"
         value=""
       />

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
@@ -702,7 +702,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertEquals('Test Collection 2', $response->title);
         $this->assertEquals('This Description 2 is only for testing', $response->description);
         $this->assertEquals($this->collection1->getId(), $response->_embedded->parent->id);
-        $this->assertTrue($response->_hasPermissions);
+        $this->assertFalse($response->_hasPermissions);
 
         $this->assertEquals(
             [],
@@ -738,7 +738,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertNotEmpty($responseFirstEntity->changed);
         $this->assertEquals('Test Collection 2', $responseFirstEntity->title);
         $this->assertEquals('This Description 2 is only for testing', $responseFirstEntity->description);
-        $this->assertTrue($response->_hasPermissions);
+        $this->assertFalse($response->_hasPermissions);
 
         $this->client->request(
             'GET',
@@ -800,6 +800,7 @@ class CollectionControllerTest extends SuluTestCase
         $response = \json_decode($this->client->getResponse()->getContent());
 
         $this->assertHttpStatusCode(200, $this->client->getResponse());
+        $this->assertTrue($response->_hasPermissions);
 
         $this->assertEquals(
             $permissions,

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
@@ -327,6 +327,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertEquals('Default Collection Type', $response->type->description);
         $this->assertEquals(\date('Y-m-d'), \date('Y-m-d', \strtotime($response->created)));
         $this->assertEquals(\date('Y-m-d'), \date('Y-m-d', \strtotime($response->changed)));
+        $this->assertFalse($response->_hasPermissions);
     }
 
     public function testCGet()
@@ -701,6 +702,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertEquals('Test Collection 2', $response->title);
         $this->assertEquals('This Description 2 is only for testing', $response->description);
         $this->assertEquals($this->collection1->getId(), $response->_embedded->parent->id);
+        $this->assertTrue($response->_hasPermissions);
 
         $this->assertEquals(
             [],
@@ -736,6 +738,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertNotEmpty($responseFirstEntity->changed);
         $this->assertEquals('Test Collection 2', $responseFirstEntity->title);
         $this->assertEquals('This Description 2 is only for testing', $responseFirstEntity->description);
+        $this->assertTrue($response->_hasPermissions);
 
         $this->client->request(
             'GET',

--- a/src/Sulu/Bundle/PageBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/services.xml
@@ -146,7 +146,6 @@
             <argument type="service" id="sulu.content.localization_finder"/>
             <argument type="service" id="sulu.content.structure_manager"/>
             <argument type="service" id="sulu.util.node_helper"/>
-            <argument type="service" id="sulu.repository.role"/>
             <argument type="service" id="sulu_security.system_store"/>
             <argument>%sulu_security.permissions%</argument>
             <tag name="sulu_security.access_control_descendant_provider"/>

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/ContentRepositoryTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/ContentRepositoryTest.php
@@ -29,7 +29,6 @@ use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\PropertyEncoder;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
 use Sulu\Component\Security\Authentication\RoleInterface;
-use Sulu\Component\Security\Authentication\RoleRepositoryInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Util\SuluNodeHelper;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
@@ -96,11 +95,6 @@ class ContentRepositoryTest extends SuluTestCase
      */
     private $systemStore;
 
-    /**
-     * @var RoleRepositoryInterface
-     */
-    private $roleRepository;
-
     public function setUp(): void
     {
         $this->purgeDatabase();
@@ -114,7 +108,6 @@ class ContentRepositoryTest extends SuluTestCase
         $this->localizationFinder = $this->getContainer()->get('sulu.content.localization_finder');
         $this->structureManager = $this->getContainer()->get('sulu.content.structure_manager');
         $this->nodeHelper = $this->getContainer()->get('sulu.util.node_helper');
-        $this->roleRepository = $this->getContainer()->get('sulu.repository.role');
         $this->systemStore = $this->getContainer()->get('sulu_security.system_store');
 
         $this->contentRepository = new ContentRepository(
@@ -124,7 +117,6 @@ class ContentRepositoryTest extends SuluTestCase
             $this->localizationFinder,
             $this->structureManager,
             $this->nodeHelper,
-            $this->roleRepository,
             $this->systemStore,
             ['view' => 64, 'add' => 32, 'edit' => 16, 'delete' => 8]
         );
@@ -189,6 +181,12 @@ class ContentRepositoryTest extends SuluTestCase
                     'edit' => false,
                     'delete' => false,
                     'archive' => true,
+                ],
+                $role3->getId() => [
+                    'view' => false,
+                    'add' => true,
+                    'edit' => false,
+                    'delete' => false,
                 ],
             ],
             $result[0]->getPermissions()
@@ -510,6 +508,12 @@ class ContentRepositoryTest extends SuluTestCase
                     'edit' => false,
                     'delete' => false,
                     'archive' => true,
+                ],
+                $role3->getId() => [
+                    'view' => false,
+                    'add' => true,
+                    'edit' => false,
+                    'delete' => false,
                 ],
             ],
             $result[0]->getPermissions()
@@ -865,6 +869,12 @@ class ContentRepositoryTest extends SuluTestCase
                     'delete' => false,
                     'archive' => true,
                 ],
+                $role3->getId() => [
+                    'view' => false,
+                    'add' => true,
+                    'edit' => false,
+                    'delete' => false,
+                ],
             ],
             $result->getPermissions()
         );
@@ -940,6 +950,12 @@ class ContentRepositoryTest extends SuluTestCase
             [
                 $role1->getId() => ['view' => false, 'add' => false, 'delete' => false, 'edit' => false],
                 $role2->getId() => ['view' => false, 'add' => false, 'edit' => false, 'delete' => false],
+                $role3->getId() => [
+                    'view' => false,
+                    'add' => false,
+                    'edit' => false,
+                    'delete' => false,
+                ],
             ],
             $result->getPermissions()
         );
@@ -1010,6 +1026,12 @@ class ContentRepositoryTest extends SuluTestCase
                     'edit' => false,
                     'delete' => false,
                     'archive' => true,
+                ],
+                $role3->getId() => [
+                    'view' => false,
+                    'add' => true,
+                    'edit' => false,
+                    'delete' => false,
                 ],
             ],
             $layer[0]->getPermissions()
@@ -1139,6 +1161,12 @@ class ContentRepositoryTest extends SuluTestCase
                         'delete' => false,
                         'archive' => true,
                     ],
+                    $role3->getId() => [
+                        'view' => false,
+                        'add' => true,
+                        'edit' => false,
+                        'delete' => false,
+                    ],
                 ],
             ],
             $items
@@ -1211,6 +1239,12 @@ class ContentRepositoryTest extends SuluTestCase
                         'edit' => false,
                         'delete' => false,
                         'archive' => true,
+                    ],
+                    $role3->getId() => [
+                        'view' => false,
+                        'add' => true,
+                        'edit' => false,
+                        'delete' => false,
                     ],
                 ],
             ],
@@ -1292,10 +1326,15 @@ class ContentRepositoryTest extends SuluTestCase
                     'delete' => false,
                     'archive' => true,
                 ],
+                $role3->getId() => [
+                    'view' => false,
+                    'add' => true,
+                    'edit' => false,
+                    'delete' => false,
+                ],
             ],
             $permissions
         );
-        $this->assertContains([], $permissions);
     }
 
     public function testFindAllNoPage()
@@ -1363,6 +1402,12 @@ class ContentRepositoryTest extends SuluTestCase
                 'edit' => false,
                 'delete' => false,
                 'archive' => true,
+            ],
+            $role3->getId() => [
+                'view' => false,
+                'add' => true,
+                'edit' => false,
+                'delete' => false,
             ],
         ], $result[1]->getPermissions());
         $urls = $result[1]->getUrls();

--- a/src/Sulu/Bundle/SecurityBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/translations/admin.de.json
@@ -18,5 +18,7 @@
     "sulu_security.security": "Sicherheit",
     "sulu_security.system_permission_heading": "Berechtigung für {system} aktivieren",
     "sulu_security.inherit_permissions_title": "Berechtigung vererben?",
-    "sulu_security.inherit_permissions_label": "Berechtigungen an Unterelementen vererben"
+    "sulu_security.inherit_permissions_label": "Berechtigungen an Unterelementen vererben",
+    "sulu_security.move_permission_title": "Hinweis",
+    "sulu_security.move_permission_warning": "Die Berechtigungen des übergeordneten Elements werden nicht übernommen."
 }

--- a/src/Sulu/Bundle/SecurityBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/translations/admin.en.json
@@ -18,5 +18,7 @@
     "sulu_security.security": "Security",
     "sulu_security.system_permission_heading": "Activate permissions for {system}",
     "sulu_security.inherit_permissions_title": "Inherit permissions?",
-    "sulu_security.inherit_permissions_label": "Override permissions of sub elements"
+    "sulu_security.inherit_permissions_label": "Override permissions of sub elements",
+    "sulu_security.move_permission_title": "Notice",
+    "sulu_security.move_permission_warning": "Permissions from the parent element will not be transferred."
 }

--- a/src/Sulu/Bundle/SecurityBundle/Serializer/Subscriber/SecuritySubscriber.php
+++ b/src/Sulu/Bundle/SecurityBundle/Serializer/Subscriber/SecuritySubscriber.php
@@ -93,9 +93,16 @@ class SecuritySubscriber implements EventSubscriberInterface
             $document->getPermissions(),
             $user
         );
+
         $visitor->visitProperty(
             new StaticPropertyMetadata('', '_permissions', $permissions),
             $permissions
+        );
+
+        $hasPermissions = !empty($document->getPermissions());
+        $visitor->visitProperty(
+            new StaticPropertyMetadata('', '_hasPermissions', $hasPermissions),
+            $hasPermissions
         );
     }
 }

--- a/src/Sulu/Component/Content/Repository/ContentRepository.php
+++ b/src/Sulu/Component/Content/Repository/ContentRepository.php
@@ -32,7 +32,6 @@ use Sulu\Component\Content\Repository\Mapping\MappingInterface;
 use Sulu\Component\DocumentManager\PropertyEncoder;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
-use Sulu\Component\Security\Authentication\RoleRepositoryInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authorization\AccessControl\DescendantProviderInterface;
 use Sulu\Component\Util\SuluNodeHelper;
@@ -97,11 +96,6 @@ class ContentRepository implements ContentRepositoryInterface, DescendantProvide
     private $nodeHelper;
 
     /**
-     * @var RoleRepositoryInterface
-     */
-    private $roleRepository;
-
-    /**
      * @var array
      */
     private $permissions;
@@ -118,7 +112,6 @@ class ContentRepository implements ContentRepositoryInterface, DescendantProvide
         LocalizationFinderInterface $localizationFinder,
         StructureManagerInterface $structureManager,
         SuluNodeHelper $nodeHelper,
-        RoleRepositoryInterface $roleRepository,
         SystemStoreInterface $systemStore,
         array $permissions
     ) {
@@ -128,7 +121,6 @@ class ContentRepository implements ContentRepositoryInterface, DescendantProvide
         $this->localizationFinder = $localizationFinder;
         $this->structureManager = $structureManager;
         $this->nodeHelper = $nodeHelper;
-        $this->roleRepository = $roleRepository;
         $this->systemStore = $systemStore;
         $this->permissions = $permissions;
 
@@ -463,7 +455,6 @@ class ContentRepository implements ContentRepositoryInterface, DescendantProvide
     private function resolveResultPermissions(array $result, UserInterface $user = null)
     {
         $permissions = [];
-        $systemRoleIds = $this->roleRepository->findRoleIdsBySystem($this->systemStore->getSystem());
 
         foreach ($result as $index => $row) {
             $permissions[$index] = [];
@@ -471,10 +462,6 @@ class ContentRepository implements ContentRepositoryInterface, DescendantProvide
 
             foreach ($securityProperties as $securityProperty) {
                 $roleId = \str_replace(SecuritySubscriber::SECURITY_PROPERTY_PREFIX, '', $securityProperty->getName());
-
-                if (!\in_array($roleId, $systemRoleIds)) {
-                    continue;
-                }
 
                 foreach ($this->permissions as $permissionKey => $permission) {
                     $permissions[$index][$roleId][$permissionKey] = false;

--- a/src/Sulu/Component/Content/Repository/Serializer/SerializerEventListener.php
+++ b/src/Sulu/Component/Content/Repository/Serializer/SerializerEventListener.php
@@ -148,5 +148,11 @@ class SerializerEventListener implements EventSubscriberInterface
             new StaticPropertyMetadata('', '_permissions', $permissions),
             $permissions
         );
+
+        $hasPermissions = !empty($content->getPermissions());
+        $visitor->visitProperty(
+            new StaticPropertyMetadata('', '_hasPermissions', $hasPermissions),
+            $hasPermissions
+        );
     }
 }

--- a/src/Sulu/Component/Content/Tests/Unit/Repository/ContentRepositoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Repository/ContentRepositoryTest.php
@@ -40,7 +40,6 @@ use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\PropertyEncoder;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
-use Sulu\Component\Security\Authentication\RoleRepositoryInterface;
 use Sulu\Component\Util\SuluNodeHelper;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Webspace;
@@ -93,11 +92,6 @@ class ContentRepositoryTest extends TestCase
     private $contentRepository;
 
     /**
-     * @var RoleRepositoryInterface
-     */
-    private $roleRepository;
-
-    /**
      * @var SystemStoreInterface
      */
     private $systemStore;
@@ -117,7 +111,6 @@ class ContentRepositoryTest extends TestCase
         $this->localizationFinder = $this->prophesize(LocalizationFinderInterface::class);
         $this->structureManager = $this->prophesize(StructureManagerInterface::class);
         $this->nodeHelper = $this->prophesize(SuluNodeHelper::class);
-        $this->roleRepository = $this->prophesize(RoleRepositoryInterface::class);
         $this->systemStore = $this->prophesize(SystemStoreInterface::class);
 
         $webspace = $this->prophesize(Webspace::class);
@@ -146,7 +139,6 @@ class ContentRepositoryTest extends TestCase
             $this->localizationFinder->reveal(),
             $this->structureManager->reveal(),
             $this->nodeHelper->reveal(),
-            $this->roleRepository->reveal(),
             $this->systemStore->reveal(),
             []
         );


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | depends on #5461
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR will ask the user if it is OK to move the item without touching the different securities of an element and its new parent. The user can only confirm or cancel that operation.

#### Why?

Because that will be enough, since the User can still move and change the permissions afterwards. Also, we think that this won't happen very often.

#### To Do

- [x] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md
- [x] Ask for confirmation
- [x] Implement the merging of the permissions
- [x] Add missing translations `sulu_security.merge_permission_title` and `sulu_security.merge_permission_warning`
