### PR TITLE
Deprecate data_path_to_auto_complete schema-option in SingleSelection

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import {computed, observable, toJS} from 'mobx';
 import type {IObservableValue} from 'mobx';
+import log from 'loglevel';
 import jsonpointer from 'json-pointer';
 import equals from 'fast-deep-equal';
 import {observer} from 'mobx-react';
@@ -392,6 +393,14 @@ class SingleSelection extends React.Component<Props>
 
         if (!Array.isArray(dataPathToAutoComplete)) {
             throw new Error('The "data_path_to_auto_complete" schemaOption must be an array!');
+        }
+
+        if (dataPathToAutoComplete.length > 0 ){
+            // @deprecated
+            log.warn(
+                'The "data_path_to_auto_complete" option is deprecated since version 2.2 and will be removed. ' +
+                'Use the "resource_store_properties_to_request" option instead.'
+            );
         }
 
         const options = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import {mount, shallow} from 'enzyme';
 import {observable} from 'mobx';
+import log from 'loglevel';
 import fieldTypeDefaultProps from '../../../../utils/TestHelper/fieldTypeDefaultProps';
 import Router from '../../../../services/Router';
 import ResourceStore from '../../../../stores/ResourceStore';
@@ -11,6 +12,10 @@ import FormInspector from '../../FormInspector';
 import ResourceFormStore from '../../stores/ResourceFormStore';
 import SingleSelection from '../../fields/SingleSelection';
 import SingleSelectionComponent from '../../../../containers/SingleSelection';
+
+jest.mock('loglevel', () => ({
+    warn: jest.fn(),
+}));
 
 jest.mock('../../../../containers/SingleListOverlay', () => jest.fn(() => null));
 
@@ -130,6 +135,7 @@ test('Pass correct options to SingleAutoComplete based on data_path_to_auto_comp
             accountId: 5,
         },
     }));
+    expect(log.warn).toBeCalledWith(expect.stringContaining('The "data_path_to_auto_complete" option is deprecated'));
 });
 
 test('Pass correct props with schema-options type to SingleAutoComplete', () => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | fixes #5507
| License | MIT

#### What's in this PR?

This PR deprecates the `data_path_to_auto_complete` schema-option of the `SingleSelection` field. See #5507.
