### PR TITLE
Allow components as children of Select Option

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/DisplayValue.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/DisplayValue.js
@@ -60,8 +60,8 @@ export default class DisplayValue extends React.PureComponent<Props> {
                 {!!icon &&
                     <Icon className={displayValueStyles.frontIcon} name={icon} />
                 }
-                {typeof children === 'string'
-                    ? <CroppedText>{children}</CroppedText>
+                {typeof children === 'string' || typeof children === 'number'
+                    ? <CroppedText>{String(children)}</CroppedText>
                     : children
                 }
                 <Icon className={displayValueStyles.toggle} name="su-angle-down" />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/DisplayValue.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/DisplayValue.js
@@ -8,7 +8,7 @@ import displayValueStyles from './displayValue.scss';
 import type {Skin} from './types';
 
 type Props = {|
-    children: string|React.Node,
+    children: any,
     disabled: boolean,
     displayValueRef?: (button: ElementRef<'button'>) => void,
     icon?: string,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/DisplayValue.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/DisplayValue.js
@@ -8,7 +8,7 @@ import displayValueStyles from './displayValue.scss';
 import type {Skin} from './types';
 
 type Props = {|
-    children: string,
+    children: string|React.Node,
     disabled: boolean,
     displayValueRef?: (button: ElementRef<'button'>) => void,
     icon?: string,
@@ -40,6 +40,7 @@ export default class DisplayValue extends React.PureComponent<Props> {
 
     render() {
         const {children, disabled, icon, skin} = this.props;
+        const childrenOnlyString = typeof children === 'string';
 
         const displayValueClass = classNames(
             displayValueStyles.displayValue,
@@ -60,7 +61,10 @@ export default class DisplayValue extends React.PureComponent<Props> {
                 {!!icon &&
                     <Icon className={displayValueStyles.frontIcon} name={icon} />
                 }
-                <CroppedText>{children}</CroppedText>
+                {childrenOnlyString
+                    ? <CroppedText>{children}</CroppedText>
+                    : children
+                }
                 <Icon className={displayValueStyles.toggle} name="su-angle-down" />
             </button>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/DisplayValue.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/DisplayValue.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import type {ElementRef} from 'react';
+import type {ElementRef, Node} from 'react';
 import classNames from 'classnames';
 import CroppedText from '../CroppedText';
 import Icon from '../Icon';
@@ -8,7 +8,7 @@ import displayValueStyles from './displayValue.scss';
 import type {Skin} from './types';
 
 type Props = {|
-    children: any,
+    children: Node,
     disabled: boolean,
     displayValueRef?: (button: ElementRef<'button'>) => void,
     icon?: string,
@@ -40,7 +40,6 @@ export default class DisplayValue extends React.PureComponent<Props> {
 
     render() {
         const {children, disabled, icon, skin} = this.props;
-        const childrenOnlyString = typeof children === 'string';
 
         const displayValueClass = classNames(
             displayValueStyles.displayValue,
@@ -61,7 +60,7 @@ export default class DisplayValue extends React.PureComponent<Props> {
                 {!!icon &&
                     <Icon className={displayValueStyles.frontIcon} name={icon} />
                 }
-                {childrenOnlyString
+                {typeof children === 'string'
                     ? <CroppedText>{children}</CroppedText>
                     : children
                 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/DisplayValue.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/DisplayValue.test.js
@@ -9,6 +9,11 @@ test('The component should render', () => {
     expect(displayValue).toMatchSnapshot();
 });
 
+test('The component should render with an inline component', () => {
+    const displayValue = render(<DisplayValue onClick={jest.fn()}><b>Value</b></DisplayValue>);
+    expect(displayValue).toMatchSnapshot();
+});
+
 test('The component should render with the flat skin', () => {
     const displayValue = render(<DisplayValue onClick={jest.fn()} skin="flat">My value</DisplayValue>);
     expect(displayValue).toMatchSnapshot();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/DisplayValue.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/DisplayValue.test.js
@@ -4,13 +4,13 @@ import React from 'react';
 import CroppedText from '../../CroppedText';
 import DisplayValue from '../DisplayValue';
 
-test('The component should render', () => {
+test('The component should render a CroppedText if value of children prop is a string', () => {
     const displayValue = render(<DisplayValue onClick={jest.fn()}>My value</DisplayValue>);
     expect(displayValue).toMatchSnapshot();
 });
 
-test('The component should render with an inline component', () => {
-    const displayValue = render(<DisplayValue onClick={jest.fn()}><b>Value</b></DisplayValue>);
+test('The component should directly render given children if value of children prop contains another component', () => {
+    const displayValue = render(<DisplayValue onClick={jest.fn()}>Some <b>bold</b> text</DisplayValue>);
     expect(displayValue).toMatchSnapshot();
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/__snapshots__/DisplayValue.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/__snapshots__/DisplayValue.test.js.snap
@@ -37,6 +37,21 @@ exports[`The component should render 1`] = `
 </button>
 `;
 
+exports[`The component should render with an inline component 1`] = `
+<button
+  class="displayValue default"
+  type="button"
+>
+  <b>
+    Value
+  </b>
+  <span
+    aria-label="su-angle-down"
+    class="su-angle-down toggle"
+  />
+</button>
+`;
+
 exports[`The component should render when disabled 1`] = `
 <button
   class="displayValue default"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/__snapshots__/DisplayValue.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/__snapshots__/DisplayValue.test.js.snap
@@ -1,6 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`The component should render 1`] = `
+exports[`The component should directly render given children if value of children prop contains another component 1`] = `
+<button
+  class="displayValue default"
+  type="button"
+>
+  Some 
+  <b>
+    bold
+  </b>
+   text
+  <span
+    aria-label="su-angle-down"
+    class="su-angle-down toggle"
+  />
+</button>
+`;
+
+exports[`The component should render a CroppedText if value of children prop is a string 1`] = `
 <button
   class="displayValue default"
   type="button"
@@ -30,21 +47,6 @@ exports[`The component should render 1`] = `
       My value
     </div>
   </div>
-  <span
-    aria-label="su-angle-down"
-    class="su-angle-down toggle"
-  />
-</button>
-`;
-
-exports[`The component should render with an inline component 1`] = `
-<button
-  class="displayValue default"
-  type="button"
->
-  <b>
-    Value
-  </b>
   <span
     aria-label="su-angle-down"
     class="su-angle-down toggle"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleSelect/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleSelect/README.md
@@ -28,9 +28,7 @@ const onActionClick = (actionValue) => console.log('clicked action with value:',
 Also a lot of options are possible and correctly handled as well as neatly styled.
 
 ```javascript
-const Action = SingleSelect.Action;
 const Option = SingleSelect.Option;
-const Divider = SingleSelect.Divider;
 
 const [selectValue, setSelectedValue] = React.useState('page-1');
 
@@ -60,5 +58,24 @@ const onChange = (value) => setSelectedValue(value);
     <Option value="20">Susan Bones</Option>
     <Option value="21">Marvolo Gaunt</Option>
     <Option value="22">Godric Gryffindor</Option>
+</SingleSelect>
+```
+
+The options can also contain render components such as icons:
+
+```javascript
+import {Icon} from 'sulu-admin-bundle/components';
+
+const Option = SingleSelect.Option;
+
+const [selectValue, setSelectedValue] = React.useState('page-1');
+
+const onChange = (value) => setSelectedValue(value);
+
+<SingleSelect value={selectValue} onChange={onChange}>
+    <Option disabled>Choose an icon</Option>
+    <Option value="fa-user"><Icon name="fa-user"/> fa-user</Option>
+    <Option value="su-inbox"><Icon name="su-inbox"/> su-inbox</Option>
+    <Option value="su-umbrella"><Icon name="su-umbrella"/> su-umbrella</Option>
 </SingleSelect>
 ```


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | 
| License | MIT
| Documentation PR | 

#### What's in this PR?

This PR allows to use html elements or React components with the `DisplayValue` component.

#### Why?

Currently `DisplayValue` only supports strings. When used in combination with other components like `Icon` the resulting display value would be `[object Object]`.

#### Example Usage

~~~js
<SingleSelect disabled={disabled} value={value} onChange={this.handleInputChange} id={dataPath} valid={!error}>
  <Option value="fa-info-circle"><Icon name="fa-info-circle"/></Option>
  <Option value="fa-user"><Icon name="fa-user"/></Option>
</SingleSelect>
~~~

#### To Do

- [ ] Create a documentation PR
