### PR TITLE
Fix media smart content for collections with multiple permissions

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
@@ -27,6 +27,7 @@ use Sulu\Bundle\SecurityBundle\Entity\AccessControl;
 use Sulu\Bundle\SecurityBundle\Entity\Role;
 use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\SecurityBundle\Entity\UserRole;
+use Sulu\Bundle\SecurityBundle\System\SystemStoreInterface;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\Media\SystemCollections\SystemCollectionManagerInterface;
 use Sulu\Component\Security\Authentication\RoleInterface;
@@ -54,6 +55,11 @@ class MediaRepositoryTest extends SuluTestCase
     private $collectionTypes = [];
 
     /**
+     * @var SystemStoreInterface
+     */
+    private $systemStore;
+
+    /**
      * @var MediaRepository
      */
     private $mediaRepository;
@@ -66,6 +72,7 @@ class MediaRepositoryTest extends SuluTestCase
         $this->em = $this->getEntityManager();
         $this->setUpMedia();
 
+        $this->systemStore = $this->getContainer()->get('sulu_security.system_store');
         $this->mediaRepository = $this->getContainer()->get('sulu.repository.media');
     }
 
@@ -227,6 +234,7 @@ class MediaRepositoryTest extends SuluTestCase
             $userRole->setUser($user);
             $userRole->setRole($role);
             $this->em->persist($userRole);
+            $user->addUserRole($userRole);
         }
 
         $this->em->persist($contact);
@@ -568,6 +576,8 @@ class MediaRepositoryTest extends SuluTestCase
 
     public function testFindMediaForUserWithViewPermissions()
     {
+        $this->systemStore->setSystem('Sulu');
+
         $role = $this->createRole();
         $user = $this->createUser($role);
 

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -321,6 +321,7 @@
             class="Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancer"
         >
             <argument type="service" id="sulu_security.system_store" />
+            <argument type="service" id="doctrine.orm.entity_manager" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | --

#### What's in this PR?

This PR fixes an issue with the smart content for media by adjusting the query adjustion done in the `AccessControlQueryEnhancer`.

#### Why?

Before that fix the media was wrongfully displayed on the website by the smart content, if the collection e.g. forbid the displaying on the system used on the website, if the collection also had all permissions for the Sulu system were set.

See e.g. the settings in the following screenshot:

![Screenshot from 2020-09-08 14-53-22](https://user-images.githubusercontent.com/405874/92478913-280c8200-f1e3-11ea-94c4-b860be6547b0.png)

#### To Do

- [ ] Write tests