### PR TITLE
Fix user refresh on test user provider

### DIFF
--- a/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
@@ -141,7 +141,7 @@ class TestUserProvider implements UserProviderInterface
      */
     public function refreshUser(UserInterface $user)
     {
-        if (self::TEST_USER_USERNAME === $this->getUser()->getUsername()) {
+        if (self::TEST_USER_USERNAME === $user->getUsername()) {
             return $this->getUser();
         }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix user refresh on test user provider. Not sure how to test it as the TestBundle itself has no test setup.

#### Why?

Currently refreshUser will return false user when requesting a none test user in it.

#### Example Usage

Website Login Test:

```php
$client->request('POST', '/login', ["_username": "..", "_password": "..."]);
$client->followRedirect(); // should be redirect to a url secured by the firewall
$this->assertHttpStatus(200, $client->getResponse()); // will fail and redirect ro login
```

Will be redirect to login as username of the refresh user doesn't match with the one in the session


