### PR TITLE
Handle empty permissions for pages correctly

### DIFF
--- a/src/Sulu/Component/Content/Document/Subscriber/SecuritySubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/SecuritySubscriber.php
@@ -72,7 +72,7 @@ class SecuritySubscriber implements EventSubscriberInterface
         /** @var SecurityBehavior $document */
         $document = $event->getDocument();
 
-        if (!$this->supports($document) || !$document->getPermissions()) {
+        if (!$this->supports($document) || !\is_array($document->getPermissions())) {
             return;
         }
 

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/SecuritySubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/SecuritySubscriberTest.php
@@ -127,6 +127,32 @@ class SecuritySubscriberTest extends SubscriberTestCase
         $this->subscriber->handlePersist($this->persistEvent->reveal());
     }
 
+    public function testPersistWithoutAnyRoles()
+    {
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getName()->willReturn('sec:role-2');
+        $this->node->getProperties('sec:role-*')->willReturn([$property->reveal()]);
+        $liveNode = $this->prophesize(NodeInterface::class);
+        $liveProperty = $this->prophesize(PropertyInterface::class);
+        $liveNode->getProperty('sec:role-2')->willReturn($liveProperty->reveal());
+        $liveNode->hasProperty('sec:role-2')->willReturn(true);
+
+        /** @var SecurityBehavior $document */
+        $document = $this->prophesize(SecurityBehavior::class);
+        $document->willImplement(PathBehavior::class);
+        $document->getPath()->willReturn('/some/path');
+        $document->getPermissions()->willReturn([]);
+
+        $this->liveSession->getNode('/some/path')->willReturn($liveNode->reveal());
+
+        $this->persistEvent->getDocument()->willReturn($document);
+
+        $property->remove()->shouldBeCalled();
+        $liveProperty->remove()->shouldBeCalled();
+
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
     public function testHydrate()
     {
         /** @var SecurityBehavior $document */


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR makes sure that the permissions are deleted from a page if en empty set of permissions is sent to the API.

#### Why?

Because otherwise it is not possible to completely remove the permissions from a page by deactivating the toggler for all systems from a page.