### PR TITLE
Fix cache:clear in admin context

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/EventSubscriber/CacheCommandSubscriber.php
+++ b/src/Sulu/Bundle/PreviewBundle/EventSubscriber/CacheCommandSubscriber.php
@@ -72,6 +72,7 @@ class CacheCommandSubscriber implements EventSubscriberInterface
         $previewKernel = $this->kernelFactory->create($this->environment);
 
         $application = $this->application ?: new Application($previewKernel);
+        $application->setAutoExit(false);
         $application->run($event->getInput(), $event->getOutput());
     }
 

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/EventSubscriber/CacheCommandSubscriberTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/EventSubscriber/CacheCommandSubscriberTest.php
@@ -63,6 +63,7 @@ class CacheCommandSubscriberTest extends TestCase
             ->shouldBeCalled()
             ->willReturn($this->previewKernel->reveal());
 
+        $this->application->setAutoExit(false)->shouldBeCalled();
         $this->application->run(Argument::any(), Argument::any())
             ->shouldBeCalled();
 
@@ -78,6 +79,7 @@ class CacheCommandSubscriberTest extends TestCase
             ->shouldBeCalled()
             ->willReturn($this->previewKernel->reveal());
 
+        $this->application->setAutoExit(false)->shouldBeCalled();
         $this->application->run(Argument::any(), Argument::any())
             ->shouldBeCalled();
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5481, fixes #5309 
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Until now, calling `bin/adminconsole cache:clear` did only clear the preview cache, not the admin cache itself. This PR fixes that problem.
