### PR TITLE
Fallback to current webspace when generating URL in WebspaceManager

### DIFF
--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
@@ -14,6 +14,7 @@ namespace Sulu\Component\Webspace\Tests\Unit;
 use Prophecy\Argument;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
 use Sulu\Component\Content\Metadata\StructureMetadata;
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
 use Sulu\Component\Webspace\Exception\InvalidTemplateException;
 use Sulu\Component\Webspace\Loader\XmlFileLoader10;
 use Sulu\Component\Webspace\Loader\XmlFileLoader11;
@@ -779,6 +780,18 @@ class WebspaceManagerTest extends WebspaceTestCase
         $this->assertEquals(['https://sulu.lo/test'], $result);
     }
 
+    public function testFindUrlsByResourceLocatorWithWebspaceFromRequest()
+    {
+        $webspace = new Webspace();
+        $webspace->setKey('dan_io');
+        $request = new Request([], [], ['_sulu' => new RequestAttributes(['webspace' => $webspace])]);
+        $this->requestStack->getCurrentRequest()->willReturn($request);
+
+        $result = $this->webspaceManager->findUrlsByResourceLocator('/test', 'dev', 'de_at');
+
+        $this->assertEquals(['http://dan.lo/de/test'], $result);
+    }
+
     public function testFindUrlsByResourceLocatorRoot()
     {
         $result = $this->webspaceManager->findUrlsByResourceLocator('/', 'dev', 'en_us', 'massiveart');
@@ -857,6 +870,17 @@ class WebspaceManagerTest extends WebspaceTestCase
             'https'
         );
         $this->assertEquals('https://sulu.lo/test', $result);
+    }
+
+    public function testFindUrlByResourceLocatorWithWebspaceFromRequest()
+    {
+        $webspace = new Webspace();
+        $webspace->setKey('dan_io');
+        $request = new Request([], [], ['_sulu' => new RequestAttributes(['webspace' => $webspace])]);
+        $this->requestStack->getCurrentRequest()->willReturn($request);
+
+        $result = $this->webspaceManager->findUrlByResourceLocator('/test', 'dev', 'de_at');
+        $this->assertEquals('http://dan.lo/de/test', $result);
     }
 
     public function testFindUrlByResourceLocatorWithCustomHttpPort()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5515
| License | MIT

#### What's in this PR?

This PR adjusts the  `WebspaceManager` to use the current webspace for generating URLs if no `$webspaceKey` is given. Without this change, the first webspace that includes the given `$languageCode` is used for generating the URL.
 
#### Why?

Because using the current webspace is a better default IMO. Also, see #5515