### PR TITLE
Fix jest regression in expect.objectContaining for observable variables

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -19,6 +19,7 @@ jest.mock('../../../../stores/MultiSelectionStore', () => jest.fn(
         this.loading = false;
         this.idFilterParameter = idFilterParameter;
         this.loadItems = jest.fn();
+        this.items = [];
 
         mockExtendObservable(this, {
             items: [],
@@ -1231,14 +1232,16 @@ test('Should pass props correctly to MultiAutoComplete component', () => {
         />
     );
 
-    expect(selection.find('MultiAutoComplete').at(0).props()).toEqual(expect.objectContaining({
+    expect(selection.find('MultiAutoComplete').at(0).props()).toEqual({
         allowAdd: false,
         disabled: true,
         displayProperty: 'name',
+        id: '/',
         idProperty: 'uuid',
+        options: {},
         searchProperties: ['name'],
         selectionStore: selection.instance().autoCompleteSelectionStore,
-    }));
+    });
 
     expect(MultiSelectionStore).toBeCalledWith('snippets', value, locale, 'names');
 });
@@ -1332,14 +1335,16 @@ test('Should pass props with schema-options type correctly to MultiAutoComplete 
         />
     );
 
-    expect(selection.find('MultiAutoComplete').props()).toEqual(expect.objectContaining({
+    expect(selection.find('MultiAutoComplete').props()).toEqual({
         allowAdd: false,
         disabled: true,
         displayProperty: 'name',
+        id: '/',
         idProperty: 'uuid',
+        options: {},
         searchProperties: ['name'],
         selectionStore: selection.instance().autoCompleteSelectionStore,
-    }));
+    });
 });
 
 test('Should trigger a reload of the auto_complete items if the value prop changes', () => {

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/tests/PageList.test.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/tests/PageList.test.js
@@ -220,10 +220,8 @@ test('Should change excludeGhostsAndShadows when value of toggler is changed', (
 
     const excludeGhostsAndShadows = webspaceOverview.instance().excludeGhostsAndShadows;
     expect(excludeGhostsAndShadows.get()).toEqual(false);
-    expect(webspaceOverview.instance().listStore.observableOptions).toEqual(expect.objectContaining({
-        'exclude-ghosts': excludeGhostsAndShadows,
-        'exclude-shadows': excludeGhostsAndShadows,
-    }));
+    expect(webspaceOverview.instance().listStore.observableOptions['exclude-ghosts']).toEqual(excludeGhostsAndShadows);
+    expect(webspaceOverview.instance().listStore.observableOptions['exclude-shadows']).toEqual(excludeGhostsAndShadows);
 
     let toolbarConfig = toolbarFunction.call(webspaceOverview.instance());
     expect(toolbarConfig.items[0].value).toEqual(true);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | https://github.com/facebook/jest/pull/10508
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR avoids the usage of `expect.objectContaining` in some cases.

#### Why?

Because https://github.com/facebook/jest/pull/10508 introduced a regression. As soon as `expect.objectContaining` is called, it seems like variables passed to it are sometimes changed. For that reason the interceptor on the `excludeGhostsAndShadows` variables was changed, so the `intercept` call stopped working.