### PR TITLE
Implement single_snippet_selection content-type

### DIFF
--- a/config/templates/pages/example.xml
+++ b/config/templates/pages/example.xml
@@ -245,6 +245,13 @@
             </meta>
         </property>
 
+        <property name="single_snippet_selection" type="single_snippet_selection">
+            <meta>
+                <title lang="en">Single Snippet Selection</title>
+                <title lang="de">Schnipsel</title>
+            </meta>
+        </property>
+
         <property name="snippet_selection" type="snippet_selection">
             <meta>
                 <title lang="en">Snippet Selection</title>

--- a/src/Sulu/Bundle/SnippetBundle/Content/SingleSnippetSelection.php
+++ b/src/Sulu/Bundle/SnippetBundle/Content/SingleSnippetSelection.php
@@ -54,7 +54,7 @@ class SingleSnippetSelection extends SimpleContentType implements PreResolvableC
         $resolvedSnippet = $this->resolveSnippet($property);
 
         if (null === $resolvedSnippet) {
-            return $this->defaultValue;
+            return null;
         }
 
         return $resolvedSnippet['content'];

--- a/src/Sulu/Bundle/SnippetBundle/Content/SingleSnippetSelection.php
+++ b/src/Sulu/Bundle/SnippetBundle/Content/SingleSnippetSelection.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SnippetBundle\Content;
+
+use Sulu\Bundle\SnippetBundle\Snippet\SnippetResolverInterface;
+use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
+use Sulu\Component\Content\Compat\PropertyInterface;
+use Sulu\Component\Content\Compat\Structure\PageBridge;
+use Sulu\Component\Content\PreResolvableContentTypeInterface;
+use Sulu\Component\Content\SimpleContentType;
+
+class SingleSnippetSelection extends SimpleContentType implements PreResolvableContentTypeInterface
+{
+    /**
+     * @var SnippetResolverInterface
+     */
+    private $snippetResolver;
+
+    /**
+     * @var ReferenceStoreInterface
+     */
+    private $snippetReferenceStore;
+
+    public function __construct(
+        SnippetResolverInterface $snippetResolver,
+        ReferenceStoreInterface $snippetReferenceStore
+    ) {
+        $this->snippetResolver = $snippetResolver;
+        $this->snippetReferenceStore = $snippetReferenceStore;
+
+        parent::__construct('SingleSnippetSelection', null);
+    }
+
+    public function getContentData(PropertyInterface $property)
+    {
+        $resolvedSnippet = $this->resolveSnippet($property);
+
+        if (null === $resolvedSnippet) {
+            return $this->defaultValue;
+        }
+
+        return $resolvedSnippet['content'];
+    }
+
+    public function getViewData(PropertyInterface $property)
+    {
+        $resolvedSnippet = $this->resolveSnippet($property);
+
+        if (null === $resolvedSnippet) {
+            return [];
+        }
+
+        return $resolvedSnippet['view'];
+    }
+
+    public function preResolve(PropertyInterface $property)
+    {
+        $snippetUuid = $property->getValue();
+
+        if (empty($snippetUuid)) {
+            return;
+        }
+
+        $this->snippetReferenceStore->add($snippetUuid);
+    }
+
+    private function resolveSnippet(PropertyInterface $property)
+    {
+        $snippetUuid = $property->getValue();
+
+        if (empty($snippetUuid)) {
+            return null;
+        }
+
+        /** @var PageBridge $page */
+        $page = $property->getStructure();
+        $webspaceKey = $page->getWebspaceKey();
+        $locale = $page->getLanguageCode();
+        $shadowLocale = null;
+        if ($page->getIsShadow()) {
+            $shadowLocale = $page->getShadowBaseLanguage();
+        }
+
+        $params = $property->getParams();
+        $loadExcerpt = isset($params['loadExcerpt']) ? $params['loadExcerpt']->getValue() : false;
+
+        /** @var array[] $resolvedSnippets */
+        $resolvedSnippets = $this->snippetResolver->resolve(
+            [$snippetUuid],
+            $webspaceKey,
+            $locale,
+            $shadowLocale,
+            $loadExcerpt
+        );
+
+        return \reset($resolvedSnippets) ?: null;
+    }
+}

--- a/src/Sulu/Bundle/SnippetBundle/Content/SnippetContent.php
+++ b/src/Sulu/Bundle/SnippetBundle/Content/SnippetContent.php
@@ -26,9 +26,6 @@ use Sulu\Component\Content\ComplexContentType;
 use Sulu\Component\Content\ContentTypeExportInterface;
 use Sulu\Component\Content\PreResolvableContentTypeInterface;
 
-/**
- * ContentType for Snippets.
- */
 class SnippetContent extends ComplexContentType implements ContentTypeExportInterface, PreResolvableContentTypeInterface
 {
     /**
@@ -114,11 +111,6 @@ class SnippetContent extends ComplexContentType implements ContentTypeExportInte
         if ($node->hasProperty($property->getName())) {
             $node->getProperty($property->getName())->remove();
         }
-    }
-
-    public function getDefaultParams(PropertyInterface $property = null)
-    {
-        return [];
     }
 
     public function getViewData(PropertyInterface $property)

--- a/src/Sulu/Bundle/SnippetBundle/DependencyInjection/SuluSnippetExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/DependencyInjection/SuluSnippetExtension.php
@@ -54,6 +54,28 @@ class SuluSnippetExtension extends Extension implements PrependExtensionInterfac
                         ],
                     ],
                     'field_type_options' => [
+                        'single_selection' => [
+                            'single_snippet_selection' => [
+                                'default_type' => 'list_overlay',
+                                'resource_key' => 'snippets',
+                                'view' => [
+                                    'name' => 'sulu_snippet.edit_form',
+                                    'result_to_view' => [
+                                        'id' => 'id',
+                                    ],
+                                ],
+                                'types' => [
+                                    'list_overlay' => [
+                                        'adapter' => 'table',
+                                        'list_key' => 'snippets',
+                                        'display_properties' => ['title'],
+                                        'icon' => 'su-snippet',
+                                        'empty_text' => 'sulu_snippet.no_snippet_selected',
+                                        'overlay_title' => 'sulu_snippet.single_snippet_selection_overlay_title',
+                                    ],
+                                ],
+                            ],
+                        ],
                         'selection' => [
                             'snippet_selection' => [
                                 'default_type' => 'list_overlay',

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/content.xml
@@ -24,6 +24,7 @@
 
         <service id="sulu_snippet.content.single_snippet_selection" class="Sulu\Bundle\SnippetBundle\Content\SingleSnippetSelection">
             <argument type="service" id="sulu_snippet.resolver"/>
+            <argument type="service" id="sulu_snippet.default_snippet.manager"/>
             <argument type="service" id="sulu_snippet.reference_store.snippet"/>
 
             <tag name="sulu.content.type" alias="single_snippet_selection"/>

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/content.xml
@@ -22,6 +22,13 @@
             <argument type="service" id="sulu_website.resolver.structure" />
         </service>
 
+        <service id="sulu_snippet.content.single_snippet_selection" class="Sulu\Bundle\SnippetBundle\Content\SingleSnippetSelection">
+            <argument type="service" id="sulu_snippet.resolver"/>
+            <argument type="service" id="sulu_snippet.reference_store.snippet"/>
+
+            <tag name="sulu.content.type" alias="single_snippet_selection"/>
+            <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
+        </service>
         <service id="sulu_snippet.content.snippet" class="Sulu\Bundle\SnippetBundle\Content\SnippetContent">
             <argument type="service" id="sulu_snippet.default_snippet.manager"/>
             <argument type="service" id="sulu_snippet.resolver"/>

--- a/src/Sulu/Bundle/SnippetBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/translations/admin.de.json
@@ -1,6 +1,8 @@
 {
     "sulu_snippet.selection_overlay_title": "Schnipsel auswählen",
     "sulu_snippet.selection_label": "{count} Schnipsel ausgewählt",
+    "sulu_snippet.no_snippet_selected": "Kein Snippet ausgewählt",
+    "sulu_snippet.single_snippet_selection_overlay_title": "Snippet auswählen",
     "sulu_snippet.snippets": "Schnipsel",
     "sulu_snippet.snippet": "Schnipsel",
     "sulu_snippet.default_snippets": "Standard Schnipsel",

--- a/src/Sulu/Bundle/SnippetBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/translations/admin.en.json
@@ -1,6 +1,8 @@
 {
     "sulu_snippet.selection_overlay_title": "Choose snippets",
     "sulu_snippet.selection_label": "{count} {count, plural, =1 {snippet} other {snippets}} selected",
+    "sulu_snippet.no_snippet_selected": "No snippet selected",
+    "sulu_snippet.single_snippet_selection_overlay_title": "Choose snippet",
     "sulu_snippet.snippets": "Snippets",
     "sulu_snippet.snippet": "Snippet",
     "sulu_snippet.default_snippets": "Default Snippets",

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SingleSnippetSelectionTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SingleSnippetSelectionTest.php
@@ -1,0 +1,218 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SnippetBundle\Tests\Unit\Content;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Sulu\Bundle\SnippetBundle\Content\SingleSnippetSelection;
+use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
+use Sulu\Bundle\SnippetBundle\Snippet\DefaultSnippetManagerInterface;
+use Sulu\Bundle\SnippetBundle\Snippet\SnippetResolverInterface;
+use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
+use Sulu\Component\Content\Compat\PropertyInterface;
+use Sulu\Component\Content\Compat\PropertyParameter;
+use Sulu\Component\Content\Compat\Structure\StructureBridge;
+
+class SingleSnippetSelectionTest extends TestCase
+{
+    /**
+     * @var DefaultSnippetManagerInterface
+     */
+    private $defaultSnippetManager;
+
+    /**
+     * @var SnippetResolverInterface
+     */
+    private $snippetResolver;
+
+    /**
+     * @var ReferenceStoreInterface
+     */
+    private $referenceStore;
+
+    /**
+     * @var SingleSnippetSelection
+     */
+    private $singleSnippetSelection;
+
+    protected function setUp(): void
+    {
+        $this->defaultSnippetManager = $this->prophesize(DefaultSnippetManagerInterface::class);
+        $this->snippetResolver = $this->prophesize(SnippetResolverInterface::class);
+        $this->referenceStore = $this->prophesize(ReferenceStoreInterface::class);
+
+        $this->singleSnippetSelection = new SingleSnippetSelection(
+            $this->snippetResolver->reveal(),
+            $this->defaultSnippetManager->reveal(),
+            $this->referenceStore->reveal()
+        );
+    }
+
+    public function testGetContentData()
+    {
+        $structure = $this->prophesize(StructureBridge::class);
+        $structure->getWebspaceKey()->willReturn('sulu_io');
+        $structure->getLanguageCode()->willReturn('de');
+        $structure->getIsShadow()->wilLReturn(true);
+        $structure->getShadowBaseLanguage()->wilLReturn('en');
+
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getStructure()->willReturn($structure->reveal());
+        $property->getValue()->willReturn('123-123-123');
+        $property->getParams()->willReturn([]);
+
+        $this->snippetResolver
+            ->resolve(['123-123-123'], 'sulu_io', 'de', 'en', false)
+            ->willReturn([
+                ['content' => ['title' => 'test-1'], 'view' => ['title' => 'test-2', 'template' => 'default']],
+            ]);
+
+        $result = $this->singleSnippetSelection->getContentData($property->reveal());
+
+        $this->assertEquals(['title' => 'test-1'], $result);
+    }
+
+    public function testGetContentDataNullValue()
+    {
+        $structure = $this->prophesize(StructureBridge::class);
+        $structure->getWebspaceKey()->willReturn('sulu_io');
+        $structure->getLanguageCode()->willReturn('de');
+        $structure->getIsShadow()->wilLReturn(true);
+        $structure->getShadowBaseLanguage()->wilLReturn('en');
+
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getStructure()->willReturn($structure->reveal());
+        $property->getValue()->willReturn(null);
+        $property->getParams()->willReturn([]);
+
+        $result = $this->singleSnippetSelection->getContentData($property->reveal());
+
+        $this->assertEquals(null, $result);
+    }
+
+    public function testGetContentDataFallbackToSnippetArea()
+    {
+        $structure = $this->prophesize(StructureBridge::class);
+        $structure->getWebspaceKey()->willReturn('sulu_io');
+        $structure->getLanguageCode()->willReturn('de');
+        $structure->getIsShadow()->wilLReturn(false);
+
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getStructure()->willReturn($structure->reveal());
+        $property->getValue()->willReturn(null);
+        $property->getParams()->willReturn(['default' => new PropertyParameter('default', 'footer-snippet')]);
+
+        $defaultSnippet = $this->prophesize(SnippetDocument::class);
+        $defaultSnippet->getUuid()->willReturn('456-456-456');
+        $this->defaultSnippetManager->load('sulu_io', 'footer-snippet', 'de')->willReturn($defaultSnippet->reveal());
+
+        $this->snippetResolver
+            ->resolve(['456-456-456'], 'sulu_io', 'de', null, false)
+            ->willReturn([
+                ['content' => ['title' => 'test-1'], 'view' => ['title' => 'test-2', 'template' => 'default']],
+            ]);
+
+        $result = $this->singleSnippetSelection->getContentData($property->reveal());
+
+        $this->assertEquals(['title' => 'test-1'], $result);
+    }
+
+    public function testGetContentDataWithExtensions()
+    {
+        $structure = $this->prophesize(StructureBridge::class);
+        $structure->getWebspaceKey()->willReturn('sulu_io');
+        $structure->getLanguageCode()->willReturn('de');
+        $structure->getIsShadow()->wilLReturn(false);
+
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getStructure()->willReturn($structure->reveal());
+        $property->getValue()->willReturn('123-123-123');
+        $property->getParams()->willReturn(['loadExcerpt' => new PropertyParameter('loadExcerpt', true)]);
+
+        $this->snippetResolver
+            ->resolve(['123-123-123'], 'sulu_io', 'de', null, true)
+            ->willReturn(
+                [
+                    [
+                        'content' => ['title' => 'test-1', 'taxonomies' => ['categories' => [], 'tags' => []]],
+                        'view' => ['title' => 'test-2', 'template' => 'default'],
+                    ],
+                ]
+            );
+
+        $result = $this->singleSnippetSelection->getContentData($property->reveal());
+
+        $this->assertEquals(['title' => 'test-1', 'taxonomies' => ['categories' => [], 'tags' => []]], $result);
+    }
+
+    public function testGetViewData()
+    {
+        $structure = $this->prophesize(StructureBridge::class);
+        $structure->getWebspaceKey()->willReturn('sulu_io');
+        $structure->getLanguageCode()->willReturn('de');
+        $structure->getIsShadow()->wilLReturn(true);
+        $structure->getShadowBaseLanguage()->wilLReturn('en');
+
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getStructure()->willReturn($structure->reveal());
+        $property->getValue()->willReturn('123-123-123');
+        $property->getParams()->willReturn([]);
+
+        $this->snippetResolver
+            ->resolve(['123-123-123'], 'sulu_io', 'de', 'en', false)
+            ->willReturn([
+                ['content' => ['title' => 'test-1'], 'view' => ['title' => 'test-2', 'template' => 'default']],
+            ]);
+
+        $result = $this->singleSnippetSelection->getViewData($property->reveal());
+
+        $this->assertEquals(['title' => 'test-2', 'template' => 'default'], $result);
+    }
+
+    public function testGetViewDataNullValue()
+    {
+        $structure = $this->prophesize(StructureBridge::class);
+        $structure->getWebspaceKey()->willReturn('sulu_io');
+        $structure->getLanguageCode()->willReturn('de');
+        $structure->getIsShadow()->wilLReturn(true);
+        $structure->getShadowBaseLanguage()->wilLReturn('en');
+
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getStructure()->willReturn($structure->reveal());
+        $property->getValue()->willReturn(null);
+        $property->getParams()->willReturn([]);
+
+        $result = $this->singleSnippetSelection->getViewData($property->reveal());
+
+        $this->assertEquals([], $result);
+    }
+
+    public function testPreResolve()
+    {
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getValue()->willReturn('123-123-123');
+
+        $this->singleSnippetSelection->preResolve($property->reveal());
+
+        $this->referenceStore->add('123-123-123')->shouldBeCalled();
+    }
+
+    public function testPreResolveNullValue()
+    {
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getValue()->willReturn(null);
+
+        $this->singleSnippetSelection->preResolve($property->reveal());
+
+        $this->referenceStore->add(Argument::cetera())->shouldNotBeCalled();
+    }
+}

--- a/templates/pages/example.html.twig
+++ b/templates/pages/example.html.twig
@@ -43,6 +43,7 @@
     <p>{{ content.page_selection|map(page => page.title)|join(', ') }}</p>
     <p>{{ content.teaser_selection|map(teaser => teaser.title)|join(', ') }}</p>
     <p>{{ content.smart_content|map(page => page.title)|join(', ') }}</p>
+    <p>{{ content.single_snippet_selection ? content.single_snippet_selection.title : '' }}</p>
     <p>{{ content.snippet_selection|map(snippet => snippet.title)|join(', ') }}</p>
     <p>{{ content.category_selection|map(category => category.name)|join(', ') }}</p>
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5568
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/576

#### What's in this PR?

This PR implements a `single_snippet_selection` content type.

#### Why?

Sulu already includes a `snippet_selection` content-type. In a lot of cases, it would be useful to allow for selecting only a single snippet in the administration interface. See #5568

#### Example Usage

```xml
<property name="single_snippet_selection" type="single_snippet_selection">
    <meta>
        <title lang="en">Single Snippet Selection</title>
        <title lang="de">Schnipsel</title>
    </meta>

    <params>
        <param name="types" value="default"/>
        <param name="loadExcerpt" value="true"/>
    </params>
</property>
```
