### PR TITLE
Reset filter parameter when navigating away from account documents

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -248,7 +248,7 @@ class ContactAdmin extends Admin
                     ->setResourceKey('accounts')
                     ->setBackView(static::ACCOUNT_LIST_VIEW)
                     ->setTitleProperty('name')
-                    ->addRouterAttributesToBlacklist(['active', 'limit', 'page', 'search', 'sortColumn', 'sortOrder'])
+                    ->addRouterAttributesToBlacklist(['active', 'filter', 'limit', 'page', 'search', 'sortColumn', 'sortOrder'])
             );
             $viewCollection->add(
                 $this->viewBuilderFactory


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5612
| License | MIT

#### What's in this PR?

This PR adds the `filter` attribute to the list of ignored attributes when navigating away from the documents list of the account.

#### Why?

Because the administration interface breaks when navigating from the documents list to the people list. See #5612 