### PR TITLE
Remove null-loader because it is not used anymore

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
         "mobx": "^4.0.0",
         "mobx-react": "^5.0.0",
         "moment-timezone": "^0.5.14",
-        "null-loader": "^3.0.0",
         "optimize-css-assets-webpack-plugin": "^5.0.3",
         "postcss-calc": "^7.0.1",
         "postcss-hexrgba": "^2.0.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR removes the `null-loader` dependency.

#### Why?

Because is not used anymore since #3463