### PR TITLE
Avoid using IS_ANONYMOUS constant introduced in Symfony 5.1

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Entity/Role.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/Role.php
@@ -18,7 +18,6 @@ use JMS\Serializer\Annotation\Groups;
 use Sulu\Component\Persistence\Model\AuditableTrait;
 use Sulu\Component\Security\Authentication\RoleInterface;
 use Sulu\Component\Security\Authentication\RoleSettingInterface;
-use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 
 /**
  * Role.
@@ -117,7 +116,7 @@ class Role implements RoleInterface
     public function getIdentifier()
     {
         if ($this->anonymous) {
-            return AuthenticatedVoter::IS_ANONYMOUS;
+            return RoleInterface::IS_SULU_ANONYMOUS;
         }
 
         $key = $this->getKey();

--- a/src/Sulu/Component/Security/Authentication/RoleInterface.php
+++ b/src/Sulu/Component/Security/Authentication/RoleInterface.php
@@ -22,6 +22,8 @@ use Sulu\Component\Persistence\Model\AuditableInterface;
  */
 interface RoleInterface extends AuditableInterface, SecurityIdentityInterface
 {
+    const IS_SULU_ANONYMOUS = 'IS_SULU_ANONYMOUS';
+
     /**
      * Set name.
      *


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5483
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR avoids using the `AuthenticatedVoter::IS_ANONYMOUS` constant, because it does not exist before Symfony 5.1.

#### Why?

As described in #5483 some requests fail when used with Symfony versions before 5.1. E.g. the permissions tab of pages does not stop loading at all.