### PR TITLE
Add flag to disable collapsing of blocks

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/Block.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/Block.js
@@ -12,8 +12,8 @@ type Props = {
     dragHandle?: Node,
     expanded: boolean,
     icons?: Array<string>,
-    onCollapse: () => void,
-    onExpand: () => void,
+    onCollapse?: () => void,
+    onExpand?: () => void,
     onRemove?: () => void,
     onSettingsClick?: () => void,
     onTypeChange?: (type: string | number) => void,
@@ -27,14 +27,14 @@ export default class Block extends React.Component<Props> {
 
     handleCollapse = () => {
         const {expanded, onCollapse} = this.props;
-        if (expanded) {
+        if (expanded && onCollapse) {
             onCollapse();
         }
     };
 
     handleExpand = () => {
         const {expanded, onExpand} = this.props;
-        if (!expanded) {
+        if (!expanded && onExpand) {
             onExpand();
         }
     };
@@ -48,7 +48,19 @@ export default class Block extends React.Component<Props> {
     };
 
     render() {
-        const {activeType, children, dragHandle, expanded, icons, onSettingsClick, onRemove, types} = this.props;
+        const {
+            activeType,
+            children,
+            dragHandle,
+            icons,
+            onCollapse,
+            onExpand,
+            onRemove,
+            onSettingsClick,
+            types,
+        } = this.props;
+
+        const expanded = this.props.expanded || (!onCollapse && !onExpand);
 
         const blockClass = classNames(
             blockStyles.block,
@@ -87,7 +99,9 @@ export default class Block extends React.Component<Props> {
                                 <div className={blockStyles.iconButtons}>
                                     {onSettingsClick && <Icon name="su-cog" onClick={onSettingsClick} />}
                                     {onRemove && <Icon name="su-trash-alt" onClick={onRemove} />}
-                                    <Icon name="su-angle-up" onClick={this.handleCollapse} />
+                                    {onCollapse && onExpand &&
+                                        <Icon name="su-angle-up" onClick={this.handleCollapse} />
+                                    }
                                 </div>
                             </Fragment>
                             : <Fragment>
@@ -97,7 +111,7 @@ export default class Block extends React.Component<Props> {
                                     </div>
                                 }
                                 {types && activeType && <div className={blockStyles.type}>{types[activeType]}</div>}
-                                <Icon name="su-angle-down" />
+                                {onCollapse && onExpand && <Icon name="su-angle-down" />}
                             </Fragment>
                         }
                     </header>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/README.md
@@ -66,3 +66,11 @@ const types = {
     That is a {activeType} Block!
 </Block>
 ```
+
+If the `onCollapse` and `onExpand` props are not set, the block cannot be collapsed:
+
+```javascript
+<Block>
+    That is a Block!
+</Block>
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/tests/Block.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/tests/Block.test.js
@@ -24,13 +24,9 @@ test('Render an expanded block with a multiple types', () => {
     )).toMatchSnapshot();
 });
 
-test('Render an expanded block without dragHandle', () => {
+test('Render an block without dragHandle or collapse or expand button', () => {
     expect(render(
-        <Block
-            expanded={true}
-            onCollapse={jest.fn()}
-            onExpand={jest.fn()}
-        >
+        <Block expanded={true}>
             Some block content
         </Block>
     )).toMatchSnapshot();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/tests/__snapshots__/Block.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/tests/__snapshots__/Block.test.js.snap
@@ -37,6 +37,30 @@ exports[`Render a collapsed block 1`] = `
 </section>
 `;
 
+exports[`Render an block without dragHandle or collapse or expand button 1`] = `
+<section
+  class="block expanded"
+  role="switch"
+>
+  <div
+    class="content"
+  >
+    <header
+      class="header"
+    >
+      <div
+        class="iconButtons"
+      />
+    </header>
+    <article
+      class="children"
+    >
+      Some block content
+    </article>
+  </div>
+</section>
+`;
+
 exports[`Render an expanded block with a multiple types 1`] = `
 <section
   class="block expanded"
@@ -119,37 +143,6 @@ exports[`Render an expanded block with a multiple types 1`] = `
           role="button"
           tabindex="0"
         />
-        <span
-          aria-label="su-angle-up"
-          class="su-angle-up clickable"
-          role="button"
-          tabindex="0"
-        />
-      </div>
-    </header>
-    <article
-      class="children"
-    >
-      Some block content
-    </article>
-  </div>
-</section>
-`;
-
-exports[`Render an expanded block without dragHandle 1`] = `
-<section
-  class="block expanded"
-  role="switch"
->
-  <div
-    class="content"
-  >
-    <header
-      class="header"
-    >
-      <div
-        class="iconButtons"
-      >
         <span
           aria-label="su-angle-up"
           class="su-angle-up clickable"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -11,6 +11,7 @@ import type {BlockEntry, RenderBlockContentCallback} from './types';
 
 type Props = {|
     addButtonText?: ?string,
+    collapsable: boolean,
     defaultType: string,
     disabled: boolean,
     icons?: Array<Array<string>>,
@@ -30,6 +31,7 @@ class BlockCollection extends React.Component<Props> {
     static idCounter = 0;
 
     static defaultProps = {
+        collapsable: true,
         disabled: false,
         movable: true,
         value: [],
@@ -46,7 +48,7 @@ class BlockCollection extends React.Component<Props> {
     }
 
     fillArrays = () => {
-        const {defaultType, onChange, minOccurs, value} = this.props;
+        const {collapsable, defaultType, onChange, minOccurs, value} = this.props;
         const {expandedBlocks, generatedBlockIds} = this;
 
         if (!value) {
@@ -61,7 +63,9 @@ class BlockCollection extends React.Component<Props> {
             generatedBlockIds.splice(value.length);
         }
 
-        expandedBlocks.push(...new Array(value.length - expandedBlocks.length).fill(false));
+        const collapsed = collapsable ? false : true;
+
+        expandedBlocks.push(...new Array(value.length - expandedBlocks.length).fill(collapsed));
         generatedBlockIds.push(
             ...new Array(value.length - generatedBlockIds.length).fill(false).map(() => ++BlockCollection.idCounter)
         );
@@ -158,7 +162,17 @@ class BlockCollection extends React.Component<Props> {
     }
 
     render() {
-        const {addButtonText, disabled, icons, movable, onSettingsClick, renderBlockContent, types, value} = this.props;
+        const {
+            addButtonText,
+            collapsable,
+            disabled,
+            icons,
+            movable,
+            onSettingsClick,
+            renderBlockContent,
+            types,
+            value,
+        } = this.props;
 
         return (
             <section className={blockCollectionStyles.blockCollection}>
@@ -169,8 +183,8 @@ class BlockCollection extends React.Component<Props> {
                     icons={icons}
                     lockAxis="y"
                     movable={movable}
-                    onCollapse={this.handleCollapse}
-                    onExpand={this.handleExpand}
+                    onCollapse={collapsable ? this.handleCollapse : undefined}
+                    onExpand={collapsable ? this.handleExpand : undefined}
                     onRemove={this.hasMinimumReached() ? undefined : this.handleRemoveBlock}
                     onSettingsClick={onSettingsClick ? this.handleSettingsClick : undefined}
                     onSortEnd={this.handleSortEnd}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/README.md
@@ -61,3 +61,14 @@ const renderBlockContent = (value) => (<p>{value.content || <i>There is no conte
 
 <BlockCollection movable={false} onChange={setValue} value={value} renderBlockContent={renderBlockContent} />
 ```
+
+Setting the `collapsable` flag to false will cause all blocks to be expanded and there will be no possibility to
+collapse them.
+
+```javascript
+const [value, setValue] = React.useState([{content: 'That is some content'}, {content: 'That is some more content'}]);
+
+const renderBlockContent = (value) => (<p>{value.content || <i>There is no content</i>}</p>);
+
+<BlockCollection collapsable={false} onChange={setValue} value={value} renderBlockContent={renderBlockContent} />
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlock.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlock.js
@@ -11,8 +11,8 @@ type Props = {
     expanded: boolean,
     icons?: Array<string>,
     movable?: boolean,
-    onCollapse: (index: number) => void,
-    onExpand: (index: number) => void,
+    onCollapse?: (index: number) => void,
+    onExpand?: (index: number) => void,
     onRemove?: (index: number) => void,
     onSettingsClick?: (index: number) => void,
     onTypeChange?: (type: string | number, index: number) => void,
@@ -26,13 +26,17 @@ class SortableBlock extends React.Component<Props> {
     handleCollapse = () => {
         const {sortIndex, onCollapse} = this.props;
 
-        onCollapse(sortIndex);
+        if (onCollapse) {
+            onCollapse(sortIndex);
+        }
     };
 
     handleExpand = () => {
         const {sortIndex, onExpand} = this.props;
 
-        onExpand(sortIndex);
+        if (onExpand) {
+            onExpand(sortIndex);
+        }
     };
 
     handleRemove = () => {
@@ -65,6 +69,8 @@ class SortableBlock extends React.Component<Props> {
             expanded,
             icons,
             movable = true,
+            onCollapse,
+            onExpand,
             onRemove,
             onSettingsClick,
             renderBlockContent,
@@ -79,8 +85,8 @@ class SortableBlock extends React.Component<Props> {
                 dragHandle={movable && <SortableHandle />}
                 expanded={expanded}
                 icons={icons}
-                onCollapse={this.handleCollapse}
-                onExpand={this.handleExpand}
+                onCollapse={onCollapse ? this.handleCollapse : undefined}
+                onExpand={onExpand ? this.handleExpand : undefined}
                 onRemove={onRemove ? this.handleRemove : undefined}
                 onSettingsClick={onSettingsClick && this.handleSettingsClick}
                 onTypeChange={this.handleTypeChange}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlockList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlockList.js
@@ -14,8 +14,8 @@ type Props = {|
     generatedBlockIds: Array<number>,
     icons?: Array<Array<string>>,
     movable: boolean,
-    onCollapse: (index: number) => void,
-    onExpand: (index: number) => void,
+    onCollapse?: (index: number) => void,
+    onExpand?: (index: number) => void,
     onRemove?: (index: number) => void,
     onSettingsClick?: (index: number) => void,
     onTypeChange?: (type: string | number, index: number) => void,
@@ -33,12 +33,16 @@ class SortableBlockList extends React.Component<Props> {
 
     handleExpand = (index: number) => {
         const {onExpand} = this.props;
-        onExpand(index);
+        if (onExpand) {
+            onExpand(index);
+        }
     };
 
     handleCollapse = (index: number) => {
         const {onCollapse} = this.props;
-        onCollapse(index);
+        if (onCollapse) {
+            onCollapse(index);
+        }
     };
 
     handleRemove = (index: number) => {
@@ -72,6 +76,8 @@ class SortableBlockList extends React.Component<Props> {
             generatedBlockIds,
             icons,
             movable,
+            onCollapse,
+            onExpand,
             onRemove,
             onSettingsClick,
             renderBlockContent,
@@ -96,8 +102,8 @@ class SortableBlockList extends React.Component<Props> {
                         index={index}
                         key={generatedBlockIds[index]}
                         movable={movable}
-                        onCollapse={this.handleCollapse}
-                        onExpand={this.handleExpand}
+                        onCollapse={onCollapse ? this.handleCollapse : undefined}
+                        onExpand={onExpand ? this.handleExpand : undefined}
                         onRemove={onRemove ? this.handleRemove : undefined}
                         onSettingsClick={onSettingsClick ? this.handleSettingsClick : undefined}
                         onTypeChange={this.handleTypeChange}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -32,17 +32,16 @@ test('Should render a fully filled block list', () => {
 });
 
 test('Should render a non-movable block list', () => {
-    const blockCollection = mount(
+    expect(render(
         <BlockCollection
+            collapsable={false}
             defaultType="editor"
             movable={false}
             onChange={jest.fn()}
             renderBlockContent={jest.fn()}
             value={[{content: 'Test 1', type: 'editor'}, {content: 'Test 2', type: 'editor'}]}
         />
-    );
-
-    expect(blockCollection.find('.handle')).toHaveLength(0);
+    )).toMatchSnapshot();
 });
 
 test('Should render a disabled block list', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/SortableBlock.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/SortableBlock.test.js
@@ -28,7 +28,7 @@ test('Render collapsed sortable block', () => {
     )).toMatchSnapshot();
 });
 
-test('Render expanded sortable block with types', () => {
+test('Render expanded sortable, non-collapsable block with types', () => {
     const renderBlockContent = jest.fn().mockImplementation(
         (value, type) => 'Test for ' + value.content + (type ? ' and type ' + type : '')
     );
@@ -37,8 +37,6 @@ test('Render expanded sortable block with types', () => {
         <SortableBlock
             activeType="type2"
             expanded={true}
-            onCollapse={jest.fn()}
-            onExpand={jest.fn()}
             onRemove={jest.fn()}
             onSettingsClick={jest.fn()}
             renderBlockContent={renderBlockContent}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/BlockCollection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/BlockCollection.test.js.snap
@@ -91,3 +91,80 @@ exports[`Should render a fully filled block list 1`] = `
   </button>
 </section>
 `;
+
+exports[`Should render a non-movable block list 1`] = `
+<section
+  class="blockCollection"
+>
+  <div
+    class="sortableBlockList"
+  >
+    <section
+      class="block expanded"
+      role="switch"
+    >
+      <div
+        class="content"
+      >
+        <header
+          class="header"
+        >
+          <div
+            class="iconButtons"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt clickable"
+              role="button"
+              tabindex="0"
+            />
+          </div>
+        </header>
+        <article
+          class="children"
+        />
+      </div>
+    </section>
+    <section
+      class="block expanded"
+      role="switch"
+    >
+      <div
+        class="content"
+      >
+        <header
+          class="header"
+        >
+          <div
+            class="iconButtons"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt clickable"
+              role="button"
+              tabindex="0"
+            />
+          </div>
+        </header>
+        <article
+          class="children"
+        />
+      </div>
+    </section>
+  </div>
+  <button
+    class="button secondary"
+    type="button"
+  >
+    <span
+      aria-label="su-plus"
+      class="su-plus buttonIcon"
+    />
+    <span
+      class="buttonText"
+    >
+      Add block
+    </span>
+  </button>
+</section>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/SortableBlock.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/SortableBlock.test.js.snap
@@ -43,7 +43,7 @@ exports[`Render collapsed sortable block 1`] = `
 </section>
 `;
 
-exports[`Render expanded sortable block with types 1`] = `
+exports[`Render expanded sortable, non-collapsable block with types 1`] = `
 <section
   class="block expanded"
   role="switch"
@@ -117,12 +117,6 @@ exports[`Render expanded sortable block with types 1`] = `
         <span
           aria-label="su-trash-alt"
           class="su-trash-alt clickable"
-          role="button"
-          tabindex="0"
-        />
-        <span
-          aria-label="su-angle-up"
-          class="su-angle-up clickable"
           role="button"
           tabindex="0"
         />


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | --
| Related issues/PRs | #5608 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds a flag to make blocks not collapsable.

#### Why?

We need that for #5608, because the schedule blocks should not be collapsable.