### PR TITLE
Log error to javascript console if administration build does not match Sulu version

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,8 @@
         "jest": true
     },
     "globals": {
-        "process": true
+        "process": true,
+        "SULU_ADMIN_BUILD_VERSION": "readonly"
     },
     "extends": [
         "eslint:recommended",

--- a/flow-typed/globals.js
+++ b/flow-typed/globals.js
@@ -1,0 +1,1 @@
+declare var SULU_ADMIN_BUILD_VERSION: string;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -310,6 +310,16 @@ function processConfig(config: Object) {
 }
 
 function startAdmin() {
+    if (Config.suluVersion !== SULU_ADMIN_BUILD_VERSION) {
+        log.error(
+            'Sulu administration interface: JavaScript build version mismatch' +
+            '\nJavaScript build of the Sulu administration interface does not match the version of the Sulu backend.' +
+            '\nBackend version: ' + Config.suluVersion + ', JavaScript build version: ' + SULU_ADMIN_BUILD_VERSION +
+            '\n\nHave you forgotten to update the build while upgrading your application?' + '' +
+            '\nhttps://docs.sulu.io/en/latest/upgrades/upgrade-2.x.html'
+        );
+    }
+
     const router = new Router(createHashHistory());
     router.addUpdateAttributesHook(updateRouterAttributesFromView);
     router.addUpdateAttributesHook(updateRouterAttributesFromUserStoreContentLocale);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,11 +20,12 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
         publicDir = composerConfig.extra['public-dir'];
     }
 
-    let suluVersion = undefined;
+    // default value for version must match default value in SuluVersionPass.php
+    let suluVersion = '_._._';
     if (fs.existsSync(path.resolve(projectRootPath, 'composer.lock'))) {
         const composerLock = JSON.parse(fs.readFileSync(path.resolve(projectRootPath, 'composer.lock')));
         const suluPackage = composerLock.packages.find((packageItem) => packageItem.name === 'sulu/sulu');
-        suluVersion = suluPackage ? suluPackage.version : undefined;
+        suluVersion = suluPackage ? suluPackage.version : suluVersion;
     }
 
     const CleanObsoleteChunksPlugin = require(path.resolve(nodeModulesPath, 'webpack-clean-obsolete-chunks'));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,9 +20,12 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
         publicDir = composerConfig.extra['public-dir'];
     }
 
-    const composerLock = JSON.parse(fs.readFileSync(path.resolve(projectRootPath, 'composer.lock')));
-    const suluPackage = composerLock.packages.find((p) => p.name === 'sulu/sulu');
-    const suluVersion = suluPackage ? suluPackage.version : 'unknown';
+    let suluVersion = undefined;
+    if (fs.existsSync(path.resolve(projectRootPath, 'composer.lock'))) {
+        const composerLock = JSON.parse(fs.readFileSync(path.resolve(projectRootPath, 'composer.lock')));
+        const suluPackage = composerLock.packages.find((packageItem) => packageItem.name === 'sulu/sulu');
+        suluVersion = suluPackage ? suluPackage.version : undefined;
+    }
 
     const CleanObsoleteChunksPlugin = require(path.resolve(nodeModulesPath, 'webpack-clean-obsolete-chunks'));
     const CleanWebpackPlugin = require(path.resolve(nodeModulesPath, 'clean-webpack-plugin')).CleanWebpackPlugin;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@
 /* eslint-disable import/no-dynamic-require */
 const fs = require('fs');
 const path = require('path');
+const webpack = require('webpack');
 const babelConfig = JSON.parse(fs.readFileSync(path.resolve(__dirname, '.babelrc'))); // eslint-disable-line no-undef
 
 module.exports = (env, argv) => { // eslint-disable-line no-undef
@@ -18,6 +19,10 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
     if (composerConfig.extra && composerConfig.extra['public-dir']) {
         publicDir = composerConfig.extra['public-dir'];
     }
+
+    const composerLock = JSON.parse(fs.readFileSync(path.resolve(projectRootPath, 'composer.lock')));
+    const suluPackage = composerLock.packages.find((p) => p.name === 'sulu/sulu');
+    const suluVersion = suluPackage ? suluPackage.version : 'unknown';
 
     const CleanObsoleteChunksPlugin = require(path.resolve(nodeModulesPath, 'webpack-clean-obsolete-chunks'));
     const CleanWebpackPlugin = require(path.resolve(nodeModulesPath, 'clean-webpack-plugin')).CleanWebpackPlugin;
@@ -47,6 +52,9 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                 fileName: outputPath + '/manifest.json',
             }),
             new CleanObsoleteChunksPlugin(),
+            new webpack.DefinePlugin({
+                SULU_ADMIN_BUILD_VERSION: JSON.stringify(suluVersion),
+            }),
         ],
         resolve: {
             alias: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,6 @@
 /* eslint-disable import/no-dynamic-require */
 const fs = require('fs');
 const path = require('path');
-const webpack = require('webpack');
 const babelConfig = JSON.parse(fs.readFileSync(path.resolve(__dirname, '.babelrc'))); // eslint-disable-line no-undef
 
 module.exports = (env, argv) => { // eslint-disable-line no-undef
@@ -28,6 +27,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
         suluVersion = suluPackage ? suluPackage.version : suluVersion;
     }
 
+    const webpack = require(path.resolve(nodeModulesPath, 'webpack'));
     const CleanObsoleteChunksPlugin = require(path.resolve(nodeModulesPath, 'webpack-clean-obsolete-chunks'));
     const CleanWebpackPlugin = require(path.resolve(nodeModulesPath, 'clean-webpack-plugin')).CleanWebpackPlugin;
     const ManifestPlugin = require(path.resolve(nodeModulesPath, 'webpack-manifest-plugin'));


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adjusts the `AdminBundle` to log an error if the version of the Sulu backend does not match the version of the admin javascript build.

#### Why?

Because a lot of users forget to update the javascript build of the administration interface when upgrading their application. 
