### PR TITLE
Include registered keys in invalid-key errors of javascript registries

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/InternalLinkPlugin/registries/internalLinkTypeRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/InternalLinkPlugin/registries/internalLinkTypeRegistry.js
@@ -38,7 +38,10 @@ class InternalLinkTypeRegistry {
 
     getOverlay(name: string): ComponentType<InternalLinkTypeOverlayProps> {
         if (!(name in this.overlays)) {
-            throw new Error('There is no overlay for an internal link type with the key "' + name + '" registered');
+            throw new Error(
+                'There is no overlay for an internal link type with the key "' + name + '" registered.' +
+                '\n\nRegistered keys: ' + Object.keys(this.overlays).sort().join(', ')
+            );
         }
 
         return this.overlays[name];
@@ -46,7 +49,10 @@ class InternalLinkTypeRegistry {
 
     getTitle(name: string): string {
         if (!(name in this.titles)) {
-            throw new Error('There is no title for an internal link type with the key "' + name + '" registered');
+            throw new Error(
+                'There is no title for an internal link type with the key "' + name + '" registered.' +
+                '\n\nRegistered keys: ' + Object.keys(this.titles).sort().join(', ')
+            );
         }
 
         return this.titles[name];
@@ -54,7 +60,10 @@ class InternalLinkTypeRegistry {
 
     getOptions(name: string): ?InternalLinkTypeOptions {
         if (!(name in this.options)) {
-            throw new Error('There are no options for an internal link type with the key "' + name + '" registered');
+            throw new Error(
+                'There are no options for an internal link type with the key "' + name + '" registered.' +
+                '\n\nRegistered keys: ' + Object.keys(this.options).sort().join(', ')
+            );
         }
 
         return this.options[name];

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/registries/blockPreviewTransformerRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/registries/blockPreviewTransformerRegistry.js
@@ -32,7 +32,8 @@ class BlockPreviewTransformerRegistry {
         if (!(name in this.blockPreviewTransformers)) {
             throw new Error(
                 'The BlockPreviewTransformer with the key "' + name + '" is not defined. ' +
-                'You probably forgot to add it to the registry using the "add" method.'
+                'You probably forgot to add it to the registry using the "add" method.' +
+                '\n\nRegistered keys: ' + Object.keys(this.blockPreviewTransformers).sort().join(', ')
             );
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/registries/fieldRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/registries/fieldRegistry.js
@@ -26,7 +26,10 @@ class FieldRegistry {
 
     get(name: string) {
         if (!(name in this.fields)) {
-            throw new Error('There is no field with key "' + name + '" registered');
+            throw new Error(
+                'There is no field with key "' + name + '" registered.' +
+                '\n\nRegistered keys: ' + Object.keys(this.fields).sort().join(', ')
+            );
         }
 
         return this.fields[name];
@@ -34,7 +37,10 @@ class FieldRegistry {
 
     getOptions(name: string) {
         if (!(name in this.options)) {
-            throw new Error('There are no options for a field with the key "' + name + '" registered');
+            throw new Error(
+                'There are no options for a field with the key "' + name + '" registered.' +
+                '\n\nRegistered keys: ' + Object.keys(this.options).sort().join(', ')
+            );
         }
 
         return this.options[name];

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/registries/listAdapterRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/registries/listAdapterRegistry.js
@@ -31,7 +31,8 @@ class ListAdapterRegistry {
         if (!(name in this.adapters)) {
             throw new Error(
                 'The list adapter with the key "' + name + '" is not defined. ' +
-                'You probably forgot to add it to the store using the "add" method.'
+                'You probably forgot to add it to the registry using the "add" method.' +
+                '\n\nRegistered keys: ' + Object.keys(this.adapters).sort().join(', ')
             );
         }
 
@@ -40,7 +41,10 @@ class ListAdapterRegistry {
 
     getOptions(name: string) {
         if (!(name in this.options)) {
-            throw new Error('There are no options for a list adapter with the key "' + name + '" registered');
+            throw new Error(
+                'There are no options for a list adapter with the key "' + name + '" registered.' +
+                '\n\nRegistered keys: ' + Object.keys(this.options).sort().join(', ')
+            );
         }
 
         return this.options[name];

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/registries/listFieldFilterTypeRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/registries/listFieldFilterTypeRegistry.js
@@ -31,7 +31,8 @@ class ListFieldFilterTypeRegistry {
         if (!(name in this.fieldFilterTypes)) {
             throw new Error(
                 'The list field filter type with the key "' + name + '" is not defined. ' +
-                'You probably forgot to add it to the registry using the "add" method.'
+                'You probably forgot to add it to the registry using the "add" method.' +
+                '\n\nRegistered keys: ' + Object.keys(this.fieldFilterTypes).sort().join(', ')
             );
         }
 
@@ -40,7 +41,10 @@ class ListFieldFilterTypeRegistry {
 
     getOptions(name: string) {
         if (!(name in this.options)) {
-            throw new Error('There are no options for a field with the key "' + name + '" registered');
+            throw new Error(
+                'There are no options for a field with the key "' + name + '" registered.' +
+                '\n\nRegistered keys: ' + Object.keys(this.options).sort().join(', ')
+            );
         }
 
         return this.options[name];

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/registries/listFieldTransformerRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/registries/listFieldTransformerRegistry.js
@@ -28,7 +28,8 @@ class ListFieldTransformerRegistry {
         if (!(name in this.fieldTransformers)) {
             throw new Error(
                 'The list field transformer with the key "' + name + '" is not defined. ' +
-                'You probably forgot to add it to the registry using the "add" method.'
+                'You probably forgot to add it to the registry using the "add" method.' +
+                '\n\nRegistered keys: ' + Object.keys(this.fieldTransformers).sort().join(', ')
             );
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/registries/resourceRouteRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/registries/resourceRouteRegistry.js
@@ -43,7 +43,10 @@ class ResourceRouteRegistry {
 
     getDetailUrl(resourceKey: string, parameters: Object = {}) {
         if (!this.endpoints[resourceKey]) {
-            throw new Error('There are no routes for the resourceKey "' + resourceKey + '"!');
+            throw new Error(
+                'There are no routes for the resourceKey "' + resourceKey + '"!' +
+                '\n\nRegistered keys: ' + Object.keys(this.endpoints).sort().join(', ')
+            );
         }
 
         if (!this.endpoints[resourceKey].routes.detail) {
@@ -58,7 +61,10 @@ class ResourceRouteRegistry {
 
     getListUrl(resourceKey: string, parameters: Object = {}) {
         if (!this.endpoints[resourceKey]) {
-            throw new Error('There are no routes for the resourceKey "' + resourceKey + '"!');
+            throw new Error(
+                'There are no routes for the resourceKey "' + resourceKey + '"!' +
+                '\n\nRegistered keys: ' + Object.keys(this.endpoints).sort().join(', ')
+            );
         }
 
         if (!this.endpoints[resourceKey].routes.list) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/registries/routeRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/registries/routeRegistry.js
@@ -36,7 +36,10 @@ class RouteRegistry {
 
     get(name: string): Route {
         if (!(name in this.routes)) {
-            throw new Error('The route with the name "' + name + '" does not exist');
+            throw new Error(
+                'The route with the name "' + name + '" does not exist.' +
+                '\n\nRegistered names: ' + Object.keys(this.routes).sort().join(', ')
+            );
         }
 
         return this.routes[name];

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/registries/formToolbarActionRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/registries/formToolbarActionRegistry.js
@@ -22,7 +22,10 @@ class FormToolbarActionRegistry {
 
     get(name: string) {
         if (!(name in this.toolbarActions)) {
-            throw new Error('There is no toolbar item with key "' + name + '" registered!');
+            throw new Error(
+                'There is no toolbar item with key "' + name + '" registered!' +
+                '\n\nRegistered keys: ' + Object.keys(this.toolbarActions).sort().join(', ')
+            );
         }
 
         return this.toolbarActions[name];

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/registries/listItemActionRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/registries/listItemActionRegistry.js
@@ -22,7 +22,10 @@ class ListItemActionRegistry {
 
     get(name: string) {
         if (!(name in this.listItemActions)) {
-            throw new Error('There is no ItemAction with key "' + name + '" registered!');
+            throw new Error(
+                'There is no ItemAction with key "' + name + '" registered!' +
+                '\n\nRegistered keys: ' + Object.keys(this.listItemActions).sort().join(', ')
+            );
         }
 
         return this.listItemActions[name];

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/registries/listToolbarActionRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/registries/listToolbarActionRegistry.js
@@ -22,7 +22,10 @@ class ListToolbarActionRegistry {
 
     get(name: string) {
         if (!(name in this.toolbarActions)) {
-            throw new Error('There is no toolbar item with key "' + name + '" registered!');
+            throw new Error(
+                'There is no toolbar item with key "' + name + '" registered!' +
+                '\n\nRegistered keys: ' + Object.keys(this.toolbarActions).sort().join(', ')
+            );
         }
 
         return this.toolbarActions[name];

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/registries/ruleRegistry.js
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/registries/ruleRegistry.js
@@ -18,7 +18,10 @@ class RuleRegistry {
 
     get(name: string): RuleType {
         if (!(name in this.rules)) {
-            throw new Error('There is no rule with key "' + name + '" registered');
+            throw new Error(
+                'There is no rule with key "' + name + '" registered.' +
+                '\n\nRegistered keys: ' + Object.keys(this.rules).sort().join(', ')
+            );
         }
 
         return this.rules[name];


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR includes the available keys in the error messages of our javascript registries. Unfortunately, there is no documentation about available keys at all at the moment.

#### Why?

Because it would be nice for the developer to gather a list of valid values somehow.