### PR TITLE
Fix refresh resource locator button

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
@@ -145,6 +145,7 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
                 parts: this.parts,
                 resourceKey: formInspector.resourceKey,
                 locale: formInspector.locale ? formInspector.locale.get() : undefined,
+                id: formInspector.id,
                 ...requestOptions,
             }
         ).then(action((response) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
@@ -835,6 +835,7 @@ test('Should request new URL with correct options and disable button when refres
         expect(Requester.post).toBeCalledWith(
             '/admin/api/resourcelocators?action=generate',
             {
+                id: 5,
                 locale: undefined,
                 parts: {title: 'title-value', subtitle: 'subtitle-value'},
                 resourceKey: 'test',

--- a/src/Sulu/Bundle/PageBundle/Controller/ResourcelocatorController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/ResourcelocatorController.php
@@ -61,7 +61,9 @@ class ResourcelocatorController implements ClassResourceInterface
             \implode('-', $this->getRequestParameter($request, 'parts', true)),
             $this->getRequestParameter($request, 'parentId'),
             $webspaceKey,
-            $this->getRequestParameter($request, 'locale')
+            $this->getRequestParameter($request, 'locale'),
+            null,
+            $this->getRequestParameter($request, 'id') ?: null
         );
 
         return $this->viewHandler->handle(View::create(['resourcelocator' => $resourceLocator]));

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/Mapper/PhpcrMapperTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/Mapper/PhpcrMapperTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\PageBundle\Tests\Functional\ResourceLocator\Mapper;
 
 use PHPCR\SessionInterface;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
+use Sulu\Bundle\PageBundle\Document\BasePageDocument;
 use Sulu\Bundle\PageBundle\Document\HomeDocument;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
@@ -180,6 +181,18 @@ class PhpcrMapperTest extends SuluTestCase
         $result = $this->phpcrMapper->getUniquePath('/news', 'sulu_io', 'de');
         $this->assertEquals('/news', $result);
         $this->assertTrue($this->phpcrMapper->unique($result, 'sulu_io', 'de'));
+    }
+
+    public function testGetUniquePathForCurrentDocument()
+    {
+        /** @var BasePageDocument $document1 */
+        $document1 = $this->document1;
+
+        $result = $this->phpcrMapper->getUniquePath($document1->getResourceSegment(), 'sulu_io', 'de', null, $document1->getUuid());
+        $this->assertEquals($document1->getResourceSegment(), $result);
+
+        $result = $this->phpcrMapper->getUniquePath($document1->getResourceSegment(), 'sulu_io', 'de', null, null);
+        $this->assertEquals($document1->getResourceSegment() . '-1', $result);
     }
 
     public function testSaveFailure()

--- a/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/ResourceLocatorStrategyTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/ResourceLocatorStrategyTest.php
@@ -111,7 +111,7 @@ class ResourceLocatorStrategyTest extends TestCase
 
         $this->resourceLocatorGenerator->generate('test', null)->willReturn('/test');
         $this->cleaner->cleanup('/test', 'de')->willReturn('/test');
-        $this->mapper->getUniquePath('/test', 'sulu_io', 'de', null)->willReturn('/test');
+        $this->mapper->getUniquePath('/test', 'sulu_io', 'de', null, null)->willReturn('/test');
 
         $this->assertEquals(
             $this->resourceLocatorStrategy->generate('test', '123-123-123', 'sulu_io', 'de'),
@@ -140,7 +140,7 @@ class ResourceLocatorStrategyTest extends TestCase
 
         $this->resourceLocatorGenerator->generate('test', '/parent')->willReturn('/parent/test');
         $this->cleaner->cleanup('/parent/test', 'de')->willReturn('/parent/test');
-        $this->mapper->getUniquePath('/parent/test', 'sulu_io', 'de', null)->willReturn('/parent/test');
+        $this->mapper->getUniquePath('/parent/test', 'sulu_io', 'de', null, null)->willReturn('/parent/test');
 
         $this->assertEquals(
             $this->resourceLocatorStrategy->generate('test', '123-123-123', 'sulu_io', 'de'),
@@ -152,7 +152,7 @@ class ResourceLocatorStrategyTest extends TestCase
     {
         $this->resourceLocatorGenerator->generate('test', null)->willReturn('/test');
         $this->cleaner->cleanup('/test', 'de')->willReturn('/test');
-        $this->mapper->getUniquePath('/test', 'sulu_io', 'de', null)->willReturn('/test');
+        $this->mapper->getUniquePath('/test', 'sulu_io', 'de', null, null)->willReturn('/test');
 
         $this->assertEquals(
             $this->resourceLocatorStrategy->generate('test', null, 'sulu_io', 'de'),

--- a/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/TreeFullEditStrategyTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/TreeFullEditStrategyTest.php
@@ -114,7 +114,7 @@ class TreeFullEditStrategyTest extends TestCase
         $this->documentInspector->getUuid($parent)->willReturn($parentUuid);
         $this->mapper->loadByContentUuid($parentUuid, $webspaceKey, $languageCode, null)->willReturn('path/to/parent');
         $this->cleaner->cleanup('path/to/parent/new-page', $languageCode)->willReturn('path/to/parent/new-page');
-        $this->mapper->getUniquePath('path/to/parent/new-page', $webspaceKey, $languageCode, null)->willReturn(
+        $this->mapper->getUniquePath('path/to/parent/new-page', $webspaceKey, $languageCode, null, null)->willReturn(
             'path/to/parent/new-page'
         );
 
@@ -137,7 +137,7 @@ class TreeFullEditStrategyTest extends TestCase
         $this->documentInspector->getUuid($parent)->willReturn($parentUuid);
         $this->mapper->loadByContentUuid($parentUuid, $webspaceKey, $languageCode, null)->willReturn('path/to/parent');
         $this->cleaner->cleanup('path/to/parent/new-page', $languageCode)->willReturn('path/to/parent/new-page');
-        $this->mapper->getUniquePath('path/to/parent/new-page', $webspaceKey, $languageCode, $segmentKey)->willReturn(
+        $this->mapper->getUniquePath('path/to/parent/new-page', $webspaceKey, $languageCode, $segmentKey, null)->willReturn(
             'path/to/parent/new-page'
         );
 
@@ -155,7 +155,7 @@ class TreeFullEditStrategyTest extends TestCase
         $parent->getPublished()->willReturn(true);
 
         $this->cleaner->cleanup('/new-page', $languageCode)->willReturn('/new-page');
-        $this->mapper->getUniquePath('/new-page', $webspaceKey, $languageCode, null)->willReturn(
+        $this->mapper->getUniquePath('/new-page', $webspaceKey, $languageCode, null, null)->willReturn(
             'path/to/parent/new-page'
         );
 

--- a/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/TreeFullEditStrategyTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/TreeFullEditStrategyTest.php
@@ -145,6 +145,29 @@ class TreeFullEditStrategyTest extends TestCase
         $this->assertEquals('path/to/parent/new-page', $result);
     }
 
+    public function testGenerateWithUuid()
+    {
+        $title = 'new-page';
+        $parentUuid = 'uuid-uuid-uuid-uuid';
+        $webspaceKey = 'sulu_io';
+        $languageCode = 'de';
+        $uuid = 'another-uuid';
+
+        $parent = $this->prophesize(PageDocument::class);
+        $parent->getPublished()->willReturn(true);
+
+        $this->documentManager->find($parentUuid, $languageCode, ['load_ghost_content' => false])->willReturn($parent);
+        $this->documentInspector->getUuid($parent)->willReturn($parentUuid);
+        $this->mapper->loadByContentUuid($parentUuid, $webspaceKey, $languageCode, null)->willReturn('path/to/parent');
+        $this->cleaner->cleanup('path/to/parent/new-page', $languageCode)->willReturn('path/to/parent/new-page');
+        $this->mapper->getUniquePath('path/to/parent/new-page', $webspaceKey, $languageCode, null, $uuid)->willReturn(
+            'path/to/parent/new-page'
+        );
+
+        $result = $this->treeStrategy->generate($title, $parentUuid, $webspaceKey, $languageCode, null, $uuid);
+        $this->assertEquals('path/to/parent/new-page', $result);
+    }
+
     public function testGenerateWithoutParentUuid()
     {
         $title = 'new-page';

--- a/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/TreeLeafEditStrategyTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/TreeLeafEditStrategyTest.php
@@ -147,6 +147,29 @@ class TreeLeafEditStrategyTest extends TestCase
         $this->assertEquals('path/to/parent/new-page', $result);
     }
 
+    public function testGenerateWithUuid()
+    {
+        $title = 'new-page';
+        $parentUuid = 'uuid-uuid-uuid-uuid';
+        $webspaceKey = 'sulu_io';
+        $languageCode = 'de';
+        $uuid = 'another-uuid';
+
+        $parent = $this->prophesize(PageDocument::class);
+        $parent->getPublished()->willReturn(true);
+
+        $this->documentManager->find($parentUuid, $languageCode, ['load_ghost_content' => false])->willReturn($parent);
+        $this->documentInspector->getUuid($parent)->willReturn($parentUuid);
+        $this->mapper->loadByContentUuid($parentUuid, $webspaceKey, $languageCode, null)->willReturn('path/to/parent');
+        $this->cleaner->cleanup('path/to/parent/new-page', $languageCode)->willReturn('path/to/parent/new-page');
+        $this->mapper->getUniquePath('path/to/parent/new-page', $webspaceKey, $languageCode, null, $uuid)->willReturn(
+            'path/to/parent/new-page'
+        );
+
+        $result = $this->treeStrategy->generate($title, $parentUuid, $webspaceKey, $languageCode, null, $uuid);
+        $this->assertEquals('path/to/parent/new-page', $result);
+    }
+
     public function testGenerateWithoutParentUuid()
     {
         $title = 'new-page';

--- a/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/TreeLeafEditStrategyTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/TreeLeafEditStrategyTest.php
@@ -116,7 +116,7 @@ class TreeLeafEditStrategyTest extends TestCase
         $this->documentInspector->getUuid($parent)->willReturn($parentUuid);
         $this->mapper->loadByContentUuid($parentUuid, $webspaceKey, $languageCode, null)->willReturn('path/to/parent');
         $this->cleaner->cleanup('path/to/parent/new-page', $languageCode)->willReturn('path/to/parent/new-page');
-        $this->mapper->getUniquePath('path/to/parent/new-page', $webspaceKey, $languageCode, null)->willReturn(
+        $this->mapper->getUniquePath('path/to/parent/new-page', $webspaceKey, $languageCode, null, null)->willReturn(
             'path/to/parent/new-page'
         );
 
@@ -139,7 +139,7 @@ class TreeLeafEditStrategyTest extends TestCase
         $this->documentInspector->getUuid($parent)->willReturn($parentUuid);
         $this->mapper->loadByContentUuid($parentUuid, $webspaceKey, $languageCode, null)->willReturn('path/to/parent');
         $this->cleaner->cleanup('path/to/parent/new-page', $languageCode)->willReturn('path/to/parent/new-page');
-        $this->mapper->getUniquePath('path/to/parent/new-page', $webspaceKey, $languageCode, $segmentKey)->willReturn(
+        $this->mapper->getUniquePath('path/to/parent/new-page', $webspaceKey, $languageCode, $segmentKey, null)->willReturn(
             'path/to/parent/new-page'
         );
 
@@ -157,7 +157,7 @@ class TreeLeafEditStrategyTest extends TestCase
         $parent->getPublished()->willReturn(true);
 
         $this->cleaner->cleanup('/new-page', $languageCode)->willReturn('/new-page');
-        $this->mapper->getUniquePath('/new-page', $webspaceKey, $languageCode, null)->willReturn(
+        $this->mapper->getUniquePath('/new-page', $webspaceKey, $languageCode, null, null)->willReturn(
             'path/to/parent/new-page'
         );
 
@@ -308,7 +308,7 @@ class TreeLeafEditStrategyTest extends TestCase
             'path/to/doc'
         );
         $this->cleaner->cleanup('path/to/doc/pub', $languageCode)->willReturn('path/to/doc/pub');
-        $this->mapper->getUniquePath('path/to/doc/pub', $webspaceKey, $languageCode, null)->willReturn(
+        $this->mapper->getUniquePath('path/to/doc/pub', $webspaceKey, $languageCode, null, null)->willReturn(
             'path/to/doc/pub'
         );
 
@@ -386,7 +386,7 @@ class TreeLeafEditStrategyTest extends TestCase
             'path/to/doc'
         );
         $this->cleaner->cleanup('path/to/doc/pub', $languageCode)->willReturn('path/to/doc/pub');
-        $this->mapper->getUniquePath('path/to/doc/pub', $webspaceKey, $languageCode, null)->willReturn(
+        $this->mapper->getUniquePath('path/to/doc/pub', $webspaceKey, $languageCode, null, null)->willReturn(
             'path/to/doc/pub'
         );
 

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
@@ -290,11 +290,11 @@ class PhpcrMapper implements ResourceLocatorMapperInterface
         return $this->isUnique($routes, $path);
     }
 
-    public function getUniquePath($path, $webspaceKey, $languageCode, $segmentKey = null)
+    public function getUniquePath($path, $webspaceKey, $languageCode, $segmentKey = null, $uuid = null)
     {
         $routes = $this->getWebspaceRouteNode($webspaceKey, $languageCode, $segmentKey);
 
-        if ($this->isUnique($routes, $path)) {
+        if ($this->isUnique($routes, $path, $uuid)) {
             // path is already unique
             return $path;
         } else {
@@ -303,7 +303,7 @@ class PhpcrMapper implements ResourceLocatorMapperInterface
             // init counter
             $i = 1;
             // while $path-$i is not unique raise counter
-            while (!$this->isUnique($routes, $path . $i)) {
+            while (!$this->isUnique($routes, $path . $i, $uuid)) {
                 ++$i;
             }
 
@@ -340,10 +340,22 @@ class PhpcrMapper implements ResourceLocatorMapperInterface
      *
      * @return bool path is unique
      */
-    private function isUnique(NodeInterface $root, $path)
+    private function isUnique(NodeInterface $root, $path, $uuid = null)
     {
-        // check if root has node
-        return !$root->hasNode(\ltrim($path, '/'));
+        $path = \ltrim($path, '/');
+
+        if (!$root->hasNode($path)) {
+            return true;
+        }
+
+        if (!$uuid) {
+            return false;
+        }
+
+        $route = $root->getNode($path);
+
+        return $route->hasProperty('sulu:content')
+            && $route->getPropertyValue('sulu:content')->getIdentifier() === $uuid;
     }
 
     /**

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
@@ -290,8 +290,14 @@ class PhpcrMapper implements ResourceLocatorMapperInterface
         return $this->isUnique($routes, $path);
     }
 
-    public function getUniquePath($path, $webspaceKey, $languageCode, $segmentKey = null, $uuid = null)
+    public function getUniquePath($path, $webspaceKey, $languageCode, $segmentKey = null/*, $uuid = null*/)
     {
+        $uuid = null;
+
+        if (\func_num_args() >= 5) {
+            $uuid = \func_get_arg(4);
+        }
+
         $routes = $this->getWebspaceRouteNode($webspaceKey, $languageCode, $segmentKey);
 
         if ($this->isUnique($routes, $path, $uuid)) {

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/ResourceLocatorMapperInterface.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/ResourceLocatorMapperInterface.php
@@ -104,7 +104,7 @@ interface ResourceLocatorMapperInterface
      *
      * @return string
      */
-    public function getUniquePath($path, $webspaceKey, $languageCode, $segmentKey = null);
+    public function getUniquePath($path, $webspaceKey, $languageCode, $segmentKey = null, $uuid = null);
 
     /**
      * Returns resource locator for parent node.

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/ResourceLocatorMapperInterface.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/ResourceLocatorMapperInterface.php
@@ -101,6 +101,7 @@ interface ResourceLocatorMapperInterface
      * @param string $webspaceKey key of portal
      * @param string $languageCode
      * @param string $segmentKey
+     * @param string $uuid
      *
      * @return string
      */

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/ResourceLocatorMapperInterface.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/ResourceLocatorMapperInterface.php
@@ -101,11 +101,10 @@ interface ResourceLocatorMapperInterface
      * @param string $webspaceKey key of portal
      * @param string $languageCode
      * @param string $segmentKey
-     * @param string $uuid
      *
      * @return string
      */
-    public function getUniquePath($path, $webspaceKey, $languageCode, $segmentKey = null, $uuid = null);
+    public function getUniquePath($path, $webspaceKey, $languageCode, $segmentKey = null/*, $uuid = null*/);
 
     /**
      * Returns resource locator for parent node.

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/ResourceLocatorStrategy.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/ResourceLocatorStrategy.php
@@ -90,8 +90,14 @@ abstract class ResourceLocatorStrategy implements ResourceLocatorStrategyInterfa
         $this->resourceLocatorGenerator = $resourceLocatorGenerator;
     }
 
-    public function generate($title, $parentUuid, $webspaceKey, $languageCode, $segmentKey = null, $uuid = null)
+    public function generate($title, $parentUuid, $webspaceKey, $languageCode, $segmentKey = null/*, $uuid = null*/)
     {
+        $uuid = null;
+
+        if (\func_num_args() >= 6) {
+            $uuid = \func_get_arg(5);
+        }
+
         // title should not have a slash
         $title = \str_replace('/', '-', $title);
 

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/ResourceLocatorStrategy.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/ResourceLocatorStrategy.php
@@ -90,7 +90,7 @@ abstract class ResourceLocatorStrategy implements ResourceLocatorStrategyInterfa
         $this->resourceLocatorGenerator = $resourceLocatorGenerator;
     }
 
-    public function generate($title, $parentUuid, $webspaceKey, $languageCode, $segmentKey = null)
+    public function generate($title, $parentUuid, $webspaceKey, $languageCode, $segmentKey = null, $uuid = null)
     {
         // title should not have a slash
         $title = \str_replace('/', '-', $title);
@@ -109,7 +109,7 @@ abstract class ResourceLocatorStrategy implements ResourceLocatorStrategyInterfa
         }
 
         // get unique path
-        $path = $this->mapper->getUniquePath($path, $webspaceKey, $languageCode, $segmentKey);
+        $path = $this->mapper->getUniquePath($path, $webspaceKey, $languageCode, $segmentKey, $uuid);
 
         return $path;
     }

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/ResourceLocatorStrategyInterface.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/ResourceLocatorStrategyInterface.php
@@ -40,6 +40,7 @@ interface ResourceLocatorStrategyInterface
      * @param string $webspaceKey key of portal
      * @param string $languageCode
      * @param string $segmentKey
+     * @param string $uuid
      *
      * @return string whole path
      */

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/ResourceLocatorStrategyInterface.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/ResourceLocatorStrategyInterface.php
@@ -43,7 +43,7 @@ interface ResourceLocatorStrategyInterface
      *
      * @return string whole path
      */
-    public function generate($title, $parentUuid, $webspaceKey, $languageCode, $segmentKey = null);
+    public function generate($title, $parentUuid, $webspaceKey, $languageCode, $segmentKey = null, $uuid = null);
 
     /**
      * Creates a new route for given path.

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/ResourceLocatorStrategyInterface.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/ResourceLocatorStrategyInterface.php
@@ -40,11 +40,10 @@ interface ResourceLocatorStrategyInterface
      * @param string $webspaceKey key of portal
      * @param string $languageCode
      * @param string $segmentKey
-     * @param string $uuid
      *
      * @return string whole path
      */
-    public function generate($title, $parentUuid, $webspaceKey, $languageCode, $segmentKey = null, $uuid = null);
+    public function generate($title, $parentUuid, $webspaceKey, $languageCode, $segmentKey = null/*, $uuid = null*/);
 
     /**
      * Creates a new route for given path.


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5603
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

This pr changes the behaviour of the resource locator generation to consider, if a generated resource locator already exists for the exact same page
