### PR TITLE
Fix template switching for pages preview

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Controller/PreviewController.php
+++ b/src/Sulu/Bundle/PreviewBundle/Controller/PreviewController.php
@@ -117,7 +117,7 @@ class PreviewController
             $token = $this->preview->start($provider, $id, $locale, $this->getUserId());
         }
 
-        $content = $this->preview->updateContext($token, $webspace, $context, $targetGroup);
+        $content = $this->preview->updateContext($token, $webspace, $context, $targetGroup, $segment);
 
         return new JsonResponse(['content' => $content]);
     }

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Controller/PreviewControllerTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Controller/PreviewControllerTest.php
@@ -204,7 +204,7 @@ class PreviewControllerTest extends TestCase
         $request->get('segment', null)->willReturn('s');
 
         $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
-        $this->preview->updateContext('test-token', 'sulu_io', ['template' => 'default'], 1)
+        $this->preview->updateContext('test-token', 'sulu_io', ['template' => 'default'], 1, 's')
             ->shouldBeCalled()
             ->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
 
@@ -228,7 +228,7 @@ class PreviewControllerTest extends TestCase
         $request->get('segment', null)->willReturn('w');
 
         $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
-        $this->preview->updateContext('test-token', 'sulu_io', ['template' => 'default'], 1)
+        $this->preview->updateContext('test-token', 'sulu_io', ['template' => 'default'], 1, 'w')
             ->shouldBeCalled()
             ->willReturn('<html><body><a href="/test">SULU is awesome</a></body></html>');
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #5277
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds the segment to the `update-context` action of the `PreviewController`.

#### Why?

Because it is required and seems to be forgotten in #5277.