### PR TITLE
Avoid warnings for composer 2 autoloader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,10 +86,6 @@ before_script:
         composer remove jackalope/jackalope-doctrine-dbal --dev --no-interaction --no-update
         composer require jackalope/jackalope-jackrabbit:~1.2  --no-update --no-interaction
     fi
-  - |
-    if [[ -z "$COMPOSER_FLAGS" ]]; then
-        composer remove phpcr/phpcr-shell --no-update --dev # this also installs every package but does not exceed memory limit
-    fi
   - composer update $COMPOSER_FLAGS
 
 script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,10 +88,9 @@ before_script:
     fi
   - |
     if [[ -z "$COMPOSER_FLAGS" ]]; then
-        composer remove phpcr/phpcr-shell --dev # this also installs every package but does not exceed memory limit
-    else
-        composer update $COMPOSER_FLAGS
+        composer remove phpcr/phpcr-shell --no-update --dev # this also installs every package but does not exceed memory limit
     fi
+  - composer update $COMPOSER_FLAGS
 
 script: 
   - time ./bin/runtests -i -a $TEST_FLAGS

--- a/composer.json
+++ b/composer.json
@@ -95,7 +95,8 @@
         },
         "exclude-from-classmap": [
             "src/Sulu/Component/*/Tests/",
-            "src/Sulu/Bundle/*/Tests/"
+            "src/Sulu/Bundle/*/Tests/",
+            "src/Sulu/Bundle/*/Resources/phpcr-migrations"
         ]
     },
     "autoload-dev": {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Avoid warnings for composer 2 autoloader.

#### Why?

```
composer dump-autoload --optimize
```

end with:

```bash
Class Sulu\Bundle\CustomUrlBundle\Version201904110902 located in ./vendor/sulu/sulu/src/Sulu/Bundle/CustomUrlBundle/Resources/phpcr-migrations/Version201904110902.php does not comply with psr-0 autoloading standard. Skipping.
Class Sulu\Bundle\PageBundle\Version201511171538 located in ./vendor/sulu/sulu/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201511171538.php does not comply with psr-0 autoloading standard. Skipping.
Class Sulu\Bundle\PageBundle\Version201510210733 located in ./vendor/sulu/sulu/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201510210733.php does not comply with psr-0 autoloading standard. Skipping.
Class Sulu\Bundle\PageBundle\Version201511240843 located in ./vendor/sulu/sulu/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201511240843.php does not comply with psr-0 autoloading standard. Skipping.
Class Sulu\Bundle\PageBundle\Version202005250917 located in ./vendor/sulu/sulu/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version202005250917.php does not comply with psr-0 autoloading standard. Skipping.
Class Sulu\Bundle\PageBundle\Version202005191116 located in ./vendor/sulu/sulu/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version202005191116.php does not comply with psr-0 autoloading standard. Skipping.
Class Sulu\Bundle\PageBundle\Version201903271333 located in ./vendor/sulu/sulu/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201903271333.php does not comply with psr-0 autoloading standard. Skipping.
Class Sulu\Bundle\PageBundle\Version201512090753 located in ./vendor/sulu/sulu/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201512090753.php does not comply with psr-0 autoloading standard. Skipping.
Class Sulu\Bundle\PageBundle\Version201504271608 located in ./vendor/sulu/sulu/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201504271608.php does not comply with psr-0 autoloading standard. Skipping.
Class Sulu\Bundle\PageBundle\Version201511240844 located in ./vendor/sulu/sulu/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201511240844.php does not comply with psr-0 autoloading standard. Skipping.
Class Sulu\Bundle\PageBundle\Version201504281842 located in ./vendor/sulu/sulu/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201504281842.php does not comply with psr-0 autoloading standard. Skipping.
Class Sulu\Bundle\PageBundle\Version201507281529 located in ./vendor/sulu/sulu/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201507281529.php does not comply with psr-0 autoloading standard. Skipping.
Class Sulu\Bundle\PageBundle\Version201702021447 located in ./vendor/sulu/sulu/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201702021447.php does not comply with psr-0 autoloading standard. Skipping.
Class Sulu\Bundle\PageBundle\Version201607181533 located in ./vendor/sulu/sulu/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201607181533.php does not comply with psr-0 autoloading standard. Skipping.
Class Sulu\Bundle\PageBundle\Version201905071542 located in ./vendor/sulu/sulu/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201905071542.php does not comply with psr-0 autoloading standard. Skipping.
Class Sulu\Bundle\PageBundle\Version201507231648 located in ./vendor/sulu/sulu/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201507231648.php does not comply with psr-0 autoloading standard. Skipping.
```

#### Example Usage

Use this branch fork and run `composer update` and then:

~~~bash
composer dump-autoload --optimize
~~~

#### BC Breaks/Deprecations

No as they could not be autoloaded before.

