### PR TITLE
Add autowire for media TypeManagerInterface

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -244,6 +244,8 @@
             <argument>%sulu_media.media.blocked_file_types%</argument>
         </service>
 
+        <service id="Sulu\Bundle\MediaBundle\Media\TypeManager\TypeManagerInterface" alias="sulu_media.type_manager"/>
+
         <service id="sulu_media.format_options_repository" class="Doctrine\ORM\EntityRepository">
             <factory service="doctrine.orm.entity_manager" method="getRepository"/>
             <argument>%sulu_media.format_options_entity%</argument>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add autowire for media TypeManagerInterface.

#### Why?

To autowire the TypeManagerInterface to the TypeManager.

#### Example Usage

~~~php
use Sulu\Bundle\MediaBundle\Media\TypeManager\TypeManagerInterface;

class MyService {

    public function __construct(
        TypeManagerInterface $mediaTypeManager
    ) {
~~~
