### PR TITLE
Throw exception if invalid default template is configured in webspace

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
@@ -76,8 +76,12 @@ class StructureFormMetadataLoader implements FormMetadataLoaderInterface, CacheW
         $this->debug = $debug;
     }
 
-    public function getMetadata(string $key, string $locale, array $metadataOptions = []): ?MetadataInterface
+    public function getMetadata(string $key, string $locale = null, array $metadataOptions = []): ?MetadataInterface
     {
+        if (!$locale) {
+            $locale = $this->locales[0];
+        }
+
         $configCache = $this->getConfigCache($key, $locale);
 
         if (!\file_exists($configCache->getPath())) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -95,7 +95,7 @@
             id="sulu_admin.form_metadata.form_metadata_mapper"
             class="Sulu\Bundle\AdminBundle\FormMetadata\FormMetadataMapper"/>
 
-        <service id="sulu_admin.structure_form_metadata_loader" class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\StructureFormMetadataLoader">
+        <service id="sulu_admin.structure_form_metadata_loader" class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\StructureFormMetadataLoader" lazy="true">
             <argument type="service" id="sulu_page.structure.factory"/>
             <argument type="service" id="sulu_admin.form_metadata.form_metadata_mapper"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
@@ -104,7 +104,7 @@
             <argument>%sulu.cache_dir%/form-structures</argument>
             <argument>%kernel.debug%</argument>
             <tag name="sulu_admin.form_metadata_loader"/>
-            <tag name="kernel.cache_warmer" />
+            <tag name="kernel.cache_warmer" priority="512" />
         </service>
 
         <service id="sulu_admin.view_registry" class="Sulu\Bundle\AdminBundle\Admin\View\ViewRegistry">

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/webspaces/sulu.io.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/webspaces/sulu.io.xml
@@ -19,7 +19,7 @@
 
     <default-templates>
         <default-template type="page">default</default-template>
-        <default-template type="homepage">overview</default-template>
+        <default-template type="homepage">default</default-template>
     </default-templates>
 
     <excluded-templates>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
@@ -29,6 +29,14 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
         $this->structureFormMetadataLoader = $this->getContainer()->get('sulu_admin_test.structure_form_metadata_loader');
     }
 
+    public function testGetMetadataWithoutLanguage()
+    {
+        $typedForm = $this->structureFormMetadataLoader->getMetadata('page');
+        $expectedTypedForm = $this->structureFormMetadataLoader->getMetadata('page', 'de');
+
+        $this->assertEquals($typedForm, $expectedTypedForm);
+    }
+
     public function testGetMetadataEnglish()
     {
         $typedForm = $this->structureFormMetadataLoader->getMetadata('page', 'en');

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/webspace.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/webspace.xml
@@ -43,6 +43,7 @@
             <argument>%kernel.environment%</argument>
             <argument>%router.request_context.host%</argument>
             <argument>%router.request_context.scheme%</argument>
+            <argument type="service" id="sulu_page.structure.factory" />
 
             <tag name="sulu.localization_provider"/>
         </service>

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Application/config/templates/pages/default.xml
@@ -5,7 +5,7 @@
           xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd"
           >
 
-    <key>hotel_page</key>
+    <key>default</key>
 
     <view>ClientWebsiteBundle:templates:default</view>
     <controller>SuluWebsiteBundle:Default:index</controller>

--- a/src/Sulu/Component/Webspace/Exception/InvalidTemplateException.php
+++ b/src/Sulu/Component/Webspace/Exception/InvalidTemplateException.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Webspace\Exception;
+
+use Sulu\Component\Webspace\Webspace;
+
+class InvalidTemplateException extends \Exception
+{
+    /**
+     * @var Webspace
+     */
+    private $webspace;
+
+    /**
+     * @var string
+     */
+    private $template;
+
+    public function __construct(Webspace $webspace, string $template)
+    {
+        parent::__construct(
+            \sprintf(
+                'The template "%s" is not valid for the webspace "%s". '
+                . 'Either it does not exist or was excluded from the webspace.',
+                $template,
+                $webspace->getKey()
+            )
+        );
+
+        $this->webspace = $webspace;
+        $this->template = $template;
+    }
+
+    public function getWebspace()
+    {
+        return $this->webspace;
+    }
+
+    public function getTemplate()
+    {
+        return $this->template;
+    }
+}

--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
@@ -11,9 +11,11 @@
 
 namespace Sulu\Component\Webspace\Manager;
 
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Environment;
+use Sulu\Component\Webspace\Exception\InvalidTemplateException;
 use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\PortalInformation;
 use Sulu\Component\Webspace\Segment;
@@ -67,18 +69,25 @@ class WebspaceCollectionBuilder
     private $portalInformations;
 
     /**
-     * @param LoaderInterface $loader The loader for the xml config files
-     * @param ReplacerInterface $urlReplacer Factory for url-replacers
-     * @param string $path The path to the xml config files
+     * @var TypedFormMetadata
      */
+    private $typedFormMetadata;
+
+    /**
+     * @var array
+     */
+    private $availableTemplates;
+
     public function __construct(
         LoaderInterface $loader,
         ReplacerInterface $urlReplacer,
-        $path
+        $path,
+        array $availableTemplates
     ) {
         $this->loader = $loader;
         $this->urlReplacer = $urlReplacer;
         $this->path = $path;
+        $this->availableTemplates = $availableTemplates;
     }
 
     public function build()
@@ -100,6 +109,17 @@ class WebspaceCollectionBuilder
 
             /** @var Webspace $webspace */
             $webspace = $this->loader->load($file->getRealPath());
+
+            foreach ($webspace->getDefaultTemplates() as $defaultTemplate) {
+                if (!\in_array($defaultTemplate, $this->availableTemplates)) {
+                    throw new InvalidTemplateException($webspace, $defaultTemplate);
+                }
+
+                if (\in_array($defaultTemplate, $webspace->getExcludedTemplates())) {
+                    throw new InvalidTemplateException($webspace, $defaultTemplate);
+                }
+            }
+
             $this->webspaces[] = $webspace;
 
             $this->buildPortals($webspace);

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\Webspace\Tests\Unit;
 
 use Prophecy\Argument;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Exception\InvalidTemplateException;
 use Sulu\Component\Webspace\Loader\XmlFileLoader10;
 use Sulu\Component\Webspace\Loader\XmlFileLoader11;
 use Sulu\Component\Webspace\Manager\WebspaceCollectionBuilder;
@@ -55,7 +56,8 @@ class WebspaceCollectionBuilderTest extends WebspaceTestCase
         $webspaceCollectionBuilder = new WebspaceCollectionBuilder(
             $this->loader,
             new Replacer(),
-            $this->getResourceDirectory() . '/DataFixtures/Webspace/multiple'
+            $this->getResourceDirectory() . '/DataFixtures/Webspace/multiple',
+            ['default', 'overview']
         );
 
         $webspaceCollection = $webspaceCollectionBuilder->build();
@@ -181,7 +183,8 @@ class WebspaceCollectionBuilderTest extends WebspaceTestCase
         $webspaceCollectionBuilder = new WebspaceCollectionBuilder(
             $this->loader,
             new Replacer(),
-            $this->getResourceDirectory() . '/DataFixtures/Webspace/multiple-localization-urls'
+            $this->getResourceDirectory() . '/DataFixtures/Webspace/multiple-localization-urls',
+            ['default', 'overview']
         );
 
         $webspaceCollection = $webspaceCollectionBuilder->build();
@@ -202,7 +205,8 @@ class WebspaceCollectionBuilderTest extends WebspaceTestCase
         $webspaceCollectionBuilder = new WebspaceCollectionBuilder(
             $this->loader,
             new Replacer(),
-            $this->getResourceDirectory() . '/DataFixtures/Webspace/main'
+            $this->getResourceDirectory() . '/DataFixtures/Webspace/main',
+            ['default', 'overview']
         );
 
         $webspaceCollection = $webspaceCollectionBuilder->build();
@@ -228,7 +232,8 @@ class WebspaceCollectionBuilderTest extends WebspaceTestCase
         $webspaceCollectionBuilder = new WebspaceCollectionBuilder(
             $this->loader,
             new Replacer(),
-            $this->getResourceDirectory() . '/DataFixtures/Webspace/custom-url'
+            $this->getResourceDirectory() . '/DataFixtures/Webspace/custom-url',
+            ['default', 'overview']
         );
 
         $webspaceCollection = $webspaceCollectionBuilder->build();
@@ -255,7 +260,8 @@ class WebspaceCollectionBuilderTest extends WebspaceTestCase
         $webspaceCollectionBuilder = new WebspaceCollectionBuilder(
             $this->loader,
             new Replacer(),
-            $this->getResourceDirectory() . '/DataFixtures/Webspace/language-specific'
+            $this->getResourceDirectory() . '/DataFixtures/Webspace/language-specific',
+            ['default', 'overview']
         );
 
         $webspaceCollection = $webspaceCollectionBuilder->build();
@@ -273,5 +279,33 @@ class WebspaceCollectionBuilderTest extends WebspaceTestCase
         $this->assertSame($portalInformations['austria.sulu.io']->getPriority(), 9);
         $this->assertSame($portalInformations['usa.sulu.io/en']->getPriority(), 10);
         $this->assertSame($portalInformations['usa.sulu.io']->getPriority(), 9);
+    }
+
+    public function testThrowForMissingDefaultTemplate()
+    {
+        $this->expectException(InvalidTemplateException::class);
+
+        $webspaceCollectionBuilder = new WebspaceCollectionBuilder(
+            $this->loader,
+            new Replacer(),
+            $this->getResourceDirectory() . '/DataFixtures/Webspace/missing-default-template',
+            []
+        );
+
+        $webspaceCollection = $webspaceCollectionBuilder->build();
+    }
+
+    public function testThrowForMissingExcludedTemplate()
+    {
+        $this->expectException(InvalidTemplateException::class);
+
+        $webspaceCollectionBuilder = new WebspaceCollectionBuilder(
+            $this->loader,
+            new Replacer(),
+            $this->getResourceDirectory() . '/DataFixtures/Webspace/excluded-default-template',
+            ['default', 'overview']
+        );
+
+        $webspaceCollection = $webspaceCollectionBuilder->build();
     }
 }

--- a/tests/Resources/DataFixtures/Webspace/excluded-default-template/sulu.xml
+++ b/tests/Resources/DataFixtures/Webspace/excluded-default-template/sulu.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<webspace xmlns="http://schemas.sulu.io/webspace/webspace"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.1.xsd">
+
+    <name>Sulu CMF</name>
+    <key>sulu_io</key>
+
+    <localizations>
+        <localization language="en" shadow="auto"/>
+    </localizations>
+
+    <theme>sulu</theme>
+
+    <default-templates>
+        <default-template type="page">default</default-template>
+        <default-template type="homepage">overview</default-template>
+    </default-templates>
+
+    <excluded-templates>
+        <excluded-template>overview</excluded-template>
+    </excluded-templates>
+
+    <navigation>
+        <contexts>
+            <context key="main">
+                <meta>
+                    <title lang="en">Mainnavigation</title>
+                </meta>
+            </context>
+        </contexts>
+    </navigation>
+
+    <portals>
+        <portal>
+            <name>Sulu CMF AT</name>
+            <key>sulucmf_at</key>
+
+            <environments>
+                <environment type="prod">
+                    <urls>
+                        <url language="en">sulu.us</url>
+                    </urls>
+                </environment>
+            </environments>
+        </portal>
+    </portals>
+</webspace>

--- a/tests/Resources/DataFixtures/Webspace/missing-default-template/sulu.xml
+++ b/tests/Resources/DataFixtures/Webspace/missing-default-template/sulu.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<webspace xmlns="http://schemas.sulu.io/webspace/webspace"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.1.xsd">
+
+    <name>Sulu CMF</name>
+    <key>sulu_io</key>
+
+    <localizations>
+        <localization language="en" shadow="auto"/>
+    </localizations>
+
+    <theme>sulu</theme>
+
+    <default-templates>
+        <default-template type="page">default</default-template>
+        <default-template type="homepage">overview</default-template>
+    </default-templates>
+
+    <navigation>
+        <contexts>
+            <context key="main">
+                <meta>
+                    <title lang="en">Mainnavigation</title>
+                </meta>
+            </context>
+        </contexts>
+    </navigation>
+
+    <portals>
+        <portal>
+            <name>Sulu CMF AT</name>
+            <key>sulucmf_at</key>
+
+            <environments>
+                <environment type="prod">
+                    <urls>
+                        <url language="en">sulu.us</url>
+                    </urls>
+                </environment>
+            </environments>
+        </portal>
+    </portals>
+</webspace>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

This PR throws an exception if a template is configured as default using the `default-template` tag in a webspace configuration, but this template does not exist in this webspace.

#### Why?

Because this leads just to confusing behavior, and the developer does not immediately know what's going wrong.