### PR TITLE
Avoid line break in tab with long text

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tabs/tab.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tabs/tab.scss
@@ -29,6 +29,7 @@ $buttonSmallHorizontalPadding: 10px;
         background-color: transparent;
         font-size: 12px;
         border: 0;
+        white-space: nowrap;
 
         /* Needed because we want to prevent the jump on font-weight changes */
         &::after {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR avoids that the tab component adds a line break to longer texts.

#### Why?

Because the text is not supposed to be broken into multiple lines. You can test that e.g. when having the navigation pinned on the page form with a preview on the right side. Then the "Excerpt & Taxonomies" tab will be written in two lines.