### PR TITLE
Fix MediaDataProvider if no security is configured

### DIFF
--- a/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
+++ b/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
@@ -45,7 +45,7 @@ class MediaDataProvider extends BaseDataProvider
         ArraySerializerInterface $serializer,
         RequestStack $requestStack,
         ReferenceStoreInterface $referenceStore,
-        Security $security,
+        Security $security = null,
         RequestAnalyzerInterface $requestAnalyzer,
         $permissions
     ) {

--- a/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
+++ b/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
@@ -45,7 +45,7 @@ class MediaDataProvider extends BaseDataProvider
         ArraySerializerInterface $serializer,
         RequestStack $requestStack,
         ReferenceStoreInterface $referenceStore,
-        Security $security = null,
+        ?Security $security,
         RequestAnalyzerInterface $requestAnalyzer,
         $permissions
     ) {

--- a/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
+++ b/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
@@ -173,6 +173,58 @@ class MediaDataProviderTest extends TestCase
         $this->assertEquals($items, $result->getItems());
     }
 
+    public function testResolveDataItemsWithoutSecurity()
+    {
+        $mediaDataProvider = new MediaDataProvider(
+            $this->dataProviderRepository->reveal(),
+            $this->collectionManager->reveal(),
+            $this->serializer->reveal(),
+            $this->requestStack->reveal(),
+            $this->referenceStore->reveal(),
+            null,
+            $this->requestAnalyzer->reveal(),
+            ['view' => 64]
+        );
+
+        $medias = [
+            $this->createMedia(1, 'Test-1')->reveal(),
+            $this->createMedia(2, 'Test-2')->reveal(),
+            $this->createMedia(3, 'Test-3')->reveal(),
+        ];
+
+        $dataItems = [];
+        foreach ($medias as $media) {
+            $dataItems[] = $this->createDataItem($media);
+        }
+
+        $this->dataProviderRepository
+             ->findByFilters(
+                 ['dataSource' => 42, 'tags' => [1]],
+                 1,
+                 3,
+                 null,
+                 'en',
+                 ['webspace' => 'sulu_io', 'locale' => 'en'],
+                 null,
+                 null
+             )
+            ->willReturn($medias);
+
+        $result = $mediaDataProvider->resolveDataItems(
+            ['dataSource' => 42, 'tags' => [1]],
+            [],
+            ['webspace' => 'sulu_io', 'locale' => 'en'],
+            null,
+            1,
+            3
+        );
+
+        $this->assertInstanceOf(DataProviderResult::class, $result);
+
+        $this->assertEquals(false, $result->getHasNextPage());
+        $this->assertEquals($dataItems, $result->getItems());
+    }
+
     public function resourceItemsDataProvider()
     {
         $medias = [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #5439 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes the signature of the `MediaDataProvider` constructor to also accept `null` for the `Security` class.

#### Why?

Because if no security is configured in `config/packages/security_website.yaml` the `Security` class is not available and therefore null. In that case the website currently breaks, if a SmartContent displaying media is on the page.