### PR TITLE
Collect tags from types only if data is an array

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
@@ -1,5 +1,5 @@
 // @flow
-import {action, computed, observable, set, toJS, untracked, when} from 'mobx';
+import {action, computed, isObservableArray, observable, set, toJS, untracked, when} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import jexl from 'jexl';
 import jsonpointer from 'json-pointer';
@@ -124,7 +124,11 @@ function collectTagPathsWithPriority(
             continue;
         }
 
-        if (types && Object.keys(types).length > 0 && data[key]) {
+        if (types
+            && Object.keys(types).length > 0
+            && data[key]
+            && (Array.isArray(data[key]) || isObservableArray(data[key]))
+        ) {
             for (const childKey of data[key].keys()) {
                 const childData = data[key][childKey];
                 pathsWithPriority.push(

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/MemoryFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/MemoryFormStore.test.js
@@ -572,6 +572,11 @@ test('Return all the values for a given tag within blocks', () => {
             {type: 'default', text: 'Block 2', description: 'Block Description 2'},
             {type: 'other', text: 'Block 3', description: 'Block Description 2'},
         ],
+        image_map: {
+            hotspots: [
+                {type: 'default', text: 'Image Map', description: 'Image Map Description 1'},
+            ],
+        },
     });
 
     const schema = {
@@ -586,6 +591,33 @@ test('Return all the values for a given tag within blocks', () => {
         },
         block: {
             type: 'block',
+            types: {
+                default: {
+                    form: {
+                        text: {
+                            tags: [
+                                {name: 'sulu.resource_locator_part'},
+                            ],
+                            type: 'text_line',
+                        },
+                        description: {
+                            type: 'text_line',
+                        },
+                    },
+                    title: 'Default',
+                },
+                other: {
+                    form: {
+                        text: {
+                            type: 'text_line',
+                        },
+                    },
+                    title: 'Other',
+                },
+            },
+        },
+        image_map: {
+            type: 'image_map',
             types: {
                 default: {
                     form: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
@@ -1247,6 +1247,11 @@ test('Return all the values for a given tag within blocks', () => {
             {type: 'default', text: 'Block 2', description: 'Block Description 2'},
             {type: 'other', text: 'Block 3', description: 'Block Description 2'},
         ],
+        image_map: {
+            hotspots: [
+                {type: 'default', text: 'Image Map', description: 'Image Map Description 1'},
+            ],
+        },
     });
 
     const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets');
@@ -1262,6 +1267,33 @@ test('Return all the values for a given tag within blocks', () => {
         },
         block: {
             type: 'block',
+            types: {
+                default: {
+                    form: {
+                        text: {
+                            tags: [
+                                {name: 'sulu.resource_locator_part'},
+                            ],
+                            type: 'text_line',
+                        },
+                        description: {
+                            type: 'text_line',
+                        },
+                    },
+                    title: 'Default',
+                },
+                other: {
+                    form: {
+                        text: {
+                            type: 'text_line',
+                        },
+                    },
+                    title: 'Other',
+                },
+            },
+        },
+        image_map: {
+            type: 'image_map',
             types: {
                 default: {
                     form: {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #5434 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR avoids collecting tags in the `AbstractFormStore`, if the passed data is not an array.

#### Why?

The code only works with arrays, and it throws an error if the passed data is of a different type. This didn't happen before, but started happening with the `image_map` field type now, since this is the first one making use of the `types` other than the blocks. The way this is implemented now, the system skips tags within the `image_map` field type. This is not an optimal solution, but the best I can come up with.

The problem is that now every property can make use of types, and we don't really have an idea where they are used. E.g. for the `image_map` field type we would have to loop over the `hotspots` property of the object it creates. For another field type it might have a different name, and another field type might not even use it in combination with an array. I guess we need to externalize that logic, in order to properly fix that, but for now that's the quickest fix to release 2.2.1.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md