### PR TITLE
Add 2.2 branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -107,8 +107,8 @@
     "extra": {
         "branch-alias": {
             "dev-release/1.6": "1.6.x-dev",
-            "dev-release/2.0": "2.0.x-dev",
             "dev-release/2.1": "2.1.x-dev",
+            "dev-release/2.2": "2.2.x-dev",
             "dev-master": "2.x-dev"
         }
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add 2.2 branch alias

#### Why?

Allows to use `2.2.*@dev`as version constraint to get the dev version of 2.2.