### PR TITLE
Display error bar when media upload fails in MediaOverview

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -21,7 +21,7 @@ type Props = {|
     mediaListStore: ListStore,
     onCollectionNavigate: (collectionId: ?string | number) => void,
     onMediaNavigate?: (mediaId: string | number) => void,
-    onUploadError?: (errorResponse: string) => void,
+    onUploadError?: (errorResponses: Array<string>) => void,
     onUploadOverlayClose: () => void,
     onUploadOverlayOpen: () => void,
     overlayType: OverlayType,
@@ -63,11 +63,11 @@ class MediaCollection extends React.Component<Props> {
         );
     };
 
-    @action handleUploadError = (errorResponse: string) => {
+    @action handleUploadError = (errorResponses: Array<string>) => {
         const {mediaListStore, onUploadError} = this.props;
 
         if (onUploadError) {
-            onUploadError(errorResponse);
+            onUploadError(errorResponses);
         }
 
         mediaListStore.reset();

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -21,6 +21,7 @@ type Props = {|
     mediaListStore: ListStore,
     onCollectionNavigate: (collectionId: ?string | number) => void,
     onMediaNavigate?: (mediaId: string | number) => void,
+    onUploadError: (error: any) => void,
     onUploadOverlayClose: () => void,
     onUploadOverlayOpen: () => void,
     overlayType: OverlayType,
@@ -62,6 +63,15 @@ class MediaCollection extends React.Component<Props> {
         );
     };
 
+    @action handleUploadError = (error: any) => {
+        const {mediaListStore, onUploadError} = this.props;
+
+        onUploadError(error);
+
+        mediaListStore.reset();
+        mediaListStore.reload();
+    };
+
     render() {
         const {
             collectionListStore,
@@ -92,6 +102,7 @@ class MediaCollection extends React.Component<Props> {
                 onClose={onUploadOverlayClose}
                 onOpen={onUploadOverlayOpen}
                 onUpload={this.handleUpload}
+                onUploadError={this.handleUploadError}
                 open={uploadOverlayOpen}
             >
                 <CollectionSection

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -21,7 +21,7 @@ type Props = {|
     mediaListStore: ListStore,
     onCollectionNavigate: (collectionId: ?string | number) => void,
     onMediaNavigate?: (mediaId: string | number) => void,
-    onUploadError: (error: any) => void,
+    onUploadError?: (error: any) => void,
     onUploadOverlayClose: () => void,
     onUploadOverlayOpen: () => void,
     overlayType: OverlayType,
@@ -66,7 +66,9 @@ class MediaCollection extends React.Component<Props> {
     @action handleUploadError = (error: any) => {
         const {mediaListStore, onUploadError} = this.props;
 
-        onUploadError(error);
+        if (onUploadError) {
+            onUploadError(error);
+        }
 
         mediaListStore.reset();
         mediaListStore.reload();

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -21,7 +21,7 @@ type Props = {|
     mediaListStore: ListStore,
     onCollectionNavigate: (collectionId: ?string | number) => void,
     onMediaNavigate?: (mediaId: string | number) => void,
-    onUploadError?: (error: any) => void,
+    onUploadError?: (errorResponse: string) => void,
     onUploadOverlayClose: () => void,
     onUploadOverlayOpen: () => void,
     overlayType: OverlayType,
@@ -63,11 +63,11 @@ class MediaCollection extends React.Component<Props> {
         );
     };
 
-    @action handleUploadError = (error: any) => {
+    @action handleUploadError = (errorResponse: string) => {
         const {mediaListStore, onUploadError} = this.props;
 
         if (onUploadError) {
-            onUploadError(error);
+            onUploadError(errorResponse);
         }
 
         mediaListStore.reset();

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {mount, render} from 'enzyme';
+import {mount, render, shallow} from 'enzyme';
 import {extendObservable as mockExtendObservable, observable} from 'mobx';
 import {RequestPromise} from 'sulu-admin-bundle/services/ResourceRequester';
 import MediaCardOverviewAdapter from '../../List/adapters/MediaCardOverviewAdapter';
@@ -79,6 +79,8 @@ jest.mock('sulu-admin-bundle/containers', () => {
             this.limit = {
                 get: jest.fn().mockReturnValue(10),
             };
+            this.reset = jest.fn();
+            this.reload = jest.fn();
             this.setLimit = jest.fn();
             this.data = (resourceKey === COLLECTIONS_RESOURCE_KEY)
                 ? collectionData
@@ -569,6 +571,57 @@ test('Render the MediaCollection without security buttons when permission is mis
     expect(mediaCollection.find('Action').find({children: 'sulu_admin.edit'})).toHaveLength(1);
     expect(mediaCollection.find('Action').find({children: 'sulu_admin.move'})).toHaveLength(1);
     expect(mediaCollection.find('Action').find({children: 'sulu_security.permissions'})).toHaveLength(0);
+});
+
+test('Reload medias and fire onUploadError callback if an error happens while uploading a file', () => {
+    const page = observable.box();
+    const locale = observable.box();
+    const onUploadErrorSpy = jest.fn();
+    const ListStore = require('sulu-admin-bundle/containers').ListStore;
+
+    const mediaListStore = new ListStore(
+        MEDIA_RESOURCE_KEY,
+        SETTINGS_KEY,
+        USER_SETTINGS_KEY,
+        {
+            page,
+            locale,
+        }
+    );
+    const collectionListStore = new ListStore(
+        COLLECTIONS_RESOURCE_KEY,
+        SETTINGS_KEY,
+        USER_SETTINGS_KEY,
+        {
+            page,
+            locale,
+        }
+    );
+    const CollectionStore = require('../../../stores/CollectionStore').default;
+    const collectionStore = new CollectionStore(1, locale);
+
+    const mediaCollection = shallow(
+        <MediaCollection
+            collectionListStore={collectionListStore}
+            collectionStore={collectionStore}
+            locale={locale}
+            mediaListAdapters={['media_card_overview']}
+            mediaListStore={mediaListStore}
+            onCollectionNavigate={jest.fn()}
+            onUploadError={onUploadErrorSpy}
+            onUploadOverlayClose={jest.fn()}
+            onUploadOverlayOpen={jest.fn()}
+            uploadOverlayOpen={false}
+        />
+    );
+
+    expect(onUploadErrorSpy).not.toBeCalled();
+
+    mediaCollection.find('MultiMediaDropzone').props().onUploadError('wrong-file-extension-error');
+
+    expect(onUploadErrorSpy).toBeCalledWith('wrong-file-extension-error');
+    expect(mediaListStore.reset).toBeCalled();
+    expect(mediaListStore.reload).toBeCalled();
 });
 
 test('Render the MediaCollection for all media', () => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
@@ -617,9 +617,9 @@ test('Reload medias and fire onUploadError callback if an error happens while up
 
     expect(onUploadErrorSpy).not.toBeCalled();
 
-    mediaCollection.find('MultiMediaDropzone').props().onUploadError('wrong-file-extension-error');
+    mediaCollection.find('MultiMediaDropzone').props().onUploadError(['wrong-file-extension-error']);
 
-    expect(onUploadErrorSpy).toBeCalledWith('wrong-file-extension-error');
+    expect(onUploadErrorSpy).toBeCalledWith(['wrong-file-extension-error']);
     expect(mediaListStore.reset).toBeCalled();
     expect(mediaListStore.reload).toBeCalled();
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
@@ -17,6 +17,7 @@ type Props = {
     onClose: () => void,
     onOpen: () => void,
     onUpload: (media: Array<Object>) => void,
+    onUploadError: (error: any) => void,
     open: boolean,
 };
 
@@ -64,6 +65,9 @@ class MultiMediaDropzone extends React.Component<Props> {
         const {
             locale,
             collectionId,
+            onClose,
+            onUpload,
+            onUploadError,
         } = this.props;
         const uploadPromises = [];
 
@@ -80,11 +84,17 @@ class MultiMediaDropzone extends React.Component<Props> {
         });
 
         return Promise.all(uploadPromises).then((...media) => {
-            this.props.onUpload(...media);
+            onUpload(...media);
 
             setTimeout(() => {
-                this.props.onClose();
+                onClose();
                 this.destroyMediaUploadStores();
+            }, 1000);
+        }).catch((e) => {
+            setTimeout(() => {
+                onClose();
+                this.destroyMediaUploadStores();
+                onUploadError(e);
             }, 1000);
         });
     };

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
@@ -17,7 +17,7 @@ type Props = {
     onClose: () => void,
     onOpen: () => void,
     onUpload: (media: Array<Object>) => void,
-    onUploadError: (error: any) => void,
+    onUploadError: (errorResponse: string) => void,
     open: boolean,
 };
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/tests/MultiMediaDropzone.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/tests/MultiMediaDropzone.test.js
@@ -181,7 +181,7 @@ test('Should fire onClose and onUploadError callback if an error happens when up
 
         expect(closeSpy).toBeCalledWith();
         expect(multiMediaDropzone.instance().mediaUploadStores.length).toBe(0);
-        expect(uploadErrorSpy).toBeCalledWith('error-while-uploading-file');
+        expect(uploadErrorSpy).toBeCalledWith(['error-while-uploading-file']);
     });
 });
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/MediaUploadStore.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/MediaUploadStore.js
@@ -173,7 +173,13 @@ export default class MediaUploadStore {
 
             xhr.open('POST', url);
 
-            xhr.onload = (event: any) => resolve(JSON.parse(event.target.response));
+            xhr.onload = (event: any) => {
+                if (event.target.status >= 200 && event.target.status <= 299) {
+                    resolve(JSON.parse(event.target.response));
+                } else {
+                    reject(event.target.response);
+                }
+            };
             xhr.onerror = (event: any) => reject(event.target.response);
 
             if (xhr.upload) {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/tests/MediaUploadStore.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/tests/MediaUploadStore.test.js
@@ -51,6 +51,78 @@ test('Calling the "update" method should make a "POST" request to the media upda
     expect(openSpy).toBeCalledWith('POST', '/media/1?action=new-version&locale=en');
 });
 
+test('Promise returned by "update" method should be resolved if request is successful', () => {
+    resourceRouteRegistry.getDetailUrl.mockReturnValue('/media/1?action=new-version&locale=en');
+
+    window.XMLHttpRequest = jest.fn(function() {
+        this.open = jest.fn();
+        this.onload = jest.fn();
+        this.onerror = jest.fn();
+        this.upload = jest.fn();
+        this.send = jest.fn();
+    });
+
+    const mediaUploadStore = new MediaUploadStore(
+        {id: 1, locale: 'en', mimeType: 'image/jpeg', title: 'test', thumbnails: {}, url: ''},
+        observable.box('en')
+    );
+    const fileData = new File([''], 'fileName');
+
+    const updatePromise = mediaUploadStore.update(fileData);
+
+    window.XMLHttpRequest.mock.instances[0].onload({target: {status: 200, response: '{"title": "test1"}'}});
+
+    return expect(updatePromise).resolves.toEqual({title: 'test1'});
+});
+
+test('Promise returned by "update" method should be rejected if request has error status', () => {
+    resourceRouteRegistry.getDetailUrl.mockReturnValue('/media/1?action=new-version&locale=en');
+
+    window.XMLHttpRequest = jest.fn(function() {
+        this.open = jest.fn();
+        this.onload = jest.fn();
+        this.onerror = jest.fn();
+        this.upload = jest.fn();
+        this.send = jest.fn();
+    });
+
+    const mediaUploadStore = new MediaUploadStore(
+        {id: 1, locale: 'en', mimeType: 'image/jpeg', title: 'test', thumbnails: {}, url: ''},
+        observable.box('en')
+    );
+    const fileData = new File([''], 'fileName');
+
+    const updatePromise = mediaUploadStore.update(fileData);
+
+    window.XMLHttpRequest.mock.instances[0].onload({target: {status: 400, response: 'invalid-format'}});
+
+    return expect(updatePromise).rejects.toEqual('invalid-format');
+});
+
+test('Promise returned by "update" method should be resolved if request is not successful', () => {
+    resourceRouteRegistry.getDetailUrl.mockReturnValue('/media/1?action=new-version&locale=en');
+
+    window.XMLHttpRequest = jest.fn(function() {
+        this.open = jest.fn();
+        this.onload = jest.fn();
+        this.onerror = jest.fn();
+        this.upload = jest.fn();
+        this.send = jest.fn();
+    });
+
+    const mediaUploadStore = new MediaUploadStore(
+        {id: 1, locale: 'en', mimeType: 'image/jpeg', title: 'test', thumbnails: {}, url: ''},
+        observable.box('en')
+    );
+    const fileData = new File([''], 'fileName');
+
+    const updatePromise = mediaUploadStore.update(fileData);
+
+    window.XMLHttpRequest.mock.instances[0].onerror({target: {response: 'network-error'}});
+
+    return expect(updatePromise).rejects.toEqual('network-error');
+});
+
 test('Calling the "create" method should make a "POST" request to the media update api', () => {
     resourceRouteRegistry.getDetailUrl.mockReturnValue('/media?locale=en&collection=1');
 
@@ -75,7 +147,7 @@ test('Calling the "create" method should make a "POST" request to the media upda
     expect(resourceRouteRegistry.getDetailUrl).toBeCalledWith('media', {collection: 1, locale: 'en'});
     expect(openSpy).toBeCalledWith('POST', '/media?locale=en&collection=1');
 
-    window.XMLHttpRequest.mock.instances[0].onload({target: {response: '{"title": "test1"}'}});
+    window.XMLHttpRequest.mock.instances[0].onload({target: {status: 200, response: '{"title": "test1"}'}});
 
     return createPromise.then(() => {
         expect(mediaUploadStore.media).toEqual({title: 'test1'});
@@ -177,7 +249,7 @@ test('After the "update" call request was successful the progress will be reset'
         }
     );
 
-    window.XMLHttpRequest.mock.instances[0].onload({target: {response: '{"title": "test1"}'}});
+    window.XMLHttpRequest.mock.instances[0].onload({target: {status: 200, response: '{"title": "test1"}'}});
 });
 
 test('After the "updatePreviewImage" call request was successful the progress will be reset', (done) => {
@@ -218,11 +290,7 @@ test('After the "updatePreviewImage" call request was successful the progress wi
     const response =
         '{"id": 1, "mimeType": "image/jpeg", "title": "test", "thumbnails": {"50x50": "image.jpg"}, "url": ""}';
 
-    window.XMLHttpRequest.mock.instances[0].onload({
-        target: {
-            response,
-        },
-    });
+    window.XMLHttpRequest.mock.instances[0].onload({target: {status: 200, response}});
 });
 
 test('Should return thumbnail path if available', () => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/tests/MediaUploadStore.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/tests/MediaUploadStore.test.js
@@ -99,7 +99,7 @@ test('Promise returned by "update" method should be rejected if request has erro
     return expect(updatePromise).rejects.toEqual('invalid-format');
 });
 
-test('Promise returned by "update" method should be resolved if request is not successful', () => {
+test('Promise returned by "update" method should be rejected if request is not successful', () => {
     resourceRouteRegistry.getDetailUrl.mockReturnValue('/media/1?action=new-version&locale=en');
 
     window.XMLHttpRequest = jest.fn(function() {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -145,7 +145,7 @@ class MediaOverview extends React.Component<ViewProps> {
     };
 
     @action handleUploadError= () => {
-        this.errors.push(translate('sulu_admin.upload_server_error'));
+        this.errors.push(translate('sulu_media.upload_server_error'));
     };
 
     @action handleUploadOverlayOpen = () => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -24,6 +24,7 @@ class MediaOverview extends React.Component<ViewProps> {
     mediaPage: IObservableValue<number> = observable.box();
     locale: IObservableValue<string> = observable.box();
     collectionId: IObservableValue<?number | string> = observable.box();
+    @observable errors: Array<string> = [];
     @observable mediaListStore: ListStore;
     @observable collectionListStore: ListStore;
     @observable collectionStore: CollectionStore;
@@ -143,6 +144,10 @@ class MediaOverview extends React.Component<ViewProps> {
         this.collectionId.set(collectionId);
     };
 
+    @action handleUploadError= () => {
+        this.errors.push(translate('sulu_admin.upload_server_error'));
+    };
+
     @action handleUploadOverlayOpen = () => {
         this.showMediaUploadOverlay = true;
     };
@@ -192,6 +197,7 @@ class MediaOverview extends React.Component<ViewProps> {
                     mediaListStore={this.mediaListStore}
                     onCollectionNavigate={this.handleCollectionNavigate}
                     onMediaNavigate={this.handleMediaNavigate}
+                    onUploadError={this.handleUploadError}
                     onUploadOverlayClose={this.handleUploadOverlayClose}
                     onUploadOverlayOpen={this.handleUploadOverlayOpen}
                     uploadOverlayOpen={this.showMediaUploadOverlay}
@@ -215,6 +221,7 @@ class MediaOverview extends React.Component<ViewProps> {
 }
 
 export default withToolbar(MediaOverview, function() {
+    const errors = this.errors;
     const router = this.props.router;
     const loading = this.collectionListStore.loading || this.mediaListStore.loading;
 
@@ -312,5 +319,6 @@ export default withToolbar(MediaOverview, function() {
             }
             : undefined,
         items,
+        errors,
     };
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -715,7 +715,7 @@ test('Should show error if upload via MediaCollection fails', () => {
 
     expect(toolbarFunction.call(mediaOverview.instance()).errors).toEqual([]);
 
-    mediaOverview.find('MediaCollection').props().onUploadError('invalid-file');
+    mediaOverview.find('MediaCollection').props().onUploadError(['invalid-file']);
 
     expect(toolbarFunction.call(mediaOverview.instance()).errors).toEqual(['sulu_media.upload_server_error']);
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -717,5 +717,5 @@ test('Should show error if upload via MediaCollection fails', () => {
 
     mediaOverview.find('MediaCollection').props().onUploadError('invalid-file');
 
-    expect(toolbarFunction.call(mediaOverview.instance()).errors).toEqual(['sulu_admin.upload_server_error']);
+    expect(toolbarFunction.call(mediaOverview.instance()).errors).toEqual(['sulu_media.upload_server_error']);
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -686,3 +686,36 @@ test('Media should be moved when overlay is confirmed', () => {
         expect(mediaOverview.find(SingleListOverlay).at(1).prop('confirmLoading')).toEqual(false);
     });
 });
+
+test('Should show error if upload via MediaCollection fails', () => {
+    const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
+    const MediaOverview = require('../MediaOverview').default;
+    const toolbarFunction = findWithHighOrderFunction(withToolbar, MediaOverview);
+
+    const router = {
+        restore: jest.fn(),
+        bind: jest.fn(),
+        route: {
+            options: {
+                locales: ['de'],
+                permissions: {
+                    add: true,
+                    delete: true,
+                    edit: true,
+                },
+            },
+        },
+        attributes: {
+            id: 4,
+        },
+    };
+    const mediaOverview = mount(<MediaOverview router={router} />);
+    mediaOverview.instance().collectionId.set(4);
+    mediaOverview.instance().locale.set('de');
+
+    expect(toolbarFunction.call(mediaOverview.instance()).errors).toEqual([]);
+
+    mediaOverview.find('MediaCollection').props().onUploadError('invalid-file');
+
+    expect(toolbarFunction.call(mediaOverview.instance()).errors).toEqual(['sulu_admin.upload_server_error']);
+});

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
@@ -43,6 +43,7 @@
     "sulu_media.formats": "Formate",
     "sulu_media.all_collections": "Alle Kollektionen",
     "sulu_media.move_media": "Medien verschieben",
+    "sulu_admin.upload_server_error": "Beim Upload einer Datei ist ein Fehler aufgetreten.",
     "sulu_media.set_focus_point": "Fokuspunkt setzen",
     "sulu_media.define_crops": "Ausschnitte festlegen",
     "sulu_media.upload_preview_image": "Vorschaubild hochladen",

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
@@ -43,7 +43,7 @@
     "sulu_media.formats": "Formate",
     "sulu_media.all_collections": "Alle Kollektionen",
     "sulu_media.move_media": "Medien verschieben",
-    "sulu_admin.upload_server_error": "Beim Upload einer Datei ist ein Fehler aufgetreten.",
+    "sulu_media.upload_server_error": "Beim Upload einer oder mehrerer Dateien ist ein Fehler aufgetreten.",
     "sulu_media.set_focus_point": "Fokuspunkt setzen",
     "sulu_media.define_crops": "Ausschnitte festlegen",
     "sulu_media.upload_preview_image": "Vorschaubild hochladen",

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
@@ -43,7 +43,7 @@
     "sulu_media.formats": "Formats",
     "sulu_media.all_collections": "All collections",
     "sulu_media.move_media": "Move media",
-    "sulu_media.upload_server_error": "There was an error while uploading one or multiple file to the server.",
+    "sulu_media.upload_server_error": "There was an error while uploading one or multiple files to the server.",
     "sulu_media.set_focus_point": "Set focus point",
     "sulu_media.define_crops": "Define crops",
     "sulu_media.upload_preview_image": "Upload preview image",

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
@@ -43,6 +43,7 @@
     "sulu_media.formats": "Formats",
     "sulu_media.all_collections": "All collections",
     "sulu_media.move_media": "Move media",
+    "sulu_admin.upload_server_error": "There was an error when uploading a file to the server.",
     "sulu_media.set_focus_point": "Set focus point",
     "sulu_media.define_crops": "Define crops",
     "sulu_media.upload_preview_image": "Upload preview image",

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
@@ -43,7 +43,7 @@
     "sulu_media.formats": "Formats",
     "sulu_media.all_collections": "All collections",
     "sulu_media.move_media": "Move media",
-    "sulu_admin.upload_server_error": "There was an error when uploading a file to the server.",
+    "sulu_media.upload_server_error": "There was an error while uploading one or multiple file to the server.",
     "sulu_media.set_focus_point": "Set focus point",
     "sulu_media.define_crops": "Define crops",
     "sulu_media.upload_preview_image": "Upload preview image",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5540
| License | MIT

#### What's in this PR?

This PR adjusts the `MediaOverview` view to display an error bar when the upload of a file fails. To do this, the `MediaUploadStore`, `MultiMediaDropzone` and `MediaCollection` were adjusted to support the handling of upload errors.

#### Why?

Because there is no feedback to the user if an error happens at the moment. See #5540.