### PR TITLE
Fix block preview with sections

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -235,7 +235,7 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
 
     removeSections(blockSchemaTypeForm: Object) {
         let filteredForm = {};
-        Object.keys(blockSchemaTypeForm).map((key) => {
+        Object.keys(blockSchemaTypeForm).forEach((key) => {
             if (blockSchemaTypeForm[key]['type'] === 'section') {
                 filteredForm = {...filteredForm, ...this.removeSections(blockSchemaTypeForm[key]['items'])};
                 return false;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -167,12 +167,14 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
     // eslint-disable-next-line no-unused-vars
     renderCollapsedBlockContent = (value: Object, type: string, index: number) => {
         const blockSchemaType = this.getBlockSchemaType(type);
-        const blockSchemaTypeForm = blockSchemaType.form;
+        const blockSchemaTypeForm = this.removeSections(blockSchemaType.form);
 
         const previewPropertyNames = Object.keys(blockSchemaTypeForm)
             .filter((schemaKey) => {
                 const schemaEntryTags = blockSchemaTypeForm[schemaKey].tags;
-                return schemaEntryTags && schemaEntryTags.some((tag) => tag.name === BLOCK_PREVIEW_TAG);
+                return schemaEntryTags &&
+                    value[schemaKey] &&
+                    schemaEntryTags.some((tag) => tag.name === BLOCK_PREVIEW_TAG);
             })
             .sort((propertyName1, propertyName2) => {
                 const propertyTags1 = blockSchemaTypeForm[propertyName1].tags;
@@ -201,7 +203,7 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
         if (previewPropertyNames.length === 0) {
             for (const fieldTypeKey of blockPreviewTransformerRegistry.blockPreviewTransformerKeysByPriority) {
                 for (const propertyName of Object.keys(blockSchemaTypeForm)) {
-                    if (blockSchemaTypeForm[propertyName].type === fieldTypeKey) {
+                    if (blockSchemaTypeForm[propertyName].type === fieldTypeKey && value[propertyName]) {
                         previewPropertyNames.push(propertyName);
                         break;
                     }
@@ -230,6 +232,20 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
             </Fragment>
         );
     };
+
+    removeSections(blockSchemaTypeForm: Object) {
+        let filteredForm = {};
+        Object.keys(blockSchemaTypeForm).map((key) => {
+            if (blockSchemaTypeForm[key]['type'] === 'section') {
+                filteredForm = {...filteredForm, ...this.removeSections(blockSchemaTypeForm[key]['items'])};
+                return false;
+            }
+
+            filteredForm[key] = blockSchemaTypeForm[key];
+        });
+
+        return filteredForm;
+    }
 
     render() {
         const {defaultType, disabled, maxOccurs, minOccurs, types} = this.props;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
@@ -139,6 +139,227 @@ test('Render collapsed blocks with block previews', () => {
     expect(fieldBlocks.render()).toMatchSnapshot();
 });
 
+test('Render collapsed blocks with block previews and sections', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+
+    const types = {
+        default: {
+            title: 'Default',
+            form: {
+                section1: {
+                    label: 'Section',
+                    type: 'section',
+                    items: {
+                        text1: {
+                            label: 'Text 1',
+                            tags: [
+                                {name: 'sulu.block_preview'},
+                            ],
+                            type: 'text_line',
+                            visible: true,
+                        },
+                        text2: {
+                            label: 'Text 2',
+                            tags: [
+                                {name: 'sulu.block_preview'},
+                            ],
+                            type: 'text_line',
+                            visible: true,
+                        },
+                        something: {
+                            label: 'Something',
+                            tags: [
+                                {name: 'sulu.block_preview'},
+                            ],
+                            type: 'text_area',
+                            visible: true,
+                        },
+                        nothing: {
+                            label: 'Nothing',
+                            type: 'text_line',
+                            visible: true,
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    formInspector.getSchemaEntryByPath.mockReturnValue({types});
+
+    const value = [
+        {
+            text1: 'Test 1',
+            text2: undefined,
+            something: 'Test 2',
+            type: 'default',
+        },
+        {
+            text1: undefined,
+            text2: 'Test 3',
+            something: 'Test 4',
+            type: 'default',
+        },
+    ];
+
+    blockPreviewTransformerRegistry.has.mockImplementation((key) => {
+        switch (key) {
+            case 'text_line':
+                return true;
+            case 'text_area':
+                return true;
+            default:
+                return false;
+        }
+    });
+
+    blockPreviewTransformerRegistry.get.mockImplementation((key) => {
+        switch (key) {
+            case 'text_line':
+                return {
+                    transform: function Transformer(value) {
+                        return <p>{value}</p>;
+                    },
+                };
+            case 'text_area':
+                return {
+                    transform: function Transformer(value) {
+                        return <p>{value}</p>;
+                    },
+                };
+        }
+    });
+
+    const fieldBlocks = shallow(
+        <FieldBlocks
+            {...fieldTypeDefaultProps}
+            defaultType="editor"
+            formInspector={formInspector}
+            types={types}
+            value={value}
+        />
+    );
+
+    expect(fieldBlocks.render()).toMatchSnapshot();
+});
+
+test('Render collapsed blocks with block previews without tags and with sections', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+
+    const types = {
+        default: {
+            title: 'Default',
+            form: {
+                section1: {
+                    label: 'Section',
+                    type: 'section',
+                    items: {
+                        nothing: {
+                            label: 'Nothing',
+                            type: 'phone',
+                            visible: true,
+                        },
+                        text1: {
+                            label: 'Text 1',
+                            type: 'text_line',
+                            visible: true,
+                        },
+                        text2: {
+                            label: 'Text 2',
+                            type: 'media_selection',
+                            visible: true,
+                        },
+                        something: {
+                            label: 'Text 3',
+                            type: 'text_editor',
+                            visible: true,
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    formInspector.getSchemaEntryByPath.mockReturnValue({types});
+
+    const value = [
+        {
+            nothing: 'phone',
+            text1: 'Test 1',
+            text2: 'Test 2',
+            something: 'Test 3',
+            type: 'default',
+        },
+        {
+            nothing: 'phone',
+            text1: 'Test 4',
+            text2: 'Test 5',
+            something: 'Test 6',
+            type: 'default',
+        },
+    ];
+
+    blockPreviewTransformerRegistry.has.mockImplementation((key) => {
+        switch (key) {
+            case 'media_selection':
+            case 'phone':
+            case 'text_line':
+            case 'text_editor':
+                return true;
+            default:
+                return false;
+        }
+    });
+
+    blockPreviewTransformerRegistry.get.mockImplementation((key) => {
+        switch (key) {
+            case 'phone':
+                return {
+                    transform: function Transformer() {
+                        return <p>phone</p>;
+                    },
+                };
+            case 'media_selection':
+                return {
+                    transform: function Transformer() {
+                        return <p>media_selection</p>;
+                    },
+                };
+            case 'text_line':
+                return {
+                    transform: function Transformer() {
+                        return <p>text_line</p>;
+                    },
+                };
+            case 'text_editor':
+                return {
+                    transform: function Transformer() {
+                        return <p>text_editor</p>;
+                    },
+                };
+        }
+    });
+
+    // $FlowFixMe
+    blockPreviewTransformerRegistry.blockPreviewTransformerKeysByPriority = [
+        'media_selection',
+        'text_line',
+        'text_editor',
+    ];
+
+    const fieldBlocks = shallow(
+        <FieldBlocks
+            {...fieldTypeDefaultProps}
+            defaultType="default"
+            formInspector={formInspector}
+            types={types}
+            value={value}
+        />
+    );
+
+    expect(fieldBlocks.render()).toMatchSnapshot();
+});
+
 test('Render collapsed blocks with block previews without tags', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
@@ -944,7 +944,223 @@ exports[`Render collapsed blocks with block previews 2`] = `
 </section>
 `;
 
+exports[`Render collapsed blocks with block previews and sections 1`] = `
+<section
+  class="blockCollection"
+>
+  <div
+    class="sortableBlockList"
+  >
+    <section
+      class="block"
+      role="switch"
+    >
+      <div
+        class="handle"
+      >
+        <span
+          aria-label="su-more"
+          class="su-more sortableHandle"
+        />
+      </div>
+      <div
+        class="content"
+      >
+        <header
+          class="header"
+        >
+          <div
+            class="type"
+          >
+            Default
+          </div>
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down"
+          />
+        </header>
+        <article
+          class="children"
+        >
+          <p>
+            Test 1
+          </p>
+          <p>
+            Test 2
+          </p>
+        </article>
+      </div>
+    </section>
+    <section
+      class="block"
+      role="switch"
+    >
+      <div
+        class="handle"
+      >
+        <span
+          aria-label="su-more"
+          class="su-more sortableHandle"
+        />
+      </div>
+      <div
+        class="content"
+      >
+        <header
+          class="header"
+        >
+          <div
+            class="type"
+          >
+            Default
+          </div>
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down"
+          />
+        </header>
+        <article
+          class="children"
+        >
+          <p>
+            Test 3
+          </p>
+          <p>
+            Test 4
+          </p>
+        </article>
+      </div>
+    </section>
+  </div>
+  <button
+    class="button secondary"
+    type="button"
+  >
+    <span
+      aria-label="su-plus"
+      class="su-plus buttonIcon"
+    />
+    <span
+      class="buttonText"
+    >
+      sulu_admin.add_block
+    </span>
+  </button>
+</section>
+`;
+
 exports[`Render collapsed blocks with block previews without tags 1`] = `
+<section
+  class="blockCollection"
+>
+  <div
+    class="sortableBlockList"
+  >
+    <section
+      class="block"
+      role="switch"
+    >
+      <div
+        class="handle"
+      >
+        <span
+          aria-label="su-more"
+          class="su-more sortableHandle"
+        />
+      </div>
+      <div
+        class="content"
+      >
+        <header
+          class="header"
+        >
+          <div
+            class="type"
+          >
+            Default
+          </div>
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down"
+          />
+        </header>
+        <article
+          class="children"
+        >
+          <p>
+            media_selection
+          </p>
+          <p>
+            text_line
+          </p>
+          <p>
+            text_editor
+          </p>
+        </article>
+      </div>
+    </section>
+    <section
+      class="block"
+      role="switch"
+    >
+      <div
+        class="handle"
+      >
+        <span
+          aria-label="su-more"
+          class="su-more sortableHandle"
+        />
+      </div>
+      <div
+        class="content"
+      >
+        <header
+          class="header"
+        >
+          <div
+            class="type"
+          >
+            Default
+          </div>
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down"
+          />
+        </header>
+        <article
+          class="children"
+        >
+          <p>
+            media_selection
+          </p>
+          <p>
+            text_line
+          </p>
+          <p>
+            text_editor
+          </p>
+        </article>
+      </div>
+    </section>
+  </div>
+  <button
+    class="button secondary"
+    type="button"
+  >
+    <span
+      aria-label="su-plus"
+      class="su-plus buttonIcon"
+    />
+    <span
+      class="buttonText"
+    >
+      sulu_admin.add_block
+    </span>
+  </button>
+</section>
+`;
+
+exports[`Render collapsed blocks with block previews without tags and with sections 1`] = `
 <section
   class="blockCollection"
 >


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Currently preview of collapsed blocks with sections doesn't work properly.
This PR removes the sections from the `blockSchemaTypeForm` for the block preview rendering and fixes this bug.

Additionally a check was added to skip potential preview fields without a value. So that the first fields with a value are shown in the preview.

#### Why?

Because the block preview should also work as properly with sections.
