### PR TITLE
Replace invalid characters in resource locator

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
@@ -17,8 +17,6 @@ type Props = {|
 |};
 
 const replacerMap = new Map([
-    // replace multiple dash with one
-    [/([-]+)/g, '-'],
     // remove dash before slash
     [/[-]+\//g, '/'],
     // remove dash after slash
@@ -29,6 +27,8 @@ const replacerMap = new Map([
     [/([/]+)/g, '/'],
     // replace spaces with dashes
     [/ /g, '-'],
+    // replace multiple dash with one
+    [/([-]+)/g, '-'],
     // remove special characters
     [/[^a-z0-9-_/]/g, ''],
 ]);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
@@ -2,12 +2,14 @@
 import React from 'react';
 import {action, computed, observable} from 'mobx';
 import {observer} from 'mobx-react';
+import type {IObservableValue} from 'mobx';
 import Input from '../Input';
 import resourceLocatorStyles from './resourceLocator.scss';
 
 type Props = {|
     disabled: boolean,
     id?: string,
+    locale: IObservableValue<string>,
     mode: string,
     onBlur?: () => void,
     onChange: (value: ?string) => void,
@@ -54,10 +56,13 @@ class ResourceLocator extends React.Component<Props> {
     }
 
     handleChange = (value: ?string) => {
-        const {mode, onChange} = this.props;
+        const {mode, onChange, locale} = this.props;
 
-        if (value && mode === 'leaf' && value.endsWith('/')) {
-            return;
+        if (value) {
+            value = value.toLocaleLowerCase(locale.get());
+            if (mode === 'leaf') {
+                value = value.replace(/\//g, '-');
+            }
         }
 
         onChange(value ? this.fixed + value : undefined);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
@@ -59,7 +59,7 @@ class ResourceLocator extends React.Component<Props> {
         const {mode, onChange, locale} = this.props;
 
         if (value) {
-            value = value.toLocaleLowerCase(locale.get());
+            value = value.toLocaleLowerCase(locale.get()).replace(/ /g, '-');
             if (mode === 'leaf') {
                 value = value.replace(/\//g, '-');
             }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/tests/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/tests/ResourceLocator.test.js
@@ -149,8 +149,8 @@ test('ResourceLocator should call the onChange callback and replace multiple das
     const resourceLocator = mount(
         <ResourceLocator locale={locale} mode="leaf" onBlur={jest.fn()} onChange={onChange} value={value} />
     );
-    resourceLocator.find('Input').props().onChange('child---test--child');
-    expect(onChange).toBeCalledWith('/parent/child-test-child');
+    resourceLocator.find('Input').props().onChange('child--- a /// test');
+    expect(onChange).toBeCalledWith('/parent/child-a-test');
 });
 
 test('ResourceLocator should call the onChange callback and replace multiple dashes with one in full mode', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/tests/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/tests/ResourceLocator.test.js
@@ -1,44 +1,70 @@
 // @flow
 import React from 'react';
 import {render, mount, shallow} from 'enzyme';
+import {observable} from 'mobx';
 import ResourceLocator from '../ResourceLocator';
 
 test('ResourceLocator should render with type full', () => {
     const onChange = jest.fn();
     const value = '/parent';
-    expect(render(<ResourceLocator mode="full" onBlur={jest.fn()} onChange={onChange} value={value} />))
-        .toMatchSnapshot();
+    const locale = observable.box('en');
+
+    expect(
+        render(<ResourceLocator locale={locale} mode="full" onBlur={jest.fn()} onChange={onChange} value={value} />)
+    ).toMatchSnapshot();
 });
 
 test('ResourceLocator should render with type full and a value of undefined', () => {
     const onChange = jest.fn();
-    expect(render(<ResourceLocator mode="full" onBlur={jest.fn()} onChange={onChange} value={undefined} />))
-        .toMatchSnapshot();
+    const locale = observable.box('en');
+
+    expect(
+        render(<ResourceLocator locale={locale} mode="full" onBlur={jest.fn()} onChange={onChange} value={undefined} />)
+    ).toMatchSnapshot();
 });
 
 test('ResourceLocator should render with type leaf', () => {
     const onChange = jest.fn();
     const value = '/parent/child';
-    expect(render(<ResourceLocator mode="leaf" onBlur={jest.fn()} onChange={onChange} value={value} />))
-        .toMatchSnapshot();
+    const locale = observable.box('en');
+
+    expect(
+        render(<ResourceLocator locale={locale} mode="leaf" onBlur={jest.fn()} onChange={onChange} value={value} />)
+    ).toMatchSnapshot();
 });
 
 test('ResourceLocator should render with type leaf and a value of undefined', () => {
     const onChange = jest.fn();
-    expect(render(<ResourceLocator mode="leaf" onBlur={jest.fn()} onChange={onChange} value={undefined} />))
-        .toMatchSnapshot();
+    const locale = observable.box('en');
+
+    expect(
+        render(<ResourceLocator locale={locale} mode="leaf" onBlur={jest.fn()} onChange={onChange} value={undefined} />)
+    ).toMatchSnapshot();
 });
 
 test('ResourceLocator should render when disabled', () => {
     const onChange = jest.fn();
     const value = '/parent';
-    expect(render(<ResourceLocator disabled={true} mode="full" onBlur={jest.fn()} onChange={onChange} value={value} />))
-        .toMatchSnapshot();
+    const locale = observable.box('en');
+
+    expect(
+        render(
+            <ResourceLocator
+                disabled={true}
+                locale={locale}
+                mode="full"
+                onBlur={jest.fn()}
+                onChange={onChange}
+                value={value}
+            />
+        )
+    ).toMatchSnapshot();
 });
 
 test('ResourceLocator should update the split leaf representation when value changes', () => {
+    const locale = observable.box('en');
     const resourceLocator = mount(
-        <ResourceLocator mode="leaf" onBlur={jest.fn()} onChange={jest.fn()} value="/child" />
+        <ResourceLocator locale={locale} mode="leaf" onBlur={jest.fn()} onChange={jest.fn()} value="/child" />
     );
 
     expect(resourceLocator.find('.fixed').prop('children')).toEqual('/');
@@ -53,8 +79,9 @@ test('ResourceLocator should update the split leaf representation when value cha
 test('ResourceLocator should call the onChange callback when the input changes with type full', () => {
     const onChange = jest.fn();
     const value = '/parent';
+    const locale = observable.box('en');
     const resourceLocator = mount(
-        <ResourceLocator mode="full" onBlur={jest.fn()} onChange={onChange} value={value} />
+        <ResourceLocator locale={locale} mode="full" onBlur={jest.fn()} onChange={onChange} value={value} />
     );
     resourceLocator.find('Input').props().onChange('parent-new');
     expect(onChange).toHaveBeenCalledWith('/parent-new');
@@ -63,28 +90,53 @@ test('ResourceLocator should call the onChange callback when the input changes w
 test('ResourceLocator should call the onChange callback when the input changes with type leaf', () => {
     const onChange = jest.fn();
     const value = '/parent/child';
+    const locale = observable.box('en');
     const resourceLocator = mount(
-        <ResourceLocator mode="leaf" onBlur={jest.fn()} onChange={onChange} value={value} />
+        <ResourceLocator locale={locale} mode="leaf" onBlur={jest.fn()} onChange={onChange} value={value} />
     );
     resourceLocator.find('Input').props().onChange('child-new');
     expect(onChange).toHaveBeenCalledWith('/parent/child-new');
 });
 
-test('ResourceLocator should not call the onChange callback when a slash is typed in leaf mode', () => {
+test('ResourceLocator should call the onChange callback and replace a typed slash with a dash in leaf mode', () => {
     const onChange = jest.fn();
     const value = '/parent/child';
+    const locale = observable.box('en');
     const resourceLocator = mount(
-        <ResourceLocator mode="leaf" onBlur={jest.fn()} onChange={onChange} value={value} />
+        <ResourceLocator locale={locale} mode="leaf" onBlur={jest.fn()} onChange={onChange} value={value} />
     );
-    resourceLocator.find('Input').props().onChange('/parent/child/');
-    expect(onChange).not.toBeCalled();
+    resourceLocator.find('Input').props().onChange('child/');
+    expect(onChange).toBeCalledWith('/parent/child-');
+});
+
+test('ResourceLocator should replace capital letters with lower case in leaf mode before calling onChange', () => {
+    const onChange = jest.fn();
+    const value = '/parent/child';
+    const locale = observable.box('en');
+    const resourceLocator = mount(
+        <ResourceLocator locale={locale} mode="leaf" onBlur={jest.fn()} onChange={onChange} value={value} />
+    );
+    resourceLocator.find('Input').props().onChange('CHILD');
+    expect(onChange).toBeCalledWith('/parent/child');
+});
+
+test('ResourceLocator should replace capital letters with lower case in full mode before calling onChange', () => {
+    const onChange = jest.fn();
+    const value = '/parent/child';
+    const locale = observable.box('en');
+    const resourceLocator = mount(
+        <ResourceLocator locale={locale} mode="full" onBlur={jest.fn()} onChange={onChange} value={value} />
+    );
+    resourceLocator.find('Input').props().onChange('parent/CHILD');
+    expect(onChange).toBeCalledWith('/parent/child');
 });
 
 test('ResourceLocator should call the onChange callback when a slash is typed in full mode', () => {
     const onChange = jest.fn();
     const value = '/parent/child';
+    const locale = observable.box('en');
     const resourceLocator = mount(
-        <ResourceLocator mode="full" onBlur={jest.fn()} onChange={onChange} value={value} />
+        <ResourceLocator locale={locale} mode="full" onBlur={jest.fn()} onChange={onChange} value={value} />
     );
     resourceLocator.find('Input').props().onChange('parent/child/');
     expect(onChange).toBeCalledWith('/parent/child/');
@@ -92,16 +144,30 @@ test('ResourceLocator should call the onChange callback when a slash is typed in
 
 test('ResourceLocator should call the onChange callback with undefined if no input is given', () => {
     const onChange = jest.fn();
-    const resourceLocator = mount(<ResourceLocator mode="leaf" onChange={onChange} value="/url" />);
+    const locale = observable.box('en');
+    const resourceLocator = mount(<ResourceLocator locale={locale} mode="leaf" onChange={onChange} value="/url" />);
     resourceLocator.find('Input').prop('onChange')(undefined);
     expect(onChange).toHaveBeenCalledWith(undefined);
 });
 
+test('ResourceLocator should call the onChange callback and replace "/" with "-"', () => {
+    const onChange = jest.fn();
+
+    const value = '/parent';
+    const locale = observable.box('en');
+    const resourceLocator = mount(
+        <ResourceLocator locale={locale} mode="full" onBlur={jest.fn()} onChange={onChange} value={value} />
+    );
+    resourceLocator.find('Input').props().onChange('parent/child/');
+    expect(onChange).toBeCalledWith('/parent/child/');
+});
+
 test('ResourceLocator should call the onBlur callback when the Input finishes editing', () => {
     const finishSpy = jest.fn();
+    const locale = observable.box('en');
 
     const resourceLocator = shallow(
-        <ResourceLocator mode="leaf" onBlur={finishSpy} onChange={jest.fn()} value="/some/url" />
+        <ResourceLocator locale={locale} mode="leaf" onBlur={finishSpy} onChange={jest.fn()} value="/some/url" />
     );
 
     resourceLocator.find('Input').simulate('blur');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/tests/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/tests/ResourceLocator.test.js
@@ -109,6 +109,28 @@ test('ResourceLocator should call the onChange callback and replace a typed slas
     expect(onChange).toBeCalledWith('/parent/child-');
 });
 
+test('ResourceLocator should call the onChange callback and replace a typed space with a dash in leaf mode', () => {
+    const onChange = jest.fn();
+    const value = '/parent/child';
+    const locale = observable.box('en');
+    const resourceLocator = mount(
+        <ResourceLocator locale={locale} mode="leaf" onBlur={jest.fn()} onChange={onChange} value={value} />
+    );
+    resourceLocator.find('Input').props().onChange('child test child');
+    expect(onChange).toBeCalledWith('/parent/child-test-child');
+});
+
+test('ResourceLocator should call the onChange callback and replace a typed space with a dash in full mode', () => {
+    const onChange = jest.fn();
+    const value = '/parent/child';
+    const locale = observable.box('en');
+    const resourceLocator = mount(
+        <ResourceLocator locale={locale} mode="full" onBlur={jest.fn()} onChange={onChange} value={value} />
+    );
+    resourceLocator.find('Input').props().onChange('parent/child test child');
+    expect(onChange).toBeCalledWith('/parent/child-test-child');
+});
+
 test('ResourceLocator should replace capital letters with lower case in leaf mode before calling onChange', () => {
     const onChange = jest.fn();
     const value = '/parent/child';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/tests/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/tests/ResourceLocator.test.js
@@ -131,6 +131,94 @@ test('ResourceLocator should call the onChange callback and replace a typed spac
     expect(onChange).toBeCalledWith('/parent/child-test-child');
 });
 
+test('ResourceLocator should call the onChange callback and replace multiple slashes with one in full mode', () => {
+    const onChange = jest.fn();
+    const value = '/parent/child';
+    const locale = observable.box('en');
+    const resourceLocator = mount(
+        <ResourceLocator locale={locale} mode="full" onBlur={jest.fn()} onChange={onChange} value={value} />
+    );
+    resourceLocator.find('Input').props().onChange('parent///child//test/child');
+    expect(onChange).toBeCalledWith('/parent/child/test/child');
+});
+
+test('ResourceLocator should call the onChange callback and replace multiple dashes with one in leaf mode', () => {
+    const onChange = jest.fn();
+    const value = '/parent/child';
+    const locale = observable.box('en');
+    const resourceLocator = mount(
+        <ResourceLocator locale={locale} mode="leaf" onBlur={jest.fn()} onChange={onChange} value={value} />
+    );
+    resourceLocator.find('Input').props().onChange('child---test--child');
+    expect(onChange).toBeCalledWith('/parent/child-test-child');
+});
+
+test('ResourceLocator should call the onChange callback and replace multiple dashes with one in full mode', () => {
+    const onChange = jest.fn();
+    const value = '/parent/child';
+    const locale = observable.box('en');
+    const resourceLocator = mount(
+        <ResourceLocator locale={locale} mode="full" onBlur={jest.fn()} onChange={onChange} value={value} />
+    );
+    resourceLocator.find('Input').props().onChange('parent/child---child--test-child');
+    expect(onChange).toBeCalledWith('/parent/child-child-test-child');
+});
+
+test('ResourceLocator should call the onChange callback and replace dash before and after slash in full mode', () => {
+    const onChange = jest.fn();
+    const value = '/parent/child';
+    const locale = observable.box('en');
+    const resourceLocator = mount(
+        <ResourceLocator locale={locale} mode="full" onBlur={jest.fn()} onChange={onChange} value={value} />
+    );
+    resourceLocator.find('Input').props().onChange('parent/-child-/-test-/-child');
+    expect(onChange).toBeCalledWith('/parent/child/test/child');
+});
+
+test('ResourceLocator should call the onChange callback and remove dash at the beginning in leaf mode', () => {
+    const onChange = jest.fn();
+    const value = '/parent/child';
+    const locale = observable.box('en');
+    const resourceLocator = mount(
+        <ResourceLocator locale={locale} mode="leaf" onBlur={jest.fn()} onChange={onChange} value={value} />
+    );
+    resourceLocator.find('Input').props().onChange('-child');
+    expect(onChange).toBeCalledWith('/parent/child');
+});
+
+test('ResourceLocator should call the onChange callback and remove dash at the beginning in full mode', () => {
+    const onChange = jest.fn();
+    const value = '/parent/child';
+    const locale = observable.box('en');
+    const resourceLocator = mount(
+        <ResourceLocator locale={locale} mode="full" onBlur={jest.fn()} onChange={onChange} value={value} />
+    );
+    resourceLocator.find('Input').props().onChange('-parent/child');
+    expect(onChange).toBeCalledWith('/parent/child');
+});
+
+test('ResourceLocator should call the onChange callback and remove special characters in leaf mode', () => {
+    const onChange = jest.fn();
+    const value = '/parent/child';
+    const locale = observable.box('en');
+    const resourceLocator = mount(
+        <ResourceLocator locale={locale} mode="leaf" onBlur={jest.fn()} onChange={onChange} value={value} />
+    );
+    resourceLocator.find('Input').props().onChange('c!h"i$&()=$%`l`#+.,d%');
+    expect(onChange).toBeCalledWith('/parent/child');
+});
+
+test('ResourceLocator should call the onChange callback and remove special characters in full mode', () => {
+    const onChange = jest.fn();
+    const value = '/parent/child';
+    const locale = observable.box('en');
+    const resourceLocator = mount(
+        <ResourceLocator locale={locale} mode="full" onBlur={jest.fn()} onChange={onChange} value={value} />
+    );
+    resourceLocator.find('Input').props().onChange('parent/chi!ld/te"§st/ch;:il%§d%');
+    expect(onChange).toBeCalledWith('/parent/child/test/child');
+});
+
 test('ResourceLocator should replace capital letters with lower case in leaf mode before calling onChange', () => {
     const onChange = jest.fn();
     const value = '/parent/child';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
@@ -145,6 +145,7 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
                     <ResourceLocatorComponent
                         disabled={!!disabled}
                         id={dataPath}
+                        locale={formInspector.locale}
                         mode={this.mode}
                         onBlur={this.handleBlur}
                         onChange={onChange}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
@@ -45,7 +45,16 @@ jest.mock('../../../../services/Requester', () => ({
 }));
 
 test('Pass props correctly to ResourceLocator', () => {
-    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            new ResourceStore(
+                'test',
+                undefined,
+                {'locale': 'en'}
+            ),
+            'test'
+        )
+    );
 
     const modePromise = Promise.resolve('full');
 
@@ -67,6 +76,7 @@ test('Pass props correctly to ResourceLocator', () => {
         expect(resourceLocator.find(ResourceLocatorComponent).prop('value')).toBe('/url');
         expect(resourceLocator.find(ResourceLocatorComponent).prop('mode')).toBe('full');
         expect(resourceLocator.find(ResourceLocatorComponent).prop('disabled')).toBe(true);
+        expect(resourceLocator.find(ResourceLocatorComponent).prop('locale')).toBe('en');
     });
 });
 
@@ -234,7 +244,7 @@ test('Should not pass any argument to onFinish callback', () => {
     });
 });
 
-test('Should not request a new URL if on an edit form', () =>{
+test('Should not request a new URL if on an edit form', () => {
     const formInspector = new FormInspector(
         new ResourceFormStore(
             new ResourceStore('test', 1),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes https://github.com/sulu/sulu/issues/5301 and https://github.com/sulu/sulu/issues/5462
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fixes https://github.com/sulu/sulu/issues/5301 and https://github.com/sulu/sulu/issues/5462
Adds validation for the `ResourceLocator` input field. Upper case letters are replaced with lower case letters and slashes are replaced with dashes in `leaf` mode.

#### Why?

The input field of the `ResourceLocator` has unexpected behaviour when inserting strings with `/` and capital letters result in a validation error on the backend. 