### PR TITLE
Add target groups to block settings

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/block.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/block.scss
@@ -33,7 +33,6 @@ $blockIconsColor: $gray;
 
         .icons {
             border-right: 1px solid $blockBorderColor;
-            padding-right: 10px;
             margin-right: 10px;
         }
     }
@@ -73,6 +72,7 @@ $blockIconsColor: $gray;
 
 .types {
     min-width: 120px;
+    margin-right: 10px;
 }
 
 .type {
@@ -87,7 +87,7 @@ $blockIconsColor: $gray;
     font-size: 14px;
 
     > * {
-        margin-left: 10px;
+        margin-right: 10px;
     }
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -119,7 +119,7 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
 
             const blockSettingsTag = schemaEntry.tags.find((tag) => tag.name === SETTINGS_TAG);
 
-            if (blockSettingsTag) {
+            if (blockSettingsTag && schemaEntry.visible !== false) {
                 iconsMapping[SETTINGS_PREFIX + schemaKey] = blockSettingsTag.attributes.icon;
             }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
@@ -103,6 +103,7 @@ test('Render collapsed blocks with block previews', () => {
                 {attributes: {icon: 'su-eye'}, name: 'sulu.block_setting_icon'},
             ],
             type: 'checkbox',
+            visibleCondition: 'false',
         },
         section: {
             items: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
@@ -785,12 +785,7 @@ exports[`Render collapsed blocks with block previews 1`] = `
         >
           <div
             class="icons"
-          >
-            <span
-              aria-label="su-eye"
-              class="su-eye"
-            />
-          </div>
+          />
           <div
             class="type"
           >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/conditionDataProviders/bundlesConditionDataProvider.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/conditionDataProviders/bundlesConditionDataProvider.js
@@ -1,0 +1,6 @@
+// @flow
+import initializer from '../../../services/initializer';
+
+export default function(): {[string]: any} {
+    return {__bundles: initializer.bundles};
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/index.js
@@ -1,6 +1,7 @@
 // @flow
 import Form from './Form';
 import FormInspector from './FormInspector';
+import bundlesConditionDataProvider from './conditionDataProviders/bundlesConditionDataProvider';
 import conditionDataProviderRegistry from './registries/conditionDataProviderRegistry';
 import fieldRegistry from './registries/fieldRegistry';
 import MemoryFormStore from './stores/MemoryFormStore';
@@ -31,6 +32,7 @@ import Url from './fields/Url';
 import type {FormStoreInterface, Schema, Types} from './types';
 
 export {
+    bundlesConditionDataProvider,
     conditionDataProviderRegistry,
     fieldRegistry,
     Selection,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/conditionDataProviders/bundlesConditionDataProvider.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/conditionDataProviders/bundlesConditionDataProvider.test.js
@@ -1,0 +1,10 @@
+// @flow
+import bundlesConditionDataProvider from '../../conditionDataProviders/bundlesConditionDataProvider';
+
+jest.mock('../../../../services/initializer', () => ({
+    bundles: ['sulu_admin', 'sulu_audience_targeting'],
+}));
+
+test('Return all bundles from initializer', () => {
+    expect(bundlesConditionDataProvider()).toEqual({__bundles: ['sulu_admin', 'sulu_audience_targeting']});
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -68,8 +68,10 @@ import FieldBlocks, {
     TimeBlockPreviewTransformer,
 } from './containers/FieldBlocks';
 import {
+    bundlesConditionDataProvider,
     Checkbox,
     ColorPicker,
+    conditionDataProviderRegistry,
     ChangelogLine,
     DatePicker,
     Email,
@@ -118,6 +120,7 @@ log.setDefaultLevel(process.env.NODE_ENV === 'production' ? log.levels.ERROR : l
 Requester.handleResponseHooks.push(logoutOnUnauthorizedResponse);
 
 jexl.addTransform('length', (value: Array<*>) => value.length);
+jexl.addTransform('includes', (value: Array<*>, search) => value.includes(search));
 jexl.addTransform('values', (value: Array<*>) => Object.values(value));
 
 const FIELD_TYPE_BLOCK = 'block';
@@ -153,6 +156,8 @@ initializer.addUpdateConfigHook('sulu_admin', (config: Object, initialized: bool
         registerFormToolbarActions();
         registerListToolbarActions();
         registerViews();
+
+        conditionDataProviderRegistry.add(bundlesConditionDataProvider);
     }
 
     processConfig(config);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/initializer/initializer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/initializer/initializer.js
@@ -1,5 +1,5 @@
 // @flow
-import {action, observable} from 'mobx';
+import {action, computed, observable} from 'mobx';
 import moment from 'moment';
 import userStore from '../../stores/userStore';
 import Config from '../Config';
@@ -32,15 +32,25 @@ function setMomentLocale() {
 }
 
 class Initializer {
+    @observable config: ?{[string]: Object};
     @observable initialized: boolean = false;
     @observable initializedTranslationsLocale: ?string;
     @observable loading: boolean = false;
     updateConfigHooks: {[string]: Array<UpdateConfigHook>} = {};
 
+    @computed get bundles(): Array<string> {
+        if (!this.config) {
+            return [];
+        }
+
+        return Object.keys(this.config);
+    }
+
     @action clear() {
         this.initialized = false;
         this.initializedTranslationsLocale = undefined;
         this.loading = false;
+        this.config = undefined;
     }
 
     @action setInitialized() {
@@ -98,6 +108,8 @@ class Initializer {
 
         return Promise.all([configPromise, routePromise])
             .then(([config]) => {
+                this.config = config;
+
                 if (!this.initialized) {
                     setMomentLocale();
                 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/initializer/tests/initializer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/initializer/tests/initializer.test.js
@@ -88,6 +88,44 @@ test('Should initialize when everything works', () => {
         });
 });
 
+test('Should initialize and return bundle names', () => {
+    const configData = {
+        sulu_admin: {},
+        sulu_audience_targeting: {},
+    };
+
+    const translationData = {
+        'sulu_admin.test1': 'Test1',
+    };
+
+    const routeData = {};
+
+    const translationPromise = Promise.resolve(translationData);
+    const configPromise = Promise.resolve(configData);
+    const routePromise = Promise.resolve(routeData);
+
+    Requester.get.mockImplementation((key) => {
+        switch (key) {
+            case 'translations_url?locale=en':
+                return translationPromise;
+            case 'config_url':
+                return configPromise;
+            case 'routing':
+                return routePromise;
+        }
+    });
+
+    const initPromise = initializer.initialize(true);
+    expect(initializer.loading).toBe(true);
+    expect(initializer.bundles).toEqual([]);
+
+    return initPromise
+        .then(() => {
+            expect(initializer.loading).toBe(false);
+            expect(initializer.bundles).toEqual(['sulu_admin', 'sulu_audience_targeting']);
+        });
+});
+
 test('Should only initialize translations if no user is logged in', () => {
     const translationData = {
         'sulu_admin.test1': 'Test1',

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
@@ -162,6 +162,7 @@
             <argument type="service" id="sulu.content.type_manager"/>
             <argument>%sulu.content.language.namespace%</argument>
             <argument type="service" id="sulu_core.webspace.request_analyzer" />
+            <argument type="service" id="sulu_audience_targeting.target_group_store" on-invalid="null" />
             <tag name="sulu.content.type" alias="block"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
         </service>

--- a/src/Sulu/Bundle/PageBundle/Resources/config/forms/page_block_settings.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/forms/page_block_settings.xml
@@ -51,5 +51,35 @@
                 <property name="segments" type="segment_select" visibleCondition="segment_enabled == true" />
             </properties>
         </section>
+
+        <section name="target_groups" visibleCondition="__bundles|includes('sulu_audience_targeting')">
+            <properties>
+                <property name="target_groups_enabled" type="checkbox">
+                    <params>
+                        <param name="description">
+                            <meta>
+                                <title>sulu_page.target_groups_description</title>
+                            </meta>
+                        </param>
+                        <param name="icon" value="su-user" />
+                        <param name="label">
+                            <meta>
+                                <title>sulu_page.target_groups_label</title>
+                            </meta>
+                        </param>
+                        <param name="skin" value="heading" />
+                        <param name="type" value="toggler" />
+                    </params>
+
+                    <tag name="sulu.block_setting_icon" icon="su-user" />
+                </property>
+
+                <property
+                    name="target_groups"
+                    type="target_group_selection"
+                    visibleCondition="target_groups_enabled == true"
+                />
+            </properties>
+        </section>
     </properties>
 </form>

--- a/src/Sulu/Bundle/PageBundle/Resources/config/forms/page_block_settings.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/forms/page_block_settings.xml
@@ -28,7 +28,11 @@
 
         <section name="segments" visibleCondition="__webspace ? __webspace.segments|length &gt; 0 : true">
             <properties>
-                <property name="segment_enabled" type="checkbox">
+                <property
+                    name="segment_enabled"
+                    type="checkbox"
+                    visibleCondition="__webspace ? __webspace.segments|length &gt; 0 : true"
+                >
                     <params>
                         <param name="description">
                             <meta>
@@ -54,7 +58,11 @@
 
         <section name="target_groups" visibleCondition="__bundles|includes('sulu_audience_targeting')">
             <properties>
-                <property name="target_groups_enabled" type="checkbox">
+                <property
+                    name="target_groups_enabled"
+                    type="checkbox"
+                    visibleCondition="__bundles|includes('sulu_audience_targeting')"
+                >
                     <params>
                         <param name="description">
                             <meta>

--- a/src/Sulu/Bundle/PageBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/PageBundle/Resources/translations/admin.de.json
@@ -55,5 +55,7 @@
     "sulu_page.hide_block_label": "Nicht auf publizierter Website darstellen",
     "sulu_page.hide_block_description": "Dieser Block wird nicht veröffentlicht, kann aber weiterhin im Admin bearbeitet werden.",
     "sulu_page.segment_label": "Segment zuweisen",
-    "sulu_page.segment_description": "Der Block wird automatisch nach dem gewählten Segment auf der Website gefiltert."
+    "sulu_page.segment_description": "Der Block wird automatisch nach dem gewählten Segment auf der Website gefiltert.",
+    "sulu_page.target_groups_label": "Zielgruppen zuweisen",
+    "sulu_page.target_groups_description": "Der Block wird nur den ausgewählten Zielgruppen angezeigt."
 }

--- a/src/Sulu/Bundle/PageBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/PageBundle/Resources/translations/admin.en.json
@@ -55,5 +55,7 @@
     "sulu_page.hide_block_label": "Don't display on public website",
     "sulu_page.hide_block_description": "This block will not be published, but remains editable in the admin.",
     "sulu_page.segment_label": "Assign segment",
-    "sulu_page.segment_description": "The block will be automatically filtered on the website by the chosen segment."
+    "sulu_page.segment_description": "The block will be automatically filtered on the website by the chosen segment.",
+    "sulu_page.target_groups_label": "Assign target groups",
+    "sulu_page.target_groups_description": "The block will only be visible for the selected target groups."
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4997 
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds a selection of target groups to block settings. Then the audience targeting feature will filter the blocks accordingly.