### PR TITLE
Add flag to disable moving in BlockCollection

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/Block.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/Block.js
@@ -59,9 +59,11 @@ export default class Block extends React.Component<Props> {
 
         return (
             <section className={blockClass} onClick={this.handleExpand} role="switch">
-                <div className={blockStyles.handle}>
-                    {dragHandle}
-                </div>
+                {dragHandle &&
+                    <div className={blockStyles.handle}>
+                        {dragHandle}
+                    </div>
+                }
                 <div className={blockStyles.content}>
                     <header className={blockStyles.header}>
                         {expanded

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/tests/Block.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/tests/Block.test.js
@@ -24,6 +24,18 @@ test('Render an expanded block with a multiple types', () => {
     )).toMatchSnapshot();
 });
 
+test('Render an expanded block without dragHandle', () => {
+    expect(render(
+        <Block
+            expanded={true}
+            onCollapse={jest.fn()}
+            onExpand={jest.fn()}
+        >
+            Some block content
+        </Block>
+    )).toMatchSnapshot();
+});
+
 test('Render a collapsed block', () => {
     expect(render(
         <Block expanded={false} icons={['su-eye', 'su-people']} onCollapse={jest.fn()} onExpand={jest.fn()}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/tests/__snapshots__/Block.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/tests/__snapshots__/Block.test.js.snap
@@ -6,9 +6,6 @@ exports[`Render a collapsed block 1`] = `
   role="switch"
 >
   <div
-    class="handle"
-  />
-  <div
     class="content"
   >
     <header
@@ -122,6 +119,37 @@ exports[`Render an expanded block with a multiple types 1`] = `
           role="button"
           tabindex="0"
         />
+        <span
+          aria-label="su-angle-up"
+          class="su-angle-up clickable"
+          role="button"
+          tabindex="0"
+        />
+      </div>
+    </header>
+    <article
+      class="children"
+    >
+      Some block content
+    </article>
+  </div>
+</section>
+`;
+
+exports[`Render an expanded block without dragHandle 1`] = `
+<section
+  class="block expanded"
+  role="switch"
+>
+  <div
+    class="content"
+  >
+    <header
+      class="header"
+    >
+      <div
+        class="iconButtons"
+      >
         <span
           aria-label="su-angle-up"
           class="su-angle-up clickable"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -16,6 +16,7 @@ type Props = {|
     icons?: Array<Array<string>>,
     maxOccurs?: ?number,
     minOccurs?: ?number,
+    movable: boolean,
     onChange: (value: Array<BlockEntry>) => void,
     onSettingsClick?: (index: number) => void,
     onSortEnd?: (oldIndex: number, newIndex: number) => void,
@@ -30,6 +31,7 @@ class BlockCollection extends React.Component<Props> {
 
     static defaultProps = {
         disabled: false,
+        movable: true,
         value: [],
     };
 
@@ -156,7 +158,7 @@ class BlockCollection extends React.Component<Props> {
     }
 
     render() {
-        const {addButtonText, disabled, icons, onSettingsClick, renderBlockContent, types, value} = this.props;
+        const {addButtonText, disabled, icons, movable, onSettingsClick, renderBlockContent, types, value} = this.props;
 
         return (
             <section className={blockCollectionStyles.blockCollection}>
@@ -166,6 +168,7 @@ class BlockCollection extends React.Component<Props> {
                     generatedBlockIds={this.generatedBlockIds}
                     icons={icons}
                     lockAxis="y"
+                    movable={movable}
                     onCollapse={this.handleCollapse}
                     onExpand={this.handleExpand}
                     onRemove={this.hasMinimumReached() ? undefined : this.handleRemoveBlock}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/README.md
@@ -51,3 +51,13 @@ const renderBlockContent = (value) => 'A not so unique block';
     value={value}
 />
 ```
+
+The `movable` flag can be used to disable the moving feature of blocks.
+
+```javascript
+const [value, setValue] = React.useState([{content: 'That is some content'}, {content: 'That is some more content'}]);
+
+const renderBlockContent = (value) => (<p>{value.content || <i>There is no content</i>}</p>);
+
+<BlockCollection movable={false} onChange={setValue} value={value} renderBlockContent={renderBlockContent} />
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlock.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlock.js
@@ -10,6 +10,7 @@ type Props = {
     activeType: string,
     expanded: boolean,
     icons?: Array<string>,
+    movable?: boolean,
     onCollapse: (index: number) => void,
     onExpand: (index: number) => void,
     onRemove?: (index: number) => void,
@@ -63,6 +64,7 @@ class SortableBlock extends React.Component<Props> {
             activeType,
             expanded,
             icons,
+            movable = true,
             onRemove,
             onSettingsClick,
             renderBlockContent,
@@ -74,7 +76,7 @@ class SortableBlock extends React.Component<Props> {
         return (
             <Block
                 activeType={activeType}
-                dragHandle={<SortableHandle />}
+                dragHandle={movable && <SortableHandle />}
                 expanded={expanded}
                 icons={icons}
                 onCollapse={this.handleCollapse}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlockList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlockList.js
@@ -13,6 +13,7 @@ type Props = {|
     expandedBlocks: Array<boolean>,
     generatedBlockIds: Array<number>,
     icons?: Array<Array<string>>,
+    movable: boolean,
     onCollapse: (index: number) => void,
     onExpand: (index: number) => void,
     onRemove?: (index: number) => void,
@@ -27,6 +28,7 @@ type Props = {|
 class SortableBlockList extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
+        movable: true,
     };
 
     handleExpand = (index: number) => {
@@ -69,6 +71,7 @@ class SortableBlockList extends React.Component<Props> {
             expandedBlocks,
             generatedBlockIds,
             icons,
+            movable,
             onRemove,
             onSettingsClick,
             renderBlockContent,
@@ -92,6 +95,7 @@ class SortableBlockList extends React.Component<Props> {
                         icons={icons && icons[index]}
                         index={index}
                         key={generatedBlockIds[index]}
+                        movable={movable}
                         onCollapse={this.handleCollapse}
                         onExpand={this.handleExpand}
                         onRemove={onRemove ? this.handleRemove : undefined}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -31,6 +31,20 @@ test('Should render a fully filled block list', () => {
     )).toMatchSnapshot();
 });
 
+test('Should render a non-movable block list', () => {
+    const blockCollection = mount(
+        <BlockCollection
+            defaultType="editor"
+            movable={false}
+            onChange={jest.fn()}
+            renderBlockContent={jest.fn()}
+            value={[{content: 'Test 1', type: 'editor'}, {content: 'Test 2', type: 'editor'}]}
+        />
+    );
+
+    expect(blockCollection.find('.handle')).toHaveLength(0);
+});
+
 test('Should render a disabled block list', () => {
     const blockCollection = mount(
         <BlockCollection

--- a/src/Sulu/Bundle/RouteBundle/Resources/js/containers/Form/tests/fields/PageTreeRoute.test.js
+++ b/src/Sulu/Bundle/RouteBundle/Resources/js/containers/Form/tests/fields/PageTreeRoute.test.js
@@ -66,6 +66,7 @@ jest.mock(
         this.options = {
             webspace: 'webspace',
         };
+        this.getPathsByTag = jest.fn().mockReturnValue([]);
     })
 );
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #5608
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds a flag to the `BlockCollection` component, that allows to disable the moving feature in it.

#### Why?

Because in #5608 we need the blocks, but it should not be possible to move them.