### PR TITLE
Adjust portal route type to match path prefix against webspace configuration

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -184,6 +184,8 @@
 
         <!-- portal loader -->
         <service id="sulu_website.routing.portal_loader" class="%sulu_website.routing.portal_loader.class%">
+            <argument type="service" id="sulu_core.webspace.webspace_manager"/>
+
             <tag name="routing.loader"/>
         </service>
 

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/PortalLoader.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/PortalLoader.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\WebsiteBundle\Routing;
 
-use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Symfony\Component\Config\Loader\Loader;
 use Symfony\Component\Routing\Route;
@@ -38,11 +37,11 @@ class PortalLoader extends Loader
         $prefixes = [];
         foreach ($this->webspaceManager->getPortalInformations() as $portalInformation) {
             // cast null to string as prefix can be empty string
-            $prefixes[] = preg_quote((string) $portalInformation->getPrefix());
+            $prefixes[] = \preg_quote((string) $portalInformation->getPrefix());
         }
 
         // need to omit prefix from path if it must be empty to pass symfony route validation
-        $prefixPattern = implode('|', array_unique($prefixes));
+        $prefixPattern = \implode('|', \array_unique($prefixes));
         $pathPrefix = empty($prefixPattern) ? '' : '{prefix}';
         $requirements = empty($prefixPattern) ? [] : ['prefix' => $prefixPattern];
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/TestController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/TestController.php
@@ -17,6 +17,6 @@ class TestController
 {
     public function index()
     {
-        return new Response(null, 200);
+        return new Response('Portal Route', 200);
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/TestController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/TestController.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Tests\Application;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class TestController
+{
+    public function index()
+    {
+        return new Response(null, 200);
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/routing_portal_loader_test.yml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/routing_portal_loader_test.yml
@@ -1,0 +1,3 @@
+portal_route:
+    path: /portal-route
+    controller: Sulu\Bundle\WebsiteBundle\Tests\Application\TestController::index

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/routing_website.yml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/routing_website.yml
@@ -7,3 +7,7 @@ sulu_website.website:
 
 sulu_media:
     resource: "@SuluMediaBundle/Resources/config/routing_website.yml"
+
+_portal_loader_test:
+    resource: "@SuluWebsiteBundle/Tests/Application/config/routing_portal_loader_test.yml"
+    type: portal

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/webspaces/example.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/webspaces/example.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<webspace xmlns="http://schemas.sulu.io/webspace/webspace"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.1.xsd">
+
+    <name>example CMF</name>
+    <key>example_io</key>
+
+    <localizations>
+        <localization language="en" default="true"/>
+        <localization language="de"/>
+    </localizations>
+
+    <default-templates>
+        <default-template type="page">default</default-template>
+        <default-template type="homepage">overview</default-template>
+    </default-templates>
+
+    <templates>
+        <template type="error">error/error</template>
+        <template type="error-404">error/error-404</template>
+    </templates>
+
+    <navigation>
+        <contexts>
+            <context key="main">
+                <meta>
+                    <title lang="en">Main Navigation</title>
+                    <title lang="de">Hauptnavigation</title>
+                </meta>
+            </context>
+        </contexts>
+    </navigation>
+
+    <portals>
+        <portal>
+            <name>example CMF</name>
+            <key>examplecmf</key>
+
+            <environments>
+                <environment type="prod">
+                    <urls>
+                        <url>example.lo/{localization}</url>
+                    </urls>
+                </environment>
+                <environment type="dev">
+                    <urls>
+                        <url>example.lo/{localization}</url>
+                    </urls>
+                </environment>
+                <environment type="test">
+                    <urls>
+                        <url>example.lo/{localization}</url>
+                        <url language="en">example-english.lo</url>
+                        <url language="en">example-english.lo/valid-prefix</url>
+                    </urls>
+                </environment>
+            </environments>
+        </portal>
+    </portals>
+</webspace>
+

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Routing/PortalLoaderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Routing/PortalLoaderTest.php
@@ -26,23 +26,46 @@ class PortalLoaderTest extends WebsiteTestCase
         $this->client = static::createWebsiteClient();
     }
 
-    public function testPortalRoute()
+    public function testPortalRouteEnDynamicLocalization()
     {
         $this->client->request('GET', 'http://example.lo/en/portal-route');
+        $response = $this->client->getResponse();
         $this->assertHttpStatusCode(200, $this->client->getResponse());
+        $this->assertSame('Portal Route', $response->getContent());
+    }
 
+    public function testPortalRouteDeDynamicLocalization()
+    {
         $this->client->request('GET', 'http://example.lo/de/portal-route');
+        $response = $this->client->getResponse();
         $this->assertHttpStatusCode(200, $this->client->getResponse());
+        $this->assertSame('Portal Route', $response->getContent());
+    }
 
+    public function testPortalRouteFrNotExistLocale()
+    {
         $this->client->request('GET', 'http://example.lo/fr/portal-route');
         $this->assertHttpStatusCode(404, $this->client->getResponse());
+    }
 
+    public function testPortalRouteWithoutPrefix()
+    {
         $this->client->request('GET', 'http://example-english.lo/portal-route');
+        $response = $this->client->getResponse();
         $this->assertHttpStatusCode(200, $this->client->getResponse());
+        $this->assertSame('Portal Route', $response->getContent());
+    }
 
+    public function testPortalRouteWithPrefix()
+    {
         $this->client->request('GET', 'http://example-english.lo/valid-prefix/portal-route');
+        $response = $this->client->getResponse();
         $this->assertHttpStatusCode(200, $this->client->getResponse());
+        $this->assertSame('Portal Route', $response->getContent());
+    }
 
+    public function testPortalRouteInvalidPrefix()
+    {
         $this->client->request('GET', 'http://example-english.lo/invalid-prefix/portal-route');
         $this->assertHttpStatusCode(404, $this->client->getResponse());
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Routing/PortalLoaderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Routing/PortalLoaderTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Tests\Functional\Routing;
+
+use Sulu\Bundle\TestBundle\Testing\WebsiteTestCase;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+class PortalLoaderTest extends WebsiteTestCase
+{
+    /**
+     * @var KernelBrowser
+     */
+    private $client;
+
+    public function setUp(): void
+    {
+        $this->client = static::createWebsiteClient();
+    }
+
+    public function testPortalRoute()
+    {
+        $this->client->request('GET', 'http://example.lo/en/portal-route');
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+
+        $this->client->request('GET', 'http://example.lo/de/portal-route');
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+
+        $this->client->request('GET', 'http://example.lo/fr/portal-route');
+        $this->assertHttpStatusCode(404, $this->client->getResponse());
+
+        $this->client->request('GET', 'http://example-english.lo/portal-route');
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+
+        $this->client->request('GET', 'http://example-english.lo/valid-prefix/portal-route');
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+
+        $this->client->request('GET', 'http://example-english.lo/invalid-prefix/portal-route');
+        $this->assertHttpStatusCode(404, $this->client->getResponse());
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/PortalLoaderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/PortalLoaderTest.php
@@ -12,9 +12,10 @@
 namespace Sulu\Bundle\WebsiteBundle\Tests\Unit\Routing;
 
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Sulu\Bundle\WebsiteBundle\Routing\PortalLoader;
 use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Component\Webspace\PortalInformation;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
 use Symfony\Component\Routing\Route;
@@ -26,6 +27,11 @@ class PortalLoaderTest extends TestCase
      * @var PortalLoader
      */
     private $portalLoader;
+
+    /**
+     * @var WebspaceManagerInterface
+     */
+    private $webspaceManager;
 
     /**
      * @var LoaderResolverInterface
@@ -42,19 +48,15 @@ class PortalLoaderTest extends TestCase
      */
     private $localizations;
 
-    /**
-     * @var string
-     */
-    private $condition = 'request.get("_sulu").getAttribute("portalInformation") !== null && request.get("_sulu").getAttribute("portalInformation").getType() === 1';
-
     public function setUp(): void
     {
         parent::setUp();
 
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
         $this->loaderResolver = $this->prophesize(LoaderResolverInterface::class);
         $this->loader = $this->prophesize(LoaderInterface::class);
 
-        $this->portalLoader = new PortalLoader();
+        $this->portalLoader = new PortalLoader($this->webspaceManager->reveal());
         $this->portalLoader->setResolver($this->loaderResolver->reveal());
 
         $de = new Localization();
@@ -66,14 +68,29 @@ class PortalLoaderTest extends TestCase
 
     public function testLoad()
     {
+        $portalInformation1 = $this->prophesize(PortalInformation::class);
+        $portalInformation1->getPrefix()->willReturn('de/');
+
+        $portalInformation2 = $this->prophesize(PortalInformation::class);
+        $portalInformation2->getPrefix()->willReturn('en/');
+
+        $portalInformation3 = $this->prophesize(PortalInformation::class);
+        $portalInformation3->getPrefix()->willReturn('custom/prefix/');
+
+        $this->webspaceManager->getPortalInformations()->willReturn([
+            $portalInformation1->reveal(),
+            $portalInformation2->reveal(),
+            $portalInformation3->reveal(),
+        ]);
+
         $importedRouteCollection = new RouteCollection();
         $importedRouteCollection->add('route1', new Route('/example/route1'));
         $importedRouteCollection->add('route2', new Route('/route2'));
 
-        $this->loaderResolver->resolve(Argument::any(), Argument::any())->willReturn($this->loader->reveal());
-        $this->loader->load(Argument::any(), Argument::any())->willReturn($importedRouteCollection);
+        $this->loaderResolver->resolve('routes.yml', null)->willReturn($this->loader->reveal());
+        $this->loader->load('routes.yml', null)->willReturn($importedRouteCollection);
 
-        $routeCollection = $this->portalLoader->load('', 'portal');
+        $routeCollection = $this->portalLoader->load('routes.yml', 'portal');
 
         $this->assertCount(2, $routeCollection);
 
@@ -85,25 +102,30 @@ class PortalLoaderTest extends TestCase
         $this->assertInstanceOf(Route::class, $routeCollection->get('route2'));
 
         $this->assertEquals('/{prefix}example/route1', $routeCollection->get('route1')->getPath());
-        $this->assertEquals(['prefix' => '(.*/)?'], $routeCollection->get('route1')->getRequirements());
+        $this->assertEquals(['prefix' => 'de/|en/|custom/prefix/'], $routeCollection->get('route1')->getRequirements());
         $this->assertEquals('/{prefix}route2', $routeCollection->get('route2')->getPath());
-        $this->assertEquals(['prefix' => '(.*/)?'], $routeCollection->get('route2')->getRequirements());
+        $this->assertEquals(['prefix' => 'de/|en/|custom/prefix/'], $routeCollection->get('route2')->getRequirements());
         $this->assertEquals('', $routeCollection->get('route1')->getHost());
         $this->assertEquals('', $routeCollection->get('route2')->getHost());
-        $this->assertEquals($this->condition, $routeCollection->get('route1')->getCondition());
-        $this->assertEquals($this->condition, $routeCollection->get('route2')->getCondition());
     }
 
-    public function testLoadWithCustomUrls()
+    public function testLoadWithEmptyPortalPrefix()
     {
+        $portalInformation1 = $this->prophesize(PortalInformation::class);
+        $portalInformation1->getPrefix()->willReturn('');
+
+        $this->webspaceManager->getPortalInformations()->willReturn([
+            $portalInformation1->reveal(),
+        ]);
+
         $importedRouteCollection = new RouteCollection();
         $importedRouteCollection->add('route1', new Route('/example/route1'));
         $importedRouteCollection->add('route2', new Route('/route2'));
 
-        $this->loaderResolver->resolve(Argument::any(), Argument::any())->willReturn($this->loader->reveal());
-        $this->loader->load(Argument::any(), Argument::any())->willReturn($importedRouteCollection);
+        $this->loaderResolver->resolve('routes.yml', null)->willReturn($this->loader->reveal());
+        $this->loader->load('routes.yml', null)->willReturn($importedRouteCollection);
 
-        $routeCollection = $this->portalLoader->load('', 'portal');
+        $routeCollection = $this->portalLoader->load('routes.yml', 'portal');
 
         $this->assertCount(2, $routeCollection);
 
@@ -114,25 +136,38 @@ class PortalLoaderTest extends TestCase
         $this->assertInstanceOf(Route::class, $routeCollection->get('route1'));
         $this->assertInstanceOf(Route::class, $routeCollection->get('route2'));
 
-        $this->assertEquals('/{prefix}example/route1', $routeCollection->get('route1')->getPath());
-        $this->assertEquals(['prefix' => '(.*/)?'], $routeCollection->get('route1')->getRequirements());
-        $this->assertEquals('/{prefix}route2', $routeCollection->get('route2')->getPath());
-        $this->assertEquals(['prefix' => '(.*/)?'], $routeCollection->get('route2')->getRequirements());
+        $this->assertEquals('/example/route1', $routeCollection->get('route1')->getPath());
+        $this->assertEquals([], $routeCollection->get('route1')->getRequirements());
+        $this->assertEquals('/route2', $routeCollection->get('route2')->getPath());
+        $this->assertEquals([], $routeCollection->get('route2')->getRequirements());
         $this->assertEquals('', $routeCollection->get('route1')->getHost());
         $this->assertEquals('', $routeCollection->get('route2')->getHost());
-        $this->assertEquals($this->condition, $routeCollection->get('route1')->getCondition());
-        $this->assertEquals($this->condition, $routeCollection->get('route2')->getCondition());
     }
 
     public function testLoadSingleRoute()
     {
+        $portalInformation1 = $this->prophesize(PortalInformation::class);
+        $portalInformation1->getPrefix()->willReturn('de/');
+
+        $portalInformation2 = $this->prophesize(PortalInformation::class);
+        $portalInformation2->getPrefix()->willReturn('en/');
+
+        $portalInformation3 = $this->prophesize(PortalInformation::class);
+        $portalInformation3->getPrefix()->willReturn('custom/prefix/');
+
+        $this->webspaceManager->getPortalInformations()->willReturn([
+            $portalInformation1->reveal(),
+            $portalInformation2->reveal(),
+            $portalInformation3->reveal(),
+        ]);
+
         $importedRouteCollection = new RouteCollection();
         $importedRouteCollection->add('route', new Route('/route'));
 
-        $this->loaderResolver->resolve(Argument::any(), Argument::any())->willReturn($this->loader->reveal());
-        $this->loader->load(Argument::any(), Argument::any())->willReturn($importedRouteCollection);
+        $this->loaderResolver->resolve('routes.yml', null)->willReturn($this->loader->reveal());
+        $this->loader->load('routes.yml', null)->willReturn($importedRouteCollection);
 
-        $routeCollection = $this->portalLoader->load('', 'portal');
+        $routeCollection = $this->portalLoader->load('routes.yml', 'portal');
 
         $this->assertCount(1, $routeCollection);
 
@@ -142,23 +177,37 @@ class PortalLoaderTest extends TestCase
         $this->assertInstanceOf(Route::class, $routeCollection->get('route'));
 
         $this->assertEquals('/{prefix}route', $routeCollection->get('route')->getPath());
-        $this->assertEquals(['prefix' => '(.*/)?'], $routeCollection->get('route')->getRequirements());
+        $this->assertEquals(['prefix' => 'de/|en/|custom/prefix/'], $routeCollection->get('route')->getRequirements());
         $this->assertEquals('', $routeCollection->get('route')->getHost());
-        $this->assertEquals($this->condition, $routeCollection->get('route')->getCondition());
     }
 
     public function testLoadSingleRouteWithHost()
     {
+        $portalInformation1 = $this->prophesize(PortalInformation::class);
+        $portalInformation1->getPrefix()->willReturn('de/');
+
+        $portalInformation2 = $this->prophesize(PortalInformation::class);
+        $portalInformation2->getPrefix()->willReturn('en/');
+
+        $portalInformation3 = $this->prophesize(PortalInformation::class);
+        $portalInformation3->getPrefix()->willReturn('custom/prefix/');
+
+        $this->webspaceManager->getPortalInformations()->willReturn([
+            $portalInformation1->reveal(),
+            $portalInformation2->reveal(),
+            $portalInformation3->reveal(),
+        ]);
+
         $route = new Route('/route');
         $route->setHost('sulu.io');
 
         $importedRouteCollection = new RouteCollection();
         $importedRouteCollection->add('route', $route);
 
-        $this->loaderResolver->resolve(Argument::any(), Argument::any())->willReturn($this->loader->reveal());
-        $this->loader->load(Argument::any(), Argument::any())->willReturn($importedRouteCollection);
+        $this->loaderResolver->resolve('routes.yml', null)->willReturn($this->loader->reveal());
+        $this->loader->load('routes.yml', null)->willReturn($importedRouteCollection);
 
-        $routeCollection = $this->portalLoader->load('', 'portal');
+        $routeCollection = $this->portalLoader->load('routes.yml', 'portal');
 
         $this->assertCount(1, $routeCollection);
 
@@ -168,13 +217,27 @@ class PortalLoaderTest extends TestCase
         $this->assertInstanceOf(Route::class, $routeCollection->get('route'));
 
         $this->assertEquals('/{prefix}route', $routeCollection->get('route')->getPath());
-        $this->assertEquals(['prefix' => '(.*/)?'], $routeCollection->get('route')->getRequirements());
+        $this->assertEquals(['prefix' => 'de/|en/|custom/prefix/'], $routeCollection->get('route')->getRequirements());
         $this->assertEquals('sulu.io', $routeCollection->get('route')->getHost());
-        $this->assertEquals($this->condition, $routeCollection->get('route')->getCondition());
     }
 
     public function testLoadSingleRouteWithCondition()
     {
+        $portalInformation1 = $this->prophesize(PortalInformation::class);
+        $portalInformation1->getPrefix()->willReturn('de/');
+
+        $portalInformation2 = $this->prophesize(PortalInformation::class);
+        $portalInformation2->getPrefix()->willReturn('en/');
+
+        $portalInformation3 = $this->prophesize(PortalInformation::class);
+        $portalInformation3->getPrefix()->willReturn('custom/prefix/');
+
+        $this->webspaceManager->getPortalInformations()->willReturn([
+            $portalInformation1->reveal(),
+            $portalInformation2->reveal(),
+            $portalInformation3->reveal(),
+        ]);
+
         $route = new Route('/route');
         $route->setHost('sulu.io');
         $route->setCondition('request.get("test") === "sulu.io"');
@@ -182,10 +245,10 @@ class PortalLoaderTest extends TestCase
         $importedRouteCollection = new RouteCollection();
         $importedRouteCollection->add('route', $route);
 
-        $this->loaderResolver->resolve(Argument::any(), Argument::any())->willReturn($this->loader->reveal());
-        $this->loader->load(Argument::any(), Argument::any())->willReturn($importedRouteCollection);
+        $this->loaderResolver->resolve('routes.yml', null)->willReturn($this->loader->reveal());
+        $this->loader->load('routes.yml', null)->willReturn($importedRouteCollection);
 
-        $routeCollection = $this->portalLoader->load('', 'portal');
+        $routeCollection = $this->portalLoader->load('routes.yml', 'portal');
 
         $this->assertCount(1, $routeCollection);
 
@@ -195,26 +258,38 @@ class PortalLoaderTest extends TestCase
         $this->assertInstanceOf(Route::class, $routeCollection->get('route'));
 
         $this->assertEquals('/{prefix}route', $routeCollection->get('route')->getPath());
-        $this->assertEquals(['prefix' => '(.*/)?'], $routeCollection->get('route')->getRequirements());
+        $this->assertEquals(['prefix' => 'de/|en/|custom/prefix/'], $routeCollection->get('route')->getRequirements());
         $this->assertEquals('sulu.io', $routeCollection->get('route')->getHost());
-        $this->assertEquals(
-            $this->condition . ' and (request.get("test") === "sulu.io")',
-            $routeCollection->get('route')->getCondition()
-        );
+        $this->assertEquals('request.get("test") === "sulu.io"', $routeCollection->get('route')->getCondition());
     }
 
     public function testLoadWithRequirements()
     {
+        $portalInformation1 = $this->prophesize(PortalInformation::class);
+        $portalInformation1->getPrefix()->willReturn('de/');
+
+        $portalInformation2 = $this->prophesize(PortalInformation::class);
+        $portalInformation2->getPrefix()->willReturn('en/');
+
+        $portalInformation3 = $this->prophesize(PortalInformation::class);
+        $portalInformation3->getPrefix()->willReturn('custom/prefix/');
+
+        $this->webspaceManager->getPortalInformations()->willReturn([
+            $portalInformation1->reveal(),
+            $portalInformation2->reveal(),
+            $portalInformation3->reveal(),
+        ]);
+
         $route = new Route('/route', [], ['requirement1' => '\d+']);
         $route->setHost('sulu.io');
 
         $importedRouteCollection = new RouteCollection();
         $importedRouteCollection->add('route', $route);
 
-        $this->loaderResolver->resolve(Argument::any(), Argument::any())->willReturn($this->loader->reveal());
-        $this->loader->load(Argument::any(), Argument::any())->willReturn($importedRouteCollection);
+        $this->loaderResolver->resolve('routes.yml', null)->willReturn($this->loader->reveal());
+        $this->loader->load('routes.yml', null)->willReturn($importedRouteCollection);
 
-        $routeCollection = $this->portalLoader->load('', 'portal');
+        $routeCollection = $this->portalLoader->load('routes.yml', 'portal');
 
         $this->assertCount(1, $routeCollection);
 
@@ -224,7 +299,7 @@ class PortalLoaderTest extends TestCase
         $this->assertInstanceOf(Route::class, $routeCollection->get('route'));
 
         $this->assertEquals(
-            ['prefix' => '(.*/)?', 'requirement1' => '\d+'],
+            ['prefix' => 'de/|en/|custom/prefix/', 'requirement1' => '\d+'],
             $routeCollection->get('route')->getRequirements()
         );
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/PortalLoaderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/PortalLoaderTest.php
@@ -75,12 +75,16 @@ class PortalLoaderTest extends TestCase
         $portalInformation2->getPrefix()->willReturn('en/');
 
         $portalInformation3 = $this->prophesize(PortalInformation::class);
-        $portalInformation3->getPrefix()->willReturn('custom/prefix/');
+        $portalInformation3->getPrefix()->willReturn('');
+
+        $portalInformation4 = $this->prophesize(PortalInformation::class);
+        $portalInformation4->getPrefix()->willReturn('custom/pre-fix/');
 
         $this->webspaceManager->getPortalInformations()->willReturn([
             $portalInformation1->reveal(),
             $portalInformation2->reveal(),
             $portalInformation3->reveal(),
+            $portalInformation4->reveal(),
         ]);
 
         $importedRouteCollection = new RouteCollection();
@@ -102,9 +106,9 @@ class PortalLoaderTest extends TestCase
         $this->assertInstanceOf(Route::class, $routeCollection->get('route2'));
 
         $this->assertEquals('/{prefix}example/route1', $routeCollection->get('route1')->getPath());
-        $this->assertEquals(['prefix' => 'de/|en/|custom/prefix/'], $routeCollection->get('route1')->getRequirements());
+        $this->assertEquals(['prefix' => 'de/|en/|()|custom/pre\-fix/'], $routeCollection->get('route1')->getRequirements());
         $this->assertEquals('/{prefix}route2', $routeCollection->get('route2')->getPath());
-        $this->assertEquals(['prefix' => 'de/|en/|custom/prefix/'], $routeCollection->get('route2')->getRequirements());
+        $this->assertEquals(['prefix' => 'de/|en/|()|custom/pre\-fix/'], $routeCollection->get('route2')->getRequirements());
         $this->assertEquals('', $routeCollection->get('route1')->getHost());
         $this->assertEquals('', $routeCollection->get('route2')->getHost());
     }
@@ -136,10 +140,10 @@ class PortalLoaderTest extends TestCase
         $this->assertInstanceOf(Route::class, $routeCollection->get('route1'));
         $this->assertInstanceOf(Route::class, $routeCollection->get('route2'));
 
-        $this->assertEquals('/example/route1', $routeCollection->get('route1')->getPath());
-        $this->assertEquals([], $routeCollection->get('route1')->getRequirements());
-        $this->assertEquals('/route2', $routeCollection->get('route2')->getPath());
-        $this->assertEquals([], $routeCollection->get('route2')->getRequirements());
+        $this->assertEquals('/{prefix}example/route1', $routeCollection->get('route1')->getPath());
+        $this->assertEquals(['prefix' => '()'], $routeCollection->get('route1')->getRequirements());
+        $this->assertEquals('/{prefix}route2', $routeCollection->get('route2')->getPath());
+        $this->assertEquals(['prefix' => '()'], $routeCollection->get('route2')->getRequirements());
         $this->assertEquals('', $routeCollection->get('route1')->getHost());
         $this->assertEquals('', $routeCollection->get('route2')->getHost());
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5489
| Related issues/PRs | #5428
| License | MIT

#### What's in this PR?

This PR adjusts the `PortalLoader` to generate routes that match only if the path prefix is configured for a webspace.
It builds upon #5428, as I am not able to test this on `release/1.6`. Would be nice if someone else is motivated to backport it 🙂 

#### Why?

At the moment, the path `/_profiler/search` does also match the search portal route. This is wrong, as only routes with a specific portal prefix should match.