### PR TITLE
Add name of title to serialized contact

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Api/Contact.php
+++ b/src/Sulu/Bundle/ContactBundle/Api/Contact.php
@@ -201,6 +201,26 @@ class Contact extends ApiWrapper
     }
 
     /**
+     * Get name of title.
+     *
+     * @return string
+     *
+     * @VirtualProperty
+     * @SerializedName("titleName")
+     * @Groups({"fullContact"})
+     */
+    public function getTitleName()
+    {
+        $title = $this->entity->getTitle();
+
+        if (!$title) {
+            return null;
+        }
+
+        return $title->getTitle();
+    }
+
+    /**
      * Set position.
      *
      * @param string $position
@@ -245,7 +265,7 @@ class Contact extends ApiWrapper
     }
 
     /**
-     * Get position.
+     * Get name of position.
      *
      * @return string
      *

--- a/src/Sulu/Bundle/ContactBundle/Entity/ContactRepository.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/ContactRepository.php
@@ -449,6 +449,7 @@ class ContactRepository extends EntityRepository implements DataProviderReposito
             ->addSelect('categories')
             ->addSelect('translations')
             ->addSelect('accountContacts')
+            ->addSelect('title')
             ->addSelect('position')
             ->leftJoin($alias . '.emails', 'emails')
             ->leftJoin('emails.emailType', 'emailType')
@@ -461,6 +462,7 @@ class ContactRepository extends EntityRepository implements DataProviderReposito
             ->leftJoin($alias . '.tags', 'tags')
             ->leftJoin($alias . '.categories', 'categories')
             ->leftJoin('categories.translations', 'translations')
+            ->leftJoin($alias . '.title', 'title')
             ->leftJoin($alias . '.accountContacts', 'accountContacts')
             ->leftJoin('accountContacts.position', 'position');
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | #5380
| License | MIT

#### What's in this PR?

This PR adds a `titleName` property to the serialized representation of the contact entity. This serializer representation is returned by the `ContactAccountSelection` and by the `contacts` smart-content data-provider.

The PR also adjusts the `ContactRepository` to join the respective table to prevent lazy-loading of `ContactTitle` entities during serialization. I tested the adjustments and did not notice any additional queries in the Symfony profiler.

#### Why?

The serialized representation already includes a `title` property that contains the id of the `ContactTitle` entity. In most cases, you dont care about the `id`, but just want to output the selected text in the backend. 

We solved a similar quirk with the `position` of the contact in #5380