### PR TITLE
Pass content-locale of user to TextEditor if Form has no locale

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/TextEditor.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/TextEditor.js
@@ -1,17 +1,21 @@
 // @flow
 import React from 'react';
+import {observable} from 'mobx';
 import TextEditorContainer from '../../../containers/TextEditor';
 import type {FieldTypeProps} from '../../../types';
+import userStore from '../../../stores/userStore';
 
 export default class TextEditor extends React.Component<FieldTypeProps<?string>> {
     render() {
         const {disabled, formInspector, onChange, onFinish, schemaOptions, value} = this.props;
 
+        const locale = formInspector.locale ? formInspector.locale : observable.box(userStore.contentLocale);
+
         return (
             <TextEditorContainer
                 adapter="ckeditor5"
                 disabled={!!disabled}
-                locale={formInspector.locale}
+                locale={locale}
                 onBlur={onFinish}
                 onChange={onChange}
                 options={schemaOptions}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/TextEditor.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/TextEditor.test.js
@@ -7,41 +7,14 @@ import ResourceStore from '../../../../stores/ResourceStore';
 import FormInspector from '../../FormInspector';
 import ResourceFormStore from '../../stores/ResourceFormStore';
 import TextEditor from '../../fields/TextEditor';
+import userStore from '../../../../stores/userStore';
 
 jest.mock('../../../../stores/ResourceStore', () => jest.fn());
 jest.mock('../../stores/ResourceFormStore', () => jest.fn());
 jest.mock('../../FormInspector', () => jest.fn());
+jest.mock('../../../../stores/userStore', () => ({}));
 
 test('Pass props correctly to TextEditor', () => {
-    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
-    const changeSpy = jest.fn();
-    const finishSpy = jest.fn();
-    const options = {};
-
-    const textEditor = shallow(
-        <TextEditor
-            {...fieldTypeDefaultProps}
-            disabled={true}
-            formInspector={formInspector}
-            onChange={changeSpy}
-            onFinish={finishSpy}
-            schemaOptions={options}
-            value="xyz"
-        />
-    );
-
-    expect(textEditor.find('TextEditor').props()).toEqual(expect.objectContaining({
-        adapter: 'ckeditor5',
-        locale: undefined,
-        onBlur: finishSpy,
-        onChange: changeSpy,
-        options,
-        value: 'xyz',
-        disabled: true,
-    }));
-});
-
-test('Pass locale prop correctly to TextEditor', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
     const changeSpy = jest.fn();
     const finishSpy = jest.fn();
@@ -64,6 +37,37 @@ test('Pass locale prop correctly to TextEditor', () => {
     );
 
     expect(textEditor.find('TextEditor').props()).toEqual(expect.objectContaining({
+        adapter: 'ckeditor5',
         locale,
+        onBlur: finishSpy,
+        onChange: changeSpy,
+        options,
+        value: 'xyz',
+        disabled: true,
     }));
+});
+
+test('Pass content locale from user to TextEditor if form has no locale', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+    const changeSpy = jest.fn();
+    const finishSpy = jest.fn();
+    const options = {};
+
+    // $FlowFixMe
+    userStore.contentLocale = 'de';
+
+    const textEditor = shallow(
+        <TextEditor
+            {...fieldTypeDefaultProps}
+            disabled={true}
+            formInspector={formInspector}
+            onChange={changeSpy}
+            onFinish={finishSpy}
+            schemaOptions={options}
+            value="xyz"
+        />
+    );
+
+    expect(textEditor.find('TextEditor').props().locale).toBeDefined();
+    expect(textEditor.find('TextEditor').props().locale.get()).toEqual('de');
 });


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adjusts the `TextEditor` field type to use the content-locale of the user when rendered inside of a unlocalized form. This is also implemented in the `Selection`, `SingleSelection` and `TeaserSelection` field type.

#### Why?

Because otherwise the locale that is passed to the `CKEditor5` component is `undefined`. This leads to an error when trying to add an internal link.
