### PR TITLE
Fix link inside of table cell in ckeditor

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/utils.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/utils.js
@@ -1,13 +1,21 @@
 // @flow
 function addLinkConversion(editor: Object, tag: string, internalAttribute: string, tagAttribute: string) {
+    // implementation is inspired by the official ckeditor5-link package:
+    // https://github.com/ckeditor/ckeditor5/blob/v23.0.0/packages/ckeditor5-link/src/linkediting.js
+
     editor.model.schema.extend('$text', {allowAttributes: internalAttribute});
 
-    editor.conversion.for('upcast').attributeToAttribute({
+    editor.conversion.for('upcast').elementToAttribute({
         view: {
             name: tag,
-            key: tagAttribute,
+            attributes: {
+                [tagAttribute]: true,
+            },
         },
-        model: internalAttribute,
+        model: {
+            key: internalAttribute,
+            value: (viewElement) => viewElement.getAttribute(tagAttribute),
+        },
     });
 
     editor.conversion.for('downcast').attributeToElement({


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5250
| License | MIT

#### What's in this PR?

This PR adjusts the upcast conversion that is created in the`addLinkConversion` helper method to match the [code of the official `ckeditor5-link` package](https://github.com/ckeditor/ckeditor5/blob/5fe1d6394bbaf4aaf7285c64401296cb58642018/packages/ckeditor5-link/src/linkediting.js#L82-L94). The method is used by the `ExternalLinkPlugin` and `InternalLinkPlugin` for the ckeditor.

#### Why?

See #5250.