### PR TITLE
Fix portal route loader

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Routing/PortalLoader.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/PortalLoader.php
@@ -41,8 +41,8 @@ class PortalLoader extends Loader
 
         $prefixes = [];
         foreach ($this->webspaceManager->getPortalInformations() as $portalInformation) {
-            // symfony does not accept an empty regex as requirement, therefore we use '()' to match an empty prefix
-            $prefixes[] = \preg_quote($portalInformation->getPrefix()) ?: '()';
+            // symfony does not accept an empty regex as requirement, therefore we use '(^$)?' to match an empty prefix
+            $prefixes[] = \preg_quote($portalInformation->getPrefix()) ?: '(^$)?';
         }
 
         foreach ($importedRoutes as $importedRouteName => $importedRoute) {

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/PortalLoaderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/PortalLoaderTest.php
@@ -106,9 +106,9 @@ class PortalLoaderTest extends TestCase
         $this->assertInstanceOf(Route::class, $routeCollection->get('route2'));
 
         $this->assertEquals('/{prefix}example/route1', $routeCollection->get('route1')->getPath());
-        $this->assertEquals(['prefix' => 'de/|en/|()|custom/pre\-fix/'], $routeCollection->get('route1')->getRequirements());
+        $this->assertEquals(['prefix' => 'de/|en/|(^$)?|custom/pre\-fix/'], $routeCollection->get('route1')->getRequirements());
         $this->assertEquals('/{prefix}route2', $routeCollection->get('route2')->getPath());
-        $this->assertEquals(['prefix' => 'de/|en/|()|custom/pre\-fix/'], $routeCollection->get('route2')->getRequirements());
+        $this->assertEquals(['prefix' => 'de/|en/|(^$)?|custom/pre\-fix/'], $routeCollection->get('route2')->getRequirements());
         $this->assertEquals('', $routeCollection->get('route1')->getHost());
         $this->assertEquals('', $routeCollection->get('route2')->getHost());
     }
@@ -141,9 +141,9 @@ class PortalLoaderTest extends TestCase
         $this->assertInstanceOf(Route::class, $routeCollection->get('route2'));
 
         $this->assertEquals('/{prefix}example/route1', $routeCollection->get('route1')->getPath());
-        $this->assertEquals(['prefix' => '()'], $routeCollection->get('route1')->getRequirements());
+        $this->assertEquals(['prefix' => '(^$)?'], $routeCollection->get('route1')->getRequirements());
         $this->assertEquals('/{prefix}route2', $routeCollection->get('route2')->getPath());
-        $this->assertEquals(['prefix' => '()'], $routeCollection->get('route2')->getRequirements());
+        $this->assertEquals(['prefix' => '(^$)?'], $routeCollection->get('route2')->getRequirements());
         $this->assertEquals('', $routeCollection->get('route1')->getHost());
         $this->assertEquals('', $routeCollection->get('route2')->getHost());
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix portal route loader by use another regex for empty prefix match.

#### Why?

When merging 2.0 to 2.1 this did fail in symfony 4.4 / 5.0 so we need to adjust it.

#### Example Usage

```php
rm -rf src/Sulu/Bundle/WebsiteBundle/Tests/Application/var/cache/

vendor/bin/phpunit src/Sulu/Bundle/WebsiteBundle/ -c src/Sulu/Bundle/WebsiteBundle/phpunit.xml.dist --filter=ErrorControllerTest::test404ErrorTemplate
```