### PR TITLE
Register route field-type only on first login

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Resources/js/stores/webspaceStore/webspaceStore.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/stores/webspaceStore/webspaceStore.js
@@ -1,12 +1,12 @@
 // @flow
-import {computed, observable} from 'mobx';
+import {action, computed, observable} from 'mobx';
 import log from 'loglevel';
 import type {Webspace} from './types';
 
 class WebspaceStore {
     @observable allWebspaces: Array<Webspace>;
 
-    setWebspaces(webspaces: Array<Webspace>) {
+    @action setWebspaces(webspaces: Array<Webspace>) {
         this.allWebspaces = webspaces;
     }
 

--- a/src/Sulu/Bundle/RouteBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/RouteBundle/Resources/js/index.js
@@ -4,7 +4,11 @@ import {fieldRegistry, ResourceLocator} from 'sulu-admin-bundle/containers';
 import initializer from 'sulu-admin-bundle/services/initializer';
 import PageTreeRoute from './containers/Form/fields/PageTreeRoute';
 
-initializer.addUpdateConfigHook('sulu_admin', () => {
+initializer.addUpdateConfigHook('sulu_admin', (config: Object, initialized: boolean) => {
+    if (initialized) {
+        return;
+    }
+
     const routeGenerationUrl = resourceRouteRegistry.getListUrl('routes', {action: 'generate'});
 
     fieldRegistry.add(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5565
| License | MIT

#### What's in this PR?

This PR adjusts the `index.js` of the `RouteBundle` to register the `route` field-type one on the first login.

#### Why?

Because otherwise, this will throw an error if somebody logs in, logs out and logs in again without reloading the application.

#### Reproducing the Problem

1. Login into the administration interface
2. Logout
3. Login again
4. Try to Logout again
5. **A third Login is not possible anymore**
