### PR TITLE
Fix ImagineImageConverterTest test for svgs

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/ImagineImageConverterTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/ImagineImageConverterTest.php
@@ -146,9 +146,10 @@ class ImagineImageConverterTest extends TestCase
         $fileVersion->setName('test.svg');
         $fileVersion->setVersion(1);
         $fileVersion->setStorageOptions(['option' => 1]);
+        $fileVersion->setMimeType('image/svg+xml');
 
         $this->storage->load(['option' => 1])->willReturn('image-resource');
-        $this->mediaImageExtractor->extract('image-resource')->willReturn('image-resource');
+        $this->mediaImageExtractor->extract('image-resource', 'image/svg+xml')->willReturn('image-resource');
         $this->svgImagine->read('image-resource')->willReturn($imagineImage->reveal());
 
         $imagineImage->palette()->willReturn($palette->reveal());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes 
| Related issues/PRs | #5526
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix ImagineImageConverterTest test for svgs.

#### Why?

Since #5526 the ImagineImageConverter give the mimeType to the extractor so it don't need to seek the resource. The expected call did so changed.

