### PR TITLE
Check permissions only if permission-check is configured in webspace security

### DIFF
--- a/config/webspaces/sulu-test.xml
+++ b/config/webspaces/sulu-test.xml
@@ -6,7 +6,7 @@
     <name>Sulu Test</name>
     <key>sulu-test</key>
 
-    <security>
+    <security permission-check="true">
         <system>Sulu Test</system>
     </security>
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
@@ -121,7 +121,8 @@ class SmartContent extends React.Component<Props> {
             formInspector.locale,
             datasourceResourceKey,
             formInspector.resourceKey === this.provider ? formInspector.id : undefined,
-            schemaOptions
+            schemaOptions,
+            formInspector.metadataOptions?.webspace
         );
 
         smartContentStorePool.add(this.smartContentStore, excludeDuplicates);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SmartContent.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SmartContent.test.js
@@ -27,14 +27,16 @@ jest.mock('../../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 
-jest.mock('../../stores/ResourceFormStore', () => jest.fn(function(resourceStore) {
+jest.mock('../../stores/ResourceFormStore', () => jest.fn(function(resourceStore, formKey, options, metadataOptions) {
     this.resourceKey = resourceStore.resourceKey;
     this.id = resourceStore.id;
+    this.metadataOptions = metadataOptions;
 }));
 
 jest.mock('../../FormInspector', () => jest.fn(function(formStore) {
     this.resourceKey = formStore.resourceKey;
     this.id = formStore.id;
+    this.metadataOptions = formStore.metadataOptions;
 }));
 
 jest.mock('../../../SmartContent/stores/SmartContentStore', () => jest.fn(function() {
@@ -63,7 +65,9 @@ beforeEach(() => {
 });
 
 test('Should correctly initialize SmartContentStore', () => {
-    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test', 1), 'test'));
+    const formInspector = new FormInspector(
+        new ResourceFormStore(new ResourceStore('test', 1), 'test', {}, {webspace: 'sulu_io'})
+    );
     smartContentConfigStore.getConfig.mockReturnValue({datasourceResourceKey: 'collections'});
 
     const value = {
@@ -102,7 +106,8 @@ test('Should correctly initialize SmartContentStore', () => {
 
     expect(smartContentStorePool.add).toBeCalledWith(smartContentStore, false);
     expect(smartContentConfigStore.getConfig).toBeCalledWith('media');
-    expect(SmartContentStore).toBeCalledWith('media', value, undefined, 'collections', undefined, schemaOptions);
+    expect(SmartContentStore)
+        .toBeCalledWith('media', value, undefined, 'collections', undefined, schemaOptions, 'sulu_io');
 
     smartContent.unmount();
     expect(smartContentStorePool.remove).toBeCalledWith(smartContentStore);
@@ -205,7 +210,7 @@ test('Should pass id to SmartContentStore if resourceKeys match', () => {
     );
 
     expect(smartContentConfigStore.getConfig).toBeCalledWith('pages');
-    expect(SmartContentStore).toBeCalledWith('pages', value, undefined, 'pages', 4, schemaOptions);
+    expect(SmartContentStore).toBeCalledWith('pages', value, undefined, 'pages', 4, schemaOptions, undefined);
 });
 
 test('Pass correct props to SmartContent component', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/stores/SmartContentStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/stores/SmartContentStore.js
@@ -13,6 +13,7 @@ export default class SmartContentStore {
     locale: ?IObservableValue<string>;
     dataSourceResourceKey: ?string;
     params: Object;
+    webspaceKey: ?string;
     @observable items: Array<Object> = [];
     @observable itemsLoading: boolean = true;
     @observable categoriesLoading: boolean;
@@ -38,13 +39,15 @@ export default class SmartContentStore {
         locale?: ?IObservableValue<string>,
         dataSourceResourceKey: ?string,
         id: ?string | number,
-        params: Object
+        params: Object,
+        webspaceKey: ?string
     ) {
         this.provider = provider;
         this.locale = locale;
         this.dataSourceResourceKey = dataSourceResourceKey;
         this.id = id;
         this.params = params;
+        this.webspaceKey = webspaceKey;
 
         if (filterCriteria) {
             this.audienceTargeting = filterCriteria.audienceTargeting;
@@ -111,6 +114,7 @@ export default class SmartContentStore {
                 excluded: [this.id, ...this.excludedIds],
                 locale: this.locale,
                 params: JSON.stringify(this.params),
+                webspace: this.webspaceKey,
                 ...this.filterCriteria,
             })
         ).then(action((response) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/stores/SmartContentStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/stores/SmartContentStore.test.js
@@ -130,11 +130,14 @@ test('Load items if FilterCriteria is given with datasource', () => {
     const datasourcePromise = Promise.resolve({id: 3});
     ResourceRequester.get.mockReturnValue(datasourcePromise);
 
-    const smartContentStore = new SmartContentStore('content', filterCriteria, locale, 'pages', 4);
+    const smartContentStore = new SmartContentStore('content', filterCriteria, locale, 'pages', 4, {}, 'sulu_io');
     smartContentStore.start();
 
     return datasourcePromise.then(() => {
-        expect(Requester.get).toBeCalledWith('/api/items?provider=content&excluded=4&locale=en&dataSource=3');
+        expect(Requester.get)
+            .toBeCalledWith(
+                '/api/items?provider=content&excluded=4&locale=en&params=%7B%7D&webspace=sulu_io&dataSource=3'
+            );
     });
 });
 

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
@@ -62,6 +62,7 @@
             <argument type="service" id="sulu_document_manager.namespace_registry" />
             <argument type="service" id="sulu_security.access_control_manager" />
             <argument>%sulu_security.permissions%</argument>
+            <argument type="service" id="security.helper" on-invalid="ignore" />
         </service>
 
         <!-- content type manager -->
@@ -172,7 +173,6 @@
             <argument type="service" id="sulu.phpcr.session"/>
             <argument type="service" id="sulu.content.mapper"/>
             <argument type="service" id="debug.stopwatch" on-invalid="null"/>
-            <argument type="service" id="security.token_storage" on-invalid="null"/>
         </service>
 
         <!-- cache warmer for structures -->

--- a/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
+++ b/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
@@ -178,17 +178,11 @@ class MediaAdmin extends Admin
         ];
 
         foreach ($this->webspaceManager->getWebspaceCollection() as $webspace) {
-            $webspaceSecurity = $webspace->getSecurity();
-            if (!$webspaceSecurity) {
+            if (!$webspace->hasWebsiteSecurity()) {
                 continue;
             }
 
-            $webspaceSystem = $webspaceSecurity->getSystem();
-            if (!$webspaceSystem) {
-                continue;
-            }
-
-            $securityContexts[$webspaceSystem] = [
+            $securityContexts[$webspace->getSecurity()->getSystem()] = [
                 static::SECURITY_CONTEXT_GROUP => [
                     static::SECURITY_CONTEXT => [
                         PermissionTypes::VIEW,

--- a/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
+++ b/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
@@ -178,11 +178,17 @@ class MediaAdmin extends Admin
         ];
 
         foreach ($this->webspaceManager->getWebspaceCollection() as $webspace) {
-            if (!$webspace->hasWebsiteSecurity()) {
+            $webspaceSecurity = $webspace->getSecurity();
+            if (!$webspaceSecurity) {
                 continue;
             }
 
-            $securityContexts[$webspace->getSecurity()->getSystem()] = [
+            $webspaceSystem = $webspaceSecurity->getSystem();
+            if (!$webspaceSystem) {
+                continue;
+            }
+
+            $securityContexts[$webspaceSystem] = [
                 static::SECURITY_CONTEXT_GROUP => [
                     static::SECURITY_CONTEXT => [
                         PermissionTypes::VIEW,

--- a/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
@@ -22,7 +22,7 @@ use Sulu\Component\Content\ContentTypeExportInterface;
 use Sulu\Component\Content\PreResolvableContentTypeInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Util\ArrayableInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 
 /**
  * content type for image selection.
@@ -40,9 +40,9 @@ class MediaSelectionContentType extends ComplexContentType implements ContentTyp
     private $referenceStore;
 
     /**
-     * @var ?TokenStorageInterface
+     * @var RequestAnalyzer
      */
-    private $tokenStorage;
+    private $requestAnalyzer;
 
     /**
      * @var ?array
@@ -52,12 +52,12 @@ class MediaSelectionContentType extends ComplexContentType implements ContentTyp
     public function __construct(
         MediaManagerInterface $mediaManager,
         ReferenceStoreInterface $referenceStore,
-        TokenStorageInterface $tokenStorage = null,
+        RequestAnalyzerInterface $requestAnalyzer = null,
         $permissions = null
     ) {
         $this->mediaManager = $mediaManager;
         $this->referenceStore = $referenceStore;
-        $this->tokenStorage = $tokenStorage;
+        $this->requestAnalyzer = $requestAnalyzer;
         $this->permissions = $permissions;
     }
 
@@ -132,6 +132,8 @@ class MediaSelectionContentType extends ComplexContentType implements ContentTyp
         $params = $this->getParams($property->getParams());
         $types = $params['types']->getValue();
 
+        $webspace = $this->requestAnalyzer->getWebspace();
+
         $container = new MediaSelectionContainer(
             isset($data['config']) ? $data['config'] : [],
             isset($data['displayOption']) ? $data['displayOption'] : '',
@@ -139,7 +141,7 @@ class MediaSelectionContentType extends ComplexContentType implements ContentTyp
             $property->getStructure()->getLanguageCode(),
             $types,
             $this->mediaManager,
-            $this->permissions[PermissionTypes::VIEW]
+            $webspace->hasWebsiteSecurity() ? $this->permissions[PermissionTypes::VIEW] : null
         );
 
         return $container->getData();

--- a/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
@@ -141,7 +141,7 @@ class MediaSelectionContentType extends ComplexContentType implements ContentTyp
             $property->getStructure()->getLanguageCode(),
             $types,
             $this->mediaManager,
-            $webspace->hasWebsiteSecurity() ? $this->permissions[PermissionTypes::VIEW] : null
+            $webspace && $webspace->hasWebsiteSecurity() ? $this->permissions[PermissionTypes::VIEW] : null
         );
 
         return $container->getData();

--- a/src/Sulu/Bundle/MediaBundle/Content/Types/SingleMediaSelection.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/SingleMediaSelection.php
@@ -23,6 +23,7 @@ use Sulu\Component\Content\SimpleContentType;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Sulu\Component\Security\Authorization\SecurityCondition;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 
 class SingleMediaSelection extends SimpleContentType implements PreResolvableContentTypeInterface
 {
@@ -37,6 +38,11 @@ class SingleMediaSelection extends SimpleContentType implements PreResolvableCon
     private $mediaReferenceStore;
 
     /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    /**
      * @var ?SecurityCheckerInterface
      */
     private $securityChecker;
@@ -44,10 +50,12 @@ class SingleMediaSelection extends SimpleContentType implements PreResolvableCon
     public function __construct(
         MediaManagerInterface $mediaManager,
         ReferenceStoreInterface $referenceStore,
+        RequestAnalyzerInterface $requestAnalyzer,
         SecurityCheckerInterface $securityChecker = null
     ) {
         $this->mediaManager = $mediaManager;
         $this->mediaReferenceStore = $referenceStore;
+        $this->requestAnalyzer = $requestAnalyzer;
         $this->securityChecker = $securityChecker;
 
         parent::__construct('SingleMediaSelection', '{"id": null}');
@@ -66,7 +74,10 @@ class SingleMediaSelection extends SimpleContentType implements PreResolvableCon
             return null;
         }
 
-        if ($this->securityChecker
+        $webspace = $this->requestAnalyzer->getWebspace();
+
+        if ($webspace->hasWebsiteSecurity()
+            && $this->securityChecker
             && !$this->securityChecker->hasPermission(
                 new SecurityCondition(
                     MediaAdmin::SECURITY_CONTEXT,

--- a/src/Sulu/Bundle/MediaBundle/Content/Types/SingleMediaSelection.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/SingleMediaSelection.php
@@ -76,7 +76,8 @@ class SingleMediaSelection extends SimpleContentType implements PreResolvableCon
 
         $webspace = $this->requestAnalyzer->getWebspace();
 
-        if ($webspace->hasWebsiteSecurity()
+        if ($webspace
+            && $webspace->hasWebsiteSecurity()
             && $this->securityChecker
             && !$this->securityChecker->hasPermission(
                 new SecurityCondition(

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
@@ -76,7 +76,8 @@ class MediaDataProviderRepository implements DataProviderRepositoryInterface
         $limit,
         $locale,
         $options = [],
-        UserInterface $user = null
+        UserInterface $user = null,
+        $permission = null
     ) {
         if (!\array_key_exists('dataSource', $filters) ||
             '' === $filters['dataSource'] ||
@@ -99,7 +100,8 @@ class MediaDataProviderRepository implements DataProviderRepositoryInterface
             $options,
             $user,
             Collection::class,
-            'collection'
+            'collection',
+            $permission
         );
 
         return \array_map(

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
@@ -132,7 +132,7 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
             $orderBy,
             $orderSort,
             $ids
-            ) = $this->extractFilterVars($filter);
+        ) = $this->extractFilterVars($filter);
 
         // if empty array of ids is requested return empty array of medias
         if (null !== $ids && 0 === \count($ids)) {

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -280,7 +280,7 @@
         <service id="sulu_media.type.media_selection" class="%sulu_media.media_selection.class%">
             <argument type="service" id="sulu_media.media_manager"/>
             <argument type="service" id="sulu_media.reference_store.media"/>
-            <argument type="service" id="security.token_storage" on-invalid="null"/>
+            <argument type="service" id="sulu_core.webspace.request_analyzer"/>
             <argument>%sulu_security.permissions%</argument>
 
             <tag name="sulu.content.type" alias="media_selection"/>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -290,6 +290,7 @@
         <service id="sulu_media.type.single_media_selection" class="Sulu\Bundle\MediaBundle\Content\Types\SingleMediaSelection">
             <argument type="service" id="sulu_media.media_manager"/>
             <argument type="service" id="sulu_media.reference_store.media"/>
+            <argument type="service" id="sulu_core.webspace.request_analyzer"/>
             <argument type="service" id="sulu_security.security_checker" on-invalid="null"/>
 
             <tag name="sulu.content.type" alias="single_media_selection"/>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -352,7 +352,9 @@
             <argument type="service" id="sulu_core.array_serializer"/>
             <argument type="service" id="request_stack"/>
             <argument type="service" id="sulu_media.reference_store.media"/>
-            <argument type="service" id="security.token_storage" on-invalid="null"/>
+            <argument type="service" id="security.helper" on-invalid="ignore"/>
+            <argument type="service" id="sulu_core.webspace.request_analyzer"/>
+            <argument>%sulu_security.permissions%</argument>
 
             <tag name="sulu.smart_content.data_provider" alias="media"/>
         </service>

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
@@ -728,7 +728,7 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
 
         $mediaResults = $this->getContainer()
             ->get('sulu_media_test.smart_content.data_provider.media.repository')
-            ->findByFilters($filters, 1, 100, 100, 'de');
+            ->findByFilters($filters, 1, 100, 100, 'de', [], null, 64);
 
         $this->assertCount(0, $mediaResults);
     }
@@ -762,7 +762,7 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
 
         $mediaResults = $this->getContainer()
             ->get('sulu_media_test.smart_content.data_provider.media.repository')
-            ->findByFilters($filters, 1, 100, 100, 'de');
+            ->findByFilters($filters, 1, 100, 100, 'de', [], null, 64);
 
         $this->assertCount(2, $mediaResults);
         $this->assertEquals('Media 1', $mediaResults[0]->getName());
@@ -791,7 +791,7 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
 
         $mediaResults = $this->getContainer()
             ->get('sulu_media_test.smart_content.data_provider.media.repository')
-            ->findByFilters($filters, 1, 100, 100, 'de');
+            ->findByFilters($filters, 1, 100, 100, 'de', [], null, 64);
 
         $this->assertCount(0, $mediaResults);
     }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Admin/MediaAdminTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Admin/MediaAdminTest.php
@@ -76,13 +76,23 @@ class MediaAdminTest extends TestCase
         $webspace1 = new Webspace();
         $security1 = new Security();
         $security1->setSystem('Webspace1');
+        $security1->setPermissionCheck(true);
         $webspace1->setSecurity($security1);
 
         $webspace2 = new Webspace();
         $security2 = new Security();
         $security2->setSystem('Webspace2');
+        $security2->setPermissionCheck(true);
         $webspace2->setSecurity($security2);
-        $this->webspaceManager->getWebspaceCollection()->willReturn(new WebspaceCollection([$webspace1, $webspace2]));
+
+        $webspace3 = new Webspace();
+        $security3 = new Security();
+        $security3->setSystem('Webspace3');
+        $security3->setPermissionCheck(false);
+        $webspace3->setSecurity($security2);
+
+        $this->webspaceManager->getWebspaceCollection()
+            ->willReturn(new WebspaceCollection([$webspace1, $webspace2, $webspace3]));
 
         $this->assertEquals(
             [

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Admin/MediaAdminTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Admin/MediaAdminTest.php
@@ -76,23 +76,13 @@ class MediaAdminTest extends TestCase
         $webspace1 = new Webspace();
         $security1 = new Security();
         $security1->setSystem('Webspace1');
-        $security1->setPermissionCheck(true);
         $webspace1->setSecurity($security1);
 
         $webspace2 = new Webspace();
         $security2 = new Security();
         $security2->setSystem('Webspace2');
-        $security2->setPermissionCheck(true);
         $webspace2->setSecurity($security2);
-
-        $webspace3 = new Webspace();
-        $security3 = new Security();
-        $security3->setSystem('Webspace3');
-        $security3->setPermissionCheck(false);
-        $webspace3->setSecurity($security2);
-
-        $this->webspaceManager->getWebspaceCollection()
-            ->willReturn(new WebspaceCollection([$webspace1, $webspace2, $webspace3]));
+        $this->webspaceManager->getWebspaceCollection()->willReturn(new WebspaceCollection([$webspace1, $webspace2]));
 
         $this->assertEquals(
             [

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/MediaSelectionContentTypeTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/MediaSelectionContentTypeTest.php
@@ -396,6 +396,8 @@ class MediaSelectionContentTypeTest extends TestCase
         $structure = $this->prophesize(StructureInterface::class);
         $property->getStructure()->willReturn($structure->reveal());
 
+        $this->requestAnalyzer->getWebspace()->willReturn(null);
+
         $this->mediaManager->getByIds([1, 2, 3], null, null)->shouldBeCalled();
 
         $result = $this->mediaSelection->getContentData($property->reveal());

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/MediaSelectionContentTypeTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/MediaSelectionContentTypeTest.php
@@ -18,7 +18,9 @@ use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Security;
+use Sulu\Component\Webspace\Webspace;
 
 class MediaSelectionContentTypeTest extends TestCase
 {
@@ -33,6 +35,16 @@ class MediaSelectionContentTypeTest extends TestCase
     private $mediaReferenceStore;
 
     /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    /**
+     * @var Webspace
+     */
+    private $webspace;
+
+    /**
      * @var MediaManagerInterface
      */
     private $mediaManager;
@@ -41,12 +53,15 @@ class MediaSelectionContentTypeTest extends TestCase
     {
         $this->mediaManager = $this->prophesize(MediaManagerInterface::class);
         $this->mediaReferenceStore = $this->prophesize(ReferenceStoreInterface::class);
-        $this->tokenStorage = $this->prophesize(TokenStorageInterface::class);
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+
+        $this->webspace = new Webspace();
+        $this->requestAnalyzer->getWebspace()->willReturn($this->webspace);
 
         $this->mediaSelection = new MediaSelectionContentType(
             $this->mediaManager->reveal(),
             $this->mediaReferenceStore->reveal(),
-            $this->tokenStorage->reveal(),
+            $this->requestAnalyzer->reveal(),
             ['view' => 64]
         );
     }
@@ -380,6 +395,25 @@ class MediaSelectionContentTypeTest extends TestCase
 
         $structure = $this->prophesize(StructureInterface::class);
         $property->getStructure()->willReturn($structure->reveal());
+
+        $this->mediaManager->getByIds([1, 2, 3], null, null)->shouldBeCalled();
+
+        $result = $this->mediaSelection->getContentData($property->reveal());
+    }
+
+    public function testGetContentDataWithPermissions()
+    {
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getValue()->willReturn(['ids' => [1, 2, 3]]);
+        $property->getParams()->willReturn([]);
+
+        $structure = $this->prophesize(StructureInterface::class);
+        $property->getStructure()->willReturn($structure->reveal());
+
+        $security = new Security();
+        $security->setSystem('website');
+        $security->setPermissionCheck(true);
+        $this->webspace->setSecurity($security);
 
         $this->mediaManager->getByIds([1, 2, 3], null, 64)->shouldBeCalled();
 

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -316,7 +316,7 @@ class PageAdmin extends Admin
             }
 
             $system = $security->getSystem();
-            if (!$webspace->hasWebsiteSecurity()) {
+            if (!$system) {
                 continue;
             }
 
@@ -358,11 +358,17 @@ class PageAdmin extends Admin
 
         /** @var Webspace $webspace */
         foreach ($this->webspaceManager->getWebspaceCollection() as $webspace) {
-            if (!$webspace->hasWebsiteSecurity()) {
+            $security = $webspace->getSecurity();
+            if (!$security) {
                 continue;
             }
 
-            $webspaceSecuritySystemContexts[$webspace->getSecurity()->getSystem()] = [
+            $system = $security->getSystem();
+            if (!$system) {
+                continue;
+            }
+
+            $webspaceSecuritySystemContexts[$system] = [
                 static::SECURITY_CONTEXT_GROUP => [
                     static::SECURITY_CONTEXT_PREFIX . '#webspace#' => [
                         PermissionTypes::VIEW,

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -316,7 +316,7 @@ class PageAdmin extends Admin
             }
 
             $system = $security->getSystem();
-            if (!$system) {
+            if (!$webspace->hasWebsiteSecurity()) {
                 continue;
             }
 
@@ -358,17 +358,11 @@ class PageAdmin extends Admin
 
         /** @var Webspace $webspace */
         foreach ($this->webspaceManager->getWebspaceCollection() as $webspace) {
-            $security = $webspace->getSecurity();
-            if (!$security) {
+            if (!$webspace->hasWebsiteSecurity()) {
                 continue;
             }
 
-            $system = $security->getSystem();
-            if (!$system) {
-                continue;
-            }
-
-            $webspaceSecuritySystemContexts[$system] = [
+            $webspaceSecuritySystemContexts[$webspace->getSecurity()->getSystem()] = [
                 static::SECURITY_CONTEXT_GROUP => [
                     static::SECURITY_CONTEXT_PREFIX . '#webspace#' => [
                         PermissionTypes::VIEW,

--- a/src/Sulu/Bundle/PageBundle/Resources/config/serializer/Security.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/serializer/Security.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <serializer>
     <class name="Sulu\Component\Webspace\Security" exclusion-policy="ALL">
+        <property name="permissionCheck" type="boolean" expose="true" groups="frontend,Default"/>
         <property name="system" type="string" expose="true" groups="frontend,Default"/>
     </class>
 </serializer>

--- a/src/Sulu/Bundle/PageBundle/Resources/js/stores/webspaceStore/types.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/stores/webspaceStore/types.js
@@ -22,6 +22,7 @@ export type ResourceLocatorStrategy = {
 };
 
 export type Security = {
+    permissionCheck: boolean,
     system: string,
 }
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/webspaces/sulu.io.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/webspaces/sulu.io.xml
@@ -6,6 +6,10 @@
     <name>Sulu CMF</name>
     <key>sulu_io</key>
 
+    <security permission-check="false">
+        <system>sulu</system>
+    </security>
+
     <localizations>
         <localization language="en" shadow="auto">
             <localization language="en" country="us" shadow="auto"/>

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/webspaces/test.io.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/webspaces/test.io.xml
@@ -6,7 +6,7 @@
     <name>Test CMF</name>
     <key>test_io</key>
 
-    <security>
+    <security permission-check="true">
         <system>test_security_system</system>
     </security>
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -84,6 +84,7 @@ class AdminControllerTest extends SuluTestCase
         $this->assertEquals('sulu_io', $pageConfig->webspaces->sulu_io->key);
         $this->assertEquals('test_io', $pageConfig->webspaces->test_io->key);
         $this->assertEquals('test_security_system', $pageConfig->webspaces->test_io->security->system);
+        $this->assertEquals(true, $pageConfig->webspaces->test_io->security->permissionCheck);
 
         $this->assertEquals('en', $pageConfig->webspaces->test_io->localizations[0]->language);
         $this->assertTrue($pageConfig->webspaces->test_io->localizations[0]->default);

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Admin/PageAdminTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Admin/PageAdminTest.php
@@ -197,13 +197,12 @@ class PageAdminTest extends TestCase
         $webspace1 = new Webspace();
         $webspace1->setKey('webspace-key-1');
 
-        $webspace2Security = new Security();
-        $webspace2Security->setSystem('webspace-security-system-2');
-        $webspace2Security->setPermissionCheck(true);
+        $webspace2Security = $this->prophesize(Security::class);
+        $webspace2Security->getSystem()->willReturn('webspace-security-system-2');
 
         $webspace2 = new Webspace();
         $webspace2->setKey('webspace-key-2');
-        $webspace2->setSecurity($webspace2Security);
+        $webspace2->setSecurity($webspace2Security->reveal());
 
         $this->webspaceManager->getWebspaceCollection()->willReturn(new WebspaceCollection([
             $webspace1,

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Admin/PageAdminTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Admin/PageAdminTest.php
@@ -197,12 +197,13 @@ class PageAdminTest extends TestCase
         $webspace1 = new Webspace();
         $webspace1->setKey('webspace-key-1');
 
-        $webspace2Security = $this->prophesize(Security::class);
-        $webspace2Security->getSystem()->willReturn('webspace-security-system-2');
+        $webspace2Security = new Security();
+        $webspace2Security->setSystem('webspace-security-system-2');
+        $webspace2Security->setPermissionCheck(true);
 
         $webspace2 = new Webspace();
         $webspace2->setKey('webspace-key-2');
-        $webspace2->setSecurity($webspace2Security->reveal());
+        $webspace2->setSecurity($webspace2Security);
 
         $this->webspaceManager->getWebspaceCollection()->willReturn(new WebspaceCollection([
             $webspace1,

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/fields/RolePermissions.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/fields/RolePermissions.js
@@ -33,14 +33,24 @@ class RolePermissions extends React.Component<FieldTypeProps<RolePermissionsType
         return key;
     }
 
-    @computed get system() {
+    @computed get webspaceSecurity() {
         const {
             webspace: {
-                security: {
-                    system,
-                } = {},
+                security = {},
             } = {},
         } = this;
+
+        return security;
+    }
+
+    @computed get permissionCheck() {
+        const {permissionCheck} = this.webspaceSecurity;
+
+        return permissionCheck;
+    }
+
+    @computed get system() {
+        const {system} = this.webspaceSecurity;
 
         return system;
     }
@@ -63,6 +73,7 @@ class RolePermissions extends React.Component<FieldTypeProps<RolePermissionsType
             <RolePermissionsContainer
                 disabled={disabled || undefined}
                 onChange={this.handleChange}
+                permissionCheck={this.permissionCheck}
                 resourceKey={formInspector.options.resourceKey}
                 system={this.system}
                 value={value ? value : {}}

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/tests/fields/RolePermissions.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/tests/fields/RolePermissions.test.js
@@ -45,6 +45,7 @@ test('Pass props correctly to component', () => {
     expect(webspaceStore.getWebspace).not.toBeCalled();
 
     expect(rolePermissions.find('RolePermissions').prop('disabled')).toEqual(false);
+    expect(rolePermissions.find('RolePermissions').prop('permissionCheck')).toBe(undefined);
     expect(rolePermissions.find('RolePermissions').prop('resourceKey')).toEqual('snippets');
     expect(rolePermissions.find('RolePermissions').prop('system')).toBe(undefined);
     expect(rolePermissions.find('RolePermissions').prop('value')).toBe(value);
@@ -82,6 +83,7 @@ test('Pass system prop correctly to component', () => {
                 key: 'test',
                 security: {
                     system: 'test_security',
+                    permissionCheck: true,
                 },
             };
         }
@@ -101,6 +103,7 @@ test('Pass system prop correctly to component', () => {
         />
     );
 
+    expect(rolePermissions.find('RolePermissions').prop('permissionCheck')).toEqual(true);
     expect(rolePermissions.find('RolePermissions').prop('system')).toEqual('test_security');
     expect(rolePermissions.find('RolePermissions').prop('webspaceKey')).toEqual('test');
 });

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/RolePermissions.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/RolePermissions.js
@@ -12,6 +12,7 @@ import type {RolePermissions as RolePermissionsType} from './types';
 type Props = {|
     disabled: boolean,
     onChange: (value: RolePermissionsType) => void,
+    permissionCheck?: ?boolean,
     resourceKey: string,
     system?: ?string,
     value: RolePermissionsType,
@@ -59,13 +60,17 @@ class RolePermissions extends React.Component<Props> {
 
     render() {
         const {roles} = this;
-        const {disabled, resourceKey, system, value, webspaceKey} = this.props;
+        const {disabled, permissionCheck, resourceKey, system, value, webspaceKey} = this.props;
 
         if (!roles) {
             return <Loader />;
         }
 
-        const systems = system ? [RolePermissions.suluSecuritySystem, system] : securityContextStore.getSystems();
+        const systems = permissionCheck && system
+            ? [RolePermissions.suluSecuritySystem, system]
+            : !permissionCheck && system
+                ? [RolePermissions.suluSecuritySystem]
+                : securityContextStore.getSystems();
 
         return systems.reduce((systemMatrices, system) => {
             const actions = securityContextStore.getAvailableActions(resourceKey, system);

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/tests/RolePermissions.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/tests/RolePermissions.test.js
@@ -81,7 +81,7 @@ test('Hide system if specific system is given', () => {
     securityContextStore.getSystems.mockReturnValue(['Sulu', 'Website', 'Blog']);
 
     const rolePermissions = mount(
-        <RolePermissions onChange={jest.fn()} resourceKey="snippets" system="Blog" value={{}} />
+        <RolePermissions onChange={jest.fn()} permissionCheck={true} resourceKey="snippets" system="Blog" value={{}} />
     );
 
     return Promise.all([rolePromise]).then(() => {
@@ -89,6 +89,34 @@ test('Hide system if specific system is given', () => {
         expect(rolePermissions.find('SystemRolePermissions')).toHaveLength(2);
         expect(rolePermissions.find('SystemRolePermissions').at(0).prop('system')).toEqual('Sulu');
         expect(rolePermissions.find('SystemRolePermissions').at(1).prop('system')).toEqual('Blog');
+    });
+});
+
+test('Show only Sulu system if specific system is given and permissionCheck is set to false for that system', () => {
+    const rolePromise = Promise.resolve(
+        {
+            _embedded: {
+                roles: [
+                    {id: 1, name: 'Admin', system: 'Sulu'},
+                    {id: 2, name: 'Contact Manager', system: 'Website'},
+                    {id: 3, name: 'Blog Manager', system: 'Blog'},
+                ],
+            },
+        }
+    );
+    ResourceRequester.get.mockReturnValue(rolePromise);
+
+    securityContextStore.getAvailableActions.mockReturnValue(['view', 'add', 'edit', 'delete', 'security']);
+    securityContextStore.getSystems.mockReturnValue(['Sulu', 'Website', 'Blog']);
+
+    const rolePermissions = mount(
+        <RolePermissions onChange={jest.fn()} permissionCheck={false} resourceKey="snippets" system="Blog" value={{}} />
+    );
+
+    return Promise.all([rolePromise]).then(() => {
+        rolePermissions.update();
+        expect(rolePermissions.find('SystemRolePermissions')).toHaveLength(1);
+        expect(rolePermissions.find('SystemRolePermissions').at(0).prop('system')).toEqual('Sulu');
     });
 });
 

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -123,7 +123,6 @@
             <argument type="service" id="sulu.content.mapper"/>
             <argument type="service" id="sulu_website.navigation_mapper"/>
             <argument type="service" id="sulu_core.webspace.request_analyzer" on-invalid="null"/>
-            <argument type="service" id="security.token_storage" on-invalid="null"/>
         </service>
         <service id="sulu_website.twig.navigation.memoized" class="%sulu_website.twig.navigation.memoized.class%">
             <argument type="service" id="sulu_website.twig.navigation"/>

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
@@ -157,7 +157,7 @@ class ContentRouteProvider implements RouteProviderInterface
                 return $collection;
             }
 
-            if ($this->securityChecker) {
+            if ($this->securityChecker && $portal->getWebspace()->hasWebsiteSecurity()) {
                 $this->securityChecker->checkPermission(
                     new SecurityCondition(
                         'sulu.webspaces.' . $document->getWebspaceName(),

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/webspaces/sulu_lo.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/webspaces/sulu_lo.xml
@@ -6,6 +6,10 @@
     <name>Sulu CMF</name>
     <key>sulu_io</key>
 
+    <security permission-check="true">
+        <system>sulu_io</system>
+    </security>
+
     <localizations>
         <localization language="en"/>
     </localizations>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Navigation/NavigationMapperTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Navigation/NavigationMapperTest.php
@@ -50,7 +50,7 @@ class NavigationMapperTest extends SuluTestCase
     /**
      * @var ContentMapperInterface
      */
-    private $mapper;
+    private $contentMapper;
 
     /**
      * @var DocumentManagerInterface
@@ -103,7 +103,7 @@ class NavigationMapperTest extends SuluTestCase
     {
         $this->purgeDatabase();
         $this->initPhpcr();
-        $this->mapper = $this->getContainer()->get('sulu.content.mapper');
+        $this->contentMapper = $this->getContainer()->get('sulu.content.mapper');
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
         $this->structureManager = $this->getContainer()->get('sulu.content.structure_manager');
         $this->extensionManager = $this->getContainer()->get('sulu_page.extension.manager');
@@ -134,10 +134,10 @@ class NavigationMapperTest extends SuluTestCase
 
         $this->data = $this->prepareTestData();
 
-        $contentQuery = new ContentQueryExecutor($this->sessionManager, $this->mapper, null, $this->tokenStorage);
+        $contentQuery = new ContentQueryExecutor($this->sessionManager, $this->contentMapper, null);
 
         $this->navigationMapper = new NavigationMapper(
-            $this->mapper,
+            $this->contentMapper,
             $contentQuery,
             new NavigationQueryBuilder($this->structureManager, $this->extensionManager, $this->languageNamespace),
             $this->sessionManager,

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/ContentRouteProviderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/ContentRouteProviderTest.php
@@ -270,7 +270,6 @@ class ContentRouteProviderTest extends TestCase
         $this->assertEquals(false, $defaults['partial']);
     }
 
-
     public function testSecurityCheckerWithoutPermissionCheck()
     {
         $attributes = $this->prophesize(RequestAttributes::class);

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/ContentRouteProviderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/ContentRouteProviderTest.php
@@ -41,6 +41,7 @@ use Sulu\Component\Webspace\Analyzer\RequestAnalyzer;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Portal;
+use Sulu\Component\Webspace\Security;
 use Sulu\Component\Webspace\Segment;
 use Sulu\Component\Webspace\Webspace;
 use Symfony\Component\HttpFoundation\Request;
@@ -199,6 +200,10 @@ class ContentRouteProviderTest extends TestCase
         $webspace = new Webspace();
         $webspace->setKey('webspace');
         $webspace->setTheme('theme');
+        $security = new Security();
+        $security->setSystem('website');
+        $security->setPermissionCheck(true);
+        $webspace->setSecurity($security);
         $portal->setWebspace($webspace);
         $attributes->getAttribute('portal', null)->willReturn($portal);
 
@@ -254,6 +259,83 @@ class ContentRouteProviderTest extends TestCase
 
             return true;
         }), PermissionTypes::VIEW)->shouldBeCalled();
+
+        $contentRouteProvider = $this->createContentRouteProvider($securityChecker->reveal());
+        $routes = $contentRouteProvider->getRouteCollectionForRequest($request);
+
+        $defaults = $routes->getIterator()->current()->getDefaults();
+
+        $this->assertCount(1, $routes);
+        $this->assertEquals($pageBridge->reveal(), $defaults['structure']);
+        $this->assertEquals(false, $defaults['partial']);
+    }
+
+
+    public function testSecurityCheckerWithoutPermissionCheck()
+    {
+        $attributes = $this->prophesize(RequestAttributes::class);
+
+        $localization = new Localization();
+        $localization->setLanguage('de');
+        $attributes->getAttribute('localization', null)->willReturn($localization);
+
+        $portal = new Portal();
+        $portal->setKey('portal');
+        $webspace = new Webspace();
+        $webspace->setKey('webspace');
+        $webspace->setTheme('theme');
+        $security = new Security();
+        $security->setSystem('website');
+        $security->setPermissionCheck(false);
+        $webspace->setSecurity($security);
+        $portal->setWebspace($webspace);
+        $attributes->getAttribute('portal', null)->willReturn($portal);
+
+        $attributes->getAttribute('matchType', null)->willReturn(RequestAnalyzer::MATCH_TYPE_FULL);
+        $attributes->getAttribute('resourceLocator', null)->willReturn(null);
+        $attributes->getAttribute('resourceLocatorPrefix', null)->willReturn('/de');
+
+        $this->resourceLocatorStrategy->loadByResourceLocator('', 'webspace', 'de')->willReturn('some-uuid');
+
+        $document = $this->prophesize(TitleBehavior::class)
+            ->willImplement(ExtensionBehavior::class)
+            ->willImplement(RedirectTypeBehavior::class)
+            ->willImplement(StructureBehavior::class)
+            ->willImplement(WebspaceBehavior::class)
+            ->willImplement(UuidBehavior::class);
+        $document->getUuid()->willReturn('some-uuid');
+        $document->getTitle()->willReturn('some-title');
+        $document->getWebspaceName()->willReturn('webspace');
+        $document->getLocale()->willReturn('de');
+        $document->getRedirectType()->willReturn(RedirectType::NONE);
+        $document->getStructureType()->willReturn('default');
+        $document->getUuid()->willReturn('some-uuid');
+        $document->getExtensionsData()->willReturn(['excerpt' => ['segments' => null]]);
+        $this->documentManager->find('some-uuid', 'de', ['load_ghost_content' => false])->willReturn($document->reveal());
+
+        $metadata = new Metadata();
+        $metadata->setAlias('page');
+        $structureMetadata = new StructureMetadata();
+        $this->documentInspector->getMetadata($document->reveal())->willReturn($metadata);
+        $this->documentInspector->getStructureMetadata($document->reveal())->willReturn($structureMetadata);
+
+        $pageBridge = $this->prophesize(PageBridge::class);
+        $pageBridge->getController()->willReturn('::Controller');
+        $this->structureManager->wrapStructure('page', $structureMetadata)->willReturn($pageBridge->reveal());
+
+        $request = new Request(
+            [],
+            [],
+            ['_sulu' => $attributes->reveal()],
+            [],
+            [],
+            ['REQUEST_URI' => \rawurlencode('/de')]
+        );
+
+        $pageBridge->setDocument($document->reveal())->shouldBeCalled();
+
+        $securityChecker = $this->prophesize(SecurityCheckerInterface::class);
+        $securityChecker->checkPermission(Argument::cetera())->shouldNotBeCalled();
 
         $contentRouteProvider = $this->createContentRouteProvider($securityChecker->reveal());
         $routes = $contentRouteProvider->getRouteCollectionForRequest($request);

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/ContentTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/ContentTwigExtensionTest.php
@@ -269,6 +269,7 @@ class ContentTwigExtensionTest extends TestCase
 
         $security = new Security();
         $security->setSystem('sulu_test');
+        $security->setPermissionCheck(true);
         $this->webspace->setSecurity($security);
 
         $this

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/NavigationTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/NavigationTwigExtensionTest.php
@@ -15,7 +15,6 @@ use Sulu\Bundle\WebsiteBundle\Twig\Navigation\NavigationTwigExtension;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 use Sulu\Component\Localization\Localization;
-use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Segment;
 use Sulu\Component\Webspace\Webspace;

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/NavigationTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/NavigationTwigExtensionTest.php
@@ -19,8 +19,6 @@ use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Segment;
 use Sulu\Component\Webspace\Webspace;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class NavigationTwigExtensionTest extends TestCase
 {
@@ -98,7 +96,7 @@ class NavigationTwigExtensionTest extends TestCase
         $localization = new Localization('de');
         $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
 
-        $navigationMapper->getNavigation('123-123-123', 'sulu_io', 'de', 1, true, null, false, 's', null)
+        $navigationMapper->getNavigation('123-123-123', 'sulu_io', 'de', 1, true, null, false, 's')
             ->willThrow(new DocumentNotFoundException());
 
         $this->assertEquals([], $extension->flatNavigationFunction('123-123-123'));
@@ -126,28 +124,21 @@ class NavigationTwigExtensionTest extends TestCase
         $localization = new Localization('de');
         $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
 
-        $navigationMapper->getNavigation('123-123-123', 'sulu_io', 'de', 1, false, null, false, 'w', null)
+        $navigationMapper->getNavigation('123-123-123', 'sulu_io', 'de', 1, false, null, false, 'w')
             ->willThrow(new DocumentNotFoundException());
 
         $this->assertEquals([], $extension->treeNavigationFunction('123-123-123'));
     }
 
-    public function testFlatRootNavigationWithUser()
+    public function testFlatRootNavigation()
     {
         $navigationMapper = $this->prophesize(NavigationMapperInterface::class);
         $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
-        $tokenStorage = $this->prophesize(TokenStorageInterface::class);
-
-        $token = $this->prophesize(TokenInterface::class);
-        $user = $this->prophesize(UserInterface::class);
-        $token->getUser()->willReturn($user->reveal());
-        $tokenStorage->getToken()->willReturn($token->reveal());
 
         $extension = new NavigationTwigExtension(
             $this->prophesize(ContentMapperInterface::class)->reveal(),
             $navigationMapper->reveal(),
-            $requestAnalyzer->reveal(),
-            $tokenStorage->reveal()
+            $requestAnalyzer->reveal()
         );
 
         $webspace = new Webspace();
@@ -159,170 +150,9 @@ class NavigationTwigExtensionTest extends TestCase
         $localization = new Localization('de');
         $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
 
-        $navigationMapper->getRootNavigation('sulu_io', 'de', 1, true, 'main', false, null, $user->reveal())
+        $navigationMapper->getRootNavigation('sulu_io', 'de', 1, true, 'main', false, null)
             ->shouldBeCalled();
 
         $extension->flatRootNavigationFunction('main', 1, false);
-    }
-
-    public function testFlatRootNavigationWithoutToken()
-    {
-        $navigationMapper = $this->prophesize(NavigationMapperInterface::class);
-        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
-        $tokenStorage = $this->prophesize(TokenStorageInterface::class);
-
-        $tokenStorage->getToken()->willReturn(null);
-
-        $extension = new NavigationTwigExtension(
-            $this->prophesize(ContentMapperInterface::class)->reveal(),
-            $navigationMapper->reveal(),
-            $requestAnalyzer->reveal(),
-            $tokenStorage->reveal()
-        );
-
-        $webspace = new Webspace();
-        $webspace->setKey('sulu_io');
-        $requestAnalyzer->getWebspace()->willReturn($webspace);
-
-        $requestAnalyzer->getSegment()->willReturn(null);
-
-        $localization = new Localization('de');
-        $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
-
-        $navigationMapper->getRootNavigation('sulu_io', 'de', 1, true, 'main', false, null, null)
-            ->shouldBeCalled();
-
-        $extension->flatRootNavigationFunction('main', 1, false);
-    }
-
-    public function testFlatRootNavigationWithoutUser()
-    {
-        $navigationMapper = $this->prophesize(NavigationMapperInterface::class);
-        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
-        $tokenStorage = $this->prophesize(TokenStorageInterface::class);
-
-        $token = $this->prophesize(TokenInterface::class);
-        $token->getUser()->willReturn(null);
-        $tokenStorage->getToken()->willReturn($token->reveal());
-
-        $extension = new NavigationTwigExtension(
-            $this->prophesize(ContentMapperInterface::class)->reveal(),
-            $navigationMapper->reveal(),
-            $requestAnalyzer->reveal(),
-            $tokenStorage->reveal()
-        );
-
-        $webspace = new Webspace();
-        $webspace->setKey('sulu_io');
-        $requestAnalyzer->getWebspace()->willReturn($webspace);
-
-        $requestAnalyzer->getSegment()->willReturn(null);
-
-        $localization = new Localization('de');
-        $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
-
-        $navigationMapper->getRootNavigation('sulu_io', 'de', 1, true, 'main', false, null, null)
-            ->shouldBeCalled();
-
-        $extension->flatRootNavigationFunction('main', 1, false);
-    }
-
-    public function testTreeRootNavigationWithUser()
-    {
-        $navigationMapper = $this->prophesize(NavigationMapperInterface::class);
-        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
-        $tokenStorage = $this->prophesize(TokenStorageInterface::class);
-
-        $token = $this->prophesize(TokenInterface::class);
-        $user = $this->prophesize(UserInterface::class);
-        $token->getUser()->willReturn($user->reveal());
-        $tokenStorage->getToken()->willReturn($token->reveal());
-
-        $extension = new NavigationTwigExtension(
-            $this->prophesize(ContentMapperInterface::class)->reveal(),
-            $navigationMapper->reveal(),
-            $requestAnalyzer->reveal(),
-            $tokenStorage->reveal()
-        );
-
-        $webspace = new Webspace();
-        $webspace->setKey('sulu_io');
-        $requestAnalyzer->getWebspace()->willReturn($webspace);
-
-        $requestAnalyzer->getSegment()->willReturn(null);
-
-        $localization = new Localization('de');
-        $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
-
-        $navigationMapper->getRootNavigation('sulu_io', 'de', 1, false, 'main', false, null, $user->reveal())
-            ->shouldBeCalled();
-
-        $extension->treeRootNavigationFunction('main', 1, false);
-    }
-
-    public function testFlatNavigationWithUser()
-    {
-        $navigationMapper = $this->prophesize(NavigationMapperInterface::class);
-        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
-        $tokenStorage = $this->prophesize(TokenStorageInterface::class);
-
-        $token = $this->prophesize(TokenInterface::class);
-        $user = $this->prophesize(UserInterface::class);
-        $token->getUser()->willReturn($user->reveal());
-        $tokenStorage->getToken()->willReturn($token->reveal());
-
-        $extension = new NavigationTwigExtension(
-            $this->prophesize(ContentMapperInterface::class)->reveal(),
-            $navigationMapper->reveal(),
-            $requestAnalyzer->reveal(),
-            $tokenStorage->reveal()
-        );
-
-        $webspace = new Webspace();
-        $webspace->setKey('sulu_io');
-        $requestAnalyzer->getWebspace()->willReturn($webspace);
-
-        $requestAnalyzer->getSegment()->willReturn(null);
-
-        $localization = new Localization('de');
-        $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
-
-        $navigationMapper->getNavigation('main', 'sulu_io', 'de', false, true, 1, false, null, $user->reveal())
-            ->shouldBeCalled();
-
-        $extension->flatNavigationFunction('main', 1, false);
-    }
-
-    public function testTreeNavigationWithUser()
-    {
-        $navigationMapper = $this->prophesize(NavigationMapperInterface::class);
-        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
-        $tokenStorage = $this->prophesize(TokenStorageInterface::class);
-
-        $token = $this->prophesize(TokenInterface::class);
-        $user = $this->prophesize(UserInterface::class);
-        $token->getUser()->willReturn($user->reveal());
-        $tokenStorage->getToken()->willReturn($token->reveal());
-
-        $extension = new NavigationTwigExtension(
-            $this->prophesize(ContentMapperInterface::class)->reveal(),
-            $navigationMapper->reveal(),
-            $requestAnalyzer->reveal(),
-            $tokenStorage->reveal()
-        );
-
-        $webspace = new Webspace();
-        $webspace->setKey('sulu_io');
-        $requestAnalyzer->getWebspace()->willReturn($webspace);
-
-        $requestAnalyzer->getSegment()->willReturn(null);
-
-        $localization = new Localization('de');
-        $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
-
-        $navigationMapper->getNavigation('main', 'sulu_io', 'de', false, false, 1, false, null, $user->reveal())
-            ->shouldBeCalled();
-
-        $extension->treeNavigationFunction('main', 1, false);
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtension.php
@@ -40,21 +40,14 @@ class NavigationTwigExtension extends AbstractExtension implements NavigationTwi
      */
     private $requestAnalyzer;
 
-    /**
-     * @var ?TokenStorageInterface
-     */
-    private $tokenStorage;
-
     public function __construct(
         ContentMapperInterface $contentMapper,
         NavigationMapperInterface $navigationMapper,
-        RequestAnalyzerInterface $requestAnalyzer = null,
-        TokenStorageInterface $tokenStorage = null
+        RequestAnalyzerInterface $requestAnalyzer = null
     ) {
         $this->contentMapper = $contentMapper;
         $this->navigationMapper = $navigationMapper;
         $this->requestAnalyzer = $requestAnalyzer;
-        $this->tokenStorage = $tokenStorage;
     }
 
     public function getFunctions()
@@ -80,8 +73,7 @@ class NavigationTwigExtension extends AbstractExtension implements NavigationTwi
             true,
             $context,
             $loadExcerpt,
-            $segment ? $segment->getKey() : null,
-            $this->getUser()
+            $segment ? $segment->getKey() : null
         );
     }
 
@@ -96,8 +88,7 @@ class NavigationTwigExtension extends AbstractExtension implements NavigationTwi
             false,
             $context,
             $loadExcerpt,
-            $segment ? $segment->getKey() : null,
-            $this->getUser()
+            $segment ? $segment->getKey() : null
         );
     }
 
@@ -131,8 +122,7 @@ class NavigationTwigExtension extends AbstractExtension implements NavigationTwi
                 true,
                 $context,
                 $loadExcerpt,
-                $segment ? $segment->getKey() : null,
-                $this->getUser()
+                $segment ? $segment->getKey() : null
             );
         } catch (DocumentNotFoundException $exception) {
             return [];
@@ -169,8 +159,7 @@ class NavigationTwigExtension extends AbstractExtension implements NavigationTwi
                 false,
                 $context,
                 $loadExcerpt,
-                $segment ? $segment->getKey() : null,
-                $this->getUser()
+                $segment ? $segment->getKey() : null
             );
         } catch (DocumentNotFoundException $exception) {
             return [];
@@ -202,25 +191,5 @@ class NavigationTwigExtension extends AbstractExtension implements NavigationTwi
         }
 
         return \preg_match(\sprintf('/%s([\/]|$)/', \preg_quote($itemPath, '/')), $requestPath);
-    }
-
-    private function getUser(): ?UserInterface
-    {
-        if (!$this->tokenStorage) {
-            return null;
-        }
-
-        $token = $this->tokenStorage->getToken();
-        if (!$token) {
-            return null;
-        }
-
-        $user = $token->getUser();
-
-        if ($user instanceof UserInterface) {
-            return $user;
-        }
-
-        return null;
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtension.php
@@ -14,9 +14,7 @@ namespace Sulu\Bundle\WebsiteBundle\Twig\Navigation;
 use Sulu\Bundle\WebsiteBundle\Navigation\NavigationMapperInterface;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
-use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -696,7 +696,13 @@ class ContentMapper implements ContentMapperInterface
             return false;
         }
 
-        if ($document instanceof SecurityBehavior && $this->security && $permission && $webspace->hasWebsiteSecurity()) {
+        if (
+            $document instanceof SecurityBehavior
+            && $this->security
+            && $permission
+            && $webspace
+            && $webspace->hasWebsiteSecurity()
+        ) {
             $permissionKey = \array_search($permission, $this->permissions);
             $documentWebspaceKey = $document->getWebspaceName();
             $documentWebspace = $this->webspaceManager->findWebspaceByKey($documentWebspaceKey);

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -58,7 +58,6 @@ use Sulu\Component\DocumentManager\DocumentManager;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 use Sulu\Component\DocumentManager\NamespaceRegistry;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
-use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authorization\AccessControl\AccessControlManagerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -699,11 +698,16 @@ class ContentMapper implements ContentMapperInterface
 
         if ($document instanceof SecurityBehavior && $this->security && $permission && $webspace->hasWebsiteSecurity()) {
             $permissionKey = \array_search($permission, $this->permissions);
+            $documentWebspaceKey = $document->getWebspaceName();
+            $documentWebspace = $this->webspaceManager->findWebspaceByKey($documentWebspaceKey);
+            $documentWebspaceSecurity = $documentWebspace->getSecurity();
+
             $permissions = $this->accessControlManager->getUserPermissionByArray(
                 $document->getLocale(),
-                PageAdmin::SECURITY_CONTEXT_PREFIX . $document->getWebspaceName(),
+                PageAdmin::SECURITY_CONTEXT_PREFIX . $documentWebspaceKey,
                 $document->getPermissions(),
-                $this->security->getUser()
+                $this->security->getUser(),
+                $documentWebspaceSecurity->getSystem()
             );
 
             if (isset($permissions[$permissionKey]) && !$permissions[$permissionKey]) {

--- a/src/Sulu/Component/Content/Query/ContentQueryExecutor.php
+++ b/src/Sulu/Component/Content/Query/ContentQueryExecutor.php
@@ -15,7 +15,6 @@ use Jackalope\Query\Row;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
 
 /**
@@ -38,21 +37,14 @@ class ContentQueryExecutor implements ContentQueryExecutorInterface
      */
     private $stopwatch;
 
-    /**
-     * @var TokenStorageInterface
-     */
-    private $tokenStorage;
-
     public function __construct(
         SessionManagerInterface $sessionManager,
         ContentMapperInterface $contentMapper,
-        Stopwatch $stopwatch = null,
-        TokenStorageInterface $tokenStorage = null
+        Stopwatch $stopwatch = null
     ) {
         $this->sessionManager = $sessionManager;
         $this->contentMapper = $contentMapper;
         $this->stopwatch = $stopwatch;
-        $this->tokenStorage = $tokenStorage;
     }
 
     public function execute(
@@ -117,7 +109,6 @@ class ContentQueryExecutor implements ContentQueryExecutorInterface
             $fields,
             $depth,
             $contentQueryBuilder->getPublished(),
-            $this->getCurrentUser(),
             $permission
         );
 
@@ -157,29 +148,5 @@ class ContentQueryExecutor implements ContentQueryExecutorInterface
         }
 
         return $query;
-    }
-
-    /**
-     * Returns current user or null if no user is loggedin.
-     *
-     * @return UserInterface|void
-     */
-    private function getCurrentUser()
-    {
-        if (!$this->tokenStorage) {
-            return;
-        }
-
-        $token = $this->tokenStorage->getToken();
-        if (!$token) {
-            return;
-        }
-
-        $user = $token->getUser();
-        if ($user instanceof UserInterface) {
-            return $user;
-        }
-
-        return;
     }
 }

--- a/src/Sulu/Component/Content/Query/ContentQueryExecutor.php
+++ b/src/Sulu/Component/Content/Query/ContentQueryExecutor.php
@@ -14,7 +14,6 @@ namespace Sulu\Component\Content\Query;
 use Jackalope\Query\Row;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
-use Sulu\Component\Security\Authentication\UserInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
 
 /**

--- a/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
+++ b/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
@@ -20,8 +20,9 @@ use Sulu\Component\SmartContent\DataProviderResult;
 use Sulu\Component\SmartContent\DatasourceItem;
 use Sulu\Component\SmartContent\Orm\BaseDataProvider;
 use Sulu\Component\SmartContent\Orm\DataProviderRepositoryInterface;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Security;
 
 /**
  * Media DataProvider for SmartContent.
@@ -44,9 +45,11 @@ class MediaDataProvider extends BaseDataProvider
         ArraySerializerInterface $serializer,
         RequestStack $requestStack,
         ReferenceStoreInterface $referenceStore,
-        TokenStorageInterface $tokenStorage = null
+        Security $security,
+        RequestAnalyzerInterface $requestAnalyzer,
+        $permissions
     ) {
-        parent::__construct($repository, $serializer, $referenceStore, $tokenStorage);
+        parent::__construct($repository, $serializer, $referenceStore, $security, $requestAnalyzer, $permissions);
 
         $this->configuration = self::createConfigurationBuilder()
             ->enableTags()

--- a/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManagerInterface.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManagerInterface.php
@@ -55,8 +55,9 @@ interface AccessControlManagerInterface
      * @param string $securityContext
      * @param mixed[] $objectPermissionsByRole
      * @param ?UserInterface $user The user for which the security is returned
+     * @param ?string $system The system in which the permission should be checked
      *
      * @return mixed[]
      */
-    public function getUserPermissionByArray($locale, $securityContext, $objectPermissionsByRole, $user);
+    public function getUserPermissionByArray($locale, $securityContext, $objectPermissionsByRole, $user, $system = null);
 }

--- a/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
+++ b/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
@@ -33,7 +33,8 @@ trait DataProviderRepositoryTrait
         $options = [],
         ?UserInterface $user = null,
         $entityClass = null,
-        $entityAlias = null
+        $entityAlias = null,
+        $permission = null
     ) {
         $alias = 'entity';
         $queryBuilder = $this->createQueryBuilder($alias)
@@ -57,7 +58,8 @@ trait DataProviderRepositoryTrait
             $options,
             $user,
             $entityClass,
-            $entityAlias
+            $entityAlias,
+            $permission
         );
         $query->setParameter('ids', $ids);
 
@@ -85,7 +87,8 @@ trait DataProviderRepositoryTrait
         $options = [],
         ?UserInterface $user = null,
         $entityClass = null,
-        $entityAlias = null
+        $entityAlias = null,
+        $permission = null
     ) {
         $parameter = [];
 
@@ -181,11 +184,11 @@ trait DataProviderRepositoryTrait
             );
         }
 
-        if ($this->accessControlQueryEnhancer && $entityClass && $entityAlias) {
+        if ($this->accessControlQueryEnhancer && $entityClass && $entityAlias && $permission) {
             $this->accessControlQueryEnhancer->enhance(
                 $queryBuilder,
                 $user,
-                64, // 64 is view permission in our bitmask, usually this is injected, but not possibl in a trait
+                $permission,
                 $entityClass,
                 $entityAlias
             );

--- a/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
@@ -129,7 +129,8 @@ class DataProviderRepositoryTraitTest extends TestCase
             [],
             $user->reveal(),
             'Some\\Entity',
-            'entity'
+            'entity',
+            64
         );
 
         $accessControlQueryEnhancer->enhance($queryBuilder->reveal(), $user->reveal(), 64, 'Some\\Entity', 'entity')

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
@@ -278,10 +278,15 @@ class XmlFileLoader10 extends BaseXmlFileLoader
      */
     protected function generateSecurity()
     {
-        $securitySystemNode = $this->xpath->query('/x:webspace/x:security/x:system');
-        if ($securitySystemNode->length > 0) {
+        $securityNodeList = $this->xpath->query('/x:webspace/x:security');
+        if ($securityNodeList->length > 0) {
+            $securityNode = $securityNodeList->item(0);
+            $securitySystemNode = $this->xpath->query('x:system', $securityNode);
+            $permissionCheckAttribute = $securityNode->attributes->getNamedItem('permission-check');
+
             $security = new Security();
             $security->setSystem($securitySystemNode->item(0)->nodeValue);
+            $security->setPermissionCheck($permissionCheckAttribute ? 'true' === $permissionCheckAttribute->nodeValue : false);
             $this->webspace->setSecurity($security);
         }
     }

--- a/src/Sulu/Component/Webspace/Loader/schema/webspace/webspace-1.0.xsd
+++ b/src/Sulu/Component/Webspace/Loader/schema/webspace/webspace-1.0.xsd
@@ -25,6 +25,7 @@
         <xs:sequence>
             <xs:element type="xs:string" name="system" maxOccurs="1" minOccurs="1"/>
         </xs:sequence>
+        <xs:attribute type="xs:string" name="permission-check" use="optional"/>
     </xs:complexType>
 
     <xs:complexType name="localizationsType">

--- a/src/Sulu/Component/Webspace/Loader/schema/webspace/webspace-1.1.xsd
+++ b/src/Sulu/Component/Webspace/Loader/schema/webspace/webspace-1.1.xsd
@@ -30,6 +30,7 @@
         <xs:sequence>
             <xs:element type="xs:string" name="system" maxOccurs="1" minOccurs="1"/>
         </xs:sequence>
+        <xs:attribute type="xs:string" name="permission-check" use="optional"/>
     </xs:complexType>
 
     <xs:complexType name="localizationsType">

--- a/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
+++ b/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
@@ -36,6 +36,7 @@ class {{ cache_class }} extends {{ base_class }}
 {% if webspace.security != null %}
         $security = new Security();
         $security->setSystem('{{ webspace.security.system }}');
+        $security->setPermissionCheck({{ webspace.security.permissionCheck ? 'true' : 'false' }});
         $webspace->setSecurity($security);
 {% endif %}
 {% for localization in webspace.localizations %}

--- a/src/Sulu/Component/Webspace/Security.php
+++ b/src/Sulu/Component/Webspace/Security.php
@@ -24,6 +24,11 @@ class Security
     private $system;
 
     /**
+     * @var string
+     */
+    private $permissionCheck;
+
+    /**
      * Sets the key of the segment.
      *
      * @param string $system
@@ -41,5 +46,15 @@ class Security
     public function getSystem()
     {
         return $this->system;
+    }
+
+    public function setPermissionCheck(bool $permissionCheck)
+    {
+        $this->permissionCheck = $permissionCheck;
+    }
+
+    public function getPermissionCheck(): bool
+    {
+        return $this->permissionCheck;
     }
 }

--- a/src/Sulu/Component/Webspace/Security.php
+++ b/src/Sulu/Component/Webspace/Security.php
@@ -24,9 +24,9 @@ class Security
     private $system;
 
     /**
-     * @var string
+     * @var bool
      */
-    private $permissionCheck;
+    private $permissionCheck = false;
 
     /**
      * Sets the key of the segment.

--- a/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoader10Test.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoader10Test.php
@@ -61,6 +61,7 @@ class XmlFileLoader10Test extends WebspaceTestCase
         $this->assertEquals('Sulu CMF', $webspace->getName());
         $this->assertEquals('sulu_io', $webspace->getKey());
         $this->assertEquals('sulu_io', $webspace->getSecurity()->getSystem());
+        $this->assertEquals(true, $webspace->getSecurity()->getPermissionCheck());
 
         $this->assertEquals('en', $webspace->getLocalizations()[0]->getLanguage());
         $this->assertEquals('us', $webspace->getLocalizations()[0]->getCountry());

--- a/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoader11Test.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoader11Test.php
@@ -60,6 +60,7 @@ class XmlFileLoader11Test extends WebspaceTestCase
         $this->assertEquals('Sulu CMF', $webspace->getName());
         $this->assertEquals('sulu_io', $webspace->getKey());
         $this->assertEquals('sulu_io', $webspace->getSecurity()->getSystem());
+        $this->assertEquals(true, $webspace->getSecurity()->getPermissionCheck());
 
         $this->assertEquals('en', $webspace->getLocalizations()[0]->getLanguage());
         $this->assertEquals('us', $webspace->getLocalizations()[0]->getCountry());
@@ -148,6 +149,7 @@ class XmlFileLoader11Test extends WebspaceTestCase
         $this->assertEquals('Massive Art', $webspace->getName());
         $this->assertEquals('massiveart', $webspace->getKey());
         $this->assertEquals('massiveart', $webspace->getSecurity()->getSystem());
+        $this->assertEquals(false, $webspace->getSecurity()->getPermissionCheck());
 
         $this->assertEquals('w', $webspace->getDefaultSegment()->getKey());
 

--- a/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
@@ -43,6 +43,7 @@ class WebspaceTest extends TestCase
             ],
             'security' => [
                 'system' => 'sec_sys',
+                'permissionCheck' => false,
             ],
             'segments' => [
                 [
@@ -88,6 +89,7 @@ class WebspaceTest extends TestCase
 
         $security = new Security();
         $security->setSystem($expected['security']['system']);
+        $security->setPermissionCheck($expected['security']['permissionCheck']);
         $webspace->setSecurity($security);
 
         $portal = new Portal();

--- a/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
@@ -323,7 +323,9 @@ class WebspaceTest extends TestCase
     public function testHasWebsiteSecurityWithoutSystem()
     {
         $webspace = new Webspace();
-        $webspace->setSecurity(new Security());
+        $security = new Security();
+        $security->setPermissionCheck(true);
+        $webspace->setSecurity($security);
         $this->assertFalse($webspace->hasWebsiteSecurity());
     }
 
@@ -332,7 +334,18 @@ class WebspaceTest extends TestCase
         $webspace = new Webspace();
         $security = new Security();
         $security->setSystem('test');
+        $security->setPermissionCheck(true);
         $webspace->setSecurity($security);
         $this->assertTrue($webspace->hasWebsiteSecurity());
+    }
+
+    public function testHasWebsiteSecurityWithoutPermissionCheck()
+    {
+        $webspace = new Webspace();
+        $security = new Security();
+        $security->setSystem('test');
+        $security->setPermissionCheck(false);
+        $webspace->setSecurity($security);
+        $this->assertFalse($webspace->hasWebsiteSecurity());
     }
 }

--- a/src/Sulu/Component/Webspace/Webspace.php
+++ b/src/Sulu/Component/Webspace/Webspace.php
@@ -601,6 +601,7 @@ class Webspace implements ArrayableInterface
         $thisSecurity = $this->getSecurity();
         if (null != $thisSecurity) {
             $res['security']['system'] = $thisSecurity->getSystem();
+            $res['security']['permissionCheck'] = $thisSecurity->getPermissionCheck();
         }
 
         $res['segments'] = [];

--- a/src/Sulu/Component/Webspace/Webspace.php
+++ b/src/Sulu/Component/Webspace/Webspace.php
@@ -418,9 +418,7 @@ class Webspace implements ArrayableInterface
             return false;
         }
 
-        $system = $security->getSystem();
-
-        return null !== $system;
+        return null !== $security->getSystem() && $security->getPermissionCheck();
     }
 
     /**

--- a/tests/Resources/DataFixtures/Webspace/valid/sulu.io.xml
+++ b/tests/Resources/DataFixtures/Webspace/valid/sulu.io.xml
@@ -6,7 +6,7 @@
     <name>Sulu CMF</name>
     <key>sulu_io</key>
 
-    <security>
+    <security permission-check="true">
         <system>sulu_io</system>
     </security>
 

--- a/tests/Resources/DataFixtures/Webspace/valid/sulu.io_deprecated.xml
+++ b/tests/Resources/DataFixtures/Webspace/valid/sulu.io_deprecated.xml
@@ -6,7 +6,7 @@
     <name>Sulu CMF</name>
     <key>sulu_io</key>
 
-    <security>
+    <security permission-check="true">
         <system>sulu_io</system>
     </security>
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5480
| Related issues/PRs | #5439 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR will only check for permissions e.g. in navigation and smart content if the `permission-check` attribute of the webspace `security` tag is set to true.

#### Why?

See discussion in #5480.

#### To Do

- [ ] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md

Copied the ones below from #5480 to remember where I have to check for the new flag

- [x] Hide navigation items without sufficient permission
- [x] Hide pages from smart content without sufficient permissions
- [x] Hide pages from a selection field without sufficient permissions
- [x] Hide pages from a single selection field without sufficient permissions
- [x] Hide entities from smart content without sufficient permissions
- [x] Hide entities from a selection field without sufficient permissions
- [x] Hide entities from a single selection field without sufficient permissions
- [x] Hide pages on sitemap not visible to anonymous users