### PR TITLE
Fix unselecting segments for live workspace

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Content/Types/SegmentSelect.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/SegmentSelect.php
@@ -21,12 +21,22 @@ class SegmentSelect extends ComplexContentType
 
     public function write(NodeInterface $node, PropertyInterface $property, $userId, $webspaceKey, $languageCode, $segmentKey)
     {
+        $propertyValue = $property->getValue();
+
         // write a separate property for per webspace to make segment queryable in the smart content data provider
-        foreach ($property->getValue() as $webspaceKeyValue => $segmentKeyValue) {
+        foreach ($propertyValue as $webspaceKeyValue => $segmentKeyValue) {
             $node->setProperty(
                 $this->getWebspaceSegmentPropertyName($property, $webspaceKeyValue),
                 $segmentKeyValue
             );
+        }
+
+        $propertyPrefix = $this->getPrefix($property);
+        foreach ($node->getProperties($propertyPrefix . '*') as $webspaceSegmentProperty) {
+            $webspaceKey = \str_replace($propertyPrefix, '', $webspaceSegmentProperty->getName());
+            if (!isset($propertyValue[$webspaceKey])) {
+                $webspaceSegmentProperty->remove();
+            }
         }
     }
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/SegmentSelectTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/SegmentSelectTest.php
@@ -67,6 +67,43 @@ class SegmentSelectTest extends TestCase
         $property->getValue()->willReturn(['sulu_io' => 'w', 'other' => 'a']);
         $property->getName()->willReturn('test');
 
+        $suluIoProperty = $this->prophesize(PhpcrPropertyInterface::class);
+        $suluIoProperty->getName()->willReturn('test-sulu_io');
+        $otherProperty = $this->prophesize(PhpcrPropertyInterface::class);
+        $otherProperty->getName()->willReturn('test-other');
+
+        $node->getProperties('test-*')->willReturn([$suluIoProperty->reveal(), $otherProperty->reveal()]);
+
+        $segmentSelect = new SegmentSelect();
+
+        $segmentSelect->write($node->reveal(), $property->reveal(), 1, 'sulu_io', 'de', null);
+    }
+
+    public function testWriteWithRemovals()
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->setProperty('test-other', 'a')->shouldBeCalled();
+        $node->setProperty('test-sulu_blog', 's')->shouldBeCalled();
+
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getValue()->willReturn(['other' => 'a', 'sulu_blog' => 's']);
+        $property->getName()->willReturn('test');
+
+        $suluWebsiteProperty = $this->prophesize(PhpcrPropertyInterface::class);
+        $suluWebsiteProperty->getName()->willReturn('test-sulu_website');
+        $otherProperty = $this->prophesize(PhpcrPropertyInterface::class);
+        $otherProperty->getName()->willReturn('test-other');
+        $suluBlogProperty = $this->prophesize(PhpcrPropertyInterface::class);
+        $suluBlogProperty->getName()->willReturn('test-sulu_blog');
+
+        $node->getProperties('test-*')->willReturn(
+            [$suluWebsiteProperty->reveal(), $otherProperty->reveal(), $suluBlogProperty->reveal()]
+        );
+
+        $suluWebsiteProperty->remove()->shouldBeCalled();
+        $suluBlogProperty->remove()->shouldNotBeCalled();
+        $otherProperty->remove()->shouldNotBeCalled();
+
         $segmentSelect = new SegmentSelect();
 
         $segmentSelect->write($node->reveal(), $property->reveal(), 1, 'sulu_io', 'de', null);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5653
| Related issues/PRs | #5425 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR makes sure the segment property is correctly removed on the live workspace, when no segment is selected anymore.