### PR TITLE
Add request parameters to SingleSelection auto_complete

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
@@ -394,19 +394,22 @@ class SingleSelection extends React.Component<Props>
             throw new Error('The "data_path_to_auto_complete" schemaOption must be an array!');
         }
 
-        const options = dataPathToAutoComplete.reduce((options, schemaEntry) => {
-            const {name, value} = schemaEntry;
-            if (typeof name !== 'string' || typeof value !== 'string') {
-                throw new Error(
-                    'An entry of the "data_path_to_auto_complete" schemaOption must provide strings for their name and '
-                    + 'value'
-                );
-            }
+        const options = {
+            ...dataPathToAutoComplete.reduce((options, schemaEntry) => {
+                const {name, value} = schemaEntry;
+                if (typeof name !== 'string' || typeof value !== 'string') {
+                    throw new Error(
+                        'An entry of the "data_path_to_auto_complete" schemaOption must provide strings for their ' +
+                        'name and value'
+                    );
+                }
 
-            options[value] = formInspector.getValueByPath('/' + name);
+                options[value] = formInspector.getValueByPath('/' + name);
 
-            return options;
-        }, {});
+                return options;
+            }, {}),
+            ...this.requestOptions,
+        };
 
         return (
             <SingleAutoComplete

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
@@ -1185,3 +1185,106 @@ test('Should pass request_parameters to auto_complete options.', () => {
         },
     }));
 });
+
+test('Should pass request_parameters and dataPathToAutoComplete to auto_complete options.', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+
+    const fieldTypeOptions = {
+        default_type: 'auto_complete',
+        resource_key: 'accounts',
+        types: {
+            auto_complete: {
+                display_property: 'name',
+                search_properties: ['name', 'number'],
+            },
+        },
+    };
+
+    const schemaOptions = {
+        data_path_to_auto_complete: {
+            name: 'data_path_to_auto_complete',
+            value: [
+                {name: 'id', value: 'accountId'},
+            ],
+        },
+        request_parameters: {
+            name: 'request_parameters',
+            type: 'collection',
+            value: [
+                {
+                    name: 'ids',
+                    value: 1,
+                },
+            ],
+        },
+    };
+
+    formInspector.getValueByPath.mockReturnValue(5);
+
+    const singleSelection = shallow(
+        <SingleSelection
+            {...fieldTypeDefaultProps}
+            fieldTypeOptions={fieldTypeOptions}
+            formInspector={formInspector}
+            schemaOptions={schemaOptions}
+        />
+    );
+
+    expect(singleSelection.find('SingleAutoComplete').props()).toEqual(expect.objectContaining({
+        options: {
+            ids: 1,
+            accountId: 5,
+        },
+    }));
+});
+
+test('Should pass same request_parameters and dataPathToAutoComplete options to auto_complete options.', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+
+    const fieldTypeOptions = {
+        default_type: 'auto_complete',
+        resource_key: 'accounts',
+        types: {
+            auto_complete: {
+                display_property: 'name',
+                search_properties: ['name', 'number'],
+            },
+        },
+    };
+
+    const schemaOptions = {
+        data_path_to_auto_complete: {
+            name: 'data_path_to_auto_complete',
+            value: [
+                {name: 'id', value: 'accountId'},
+            ],
+        },
+        request_parameters: {
+            name: 'request_parameters',
+            type: 'collection',
+            value: [
+                {
+                    name: 'accountId',
+                    value: 1,
+                },
+            ],
+        },
+    };
+
+    formInspector.getValueByPath.mockReturnValue(5);
+
+    const singleSelection = shallow(
+        <SingleSelection
+            {...fieldTypeDefaultProps}
+            fieldTypeOptions={fieldTypeOptions}
+            formInspector={formInspector}
+            schemaOptions={schemaOptions}
+        />
+    );
+
+    expect(singleSelection.find('SingleAutoComplete').props()).toEqual(expect.objectContaining({
+        options: {
+            accountId: 1,
+        },
+    }));
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
@@ -1143,7 +1143,7 @@ test('Should throw an error if no "resource_key" option is passed in fieldOption
     )).toThrowError(/"resource_key"/);
 });
 
-test('Should pass request_parameters to auto_complete options.', () => {
+test('Should pass request_parameters to auto_complete options', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
 
     const fieldTypeOptions = {
@@ -1186,7 +1186,7 @@ test('Should pass request_parameters to auto_complete options.', () => {
     }));
 });
 
-test('Should pass request_parameters and dataPathToAutoComplete to auto_complete options.', () => {
+test('Should pass request_parameters and dataPathToAutoComplete to auto_complete options', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
 
     const fieldTypeOptions = {
@@ -1238,7 +1238,7 @@ test('Should pass request_parameters and dataPathToAutoComplete to auto_complete
     }));
 });
 
-test('Should pass same request_parameters and dataPathToAutoComplete options to auto_complete options.', () => {
+test('Should pass same request_parameters and dataPathToAutoComplete options to auto_complete options', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
 
     const fieldTypeOptions = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
@@ -346,8 +346,7 @@ test('Throw an error if no display_property is passed to the the single_select',
         default_type: 'single_select',
         resource_key: 'accounts',
         types: {
-            single_select: {
-            },
+            single_select: {},
         },
     };
 
@@ -1142,4 +1141,47 @@ test('Should throw an error if no "resource_key" option is passed in fieldOption
             schemaOptions={{types: {name: 'types', value: []}}}
         />
     )).toThrowError(/"resource_key"/);
+});
+
+test('Should pass request_parameters to auto_complete options.', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+
+    const fieldTypeOptions = {
+        default_type: 'auto_complete',
+        resource_key: 'accounts',
+        types: {
+            auto_complete: {
+                display_property: 'name',
+                search_properties: ['name', 'number'],
+            },
+        },
+    };
+
+    const schemaOptions = {
+        request_parameters: {
+            name: 'request_parameters',
+            type: 'collection',
+            value: [
+                {
+                    name: 'ids',
+                    value: 1,
+                },
+            ],
+        },
+    };
+
+    const singleSelection = shallow(
+        <SingleSelection
+            {...fieldTypeDefaultProps}
+            fieldTypeOptions={fieldTypeOptions}
+            formInspector={formInspector}
+            schemaOptions={schemaOptions}
+        />
+    );
+
+    expect(singleSelection.find('SingleAutoComplete').props()).toEqual(expect.objectContaining({
+        options: {
+            ids: 1,
+        },
+    }));
 });


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Adds the `request_parameters` to the options of the `SingleAutoComplete` component.

#### Why?

The same functionality was already implemented for the multi-selection types.

