### PR TITLE
Fix broken type select in blocks

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -81,6 +81,13 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
         onChange(newValues);
     };
 
+    handleBlocksChange = (value: Object) => {
+        const {onChange} = this.props;
+
+        this.updateValue(value);
+        onChange(value);
+    };
+
     handleSortEnd = () => {
         const {onFinish} = this.props;
         onFinish();
@@ -225,7 +232,7 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
     };
 
     render() {
-        const {defaultType, disabled, maxOccurs, minOccurs, onChange, types} = this.props;
+        const {defaultType, disabled, maxOccurs, minOccurs, types} = this.props;
         const value = this.value || [];
 
         if (!defaultType) {
@@ -247,7 +254,7 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
                 disabled={!!disabled}
                 maxOccurs={maxOccurs}
                 minOccurs={minOccurs}
-                onChange={onChange}
+                onChange={this.handleBlocksChange}
                 onSortEnd={this.handleSortEnd}
                 renderBlockContent={this.renderBlockContent}
                 types={blockTypes}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
@@ -715,7 +715,6 @@ test('Should correctly pass props to the BlockCollection', () => {
         },
     };
     const value = [];
-    const changeSpy = jest.fn();
 
     const fieldBlocks = shallow(
         <FieldBlocks
@@ -726,7 +725,6 @@ test('Should correctly pass props to the BlockCollection', () => {
             label="Test"
             maxOccurs={2}
             minOccurs={1}
-            onChange={changeSpy}
             types={types}
             value={value}
         />
@@ -736,7 +734,6 @@ test('Should correctly pass props to the BlockCollection', () => {
         disabled: true,
         maxOccurs: 2,
         minOccurs: 1,
-        onChange: changeSpy,
         types: {
             default: 'Default',
         },
@@ -899,6 +896,50 @@ test('Should call onFinish when the order of the blocks has changed', () => {
     fieldBlocks.find('BlockCollection').prop('onSortEnd')(0, 2);
 
     expect(finishSpy).toBeCalledWith();
+});
+
+test('Should show correct value in type select after type is changed', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+    const types = {
+        default: {
+            title: 'Default',
+            form: {
+                text: {
+                    label: 'Text',
+                    type: 'text_line',
+                    visible: true,
+                },
+            },
+        },
+        other: {
+            title: 'Other',
+            form: {
+                other_text: {
+                    label: 'Other Text',
+                    type: 'text_line',
+                    visible: true,
+                },
+            },
+        },
+    };
+    const value = [{type: 'default'}];
+    formInspector.getSchemaEntryByPath.mockReturnValue({types});
+
+    const fieldBlocks = mount(
+        <FieldBlocks
+            {...fieldTypeDefaultProps}
+            defaultType="editor"
+            formInspector={formInspector}
+            types={types}
+            value={value}
+        />
+    );
+
+    fieldBlocks.find('BlockCollection Block').at(0).simulate('click');
+    fieldBlocks.find('BlockCollection').prop('onChange')([{type: 'other'}]);
+
+    fieldBlocks.update();
+    expect(fieldBlocks.find('BlockCollection Block').at(0).find('SingleSelect').prop('value')).toEqual('other');
 });
 
 test('Should set correct default values for multiple single_select in blocks', () => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #5576 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR updates the redundant `value` variable in the `FieldBlocks` also when the type changes.

#### Why?

Otherwise the type change does nothing.

