### PR TITLE
Remove jsx-indent-props rule because indent rule covers it already

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -174,9 +174,14 @@
             }
         ],
         "react/jsx-key": "error",
-        "react/jsx-indent": "error",
+        "react/jsx-indent": [
+            "error",
+            4,
+            {
+                "indentLogicalExpressions": true
+            }
+        ],
         "react/jsx-no-bind": "error",
-        "react/jsx-indent-props": "error",
         "react/jsx-equals-spacing": "error",
         "react/jsx-handler-names": "error",
         "react/jsx-first-prop-new-line": [

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/Application.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/Application.js
@@ -197,7 +197,7 @@ class Application extends React.Component<Props>{
                                     </header>
                                     <div className={applicationStyles.viewContainer}>
                                         {router.route &&
-                                        <ViewRenderer router={router} />
+                                            <ViewRenderer router={router} />
                                         }
                                     </div>
                                 </main>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/SmartContentItem.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/SmartContentItem.js
@@ -27,8 +27,7 @@ export default class SmartContentItem extends React.Component<Props> {
                     </div>
                 }
                 <div className={smartContentItemStyles.title}>
-                    {(publishedState !== undefined || published !== undefined)
-                        && !(publishedState && published) &&
+                    {(publishedState !== undefined || published !== undefined) && !(publishedState && published) &&
                         <div className={smartContentItemStyles.publishIndicator}>
                             <PublishIndicator
                                 draft={!publishedState}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

It seems like there was a change in the `jsx-indent-props` rule. I would argue that we don't want that change, and even if I apply that change, `eslint` still fails, because it seems that the standard `indent` rule of eslint already checks JSX by itself. So I decided to remove two of the react rules from eslint, because invalid formatted JSX still fails.