### PR TITLE
Improve assert http status code error message

### DIFF
--- a/src/Sulu/Bundle/TestBundle/Testing/AssertHttpStatusCodeTrait.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/AssertHttpStatusCodeTrait.php
@@ -51,10 +51,17 @@ trait AssertHttpStatusCodeTrait
                 }
 
                 $message = \implode(\PHP_EOL, \array_slice($message, 0, $debugLength));
+
                 $message = \sprintf(
-                    'HTTP status code %s is not expected %s, showing %s lines of the response body: %s',
+                    'HTTP status code %s is not expected %s!' . \PHP_EOL
+                    . 'Exception: %s' . \PHP_EOL
+                    . 'Exception-File: %s' . \PHP_EOL
+                    . 'Showing %s lines of the response body:' . \PHP_EOL
+                    . '%s',
                     $httpCode,
                     $code,
+                    \rawurldecode($response->headers->get('X-Debug-Exception')),
+                    \rawurldecode($response->headers->get('X-Debug-Exception-File')),
                     $debugLength,
                     $message
                 );


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Improve assert http status code error message with exception message and exception file.

#### Why?

If you have a html error page 

#### Example Usage

~~~php
echo '{{% block test %}' > src/Sulu/Bundle/WebsiteBundle/Tests/Application/templates/default.html.twig
bin/runtests -i -t WebsiteBundle -C --flags="--filter=WebsiteControllerTest::testPage"
~~~

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
