### PR TITLE
Update BlockCollection arrays on setting new block-data

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -37,10 +37,10 @@ class BlockCollection extends React.Component<Props> {
         super(props);
 
         this.fillArrays();
-        reaction(() => this.props.value.length, this.fillArrays.bind(this));
+        reaction(() => this.props.value.length, this.fillArrays);
     }
 
-    fillArrays() {
+    fillArrays = () => {
         const {defaultType, onChange, minOccurs, value} = this.props;
         const {expandedBlocks, generatedBlockIds} = this;
 
@@ -75,7 +75,7 @@ class BlockCollection extends React.Component<Props> {
                 ),
             ]);
         }
-    }
+    };
 
     @action handleAddBlock = () => {
         const {defaultType, onChange, value} = this.props;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {action, observable, toJS} from 'mobx';
+import {action, observable, toJS, reaction} from 'mobx';
 import {observer} from 'mobx-react';
 import {arrayMove} from 'react-sortable-hoc';
 import {translate} from '../../utils/Translator';
@@ -37,14 +37,24 @@ class BlockCollection extends React.Component<Props> {
         super(props);
 
         this.fillArrays();
+        reaction(() => this.props.value.length, this.fillArrays.bind(this));
     }
 
     fillArrays() {
         const {defaultType, onChange, minOccurs, value} = this.props;
         const {expandedBlocks, generatedBlockIds} = this;
 
-        if (!value) {
+        if ((!value || expandedBlocks.length === value.length || generatedBlockIds.length === value.length)
+                && value.length !== 0) {
             return;
+        }
+
+        if (expandedBlocks.length > value.length) {
+            expandedBlocks.length = 0;
+        }
+
+        if (generatedBlockIds.length > value.length) {
+            generatedBlockIds.length = 0;
         }
 
         expandedBlocks.push(...new Array(value.length - expandedBlocks.length).fill(false));

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -44,17 +44,16 @@ class BlockCollection extends React.Component<Props> {
         const {defaultType, onChange, minOccurs, value} = this.props;
         const {expandedBlocks, generatedBlockIds} = this;
 
-        if ((!value || expandedBlocks.length === value.length || generatedBlockIds.length === value.length)
-                && value.length !== 0) {
+        if (!value) {
             return;
         }
 
         if (expandedBlocks.length > value.length) {
-            expandedBlocks.length = 0;
+            expandedBlocks.splice(value.length);
         }
 
         if (generatedBlockIds.length > value.length) {
-            generatedBlockIds.length = 0;
+            generatedBlockIds.splice(value.length);
         }
 
         expandedBlocks.push(...new Array(value.length - expandedBlocks.length).fill(false));

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -406,3 +406,52 @@ test('Should apply renderBlockContent before rendering the block content includi
     expect(blockCollection.find('Block').at(1).prop('children'))
         .toEqual(prefix + value[1].content + typePrefix + 'type1');
 });
+
+test('Should adjust expandedBlocks and generatedBlockIds after updating the value variable', () => {
+    const types = {
+        type1: 'Type 1',
+        type2: 'Type 2',
+    };
+
+    let value: any = [
+        {
+            type: 'type1',
+            content: 'Test 1',
+        },
+        {
+            type: 'type2',
+            content: 'Test 2',
+        },
+        {
+            type: 'type1',
+            content: 'Test 3',
+        },
+    ];
+
+    const blockCollection = mount(
+        <BlockCollection
+            defaultType="editor"
+            onChange={jest.fn()}
+            renderBlockContent={jest.fn()}
+            types={types}
+            value={value}
+        />
+    );
+
+    value = [
+        {
+            type: 'type1',
+            content: 'Test 1',
+        },
+    ];
+
+    expect(blockCollection.props().value.length).toBe(3);
+    expect(blockCollection.instance().expandedBlocks.length).toBe(3);
+    expect(blockCollection.instance().generatedBlockIds.length).toBe(3);
+
+    blockCollection.setProps({value});
+
+    expect(blockCollection.props().value.length).toBe(1);
+    expect(blockCollection.instance().expandedBlocks.length).toBe(1);
+    expect(blockCollection.instance().generatedBlockIds.length).toBe(1);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -413,7 +413,7 @@ test('Should adjust expandedBlocks and generatedBlockIds after updating the valu
         type2: 'Type 2',
     };
 
-    let value: any = [
+    const value = [
         {
             type: 'type1',
             content: 'Test 1',
@@ -438,20 +438,24 @@ test('Should adjust expandedBlocks and generatedBlockIds after updating the valu
         />
     );
 
-    value = [
-        {
-            type: 'type1',
-            content: 'Test 1',
-        },
-    ];
+    blockCollection.instance().expandedBlocks[0] = true;
 
     expect(blockCollection.props().value.length).toBe(3);
     expect(blockCollection.instance().expandedBlocks.length).toBe(3);
     expect(blockCollection.instance().generatedBlockIds.length).toBe(3);
+    expect(blockCollection.instance().expandedBlocks[0]).toBe(true);
 
-    blockCollection.setProps({value});
+    blockCollection.setProps({
+        value: [
+            {
+                type: 'type1',
+                content: 'Test 1',
+            },
+        ],
+    });
 
     expect(blockCollection.props().value.length).toBe(1);
     expect(blockCollection.instance().expandedBlocks.length).toBe(1);
     expect(blockCollection.instance().generatedBlockIds.length).toBe(1);
+    expect(blockCollection.instance().expandedBlocks[0]).toBe(true);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -513,7 +513,7 @@ test('Should adjust expandedBlocks and generatedBlockIds after updating the valu
     expect(blockCollection.instance().expandedBlocks[0]).toBe(true);
 });
 
-test('Updating value with same length should not adjust expandedBlocks and generatedBlockIds.', () => {
+test('Updating value with same length should not adjust expandedBlocks and generatedBlockIds', () => {
     const types = {
         type1: 'Type 1',
         type2: 'Type 2',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -407,7 +407,7 @@ test('Should apply renderBlockContent before rendering the block content includi
         .toEqual(prefix + value[1].content + typePrefix + 'type1');
 });
 
-test('Should adjust expandedBlocks and generatedBlockIds after updating the value variable', () => {
+test('Should adjust expandedBlocks and generatedBlockIds after updating the value variable with fewer entries', () => {
     const types = {
         type1: 'Type 1',
         type2: 'Type 2',
@@ -459,3 +459,117 @@ test('Should adjust expandedBlocks and generatedBlockIds after updating the valu
     expect(blockCollection.instance().generatedBlockIds.length).toBe(1);
     expect(blockCollection.instance().expandedBlocks[0]).toBe(true);
 });
+
+test('Should adjust expandedBlocks and generatedBlockIds after updating the value variable with more entries', () => {
+    const types = {
+        type1: 'Type 1',
+        type2: 'Type 2',
+    };
+
+    const value = [
+        {
+            type: 'type1',
+            content: 'Test 1',
+        },
+    ];
+
+    const blockCollection = mount(
+        <BlockCollection
+            defaultType="editor"
+            onChange={jest.fn()}
+            renderBlockContent={jest.fn()}
+            types={types}
+            value={value}
+        />
+    );
+
+    blockCollection.instance().expandedBlocks[0] = true;
+
+    expect(blockCollection.props().value.length).toBe(1);
+    expect(blockCollection.instance().expandedBlocks.length).toBe(1);
+    expect(blockCollection.instance().generatedBlockIds.length).toBe(1);
+    expect(blockCollection.instance().expandedBlocks[0]).toBe(true);
+
+    blockCollection.setProps({
+        value: [
+            {
+                type: 'type1',
+                content: 'Test 1',
+            },
+            {
+                type: 'type2',
+                content: 'Test 2',
+            },
+            {
+                type: 'type1',
+                content: 'Test 3',
+            },
+        ],
+    });
+
+    expect(blockCollection.props().value.length).toBe(3);
+    expect(blockCollection.instance().expandedBlocks.length).toBe(3);
+    expect(blockCollection.instance().generatedBlockIds.length).toBe(3);
+    expect(blockCollection.instance().expandedBlocks[0]).toBe(true);
+});
+
+test('Should not adjust expandedBlocks and generatedBlockIds after updating the value variable with the same ' +
+    'amount of entries', () => {
+    const types = {
+        type1: 'Type 1',
+        type2: 'Type 2',
+    };
+
+    const value = [
+        {
+            type: 'type1',
+            content: 'Test 1',
+        },
+        {
+            type: 'type2',
+            content: 'Test 2',
+        },
+        {
+            type: 'type1',
+            content: 'Test 3',
+        },
+    ];
+
+    const blockCollection = mount(
+        <BlockCollection
+            defaultType="editor"
+            onChange={jest.fn()}
+            renderBlockContent={jest.fn()}
+            types={types}
+            value={value}
+        />
+    );
+
+    blockCollection.instance().expandedBlocks[0] = true;
+
+    expect(blockCollection.props().value.length).toBe(3);
+    expect(blockCollection.instance().expandedBlocks.length).toBe(3);
+    expect(blockCollection.instance().generatedBlockIds.length).toBe(3);
+    expect(blockCollection.instance().expandedBlocks[0]).toBe(true);
+
+    blockCollection.setProps({
+        value: [
+            {
+                type: 'type2',
+                content: 'Test 3',
+            },
+            {
+                type: 'type1',
+                content: 'Test 1',
+            },
+            {
+                type: 'type2',
+                content: 'Test 2',
+            },
+        ],
+    });
+
+    expect(blockCollection.props().value.length).toBe(3);
+    expect(blockCollection.instance().expandedBlocks.length).toBe(3);
+    expect(blockCollection.instance().generatedBlockIds.length).toBe(3);
+    expect(blockCollection.instance().expandedBlocks[0]).toBe(true);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -513,8 +513,7 @@ test('Should adjust expandedBlocks and generatedBlockIds after updating the valu
     expect(blockCollection.instance().expandedBlocks[0]).toBe(true);
 });
 
-test('Should not adjust expandedBlocks and generatedBlockIds after updating the value variable with the same ' +
-    'amount of entries', () => {
+test('Updating value with same length should not adjust expandedBlocks and generatedBlockIds.', () => {
     const types = {
         type1: 'Type 1',
         type2: 'Type 2',
@@ -573,3 +572,4 @@ test('Should not adjust expandedBlocks and generatedBlockIds after updating the 
     expect(blockCollection.instance().expandedBlocks.length).toBe(3);
     expect(blockCollection.instance().generatedBlockIds.length).toBe(3);
     expect(blockCollection.instance().expandedBlocks[0]).toBe(true);
+});


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add a `reaction` to call the `fillArrays` function when the `blocks` data is updated e.g. via the `ResourceFormStore`.

#### Why?

For a project I have the use-case, that I have to copy data from `Tab 1` to `Tab 2`.
The `fillArrays` method is only called in the `constructor`, thus after copying the `blocks` from `Tab 1` to `Tab 2` the two arrays `generatedBlockIds` and `expandedBlocks` are not updated accordingly.

