### PR TITLE
Isolate styling of modals from their children

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/Dialog.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/Dialog.js
@@ -103,13 +103,13 @@ class Dialog extends React.Component<Props> {
                         >
                             <div className={dialogClass}>
                                 <section className={dialogStyles.content}>
-                                    <header>
+                                    <header className={dialogStyles.header}>
                                         {title}
                                     </header>
-                                    <article>
+                                    <article className={dialogStyles.article}>
                                         {children}
                                     </article>
-                                    <footer>
+                                    <footer className={dialogStyles.footer}>
                                         <Button
                                             disabled={confirmDisabled}
                                             loading={confirmLoading}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/dialog.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/dialog.scss
@@ -59,7 +59,7 @@ $transitionDuration: 300ms;
     overflow: hidden;
     position: relative;
 
-    header {
+    .header {
         color: $titleColor;
         font-size: 22px;
         font-weight: bold;
@@ -68,7 +68,7 @@ $transitionDuration: 300ms;
         line-height: $dialogHeaderHeight;
     }
 
-    article {
+    .article {
         max-height: $dialogContentMaxHeight;
         color: $contentColor;
         font-size: 12px;
@@ -82,7 +82,7 @@ $transitionDuration: 300ms;
         }
     }
 
-    footer {
+    .footer {
         background: $footerBackgroundColor;
         border-top: 1px solid $footerBorderColor;
         height: $dialogFooterHeight;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/__snapshots__/Dialog.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/__snapshots__/Dialog.test.js.snap
@@ -15,15 +15,21 @@ Array [
       <section
         class="content"
       >
-        <header>
+        <header
+          class="header"
+        >
           My dialog title
         </header>
-        <article>
+        <article
+          class="article"
+        >
           <div>
             My dialog content
           </div>
         </article>
-        <footer>
+        <footer
+          class="footer"
+        >
           <button
             class="button primary"
             type="button"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
@@ -134,7 +134,7 @@ class Overlay extends React.Component<Props> {
                         >
                             <div className={overlayClass}>
                                 <section className={overlayStyles.content}>
-                                    <header>
+                                    <header className={overlayStyles.header}>
                                         <h2>{title}</h2>
                                         <Icon
                                             className={overlayStyles.icon}
@@ -142,8 +142,8 @@ class Overlay extends React.Component<Props> {
                                             onClick={this.handleIconClick}
                                         />
                                     </header>
-                                    <article>{children}</article>
-                                    <footer>
+                                    <article className={overlayStyles.article}>{children}</article>
+                                    <footer className={overlayStyles.footer}>
                                         <Actions actions={actions} />
                                         <Button
                                             disabled={confirmDisabled}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/overlay.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/overlay.scss
@@ -66,7 +66,7 @@ $transitionDuration: 300ms;
     overflow: hidden;
     box-shadow: 0 10px 18px 0 rgba($mineShaft, .5);
 
-    header {
+    .header {
         background: $primaryBackground;
         border-bottom: 1px solid $overlayBorderColor;
         height: $overlayHeaderHeight;
@@ -79,13 +79,13 @@ $transitionDuration: 300ms;
         }
     }
 
-    article {
+    .article {
         max-height: $overlayContentMaxHeight;
         overflow: auto;
         background: $primaryBackground;
     }
 
-    footer {
+    .footer {
         background: $secondaryBackground;
         border-top: 1px solid $overlayBorderColor;
         height: $overlayFooterHeight;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/__snapshots__/Overlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/__snapshots__/Overlay.test.js.snap
@@ -15,7 +15,9 @@ Array [
       <section
         class="content"
       >
-        <header>
+        <header
+          class="header"
+        >
           <h2>
             My overlay title
           </h2>
@@ -26,12 +28,16 @@ Array [
             tabindex="0"
           />
         </header>
-        <article>
+        <article
+          class="article"
+        >
           <p>
             My overlay content
           </p>
         </article>
-        <footer>
+        <footer
+          class="footer"
+        >
           <div
             class="actions"
           >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/GhostDialog.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/GhostDialog.test.js.snap
@@ -15,10 +15,14 @@ Array [
       <section
         class="content"
       >
-        <header>
+        <header
+          class="header"
+        >
           sulu_admin.ghost_dialog_title
         </header>
-        <article>
+        <article
+          class="article"
+        >
           <div
             class="ghostDialog"
           >
@@ -75,7 +79,9 @@ Array [
             </div>
           </div>
         </article>
-        <footer>
+        <footer
+          class="footer"
+        >
           <button
             class="button primary"
             type="button"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/__snapshots__/MultiSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/__snapshots__/MultiSelection.test.js.snap
@@ -335,7 +335,9 @@ Array [
       <section
         class="content"
       >
-        <header>
+        <header
+          class="header"
+        >
           <h2>
             Selection
           </h2>
@@ -346,7 +348,9 @@ Array [
             tabindex="0"
           />
         </header>
-        <article>
+        <article
+          class="article"
+        >
           <div
             class="adapterContainer overlay table"
           >
@@ -359,7 +363,9 @@ Array [
             </div>
           </div>
         </article>
-        <footer>
+        <footer
+          class="footer"
+        >
           <button
             class="button primary"
             type="button"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/tests/__snapshots__/ResourceLocatorHistory.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/tests/__snapshots__/ResourceLocatorHistory.test.js.snap
@@ -15,7 +15,9 @@ Array [
       <section
         class="content"
       >
-        <header>
+        <header
+          class="header"
+        >
           <h2>
             sulu_admin.history
           </h2>
@@ -26,7 +28,9 @@ Array [
             tabindex="0"
           />
         </header>
-        <article>
+        <article
+          class="article"
+        >
           <div
             class="resourceLocatorHistoryOverlay"
           >
@@ -144,7 +148,9 @@ Array [
             </div>
           </div>
         </article>
-        <footer>
+        <footer
+          class="footer"
+        >
           <button
             class="button primary"
             type="button"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceSingleSelect/tests/__snapshots__/EditOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceSingleSelect/tests/__snapshots__/EditOverlay.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Render data in EditLines 1`] = `
-<header>
+<header
+  class="header"
+>
   <h2>
     Add something
   </h2>
@@ -78,7 +80,9 @@ exports[`Render data in EditLines 2`] = `
 `;
 
 exports[`Render data in EditLines with other properties 1`] = `
-<header>
+<header
+  class="header"
+>
   <h2>
     Add something
   </h2>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/__snapshots__/FilterOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/__snapshots__/FilterOverlay.test.js.snap
@@ -15,7 +15,9 @@ Array [
       <section
         class="content"
       >
-        <header>
+        <header
+          class="header"
+        >
           <h2>
             Test
           </h2>
@@ -26,7 +28,9 @@ Array [
             tabindex="0"
           />
         </header>
-        <article>
+        <article
+          class="article"
+        >
           <div
             class="content"
           >
@@ -391,7 +395,9 @@ Array [
             </section>
           </div>
         </article>
-        <footer>
+        <footer
+          class="footer"
+        >
           <div
             class="actions"
           >
@@ -438,7 +444,9 @@ Array [
       <section
         class="content"
       >
-        <header>
+        <header
+          class="header"
+        >
           <h2>
             Test
           </h2>
@@ -449,12 +457,16 @@ Array [
             tabindex="0"
           />
         </header>
-        <article>
+        <article
+          class="article"
+        >
           <div
             class="content"
           />
         </article>
-        <footer>
+        <footer
+          class="footer"
+        >
           <div
             class="actions"
           >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/__snapshots__/FormOverlayList.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/__snapshots__/FormOverlayList.test.js.snap
@@ -24,7 +24,9 @@ Array [
       <section
         class="content"
       >
-        <header>
+        <header
+          class="header"
+        >
           <h2>
             app.add_overlay_title
           </h2>
@@ -35,7 +37,9 @@ Array [
             tabindex="0"
           />
         </header>
-        <article>
+        <article
+          class="article"
+        >
           <div
             class="snackbar error"
             role="button"
@@ -67,7 +71,9 @@ Array [
             </div>
           </div>
         </article>
-        <footer>
+        <footer
+          class="footer"
+        >
           <button
             class="button primary"
             disabled=""

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
@@ -15,7 +15,9 @@ Array [
       <section
         class="content"
       >
-        <header>
+        <header
+          class="header"
+        >
           <h2 />
           <span
             aria-label="su-times"
@@ -24,7 +26,9 @@ Array [
             tabindex="0"
           />
         </header>
-        <article>
+        <article
+          class="article"
+        >
           <div
             class="overlay"
           >
@@ -236,7 +240,9 @@ Array [
             </div>
           </div>
         </article>
-        <footer>
+        <footer
+          class="footer"
+        >
           <button
             class="button primary"
             type="button"

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/__snapshots__/RuleOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/__snapshots__/RuleOverlay.test.js.snap
@@ -15,7 +15,9 @@ Array [
       <section
         class="content"
       >
-        <header>
+        <header
+          class="header"
+        >
           <h2>
             sulu_audience_targeting.configure_rule
           </h2>
@@ -26,7 +28,9 @@ Array [
             tabindex="0"
           />
         </header>
-        <article>
+        <article
+          class="article"
+        >
           <div
             class="overlay"
           >
@@ -150,7 +154,9 @@ Array [
             </div>
           </div>
         </article>
-        <footer>
+        <footer
+          class="footer"
+        >
           <button
             class="button primary"
             type="button"

--- a/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/__snapshots__/LocationOverlay.test.js.snap
+++ b/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/__snapshots__/LocationOverlay.test.js.snap
@@ -15,7 +15,9 @@ Array [
       <section
         class="content"
       >
-        <header>
+        <header
+          class="header"
+        >
           <h2>
             sulu_location.select_location
           </h2>
@@ -26,7 +28,9 @@ Array [
             tabindex="0"
           />
         </header>
-        <article>
+        <article
+          class="article"
+        >
           <div
             class="container"
           >
@@ -414,7 +418,9 @@ Array [
             </div>
           </div>
         </article>
-        <footer>
+        <footer
+          class="footer"
+        >
           <div
             class="actions"
           >
@@ -461,7 +467,9 @@ Array [
       <section
         class="content"
       >
-        <header>
+        <header
+          class="header"
+        >
           <h2>
             sulu_location.select_location
           </h2>
@@ -472,7 +480,9 @@ Array [
             tabindex="0"
           />
         </header>
-        <article>
+        <article
+          class="article"
+        >
           <div
             class="container"
           >
@@ -881,7 +891,9 @@ Array [
             </div>
           </div>
         </article>
-        <footer>
+        <footer
+          class="footer"
+        >
           <div
             class="actions"
           >

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
@@ -15,7 +15,9 @@ Array [
       <section
         class="content"
       >
-        <header>
+        <header
+          class="header"
+        >
           <h2>
             sulu_media.select_media_plural
           </h2>
@@ -26,7 +28,9 @@ Array [
             tabindex="0"
           />
         </header>
-        <article>
+        <article
+          class="article"
+        >
           <div
             class="overlay"
           >
@@ -583,7 +587,9 @@ Array [
             </div>
           </div>
         </article>
-        <footer>
+        <footer
+          class="footer"
+        >
           <div
             class="actions"
           >
@@ -631,7 +637,9 @@ Array [
       <section
         class="content"
       >
-        <header>
+        <header
+          class="header"
+        >
           <h2>
             sulu_media.select_media_plural
           </h2>
@@ -642,7 +650,9 @@ Array [
             tabindex="0"
           />
         </header>
-        <article>
+        <article
+          class="article"
+        >
           <div
             class="overlay"
           >
@@ -1199,7 +1209,9 @@ Array [
             </div>
           </div>
         </article>
-        <footer>
+        <footer
+          class="footer"
+        >
           <div
             class="actions"
           >


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #5608
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR uses specific classes to style some stuff of the `Dialog` and `Overlay` components instead of relying on the tag name.

#### Why?

Because using the tag names might introduce problems (as happened in #5608). When some children are passed to the `Dialog` or `Overlay` their styling is affected if they use some `header`, `article` or `footer` tags.