### PR TITLE
Add add_button_text param to adjust text of add button to block content-type

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -10,6 +10,7 @@ import blockCollectionStyles from './blockCollection.scss';
 import type {BlockEntry, RenderBlockContentCallback} from './types';
 
 type Props = {|
+    addText?: ?string,
     defaultType: string,
     disabled: boolean,
     icons?: Array<Array<string>>,
@@ -155,7 +156,7 @@ class BlockCollection extends React.Component<Props> {
     }
 
     render() {
-        const {disabled, icons, onSettingsClick, renderBlockContent, types, value} = this.props;
+        const {addText, disabled, icons, onSettingsClick, renderBlockContent, types, value} = this.props;
 
         return (
             <section className={blockCollectionStyles.blockCollection}>
@@ -182,7 +183,7 @@ class BlockCollection extends React.Component<Props> {
                     onClick={this.handleAddBlock}
                     skin="secondary"
                 >
-                    {translate('sulu_admin.add_block')}
+                    {addText ? addText : translate('sulu_admin.add_block')}
                 </Button>
             </section>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -10,7 +10,7 @@ import blockCollectionStyles from './blockCollection.scss';
 import type {BlockEntry, RenderBlockContentCallback} from './types';
 
 type Props = {|
-    addText?: ?string,
+    addButtonText?: ?string,
     defaultType: string,
     disabled: boolean,
     icons?: Array<Array<string>>,
@@ -156,7 +156,7 @@ class BlockCollection extends React.Component<Props> {
     }
 
     render() {
-        const {addText, disabled, icons, onSettingsClick, renderBlockContent, types, value} = this.props;
+        const {addButtonText, disabled, icons, onSettingsClick, renderBlockContent, types, value} = this.props;
 
         return (
             <section className={blockCollectionStyles.blockCollection}>
@@ -183,7 +183,7 @@ class BlockCollection extends React.Component<Props> {
                     onClick={this.handleAddBlock}
                     skin="secondary"
                 >
-                    {addText ? addText : translate('sulu_admin.add_block')}
+                    {addButtonText ? addButtonText : translate('sulu_admin.add_block')}
                 </Button>
             </section>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -60,6 +60,21 @@ test('Should mark the add button disabled if maxOccurs is reached', () => {
     expect(blockCollection.find('Button[icon="su-plus"]').prop('disabled')).toEqual(true);
 });
 
+test('Should render add button with the given addText', () => {
+    const blockCollection = shallow(
+        <BlockCollection
+            addText="custom-add-button-text"
+            defaultType="editor"
+            maxOccurs={2}
+            onChange={jest.fn()}
+            renderBlockContent={jest.fn()}
+            value={[{content: 'Test 1', type: 'editor'}, {content: 'Test 2', type: 'editor'}]}
+        />
+    );
+
+    expect(blockCollection.find('Button[icon="su-plus"]').prop('children')).toEqual('custom-add-button-text');
+});
+
 test('Should add at least the minOccurs amount of blocks', () => {
     const changeSpy = jest.fn();
     const value = [{type: 'editor'}];

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -60,10 +60,10 @@ test('Should mark the add button disabled if maxOccurs is reached', () => {
     expect(blockCollection.find('Button[icon="su-plus"]').prop('disabled')).toEqual(true);
 });
 
-test('Should render add button with the given addText', () => {
+test('Should render add button with the given addButtonText', () => {
     const blockCollection = shallow(
         <BlockCollection
-            addText="custom-add-button-text"
+            addButtonText="custom-add-button-text"
             defaultType="editor"
             maxOccurs={2}
             onChange={jest.fn()}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -94,20 +94,20 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
         return settingsFormKey;
     }
 
-    @computed get addText() {
+    @computed get addButtonText() {
         const {
             schemaOptions: {
-                add_text: {
-                    title: addText,
+                add_button_text: {
+                    title: addButtonText,
                 } = {},
             },
         } = this.props;
 
-        if (addText !== undefined && typeof addText !== 'string') {
-            throw new Error('The "block" field types only accepts strings as "add_text" schema option!');
+        if (addButtonText !== undefined && typeof addButtonText !== 'string') {
+            throw new Error('The "block" field types only accepts strings as "add_button_text" schema option!');
         }
 
-        return addText;
+        return addButtonText;
     }
 
     @computed get iconsMapping() {
@@ -381,7 +381,7 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
         return (
             <>
                 <BlockCollection
-                    addText={this.addText}
+                    addButtonText={this.addButtonText}
                     defaultType={defaultType}
                     disabled={!!disabled}
                     icons={this.icons}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -94,6 +94,22 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
         return settingsFormKey;
     }
 
+    @computed get addText() {
+        const {
+            schemaOptions: {
+                add_text: {
+                    title: addText,
+                } = {},
+            },
+        } = this.props;
+
+        if (addText !== undefined && typeof addText !== 'string') {
+            throw new Error('The "block" field types only accepts strings as "add_text" schema option!');
+        }
+
+        return addText;
+    }
+
     @computed get iconsMapping() {
         const settingsSchema = this.blockSettingsFormStore?.schema;
 
@@ -365,6 +381,7 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
         return (
             <>
                 <BlockCollection
+                    addText={this.addText}
                     defaultType={defaultType}
                     disabled={!!disabled}
                     icons={this.icons}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
@@ -767,14 +767,14 @@ test('Should correctly pass props to the BlockCollection', () => {
             maxOccurs={2}
             minOccurs={1}
             onChange={changeSpy}
-            schemaOptions={{add_text: {name: 'add_text', title: 'custom-add-text'}}}
+            schemaOptions={{add_button_text: {name: 'add_button_text', title: 'custom-add-text'}}}
             types={types}
             value={value}
         />
     );
 
     expect(fieldBlocks.find('BlockCollection').props()).toEqual(expect.objectContaining({
-        addText: 'custom-add-text',
+        addButtonText: 'custom-add-text',
         disabled: true,
         maxOccurs: 2,
         minOccurs: 1,
@@ -1196,7 +1196,7 @@ test('Throw error if passed settings_form_key schema option is not a string', ()
     )).toThrow('The "block" field types only accepts strings as "settings_form_key" schema option!');
 });
 
-test('Throw error if passed add_text schema option is not a string', () => {
+test('Throw error if passed add_button_text schema option is not a string', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
 
     const types = {
@@ -1217,9 +1217,9 @@ test('Throw error if passed add_text schema option is not a string', () => {
             {...fieldTypeDefaultProps}
             defaultType="editor"
             formInspector={formInspector}
-            schemaOptions={{add_text: {name: 'add_text', title: ([]: any)}}}
+            schemaOptions={{add_button_text: {name: 'add_button_text', title: ([]: any)}}}
             types={types}
             value={[]}
         />
-    )).toThrow('The "block" field types only accepts strings as "add_text" schema option!');
+    )).toThrow('The "block" field types only accepts strings as "add_button_text" schema option!');
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
@@ -767,12 +767,14 @@ test('Should correctly pass props to the BlockCollection', () => {
             maxOccurs={2}
             minOccurs={1}
             onChange={changeSpy}
+            schemaOptions={{add_text: {name: 'add_text', title: 'custom-add-text'}}}
             types={types}
             value={value}
         />
     );
 
     expect(fieldBlocks.find('BlockCollection').props()).toEqual(expect.objectContaining({
+        addText: 'custom-add-text',
         disabled: true,
         maxOccurs: 2,
         minOccurs: 1,
@@ -1192,4 +1194,32 @@ test('Throw error if passed settings_form_key schema option is not a string', ()
             value={[]}
         />
     )).toThrow('The "block" field types only accepts strings as "settings_form_key" schema option!');
+});
+
+test('Throw error if passed add_text schema option is not a string', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+
+    const types = {
+        default: {
+            title: 'Default',
+            form: {
+                nothing: {
+                    label: 'Nothing',
+                    type: 'phone',
+                    visible: true,
+                },
+            },
+        },
+    };
+
+    expect(() => shallow(
+        <FieldBlocks
+            {...fieldTypeDefaultProps}
+            defaultType="editor"
+            formInspector={formInspector}
+            schemaOptions={{add_text: {name: 'add_text', title: ([]: any)}}}
+            types={types}
+            value={[]}
+        />
+    )).toThrow('The "block" field types only accepts strings as "add_text" schema option!');
 });


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | sulu/sulu-docs#567

#### What's in this PR?

This PR adds a `add_button_text ` param to the `block` content-type. The `add_button_text ` param allows to set the text of the add button which is displayed in the administration interface. The param is implemented analogous to the `label` param of the `checkbox` content-type.

#### Why?

The `block` content type is often used in a specific context. For example, in the Sulu demo, the `block` content-type is used for managing tracks of an album. In these cases, it would be nice to set a specific text instead of the generic `Add block` to the add button. 

![Screenshot 2020-10-08 at 13 45 29](https://user-images.githubusercontent.com/13310795/95454308-907a8a80-096c-11eb-9459-7f59496dfb3c.png)

#### Example Usage

~~~xml
<params>
    <param name="add_button_text">
        <meta>
            <title lang="en">Add track</title>
            <title lang="de">Track hinzufügen</title>
        </meta>
    </param>
</params>
~~~
