### PR TITLE
Render anchor tag instead of text if target of sulu-link is not published in preview

### DIFF
--- a/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
@@ -40,22 +40,22 @@ class LinkTag implements TagInterface
         $result = [];
         foreach ($attributesByTag as $tag => $attributes) {
             $provider = $this->getValue($attributes, 'provider', self::DEFAULT_PROVIDER);
-            if (!isset($attributes['href'])
-                || !\array_key_exists($provider . '-' . $attributes['href'], $contents)
-            ) {
-                $result[$tag] = $this->getContent($attributes);
 
-                continue;
+            if (isset($attributes['href']) && \array_key_exists($provider . '-' . $attributes['href'], $contents)) {
+                $item = $contents[$provider . '-' . $attributes['href']];
+
+                $title = $item->getTitle();
+                $attributes['href'] = $item->getUrl();
+                $attributes['title'] = $this->getValue($attributes, 'title', $item->getTitle());
+            } else {
+                $title = $this->getContent($attributes);
+                $attributes['href'] = null;
+                $attributes['title'] = $this->getValue($attributes, 'title');
             }
-
-            $item = $contents[$provider . '-' . $attributes['href']];
-
-            $attributes['href'] = $item->getUrl();
-            $attributes['title'] = $this->getValue($attributes, 'title', $item->getTitle());
 
             $htmlAttributes = \array_map(
                 function($value, $name) {
-                    if (\in_array($name, ['provider', 'content', 'validation-state']) || empty($value)) {
+                    if (\in_array($name, ['provider', 'content', 'sulu-validation-state']) || empty($value)) {
                         return;
                     }
 
@@ -68,7 +68,7 @@ class LinkTag implements TagInterface
             $result[$tag] = \sprintf(
                 '<a %s>%s</a>',
                 \implode(' ', \array_filter($htmlAttributes)),
-                $this->getValue($attributes, 'content', $item->getTitle())
+                $this->getValue($attributes, 'content', $title)
             );
         }
 

--- a/src/Sulu/Bundle/MarkupBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MarkupBundle/Resources/config/services.xml
@@ -45,6 +45,7 @@
 
         <service id="sulu_markup.link_tag" class="Sulu\Bundle\MarkupBundle\Markup\LinkTag">
             <argument type="service" id="sulu_markup.link_tag.provider_pool"/>
+            <argument type="expression">container.hasParameter('sulu.preview') ? parameter('sulu.preview') : false</argument>
 
             <tag name="sulu_markup.tag" tag="link" type="html"/>
         </service>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adjusts the implementation of the `<sulu-link>` tag to render an `<a>` tag without any `href` if the target of the link is not published. Right now, only the text of the link is rendered, this breaks the styling for unpublished links in the preview.

#### Why?

Right now, only the text of the link is rendered. This means that the style for `<a>` elements will not be applied to unpublished links. This is behaviour is a bit confusing for the content manager.

