### PR TITLE
Sort templates by their title by adding sort_by option to TypeToolbarAction

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TypeToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TypeToolbarAction.test.js
@@ -55,13 +55,13 @@ test('Return item config with correct disabled, loading, options, icon, type and
     typeToolbarAction.resourceFormStore.typesLoading = false;
     typeToolbarAction.resourceFormStore.type = 'default';
     typeToolbarAction.resourceFormStore.types = {
-        default: {
-            key: 'default',
-            title: 'Default',
-        },
         homepage: {
             key: 'homepage',
             title: 'Homepage',
+        },
+        default: {
+            key: 'default',
+            title: 'Default',
         },
     };
 
@@ -70,17 +70,44 @@ test('Return item config with correct disabled, loading, options, icon, type and
         loading: false,
         options: [
             {
-                label: 'Default',
-                value: 'default',
-            },
-            {
                 label: 'Homepage',
                 value: 'homepage',
+            },
+            {
+                label: 'Default',
+                value: 'default',
             },
         ],
         type: 'select',
         value: 'default',
     }));
+});
+
+test('Return item config with sorted options if sort_by_title is set', () => {
+    const typeToolbarAction = createTypeToolbarAction({sort_by_title: true});
+    typeToolbarAction.resourceFormStore.typesLoading = false;
+    typeToolbarAction.resourceFormStore.type = 'default';
+    typeToolbarAction.resourceFormStore.types = {
+        homepage: {
+            key: 'homepage',
+            title: 'Homepage',
+        },
+        default: {
+            key: 'default',
+            title: 'Default',
+        },
+    };
+
+    expect(typeToolbarAction.getToolbarItemConfig().options).toEqual([
+        {
+            label: 'Default',
+            value: 'default',
+        },
+        {
+            label: 'Homepage',
+            value: 'homepage',
+        },
+    ]);
 });
 
 test('Return item config with loading select', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TypeToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TypeToolbarAction.test.js
@@ -98,16 +98,18 @@ test('Return item config with sorted options if sort_by_title is set', () => {
         },
     };
 
-    expect(typeToolbarAction.getToolbarItemConfig().options).toEqual([
-        {
-            label: 'Default',
-            value: 'default',
-        },
-        {
-            label: 'Homepage',
-            value: 'homepage',
-        },
-    ]);
+    expect(typeToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        options: [
+            {
+                label: 'Default',
+                value: 'default',
+            },
+            {
+                label: 'Homepage',
+                value: 'homepage',
+            },
+        ],
+    }));
 });
 
 test('Return item config with loading select', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TypeToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TypeToolbarAction.test.js
@@ -83,8 +83,8 @@ test('Return item config with correct disabled, loading, options, icon, type and
     }));
 });
 
-test('Return item config with sorted options if sort_by_title is set', () => {
-    const typeToolbarAction = createTypeToolbarAction({sort_by_title: true});
+test('Return item config with options sorted by title if sort_by is set to title', () => {
+    const typeToolbarAction = createTypeToolbarAction({sort_by: 'title'});
     typeToolbarAction.resourceFormStore.typesLoading = false;
     typeToolbarAction.resourceFormStore.type = 'default';
     typeToolbarAction.resourceFormStore.types = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/TypeToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/TypeToolbarAction.js
@@ -24,7 +24,7 @@ export default class TypeToolbarAction extends AbstractFormToolbarAction {
         }));
 
         const sortedOptions = sortByTitle
-            ? unsortedOptions.sort((t1, t2) => t1.label.localeCompare(t2.label))
+            ? unsortedOptions.sort((t1, t2) => String(t1.label).localeCompare(String(t2.label)))
             : unsortedOptions;
 
         return {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/TypeToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/TypeToolbarAction.js
@@ -13,9 +13,19 @@ export default class TypeToolbarAction extends AbstractFormToolbarAction {
 
         const {
             disabled_condition: disabledCondition,
+            sort_by_title: sortByTitle = false,
         } = this.options;
 
         const isDisabled = disabledCondition ? jexl.evalSync(disabledCondition, this.resourceFormStore.data) : false;
+
+        const unsortedOptions = Object.keys(formTypes).map((key: string) => ({
+            value: formTypes[key].key,
+            label: formTypes[key].title,
+        }));
+
+        const sortedOptions = sortByTitle
+            ? unsortedOptions.sort((t1, t2) => t1.label.localeCompare(t2.label))
+            : unsortedOptions;
 
         return {
             type: 'select',
@@ -30,10 +40,7 @@ export default class TypeToolbarAction extends AbstractFormToolbarAction {
             loading: this.resourceFormStore.typesLoading,
             value: this.resourceFormStore.type,
             disabled: isDisabled,
-            options: Object.keys(formTypes).map((key: string) => ({
-                value: formTypes[key].key,
-                label: formTypes[key].title,
-            })),
+            options: sortedOptions,
         };
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/TypeToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/TypeToolbarAction.js
@@ -5,27 +5,26 @@ import AbstractFormToolbarAction from './AbstractFormToolbarAction';
 
 export default class TypeToolbarAction extends AbstractFormToolbarAction {
     getToolbarItemConfig(): ?ToolbarItemConfig<string> {
-        const formTypes = this.resourceFormStore.types;
+        const formTypes = Object.keys(this.resourceFormStore.types).map((key) => this.resourceFormStore.types[key]);
 
-        if (!this.resourceFormStore.typesLoading && Object.keys(formTypes).length === 0) {
+        if (!this.resourceFormStore.typesLoading && formTypes.length === 0) {
             throw new Error('The ToolbarAction for types only works with entities actually supporting types!');
         }
 
         const {
             disabled_condition: disabledCondition,
-            sort_by_title: sortByTitle = false,
+            sort_by: sortBy,
         } = this.options;
+
+        if (sortBy !== undefined && typeof sortBy !== 'string') {
+            throw new Error('The "sort_by" option must be a string if given!');
+        }
 
         const isDisabled = disabledCondition ? jexl.evalSync(disabledCondition, this.resourceFormStore.data) : false;
 
-        const unsortedOptions = Object.keys(formTypes).map((key: string) => ({
-            value: formTypes[key].key,
-            label: formTypes[key].title,
-        }));
-
-        const sortedOptions = sortByTitle
-            ? unsortedOptions.sort((t1, t2) => String(t1.label).localeCompare(String(t2.label)))
-            : unsortedOptions;
+        const sortedTypes = sortBy
+            ? formTypes.sort((t1, t2) => String(t1[sortBy]).localeCompare(String(t2[sortBy])))
+            : formTypes;
 
         return {
             type: 'select',
@@ -40,7 +39,10 @@ export default class TypeToolbarAction extends AbstractFormToolbarAction {
             loading: this.resourceFormStore.typesLoading,
             value: this.resourceFormStore.type,
             disabled: isDisabled,
-            options: sortedOptions,
+            options: sortedTypes.map((type) => ({
+                value: type.key,
+                label: type.title,
+            })),
         };
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -121,7 +121,7 @@ class PageAdmin extends Admin
             new ToolbarAction(
                 'sulu_admin.type',
                 [
-                    'sort_by_title' => true,
+                    'sort_by' => 'title',
                     'disabled_condition' => '(_permissions && !_permissions.edit)',
                 ]
             ),

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -121,6 +121,7 @@ class PageAdmin extends Admin
             new ToolbarAction(
                 'sulu_admin.type',
                 [
+                    'sort_by_title' => true,
                     'disabled_condition' => '(_permissions && !_permissions.edit)',
                 ]
             ),

--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -107,7 +107,7 @@ class SnippetAdmin extends Admin
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
             $formToolbarActionsWithoutType[] = new ToolbarAction('sulu_admin.save');
             $formToolbarActionsWithType[] = new ToolbarAction('sulu_admin.save');
-            $formToolbarActionsWithType[] = new ToolbarAction('sulu_admin.type', ['sort_by_title' => true]);
+            $formToolbarActionsWithType[] = new ToolbarAction('sulu_admin.type', ['sort_by' => 'title']);
         }
 
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::DELETE)) {

--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -107,7 +107,7 @@ class SnippetAdmin extends Admin
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
             $formToolbarActionsWithoutType[] = new ToolbarAction('sulu_admin.save');
             $formToolbarActionsWithType[] = new ToolbarAction('sulu_admin.save');
-            $formToolbarActionsWithType[] = new ToolbarAction('sulu_admin.type');
+            $formToolbarActionsWithType[] = new ToolbarAction('sulu_admin.type', ['sort_by_title' => true]);
         }
 
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::DELETE)) {

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
@@ -113,7 +113,7 @@ class SnippetAdminTest extends TestCase
             'editView' => 'sulu_snippet.edit_form',
             'toolbarActions' => [
                 new Toolbaraction('sulu_admin.save'),
-                new Toolbaraction('sulu_admin.type'),
+                new Toolbaraction('sulu_admin.type', ['sort_by_title' => true]),
                 new Toolbaraction('sulu_admin.delete'),
             ],
         ], $this->readObjectAttribute($addDetailView, 'options'));
@@ -132,7 +132,7 @@ class SnippetAdminTest extends TestCase
             'formKey' => 'snippet',
             'toolbarActions' => [
                 new Toolbaraction('sulu_admin.save'),
-                new Toolbaraction('sulu_admin.type'),
+                new Toolbaraction('sulu_admin.type', ['sort_by_title' => true]),
                 new Toolbaraction('sulu_admin.delete'),
             ],
         ], $this->readObjectAttribute($editDetailView, 'options'));

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
@@ -113,7 +113,7 @@ class SnippetAdminTest extends TestCase
             'editView' => 'sulu_snippet.edit_form',
             'toolbarActions' => [
                 new Toolbaraction('sulu_admin.save'),
-                new Toolbaraction('sulu_admin.type', ['sort_by_title' => true]),
+                new Toolbaraction('sulu_admin.type', ['sort_by' => 'title']),
                 new Toolbaraction('sulu_admin.delete'),
             ],
         ], $this->readObjectAttribute($addDetailView, 'options'));
@@ -132,7 +132,7 @@ class SnippetAdminTest extends TestCase
             'formKey' => 'snippet',
             'toolbarActions' => [
                 new Toolbaraction('sulu_admin.save'),
-                new Toolbaraction('sulu_admin.type', ['sort_by_title' => true]),
+                new Toolbaraction('sulu_admin.type', ['sort_by' => 'title']),
                 new Toolbaraction('sulu_admin.delete'),
             ],
         ], $this->readObjectAttribute($editDetailView, 'options'));


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5288
| License | MIT

#### What's in this PR?

This PR adds a `sort_by` option to the `TypeToolbarAction`. Furthermore it adjusts the `PageAdmin` and the `SnippetAdmin` to enable this option for page templates and snippet types. 

#### Why?

Because there should be a understandable sorting. See #5288
