### PR TITLE
Load content for new locale when copying content from another locale

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
@@ -232,13 +232,22 @@ export default class ResourceStore {
             throw new Error('Copying from another locale does only work for objects with locales!');
         }
 
+        const destinationLocale = this.locale.get();
+
         return ResourceRequester
             .post(
                 this.resourceKey,
                 {},
-                {...options, action: 'copy-locale', dest: this.locale.get(), id: this.id, locale}
-            ).then(action((response) => {
+                {...options, action: 'copy-locale', dest: destinationLocale, id: this.id, locale}
+            ).then(action(() => {
+                // api will return data of there source locale, therefore we need to load the data of the new locale
+                return ResourceRequester.get(
+                    this.resourceKey,
+                    {...options, ...this.loadOptions, locale: destinationLocale, id: this.id}
+                );
+            })).then(action((response) => {
                 this.setMultiple(response);
+
                 return response;
             }));
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5548
| Related issues/PRs | #5558
| License | MIT

#### What's in this PR?

This PR adjusts the `ResourceStore` to load and return the content of the destination locale. 

#### Why?

Because the `copy-locale` API returns the content of the source locale. At the moment, when copying the data of an existing source locale, the data of the source locale is set to the form. This causes problems because the data of the source locale contains the **wrong resource locator (see #5548) and the wrong `publishedState`**.

#### Reproducing the Problem

1. Save and publish a page `England` in the `en` locale
2. Switch to the `de` locale
3. Save and publish the page as `Deutschland`
3. Add a child page `London` in the `en` locale
4. Switch to the `de` locale
5. Confirm the copy dialog
6. **The form displays the wrong resource locator and wrongly indicates that the locale is published**