### PR TITLE
Fix tests for different timezone

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/tests/registries/resourceRouteRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/tests/registries/resourceRouteRegistry.test.js
@@ -35,9 +35,9 @@ test('Set and get endpoints for given key with date parameter', () => {
         },
     });
 
-    expect(resourceRouteRegistry.getDetailUrl('snippets', {value: new Date('2013-12-24')}))
+    expect(resourceRouteRegistry.getDetailUrl('snippets', {value: new Date('2013-12-24 00:00')}))
         .toEqual('get_snippet?value=2013-12-24 00:00');
-    expect(resourceRouteRegistry.getListUrl('snippets', {value: new Date('2020-09-07')}))
+    expect(resourceRouteRegistry.getListUrl('snippets', {value: new Date('2020-09-07 00:00')}))
         .toEqual('get_snippets?value=2020-09-07 00:00');
 });
 
@@ -77,11 +77,11 @@ test('Set and get endpoints for given key with date array parameter', () => {
 
     expect(resourceRouteRegistry.getDetailUrl(
         'snippets',
-        {dates: [new Date('2013-12-24 12:00'), new Date('2020-12-24')]})
+        {dates: [new Date('2013-12-24 12:00'), new Date('2020-12-24 00:00')]})
     ).toEqual('get_snippet?dates=2013-12-24 12:00,2020-12-24 00:00');
     expect(resourceRouteRegistry.getListUrl(
         'snippets',
-        {dates: [new Date('2020-09-07'), new Date('2020-11-05')]})
+        {dates: [new Date('2020-09-07 00:00'), new Date('2020-11-05 00:00')]})
     ).toEqual('get_snippets?dates=2020-09-07 00:00,2020-11-05 00:00');
 });
 
@@ -95,13 +95,13 @@ test('Set and get endpoints for given key with date in object parameter', () => 
         },
     });
 
-    resourceRouteRegistry.getDetailUrl('snippets', {value: {name: 'test', date: new Date('2020-09-07')}});
+    resourceRouteRegistry.getDetailUrl('snippets', {value: {name: 'test', date: new Date('2020-09-07 00:00')}});
     expect(SymfonyRouting.generate).toBeCalledWith(
         'get_snippet',
         {'value': {'name': 'test', 'date': '2020-09-07 00:00'}}
     );
 
-    resourceRouteRegistry.getListUrl('snippets', {value: {name: 'test', date: new Date('2020-09-07')}});
+    resourceRouteRegistry.getListUrl('snippets', {value: {name: 'test', date: new Date('2020-09-07 00:00')}});
     expect(SymfonyRouting.generate).toBeCalledWith(
         'get_snippets',
         {'value': {'name': 'test', 'date': '2020-09-07 00:00'}}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Date/tests/transformDateForUrl.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Date/tests/transformDateForUrl.test.js
@@ -2,9 +2,9 @@
 import transformDateForUrl from '../transformDateForUrl';
 
 test.each([
-    [new Date('2020-02-28'), '2020-02-28 00:00'],
+    [new Date('2020-02-28 00:00'), '2020-02-28 00:00'],
     [new Date('2000-08-31 12:00'), '2000-08-31 12:00'],
-    [new Date('2006-12-31'), '2006-12-31 00:00'],
+    [new Date('2006-12-31 00:00'), '2006-12-31 00:00'],
     [new Date('1940-12-01 12:00'), '1940-12-01 12:00'],
 ])('Transform date "%s"', (date, expectedValue) => {
     expect(transformDateForUrl(date)).toEqual(expectedValue);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes the timezone issues in tests by always setting a time when a date object is created in the tests.

#### Why?

In the real application creating a date object never happens without a time. Even if only a date is passed, e.g. the [`Router` makes sure that a time is appended](https://github.com/sulu/sulu/blob/da60751a0249eaf23d46ccfb4c97a419797d4b26/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js#L28). Therefore it also does not make sense to test these functions with a `Date` object that does not have a time attached.

In addition to that the current tests fail based on the timezone setting of the machine it is running on. And if that would really be an issue we would have to fix it in a different way than relying on the CI server to be running in the correct timezone.