### PR TITLE
Fix xliff export/import for documents with route content-types

### DIFF
--- a/src/Sulu/Bundle/RouteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/RouteBundle/Resources/config/services.xml
@@ -6,6 +6,7 @@
     <services>
         <service id="sulu_route.content_type" class="Sulu\Bundle\RouteBundle\Content\Type\RouteContentType">
             <tag name="sulu.content.type" alias="route"/>
+            <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
         </service>
 
         <service id="sulu_route.content_type.page_tree_route" class="Sulu\Bundle\RouteBundle\Content\Type\PageTreeRouteContentType">
@@ -16,6 +17,7 @@
             <argument type="service" id="doctrine.orm.entity_manager"/>
 
             <tag name="sulu.content.type" alias="page_tree_route"/>
+            <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
         </service>
 
         <service id="sulu_route.subscriber.routable"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/sulu/SuluArticleBundle/pull/508
| License | MIT
| Documentation PR | none

#### What's in this PR?

Add export tag to service definition of route and page-tree-route content-type.

#### Why?

To be able to export them in the article bundle.