### PR TITLE
Add refresh button to ResourceLocator field-type

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {action, observable, toJS} from 'mobx';
+import {action, comparer, computed, observable, reaction, toJS} from 'mobx';
 import {observer} from 'mobx-react';
 import ResourceLocatorComponent from '../../../components/ResourceLocator';
 import ResourceLocatorHistory from '../../../containers/ResourceLocatorHistory';
@@ -18,59 +18,12 @@ const HOMEPAGE_RESOURCE_LOCATOR = '/';
 class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
     @observable mode: string;
     @observable enableRefreshButton: boolean = false;
+    @observable wasModifiedManually: boolean = false;
 
-    constructor(props: FieldTypeProps<?string>) {
-        super(props);
+    partsChangeDisposer: () => mixed;
 
+    @computed get parts(): {[string]: mixed} {
         const {
-            dataPath,
-            fieldTypeOptions: {
-                generationUrl,
-                modeResolver,
-            },
-            formInspector,
-            value: initialValue,
-        } = this.props;
-
-        if (!modeResolver) {
-            throw new Error('The "modeResolver" must be a function returning a promise with the desired mode');
-        }
-
-        modeResolver(this.props).then(action((mode) => this.mode = mode));
-
-        if (!generationUrl) {
-            return;
-        }
-
-        if (typeof generationUrl !== 'string') {
-            throw new Error('The "generationUrl" fieldTypeOption must be a string!');
-        }
-
-        if (initialValue === HOMEPAGE_RESOURCE_LOCATOR) {
-            return;
-        }
-
-        formInspector.addFinishFieldHandler(action((finishedFieldDataPath, finishedFieldSchemaPath) => {
-            const {tags: finishedFieldTags} = formInspector.getSchemaEntryByPath(finishedFieldSchemaPath) || {};
-            if (!finishedFieldTags || !finishedFieldTags.some((tag) => tag.name === PART_TAG)) {
-                return;
-            }
-
-            if (initialValue === undefined && !formInspector.isFieldModified(dataPath)) {
-                this.refreshResourceLocator();
-            } else {
-                this.enableRefreshButton = true;
-            }
-        }));
-    }
-
-    refreshResourceLocator = () => {
-        const {
-            onChange,
-            fieldTypeOptions: {
-                generationUrl,
-                resourceStorePropertiesToRequest = {},
-            },
             formInspector,
         } = this.props;
 
@@ -86,9 +39,84 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
                 return [path, value];
             });
 
-        if (partEntries.length === 0) {
+        return Object.fromEntries(partEntries);
+    }
+
+    @computed get enableAutoGeneration(): boolean {
+        const {
+            formInspector: {
+                id,
+            },
+        } = this.props;
+
+        return !id && !this.wasModifiedManually;
+    }
+
+    constructor(props: FieldTypeProps<?string>) {
+        super(props);
+
+        const {
+            fieldTypeOptions: {
+                generationUrl,
+                modeResolver,
+            },
+            formInspector,
+            value: initialValue,
+        } = this.props;
+
+        if (!modeResolver) {
+            throw new Error('The "modeResolver" must be a function returning a promise with the desired mode');
+        }
+
+        modeResolver(this.props).then(action((mode) => this.mode = mode));
+
+        if (initialValue === HOMEPAGE_RESOURCE_LOCATOR) {
             return;
         }
+
+        if (!generationUrl) {
+            return;
+        }
+
+        if (typeof generationUrl !== 'string') {
+            throw new Error('The "generationUrl" fieldTypeOption must be a string!');
+        }
+
+        this.partsChangeDisposer = reaction(
+            () => (this.parts),
+            action(() => {
+                if (!this.enableAutoGeneration) {
+                    this.enableRefreshButton = true;
+                }
+            }),
+            {equals: comparer.structural}
+        );
+
+        formInspector.addFinishFieldHandler(action((finishedFieldDataPath, finishedFieldSchemaPath) => {
+            const {tags: finishedFieldTags} = formInspector.getSchemaEntryByPath(finishedFieldSchemaPath) || {};
+            if (!finishedFieldTags || !finishedFieldTags.some((tag) => tag.name === PART_TAG)) {
+                return;
+            }
+
+            if (this.enableAutoGeneration) {
+                this.refreshResourceLocator();
+            }
+        }));
+    }
+
+    componentWillUnmount() {
+        this.partsChangeDisposer();
+    }
+
+    @action refreshResourceLocator = () => {
+        const {
+            fieldTypeOptions: {
+                generationUrl,
+                resourceStorePropertiesToRequest = {},
+            },
+            formInspector,
+            onChange,
+        } = this.props;
 
         const requestOptions = {...formInspector.options};
 
@@ -99,23 +127,33 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
             }
         });
 
+        this.enableRefreshButton = false;
+
         Requester.post(
             generationUrl,
             {
-                parts: Object.fromEntries(partEntries),
+                parts: this.parts,
                 resourceKey: formInspector.resourceKey,
                 locale: formInspector.locale ? formInspector.locale.get() : undefined,
                 ...requestOptions,
             }
         ).then(action((response) => {
-            this.enableRefreshButton = false;
             onChange(response.resourcelocator);
         }));
     };
 
-    handleBlur = () => {
+    handleInputBlur = () => {
         const {onFinish} = this.props;
         onFinish();
+    };
+
+    @action handleInputChange = (value: ?string) => {
+        const {onChange} = this.props;
+
+        this.enableRefreshButton = true;
+        this.wasModifiedManually = true;
+
+        onChange(value);
     };
 
     handleRefreshButtonClick = () => {
@@ -146,7 +184,6 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
             dataPath,
             disabled,
             formInspector,
-            onChange,
             value,
         } = this.props;
 
@@ -160,8 +197,8 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
                     disabled={!!disabled}
                     id={dataPath}
                     mode={this.mode}
-                    onBlur={this.handleBlur}
-                    onChange={onChange}
+                    onBlur={this.handleInputBlur}
+                    onChange={this.handleInputChange}
                     value={value}
                 />
                 <div className={resourceLocatorStyles.buttonContainer}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
@@ -175,7 +175,6 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
                         {translate('sulu_admin.refresh_url')}
                     </Button>
                     <ResourceLocatorHistory
-                        disabled={!formInspector.id}
                         id={formInspector.id}
                         options={{
                             locale: formInspector.locale,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
@@ -21,7 +21,7 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
     @observable inputChangedSinceRefresh: boolean = false;
     @observable partsChangedSinceRefresh: boolean = false;
 
-    partsChangeDisposer: () => mixed;
+    partsChangeDisposer: ?() => mixed;
 
     @computed get parts(): {[string]: mixed} {
         const {
@@ -112,7 +112,9 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
     }
 
     componentWillUnmount() {
-        this.partsChangeDisposer();
+        if (this.partsChangeDisposer) {
+            this.partsChangeDisposer();
+        }
     }
 
     @action refreshResourceLocator = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
@@ -6,6 +6,8 @@ import ResourceLocatorComponent from '../../../components/ResourceLocator';
 import ResourceLocatorHistory from '../../../containers/ResourceLocatorHistory';
 import Requester from '../../../services/Requester';
 import type {FieldTypeProps} from '../../../types';
+import {translate} from '../../../utils/Translator';
+import Button from '../../../components/Button';
 import resourceLocatorStyles from './resourceLocator.scss';
 
 const PART_TAG = 'sulu.rlp.part';
@@ -15,6 +17,7 @@ const HOMEPAGE_RESOURCE_LOCATOR = '/';
 @observer
 class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
     @observable mode: string;
+    @observable enableRefreshButton: boolean = false;
 
     constructor(props: FieldTypeProps<?string>) {
         super(props);
@@ -24,11 +27,9 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
             fieldTypeOptions: {
                 generationUrl,
                 modeResolver,
-                resourceStorePropertiesToRequest = {},
             },
             formInspector,
-            onChange,
-            value,
+            value: initialValue,
         } = this.props;
 
         if (!modeResolver) {
@@ -45,66 +46,80 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
             throw new Error('The "generationUrl" fieldTypeOption must be a string!');
         }
 
-        if (value === HOMEPAGE_RESOURCE_LOCATOR) {
+        if (initialValue === HOMEPAGE_RESOURCE_LOCATOR) {
             return;
         }
 
-        formInspector.addFinishFieldHandler((finishedFieldDataPath, finishedFieldSchemaPath) => {
-            if (value !== undefined) {
-                return;
-            }
-
-            if (formInspector.isFieldModified(dataPath)) {
-                return;
-            }
-
+        formInspector.addFinishFieldHandler(action((finishedFieldDataPath, finishedFieldSchemaPath) => {
             const {tags: finishedFieldTags} = formInspector.getSchemaEntryByPath(finishedFieldSchemaPath) || {};
             if (!finishedFieldTags || !finishedFieldTags.some((tag) => tag.name === PART_TAG)) {
                 return;
             }
 
-            const partEntries = formInspector.getPathsByTag(PART_TAG)
-                .map((path: string) => [path, formInspector.getValueByPath(path)])
-                .filter(([, value: mixed]) => !!value)
-                .map(([path: string, value: mixed]) => {
-                    // path is a jsonpointer but the api controller requires property names
-                    if (path.startsWith('/')) {
-                        return [path.substr(1), value];
-                    }
-
-                    return [path, value];
-                });
-
-            if (partEntries.length === 0) {
-                return;
+            if (initialValue === undefined && !formInspector.isFieldModified(dataPath)) {
+                this.refreshResourceLocator();
+            } else {
+                this.enableRefreshButton = true;
             }
-
-            const requestOptions = {...formInspector.options};
-
-            Object.entries(resourceStorePropertiesToRequest).forEach(([propertyName, parameterName]) => {
-                const propertyValue = toJS(formInspector.getValueByPath('/' + propertyName));
-                if (propertyValue !== undefined) {
-                    requestOptions[parameterName] = propertyValue;
-                }
-            });
-
-            Requester.post(
-                generationUrl,
-                {
-                    parts: Object.fromEntries(partEntries),
-                    resourceKey: formInspector.resourceKey,
-                    locale: formInspector.locale ? formInspector.locale.get() : undefined,
-                    ...requestOptions,
-                }
-            ).then((response) => {
-                onChange(response.resourcelocator);
-            });
-        });
+        }));
     }
+
+    refreshResourceLocator = () => {
+        const {
+            onChange,
+            fieldTypeOptions: {
+                generationUrl,
+                resourceStorePropertiesToRequest = {},
+            },
+            formInspector,
+        } = this.props;
+
+        const partEntries = formInspector.getPathsByTag(PART_TAG)
+            .map((path: string) => [path, formInspector.getValueByPath(path)])
+            .filter(([, value: mixed]) => !!value)
+            .map(([path: string, value: mixed]) => {
+                // path is a jsonpointer but the api controller requires property names
+                if (path.startsWith('/')) {
+                    return [path.substr(1), value];
+                }
+
+                return [path, value];
+            });
+
+        if (partEntries.length === 0) {
+            return;
+        }
+
+        const requestOptions = {...formInspector.options};
+
+        Object.entries(resourceStorePropertiesToRequest).forEach(([propertyName, parameterName]) => {
+            const propertyValue = toJS(formInspector.getValueByPath('/' + propertyName));
+            if (propertyValue !== undefined) {
+                requestOptions[parameterName] = propertyValue;
+            }
+        });
+
+        Requester.post(
+            generationUrl,
+            {
+                parts: Object.fromEntries(partEntries),
+                resourceKey: formInspector.resourceKey,
+                locale: formInspector.locale ? formInspector.locale.get() : undefined,
+                ...requestOptions,
+            }
+        ).then(action((response) => {
+            this.enableRefreshButton = false;
+            onChange(response.resourcelocator);
+        }));
+    };
 
     handleBlur = () => {
         const {onFinish} = this.props;
         onFinish();
+    };
+
+    handleRefreshButtonClick = () => {
+        this.refreshResourceLocator();
     };
 
     render() {
@@ -140,31 +155,37 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
         }
 
         return (
-            <div className={resourceLocatorStyles.resourceLocatorContainer}>
-                <div className={resourceLocatorStyles.resourceLocator}>
-                    <ResourceLocatorComponent
-                        disabled={!!disabled}
-                        id={dataPath}
-                        mode={this.mode}
-                        onBlur={this.handleBlur}
-                        onChange={onChange}
-                        value={value}
+            <div>
+                <ResourceLocatorComponent
+                    disabled={!!disabled}
+                    id={dataPath}
+                    mode={this.mode}
+                    onBlur={this.handleBlur}
+                    onChange={onChange}
+                    value={value}
+                />
+                <div className={resourceLocatorStyles.buttonContainer}>
+                    <Button
+                        className={resourceLocatorStyles.refreshButton}
+                        disabled={!this.enableRefreshButton}
+                        icon="su-sync"
+                        onClick={this.handleRefreshButtonClick}
+                        skin="link"
+                    >
+                        {translate('sulu_admin.refresh_url')}
+                    </Button>
+                    <ResourceLocatorHistory
+                        disabled={!formInspector.id}
+                        id={formInspector.id}
+                        options={{
+                            locale: formInspector.locale,
+                            resourceKey: formInspector.resourceKey,
+                            webspace: formInspector.options.webspace,
+                            ...options,
+                        }}
+                        resourceKey={historyResourceKey}
                     />
                 </div>
-                {formInspector.id &&
-                    <div className={resourceLocatorStyles.resourceLocatorHistory}>
-                        <ResourceLocatorHistory
-                            id={formInspector.id}
-                            options={{
-                                locale: formInspector.locale,
-                                resourceKey: formInspector.resourceKey,
-                                webspace: formInspector.options.webspace,
-                                ...options,
-                            }}
-                            resourceKey={historyResourceKey}
-                        />
-                    </div>
-                }
             </div>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import React, {Fragment} from 'react';
 import {action, comparer, computed, observable, reaction, toJS} from 'mobx';
 import {observer} from 'mobx-react';
 import ResourceLocatorComponent from '../../../components/ResourceLocator';
@@ -61,7 +61,7 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
                 modeResolver,
             },
             formInspector,
-            value: initialValue,
+            value,
         } = this.props;
 
         if (!modeResolver) {
@@ -70,7 +70,7 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
 
         modeResolver(this.props).then(action((mode) => this.mode = mode));
 
-        if (initialValue === HOMEPAGE_RESOURCE_LOCATOR) {
+        if (value === HOMEPAGE_RESOURCE_LOCATOR) {
             return;
         }
 
@@ -192,7 +192,7 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
         }
 
         return (
-            <div>
+            <Fragment>
                 <ResourceLocatorComponent
                     disabled={!!disabled}
                     id={dataPath}
@@ -201,7 +201,7 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
                     onChange={this.handleInputChange}
                     value={value}
                 />
-                <div className={resourceLocatorStyles.buttonContainer}>
+                <div className={resourceLocatorStyles.buttonsContainer}>
                     <Button
                         className={resourceLocatorStyles.refreshButton}
                         disabled={!this.enableRefreshButton}
@@ -222,7 +222,7 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
                         resourceKey={historyResourceKey}
                     />
                 </div>
-            </div>
+            </Fragment>
         );
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/resourceLocator.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/resourceLocator.scss
@@ -1,13 +1,9 @@
-.resource-locator-container {
+.button-container {
+    margin-top: 10px;
     display: flex;
-    align-items: center;
+    flex-direction: row;
 }
 
-.resource-locator {
-    flex-grow: 1;
-}
-
-.resource-locator-history {
-    padding-left: 10px;
-    flex-shrink: 1;
+.refresh-button {
+    margin-right: 20px;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/resourceLocator.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/resourceLocator.scss
@@ -1,4 +1,4 @@
-.button-container {
+.buttons-container {
     margin-top: 10px;
     display: flex;
     flex-direction: row;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 import {mount, shallow} from 'enzyme';
-import {observable} from 'mobx';
+import {extendObservable as mockExtendObservable, observable} from 'mobx';
 import fieldTypeDefaultProps from '../../../../utils/TestHelper/fieldTypeDefaultProps';
 import FormInspector from '../../FormInspector';
 import ResourceFormStore from '../../stores/ResourceFormStore';
@@ -18,13 +18,18 @@ jest.mock('../../../../stores/ResourceStore', () => jest.fn(function(resourceKey
     this.resourceKey = resourceKey;
     this.id = id;
     this.locale = observableOptions.locale;
+
+    mockExtendObservable(this, {
+        data: {},
+    });
 }));
 
 jest.mock('../../stores/ResourceFormStore', () => jest.fn(function(resourceStore, formKey, options) {
     this.resourceKey = resourceStore.resourceKey;
     this.id = resourceStore.id;
     this.locale = resourceStore.locale;
-    this.options = options;
+    this.options = options || {};
+    this.resourceStore = resourceStore;
 }));
 
 jest.mock('../../FormInspector', () => jest.fn(function(formStore) {
@@ -34,8 +39,8 @@ jest.mock('../../FormInspector', () => jest.fn(function(formStore) {
     this.resourceKey = formStore.resourceKey;
     this.errors = {};
     this.addFinishFieldHandler = jest.fn();
-    this.getPathsByTag = jest.fn();
-    this.getValueByPath = jest.fn();
+    this.getPathsByTag = jest.fn().mockReturnValue([]);
+    this.getValueByPath = jest.fn((path) => formStore.resourceStore.data[path]);
     this.getSchemaEntryByPath = jest.fn().mockReturnValue({});
     this.isFieldModified = jest.fn().mockReturnValue(false);
 }));
@@ -126,23 +131,6 @@ test('Pass correct options to ResourceLocatorHistory if entity already existed',
     });
 });
 
-test('Do not add an addFinishFieldHandler for URL generation if no generationUrl was passed', () => {
-    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
-
-    shallow(
-        <ResourceLocator
-            {...fieldTypeDefaultProps}
-            fieldTypeOptions={{
-                historyResourceKey: 'page_resourcelocators',
-                modeResolver: () => Promise.resolve('leaf'),
-            }}
-            formInspector={formInspector}
-        />
-    );
-
-    expect(formInspector.addFinishFieldHandler).not.toBeCalled();
-});
-
 test('Do not add an addFinishFieldHandler for URL generation if used on the homepage', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
 
@@ -156,6 +144,23 @@ test('Do not add an addFinishFieldHandler for URL generation if used on the home
             }}
             formInspector={formInspector}
             value="/"
+        />
+    );
+
+    expect(formInspector.addFinishFieldHandler).not.toBeCalled();
+});
+
+test('Do not add an addFinishFieldHandler for URL generation if no generationUrl was passed', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+
+    shallow(
+        <ResourceLocator
+            {...fieldTypeDefaultProps}
+            fieldTypeOptions={{
+                historyResourceKey: 'page_resourcelocators',
+                modeResolver: () => Promise.resolve('leaf'),
+            }}
+            formInspector={formInspector}
         />
     );
 
@@ -185,7 +190,7 @@ test.each(['leaf', 'full'])('Set mode correctly', (mode) => {
     });
 });
 
-test('Should not pass any argument to onFinish callback', () => {
+test('Should fire onFinish callback without argument when ResourceLocatorComponent is blurred', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
     const finishSpy = jest.fn();
 
@@ -212,24 +217,30 @@ test('Should not pass any argument to onFinish callback', () => {
     });
 });
 
-test('Should request a new URL if no URL was defined initially', () => {
+test('Should automatically request new URL when part field is finished on add form', () => {
+    const resourceStore = new ResourceStore('tests', undefined, {locale: observable.box('en')});
     const formInspector = new FormInspector(
         new ResourceFormStore(
-            new ResourceStore('tests', undefined, {locale: observable.box('en')}),
+            resourceStore,
             'test'
         )
     );
     const changeSpy = jest.fn();
-    const modePromise = Promise.resolve('leaf');
 
-    const resourceLocator = shallow(
+    formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
+    resourceStore.data = {
+        '/title': 'title-value',
+        '/subtitle': 'subtitle-value',
+    };
+
+    shallow(
         <ResourceLocator
             {...fieldTypeDefaultProps}
             dataPath="/block/0/url"
             fieldTypeOptions={{
                 generationUrl: '/admin/api/resourcelocators?action=generate',
                 historyResourceKey: 'page_resourcelocators',
-                modeResolver: () => modePromise,
+                modeResolver: () => Promise.resolve('leaf'),
             }}
             formInspector={formInspector}
             onChange={changeSpy}
@@ -244,50 +255,47 @@ test('Should request a new URL if no URL was defined initially', () => {
             {name: 'sulu.rlp.part'},
         ],
     });
-    formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
-    formInspector.getValueByPath.mockReturnValueOnce('title-value');
-    formInspector.getValueByPath.mockReturnValueOnce('subtitle-value');
 
     const resourceLocatorPromise = Promise.resolve({
         resourcelocator: '/test',
     });
     Requester.post.mockReturnValue(resourceLocatorPromise);
 
-    return modePromise.then(() => {
-        resourceLocator.update();
-        expect(resourceLocator.find('Button').props().disabled).toBeTruthy();
+    finishFieldHandler('/block/0/title', '/title');
 
-        finishFieldHandler('/block/0/url', '/url');
+    expect(formInspector.getSchemaEntryByPath).toBeCalledWith('/title');
+    expect(formInspector.getPathsByTag).toBeCalledWith('sulu.rlp.part');
+    expect(Requester.post).toBeCalledWith(
+        '/admin/api/resourcelocators?action=generate',
+        {
+            locale: 'en',
+            resourceKey: 'tests',
+            parts: {title: 'title-value', subtitle: 'subtitle-value'},
+        }
+    );
 
-        expect(formInspector.getSchemaEntryByPath).toBeCalledWith('/url');
-        expect(resourceLocator.find('Button').props().disabled).toBeTruthy();
-        expect(formInspector.getPathsByTag).toBeCalledWith('sulu.rlp.part');
-        expect(formInspector.getValueByPath).toBeCalledWith('/title');
-        expect(formInspector.getValueByPath).toBeCalledWith('/subtitle');
-        expect(Requester.post).toBeCalledWith(
-            '/admin/api/resourcelocators?action=generate',
-            {
-                locale: 'en',
-                resourceKey: 'tests',
-                parts: {title: 'title-value', subtitle: 'subtitle-value'},
-            }
-        );
-
-        return resourceLocatorPromise.then(() => {
-            expect(changeSpy).toBeCalledWith('/test');
-        });
+    return resourceLocatorPromise.then(() => {
+        expect(changeSpy).toBeCalledWith('/test');
     });
 });
 
-test('Request new URL with options from FormInspector and resourceStorePropertiesToRequest field-type-option', () => {
+test('Should request URL with FormInspector options and resourceStorePropertiesToRequest field-type-option', () => {
+    const resourceStore = new ResourceStore('test');
     const formInspector = new FormInspector(
         new ResourceFormStore(
-            new ResourceStore('test'),
+            resourceStore,
             'test',
             {webspace: 'example'}
         )
     );
     const changeSpy = jest.fn();
+
+    formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
+    resourceStore.data = {
+        '/title': 'title-value',
+        '/subtitle': 'subtitle-value',
+        '/propertyName': 'property-value',
+    };
 
     shallow(
         <ResourceLocator
@@ -314,23 +322,16 @@ test('Request new URL with options from FormInspector and resourceStorePropertie
             {name: 'sulu.rlp.part'},
         ],
     });
-    formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
-    formInspector.getValueByPath.mockReturnValueOnce('title-value');
-    formInspector.getValueByPath.mockReturnValueOnce('subtitle-value');
-    formInspector.getValueByPath.mockReturnValueOnce('property-value');
 
     const resourceLocatorPromise = Promise.resolve({
         resourcelocator: '/test',
     });
     Requester.post.mockReturnValue(resourceLocatorPromise);
 
-    finishFieldHandler('/block/0/url', '/url');
+    finishFieldHandler('/block/0/title', '/title');
 
-    expect(formInspector.getSchemaEntryByPath).toBeCalledWith('/url');
+    expect(formInspector.getSchemaEntryByPath).toBeCalledWith('/title');
     expect(formInspector.getPathsByTag).toBeCalledWith('sulu.rlp.part');
-    expect(formInspector.getValueByPath).toBeCalledWith('/title');
-    expect(formInspector.getValueByPath).toBeCalledWith('/subtitle');
-    expect(formInspector.getValueByPath).toBeCalledWith('/propertyName');
     expect(Requester.post).toBeCalledWith(
         '/admin/api/resourcelocators?action=generate',
         {
@@ -347,23 +348,29 @@ test('Request new URL with options from FormInspector and resourceStorePropertie
     });
 });
 
-test('Should enable refresh button instead of requesting new URL if URL was defined initially', () => {
+test('Should not request new URL when part field is finished on edit form', () => {
+    const resourceStore = new ResourceStore('test', 5, {locale: observable.box('en')});
     const formInspector = new FormInspector(
         new ResourceFormStore(
-            new ResourceStore('test', undefined, {locale: observable.box('en')}),
+            resourceStore,
             'test'
         )
     );
-    const modePromise = Promise.resolve('leaf');
 
-    const resourceLocator = shallow(
+    formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
+    resourceStore.data = {
+        '/title': 'title-value',
+        '/subtitle': 'subtitle-value',
+    };
+
+    shallow(
         <ResourceLocator
             {...fieldTypeDefaultProps}
             dataPath="/block/0/url"
             fieldTypeOptions={{
                 generationUrl: '/admin/api/resourcelocators?action=generate',
                 historyResourceKey: 'page_resourcelocators',
-                modeResolver: () => modePromise,
+                modeResolver: () => Promise.resolve('leaf'),
             }}
             formInspector={formInspector}
             schemaPath="/url"
@@ -379,192 +386,75 @@ test('Should enable refresh button instead of requesting new URL if URL was defi
         ],
     });
 
-    return modePromise.then(() => {
-        resourceLocator.update();
-        expect(resourceLocator.find('Button').props().disabled).toBeTruthy();
-
-        finishFieldHandler('/block/0/url', '/url');
-
-        expect(resourceLocator.find('Button').props().disabled).toBeFalsy();
-        expect(formInspector.getPathsByTag).not.toBeCalled();
-        expect(formInspector.getValueByPath).not.toBeCalled();
-        expect(Requester.post).not.toBeCalled();
-    });
+    finishFieldHandler('/block/0/title', '/title');
+    expect(Requester.post).not.toBeCalled();
 });
 
-test('Should not enable refresh button or request a new URL if no parts are available', () => {
-    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
-    const modePromise = Promise.resolve('leaf');
-
-    const resourceLocator = shallow(
-        <ResourceLocator
-            {...fieldTypeDefaultProps}
-            dataPath="/block/0/url"
-            fieldTypeOptions={{
-                generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'page_resourcelocators',
-                modeResolver: () => modePromise,
-            }}
-            formInspector={formInspector}
-            schemaPath="/url"
-        />
-    );
-
-    const finishFieldHandler = formInspector.addFinishFieldHandler.mock.calls[0][0];
-
-    formInspector.getSchemaEntryByPath.mockReturnValue({
-        tags: [
-            {name: 'sulu.rlp.part'},
-        ],
-    });
-    formInspector.getPathsByTag.mockReturnValue([]);
-
-    return modePromise.then(() => {
-        resourceLocator.update();
-        expect(resourceLocator.find('Button').props().disabled).toBeTruthy();
-
-        finishFieldHandler('/block/0/url', '/url');
-
-        expect(formInspector.getSchemaEntryByPath).toBeCalledWith('/url');
-        expect(resourceLocator.find('Button').props().disabled).toBeTruthy();
-        expect(formInspector.getPathsByTag).toBeCalledWith('sulu.rlp.part');
-        expect(Requester.post).not.toBeCalled();
-    });
-});
-
-test('Should not enable refresh button or request a new URL if only empty parts are available', () => {
-    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
-    const modePromise = Promise.resolve('leaf');
-
-    const resourceLocator = shallow(
-        <ResourceLocator
-            {...fieldTypeDefaultProps}
-            dataPath="/block/0/url"
-            fieldTypeOptions={{
-                generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'page_resourcelocators',
-                modeResolver: () => modePromise,
-            }}
-            formInspector={formInspector}
-            schemaPath="/url"
-        />
-    );
-
-    const finishFieldHandler = formInspector.addFinishFieldHandler.mock.calls[0][0];
-
-    formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
-    formInspector.getValueByPath.mockReturnValueOnce(null);
-    formInspector.getValueByPath.mockReturnValueOnce(undefined);
-    formInspector.getSchemaEntryByPath.mockReturnValue({
-        tags: [
-            {name: 'sulu.rlp.part'},
-        ],
-    });
-
-    return modePromise.then(() => {
-        resourceLocator.update();
-        expect(resourceLocator.find('Button').props().disabled).toBeTruthy();
-
-        finishFieldHandler('/block/0/url', '/url');
-
-        expect(formInspector.getSchemaEntryByPath).toBeCalledWith('/url');
-        expect(resourceLocator.find('Button').props().disabled).toBeTruthy();
-        expect(formInspector.getPathsByTag).toBeCalledWith('sulu.rlp.part');
-        expect(formInspector.getValueByPath).toBeCalledWith('/title');
-        expect(formInspector.getValueByPath).toBeCalledWith('/subtitle');
-        expect(Requester.post).not.toBeCalled();
-    });
-});
-
-test('Should not enable refresh button or request new URL if field without the "sulu.rlp.part" tag is finished', () => {
-    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
-    const modePromise = Promise.resolve('leaf');
-
-    const resourceLocator = shallow(
-        <ResourceLocator
-            {...fieldTypeDefaultProps}
-            dataPath="/block/0/url"
-            fieldTypeOptions={{
-                generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'page_resourcelocators',
-                modeResolver: () => modePromise,
-            }}
-            formInspector={formInspector}
-            schemaPath="/url"
-        />
-    );
-
-    const finishFieldHandler = formInspector.addFinishFieldHandler.mock.calls[0][0];
-
-    formInspector.getSchemaEntryByPath.mockReturnValue({
-        tags: [
-            {name: 'sulu.rlp'},
-        ],
-    });
-    formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
-    formInspector.getValueByPath.mockReturnValueOnce('title-value');
-    formInspector.getValueByPath.mockReturnValueOnce('subtitle-value');
-
-    return modePromise.then(() => {
-        resourceLocator.update();
-        expect(resourceLocator.find('Button').props().disabled).toBeTruthy();
-
-        finishFieldHandler('/block/0/url', '/url');
-
-        expect(formInspector.getSchemaEntryByPath).toBeCalledWith('/url');
-        expect(resourceLocator.find('Button').props().disabled).toBeTruthy();
-        expect(formInspector.getPathsByTag).not.toBeCalledWith('sulu.rlp.part');
-        expect(Requester.post).not.toBeCalled();
-    });
-});
-
-test('Should not enable refresh button or request a new URL if a field without any tags has finished editing', () => {
-    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
-    const modePromise = Promise.resolve('leaf');
-
-    const resourceLocator = shallow(
-        <ResourceLocator
-            {...fieldTypeDefaultProps}
-            dataPath="/block/0/url"
-            fieldTypeOptions={{
-                generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'page_resourcelocators',
-                modeResolver: () => modePromise,
-            }}
-            formInspector={formInspector}
-            schemaPath="/url"
-        />
-    );
-
-    const finishFieldHandler = formInspector.addFinishFieldHandler.mock.calls[0][0];
-
-    formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
-    formInspector.getValueByPath.mockReturnValueOnce('title-value');
-    formInspector.getValueByPath.mockReturnValueOnce('subtitle-value');
-
-    return modePromise.then(() => {
-        resourceLocator.update();
-        expect(resourceLocator.find('Button').props().disabled).toBeTruthy();
-
-        finishFieldHandler('/block/0/url', '/url');
-
-        expect(formInspector.getSchemaEntryByPath).toBeCalledWith('/url');
-        expect(resourceLocator.find('Button').props().disabled).toBeTruthy();
-        expect(formInspector.getPathsByTag).not.toBeCalledWith('sulu.rlp.part');
-        expect(Requester.post).not.toBeCalled();
-    });
-});
-
-test('Should enable refresh button instead of requesting new URL if the field has already been edited', () => {
+test('Should not request new URL when part field is finished if all parts are empty', () => {
+    const resourceStore = new ResourceStore('tests', undefined, {locale: observable.box('en')});
     const formInspector = new FormInspector(
         new ResourceFormStore(
-            new ResourceStore('test'),
-            'test',
-            {webspace: 'example'}
+            resourceStore,
+            'test'
+        )
+    );
+
+    formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
+    resourceStore.data = {
+        '/title': 'title-value',
+        '/subtitle': 'subtitle-value',
+    };
+
+    shallow(
+        <ResourceLocator
+            {...fieldTypeDefaultProps}
+            dataPath="/block/0/url"
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+                modeResolver: () => Promise.resolve('leaf'),
+            }}
+            formInspector={formInspector}
+            schemaPath="/url"
+        />
+    );
+
+    const finishFieldHandler = formInspector.addFinishFieldHandler.mock.calls[0][0];
+
+    formInspector.getSchemaEntryByPath.mockReturnValue({
+        tags: [
+            {name: 'sulu.rlp.part'},
+        ],
+    });
+
+    resourceStore.data = {
+        '/title': '',
+        '/subtitle': undefined,
+    };
+
+    finishFieldHandler('/block/0/title', '/title');
+
+    expect(formInspector.getSchemaEntryByPath).toBeCalledWith('/title');
+    expect(formInspector.getPathsByTag).toBeCalledWith('sulu.rlp.part');
+    expect(Requester.post).not.toBeCalled();
+});
+
+test('Should not request new URL when part field is finished if input was already changed manually', () => {
+    const resourceStore = new ResourceStore('tests', undefined, {locale: observable.box('en')});
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            resourceStore,
+            'test'
         )
     );
     const modePromise = Promise.resolve('leaf');
 
+    formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
+    resourceStore.data = {
+        '/title': 'title-value',
+        '/subtitle': 'subtitle-value',
+    };
+
     const resourceLocator = shallow(
         <ResourceLocator
             {...fieldTypeDefaultProps}
@@ -586,29 +476,310 @@ test('Should enable refresh button instead of requesting new URL if the field ha
             {name: 'sulu.rlp.part'},
         ],
     });
+
+    return modePromise.then(() => {
+        resourceLocator.find(ResourceLocatorComponent).props().onChange('manual-change');
+
+        finishFieldHandler('/block/0/title', '/title');
+
+        expect(formInspector.getSchemaEntryByPath).toBeCalledWith('/title');
+        expect(formInspector.getPathsByTag).toBeCalledWith('sulu.rlp.part');
+        expect(Requester.post).not.toBeCalled();
+    });
+});
+
+test('Should not request new URL when field without the "sulu.rlp.part" tag is finished', () => {
+    const resourceStore = new ResourceStore('tests', undefined, {locale: observable.box('en')});
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            resourceStore,
+            'test'
+        )
+    );
+
     formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
-    formInspector.getValueByPath.mockReturnValueOnce('title-value');
-    formInspector.getValueByPath.mockReturnValueOnce('subtitle-value');
-    formInspector.isFieldModified.mockReturnValue(true);
+    resourceStore.data = {
+        '/title': 'title-value',
+        '/subtitle': 'subtitle-value',
+    };
+
+    shallow(
+        <ResourceLocator
+            {...fieldTypeDefaultProps}
+            dataPath="/block/0/url"
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+                modeResolver: () => Promise.resolve('leaf'),
+            }}
+            formInspector={formInspector}
+            schemaPath="/url"
+        />
+    );
+
+    const finishFieldHandler = formInspector.addFinishFieldHandler.mock.calls[0][0];
+
+    formInspector.getSchemaEntryByPath.mockReturnValue({
+        tags: [
+            {name: 'other-tag'},
+        ],
+    });
+
+    finishFieldHandler('/block/0/title', '/title');
+
+    expect(formInspector.getSchemaEntryByPath).toBeCalledWith('/title');
+    expect(Requester.post).not.toBeCalled();
+});
+
+test('Should not request new URL when field without any tags has finished editing', () => {
+    const resourceStore = new ResourceStore('tests', undefined, {locale: observable.box('en')});
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            resourceStore,
+            'test'
+        )
+    );
+
+    formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
+    resourceStore.data = {
+        '/title': 'title-value',
+        '/subtitle': 'subtitle-value',
+    };
+
+    shallow(
+        <ResourceLocator
+            {...fieldTypeDefaultProps}
+            dataPath="/block/0/url"
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+                modeResolver: () => Promise.resolve('leaf'),
+            }}
+            formInspector={formInspector}
+            schemaPath="/url"
+        />
+    );
+
+    const finishFieldHandler = formInspector.addFinishFieldHandler.mock.calls[0][0];
+
+    formInspector.getSchemaEntryByPath.mockReturnValue({});
+
+    finishFieldHandler('/block/0/title', '/title');
+
+    expect(formInspector.getSchemaEntryByPath).toBeCalledWith('/title');
+    expect(Requester.post).not.toBeCalled();
+});
+
+test('Should enable refresh button when value of part field changes on edit form', () => {
+    const resourceStore = new ResourceStore('tests', 5);
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            resourceStore,
+            'test'
+        )
+    );
+    const modePromise = Promise.resolve('leaf');
+
+    formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
+    resourceStore.data = {
+        '/title': 'title-value',
+        '/subtitle': 'subtitle-value',
+    };
+
+    const resourceLocator = shallow(
+        <ResourceLocator
+            {...fieldTypeDefaultProps}
+            dataPath="/block/0/url"
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+                modeResolver: () => modePromise,
+            }}
+            formInspector={formInspector}
+            schemaPath="/url"
+        />
+    );
 
     return modePromise.then(() => {
         resourceLocator.update();
         expect(resourceLocator.find('Button').props().disabled).toBeTruthy();
-        finishFieldHandler('/block/0/url', '/url');
 
-        expect(formInspector.getSchemaEntryByPath).toBeCalledWith('/url');
-        expect(formInspector.isFieldModified).toHaveBeenCalledTimes(1);
-        expect(formInspector.isFieldModified).toBeCalledWith('/block/0/url');
+        resourceStore.data['/title'] = 'new-title-value';
+
         expect(resourceLocator.find('Button').props().disabled).toBeFalsy();
-        expect(formInspector.getPathsByTag).not.toBeCalledWith('sulu.rlp.part');
-        expect(Requester.post).not.toBeCalledWith();
     });
 });
 
-test('Should request a new URL with the FormInspector options included if refresh button is clicked', () => {
+test('Should enable refresh button when input is changed manually on edit form', () => {
+    const resourceStore = new ResourceStore('tests', 5);
     const formInspector = new FormInspector(
         new ResourceFormStore(
-            new ResourceStore('test'),
+            resourceStore,
+            'test'
+        )
+    );
+    const modePromise = Promise.resolve('leaf');
+
+    formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
+    resourceStore.data = {
+        '/title': 'title-value',
+        '/subtitle': 'subtitle-value',
+    };
+
+    const resourceLocator = shallow(
+        <ResourceLocator
+            {...fieldTypeDefaultProps}
+            dataPath="/block/0/url"
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+                modeResolver: () => modePromise,
+            }}
+            formInspector={formInspector}
+            schemaPath="/url"
+        />
+    );
+
+    return modePromise.then(() => {
+        resourceLocator.update();
+        expect(resourceLocator.find('Button').props().disabled).toBeTruthy();
+
+        resourceLocator.find(ResourceLocatorComponent).props().onChange('manual-change');
+
+        expect(resourceLocator.find('Button').props().disabled).toBeFalsy();
+    });
+});
+
+test('Should not enable refresh button when value of part field changes on add form', () => {
+    const resourceStore = new ResourceStore('tests', undefined);
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            resourceStore,
+            'test'
+        )
+    );
+    const modePromise = Promise.resolve('leaf');
+
+    formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
+    resourceStore.data = {
+        '/title': 'title-value',
+        '/subtitle': 'subtitle-value',
+    };
+
+    const resourceLocator = shallow(
+        <ResourceLocator
+            {...fieldTypeDefaultProps}
+            dataPath="/block/0/url"
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+                modeResolver: () => modePromise,
+            }}
+            formInspector={formInspector}
+            schemaPath="/url"
+        />
+    );
+
+    return modePromise.then(() => {
+        resourceLocator.update();
+        expect(resourceLocator.find('Button').props().disabled).toBeTruthy();
+
+        resourceStore.data['/title'] = 'new-title-value';
+
+        expect(resourceLocator.find('Button').props().disabled).toBeTruthy();
+    });
+});
+
+test('Should enable refresh button when input is changed manually on add form', () => {
+    const resourceStore = new ResourceStore('tests', undefined);
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            resourceStore,
+            'test'
+        )
+    );
+    const modePromise = Promise.resolve('leaf');
+
+    formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
+    resourceStore.data = {
+        '/title': 'title-value',
+        '/subtitle': 'subtitle-value',
+    };
+
+    const resourceLocator = shallow(
+        <ResourceLocator
+            {...fieldTypeDefaultProps}
+            dataPath="/block/0/url"
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+                modeResolver: () => modePromise,
+            }}
+            formInspector={formInspector}
+            schemaPath="/url"
+        />
+    );
+
+    return modePromise.then(() => {
+        resourceLocator.update();
+        expect(resourceLocator.find('Button').props().disabled).toBeTruthy();
+
+        resourceLocator.find(ResourceLocatorComponent).props().onChange('manual-change');
+
+        expect(resourceLocator.find('Button').props().disabled).toBeFalsy();
+    });
+});
+
+test('Should not enable refresh button when value of part field changes if all parts are empty', () => {
+    const resourceStore = new ResourceStore('tests', 5);
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            resourceStore,
+            'test'
+        )
+    );
+    const modePromise = Promise.resolve('leaf');
+
+    formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
+    resourceStore.data = {
+        '/title': 'title-value',
+        '/subtitle': 'subtitle-value',
+    };
+
+    const resourceLocator = shallow(
+        <ResourceLocator
+            {...fieldTypeDefaultProps}
+            dataPath="/block/0/url"
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+                modeResolver: () => modePromise,
+            }}
+            formInspector={formInspector}
+            schemaPath="/url"
+        />
+    );
+
+    return modePromise.then(() => {
+        resourceLocator.update();
+        expect(resourceLocator.find('Button').props().disabled).toBeTruthy();
+
+        resourceStore.data['/title'] = '';
+        resourceStore.data['/subtitle'] = undefined;
+
+        expect(resourceLocator.find('Button').props().disabled).toBeTruthy();
+
+        resourceLocator.find(ResourceLocatorComponent).props().onChange('manual-change');
+
+        expect(resourceLocator.find('Button').props().disabled).toBeTruthy();
+    });
+});
+
+test('Should request new URL with correct options and disable button when refresh button is clicked', () => {
+    const resourceStore = new ResourceStore('test', 5);
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            resourceStore,
             'test',
             {webspace: 'example'}
         )
@@ -616,6 +787,13 @@ test('Should request a new URL with the FormInspector options included if refres
     const changeSpy = jest.fn();
     const modePromise = Promise.resolve('leaf');
 
+    formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
+    resourceStore.data = {
+        '/title': 'title-value',
+        '/subtitle': 'subtitle-value',
+        '/propertyName': 'property-value',
+    };
+
     const resourceLocator = shallow(
         <ResourceLocator
             {...fieldTypeDefaultProps}
@@ -624,18 +802,15 @@ test('Should request a new URL with the FormInspector options included if refres
                 generationUrl: '/admin/api/resourcelocators?action=generate',
                 historyResourceKey: 'page_resourcelocators',
                 modeResolver: () => modePromise,
+                resourceStorePropertiesToRequest: {
+                    requestParamKey: 'propertyName',
+                },
             }}
             formInspector={formInspector}
             onChange={changeSpy}
             schemaPath="/url"
         />
     );
-    resourceLocator.instance().enableRefreshButton = true;
-
-    formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
-    formInspector.getValueByPath.mockReturnValueOnce('title-value');
-    formInspector.getValueByPath.mockReturnValueOnce('subtitle-value');
-
     const resourceLocatorPromise = Promise.resolve({
         resourcelocator: '/test',
     });
@@ -643,13 +818,14 @@ test('Should request a new URL with the FormInspector options included if refres
 
     return modePromise.then(() => {
         resourceLocator.update();
+
+        resourceLocator.find(ResourceLocatorComponent).props().onChange('manual-change');
         expect(resourceLocator.find('Button').props().disabled).toBeFalsy();
 
         resourceLocator.find('Button').props().onClick();
 
+        expect(resourceLocator.find('Button').props().disabled).toBeTruthy();
         expect(formInspector.getPathsByTag).toBeCalledWith('sulu.rlp.part');
-        expect(formInspector.getValueByPath).toBeCalledWith('/title');
-        expect(formInspector.getValueByPath).toBeCalledWith('/subtitle');
         expect(Requester.post).toBeCalledWith(
             '/admin/api/resourcelocators?action=generate',
             {
@@ -657,12 +833,12 @@ test('Should request a new URL with the FormInspector options included if refres
                 parts: {title: 'title-value', subtitle: 'subtitle-value'},
                 resourceKey: 'test',
                 webspace: 'example',
+                requestParamKey: 'property-value',
             }
         );
 
         return resourceLocatorPromise.then(() => {
             expect(changeSpy).toBeCalledWith('/test');
-            expect(resourceLocator.find('Button').props().disabled).toBeTruthy();
         });
     });
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
@@ -72,6 +72,9 @@ test('Pass props correctly to ResourceLocator', () => {
         expect(resourceLocator.find(ResourceLocatorComponent).prop('value')).toBe('/url');
         expect(resourceLocator.find(ResourceLocatorComponent).prop('mode')).toBe('full');
         expect(resourceLocator.find(ResourceLocatorComponent).prop('disabled')).toBe(true);
+
+        // should not throw any error on unmount
+        resourceLocator.unmount();
     });
 });
 
@@ -98,6 +101,9 @@ test('Render just slash instead of ResourceLocatorComponent if used on the homep
         resourceLocator.update();
         expect(resourceLocator.find(ResourceLocatorComponent)).toHaveLength(0);
         expect(resourceLocator.text()).toEqual('/');
+
+        // should not throw any error on unmount
+        resourceLocator.unmount();
     });
 });
 
@@ -803,7 +809,7 @@ test('Should request new URL with correct options and disable button when refres
                 historyResourceKey: 'page_resourcelocators',
                 modeResolver: () => modePromise,
                 resourceStorePropertiesToRequest: {
-                    requestParamKey: 'propertyName',
+                    propertyName: 'requestParamKey',
                 },
             }}
             formInspector={formInspector}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
@@ -96,28 +96,6 @@ test('Render just slash instead of ResourceLocatorComponent if used on the homep
     });
 });
 
-test('Disable ResourceLocatorHistory if new entity is created', () => {
-    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
-    const modePromise = Promise.resolve('leaf');
-
-    const resourceLocator = mount(
-        <ResourceLocator
-            {...fieldTypeDefaultProps}
-            fieldTypeOptions={{
-                generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'page_resourcelocators',
-                modeResolver: () => modePromise,
-            }}
-            formInspector={formInspector}
-        />
-    );
-
-    return modePromise.then(() => {
-        resourceLocator.update();
-        expect(resourceLocator.find('ResourceLocatorHistory').props().disabled).toBeTruthy();
-    });
-});
-
 test('Pass correct options to ResourceLocatorHistory if entity already existed', () => {
     const formInspector = new FormInspector(
         new ResourceFormStore(new ResourceStore('test', 1), 'test', {webspace: 'sulu'})

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/ResourceLocatorHistory.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/ResourceLocatorHistory.js
@@ -12,18 +12,13 @@ import ResourceListStore from '../../stores/ResourceListStore';
 import resourceLocatorHistoryStyles from './resourceLocatorHistory.scss';
 
 type Props = {|
-    disabled: boolean,
-    id: string | number,
+    id: ?string | number,
     options: Object,
     resourceKey: string,
 |};
 
 @observer
 class ResourceLocatorHistory extends React.Component<Props> {
-    static defaultProps = {
-        disabled: false,
-    };
-
     resourceListStore: ?ResourceListStore;
     @observable open = false;
     @observable showDeleteWarning = false;
@@ -72,13 +67,13 @@ class ResourceLocatorHistory extends React.Component<Props> {
 
     render() {
         const {resourceListStore, props} = this;
-        const {disabled} = props;
+        const {id} = props;
 
         const historyRoutes = resourceListStore ? resourceListStore.data : [];
 
         return (
             <Fragment>
-                <Button disabled={disabled} icon="su-process" onClick={this.handleButtonClick} skin="link">
+                <Button disabled={!id} icon="su-process" onClick={this.handleButtonClick} skin="link">
                     {translate('sulu_admin.show_history')}
                 </Button>
                 <Overlay

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/ResourceLocatorHistory.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/ResourceLocatorHistory.js
@@ -12,6 +12,7 @@ import ResourceListStore from '../../stores/ResourceListStore';
 import resourceLocatorHistoryStyles from './resourceLocatorHistory.scss';
 
 type Props = {|
+    disabled: boolean,
     id: string | number,
     options: Object,
     resourceKey: string,
@@ -19,6 +20,10 @@ type Props = {|
 
 @observer
 class ResourceLocatorHistory extends React.Component<Props> {
+    static defaultProps = {
+        disabled: false,
+    };
+
     resourceListStore: ?ResourceListStore;
     @observable open = false;
     @observable showDeleteWarning = false;
@@ -66,13 +71,14 @@ class ResourceLocatorHistory extends React.Component<Props> {
     };
 
     render() {
-        const {resourceListStore} = this;
+        const {resourceListStore, props} = this;
+        const {disabled} = props;
 
         const historyRoutes = resourceListStore ? resourceListStore.data : [];
 
         return (
             <Fragment>
-                <Button icon="su-process" onClick={this.handleButtonClick} skin="link">
+                <Button disabled={disabled} icon="su-process" onClick={this.handleButtonClick} skin="link">
                     {translate('sulu_admin.show_history')}
                 </Button>
                 <Overlay

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/tests/ResourceLocatorHistory.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/tests/ResourceLocatorHistory.test.js
@@ -35,7 +35,6 @@ test('Pass props correctly to ResourceListStore', () => {
 test('Pass correct props to Button', () => {
     const resourceLocatorHistory = shallow(
         <ResourceLocatorHistory
-            disabled={true}
             id={5}
             options={{webspace: 'sulu'}}
             resourceKey="history_routes"
@@ -43,9 +42,23 @@ test('Pass correct props to Button', () => {
     );
 
     expect(resourceLocatorHistory.find('Button[icon="su-process"]').props()).toEqual(expect.objectContaining({
-        disabled: true,
+        disabled: false,
         icon: 'su-process',
         skin: 'link',
+    }));
+});
+
+test('Disable button if id is not set', () => {
+    const resourceLocatorHistory = shallow(
+        <ResourceLocatorHistory
+            id={undefined}
+            options={{webspace: 'sulu'}}
+            resourceKey="history_routes"
+        />
+    );
+
+    expect(resourceLocatorHistory.find('Button[icon="su-process"]').props()).toEqual(expect.objectContaining({
+        disabled: true,
     }));
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/tests/ResourceLocatorHistory.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/tests/ResourceLocatorHistory.test.js
@@ -32,6 +32,23 @@ test('Pass props correctly to ResourceListStore', () => {
     expect(ResourceListStore).toBeCalledWith('history_routes', {id: 5, webspace: 'sulu'});
 });
 
+test('Pass correct props to Button', () => {
+    const resourceLocatorHistory = shallow(
+        <ResourceLocatorHistory
+            disabled={true}
+            id={5}
+            options={{webspace: 'sulu'}}
+            resourceKey="history_routes"
+        />
+    );
+
+    expect(resourceLocatorHistory.find('Button[icon="su-process"]').props()).toEqual(expect.objectContaining({
+        disabled: true,
+        icon: 'su-process',
+        skin: 'link',
+    }));
+});
+
 test('Show history routes in overlay', () => {
     const resourceLocatorHistory = mount(
         <ResourceLocatorHistory

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -148,6 +148,7 @@
     "sulu_admin.form_contains_invalid_values": "Das Formular beinhaltet ungültige Werte",
     "sulu_admin.form_save_server_error": "Beim Speichern des Formulars ist ein Fehler aufgetreten",
     "sulu_admin.form_used_by": "Dieses Formular wird momentan benutzt von",
+    "sulu_admin.refresh_url": "URL neu generieren",
     "sulu_admin.from": "ab",
     "sulu_admin.until": "bis",
     "sulu_admin.block_settings": "Block Einstellungen",

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -148,6 +148,7 @@
     "sulu_admin.form_contains_invalid_values": "The form contains invalid values",
     "sulu_admin.form_save_server_error": "There was an error when trying to save the form",
     "sulu_admin.form_used_by": "This form is currently used by",
+    "sulu_admin.refresh_url": "Refresh URL",
     "sulu_admin.from": "from",
     "sulu_admin.until": "until",
     "sulu_admin.block_settings": "Block settings",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4221, fixes #5547
| Related issues/PRs | #5340
| License | MIT

#### What's in this PR?

This PR adds a *Refresh URL* button to the `ResourceLocator` field-type. The button allows to regenerate the URL based on the current values of the Form.

![Screenshot 2020-10-14 at 12 09 57](https://user-images.githubusercontent.com/13310795/95975245-323f2300-0e16-11eb-8bfb-4a5ffc98d55b.png)

#### Why?

Because it is frequently requested feature 🙂 
See #4221 and #5340.
