### PR TITLE
Fix condition parsing for xml-files

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/forms/form_with_evaluations.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/forms/form_with_evaluations.xml
@@ -98,5 +98,12 @@
                 <title lang="de">Anrede</title>
             </meta>
         </property>
+
+        <property name="title" type="text_line" visibleCondition="false" disabledCondition="true">
+            <meta>
+                <title lang="en">Title</title>
+                <title lang="de">Titel</title>
+            </meta>
+        </property>
     </properties>
 </form>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
@@ -168,7 +168,7 @@ class FormXmlLoaderTest extends TestCase
 
         $this->assertInstanceOf(FormMetadata::class, $formMetadata);
 
-        $this->assertCount(5, $formMetadata->getItems());
+        $this->assertCount(6, $formMetadata->getItems());
 
         $this->assertEquals(
             'lastName == \'section_property\'',
@@ -204,6 +204,16 @@ class FormXmlLoaderTest extends TestCase
         $this->assertEquals(
             'firstName == \'property\'',
             $formMetadata->getItems()['salutation']->getVisibleCondition()
+        );
+
+        $this->assertEquals(
+            'false',
+            $formMetadata->getItems()['title']->getVisibleCondition()
+        );
+
+        $this->assertEquals(
+            'true',
+            $formMetadata->getItems()['title']->getDisabledCondition()
         );
     }
 

--- a/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
@@ -399,11 +399,11 @@ class PropertiesXmlParser
         }
 
         if (isset($data['disabledCondition'])) {
-            $section->setDisabledCondition($data['disabledCondition']);
+            $section->setDisabledCondition($this->normalizeConditionData($data['disabledCondition']));
         }
 
         if (isset($data['visibleCondition'])) {
-            $section->setVisibleCondition($data['visibleCondition']);
+            $section->setVisibleCondition($this->normalizeConditionData($data['visibleCondition']));
         }
 
         foreach ($data['properties'] as $name => $property) {
@@ -420,11 +420,11 @@ class PropertiesXmlParser
         $blockProperty->defaultComponentName = $data['default-type'];
 
         if (isset($data['disabledCondition'])) {
-            $blockProperty->setDisabledCondition($data['disabledCondition']);
+            $blockProperty->setDisabledCondition($this->normalizeConditionData($data['disabledCondition']));
         }
 
         if (isset($data['visibleCondition'])) {
-            $blockProperty->setVisibleCondition($data['visibleCondition']);
+            $blockProperty->setVisibleCondition($this->normalizeConditionData($data['visibleCondition']));
         }
 
         if (isset($data['meta']['title'])) {
@@ -472,12 +472,8 @@ class PropertiesXmlParser
         $property->setTags($data['tags']);
         $property->setMinOccurs(null !== $data['minOccurs'] ? \intval($data['minOccurs']) : null);
         $property->setMaxOccurs(null !== $data['maxOccurs'] ? \intval($data['maxOccurs']) : null);
-        $property->setDisabledCondition(
-            \array_key_exists('disabledCondition', $data) ? $data['disabledCondition'] : null
-        );
-        $property->setVisibleCondition(
-            \array_key_exists('visibleCondition', $data) ? $data['visibleCondition'] : null
-        );
+        $property->setDisabledCondition($this->normalizeConditionData($data['disabledCondition'] ?? null));
+        $property->setVisibleCondition($this->normalizeConditionData($data['visibleCondition'] ?? null));
         $property->setParameters($data['params']);
         $property->setOnInvalid(\array_key_exists('onInvalid', $data) ? $data['onInvalid'] : null);
         $this->mapMeta($property, $data['meta']);
@@ -498,6 +494,15 @@ class PropertiesXmlParser
             ],
             $this->normalizeItem($data)
         );
+
+        return $data;
+    }
+
+    private function normalizeConditionData($data): ?string
+    {
+        if (\is_bool($data)) {
+            return $data ? 'true' : 'false';
+        }
 
         return $data;
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes https://github.com/sulu/sulu/issues/5539
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

See https://github.com/sulu/sulu/issues/5539

#### Why?

Simple conditions like `true` didn't work as expected.