### PR TITLE
Fix segment request processor without webspace

### DIFF
--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/SegmentRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/SegmentRequestProcessor.php
@@ -11,6 +11,8 @@
 
 namespace Sulu\Component\Webspace\Analyzer\Attributes;
 
+use Sulu\Component\Webspace\PortalInformation;
+use Sulu\Component\Webspace\Webspace;
 use Symfony\Component\HttpFoundation\Request;
 
 class SegmentRequestProcessor implements RequestProcessorInterface
@@ -28,7 +30,18 @@ class SegmentRequestProcessor implements RequestProcessorInterface
     public function process(Request $request, RequestAttributes $requestAttributes)
     {
         $attributes = [];
-        $webspace = $requestAttributes->getAttribute('portalInformation')->getWebspace();
+
+        $portalInformation = $requestAttributes->getAttribute('portalInformation');
+
+        if (!$portalInformation instanceof PortalInformation) {
+            return new RequestAttributes($attributes);
+        }
+
+        $webspace = $portalInformation->getWebspace();
+
+        if (!$webspace instanceof Webspace) {
+            return new RequestAttributes($attributes);
+        }
 
         $segmentKey = $request->cookies->get($this->segmentCookieName);
         $cookieSegment = $segmentKey ? $webspace->getSegment($segmentKey) : null;

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/SegmentRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/SegmentRequestProcessorTest.php
@@ -50,6 +50,36 @@ class SegmentRequestProcessorTest extends TestCase
         $this->assertNull($attributes->getAttribute('segment'));
     }
 
+    public function testProcessWithoutWebspace()
+    {
+        $request = new Request();
+
+        $webspace = null;
+        $portalInformation = new PortalInformation(
+            RequestAnalyzerInterface::MATCH_TYPE_FULL,
+            $webspace
+        );
+
+        $attributes = $this->segmentRequestProcessor->process(
+            $request,
+            new RequestAttributes(['portalInformation' => $portalInformation])
+        );
+
+        $this->assertNull($attributes->getAttribute('segment'));
+    }
+
+    public function testProcessWithoutPortalInformation()
+    {
+        $request = new Request();
+
+        $attributes = $this->segmentRequestProcessor->process(
+            $request,
+            new RequestAttributes()
+        );
+
+        $this->assertNull($attributes->getAttribute('segment'));
+    }
+
     public function provideProcessWithDefaultSegmentValue()
     {
         return [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR |-

#### What's in this PR?

Currently the SegmentProcessor will fail if no portalInformation or Webspace is set.

#### Why?

This should not fail as you could run under an own domain.
