### PR TITLE
Handle permissions of SinglePageSelection correctly

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Content/Types/SinglePageSelection.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/SinglePageSelection.php
@@ -12,15 +12,10 @@
 namespace Sulu\Bundle\PageBundle\Content\Types;
 
 use PHPCR\NodeInterface;
-use Sulu\Bundle\PageBundle\Admin\PageAdmin;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
-use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
 use Sulu\Component\Content\PreResolvableContentTypeInterface;
 use Sulu\Component\Content\SimpleContentType;
-use Sulu\Component\Security\Authorization\PermissionTypes;
-use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
-use Sulu\Component\Security\Authorization\SecurityCondition;
 
 /**
  * ContentType for SinglePageSelection.

--- a/src/Sulu/Bundle/PageBundle/Content/Types/SinglePageSelection.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/SinglePageSelection.php
@@ -32,19 +32,12 @@ class SinglePageSelection extends SimpleContentType implements PreResolvableCont
      */
     private $referenceStore;
 
-    /**
-     * @var ?SecurityCheckerInterface
-     */
-    private $securityChecker;
-
     public function __construct(
-        ReferenceStoreInterface $referenceStore,
-        SecurityCheckerInterface $securityChecker = null
+        ReferenceStoreInterface $referenceStore
     ) {
         parent::__construct('SinglePageSelection', '');
 
         $this->referenceStore = $referenceStore;
-        $this->securityChecker = $securityChecker;
     }
 
     public function write(
@@ -79,25 +72,6 @@ class SinglePageSelection extends SimpleContentType implements PreResolvableCont
         $property->setValue($value);
 
         return $value;
-    }
-
-    public function getContentData(PropertyInterface $property)
-    {
-        if ($this->securityChecker
-            && !$this->securityChecker->hasPermission(
-                new SecurityCondition(
-                    PageAdmin::SECURITY_CONTEXT_PREFIX . $property->getStructure()->getWebspaceKey(),
-                    $property->getStructure()->getLanguageCode(),
-                    SecurityBehavior::class,
-                    $property->getValue()
-                ),
-                PermissionTypes::VIEW
-            )
-        ) {
-            return null;
-        }
-
-        return parent::getContentData($property);
     }
 
     public function preResolve(PropertyInterface $property)

--- a/src/Sulu/Bundle/PageBundle/Markup/Link/PageLinkProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Markup/Link/PageLinkProvider.php
@@ -69,7 +69,7 @@ class PageLinkProvider implements LinkProviderInterface
         TranslatorInterface $translator,
         string $environment,
         AccessControlManagerInterface $accessControlManager,
-        TokenStorageInterface $tokenStorage
+        TokenStorageInterface $tokenStorage = null
     ) {
         $this->contentRepository = $contentRepository;
         $this->webspaceManager = $webspaceManager;

--- a/src/Sulu/Bundle/PageBundle/Resources/config/content_types.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/content_types.xml
@@ -15,7 +15,6 @@
 
         <service id="sulu.content.type.single_page_selection" class="Sulu\Bundle\PageBundle\Content\Types\SinglePageSelection">
             <argument type="service" id="sulu_page.reference_store.content"/>
-            <argument type="service" id="sulu_security.security_checker" on-invalid="null"/>
 
             <tag name="sulu.content.type" alias="single_page_selection"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />

--- a/src/Sulu/Bundle/PageBundle/Resources/config/link-tag.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/link-tag.xml
@@ -9,6 +9,8 @@
             <argument type="service" id="request_stack"/>
             <argument type="service" id="translator"/>
             <argument type="string">%kernel.environment%</argument>
+            <argument type="service" id="sulu_security.access_control_manager"/>
+            <argument type="service" id="security.token_storage"/>
 
             <tag name="sulu.link.provider" alias="page"/>
         </service>

--- a/src/Sulu/Bundle/PageBundle/Resources/config/link-tag.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/link-tag.xml
@@ -10,7 +10,7 @@
             <argument type="service" id="translator"/>
             <argument type="string">%kernel.environment%</argument>
             <argument type="service" id="sulu_security.access_control_manager"/>
-            <argument type="service" id="security.token_storage"/>
+            <argument type="service" id="security.token_storage" on-invalid="null"/>
 
             <tag name="sulu.link.provider" alias="page"/>
         </service>

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/SinglePageSelectionTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/SinglePageSelectionTest.php
@@ -35,11 +35,6 @@ class SinglePageSelectionTest extends TestCase
     private $referenceStore;
 
     /**
-     * @var ObjectProphecy
-     */
-    private $securityChecker;
-
-    /**
      * @var SinglePageSelection
      */
     private $type;
@@ -50,12 +45,8 @@ class SinglePageSelectionTest extends TestCase
 
         $this->property = $this->prophesize(PropertyInterface::class);
         $this->referenceStore = $this->prophesize(ReferenceStoreInterface::class);
-        $this->securityChecker = $this->prophesize(SecurityCheckerInterface::class);
 
-        $this->type = new SinglePageSelection(
-            $this->referenceStore->reveal(),
-            $this->securityChecker->reveal()
-        );
+        $this->type = new SinglePageSelection($this->referenceStore->reveal());
     }
 
     public function providePreResolve()
@@ -102,38 +93,6 @@ class SinglePageSelectionTest extends TestCase
         $this->property->getValue()->willReturn('some-uuid');
         $this->property->getStructure()->willReturn($structure->reveal());
 
-        $this->securityChecker->hasPermission(
-            new SecurityCondition(
-                'sulu.webspaces.sulu_io',
-                'de',
-                SecurityBehavior::class,
-                'some-uuid'
-            ),
-            PermissionTypes::VIEW
-        )->willReturn(true);
-
         $this->assertEquals('some-uuid', $this->type->getContentData($this->property->reveal()));
-    }
-
-    public function testContentDataForMissingPermissions()
-    {
-        $structure = $this->prophesize(StructureInterface::class);
-        $structure->getLanguageCode()->willReturn('de');
-        $structure->getWebspaceKey()->willReturn('sulu_io');
-
-        $this->property->getValue()->willReturn('some-uuid');
-        $this->property->getStructure()->willReturn($structure->reveal());
-
-        $this->securityChecker->hasPermission(
-            new SecurityCondition(
-                'sulu.webspaces.sulu_io',
-                'de',
-                SecurityBehavior::class,
-                'some-uuid'
-            ),
-            PermissionTypes::VIEW
-        )->willReturn(false);
-
-        $this->assertNull($this->type->getContentData($this->property->reveal()));
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/SinglePageSelectionTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/SinglePageSelectionTest.php
@@ -17,10 +17,6 @@ use Sulu\Bundle\PageBundle\Content\Types\SinglePageSelection;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
-use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
-use Sulu\Component\Security\Authorization\PermissionTypes;
-use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
-use Sulu\Component\Security\Authorization\SecurityCondition;
 
 class SinglePageSelectionTest extends TestCase
 {

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -122,6 +122,7 @@
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="sulu_security.system_store"/>
             <argument type="tagged_iterator" tag="sulu_security.access_control_descendant_provider"/>
+            <argument type="service" id="sulu.repository.role"/>
         </service>
 
         <service id="sulu_security.system_store" class="Sulu\Bundle\SecurityBundle\System\SystemStore">

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -156,6 +156,7 @@
             <argument type="service" id="sulu_core.webspace.request_analyzer"/>
             <argument type="service" id="logger" on-invalid="null"/>
             <argument type="service" id="sulu_security.security_checker" on-invalid="null"/>
+            <argument type="service" id="sulu_core.webspace.webspace_manager"/>
         </service>
         <service id="sulu_website.twig.content.memoized" class="%sulu_website.twig.content.memoized.class%">
             <argument type="service" id="sulu_website.twig.content"/>

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -155,6 +155,7 @@
             <argument type="service" id="sulu.phpcr.session"/>
             <argument type="service" id="sulu_core.webspace.request_analyzer"/>
             <argument type="service" id="logger" on-invalid="null"/>
+            <argument type="service" id="sulu_security.security_checker" on-invalid="null"/>
         </service>
         <service id="sulu_website.twig.content.memoized" class="%sulu_website.twig.content.memoized.class%">
             <argument type="service" id="sulu_website.twig.content"/>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/ContentTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/ContentTwigExtensionTest.php
@@ -34,6 +34,7 @@ use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Sulu\Component\Security\Authorization\SecurityCondition;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Webspace;
 
 class ContentTwigExtensionTest extends TestCase
@@ -99,9 +100,14 @@ class ContentTwigExtensionTest extends TestCase
     private $extension;
 
     /**
-     * @var ObjectProphecy
+     * @var SecurityCheckerInterface
      */
     private $securityChecker;
+
+    /**
+     * @var WebspaceManagerInterface
+     */
+    private $webspaceManager;
 
     protected function setUp(): void
     {
@@ -117,6 +123,7 @@ class ContentTwigExtensionTest extends TestCase
         $this->parentNode = $this->prophesize(NodeInterface::class);
         $this->startPageNode = $this->prophesize(NodeInterface::class);
         $this->logger = $this->prophesize(LoggerInterface::class);
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
 
         $webspace = new Webspace();
         $webspace->setKey('sulu_test');
@@ -124,6 +131,8 @@ class ContentTwigExtensionTest extends TestCase
         $locale = new Localization();
         $locale->setCountry('us');
         $locale->setLanguage('en');
+
+        $this->webspaceManager->findWebspaceByKey('sulu_test')->willReturn($webspace);
 
         $this->requestAnalyzer->getWebspace()->willReturn($webspace);
         $this->requestAnalyzer->getCurrentLocalization()->willReturn($locale);
@@ -159,7 +168,8 @@ class ContentTwigExtensionTest extends TestCase
             $this->sessionManager->reveal(),
             $this->requestAnalyzer->reveal(),
             null,
-            $this->securityChecker->reveal()
+            $this->securityChecker->reveal(),
+            $this->webspaceManager->reveal()
         );
     }
 
@@ -174,7 +184,7 @@ class ContentTwigExtensionTest extends TestCase
         $testStructure->getCreated()->willReturn(null);
         $testStructure->getChanged()->willReturn(null);
         $testStructure->getDocument()->willReturn(null);
-        $testStructure->getWebspaceKey()->willReturn('sulu_io');
+        $testStructure->getWebspaceKey()->willReturn('sulu_test');
 
         $titleProperty = new Property('title', [], 'text_line');
         $titleProperty->setValue('test');
@@ -210,7 +220,7 @@ class ContentTwigExtensionTest extends TestCase
         $testStructure->getCreated()->willReturn(null);
         $testStructure->getChanged()->willReturn(null);
         $testStructure->getDocument()->willReturn(null);
-        $testStructure->getWebspaceKey()->willReturn('sulu_io');
+        $testStructure->getWebspaceKey()->willReturn('sulu_test');
 
         $titleProperty = new Property('title', [], 'text_line');
         $titleProperty->setValue('test');
@@ -218,7 +228,7 @@ class ContentTwigExtensionTest extends TestCase
 
         $this->securityChecker->hasPermission(
             new SecurityCondition(
-                PageAdmin::SECURITY_CONTEXT_PREFIX . 'sulu_io',
+                PageAdmin::SECURITY_CONTEXT_PREFIX . 'sulu_test',
                 'en_us',
                 SecurityBehavior::class,
                 '123-123-123'
@@ -270,7 +280,7 @@ class ContentTwigExtensionTest extends TestCase
         $testStructure->getCreated()->willReturn(null);
         $testStructure->getChanged()->willReturn(null);
         $testStructure->getDocument()->willReturn(null);
-        $testStructure->getWebspaceKey()->willReturn('sulu_io');
+        $testStructure->getWebspaceKey()->willReturn('sulu_test');
 
         $titleProperty = new Property('title', [], 'text_line');
         $titleProperty->setValue('test');

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
@@ -116,7 +116,8 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
             $security = $targetWebspace->getSecurity();
             $system = $security ? $security->getSystem() : null;
 
-            if ($this->securityChecker
+            if ($targetWebspace->hasWebsiteSecurity()
+                && $this->securityChecker
                 && !$this->securityChecker->hasPermission(
                     new SecurityCondition(
                         PageAdmin::SECURITY_CONTEXT_PREFIX . $contentStructure->getWebspaceKey(),

--- a/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
@@ -154,9 +154,12 @@ class AccessControlManager implements AccessControlManagerInterface
         $locale,
         $securityContext,
         $objectPermissionsByRole,
-        $user
+        $user,
+        $system = null
     ) {
-        $system = $this->systemStore->getSystem();
+        if (!$system) {
+            $system = $this->systemStore->getSystem();
+        }
 
         if (!$system) {
             return $this->maskConverter->convertPermissionsToArray(127);

--- a/src/Sulu/Component/Security/Authorization/SecurityCondition.php
+++ b/src/Sulu/Component/Security/Authorization/SecurityCondition.php
@@ -44,12 +44,20 @@ class SecurityCondition
      */
     private $locale;
 
-    public function __construct($securityContext, $locale = null, $objectType = null, $objectId = null)
+    /**
+     * The security system for which the permissions should be checked.
+     *
+     * @var string
+     */
+    private $system;
+
+    public function __construct($securityContext, $locale = null, $objectType = null, $objectId = null, $system = null)
     {
         $this->securityContext = $securityContext;
         $this->locale = $locale;
         $this->objectType = $objectType;
         $this->objectId = $objectId;
+        $this->system = $system;
     }
 
     /**
@@ -88,5 +96,13 @@ class SecurityCondition
     public function getLocale()
     {
         return $this->locale;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSystem()
+    {
+        return $this->system;
     }
 }

--- a/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/AccessControlManagerTest.php
+++ b/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/AccessControlManagerTest.php
@@ -424,6 +424,103 @@ class AccessControlManagerTest extends TestCase
         ], $permissions);
     }
 
+    public function testGetUserPermissionByArrayWithSystem()
+    {
+        $this->systemStore->getSystem()->willReturn('system1');
+
+        /** @var Permission $permission1 */
+        $permission1 = $this->prophesize(Permission::class);
+        $permission1->getPermissions()->willReturn(64);
+        $permission1->getContext()->willReturn('example');
+        /** @var Role $anonymousRole1 */
+        $anonymousRole1 = $this->prophesize(Role::class);
+        $anonymousRole1->getPermissions()->willReturn([$permission1->reveal()]);
+        $anonymousRole1->getSystem()->willReturn('system1');
+        $anonymousRole1->getId()->willReturn(1);
+
+        /** @var Permission $permission2 */
+        $permission2 = $this->prophesize(Permission::class);
+        $permission2->getPermissions()->willReturn(32);
+        $permission2->getContext()->willReturn('example');
+        /** @var Role $anonymousRole2 */
+        $anonymousRole2 = $this->prophesize(Role::class);
+        $anonymousRole2->getPermissions()->willReturn([$permission2->reveal()]);
+        $anonymousRole2->getSystem()->willReturn('system2');
+        $anonymousRole2->getId()->willReturn(2);
+
+        $this->roleRepository->findAllRoles(['anonymous' => true])->willReturn([$anonymousRole1, $anonymousRole2]);
+
+        $permissions = $this->accessControlManager->getUserPermissionByArray(
+            'de',
+            'sulu_page.pages',
+            [
+                1 => [
+                    'view' => true,
+                    'edit' => true,
+                ],
+                2 => [
+                    'view' => true,
+                    'edit' => false,
+                ],
+            ],
+            null,
+            'system2'
+        );
+
+        $this->assertEquals([
+            'view' => true,
+            'edit' => false,
+        ], $permissions);
+    }
+
+    public function testGetUserPermissionByArrayWithSystemFromSystemStore()
+    {
+        $this->systemStore->getSystem()->willReturn('system1');
+
+        /** @var Permission $permission1 */
+        $permission1 = $this->prophesize(Permission::class);
+        $permission1->getPermissions()->willReturn(64);
+        $permission1->getContext()->willReturn('example');
+        /** @var Role $anonymousRole1 */
+        $anonymousRole1 = $this->prophesize(Role::class);
+        $anonymousRole1->getPermissions()->willReturn([$permission1->reveal()]);
+        $anonymousRole1->getSystem()->willReturn('system1');
+        $anonymousRole1->getId()->willReturn(1);
+
+        /** @var Permission $permission2 */
+        $permission2 = $this->prophesize(Permission::class);
+        $permission2->getPermissions()->willReturn(32);
+        $permission2->getContext()->willReturn('example');
+        /** @var Role $anonymousRole2 */
+        $anonymousRole2 = $this->prophesize(Role::class);
+        $anonymousRole2->getPermissions()->willReturn([$permission2->reveal()]);
+        $anonymousRole2->getSystem()->willReturn('system2');
+        $anonymousRole2->getId()->willReturn(2);
+
+        $this->roleRepository->findAllRoles(['anonymous' => true])->willReturn([$anonymousRole1, $anonymousRole2]);
+
+        $permissions = $this->accessControlManager->getUserPermissionByArray(
+            'de',
+            'sulu_page.pages',
+            [
+                1 => [
+                    'view' => true,
+                    'edit' => true,
+                ],
+                2 => [
+                    'view' => true,
+                    'edit' => false,
+                ],
+            ],
+            null
+        );
+
+        $this->assertEquals([
+            'view' => true,
+            'edit' => true,
+        ], $permissions);
+    }
+
     public function testGetUserPermissionByArrayWithoutSystem()
     {
         $this->systemStore->getSystem()->willReturn(null);

--- a/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/AccessControlManagerTest.php
+++ b/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/AccessControlManagerTest.php
@@ -20,6 +20,7 @@ use Sulu\Bundle\SecurityBundle\Entity\UserRole;
 use Sulu\Bundle\SecurityBundle\Exception\AccessControlDescendantProviderNotFoundException;
 use Sulu\Bundle\SecurityBundle\System\SystemStoreInterface;
 use Sulu\Bundle\TestBundle\Testing\ReadObjectAttributeTrait;
+use Sulu\Component\Security\Authentication\RoleRepositoryInterface;
 use Sulu\Component\Security\Authorization\AccessControl\AccessControlManager;
 use Sulu\Component\Security\Authorization\AccessControl\AccessControlProviderInterface;
 use Sulu\Component\Security\Authorization\AccessControl\DescendantProviderInterface;
@@ -62,13 +63,20 @@ class AccessControlManagerTest extends TestCase
      */
     private $systemStore;
 
+    /**
+     * @var RoleRepositoryInterface
+     */
+    private $roleRepository;
+
     public function setUp(): void
     {
         $this->maskConverter = $this->prophesize(MaskConverterInterface::class);
         $this->eventDispatcher = $this->prophesize(EventDispatcherInterface::class);
         $this->systemStore = $this->prophesize(SystemStoreInterface::class);
+        $this->roleRepository = $this->prophesize(RoleRepositoryInterface::class);
 
         $this->maskConverter->convertPermissionsToArray(0)->willReturn(['view' => false, 'edit' => false]);
+        $this->maskConverter->convertPermissionsToArray(32)->willReturn(['view' => false, 'edit' => true]);
         $this->maskConverter->convertPermissionsToArray(64)->willReturn(['view' => true, 'edit' => false]);
         $this->maskConverter->convertPermissionsToArray(127)->willReturn([
             'view' => true,
@@ -90,7 +98,8 @@ class AccessControlManagerTest extends TestCase
             [
                 $this->descendantProvider1->reveal(),
                 $this->descendantProvider2->reveal(),
-            ]
+            ],
+            $this->roleRepository->reveal()
         );
     }
 
@@ -336,7 +345,7 @@ class AccessControlManagerTest extends TestCase
         $anonymousRole->getSystem()->willReturn('Sulu');
         $anonymousRole->getId()->willReturn(1);
 
-        $this->systemStore->getAnonymousRole()->willReturn($anonymousRole);
+        $this->roleRepository->findAllRoles(['anonymous' => true])->willReturn([$anonymousRole]);
 
         $permissions = $this->accessControlManager->getUserPermissions(
             new SecurityCondition('example', 'de', \stdClass::class, '1'),
@@ -369,6 +378,49 @@ class AccessControlManagerTest extends TestCase
             'live' => true,
             'security' => true,
             'archive' => true,
+        ], $permissions);
+    }
+
+    public function testGetUserPermissionsWithSystemFromSecurityCondition()
+    {
+        $this->systemStore->getSystem()->willReturn('system1');
+
+        /** @var AccessControlProviderInterface $accessControlProvider */
+        $accessControlProvider = $this->prophesize(AccessControlProviderInterface::class);
+        $accessControlProvider->supports(\stdClass::class)->willReturn(true);
+        $accessControlProvider->getPermissions(\stdClass::class, '1', 'system2')->shouldBeCalled();
+        $this->accessControlManager->addAccessControlProvider($accessControlProvider->reveal());
+
+        /** @var Permission $permission1 */
+        $permission1 = $this->prophesize(Permission::class);
+        $permission1->getPermissions()->willReturn(64);
+        $permission1->getContext()->willReturn('example');
+        /** @var Role $anonymousRole1 */
+        $anonymousRole1 = $this->prophesize(Role::class);
+        $anonymousRole1->getPermissions()->willReturn([$permission1->reveal()]);
+        $anonymousRole1->getSystem()->willReturn('system1');
+        $anonymousRole1->getId()->willReturn(1);
+
+        /** @var Permission $permission2 */
+        $permission2 = $this->prophesize(Permission::class);
+        $permission2->getPermissions()->willReturn(32);
+        $permission2->getContext()->willReturn('example');
+        /** @var Role $anonymousRole2 */
+        $anonymousRole2 = $this->prophesize(Role::class);
+        $anonymousRole2->getPermissions()->willReturn([$permission2->reveal()]);
+        $anonymousRole2->getSystem()->willReturn('system2');
+        $anonymousRole2->getId()->willReturn(2);
+
+        $this->roleRepository->findAllRoles(['anonymous' => true])->willReturn([$anonymousRole1, $anonymousRole2]);
+
+        $permissions = $this->accessControlManager->getUserPermissions(
+            new SecurityCondition('example', 'de', \stdClass::class, '1', 'system2'),
+            null
+        );
+
+        $this->assertEquals([
+            'view' => false,
+            'edit' => true,
         ], $permissions);
     }
 
@@ -415,7 +467,7 @@ class AccessControlManagerTest extends TestCase
         $anonymousRole->getSystem()->willReturn('Sulu');
         $anonymousRole->getId()->willReturn(1);
 
-        $this->systemStore->getAnonymousRole()->willReturn($anonymousRole);
+        $this->roleRepository->findAllRoles(['anonymous' => true])->willReturn([$anonymousRole]);
 
         $permissions = $this->accessControlManager->getUserPermissions(
             new SecurityCondition('example', 'de', \stdClass::class, '1'),

--- a/src/Sulu/Component/Webspace/Webspace.php
+++ b/src/Sulu/Component/Webspace/Webspace.php
@@ -410,6 +410,19 @@ class Webspace implements ArrayableInterface
         return $this->security;
     }
 
+    public function hasWebsiteSecurity()
+    {
+        $security = $this->getSecurity();
+
+        if (!$security) {
+            return false;
+        }
+
+        $system = $security->getSystem();
+
+        return null !== $system;
+    }
+
     /**
      * @return Navigation
      */

--- a/templates/pages/example.html.twig
+++ b/templates/pages/example.html.twig
@@ -48,7 +48,10 @@
     <p>{{ content.link }}</p>
 
     {% if content.single_page_selection %}
-        <p>{{ sulu_content_load(content.single_page_selection).content.title }}</p>
+        {% set page = sulu_content_load(content.single_page_selection) %}
+        {% if page %}
+            <a href="{{ sulu_content_path(page.content.url) }}">{{ page.content.title }}</a>
+        {% endif %}
     {% endif %}
 
     <p>{{ content.page_selection|map(page => page.title)|join(', ') }}</p>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5530
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR moves the permission check from the `SinglePageSelection` to the `sulu_content_load` twig function and to the `sulu-link` tag.

#### Example Usage

~~~php
// If you added new features, show examples of how to use them here
// (remove this section if not a new feature)

$foo = new Foo();

// Now we can do
$foo->doSomething();
~~~

#### BC Breaks/Deprecations

Describe BC breaks/deprecations here. (remove this section if not needed)

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
- [ ] Check correct permission handling when linking to other webspace
- [ ] Check if working with logged in user as well