### PR TITLE
Improve performance of azure resources

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/AzureBlobStorage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/AzureBlobStorage.php
@@ -50,25 +50,6 @@ class AzureBlobStorage extends FlysystemStorage
         $this->adapter = $filesystem->getAdapter();
     }
 
-    /**
-     * Azure Filesystem returns a not seekable resource.
-     *
-     * {@inheritdoc}
-     */
-    public function load(array $storageOptions)
-    {
-        $resource = parent::load($storageOptions);
-        // Azure Filesystem returns a not seekable resource
-        // Need converted to a seekable resource to allow get mimetype from it in the MediaImageExtractor
-        $contents = \stream_get_contents($resource);
-
-        $stream = \fopen('php://memory', 'r+');
-        \fwrite($stream, $contents);
-        \rewind($stream);
-
-        return $stream;
-    }
-
     public function getPath(array $storageOptions): string
     {
         $segment = $this->getStorageOption($storageOptions, 'segment');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | part of #5468
| Related issues/PRs | Requires #5526
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Build on top of #5526 it does not longer require that azure storage return a seekable resource so the performance can be improved so not the whole resource need to be inside the memory.

#### Why?

It should be avoided to load big files inside the memory.