### PR TITLE
Fix sulu_content_load for non pages

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
@@ -115,7 +115,10 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
 
             $document = $contentStructure->getDocument();
 
-            if (!$document || !$document instanceof WebspaceBehavior) {
+            if (!$this->securityChecker
+                || !$document instanceof WebspaceBehavior
+                || !$document instanceof SecurityBehavior
+            ) {
                 return $this->structureResolver->resolve($contentStructure);
             }
 
@@ -124,7 +127,6 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
             $system = $security ? $security->getSystem() : null;
 
             if ($targetWebspace->hasWebsiteSecurity()
-                && $this->securityChecker
                 && !$this->securityChecker->hasPermission(
                     new SecurityCondition(
                         PageAdmin::SECURITY_CONTEXT_PREFIX . $contentStructure->getWebspaceKey(),

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
@@ -17,6 +17,7 @@ use Sulu\Bundle\PageBundle\Admin\PageAdmin;
 use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;
 use Sulu\Bundle\WebsiteBundle\Twig\Exception\ParentNotFoundException;
 use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
+use Sulu\Component\Content\Document\Behavior\WebspaceBehavior;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
@@ -111,6 +112,12 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
                 $this->requestAnalyzer->getWebspace()->getKey(),
                 $locale
             );
+
+            $document = $contentStructure->getDocument();
+
+            if (!$document || !$document instanceof WebspaceBehavior) {
+                return $this->structureResolver->resolve($contentStructure);
+            }
 
             $targetWebspace = $this->webspaceManager->findWebspaceByKey($contentStructure->getWebspaceKey());
             $security = $targetWebspace->getSecurity();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | https://github.com/sulu/sulu/pull/5599
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix for sulu_content_load when is used in articles and snippets
@alexander-schranz getStructureType does not exists and no there is no similar function. I use PageInterface to check it , WDT? 

#### Why?

Because now the error `Call to a member function getSecurity() on null` occurs


