### PR TITLE
Include parentId in request of resource_locator field-type after copying language

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
@@ -81,8 +81,8 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
 
             const requestOptions = {...formInspector.options};
 
-            Object.entries(resourceStorePropertiesToRequest).forEach(([parameterName, propertyName]) => {
-                const propertyValue = toJS(formInspector.getValueByPath('/' + String(propertyName)));
+            Object.entries(resourceStorePropertiesToRequest).forEach(([propertyName, parameterName]) => {
+                const propertyValue = toJS(formInspector.getValueByPath('/' + propertyName));
                 if (propertyValue !== undefined) {
                     requestOptions[parameterName] = propertyValue;
                 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
@@ -379,7 +379,7 @@ test('Request new URL with options from FormInspector and resourceStorePropertie
                 historyResourceKey: 'page_resourcelocators',
                 modeResolver: () => Promise.resolve('leaf'),
                 resourceStorePropertiesToRequest: {
-                    requestParamKey: 'propertyName',
+                    propertyName: 'requestParamKey',
                 },
             }}
             formInspector={formInspector}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
@@ -360,7 +360,7 @@ test('Should not request a new URL if URL was defined', () => {
     expect(Requester.post).not.toBeCalled();
 });
 
-test('Should request a new URL including the options from the ResourceFormStore if no URL was defined', () => {
+test('Request new URL with options from FormInspector and resourceStorePropertiesToRequest field-type-option ', () => {
     const formInspector = new FormInspector(
         new ResourceFormStore(
             new ResourceStore('test'),
@@ -378,6 +378,9 @@ test('Should request a new URL including the options from the ResourceFormStore 
                 generationUrl: '/admin/api/resourcelocators?action=generate',
                 historyResourceKey: 'page_resourcelocators',
                 modeResolver: () => Promise.resolve('leaf'),
+                resourceStorePropertiesToRequest: {
+                    requestParamKey: 'propertyName',
+                },
             }}
             formInspector={formInspector}
             onChange={changeSpy}
@@ -390,6 +393,7 @@ test('Should request a new URL including the options from the ResourceFormStore 
     formInspector.getPathsByTag.mockReturnValue(['/title', '/subtitle']);
     formInspector.getValueByPath.mockReturnValueOnce('title-value');
     formInspector.getValueByPath.mockReturnValueOnce('subtitle-value');
+    formInspector.getValueByPath.mockReturnValueOnce('property-value');
     formInspector.getSchemaEntryByPath.mockReturnValue({
         tags: [
             {name: 'sulu.rlp.part'},
@@ -407,6 +411,7 @@ test('Should request a new URL including the options from the ResourceFormStore 
     expect(formInspector.getPathsByTag).toBeCalledWith('sulu.rlp.part');
     expect(formInspector.getValueByPath).toBeCalledWith('/title');
     expect(formInspector.getValueByPath).toBeCalledWith('/subtitle');
+    expect(formInspector.getValueByPath).toBeCalledWith('/propertyName');
     expect(Requester.post).toBeCalledWith(
         '/admin/api/resourcelocators?action=generate',
         {
@@ -414,6 +419,7 @@ test('Should request a new URL including the options from the ResourceFormStore 
             parts: {title: 'title-value', subtitle: 'subtitle-value'},
             resourceKey: 'test',
             webspace: 'example',
+            requestParamKey: 'property-value',
         }
     );
 

--- a/src/Sulu/Bundle/PageBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/index.js
@@ -37,6 +37,9 @@ initializer.addUpdateConfigHook('sulu_page', (config: Object, initialized: boole
             modeResolver: (props) => loadResourceLocatorInputTypeByWebspace(props.formInspector.options.webspace),
             generationUrl: Config.endpoints.generateUrl,
             historyResourceKey: 'page_resourcelocators',
+            resourceStorePropertiesToRequest: {
+                parentId: 'parentUuid',
+            },
         }
     );
 

--- a/src/Sulu/Bundle/PageBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/index.js
@@ -38,7 +38,7 @@ initializer.addUpdateConfigHook('sulu_page', (config: Object, initialized: boole
             generationUrl: Config.endpoints.generateUrl,
             historyResourceKey: 'page_resourcelocators',
             resourceStorePropertiesToRequest: {
-                parentId: 'parentUuid',
+                parentUuid: 'parentId',
             },
         }
     );


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | #5548
| License | MIT

#### What's in this PR?

This PR adjusts the `resource_locator` field-type to include the `parentId` in the request for generating the URL on the edit form. This is needed for including the parent in the generated URL when editing an **existing page in a new language**.

This fixes one aspect of #5548

#### Why?

On the **add form**, the `parentId` is included via the `FormInspector::options` object. The `parentId` is set to the `FormInspector::options` object because of the `addRouterAttributesToFormRequest` call in the `PageAdmin`.

This strategy does not work on the **edit form**, because the `routerAttributes` do not contain the `parentId` in that case.

#### Reproducing the Problem

1. Save and publish a page `England` in the `en` locale
2. Switch to the `de` locale
3. Save and publish the page as `Deutschland`
3. Add a child page `London` in the `en` locale
4. Switch to the `de` locale
5. Click a random button on the copy dialog (the answer does not matter)
6. Adjust the title of the page to `Berlin` and click outside of the field
7. **The generated URL does not include the expected `/deutschland` prefix**