### PR TITLE
Do not discard existing data in setMultiple method of MemoryFormStore

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/MemoryFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/MemoryFormStore.js
@@ -47,7 +47,7 @@ export default class MemoryFormStore extends AbstractFormStore implements FormSt
     }
 
     @action setMultiple(data: Object) {
-        this.data = data;
+        this.data = {...this.data, ...data};
 
         super.setMultiple();
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/MemoryFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/MemoryFormStore.test.js
@@ -384,6 +384,16 @@ test('Set nested value', () => {
     memoryFormStore.destroy();
 });
 
+test('Set multiple values', () => {
+    const memoryFormStore = new MemoryFormStore({}, {});
+
+    memoryFormStore.setMultiple({key1: 'value1', key2: 'value2'});
+    memoryFormStore.setMultiple({key2: 'newValue2', key3: 'value3'});
+
+    expect(memoryFormStore.data).toEqual({key1: 'value1', key2: 'newValue2', key3: 'value3'});
+    memoryFormStore.destroy();
+});
+
 test('Loading flag should always be false', () => {
     const memoryFormStore = new MemoryFormStore({}, {});
     expect(memoryFormStore.loading).toEqual(false);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### Why?

Right now, it is not possible to use a `text_line` property inside of the `page_block_settings` form because of this. See https://github.com/sulu/sulu-demo/pull/86 for how to extend the `page_block_settings` form.