### PR TITLE
Update react-datepicker

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
@@ -209,8 +209,8 @@ class DatePicker extends React.Component<Props> {
                                 <ReactDatetime
                                     {...fieldOptions}
                                     inputProps={inputProps}
-                                    onBlur={this.handleCloseOverlay}
                                     onChange={this.handleDatepickerChange}
+                                    onClose={this.handleCloseOverlay}
                                     open={this.open}
                                     renderInput={this.renderInput}
                                     value={this.value}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
@@ -35,7 +35,7 @@
         "path-to-regexp": "^6.1.0",
         "react-circular-progressbar": "^2.0.3",
         "react-color": "^2.14.1",
-        "react-datetime": "^2.11.0",
+        "react-datetime": "^3.0.3",
         "react-dropzone": "^10.2.2",
         "react-portal": "^4.1.0",
         "react-sortable-hoc": "^1.11.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR updates to the latest version of react-datepicker. However, they have introduce a BC break I tried to fix in https://github.com/arqex/react-datetime/pull/741, let's see if they merge it. We have to wait for it, because currently the datepicker does not close itself automatically after a date has been chosen.

#### Why?

Because we want to use the latest versions.