### PR TITLE
Fix setting value prop of FieldBlocks from the outside

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -27,7 +27,7 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
         const {defaultType, onChange, types, value} = this.props;
         const {types: oldTypes} = prevProps;
 
-        if (!equals(prevProps.value, value)){
+        if (!equals(toJS(prevProps.value), toJS(value))){
             this.updateValue(value);
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
@@ -962,6 +962,46 @@ test('Should correctly pass props to the BlockCollection', () => {
     }));
 });
 
+test('Should pass new value to the BlockCollection if value prop is updated', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+    const types = {
+        default: {
+            title: 'Default',
+            form: {
+                text: {
+                    label: 'Text',
+                    type: 'text_line',
+                    visible: true,
+                },
+            },
+        },
+    };
+
+    const fieldBlocks = shallow(
+        <FieldBlocks
+            {...fieldTypeDefaultProps}
+            defaultType="editor"
+            disabled={true}
+            formInspector={formInspector}
+            label="Test"
+            maxOccurs={2}
+            minOccurs={1}
+            types={types}
+            value={[]}
+        />
+    );
+    expect(fieldBlocks.find('BlockCollection').props().value).toEqual([]);
+
+    fieldBlocks.setProps({value: [{type: 'default', text: 'One'}]});
+    expect(fieldBlocks.find('BlockCollection').props().value).toEqual([{type: 'default', text: 'One'}]);
+
+    fieldBlocks.setProps({value: observable([{type: 'default', text: 'Two'}])});
+    expect(fieldBlocks.find('BlockCollection').props().value).toEqual([{type: 'default', text: 'Two'}]);
+
+    fieldBlocks.setProps({value: observable([{type: 'default', text: 'Three'}])});
+    expect(fieldBlocks.find('BlockCollection').props().value).toEqual([{type: 'default', text: 'Three'}]);
+});
+
 test('Should pass correct schemaPath and router to FieldRenderer', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
     const router = new Router();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5641
| License | MIT

#### Why?

Somehow the `fast-deep-equal` package does not work with observable arrays that contain objects. As far as I tested, even `equals(observable([{key: 'value1'}]), observable([{key: 'value2'}]))` returns `true` 🙈. 

Because of this, setting the `value` props of the `FieldBlocks` component does not update the internal `this.value`. This means that the value that was set from the outside will be discarded as soon as a block is changed. 

Unfortunately, I am not sure how to reproduce this in the core. But it happens with the `SuluFormBundle` (see #5641)
