### PR TITLE
Fix sulu_content_load for none pages

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
@@ -112,24 +112,28 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
                 $locale
             );
 
-            $targetWebspace = $this->webspaceManager->findWebspaceByKey($contentStructure->getWebspaceKey());
-            $security = $targetWebspace->getSecurity();
-            $system = $security ? $security->getSystem() : null;
+            $targetWebspaceKey = $contentStructure->getWebspaceKey();
 
-            if ($targetWebspace->hasWebsiteSecurity()
-                && $this->securityChecker
-                && !$this->securityChecker->hasPermission(
-                    new SecurityCondition(
-                        PageAdmin::SECURITY_CONTEXT_PREFIX . $contentStructure->getWebspaceKey(),
-                        $locale,
-                        SecurityBehavior::class,
-                        $uuid,
-                        $system
-                    ),
-                    PermissionTypes::VIEW
-                )
-            ) {
-                return null;
+            if ($targetWebspaceKey) {
+                $targetWebspace = $this->webspaceManager->findWebspaceByKey($targetWebspaceKey);
+                $security = $targetWebspace->getSecurity();
+                $system = $security ? $security->getSystem() : null;
+
+                if ($targetWebspace->hasWebsiteSecurity()
+                    && $this->securityChecker
+                    && !$this->securityChecker->hasPermission(
+                        new SecurityCondition(
+                            PageAdmin::SECURITY_CONTEXT_PREFIX . $contentStructure->getWebspaceKey(),
+                            $locale,
+                            SecurityBehavior::class,
+                            $uuid,
+                            $system
+                        ),
+                        PermissionTypes::VIEW
+                    )
+                ) {
+                    return null;
+                }
             }
 
             return $this->structureResolver->resolve($contentStructure);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix sulu_content_load for none pages.

#### Why?

As reported by @patrickpotthoff `sulu_content_load` can be used to load articles or I think also snippets and currently as they don't have a webspacekey it will fail.

> request.CRITICAL: Uncaught PHP Exception Error: "Call to a member function getSecurity() on null" at /var/www/example.org/releases/16/vendor/sulu/sulu/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php line 116 {"exception":"[object] (Error(code: 0): Call to a member function getSecurity() on null at /var/www/example.org/releases/16/vendor/sulu/sulu/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php:116)"} []

#### To Do

- [ ] Add Test
- [ ] Adopt to check permission only for page structure
