### PR TITLE
Remove AudienceTargeting reference in DataProviderPool

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -28,6 +28,9 @@ The `MediaDataprovider` requires the `EntityManagerInterface` and the `Translato
 
 For the type filtering to work properly all those mentioned services are necessary.
 
+In addition the reference to the `AudienceTargetingBundle` in the DataProviderPool is removed. Now every provider,
+which requires the `AudienceTargetingBundle`, has to enable it by itself only when the `AudienceTargetingBundle` is really enabled.
+
 ## 2.1.3
 
 ### GhostDialog

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -359,6 +359,7 @@
             <argument type="service" id="sulu_core.array_serializer"/>
             <argument type="service" id="request_stack"/>
             <argument type="service" id="sulu_media.reference_store.media"/>
+            <argument type="expression">container.hasParameter('sulu_audience_targeting.enabled')</argument>
             <argument type="service" id="doctrine.orm.default_entity_manager"/>
             <argument type="service" id="translator"/>
 

--- a/src/Sulu/Bundle/PageBundle/Resources/config/smart_content.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/smart_content.xml
@@ -16,9 +16,7 @@
     <services>
         <!-- data provider -->
         <service id="sulu_page.smart_content.data_provider_pool"
-                 class="%sulu_page.smart_content.data_provider_pool.class%" public="true">
-            <argument type="expression">container.hasParameter('sulu_audience_targeting.enabled')</argument>
-        </service>
+                 class="%sulu_page.smart_content.data_provider_pool.class%" public="true"/>
 
         <!-- content provider -->
         <service id="sulu_page.smart_content.data_provider.content.proxy_factory"
@@ -41,6 +39,7 @@
             <argument type="service" id="sulu_document_manager.default_session"/>
             <argument type="service" id="sulu_page.reference_store.content"/>
             <argument>%sulu_document_manager.show_drafts%</argument>
+            <argument type="expression">container.hasParameter('sulu_audience_targeting.enabled')</argument>
             <argument type="service" id="sulu_admin.form_metadata_provider" on-invalid="null"/>
             <argument type="service" id="security.token_storage" on-invalid="null"/>
 

--- a/src/Sulu/Bundle/SnippetBundle/Content/SnippetDataProvider.php
+++ b/src/Sulu/Bundle/SnippetBundle/Content/SnippetDataProvider.php
@@ -72,6 +72,11 @@ class SnippetDataProvider implements DataProviderInterface
     private $referenceStore;
 
     /**
+     * @var bool
+     */
+    private $hasAudienceTargeting;
+
+    /**
      * @var FormMetadataProvider|null
      */
     private $formMetadataProvider;
@@ -88,6 +93,7 @@ class SnippetDataProvider implements DataProviderInterface
         LazyLoadingValueHolderFactory $proxyFactory,
         DocumentManagerInterface $documentManager,
         ReferenceStoreInterface $referenceStore,
+        bool $hasAudienceTargeting = false,
         FormMetadataProvider $formMetadataProvider = null,
         TokenStorageInterface $tokenStorage = null
     ) {
@@ -97,6 +103,7 @@ class SnippetDataProvider implements DataProviderInterface
         $this->proxyFactory = $proxyFactory;
         $this->documentManager = $documentManager;
         $this->referenceStore = $referenceStore;
+        $this->hasAudienceTargeting = $hasAudienceTargeting;
         $this->formMetadataProvider = $formMetadataProvider;
         $this->tokenStorage = $tokenStorage;
 
@@ -108,13 +115,12 @@ class SnippetDataProvider implements DataProviderInterface
     public function getConfiguration()
     {
         if (!$this->configuration) {
-            $this->configuration = Builder::create()
+            $builder = Builder::create()
                 ->enableTags()
                 ->enableCategories()
                 ->enablePresentAs()
                 ->enablePagination()
                 ->enableLimit()
-                ->enableAudienceTargeting()
                 ->enableSorting(
                     [
                         ['column' => 'title', 'title' => 'sulu_admin.title'],
@@ -123,8 +129,13 @@ class SnippetDataProvider implements DataProviderInterface
                     ]
                 )
                 ->enableTypes($this->getTypes())
-                ->enableView(SnippetAdmin::EDIT_FORM_VIEW, ['id' => 'id'])
-                ->getConfiguration();
+                ->enableView(SnippetAdmin::EDIT_FORM_VIEW, ['id' => 'id']);
+
+            if ($this->hasAudienceTargeting) {
+                $builder->enableAudienceTargeting();
+            }
+
+            $this->configuration = $builder->getConfiguration();
         }
 
         return $this->configuration;

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/content.xml
@@ -54,6 +54,7 @@
             <argument type="service" id="sulu_page.smart_content.data_provider.content.proxy_factory"/>
             <argument type="service" id="sulu_document_manager.document_manager"/>
             <argument type="service" id="sulu_snippet.reference_store.snippet"/>
+            <argument type="expression">container.hasParameter('sulu_audience_targeting.enabled')</argument>
             <argument type="service" id="sulu_admin.form_metadata_provider" on-invalid="null"/>
             <argument type="service" id="security.token_storage" on-invalid="null"/>
 

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SnippetDataProviderTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SnippetDataProviderTest.php
@@ -136,6 +136,7 @@ class SnippetDataProviderTest extends TestCase
             $this->proxyFactory->reveal(),
             $this->documentManager->reveal(),
             $this->referenceStore->reveal(),
+            false,
             $formMetadataProvider->reveal(),
             $tokenStorage->reveal()
         );

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SnippetDataProviderTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SnippetDataProviderTest.php
@@ -91,6 +91,40 @@ class SnippetDataProviderTest extends TestCase
         $this->referenceStore->getAll()->willReturn([]);
     }
 
+    public function testEnabledAudienceTargeting()
+    {
+        $provider = new SnippetDataProvider(
+            $this->contentQueryExecutor->reveal(),
+            $this->snippetQueryBuilder->reveal(),
+            $this->nodeHelper->reveal(),
+            $this->proxyFactory->reveal(),
+            $this->documentManager->reveal(),
+            $this->referenceStore->reveal(),
+            true
+        );
+
+        $configuration = $provider->getConfiguration();
+
+        $this->assertTrue($configuration->hasAudienceTargeting());
+    }
+
+    public function testDisabledAudienceTargeting()
+    {
+        $provider = new SnippetDataProvider(
+            $this->contentQueryExecutor->reveal(),
+            $this->snippetQueryBuilder->reveal(),
+            $this->nodeHelper->reveal(),
+            $this->proxyFactory->reveal(),
+            $this->documentManager->reveal(),
+            $this->referenceStore->reveal(),
+            false
+        );
+
+        $configuration = $provider->getConfiguration();
+
+        $this->assertFalse($configuration->hasAudienceTargeting());
+    }
+
     public function testGetTypesConfiguration()
     {
         /** @var TokenStorageInterface|ObjectProphecy $tokenStorage */

--- a/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
+++ b/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
@@ -80,6 +80,11 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
     private $showDrafts;
 
     /**
+     * @var bool
+     */
+    private $hasAudienceTargeting;
+
+    /**
      * @var FormMetadataProvider|null
      */
     private $formMetadataProvider;
@@ -97,6 +102,7 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
         SessionInterface $session,
         ReferenceStoreInterface $referenceStore,
         $showDrafts,
+        bool $hasAudienceTargeting = false,
         FormMetadataProvider $formMetadataProvider = null,
         TokenStorageInterface $tokenStorage = null
     ) {
@@ -107,6 +113,7 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
         $this->session = $session;
         $this->referenceStore = $referenceStore;
         $this->showDrafts = $showDrafts;
+        $this->hasAudienceTargeting = $hasAudienceTargeting;
         $this->formMetadataProvider = $formMetadataProvider;
         $this->tokenStorage = $tokenStorage;
 
@@ -131,13 +138,12 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
      */
     private function initConfiguration()
     {
-        $this->configuration = Builder::create()
+        $builder = Builder::create()
             ->enableTags()
             ->enableCategories()
             ->enableLimit()
             ->enablePagination()
             ->enablePresentAs()
-            ->enableAudienceTargeting()
             ->enableDatasource('pages', 'pages', 'column_list')
             ->enableSorting(
                 [
@@ -150,8 +156,13 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
                 ]
             )
             ->enableTypes($this->getTypes())
-            ->enableView(PageAdmin::EDIT_FORM_VIEW, ['id' => 'id', 'webspace' => 'webspace'])
-            ->getConfiguration();
+            ->enableView(PageAdmin::EDIT_FORM_VIEW, ['id' => 'id', 'webspace' => 'webspace']);
+
+        if ($this->hasAudienceTargeting) {
+            $builder->enableAudienceTargeting();
+        }
+
+        $this->configuration = $builder->getConfiguration();
 
         return $this->configuration;
     }

--- a/src/Sulu/Component/Content/Tests/Unit/SmartContent/PageDataProviderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/SmartContent/PageDataProviderTest.php
@@ -136,6 +136,42 @@ class PageDataProviderTest extends TestCase
         $this->assertInstanceOf(ProviderConfigurationInterface::class, $configuration);
     }
 
+    public function testEnabledAudienceTargeting()
+    {
+        $provider = new PageDataProvider(
+            $this->getContentQueryBuilder(),
+            $this->getContentQueryExecutor(),
+            $this->getDocumentManager(),
+            $this->getProxyFactory(),
+            $this->getSession(),
+            new ReferenceStore(),
+            false,
+            true
+        );
+
+        $configuration = $provider->getConfiguration();
+
+        $this->assertTrue($configuration->hasAudienceTargeting());
+    }
+
+    public function testDisabledAudienceTargeting()
+    {
+        $provider = new PageDataProvider(
+            $this->getContentQueryBuilder(),
+            $this->getContentQueryExecutor(),
+            $this->getDocumentManager(),
+            $this->getProxyFactory(),
+            $this->getSession(),
+            new ReferenceStore(),
+            false,
+            false
+        );
+
+        $configuration = $provider->getConfiguration();
+
+        $this->assertFalse($configuration->hasAudienceTargeting());
+    }
+
     public function testGetTypesConfiguration()
     {
         /** @var TokenStorageInterface|ObjectProphecy $tokenStorage */

--- a/src/Sulu/Component/Content/Tests/Unit/SmartContent/PageDataProviderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/SmartContent/PageDataProviderTest.php
@@ -182,6 +182,7 @@ class PageDataProviderTest extends TestCase
             $this->getSession(),
             new ReferenceStore(),
             ['view' => 64],
+            false,
             $formMetadataProvider->reveal(),
             $tokenStorage->reveal()
         );

--- a/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
+++ b/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
@@ -41,6 +41,11 @@ class MediaDataProvider extends BaseDataProvider
     private $collectionManager;
 
     /**
+     * @var bool
+     */
+    private $hasAudienceTargeting;
+
+    /**
      * @var EntityManagerInterface|null
      */
     private $entityManager;
@@ -56,6 +61,7 @@ class MediaDataProvider extends BaseDataProvider
         ArraySerializerInterface $serializer,
         RequestStack $requestStack,
         ReferenceStoreInterface $referenceStore,
+        bool $hasAudienceTargeting = false,
         EntityManagerInterface $entityManager = null,
         TranslatorInterface $translator = null
     ) {
@@ -64,6 +70,7 @@ class MediaDataProvider extends BaseDataProvider
         $this->translator = $translator;
         $this->requestStack = $requestStack;
         $this->collectionManager = $collectionManager;
+        $this->hasAudienceTargeting = $hasAudienceTargeting;
 
         if (!$entityManager) {
             @\trigger_error('The usage of the "MediaDataProvider" without setting the "EntityManager" is deprecated. Please inject the "EntityManager".', \E_USER_DEPRECATED);
@@ -77,13 +84,12 @@ class MediaDataProvider extends BaseDataProvider
     public function getConfiguration()
     {
         if (!$this->configuration) {
-            $this->configuration = self::createConfigurationBuilder()
+            $builder = self::createConfigurationBuilder()
                 ->enableTags()
                 ->enableCategories()
                 ->enableLimit()
                 ->enablePagination()
                 ->enablePresentAs()
-                ->enableAudienceTargeting()
                 ->enableDatasource('collections', 'collections', 'column_list')
                 ->enableSorting(
                     [
@@ -91,8 +97,13 @@ class MediaDataProvider extends BaseDataProvider
                     ]
                 )
                 ->enableTypes($this->getTypes())
-                ->enableView(MediaAdmin::EDIT_FORM_VIEW, ['id' => 'id'])
-                ->getConfiguration();
+                ->enableView(MediaAdmin::EDIT_FORM_VIEW, ['id' => 'id']);
+
+            if ($this->hasAudienceTargeting) {
+                $builder->enableAudienceTargeting();
+            }
+
+            $this->configuration = $builder->getConfiguration();
         }
 
         return $this->configuration;

--- a/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
+++ b/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
@@ -47,7 +47,8 @@ class MediaDataProviderTest extends TestCase
             $collectionManager->reveal(),
             $serializer->reveal(),
             $requestStack->reveal(),
-            $referenceStore->reveal()
+            $referenceStore->reveal(),
+            true
         );
 
         $configuration = $provider->getConfiguration();
@@ -100,6 +101,7 @@ class MediaDataProviderTest extends TestCase
             $serializer->reveal(),
             $requestStack->reveal(),
             $referenceStore->reveal(),
+            false,
             $entityManager->reveal(),
             $translator->reveal()
         );

--- a/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
+++ b/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
@@ -53,7 +53,6 @@ class MediaDataProviderTest extends TestCase
         $configuration = $provider->getConfiguration();
 
         $this->assertInstanceOf(ProviderConfigurationInterface::class, $configuration);
-        $this->assertFalse($configuration->hasAudienceTargeting());
     }
 
     public function testEnabledAudienceTargeting()
@@ -74,6 +73,26 @@ class MediaDataProviderTest extends TestCase
         $configuration = $provider->getConfiguration();
 
         $this->assertTrue($configuration->hasAudienceTargeting());
+    }
+
+    public function testDisabledAudienceTargeting()
+    {
+        $serializer = $this->prophesize(ArraySerializerInterface::class);
+        $collectionManager = $this->prophesize(CollectionManagerInterface::class);
+        $requestStack = $this->prophesize(RequestStack::class);
+        $referenceStore = $this->prophesize(ReferenceStoreInterface::class);
+        $provider = new MediaDataProvider(
+            $this->getRepository(),
+            $collectionManager->reveal(),
+            $serializer->reveal(),
+            $requestStack->reveal(),
+            $referenceStore->reveal(),
+            false
+        );
+
+        $configuration = $provider->getConfiguration();
+
+        $this->assertFalse($configuration->hasAudienceTargeting());
     }
 
     public function testGetTypesConfiguration()

--- a/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
+++ b/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
@@ -47,13 +47,32 @@ class MediaDataProviderTest extends TestCase
             $collectionManager->reveal(),
             $serializer->reveal(),
             $requestStack->reveal(),
+            $referenceStore->reveal()
+        );
+
+        $configuration = $provider->getConfiguration();
+
+        $this->assertInstanceOf(ProviderConfigurationInterface::class, $configuration);
+        $this->assertFalse($configuration->hasAudienceTargeting());
+    }
+
+    public function testEnabledAudienceTargeting()
+    {
+        $serializer = $this->prophesize(ArraySerializerInterface::class);
+        $collectionManager = $this->prophesize(CollectionManagerInterface::class);
+        $requestStack = $this->prophesize(RequestStack::class);
+        $referenceStore = $this->prophesize(ReferenceStoreInterface::class);
+        $provider = new MediaDataProvider(
+            $this->getRepository(),
+            $collectionManager->reveal(),
+            $serializer->reveal(),
+            $requestStack->reveal(),
             $referenceStore->reveal(),
             true
         );
 
         $configuration = $provider->getConfiguration();
 
-        $this->assertInstanceOf(ProviderConfigurationInterface::class, $configuration);
         $this->assertTrue($configuration->hasAudienceTargeting());
     }
 

--- a/src/Sulu/Component/SmartContent/DataProviderPool.php
+++ b/src/Sulu/Component/SmartContent/DataProviderPool.php
@@ -20,28 +20,14 @@ use Sulu\Component\SmartContent\Exception\DataProviderNotExistsException;
 class DataProviderPool implements DataProviderPoolInterface
 {
     /**
-     * @var bool
-     */
-    private $hasAudienceTargeting = false;
-
-    /**
      * @var DataProviderInterface[]
      */
     private $providers = [];
-
-    public function __construct(bool $hasAudienceTargeting)
-    {
-        $this->hasAudienceTargeting = $hasAudienceTargeting;
-    }
 
     public function add($alias, DataProviderInterface $provider)
     {
         if ($this->exists($alias)) {
             throw new DataProviderAliasAlreadyExistsException($alias);
-        }
-
-        if (!$this->hasAudienceTargeting) {
-            $provider->getConfiguration()->setAudienceTargeting(false);
         }
 
         $this->providers[$alias] = $provider;

--- a/src/Sulu/Component/SmartContent/Tests/Unit/DataProviderPoolTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/DataProviderPoolTest.php
@@ -12,7 +12,6 @@
 namespace Sulu\Component\SmartContent\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
-use Sulu\Component\SmartContent\Configuration\ProviderConfigurationInterface;
 use Sulu\Component\SmartContent\DataProviderInterface;
 use Sulu\Component\SmartContent\DataProviderPool;
 use Sulu\Component\SmartContent\Exception\DataProviderAliasAlreadyExistsException;
@@ -81,18 +80,6 @@ class DataProviderPoolTest extends TestCase
         }
 
         $this->assertEquals($expectedProviders, $pool->getAll());
-    }
-
-    public function testAddWithoutAudienceTargeting()
-    {
-        $pool = new DataProviderPool(false);
-        $provider = $this->prophesize(DataProviderInterface::class);
-        $configuration = $this->prophesize(ProviderConfigurationInterface::class);
-        $provider->getConfiguration()->willReturn($configuration);
-
-        $configuration->setAudienceTargeting(false)->shouldBeCalled();
-
-        $pool->add('test', $provider->reveal());
     }
 
     public function existsProvider()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Removes the reference to the `AudienceTargetingBundle` in the `DataProviderPool`. Now every provider, which requires the audience targeting bundle has to enable it by itself only when the `AudienceTargetingBundle` is really enabled.
