### PR TITLE
Fix default-values for multiple-select in blocks

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -14,7 +14,7 @@ const MISSING_BLOCK_ERROR_MESSAGE = 'The "block" field type needs at least one t
 const BLOCK_PREVIEW_TAG = 'sulu.block_preview';
 
 @observer
-export default class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
+class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
     @observable value: Object;
 
     constructor(props: FieldTypeProps<Array<BlockEntry>>) {
@@ -27,7 +27,9 @@ export default class FieldBlocks extends React.Component<FieldTypeProps<Array<Bl
         const {defaultType, onChange, types, value} = this.props;
         const {types: oldTypes} = prevProps;
 
-        this.updateValue(value);
+        if (!equals(prevProps.value, value) ){
+            this.updateValue(value);
+        }
 
         if (!types || !oldTypes) {
             throw new Error(MISSING_BLOCK_ERROR_MESSAGE);
@@ -254,3 +256,5 @@ export default class FieldBlocks extends React.Component<FieldTypeProps<Array<Bl
         );
     }
 }
+
+export default FieldBlocks;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -2,7 +2,7 @@
 import equals from 'fast-deep-equal';
 import jsonpointer from 'json-pointer';
 import React, {Fragment} from 'react';
-import {observable, action, toJS} from 'mobx';
+import {action, observable, toJS} from 'mobx';
 import {observer} from 'mobx-react';
 import BlockCollection from '../../components/BlockCollection';
 import type {BlockEntry} from '../../components/BlockCollection/types';
@@ -27,7 +27,7 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
         const {defaultType, onChange, types, value} = this.props;
         const {types: oldTypes} = prevProps;
 
-        if (!equals(prevProps.value, value) ){
+        if (!equals(prevProps.value, value)){
             this.updateValue(value);
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -2,7 +2,8 @@
 import equals from 'fast-deep-equal';
 import jsonpointer from 'json-pointer';
 import React, {Fragment} from 'react';
-import {toJS} from 'mobx';
+import {observable, action, toJS} from 'mobx';
+import {observer} from 'mobx-react';
 import BlockCollection from '../../components/BlockCollection';
 import type {BlockEntry} from '../../components/BlockCollection/types';
 import type {BlockError, FieldTypeProps} from '../Form/types';
@@ -12,10 +13,21 @@ import FieldRenderer from './FieldRenderer';
 const MISSING_BLOCK_ERROR_MESSAGE = 'The "block" field type needs at least one type to be configured!';
 const BLOCK_PREVIEW_TAG = 'sulu.block_preview';
 
+@observer
 export default class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
+    @observable value: Object;
+
+    constructor(props: FieldTypeProps<Array<BlockEntry>>) {
+        super(props);
+
+        this.value = this.props.value;
+    }
+
     componentDidUpdate(prevProps: FieldTypeProps<Array<BlockEntry>>) {
         const {defaultType, onChange, types, value} = this.props;
         const {types: oldTypes} = prevProps;
+
+        this.updateValue(value);
 
         if (!types || !oldTypes) {
             throw new Error(MISSING_BLOCK_ERROR_MESSAGE);
@@ -47,8 +59,13 @@ export default class FieldBlocks extends React.Component<FieldTypeProps<Array<Bl
         }
     }
 
+    @action updateValue = (value: Object) => {
+        this.value = value;
+    };
+
     handleBlockChange = (index: number, name: string, value: Object) => {
-        const {onChange, value: oldValues} = this.props;
+        const {onChange} = this.props;
+        const oldValues = this.value;
 
         if (!oldValues) {
             return;
@@ -56,6 +73,8 @@ export default class FieldBlocks extends React.Component<FieldTypeProps<Array<Bl
 
         const newValues = toJS(oldValues);
         jsonpointer.set(newValues[index], '/' + name, value);
+
+        this.updateValue(newValues);
 
         onChange(newValues);
     };
@@ -204,7 +223,8 @@ export default class FieldBlocks extends React.Component<FieldTypeProps<Array<Bl
     };
 
     render() {
-        const {defaultType, disabled, maxOccurs, minOccurs, onChange, types, value} = this.props;
+        const {defaultType, disabled, maxOccurs, minOccurs, onChange, types} = this.props;
+        const value = this.value || [];
 
         if (!defaultType) {
             throw new Error('The "block" field type needs a defaultType!');
@@ -229,7 +249,7 @@ export default class FieldBlocks extends React.Component<FieldTypeProps<Array<Bl
                 onSortEnd={this.handleSortEnd}
                 renderBlockContent={this.renderBlockContent}
                 types={blockTypes}
-                value={value || []}
+                value={value}
             />
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
@@ -909,7 +909,7 @@ test('Should set correct default values for multiple single_select in blocks', (
             title: 'Default',
             form: {
                 position_center: {
-                    label: 'Position Left',
+                    label: 'Position Center',
                     type: 'single_select',
                     options: {
                         values: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
 import {mount, shallow} from 'enzyme';
+import {observable} from 'mobx';
 import Router from '../../../services/Router';
 import fieldTypeDefaultProps from '../../../utils/TestHelper/fieldTypeDefaultProps';
 import FieldBlocks from '../FieldBlocks';
@@ -8,6 +9,8 @@ import FormInspector from '../../Form/FormInspector';
 import ResourceFormStore from '../../Form/stores/ResourceFormStore';
 import ResourceStore from '../../../stores/ResourceStore';
 import blockPreviewTransformerRegistry from '../registries/blockPreviewTransformerRegistry';
+import fieldRegistry from '../../Form/registries/fieldRegistry';
+import SingleSelect from '../../Form/fields/SingleSelect';
 
 jest.mock('../../../services/Router/Router', () => jest.fn());
 jest.mock('../../Form/FormInspector', () => jest.fn(function() {
@@ -896,6 +899,130 @@ test('Should call onFinish when the order of the blocks has changed', () => {
     fieldBlocks.find('BlockCollection').prop('onSortEnd')(0, 2);
 
     expect(finishSpy).toBeCalledWith();
+});
+
+test('Should set correct default values for multiple single_select in blocks', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+
+    const types = {
+        default: {
+            title: 'Default',
+            form: {
+                position_center: {
+                    label: 'Position Left',
+                    type: 'single_select',
+                    options: {
+                        values: {
+                            name: 'values',
+                            type: 'collection',
+                            value: [
+                                {
+                                    name: 'left',
+                                    title: 'Left',
+                                },
+                                {
+                                    name: 'center',
+                                    title: 'Center',
+                                },
+                                {
+                                    name: 'right',
+                                    title: 'Right',
+                                },
+                            ],
+                        },
+                    },
+                },
+                position_left: {
+                    label: 'Position Left',
+                    type: 'single_select',
+                    options: {
+                        default_value: {
+                            name: 'default_value',
+                            type: 'string',
+                            value: 'left',
+                        },
+                        values: {
+                            name: 'values',
+                            type: 'collection',
+                            value: [
+                                {
+                                    name: 'left',
+                                    title: 'Left',
+                                },
+                                {
+                                    name: 'center',
+                                    title: 'Center',
+                                },
+                                {
+                                    name: 'right',
+                                    title: 'Right',
+                                },
+                            ],
+                        },
+                    },
+                },
+                position_right: {
+                    label: 'Position Right',
+                    type: 'single_select',
+                    options: {
+                        default_value: {
+                            name: 'default_value',
+                            type: 'string',
+                            value: 'right',
+                        },
+                        values: {
+                            name: 'values',
+                            type: 'collection',
+                            value: [
+                                {
+                                    name: 'left',
+                                    title: 'Left',
+                                },
+                                {
+                                    name: 'center',
+                                    title: 'Center',
+                                },
+                                {
+                                    name: 'right',
+                                    title: 'Right',
+                                },
+                            ],
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    formInspector.getSchemaEntryByPath.mockReturnValue({types});
+
+    fieldRegistry.get.mockReturnValue(SingleSelect);
+
+    const changeSpy = jest.fn();
+
+    const fieldBlocks = mount(
+        <FieldBlocks
+            {...fieldTypeDefaultProps}
+            defaultType="default"
+            formInspector={formInspector}
+            minOccurs={1}
+            onChange={changeSpy}
+            types={types}
+            value={observable([{type: 'default'}])}
+        />
+    );
+
+    fieldBlocks.find('Block').at(0).simulate('click');
+
+    expect(changeSpy).toBeCalledWith(
+        [
+            {
+                'position_left': 'left',
+                'position_right': 'right',
+                'type': 'default',
+            },
+        ]
+    );
 });
 
 test('Throw error if no default type are passed', () => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes https://github.com/sulu/sulu/issues/4987
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fixes the default-values in blocks. See https://github.com/sulu/sulu/issues/4987

An additional `value` attribute is introduced to save the state of the `value`. Previously the `value` was saved in the properties (`this.props`), but the properties are updated after the `default-value` is set for the next `single_select`, thus the `value` is not up to date during the rendering of the other components.

Now the new `value` attribute is manually updated before the next component is rendered.

#### Why?

The default value was only working for the last component.

#### Todo

 - [ ] Tests
 - [x] Rebase to 2.1
 - [ ] Check Imagemap