### PR TITLE
Load correct language after copying content for ghost page from other language

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,29 @@
 
 ## dev-release/2.1
 
+### GhostDialog
+
+When a page was opened in a ghost language, the `GhostDialog`, which allows to copy content from another locale,
+appeared. But after copying the language, the API returned the wrong locale, and therefore the UI was broken. We fixed
+that by separating the `src` and `locale` parameter in the pages API. This results in a different request being sent to
+that API:
+
+Before:
+
+```
+/admin/api/pages/d3354303-a11b-443f-9cb7-cace67a4e57c?webspace=sulu-test&action=copy-locale&dest=de&locale=en
+```
+
+After:
+
+```
+/admin/api/pages/d3354303-a11b-443f-9cb7-cace67a4e57c?webspace=sulu-test&action=copy-locale&src=en&dest=de&locale=de
+```
+
+Mind the change of the `locale` query parameter and the addition of the `src` parameter. In case you have reused that
+functionality with some of your custom entities, you need to adjust your API so that they work with the new query
+parameters.
+
 ### DateTime filter type
 
 The DateTime filter type does now support time by default. If you want to reuse the "old" behaviour we have introduced

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColorPicker/tests/__snapshots__/ColorPicker.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColorPicker/tests/__snapshots__/ColorPicker.test.js.snap
@@ -140,15 +140,17 @@ Array [
               style="position: relative;"
             >
               <input
+                id="rc-editable-input-1"
                 spellcheck="false"
                 style="width: 80%; padding: 4px 10% 3px; box-shadow: inset 0 0 0 1px #ccc; font-size: 11px;"
                 value="AABBCC"
               />
-              <span
+              <label
+                for="rc-editable-input-1"
                 style="display: block; text-align: center; font-size: 11px; color: rgb(34, 34, 34); padding-top: 3px; padding-bottom: 4px; text-transform: capitalize;"
               >
                 hex
-              </span>
+              </label>
             </div>
           </div>
           <div
@@ -158,15 +160,17 @@ Array [
               style="position: relative;"
             >
               <input
+                id="rc-editable-input-2"
                 spellcheck="false"
                 style="width: 80%; padding: 4px 10% 3px; box-shadow: inset 0 0 0 1px #ccc; font-size: 11px;"
                 value="170"
               />
-              <span
+              <label
+                for="rc-editable-input-2"
                 style="display: block; text-align: center; font-size: 11px; color: rgb(34, 34, 34); padding-top: 3px; padding-bottom: 4px; text-transform: capitalize; cursor: ew-resize;"
               >
                 r
-              </span>
+              </label>
             </div>
           </div>
           <div
@@ -176,15 +180,17 @@ Array [
               style="position: relative;"
             >
               <input
+                id="rc-editable-input-3"
                 spellcheck="false"
                 style="width: 80%; padding: 4px 10% 3px; box-shadow: inset 0 0 0 1px #ccc; font-size: 11px;"
                 value="187"
               />
-              <span
+              <label
+                for="rc-editable-input-3"
                 style="display: block; text-align: center; font-size: 11px; color: rgb(34, 34, 34); padding-top: 3px; padding-bottom: 4px; text-transform: capitalize; cursor: ew-resize;"
               >
                 g
-              </span>
+              </label>
             </div>
           </div>
           <div
@@ -194,15 +200,17 @@ Array [
               style="position: relative;"
             >
               <input
+                id="rc-editable-input-4"
                 spellcheck="false"
                 style="width: 80%; padding: 4px 10% 3px; box-shadow: inset 0 0 0 1px #ccc; font-size: 11px;"
                 value="204"
               />
-              <span
+              <label
+                for="rc-editable-input-4"
                 style="display: block; text-align: center; font-size: 11px; color: rgb(34, 34, 34); padding-top: 3px; padding-bottom: 4px; text-transform: capitalize; cursor: ew-resize;"
               >
                 b
-              </span>
+              </label>
             </div>
           </div>
           <div
@@ -212,15 +220,17 @@ Array [
               style="position: relative;"
             >
               <input
+                id="rc-editable-input-5"
                 spellcheck="false"
                 style="width: 80%; padding: 4px 10% 3px; box-shadow: inset 0 0 0 1px #ccc; font-size: 11px;"
                 value="100"
               />
-              <span
+              <label
+                for="rc-editable-input-5"
                 style="display: block; text-align: center; font-size: 11px; color: rgb(34, 34, 34); padding-top: 3px; padding-bottom: 4px; text-transform: capitalize; cursor: ew-resize;"
               >
                 a
-              </span>
+              </label>
             </div>
           </div>
         </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
@@ -128,8 +128,8 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
         return this.resourceStore.delete({...this.options, ...options});
     }
 
-    copyFromLocale(locale: string) {
-        return this.resourceStore.copyFromLocale(locale, this.options)
+    copyFromLocale(sourceLocale: string) {
+        return this.resourceStore.copyFromLocale(sourceLocale, this.options)
             .then((response) => {
                 if (this.hasTypes) {
                     this.setType(response[TYPE]);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
@@ -223,7 +223,7 @@ export default class ResourceStore {
             }));
     };
 
-    copyFromLocale(locale: string, options: Object = {}) {
+    copyFromLocale(sourceLocale: string, options: Object = {}) {
         if (!this.id) {
             throw new Error('Copying from another locale does not work for new objects!');
         }
@@ -232,11 +232,20 @@ export default class ResourceStore {
             throw new Error('Copying from another locale does only work for objects with locales!');
         }
 
+        const locale = this.locale.get();
+
         return ResourceRequester
             .post(
                 this.resourceKey,
                 {},
-                {...options, action: 'copy-locale', dest: this.locale.get(), id: this.id, locale}
+                {
+                    ...options,
+                    action: 'copy-locale',
+                    dest: locale,
+                    id: this.id,
+                    locale,
+                    src: sourceLocale,
+                }
             ).then(action((response) => {
                 this.setMultiple(response);
                 return response;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
@@ -525,7 +525,7 @@ test('Copy the content from different locale', () => {
     resourceStore.copyFromLocale('de');
 
     expect(ResourceRequester.post)
-        .toBeCalledWith('pages', {}, {action: 'copy-locale', id: 4, locale: 'de', dest: 'en'});
+        .toBeCalledWith('pages', {}, {action: 'copy-locale', id: 4, locale: 'en', dest: 'en', src: 'de'});
 
     return promise.then(() => {
         expect(resourceStore.data).toEqual(germanContent);

--- a/src/Sulu/Bundle/PageBundle/Controller/PageController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/PageController.php
@@ -232,11 +232,17 @@ class PageController extends AbstractRestController implements ClassResourceInte
                     $data = $this->nodeRepository->orderAt($id, $position, $webspace, $locale, $userId);
                     break;
                 case 'copy-locale':
+                    $srcLocale = $this->getRequestParameter($request, 'src', false, $locale);
                     $destLocale = $this->getRequestParameter($request, 'dest', true);
                     $webspace = $this->getWebspace($request);
 
                     // call repository method
-                    $data = $this->nodeRepository->copyLocale($id, $userId, $webspace, $locale, \explode(',', $destLocale));
+                    $data = $this->nodeRepository->copyLocale($id, $userId, $webspace, $srcLocale, \explode(',', $destLocale));
+
+                    if ($srcLocale !== $locale) {
+                        $data = $this->nodeRepository->getNode($id, $webspace, $locale);
+                    }
+
                     break;
                 case 'unpublish':
                     $document = $this->documentManager->find($id, $locale);

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
@@ -1887,6 +1887,52 @@ class PageControllerTest extends SuluTestCase
         $this->assertContains('en', $result['contentLocales']);
     }
 
+    public function testCopyLocaleWithSource()
+    {
+        $data = [
+            'title' => 'test1',
+            'template' => 'default',
+            'url' => '/test1',
+            'article' => 'Test',
+        ];
+
+        $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
+
+        $this->client->request(
+            'POST',
+            '/api/pages?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&language=en&action=publish',
+            $data
+        );
+        $data = \json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->client->request(
+            'POST',
+            '/api/pages/' . $data['id'] . '?action=copy-locale&webspace=sulu_io&language=de&src=en&dest=de'
+        );
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+        $result = \json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals($data['id'], $result['id']);
+        $this->assertEquals($data['title'], $result['title']);
+        $this->assertEquals($data['url'], $result['url']);
+        $this->assertEquals($data['article'], $result['article']);
+        $this->assertFalse($result['publishedState']);
+        $this->assertContains('de', $result['contentLocales']);
+        $this->assertContains('en', $result['contentLocales']);
+
+        $this->client->request(
+            'GET',
+            '/api/pages/' . $data['id'] . '?webspace=sulu_io&language=de'
+        );
+        $result = \json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals($data['id'], $result['id']);
+        $this->assertEquals($data['title'], $result['title']);
+        $this->assertEquals($data['url'], $result['url']);
+        $this->assertEquals($data['article'], $result['article']);
+        $this->assertFalse($result['publishedState']);
+        $this->assertContains('de', $result['contentLocales']);
+        $this->assertContains('en', $result['contentLocales']);
+    }
+
     public function testCopyMultipleLocales()
     {
         $data = [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5548
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR makes the request after confirming the `GhostDialog` return the language of the destination language. In addition it adjusts the page REST API in a way to make this possible without a BC break.

This also replaces #5559.