### PR TITLE
Update history package

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
@@ -21,7 +21,7 @@
         "debounce": "^1.0.2",
         "fast-deep-equal": "^3.1.1",
         "font-awesome": "^4.7.0",
-        "history": "^4.6.3",
+        "history": "^5.0.0",
         "imagesloaded": "^4.1.3",
         "intl-messageformat": "^8.3.2",
         "isemail": "^3.1.2",

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -4,6 +4,7 @@ import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
 import equal from 'fast-deep-equal';
 import log from 'loglevel';
 import {compile} from 'path-to-regexp';
+import {parsePath} from 'history';
 import {transformDateForUrl} from '../../utils/Date';
 import type {AttributeMap, UpdateAttributesHook, UpdateRouteHook, UpdateRouteMethod} from './types';
 import routeRegistry from './registries/routeRegistry';
@@ -128,7 +129,7 @@ export default class Router {
     constructor(history: Object) {
         this.history = history;
 
-        this.history.listen((location) => {
+        this.history.listen(({location}) => {
             log.info('URL was changed to "' + location.pathname + location.search + '"');
             this.match(location.pathname, location.search);
         });
@@ -141,7 +142,8 @@ export default class Router {
                 // have to use the historyUrl as a fallback, because currentUrl could be undefined and break the routing
                 const url = currentUrl || historyUrl;
                 log.info('Router changes URL to "' + url + '"' + (this.redirectFlag ? ' replacing history' : ''));
-                this.redirectFlag ? this.history.replace(url) : this.history.push(url);
+                const newLocation = {search: '', ...parsePath(url)};
+                this.redirectFlag ? this.history.replace(newLocation) : this.history.push(newLocation);
                 this.redirectFlag = false;
             }
         });
@@ -226,7 +228,7 @@ export default class Router {
     };
 
     reset = () => {
-        this.history.replace('');
+        this.history.replace({search: '', ...parsePath('/')});
     };
 
     @action match(path: string, queryString: string) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
@@ -19,6 +19,11 @@ jest.mock('../registries/routeRegistry', () => {
 
 test('Navigate to route using state', () => {
     routeRegistry.getAll.mockReturnValue({
+        test: new Route({
+            name: 'test',
+            path: '/test',
+            type: 'form',
+        }),
         page: new Route({
             name: 'page',
             options: {
@@ -32,14 +37,16 @@ test('Navigate to route using state', () => {
     const history = createMemoryHistory();
     const router = new Router(history);
 
+    router.navigate('test');
     router.navigate('page', {uuid: 'some-uuid'});
     expect(isObservable(router.route)).toBe(true);
     expect(router.route.type).toBe('form');
     expect(router.route.options.type).toBe('page');
     expect(router.attributes.uuid).toBe('some-uuid');
     expect(history.location.pathname).toBe('/pages/some-uuid');
-    expect(history.entries.some((entry) => entry.pathname === '/')).toEqual(true);
-    expect(history.entries.some((entry) => entry.pathname === '/pages/some-uuid')).toEqual(true);
+
+    history.back();
+    expect(history.location.pathname).toBe('/test');
 });
 
 test('Reset route using the reset method', () => {
@@ -62,12 +69,38 @@ test('Reset route using the reset method', () => {
     expect(history.location.pathname).toBe('/');
 });
 
+test('Reset route using the reset method with hash and search', () => {
+    routeRegistry.getAll.mockReturnValue({
+        page: new Route({
+            name: 'page',
+            path: '/pages',
+            options: {
+                type: 'page',
+            },
+            type: 'list',
+        }),
+    });
+
+    const history = createMemoryHistory();
+    history.replace('/pages/some-uuid?test=value');
+    const router = new Router(history);
+
+    router.reset();
+    expect(history.location.pathname).toBe('/');
+    expect(history.location.search).toBe('');
+});
+
 test('Redirect to route using state', () => {
     routeRegistry.getAll.mockReturnValue({
-        test: new Route({
-            name: 'test',
-            type: 'test',
-            path: '/test',
+        test1: new Route({
+            name: 'test1',
+            type: 'test1',
+            path: '/test1',
+        }),
+        test2: new Route({
+            name: 'test2',
+            type: 'test2',
+            path: '/test2',
         }),
         page: new Route({
             name: 'page',
@@ -82,15 +115,17 @@ test('Redirect to route using state', () => {
     const history = createMemoryHistory();
     const router = new Router(history);
 
-    router.navigate('test', {uuid: 'some-uuid'});
+    router.navigate('test1');
+    router.navigate('test2');
     router.redirect('page', {uuid: 'some-uuid'});
     expect(isObservable(router.route)).toBe(true);
     expect(router.route.type).toBe('form');
     expect(router.route.options.type).toBe('page');
     expect(router.attributes.uuid).toBe('some-uuid');
     expect(history.location.pathname).toBe('/pages/some-uuid');
-    expect(history.entries.some((entry) => entry.pathname === '/test')).toEqual(false);
-    expect(history.entries.some((entry) => entry.pathname === '/pages/some-uuid')).toEqual(true);
+
+    history.back();
+    expect(history.location.pathname).toBe('/test1');
 });
 
 test('Navigate to route with search parameters using state', () => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR updates the `history` package to its latest version. There a [lots of undocumented breaking changes](https://github.com/ReactTraining/history/issues/811), but the most important ones for us are:

- The `entries` are not available anymore externally, therefore I had to rewrite some tests
- The `push` function does not reset the `search` property of the `location` anymore (they argue that the browser API itself handles it the same way), had to adjust the `Router` because of that

#### Why?

Because we want to use up to date dependencies.