### PR TITLE
Initialize ListStore with page 1 in MediaSelectionOverlay

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/MediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/MediaSelectionOverlay.js
@@ -44,7 +44,7 @@ class MediaSelectionOverlay extends React.Component<Props> {
             COLLECTIONS_RESOURCE_KEY,
             USER_SETTINGS_KEY,
             {
-                page: observable.box(),
+                page: observable.box(1),
                 locale,
                 parentId: collectionId,
             }
@@ -80,7 +80,7 @@ class MediaSelectionOverlay extends React.Component<Props> {
             MEDIA_RESOURCE_KEY,
             USER_SETTINGS_KEY,
             {
-                page: observable.box(),
+                page: observable.box(1),
                 collection: collectionId,
                 excludedIds,
                 locale,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5411
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

This PR passes 1 as initial pages when constructing the `ListStore` in the `MediaSelectionOverlay`. The same thing is done in the `SingleListOverlay`, `MultiListOverlay` and `PageSettingsVersions`.

#### Why?

Because otherwise, the paginator will be disabled. See #5411
