### PR TITLE
Add sulu icons to js docs

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/README.md
@@ -29,3 +29,27 @@ To use a Sulu icon just use the `su-` prefix:
 ```
 <Icon name="su-link" />
 ```
+
+List of all sulu icons:
+
+```
+const iconSettings = require('./fonts/selection.json');
+
+<div style={{display: 'flex', flexWrap: 'wrap'}}>
+    {
+        iconSettings.icons.map((iconSetting) => {
+            const iconClass = 'su-' + iconSetting.properties.name;
+
+            return <div style={{textAlign: 'center', margin: '10px', width: '70px'}}>
+                <div style={{fontSize: '20px'}}>
+                    <Icon name={iconClass} />
+                </div>
+
+                <div style={{fontSize: '8px'}}>
+                    {iconClass}
+                </div>
+            </div>
+        })
+    }
+</div>
+```


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add sulu icons to js docs.

#### Why?

To improve the developer experience the js docs should contain all available icons.

#### Example Usage

Open JS docs:

<img width="651" alt="Bildschirmfoto 2020-10-12 um 15 16 36" src="https://user-images.githubusercontent.com/1698337/95750941-2a5c7300-0c9e-11eb-9672-72fdfb104ff8.png">

