### PR TITLE
Add updating of exist anonymous roles

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Command/InitCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/InitCommand.php
@@ -102,14 +102,14 @@ final class InitCommand extends Command
             }
 
             $permissionAdded = false;
-            $existSecurityContexts = [];
+            $existingSecurityContexts = [];
 
             foreach ($role->getPermissions() as $permission) {
-                $existSecurityContexts[] = $permission->getContext();
+                $existingSecurityContexts[] = $permission->getContext();
             }
 
             foreach ($securityContextsFlat as $securityContext) {
-                if (\in_array($securityContext, $existSecurityContexts)) {
+                if (\in_array($securityContext, $existingSecurityContexts)) {
                     continue;
                 }
 

--- a/src/Sulu/Bundle/SecurityBundle/Command/InitCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/InitCommand.php
@@ -75,24 +75,15 @@ final class InitCommand extends Command
             }
         }
 
-        $count = 0;
+        $addedCount = 0;
+        $updatedCount = 0;
         foreach ($systems as $system) {
             if (Admin::SULU_ADMIN_SECURITY_SYSTEM === $system) {
                 continue;
             }
 
-            if (isset($existingAnonymousRoles[$system])) {
-                $ui->text(\sprintf(
-                    '[ ] Anonymous role named "%s" exists in system "%s" already.',
-                    $system,
-                    $existingAnonymousRoles[$system]->getName()
-                ));
-
-                continue;
-            }
-
             /** @var RoleInterface $role */
-            $role = $this->roleRepository->createNew();
+            $role = $existingAnonymousRoles[$system] ?? $this->roleRepository->createNew();
             $role->setName('Anonymous User ' . $system);
             $role->setAnonymous(true);
             $role->setSystem($system);
@@ -110,27 +101,62 @@ final class InitCommand extends Command
                 }
             }
 
+            $permissionAdded = false;
+            $existSecurityContexts = [];
+
+            foreach ($role->getPermissions() as $permission) {
+                $existSecurityContexts[] = $permission->getContext();
+            }
+
             foreach ($securityContextsFlat as $securityContext) {
+                if (\in_array($securityContext, $existSecurityContexts)) {
+                    continue;
+                }
+
                 $permission = new Permission();
                 $permission->setRole($role);
                 $permission->setContext($securityContext);
                 $permission->setPermissions(127);
                 $role->addPermission($permission);
+                $permissionAdded = true;
             }
 
-            $ui->text(\sprintf('[+] Create anonymous role in system "%s" as "%s".', $system, $role->getName()));
+            if ($role->getId()) {
+                if (!$permissionAdded) {
+                    $ui->text(\sprintf(
+                        '[ ] Anonymous role named "%s" exists in system "%s" already.',
+                        $existingAnonymousRoles[$system]->getName(),
+                        $system
+                    ));
+
+                    continue;
+                }
+
+                $ui->text(\sprintf(
+                    '[*] Anonymous role named "%s" in system "%s" was updated.',
+                    $existingAnonymousRoles[$system]->getName(),
+                    $system
+                ));
+                ++$updatedCount;
+            } else {
+                $ui->text(\sprintf('[+] Create anonymous role in system "%s" as "%s".', $system, $role->getName()));
+                ++$addedCount;
+            }
 
             $this->entityManager->persist($role);
-
-            ++$count;
         }
 
         $output->writeln('');
         $output->writeln('<comment>*</comment> Legend: [+] Added [*] Updated [-] Purged [ ] No change');
 
-        if ($count) {
-            $ui->success(\sprintf('Created "%s" new anonymous roles.', $count));
+        if ($addedCount) {
+            $ui->success(\sprintf('Created "%s" new anonymous roles.', $addedCount));
         }
+
+        if ($updatedCount) {
+            $ui->success(\sprintf('Updated "%s" anonymous roles.', $updatedCount));
+        }
+
         $this->entityManager->flush();
 
         return 0;

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/InitCommandTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/InitCommandTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\Tests\Functional\Command;
+
+use Sulu\Bundle\SecurityBundle\Command\InitCommand;
+use Sulu\Bundle\SecurityBundle\Entity\Permission;
+use Sulu\Bundle\SecurityBundle\Entity\Role;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Component\Security\Authentication\RoleRepositoryInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class InitCommandTest extends SuluTestCase
+{
+    /**
+     * @var CommandTester
+     */
+    private $tester;
+
+    /**
+     * @var RoleRepositoryInterface
+     */
+    private $roleRepository;
+
+    public function setUp(): void
+    {
+        $this->purgeDatabase();
+        $application = new Application($this->getContainer()->get('kernel'));
+
+        $this->roleRepository = $this->getContainer()->get('sulu.repository.role');
+
+        $initCommand = new InitCommand(
+            $this->getContainer()->get('doctrine.orm.entity_manager'),
+            $this->roleRepository,
+            $this->getContainer()->get('sulu_admin.admin_pool')
+        );
+        $initCommand->setApplication($application);
+        $this->tester = new CommandTester($initCommand);
+    }
+
+    public function testCreateAnonymousRole(): void
+    {
+        $this->runCommand();
+
+        $this->assertStringContainsString(
+            '[+] Create anonymous role in system "Sulu CMF" as "Anonymous User Sulu CMF".',
+            $this->tester->getDisplay()
+        );
+
+        $this->assertStringContainsString(
+            '[OK] Created "1" new anonymous roles.',
+            $this->tester->getDisplay()
+        );
+
+        $this->assertAnonymousRole('Sulu CMF');
+    }
+
+    public function testUpdateAnonymousRole(): void
+    {
+        $this->createAnonymousRole('Sulu CMF');
+        $this->getEntityManager()->flush();
+
+        $this->runCommand();
+
+        $this->assertStringContainsString(
+            '[*] Anonymous role named "Anonymous User Sulu CMF" in system "Sulu CMF" was updated.',
+            $this->tester->getDisplay()
+        );
+
+        $this->assertStringContainsString(
+            '[OK] Updated "1" anonymous roles.',
+            $this->tester->getDisplay()
+        );
+
+        $this->assertAnonymousRole('Sulu CMF');
+    }
+
+    private function assertAnonymousRole(string $system): void
+    {
+        /** @var Role $role */
+        $role = $this->roleRepository->findOneBy(['system' => $system]);
+
+        $this->assertSame($system, $role->getSystem());
+        $this->assertTrue($role->getAnonymous());
+
+        $permissions = $role->getPermissions();
+
+        $this->assertCount(2, $permissions);
+
+        /** @var Permission|null $webspacePermission */
+        $webspacePermission = $permissions->filter(function(Permission $permission) {
+            return 'sulu.webspaces.sulu_io' === $permission->getContext();
+        })->first();
+        $this->assertNotNull($webspacePermission);
+        $this->assertSame(127, $webspacePermission->getPermissions());
+
+        /** @var Permission|null $pagePermissions */
+        $collectionPermissions = $permissions->filter(function(Permission $permission) {
+            return 'sulu.media.collections' === $permission->getContext();
+        })->first();
+        $this->assertNotNull($collectionPermissions);
+        $this->assertSame(127, $collectionPermissions->getPermissions());
+    }
+
+    private function createAnonymousRole(string $system): Role
+    {
+        $role = $this->roleRepository->createNew();
+        $role->setAnonymous(true);
+        $role->setName('Anonymous User ' . $system);
+        $role->setSystem($system);
+
+        $this->getEntityManager()->persist($role);
+
+        return $role;
+    }
+
+    private function runCommand(): void
+    {
+        $this->tester->execute(
+            [],
+            ['interactive' => false]
+        );
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5499
| Related issues/PRs | 
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add updating of exist anonymous roles.

#### Why?

As the content manager can not add permission for anonymous user a new added webspace need to add permission over the `sulu:security:init` command else the anonymous user will not have access to a new webspace in the same security system.

#### Example Usage

1. `cp sulu-blog.xml sulu-blog2.xml`
2. Change `<key>` to `sulu-blog2`
3. `bin/console sulu:security:init`

Exist anonymous role for same system should be updated and anonymous role should now have access to the new webspace.
