### PR TITLE
Lazy loaded Twig extensions

### DIFF
--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/services.xml
@@ -42,12 +42,16 @@
         </service>
 
         <service id="sulu_category.twig_extension" class="Sulu\Bundle\CategoryBundle\Twig\CategoryTwigExtension">
+            <tag name="twig.extension"/>
+        </service>
+
+        <service id="sulu_category.twig_runtime" class="Sulu\Bundle\CategoryBundle\Twig\CategoryRuntime">
             <argument type="service" id="sulu_category.category_manager"/>
             <argument type="service" id="sulu_category.category_request_handler"/>
             <argument type="service" id="sulu_core.array_serializer"/>
             <argument type="service" id="sulu_core.cache.memoize"/>
 
-            <tag name="twig.extension"/>
+            <tag name="twig.runtime"/>
         </service>
 
         <service id="sulu_category.keyword_manager"

--- a/src/Sulu/Bundle/CategoryBundle/Twig/CategoryRuntime.php
+++ b/src/Sulu/Bundle/CategoryBundle/Twig/CategoryRuntime.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CategoryBundle\Twig;
+
+use JMS\Serializer\SerializationContext;
+use Sulu\Bundle\CategoryBundle\Category\CategoryManagerInterface;
+use Sulu\Component\Cache\MemoizeInterface;
+use Sulu\Component\Category\Request\CategoryRequestHandlerInterface;
+use Sulu\Component\Serializer\ArraySerializerInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\Extension\RuntimeExtensionInterface;
+use Twig\TwigFunction;
+
+/**
+ * Provides functionality to handle categories in twig templates.
+ */
+class CategoryRuntime implements RuntimeExtensionInterface
+{
+    /**
+     * @var CategoryManagerInterface
+     */
+    private $categoryManager;
+
+    /**
+     * @var CategoryRequestHandlerInterface
+     */
+    private $categoryRequestHandler;
+
+    /**
+     * @var ArraySerializerInterface
+     */
+    private $serializer;
+
+    /**
+     * @var MemoizeInterface
+     */
+    private $memoizeCache;
+
+    public function __construct(
+        CategoryManagerInterface $categoryManager,
+        CategoryRequestHandlerInterface $categoryRequestHandler,
+        ArraySerializerInterface $serializer,
+        MemoizeInterface $memoizeCache
+    ) {
+        $this->categoryManager = $categoryManager;
+        $this->categoryRequestHandler = $categoryRequestHandler;
+        $this->serializer = $serializer;
+        $this->memoizeCache = $memoizeCache;
+    }
+
+    /**
+     * Returns an array of serialized categories.
+     * If parentKey is set, only the children of the category which is assigned to the given key are returned.
+     *
+     * @param string $locale
+     * @param string $parentKey key of parent category
+     *
+     * @return array
+     */
+    public function getCategoriesFunction($locale, $parentKey = null)
+    {
+        return $this->memoizeCache->memoizeById(
+            'sulu_categories',
+            \func_get_args(),
+            function($locale, $parentKey = null) {
+                $entities = $this->categoryManager->findChildrenByParentKey($parentKey);
+                $categories = $this->categoryManager->getApiObjects($entities, $locale);
+                $context = SerializationContext::create();
+                $context->setSerializeNull(true);
+
+                return $this->serializer->serialize($categories, $context);
+            }
+        );
+    }
+
+    /**
+     * Extends current URL with given category.
+     *
+     * @param array $category will be included in the URL
+     * @param string $categoriesParameter GET parameter name
+     *
+     * @return string
+     */
+    public function appendCategoryUrlFunction($category, $categoriesParameter = 'categories')
+    {
+        return $this->categoryRequestHandler->appendCategoryToUrl($category, $categoriesParameter);
+    }
+
+    /**
+     * Set category to current URL.
+     *
+     * @param array $category will be included in the URL
+     * @param string $categoriesParameter GET parameter name
+     *
+     * @return string
+     */
+    public function setCategoryUrlFunction($category, $categoriesParameter = 'categories')
+    {
+        return $this->categoryRequestHandler->setCategoryToUrl($category, $categoriesParameter);
+    }
+
+    /**
+     * Remove categories from current URL.
+     *
+     * @param string $categoriesParameter GET parameter name
+     *
+     * @return string
+     */
+    public function clearCategoryUrlFunction($categoriesParameter = 'categories')
+    {
+        return $this->categoryRequestHandler->removeCategoriesFromUrl($categoriesParameter);
+    }
+}

--- a/src/Sulu/Bundle/CategoryBundle/Twig/CategoryRuntime.php
+++ b/src/Sulu/Bundle/CategoryBundle/Twig/CategoryRuntime.php
@@ -16,14 +16,9 @@ use Sulu\Bundle\CategoryBundle\Category\CategoryManagerInterface;
 use Sulu\Component\Cache\MemoizeInterface;
 use Sulu\Component\Category\Request\CategoryRequestHandlerInterface;
 use Sulu\Component\Serializer\ArraySerializerInterface;
-use Twig\Extension\AbstractExtension;
 use Twig\Extension\RuntimeExtensionInterface;
-use Twig\TwigFunction;
 
-/**
- * Provides functionality to handle categories in twig templates.
- */
-class CategoryRuntime implements RuntimeExtensionInterface
+final class CategoryRuntime implements RuntimeExtensionInterface
 {
     /**
      * @var CategoryManagerInterface

--- a/src/Sulu/Bundle/CategoryBundle/Twig/CategoryTwigExtension.php
+++ b/src/Sulu/Bundle/CategoryBundle/Twig/CategoryTwigExtension.php
@@ -11,11 +11,6 @@
 
 namespace Sulu\Bundle\CategoryBundle\Twig;
 
-use JMS\Serializer\SerializationContext;
-use Sulu\Bundle\CategoryBundle\Category\CategoryManagerInterface;
-use Sulu\Component\Cache\MemoizeInterface;
-use Sulu\Component\Category\Request\CategoryRequestHandlerInterface;
-use Sulu\Component\Serializer\ArraySerializerInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -24,108 +19,13 @@ use Twig\TwigFunction;
  */
 class CategoryTwigExtension extends AbstractExtension
 {
-    /**
-     * @var CategoryManagerInterface
-     */
-    private $categoryManager;
-
-    /**
-     * @var CategoryRequestHandlerInterface
-     */
-    private $categoryRequestHandler;
-
-    /**
-     * @var ArraySerializerInterface
-     */
-    private $serializer;
-
-    /**
-     * @var MemoizeInterface
-     */
-    private $memoizeCache;
-
-    public function __construct(
-        CategoryManagerInterface $categoryManager,
-        CategoryRequestHandlerInterface $categoryRequestHandler,
-        ArraySerializerInterface $serializer,
-        MemoizeInterface $memoizeCache
-    ) {
-        $this->categoryManager = $categoryManager;
-        $this->categoryRequestHandler = $categoryRequestHandler;
-        $this->serializer = $serializer;
-        $this->memoizeCache = $memoizeCache;
-    }
-
     public function getFunctions()
     {
         return [
-            new TwigFunction('sulu_categories', [$this, 'getCategoriesFunction']),
-            new TwigFunction('sulu_category_url', [$this, 'setCategoryUrlFunction']),
-            new TwigFunction('sulu_category_url_append', [$this, 'appendCategoryUrlFunction']),
-            new TwigFunction('sulu_category_url_clear', [$this, 'clearCategoryUrlFunction']),
+            new TwigFunction('sulu_categories', [CategoryRuntime::class, 'getCategoriesFunction']),
+            new TwigFunction('sulu_category_url', [CategoryRuntime::class, 'setCategoryUrlFunction']),
+            new TwigFunction('sulu_category_url_append', [CategoryRuntime::class, 'appendCategoryUrlFunction']),
+            new TwigFunction('sulu_category_url_clear', [CategoryRuntime::class, 'clearCategoryUrlFunction']),
         ];
-    }
-
-    /**
-     * Returns an array of serialized categories.
-     * If parentKey is set, only the children of the category which is assigned to the given key are returned.
-     *
-     * @param string $locale
-     * @param string $parentKey key of parent category
-     *
-     * @return array
-     */
-    public function getCategoriesFunction($locale, $parentKey = null)
-    {
-        return $this->memoizeCache->memoizeById(
-            'sulu_categories',
-            \func_get_args(),
-            function($locale, $parentKey = null) {
-                $entities = $this->categoryManager->findChildrenByParentKey($parentKey);
-                $categories = $this->categoryManager->getApiObjects($entities, $locale);
-                $context = SerializationContext::create();
-                $context->setSerializeNull(true);
-
-                return $this->serializer->serialize($categories, $context);
-            }
-        );
-    }
-
-    /**
-     * Extends current URL with given category.
-     *
-     * @param array $category will be included in the URL
-     * @param string $categoriesParameter GET parameter name
-     *
-     * @return string
-     */
-    public function appendCategoryUrlFunction($category, $categoriesParameter = 'categories')
-    {
-        return $this->categoryRequestHandler->appendCategoryToUrl($category, $categoriesParameter);
-    }
-
-    /**
-     * Set category to current URL.
-     *
-     * @param array $category will be included in the URL
-     * @param string $categoriesParameter GET parameter name
-     *
-     * @return string
-     */
-    public function setCategoryUrlFunction($category, $categoriesParameter = 'categories')
-    {
-        return $this->categoryRequestHandler->setCategoryToUrl($category, $categoriesParameter);
-    }
-
-    /**
-     * Remove categories from current URL.
-     *
-     * @param string $categoriesParameter GET parameter name
-     *
-     * @return string
-     */
-    public function clearCategoryUrlFunction($categoriesParameter = 'categories')
-    {
-        return $this->categoryRequestHandler->removeCategoriesFromUrl($categoriesParameter);
     }
 }

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
@@ -47,12 +47,15 @@
         </service>
         <service id="sulu_contact.twig.cache" class="Doctrine\Common\Cache\ArrayCache"/>
         <service id="sulu_contact.twig" class="Sulu\Bundle\ContactBundle\Twig\ContactTwigExtension">
-            <argument type="service" id="sulu_contact.twig.cache"/>
-            <argument type="service" id="sulu.repository.contact"/>
 
             <tag name="twig.extension"/>
         </service>
+        <service id="Sulu\Bundle\ContactBundle\Twig\ContactRuntime">
+            <argument type="service" id="sulu_contact.twig.cache"/>
+            <argument type="service" id="sulu.repository.contact"/>
 
+            <tag name="twig.runtime"/>
+        </service>
         <service id="sulu_contact.account_factory" class="Sulu\Bundle\ContactBundle\Contact\AccountFactory" public="true">
             <argument type="string">%sulu.model.account.class%</argument>
         </service>

--- a/src/Sulu/Bundle/ContactBundle/Twig/ContactRuntime.php
+++ b/src/Sulu/Bundle/ContactBundle/Twig/ContactRuntime.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Twig;
+
+use Doctrine\Common\Cache\Cache;
+use Sulu\Bundle\ContactBundle\Entity\Contact;
+use Sulu\Bundle\ContactBundle\Entity\ContactRepository;
+use Twig\Extension\RuntimeExtensionInterface;
+
+/**
+ * Extension to handle contacts in frontend.
+ */
+class ContactRuntime implements RuntimeExtensionInterface
+{
+    /**
+     * @var ContactRepository
+     */
+    private $contactRepository;
+
+    /**
+     * @var Cache
+     */
+    private $cache;
+
+    public function __construct(Cache $cache, ContactRepository $contactRepository)
+    {
+        $this->cache = $cache;
+        $this->contactRepository = $contactRepository;
+    }
+
+    /**
+     * @param int $id id to resolve
+     *
+     * @return Contact
+     */
+    public function resolveContactFunction($id)
+    {
+        if ($this->cache->contains($id)) {
+            return $this->cache->fetch($id);
+        }
+
+        $contact = $this->contactRepository->find($id);
+        if (null === $contact) {
+            return;
+        }
+
+        $this->cache->save($id, $contact);
+
+        return $contact;
+    }
+}

--- a/src/Sulu/Bundle/ContactBundle/Twig/ContactTwigExtension.php
+++ b/src/Sulu/Bundle/ContactBundle/Twig/ContactTwigExtension.php
@@ -11,9 +11,6 @@
 
 namespace Sulu\Bundle\ContactBundle\Twig;
 
-use Doctrine\Common\Cache\Cache;
-use Sulu\Bundle\ContactBundle\Entity\Contact;
-use Sulu\Bundle\ContactBundle\Entity\ContactRepository;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -22,47 +19,10 @@ use Twig\TwigFunction;
  */
 class ContactTwigExtension extends AbstractExtension
 {
-    /**
-     * @var ContactRepository
-     */
-    private $contactRepository;
-
-    /**
-     * @var Cache
-     */
-    private $cache;
-
-    public function __construct(Cache $cache, ContactRepository $contactRepository)
-    {
-        $this->cache = $cache;
-        $this->contactRepository = $contactRepository;
-    }
-
     public function getFunctions()
     {
         return [
-            new TwigFunction('sulu_resolve_contact', [$this, 'resolveContactFunction']),
+            new TwigFunction('sulu_resolve_contact', [ContactRuntime::class, 'resolveContactFunction']),
         ];
-    }
-
-    /**
-     * @param int $id id to resolve
-     *
-     * @return Contact
-     */
-    public function resolveContactFunction($id)
-    {
-        if ($this->cache->contains($id)) {
-            return $this->cache->fetch($id);
-        }
-
-        $contact = $this->contactRepository->find($id);
-        if (null === $contact) {
-            return;
-        }
-
-        $this->cache->save($id, $contact);
-
-        return $contact;
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -319,9 +319,14 @@
         </service>
 
         <service id="sulu_media.twig_extension.media" class="%sulu_media.twig_extension.media.class%">
-            <argument type="service" id="sulu_media.media_manager"/>
 
             <tag name="twig.extension"/>
+        </service>
+
+        <service id="Sulu\Bundle\MediaBundle\Twig\MediaRuntime">
+            <argument type="service" id="sulu_media.media_manager"/>
+
+            <tag name="twig.runtime"/>
         </service>
 
         <service id="sulu_media.video_thumbnail_generator" class="%sulu_media.video_thumbnail_generator.class%">

--- a/src/Sulu/Bundle/MediaBundle/Twig/MediaRuntime.php
+++ b/src/Sulu/Bundle/MediaBundle/Twig/MediaRuntime.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Twig;
+
+use Sulu\Bundle\MediaBundle\Api\Media as MediaApi;
+use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
+use Sulu\Bundle\MediaBundle\Media\Exception\MediaNotFoundException;
+use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
+use Twig\Extension\RuntimeExtensionInterface;
+
+final class MediaRuntime implements RuntimeExtensionInterface
+{
+    /**
+     * @var MediaManagerInterface
+     */
+    private $mediaManager;
+
+    public function __construct(MediaManagerInterface $mediaManager)
+    {
+        $this->mediaManager = $mediaManager;
+    }
+
+    /**
+     * resolves media id or object.
+     *
+     * @param int|MediaInterface $media id to resolve
+     * @param string $locale
+     *
+     * @return MediaApi|null
+     */
+    public function resolveMediaFunction($media, $locale)
+    {
+        if (!$media) {
+            return;
+        }
+
+        if (\is_object($media)) {
+            return $this->resolveMediaObject($media, $locale);
+        }
+
+        try {
+            return $this->mediaManager->getById($media, $locale);
+        } catch (MediaNotFoundException $e) {
+            return;
+        }
+    }
+
+    /**
+     * resolves media id or object.
+     *
+     * @param int[]|MediaInterface[] $medias ids to resolve
+     * @param string $locale
+     *z
+     *
+     * @return MediaApi
+     */
+    public function resolveMediasFunction($medias, $locale)
+    {
+        if (0 === \count($medias)) {
+            return [];
+        }
+
+        $ids = [];
+        $entities = [];
+        $entitiesIndex = [];
+        for ($i = 0; $i < \count($medias); ++$i) {
+            $media = $medias[$i];
+
+            if (\is_object($media)) {
+                $entities[$i] = $this->resolveMediaObject($media, $locale);
+            } else {
+                $ids[] = $media;
+                $entitiesIndex[$media] = $i;
+            }
+        }
+
+        if (\count($ids) > 0) {
+            foreach ($this->mediaManager->getByIds($ids, $locale) as $media) {
+                $entities[$entitiesIndex[$media->getId()]] = $media;
+            }
+        }
+
+        \ksort($entities);
+
+        return \array_values($entities);
+    }
+
+    private function resolveMediaObject($media, $locale)
+    {
+        if ($media instanceof MediaInterface) {
+            return $this->mediaManager->addFormatsAndUrl(
+                new MediaApi($media, $locale)
+            );
+        } elseif ($media instanceof MediaApi) {
+            return $this->mediaManager->addFormatsAndUrl($media);
+        }
+
+        return;
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Twig/MediaTwigExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/Twig/MediaTwigExtension.php
@@ -11,10 +11,6 @@
 
 namespace Sulu\Bundle\MediaBundle\Twig;
 
-use Sulu\Bundle\MediaBundle\Api\Media as MediaApi;
-use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
-use Sulu\Bundle\MediaBundle\Media\Exception\MediaNotFoundException;
-use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -23,99 +19,11 @@ use Twig\TwigFunction;
  */
 class MediaTwigExtension extends AbstractExtension
 {
-    /**
-     * @var MediaManagerInterface
-     */
-    private $mediaManager;
-
-    public function __construct(MediaManagerInterface $mediaManager)
-    {
-        $this->mediaManager = $mediaManager;
-    }
-
     public function getFunctions()
     {
         return [
-            new TwigFunction('sulu_resolve_media', [$this, 'resolveMediaFunction']),
-            new TwigFunction('sulu_resolve_medias', [$this, 'resolveMediasFunction']),
+            new TwigFunction('sulu_resolve_media', [MediaRuntime::class, 'resolveMediaFunction']),
+            new TwigFunction('sulu_resolve_medias', [MediaRuntime::class, 'resolveMediasFunction']),
         ];
-    }
-
-    /**
-     * resolves media id or object.
-     *
-     * @param int|MediaInterface $media id to resolve
-     * @param string $locale
-     *
-     * @return MediaApi|null
-     */
-    public function resolveMediaFunction($media, $locale)
-    {
-        if (!$media) {
-            return;
-        }
-
-        if (\is_object($media)) {
-            return $this->resolveMediaObject($media, $locale);
-        }
-
-        try {
-            return $this->mediaManager->getById($media, $locale);
-        } catch (MediaNotFoundException $e) {
-            return;
-        }
-    }
-
-    /**
-     * resolves media id or object.
-     *
-     * @param int[]|MediaInterface[] $medias ids to resolve
-     * @param string $locale
-     *z
-     *
-     * @return MediaApi
-     */
-    public function resolveMediasFunction($medias, $locale)
-    {
-        if (0 === \count($medias)) {
-            return [];
-        }
-
-        $ids = [];
-        $entities = [];
-        $entitiesIndex = [];
-        for ($i = 0; $i < \count($medias); ++$i) {
-            $media = $medias[$i];
-
-            if (\is_object($media)) {
-                $entities[$i] = $this->resolveMediaObject($media, $locale);
-            } else {
-                $ids[] = $media;
-                $entitiesIndex[$media] = $i;
-            }
-        }
-
-        if (\count($ids) > 0) {
-            foreach ($this->mediaManager->getByIds($ids, $locale) as $media) {
-                $entities[$entitiesIndex[$media->getId()]] = $media;
-            }
-        }
-
-        \ksort($entities);
-
-        return \array_values($entities);
-    }
-
-    private function resolveMediaObject($media, $locale)
-    {
-        if ($media instanceof MediaInterface) {
-            return $this->mediaManager->addFormatsAndUrl(
-                new MediaApi($media, $locale)
-            );
-        } elseif ($media instanceof MediaApi) {
-            return $this->mediaManager->addFormatsAndUrl($media);
-        }
-
-        return;
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Resources/config/export.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/export.xml
@@ -44,7 +44,11 @@
 
         <service id="sulu_page.export_twig_extension" class="Sulu\Bundle\PageBundle\Twig\ExportTwigExtension">
             <tag name="twig.extension"/>
+        </service>
+
+        <service id="Sulu\Bundle\PageBundle\Twig\ExportRuntime">
             <argument type="service" id="sulu_page.export.manager"/>
+            <tag name="twig.runtime"/>
         </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/PageBundle/Twig/ExportRuntime.php
+++ b/src/Sulu/Bundle/PageBundle/Twig/ExportRuntime.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PageBundle\Twig;
+
+use Sulu\Component\Export\Manager\ExportManagerInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\Extension\RuntimeExtensionInterface;
+use Twig\TwigFunction;
+
+final class ExportRuntime implements RuntimeExtensionInterface
+{
+    /**
+     * @var ExportManagerInterface
+     */
+    private $exportManager;
+
+    /**
+     * @var int
+     */
+    private $counter = 0;
+
+    public function __construct(ExportManagerInterface $exportManager)
+    {
+        $this->exportManager = $exportManager;
+    }
+
+    /**
+     * @return int
+     */
+    public function counter()
+    {
+        return $this->counter++;
+    }
+
+    /**
+     * @param $content
+     *
+     * @return string
+     */
+    public function escapeXmlContent($content)
+    {
+        if (\is_object($content) || \is_array($content)) {
+            if (\method_exists($content, 'getUuid')) {
+                return $content->getUuid();
+            }
+
+            return 'ERROR: wrong data';
+        }
+
+        if (\preg_match('/[<>{}"&]/', $content)) {
+            $content = '<![CDATA[' . $content . ']]>';
+        }
+
+        return $content;
+    }
+}

--- a/src/Sulu/Bundle/PageBundle/Twig/ExportTwigExtension.php
+++ b/src/Sulu/Bundle/PageBundle/Twig/ExportTwigExtension.php
@@ -28,7 +28,7 @@ class ExportTwigExtension extends AbstractExtension
     {
         return [
             new TwigFunction('sulu_content_type_export_escape', [ExportRuntime::class, 'escapeXmlContent']),
-            new TwigFunction('sulu_content_type_export_counter', [ExportManagerInterface::class, 'counter']),
+            new TwigFunction('sulu_content_type_export_counter', [ExportRuntime::class, 'counter']),
         ];
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Twig/ExportTwigExtension.php
+++ b/src/Sulu/Bundle/PageBundle/Twig/ExportTwigExtension.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\PageBundle\Twig;
 
-use Sulu\Component\Export\Manager\ExportManagerInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -21,21 +20,6 @@ use Twig\TwigFunction;
 class ExportTwigExtension extends AbstractExtension
 {
     /**
-     * @var ExportManagerInterface
-     */
-    private $exportManager;
-
-    /**
-     * @var int
-     */
-    private $counter = 0;
-
-    public function __construct(ExportManagerInterface $exportManager)
-    {
-        $this->exportManager = $exportManager;
-    }
-
-    /**
      * Returns an array of possible function in this extension.
      *
      * @return array
@@ -43,38 +27,8 @@ class ExportTwigExtension extends AbstractExtension
     public function getFunctions()
     {
         return [
-            new TwigFunction('sulu_content_type_export_escape', [$this, 'escapeXmlContent']),
-            new TwigFunction('sulu_content_type_export_counter', [$this, 'counter']),
+            new TwigFunction('sulu_content_type_export_escape', [ExportRuntime::class, 'escapeXmlContent']),
+            new TwigFunction('sulu_content_type_export_counter', [ExportManagerInterface::class, 'counter']),
         ];
-    }
-
-    /**
-     * @return int
-     */
-    public function counter()
-    {
-        return $this->counter++;
-    }
-
-    /**
-     * @param $content
-     *
-     * @return string
-     */
-    public function escapeXmlContent($content)
-    {
-        if (\is_object($content) || \is_array($content)) {
-            if (\method_exists($content, 'getUuid')) {
-                return $content->getUuid();
-            }
-
-            return 'ERROR: wrong data';
-        }
-
-        if (\preg_match('/[<>{}"&]/', $content)) {
-            $content = '<![CDATA[' . $content . ']]>';
-        }
-
-        return $content;
     }
 }

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/.preload.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/.preload.php
@@ -1,5 +1,0 @@
-<?php
-
-if (file_exists(__DIR__.'/../../../../../../../../../var/cache/preview/dev/App_KernelDevDebugContainer.preload.php')) {
-    require __DIR__.'/../../../../../../../../../var/cache/preview/dev/App_KernelDevDebugContainer.preload.php';
-}

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/.preload.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/.preload.php
@@ -1,0 +1,5 @@
+<?php
+
+if (file_exists(__DIR__.'/../../../../../../../../../var/cache/preview/dev/App_KernelDevDebugContainer.preload.php')) {
+    require __DIR__.'/../../../../../../../../../var/cache/preview/dev/App_KernelDevDebugContainer.preload.php';
+}

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -281,11 +281,16 @@
         </service>
 
         <service id="sulu_security.twig_extension.user.cache" class="Doctrine\Common\Cache\ArrayCache"/>
+
         <service id="sulu_security.twig_extension.user" class="Sulu\Bundle\SecurityBundle\Twig\UserTwigExtension">
+            <tag name="twig.extension"/>
+        </service>
+
+        <service id="Sulu\Bundle\SecurityBundle\Twig\UserRuntime">
             <argument type="service" id="sulu_security.twig_extension.user.cache"/>
             <argument type="service" id="sulu.repository.user"/>
 
-            <tag name="twig.extension"/>
+            <tag name="twig.runtime"/>
         </service>
 
         <service id="sulu_security.user_locale_listener"

--- a/src/Sulu/Bundle/SecurityBundle/Twig/UserRuntime.php
+++ b/src/Sulu/Bundle/SecurityBundle/Twig/UserRuntime.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\Twig;
+
+use Doctrine\Common\Cache\Cache;
+use Sulu\Bundle\SecurityBundle\Entity\User;
+use Sulu\Bundle\SecurityBundle\Entity\UserRepository;
+use Twig\Extension\RuntimeExtensionInterface;
+
+final class UserRuntime implements RuntimeExtensionInterface
+{
+    /**
+     * @var UserRepository
+     */
+    private $userRepository;
+
+    /**
+     * @var Cache
+     */
+    private $cache;
+
+    public function __construct(Cache $cache, UserRepository $userRepository)
+    {
+        $this->cache = $cache;
+        $this->userRepository = $userRepository;
+    }
+
+    /**
+     * resolves user id to user data.
+     *
+     * @param int $id id to resolve
+     *
+     * @return User
+     */
+    public function resolveUserFunction($id)
+    {
+        if ($this->cache->contains($id)) {
+            return $this->cache->fetch($id);
+        }
+
+        $user = $this->userRepository->findUserById($id);
+        if (null === $user) {
+            return;
+        }
+
+        $this->cache->save($id, $user);
+
+        return $user;
+    }
+}

--- a/src/Sulu/Bundle/SecurityBundle/Twig/UserTwigExtension.php
+++ b/src/Sulu/Bundle/SecurityBundle/Twig/UserTwigExtension.php
@@ -11,9 +11,6 @@
 
 namespace Sulu\Bundle\SecurityBundle\Twig;
 
-use Doctrine\Common\Cache\Cache;
-use Sulu\Bundle\SecurityBundle\Entity\User;
-use Sulu\Bundle\SecurityBundle\Entity\UserRepository;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -23,51 +20,12 @@ use Twig\TwigFunction;
 class UserTwigExtension extends AbstractExtension
 {
     /**
-     * @var UserRepository
-     */
-    private $userRepository;
-
-    /**
-     * @var Cache
-     */
-    private $cache;
-
-    public function __construct(Cache $cache, UserRepository $userRepository)
-    {
-        $this->cache = $cache;
-        $this->userRepository = $userRepository;
-    }
-
-    /**
      * @return array
      */
     public function getFunctions()
     {
         return [
-            new TwigFunction('sulu_resolve_user', [$this, 'resolveUserFunction']),
+            new TwigFunction('sulu_resolve_user', [UserRuntime::class, 'resolveUserFunction']),
         ];
-    }
-
-    /**
-     * resolves user id to user data.
-     *
-     * @param int $id id to resolve
-     *
-     * @return User
-     */
-    public function resolveUserFunction($id)
-    {
-        if ($this->cache->contains($id)) {
-            return $this->cache->fetch($id);
-        }
-
-        $user = $this->userRepository->findUserById($id);
-        if (null === $user) {
-            return;
-        }
-
-        $this->cache->save($id, $user);
-
-        return $user;
     }
 }

--- a/src/Sulu/Bundle/TagBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/TagBundle/Resources/config/services.xml
@@ -28,12 +28,16 @@
         </service>
 
         <service id="sulu_tag.twig_extension" class="Sulu\Bundle\TagBundle\Twig\TagTwigExtension">
+            <tag name="twig.extension"/>
+        </service>
+
+        <service id="sulu_tag.twig_runtime" class="Sulu\Bundle\TagBundle\Twig\TagRuntime">
             <argument type="service" id="sulu_tag.tag_manager"/>
             <argument type="service" id="sulu_tag.tag_request_handler"/>
             <argument type="service" id="sulu_core.array_serializer"/>
             <argument type="service" id="sulu_core.cache.memoize"/>
 
-            <tag name="twig.extension"/>
+            <tag name="twig.runtime"/>
         </service>
 
         <service id="sulu_tag.search.tags_converter" class="Sulu\Bundle\TagBundle\Search\TagsConverter">

--- a/src/Sulu/Bundle/TagBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/TagBundle/Resources/config/services.xml
@@ -31,7 +31,7 @@
             <tag name="twig.extension"/>
         </service>
 
-        <service id="sulu_tag.twig_runtime" class="Sulu\Bundle\TagBundle\Twig\TagRuntime">
+        <service id="Sulu\Bundle\TagBundle\Twig\TagRuntime">
             <argument type="service" id="sulu_tag.tag_manager"/>
             <argument type="service" id="sulu_tag.tag_request_handler"/>
             <argument type="service" id="sulu_core.array_serializer"/>

--- a/src/Sulu/Bundle/TagBundle/Twig/TagRuntime.php
+++ b/src/Sulu/Bundle/TagBundle/Twig/TagRuntime.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\TagBundle\Twig;
+
+use JMS\Serializer\SerializationContext;
+use Sulu\Bundle\TagBundle\Tag\TagManagerInterface;
+use Sulu\Component\Cache\MemoizeInterface;
+use Sulu\Component\Serializer\ArraySerializerInterface;
+use Sulu\Component\Tag\Request\TagRequestHandlerInterface;
+use Twig\Extension\RuntimeExtensionInterface;
+
+class TagRuntime implements RuntimeExtensionInterface
+{
+    /**
+     * @var TagManagerInterface
+     */
+    private $tagManager;
+
+    /**
+     * @var TagRequestHandlerInterface
+     */
+    private $tagRequestHandler;
+
+    /**
+     * @var ArraySerializerInterface
+     */
+    private $serializer;
+
+    /**
+     * @var MemoizeInterface
+     */
+    private $memoizeCache;
+
+    public function __construct(
+        TagManagerInterface $tagManager,
+        TagRequestHandlerInterface $tagRequestHandler,
+        ArraySerializerInterface $serializer,
+        MemoizeInterface $memoizeCache
+    ) {
+        $this->tagManager = $tagManager;
+        $this->tagRequestHandler = $tagRequestHandler;
+        $this->serializer = $serializer;
+        $this->memoizeCache = $memoizeCache;
+    }
+
+    /**
+     * @return array
+     */
+    public function getTagsFunction()
+    {
+        return $this->memoizeCache->memoizeById(
+            'sulu_tags',
+            \func_get_args(),
+            function() {
+                $tags = $this->tagManager->findAll();
+
+                $context = SerializationContext::create();
+                $context->setSerializeNull(true);
+                $context->setGroups(['partialTag']);
+
+                return $this->serializer->serialize($tags, $context);
+            }
+        );
+    }
+
+    /**
+     * Extends current URL with given tag.
+     *
+     * @param array $tag will be included in the URL
+     * @param string $tagsParameter GET parameter name
+     *
+     * @return string
+     */
+    public function appendTagUrlFunction($tag, $tagsParameter = 'tags')
+    {
+        return $this->tagRequestHandler->appendTagToUrl($tag, $tagsParameter);
+    }
+
+    /**
+     * Set tag to current URL.
+     *
+     * @param array $tag will be included in the URL
+     * @param string $tagsParameter GET parameter name
+     *
+     * @return string
+     */
+    public function setTagUrlFunction($tag, $tagsParameter = 'tags')
+    {
+        return $this->tagRequestHandler->setTagToUrl($tag, $tagsParameter);
+    }
+
+    /**
+     * Remove tag from current URL.
+     *
+     * @param string $tagsParameter GET parameter name
+     *
+     * @return string
+     */
+    public function clearTagUrlFunction($tagsParameter = 'tags')
+    {
+        return $this->tagRequestHandler->removeTagsFromUrl($tagsParameter);
+    }
+}

--- a/src/Sulu/Bundle/TagBundle/Twig/TagRuntime.php
+++ b/src/Sulu/Bundle/TagBundle/Twig/TagRuntime.php
@@ -18,7 +18,7 @@ use Sulu\Component\Serializer\ArraySerializerInterface;
 use Sulu\Component\Tag\Request\TagRequestHandlerInterface;
 use Twig\Extension\RuntimeExtensionInterface;
 
-class TagRuntime implements RuntimeExtensionInterface
+final class TagRuntime implements RuntimeExtensionInterface
 {
     /**
      * @var TagManagerInterface

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -173,12 +173,18 @@
         </service>
 
         <service id="sulu_website.twig.seo" class="%sulu_website.twig.seo.class%">
+
+            <tag name="twig.extension"/>
+        </service>
+
+        <service id="Sulu\Bundle\WebsiteBundle\Twig\Seo\SeoRuntime">
             <argument type="service" id="sulu_core.webspace.request_analyzer"/>
             <argument type="service" id="sulu_website.twig.content_path"/>
             <argument type="service" id="request_stack"/>
 
-            <tag name="twig.extension"/>
+            <tag name="twig.runtime"/>
         </service>
+
 
         <!-- twig extension: util -->
         <service id="sulu_website.twig.util" class="%sulu_website.twig.util.class%">

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoRuntime.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoRuntime.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Twig\Seo;
+
+use Sulu\Bundle\WebsiteBundle\Twig\Content\ContentPathInterface;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\Environment;
+use Twig\Extension\RuntimeExtensionInterface;
+
+final class SeoRuntime implements RuntimeExtensionInterface
+{
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    /**
+     * @var ContentPathInterface
+     */
+    private $contentPath;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    public function __construct(
+        RequestAnalyzerInterface $requestAnalyzer,
+        ContentPathInterface $contentPath,
+        RequestStack $requestStack
+    ) {
+        $this->requestAnalyzer = $requestAnalyzer;
+        $this->requestStack = $requestStack;
+        // FIXME Should not use another twig extension here, that is not the intended use case of twig extensions
+        $this->contentPath = $contentPath;
+        $this->requestStack = $requestStack;
+    }
+
+    public function getFunctions()
+    {
+        return [
+            new TwigFunction('sulu_seo', [$this, 'renderSeoTags'], ['needs_environment' => true]),
+        ];
+    }
+
+    /**
+     * Renders the correct title of the current page. The correct title is either the title provided by the SEO
+     * extension, or the title of the content, if the SEO extension does not provide one.
+     *
+     * @deprecated use the twig include function to render the seo
+     */
+    public function renderSeoTags(
+        Environment $twig,
+        array $seoExtension,
+        array $content,
+        array $urls,
+        $shadowBaseLocale
+    ) {
+        $template = '@SuluWebsite/Extension/seo.html.twig';
+
+        @\trigger_error(\sprintf(
+            'This twig extension is deprecated and should not be used anymore, include the "%s".',
+            $template
+        ));
+
+        $defaultLocale = null;
+        $portal = $this->requestAnalyzer->getPortal();
+        if ($portal) {
+            $defaultLocale = $portal->getXDefaultLocalization()->getLocale();
+        }
+
+        return $twig->render(
+            $template,
+            [
+                'seo' => $seoExtension,
+                'content' => $content,
+                'urls' => $urls,
+                'defaultLocale' => $defaultLocale,
+                'shadowBaseLocale' => $shadowBaseLocale,
+            ]
+        );
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtension.php
@@ -11,10 +11,6 @@
 
 namespace Sulu\Bundle\WebsiteBundle\Twig\Seo;
 
-use Sulu\Bundle\WebsiteBundle\Twig\Content\ContentPathInterface;
-use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
-use Twig\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -23,75 +19,10 @@ use Twig\TwigFunction;
  */
 class SeoTwigExtension extends AbstractExtension
 {
-    /**
-     * @var RequestAnalyzerInterface
-     */
-    private $requestAnalyzer;
-
-    /**
-     * @var ContentPathInterface
-     */
-    private $contentPath;
-
-    /**
-     * @var RequestStack
-     */
-    private $requestStack;
-
-    public function __construct(
-        RequestAnalyzerInterface $requestAnalyzer,
-        ContentPathInterface $contentPath,
-        RequestStack $requestStack
-    ) {
-        $this->requestAnalyzer = $requestAnalyzer;
-        $this->requestStack = $requestStack;
-        // FIXME Should not use another twig extension here, that is not the intended use case of twig extensions
-        $this->contentPath = $contentPath;
-        $this->requestStack = $requestStack;
-    }
-
     public function getFunctions()
     {
         return [
             new TwigFunction('sulu_seo', [$this, 'renderSeoTags'], ['needs_environment' => true]),
         ];
-    }
-
-    /**
-     * Renders the correct title of the current page. The correct title is either the title provided by the SEO
-     * extension, or the title of the content, if the SEO extension does not provide one.
-     *
-     * @deprecated use the twig include function to render the seo
-     */
-    public function renderSeoTags(
-        Environment $twig,
-        array $seoExtension,
-        array $content,
-        array $urls,
-        $shadowBaseLocale
-    ) {
-        $template = '@SuluWebsite/Extension/seo.html.twig';
-
-        @\trigger_error(\sprintf(
-            'This twig extension is deprecated and should not be used anymore, include the "%s".',
-            $template
-        ));
-
-        $defaultLocale = null;
-        $portal = $this->requestAnalyzer->getPortal();
-        if ($portal) {
-            $defaultLocale = $portal->getXDefaultLocalization()->getLocale();
-        }
-
-        return $twig->render(
-            $template,
-            [
-                'seo' => $seoExtension,
-                'content' => $content,
-                'urls' => $urls,
-                'defaultLocale' => $defaultLocale,
-                'shadowBaseLocale' => $shadowBaseLocale,
-            ]
-        );
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | ?
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

There are some references that indicate that using runtime for twig extensions improves performance. Especially for the less used ones. 

I will try well with blackfire if the improvement is really good

References:
https://symfony.com/doc/current/templating/twig_extension.html#creating-lazy-loaded-twig-extensions
https://github.com/liip/LiipImagineBundle/issues/1261

#### Why?

Because we want to improve performance in some cases.


#### BC Breaks/Deprecations

Maybe is someone extend the extension. I think it's better to make runtime final.

#### To Do

- [ ] Change all extensions that can be improved
- [ ] Make tests
