### PR TITLE
Replace obsolete size property with colSpan in Form documentation

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/README.md
@@ -19,16 +19,22 @@ const handleTypeChange = (type) => {
 };
 
 <Form>
-    <Form.Section label="Section 1" size={3}>
+    <Form.Section label="Section 1" colSpan={3}>
         <Form.Field label="Author" onTypeChange={handleTypeChange} types={types} type={state.type}>
             <input type="text" style={{width: '100%'}} />
         </Form.Field>
     </Form.Section>
-    <Form.Section label="Section 2" size={9}>
-        <Form.Field description="This is the title" label="Title" required={true} size={3}>
+    <Form.Section label="Section 2" colSpan={9}>
+        <Form.Field description="This is the title" label="Title" required={true} colSpan={3}>
             <input type="text" style={{width: '100%'}} />
         </Form.Field>
-        <Form.Field description="This is the second title" error="Error!" label="Second title" required={true} size={9}>
+        <Form.Field
+            description="This is the second title"
+            error="Error!"
+            label="Second title"
+            required={true}
+            colSpan={9}
+        >
             <input type="text" style={{width: '100%'}} />
         </Form.Field>
         <Form.Field description="Article" label="Article">


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #4459
| License | MIT
| Documentation PR |---

#### What's in this PR?

This PR fixes the documentation for the `Form` component in our styleguide.

#### Why?

The name of the `size` property was changed to `colSpan` in #4459, and it seems updating the documentation was forgotten.