### PR TITLE
Check if segments key exists in webspace

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
@@ -200,7 +200,9 @@ class ContentRouteProvider implements RouteProviderInterface
             } elseif (!$this->checkResourceLocator($resourceLocator, $prefix)) {
                 return $collection;
             } else {
-                if ($document instanceof ExtensionBehavior) {
+                if ($document instanceof ExtensionBehavior
+                    && \array_key_exists('segments', $document->getExtensionsData()['excerpt'])
+                ) {
                     $documentSegments = $document->getExtensionsData()['excerpt']['segments'];
                     $documentSegmentKey = $documentSegments[$portal->getWebspace()->getKey()] ?? null;
                     $segment = $this->requestAnalyzer->getSegment();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix for optional segment

#### Why?

Segments is a optional configuration but if segments is not set an error occurs
```
Notice: Undefined index: segments
```
