### PR TITLE
Fix auto detection for imagine adapter without vips extension

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -277,13 +277,15 @@ class SuluMediaExtension extends Extension implements PrependExtensionInterface
             $loader->load('services_imagine_svg.xml');
         }
 
-        if (\class_exists(VipsImagine::class)) {
+        $hasVipsAdapter = false;
+        if (\class_exists(VipsImagine::class) && \extension_loaded('vips')) {
             $loader->load('services_imagine_vips.xml');
+            $hasVipsAdapter = true;
         }
 
         if ('auto' === $config['adapter']) {
             $adapter = 'gd';
-            if (\class_exists(VipsImagine::class)) {
+            if ($hasVipsAdapter) {
                 $adapter = 'vips';
             } elseif (\class_exists(\Imagick::class)) {
                 $adapter = 'imagick';


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix auto detection for imagine adapter without vips extension, by check also if the extension is installed correctly.

#### Why?

If you have a website like sulu.io which example have the imagine vips adapter installed, it will fail if a developer check it out with a php version not having the extension installed. The auto detection should use vips only when the adapter is installed and the extension loaded else it should fallback to the other adapters.

#### Example Usage

1. Install the vips imagine adapter
2. Have no vips extension installed
3. Sulu should use imagick/gd then instead
