### PR TITLE
Fix redirect after navigation with confirmation dialog from dirty Form

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -234,6 +234,14 @@ class Form extends React.Component<Props> {
             return true;
         }
 
+        const {route: viewRoute, router} = this.props;
+        if (router.route !== viewRoute) {
+            // If the route of this view does not match the currently active route anymore, then another view has
+            // already been loaded, and the warning does not need to be shown anymore. This happens e.g. when this view
+            // navigates to a Tab view, which will in turn do a redirect.
+            return true;
+        }
+
         if (
             this.showDirtyWarning === true
             && this.postponedRoute === route

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -798,6 +798,43 @@ test('Should navigate to defined route after dialog has been confirmed', () => {
     expect(router.navigate).toBeCalledWith('test_route', backViewAttributes);
 });
 
+test('Should not show dialog on navigation if another route has already been loaded', () => {
+    const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const resourceStore = new ResourceStore('snippet', 1);
+
+    const route = {
+        options: {
+            backView: 'test_route',
+            formKey: 'snippets',
+            toolbarActions: [],
+        },
+    };
+    const otherRoute = {
+        options: {
+            toolbarActions: [],
+        },
+    };
+
+    const router = {
+        addUpdateRouteHook: jest.fn(),
+        attributes: {},
+        bind: jest.fn(),
+        navigate: jest.fn(),
+        route: otherRoute,
+    };
+    const form = mount(<Form resourceStore={resourceStore} route={route} router={router} />);
+
+    form.instance().resourceFormStore.dirty = true;
+
+    const checkFormStoreDirtyStateBeforeNavigation = router.addUpdateRouteHook.mock.calls[0][0];
+
+    const backViewAttributes = {};
+
+    expect(form.find('Dialog[title="sulu_admin.dirty_warning_dialog_title"]').prop('open')).toEqual(false);
+    expect(checkFormStoreDirtyStateBeforeNavigation({}, backViewAttributes, router.navigate)).toEqual(true);
+});
+
 test('Should navigate to defined route after dialog has been confirmed using restore', () => {
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5621
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR avoids that the navigation is stopped from the `Form` view, if the form has been changed, but it was already confirmed that this is ok.

#### Why?

Because as in #5621 reported, that made problems when the user navigated to a `Tab` view starting from a dirty `Form` view. The `Tab` view did another `redirect`, which caused the `UpdateRouteHook` of the `Form` view to be called again, stopping that redirect from happening.

Therefore we included a check in that hook now, which makes sure it only runs if the view is still active. Until now it was also ran if React already showed another view, but this one was not destroyed yet.