### PR TITLE
Add table list to MediaSelectionOverlay

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/MediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/MediaSelectionOverlay.js
@@ -181,7 +181,7 @@ class MediaSelectionOverlay extends React.Component<Props> {
                         collectionListStore={collectionListStore}
                         collectionStore={this.collectionStore}
                         locale={locale}
-                        mediaListAdapters={['media_card_selection']}
+                        mediaListAdapters={['media_card_selection', 'table']}
                         mediaListStore={mediaListStore}
                         onCollectionNavigate={this.handleCollectionNavigate}
                         onUploadOverlayClose={this.handleUploadOverlayClose}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/MediaSelectionOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/MediaSelectionOverlay.test.js
@@ -29,6 +29,7 @@ jest.mock('sulu-admin-bundle/containers/List/registries/listAdapterRegistry', ()
             const adapters = {
                 'folder': require('sulu-admin-bundle/containers/List/adapters/FolderAdapter').default,
                 'media_card_selection': require('../../List/adapters/MediaCardSelectionAdapter').default,
+                'table': require('sulu-admin-bundle/containers/List/adapters/TableAdapter').default,
             };
             return adapters[key];
         }),

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
@@ -287,6 +287,36 @@ Array [
                     <div
                       class="fieldFilter"
                     />
+                    <div
+                      class="buttonGroup"
+                    >
+                      <button
+                        class="button icon active button"
+                        type="button"
+                      >
+                        <span
+                          class="buttonText"
+                        >
+                          <span
+                            aria-label="su-th-large"
+                            class="su-th-large"
+                          />
+                        </span>
+                      </button>
+                      <button
+                        class="button icon button"
+                        type="button"
+                      >
+                        <span
+                          class="buttonText"
+                        >
+                          <span
+                            aria-label="su-align-justify"
+                            class="su-align-justify"
+                          />
+                        </span>
+                      </button>
+                    </div>
                   </div>
                   <div
                     class="list"
@@ -900,6 +930,36 @@ Array [
                     <div
                       class="fieldFilter"
                     />
+                    <div
+                      class="buttonGroup"
+                    >
+                      <button
+                        class="button icon active button"
+                        type="button"
+                      >
+                        <span
+                          class="buttonText"
+                        >
+                          <span
+                            aria-label="su-th-large"
+                            class="su-th-large"
+                          />
+                        </span>
+                      </button>
+                      <button
+                        class="button icon button"
+                        type="button"
+                      >
+                        <span
+                          class="buttonText"
+                        >
+                          <span
+                            aria-label="su-align-justify"
+                            class="su-align-justify"
+                          />
+                        </span>
+                      </button>
+                    </div>
                   </div>
                   <div
                     class="list"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds the table adapter to the list in the `MediaSelection`.

#### Why?

Because this view is more useful if a list of documents with similar names are displayed.