### PR TITLE
Refactor preview to avoid changing interface for every addition

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Controller/PreviewController.php
+++ b/src/Sulu/Bundle/PreviewBundle/Controller/PreviewController.php
@@ -56,7 +56,7 @@ class PreviewController
 
         return new JsonResponse(
             [
-                'token' => $this->preview->start($provider, $id, $locale, $this->getUserId()),
+                'token' => $this->preview->start($provider, $id, $this->getUserId()),
             ]
         );
     }
@@ -71,16 +71,18 @@ class PreviewController
         $targetGroup = $this->getRequestParameter($request, 'targetGroup', false, null);
         $segment = $this->getRequestParameter($request, 'segment', false, null);
 
+        $options = [
+            'targetGroupId' => $targetGroup,
+            'segmentKey' => $segment,
+            'webspaceKey' => $webspace,
+            'locale' => $locale,
+        ];
+
         if (!$this->preview->exists($token)) {
-            $token = $this->preview->start($provider, $id, $locale, $this->getUserId());
+            $token = $this->preview->start($provider, $id, $this->getUserId(), $options);
         }
 
-        $content = $this->preview->render(
-            $token,
-            $webspace,
-            $locale,
-            ['targetGroupId' => $targetGroup, 'segmentKey' => $segment]
-        );
+        $content = $this->preview->render($token, $options);
 
         $this->disableProfiler();
 
@@ -98,15 +100,21 @@ class PreviewController
         $targetGroup = $this->getRequestParameter($request, 'targetGroup', false, null);
         $segment = $this->getRequestParameter($request, 'segment', false, null);
 
+        $options = [
+            'targetGroupId' => $targetGroup,
+            'segmentKey' => $segment,
+            'webspaceKey' => $webspace,
+            'locale' => $locale,
+        ];
+
         if (!$this->preview->exists($token)) {
-            $token = $this->preview->start($provider, $id, $locale, $this->getUserId());
+            $token = $this->preview->start($provider, $id, $this->getUserId(), $options);
         }
 
         $content = $this->preview->update(
             $token,
-            $webspace,
             $data,
-            ['targetGroupId' => $targetGroup, 'segmentKey' => $segment]
+            $options
         );
 
         return new JsonResponse(['content' => $content]);
@@ -123,15 +131,21 @@ class PreviewController
         $targetGroup = $this->getRequestParameter($request, 'targetGroup', false, null);
         $segment = $this->getRequestParameter($request, 'segment', false, null);
 
+        $options = [
+            'targetGroupId' => $targetGroup,
+            'segmentKey' => $segment,
+            'webspaceKey' => $webspace,
+            'locale' => $locale,
+        ];
+
         if (!$this->preview->exists($token)) {
-            $token = $this->preview->start($provider, $id, $locale, $this->getUserId());
+            $token = $this->preview->start($provider, $id, $this->getUserId(), $options);
         }
 
         $content = $this->preview->updateContext(
             $token,
-            $webspace,
             $context,
-            ['targetGroupId' => $targetGroup, 'segmentKey' => $segment]
+            $options
         );
 
         return new JsonResponse(['content' => $content]);

--- a/src/Sulu/Bundle/PreviewBundle/Controller/PreviewController.php
+++ b/src/Sulu/Bundle/PreviewBundle/Controller/PreviewController.php
@@ -75,7 +75,12 @@ class PreviewController
             $token = $this->preview->start($provider, $id, $locale, $this->getUserId());
         }
 
-        $content = $this->preview->render($token, $webspace, $locale, $targetGroup, $segment);
+        $content = $this->preview->render(
+            $token,
+            $webspace,
+            $locale,
+            ['targetGroupId' => $targetGroup, 'segmentKey' => $segment]
+        );
 
         $this->disableProfiler();
 
@@ -97,7 +102,12 @@ class PreviewController
             $token = $this->preview->start($provider, $id, $locale, $this->getUserId());
         }
 
-        $content = $this->preview->update($token, $webspace, $data, $targetGroup, $segment);
+        $content = $this->preview->update(
+            $token,
+            $webspace,
+            $data,
+            ['targetGroupId' => $targetGroup, 'segmentKey' => $segment]
+        );
 
         return new JsonResponse(['content' => $content]);
     }
@@ -117,7 +127,12 @@ class PreviewController
             $token = $this->preview->start($provider, $id, $locale, $this->getUserId());
         }
 
-        $content = $this->preview->updateContext($token, $webspace, $context, $targetGroup, $segment);
+        $content = $this->preview->updateContext(
+            $token,
+            $webspace,
+            $context,
+            ['targetGroupId' => $targetGroup, 'segmentKey' => $segment]
+        );
 
         return new JsonResponse(['content' => $content]);
     }

--- a/src/Sulu/Bundle/PreviewBundle/Controller/PreviewController.php
+++ b/src/Sulu/Bundle/PreviewBundle/Controller/PreviewController.php
@@ -66,17 +66,8 @@ class PreviewController
         $provider = $this->getRequestParameter($request, 'provider', true);
         $id = $this->getRequestParameter($request, 'id', true);
         $token = $this->getRequestParameter($request, 'token', true);
-        $webspace = $this->getRequestParameter($request, 'webspace', true, null);
-        $locale = $this->getRequestParameter($request, 'locale', true, null);
-        $targetGroup = $this->getRequestParameter($request, 'targetGroup', false, null);
-        $segment = $this->getRequestParameter($request, 'segment', false, null);
 
-        $options = [
-            'targetGroupId' => $targetGroup,
-            'segmentKey' => $segment,
-            'webspaceKey' => $webspace,
-            'locale' => $locale,
-        ];
+        $options = $this->getOptionsFromRequest($request);
 
         if (!$this->preview->exists($token)) {
             $token = $this->preview->start($provider, $id, $this->getUserId(), $options);
@@ -95,17 +86,8 @@ class PreviewController
         $id = $this->getRequestParameter($request, 'id', true);
         $token = $this->getRequestParameter($request, 'token', true);
         $data = $this->getRequestParameter($request, 'data', true);
-        $locale = $this->getRequestParameter($request, 'locale', true, null);
-        $webspace = $this->getRequestParameter($request, 'webspace', true);
-        $targetGroup = $this->getRequestParameter($request, 'targetGroup', false, null);
-        $segment = $this->getRequestParameter($request, 'segment', false, null);
 
-        $options = [
-            'targetGroupId' => $targetGroup,
-            'segmentKey' => $segment,
-            'webspaceKey' => $webspace,
-            'locale' => $locale,
-        ];
+        $options = $this->getOptionsFromRequest($request);
 
         if (!$this->preview->exists($token)) {
             $token = $this->preview->start($provider, $id, $this->getUserId(), $options);
@@ -126,17 +108,8 @@ class PreviewController
         $provider = $this->getRequestParameter($request, 'provider', true);
         $token = $this->getRequestParameter($request, 'token', true);
         $context = $this->getRequestParameter($request, 'context', true);
-        $locale = $this->getRequestParameter($request, 'locale', true, null);
-        $webspace = $this->getRequestParameter($request, 'webspace', true);
-        $targetGroup = $this->getRequestParameter($request, 'targetGroup', false, null);
-        $segment = $this->getRequestParameter($request, 'segment', false, null);
 
-        $options = [
-            'targetGroupId' => $targetGroup,
-            'segmentKey' => $segment,
-            'webspaceKey' => $webspace,
-            'locale' => $locale,
-        ];
+        $options = $this->getOptionsFromRequest($request);
 
         if (!$this->preview->exists($token)) {
             $token = $this->preview->start($provider, $id, $this->getUserId(), $options);
@@ -158,7 +131,7 @@ class PreviewController
         return new JsonResponse();
     }
 
-    protected function disableProfiler()
+    private function disableProfiler()
     {
         if (!$this->profiler) {
             return;
@@ -167,7 +140,7 @@ class PreviewController
         $this->profiler->disable();
     }
 
-    protected function getUserId(): ?int
+    private function getUserId(): ?int
     {
         $token = $this->tokenStorage->getToken();
         if (!$token) {
@@ -180,5 +153,19 @@ class PreviewController
         }
 
         return $user->getId();
+    }
+
+    private function getOptionsFromRequest(Request $request)
+    {
+        return \array_filter($request->query->all(), function($key) {
+            switch ($key) {
+                case 'id':
+                case 'provider':
+                case 'token':
+                    return false;
+                default:
+                    return true;
+            }
+        }, \ARRAY_FILTER_USE_KEY);
     }
 }

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
@@ -90,8 +90,7 @@ class Preview implements PreviewInterface
         string $token,
         string $webspaceKey,
         array $data,
-        ?int $targetGroupId,
-        ?string $segmentKey
+        array $options = []
     ): string {
         $cacheItem = $this->fetch($token);
 
@@ -101,15 +100,14 @@ class Preview implements PreviewInterface
             $this->save($cacheItem);
         }
 
-        return $this->renderPartial($cacheItem, $webspaceKey, $targetGroupId, $segmentKey);
+        return $this->renderPartial($cacheItem, $webspaceKey, $options);
     }
 
     public function updateContext(
         string $token,
         string $webspaceKey,
         array $context,
-        ?int $targetGroupId,
-        ?string $segmentKey
+        array $options = []
     ): string {
         $cacheItem = $this->fetch($token);
 
@@ -121,8 +119,7 @@ class Preview implements PreviewInterface
                 $webspaceKey,
                 $cacheItem->getLocale(),
                 false,
-                $targetGroupId,
-                $segmentKey
+                $options
             );
         }
 
@@ -134,22 +131,20 @@ class Preview implements PreviewInterface
             $webspaceKey,
             $cacheItem->getLocale(),
             false,
-            $targetGroupId,
-            $segmentKey
+            $options
         );
 
         $cacheItem->setHtml($this->removeContent($html));
         $this->save($cacheItem);
 
-        return $this->renderPartial($cacheItem, $webspaceKey, $targetGroupId, $segmentKey);
+        return $this->renderPartial($cacheItem, $webspaceKey, $options);
     }
 
     public function render(
         string $token,
         string $webspaceKey,
         string $locale,
-        ?int $targetGroupId,
-        ?string $segmentKey
+        array $options = []
     ): string {
         $cacheItem = $this->fetch($token);
 
@@ -159,21 +154,19 @@ class Preview implements PreviewInterface
             $webspaceKey,
             $cacheItem->getLocale(),
             false,
-            $targetGroupId,
-            $segmentKey
+            $options
         );
 
         $cacheItem->setHtml($this->removeContent($html));
         $this->save($cacheItem);
 
-        return $this->renderPartial($cacheItem, $webspaceKey, $targetGroupId, $segmentKey);
+        return $this->renderPartial($cacheItem, $webspaceKey, $options);
     }
 
     protected function renderPartial(
         PreviewCacheItem $cacheItem,
         string $webspaceKey,
-        ?int $targetGroupId,
-        ?string $segmentKey
+        array $options = []
     ): string {
         $partialHtml = $this->renderer->render(
             $cacheItem->getObject(),
@@ -181,8 +174,7 @@ class Preview implements PreviewInterface
             $webspaceKey,
             $cacheItem->getLocale(),
             true,
-            $targetGroupId,
-            $segmentKey
+            $options
         );
 
         return \str_replace(self::CONTENT_REPLACER, $partialHtml, $cacheItem->getHtml());

--- a/src/Sulu/Bundle/PreviewBundle/Preview/PreviewCacheItem.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/PreviewCacheItem.php
@@ -19,11 +19,6 @@ class PreviewCacheItem
     private $id;
 
     /**
-     * @var string
-     */
-    private $locale;
-
-    /**
      * @var int
      */
     private $userId;
@@ -43,10 +38,9 @@ class PreviewCacheItem
      */
     private $html;
 
-    public function __construct(string $id, string $locale, int $userId, string $providerKey, $object)
+    public function __construct(string $id, int $userId, string $providerKey, $object)
     {
         $this->id = $id;
-        $this->locale = $locale;
         $this->userId = $userId;
         $this->providerKey = $providerKey;
         $this->object = $object;
@@ -55,11 +49,6 @@ class PreviewCacheItem
     public function getId(): string
     {
         return $this->id;
-    }
-
-    public function getLocale(): string
-    {
-        return $this->locale;
     }
 
     public function getUserId(): int
@@ -94,6 +83,6 @@ class PreviewCacheItem
 
     public function getToken(): string
     {
-        return \md5(\sprintf('%s.%s.%s.%s', $this->providerKey, $this->id, $this->locale, $this->userId));
+        return \md5(\sprintf('%s.%s.%s', $this->providerKey, $this->id, $this->userId));
     }
 }

--- a/src/Sulu/Bundle/PreviewBundle/Preview/PreviewInterface.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/PreviewInterface.php
@@ -25,7 +25,7 @@ interface PreviewInterface
      *
      * @throws ProviderNotFoundException
      */
-    public function start(string $providerKey, string $id, string $locale, int $userId, array $data = []): string;
+    public function start(string $providerKey, string $id, int $userId, array $data = [], array $options = []): string;
 
     /**
      * Stops the preview-session and deletes the data.
@@ -44,7 +44,6 @@ interface PreviewInterface
      */
     public function update(
         string $token,
-        string $webspaceKey,
         array $data,
         array $options = []
     ): string;
@@ -56,7 +55,6 @@ interface PreviewInterface
      */
     public function updateContext(
         string $token,
-        string $webspaceKey,
         array $context,
         array $options = []
     ): string;
@@ -68,8 +66,6 @@ interface PreviewInterface
      */
     public function render(
         string $token,
-        string $webspaceKey,
-        string $locale,
         array $options = []
     ): string;
 }

--- a/src/Sulu/Bundle/PreviewBundle/Preview/PreviewInterface.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/PreviewInterface.php
@@ -46,8 +46,7 @@ interface PreviewInterface
         string $token,
         string $webspaceKey,
         array $data,
-        ?int $targetGroupId,
-        ?string $segmentKey
+        array $options = []
     ): string;
 
     /**
@@ -59,8 +58,7 @@ interface PreviewInterface
         string $token,
         string $webspaceKey,
         array $context,
-        ?int $targetGroupId,
-        ?string $segmentKey
+        array $options = []
     ): string;
 
     /**
@@ -72,7 +70,6 @@ interface PreviewInterface
         string $token,
         string $webspaceKey,
         string $locale,
-        ?int $targetGroupId,
-        ?string $segmentKey
+        array $options = []
     ): string;
 }

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -115,8 +115,7 @@ class PreviewRenderer implements PreviewRendererInterface
         $webspaceKey,
         $locale,
         $partial = false,
-        $targetGroupId = null,
-        $segmentKey = null
+        $options = []
     ) {
         if (!$this->routeDefaultsProvider->supports(\get_class($object))) {
             throw new RouteDefaultsProviderNotFoundException($object, $id, $webspaceKey, $locale);
@@ -136,7 +135,7 @@ class PreviewRenderer implements PreviewRendererInterface
         }
 
         $webspace = $portalInformation->getWebspace();
-        $segment = $segmentKey ? $webspace->getSegment($segmentKey) : null;
+        $segment = isset($options['segmentKey']) ? $webspace->getSegment($options['segmentKey']) : null;
         $localization = $webspace->getLocalization($locale);
 
         $query = [];
@@ -174,8 +173,8 @@ class PreviewRenderer implements PreviewRendererInterface
         $request = new Request($query, $request, $attributes, [], [], $server);
         $request->setLocale($locale);
 
-        if ($this->targetGroupHeader && $targetGroupId) {
-            $request->headers->set($this->targetGroupHeader, $targetGroupId);
+        if ($this->targetGroupHeader && isset($options['targetGroupId'])) {
+            $request->headers->set($this->targetGroupHeader, $options['targetGroupId']);
         }
 
         // TODO Remove this event in 2.0 as it is not longer needed to set the correct theme.

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -112,11 +112,12 @@ class PreviewRenderer implements PreviewRendererInterface
     public function render(
         $object,
         $id,
-        $webspaceKey,
-        $locale,
         $partial = false,
         $options = []
     ) {
+        $webspaceKey = $options['webspaceKey'];
+        $locale = $options['locale'];
+
         if (!$this->routeDefaultsProvider->supports(\get_class($object))) {
             throw new RouteDefaultsProviderNotFoundException($object, $id, $webspaceKey, $locale);
         }

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRendererInterface.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRendererInterface.php
@@ -20,8 +20,6 @@ interface PreviewRendererInterface
      * Renders object in given webspace and locale.
      *
      * @param string $id
-     * @param string $webspaceKey
-     * @param string $locale
      * @param bool $partial
      *
      * @return string
@@ -29,8 +27,6 @@ interface PreviewRendererInterface
     public function render(
         $object,
         $id,
-        $webspaceKey,
-        $locale,
         $partial = false,
         $options = []
     );

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRendererInterface.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRendererInterface.php
@@ -23,7 +23,6 @@ interface PreviewRendererInterface
      * @param string $webspaceKey
      * @param string $locale
      * @param bool $partial
-     * @param int $targetGroupId
      *
      * @return string
      */
@@ -33,7 +32,6 @@ interface PreviewRendererInterface
         $webspaceKey,
         $locale,
         $partial = false,
-        $targetGroupId = null,
-        $segmentKey = null
+        $options = []
     );
 }

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/stores/PreviewStore.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/stores/PreviewStore.js
@@ -39,13 +39,13 @@ export default class PreviewStore {
 
     @computed get renderRoute() {
         return generateRoute('render', {
-            webspace: this.webspace,
-            segment: this.segment,
+            webspaceKey: this.webspace,
+            segmentKey: this.segment,
             provider: this.resourceKey,
             id: this.id,
             locale: this.locale,
             token: this.token,
-            targetGroup: this.targetGroup,
+            targetGroupId: this.targetGroup,
         });
     }
 
@@ -70,7 +70,7 @@ export default class PreviewStore {
             provider: this.resourceKey,
             id: this.id,
             locale: this.locale,
-            targetGroup: this.targetGroup,
+            targetGroupId: this.targetGroup,
         });
 
         return Requester.post(route).then((response) => {
@@ -81,12 +81,12 @@ export default class PreviewStore {
     update(data: Object): Promise<string> {
         const route = generateRoute('update', {
             locale: this.locale,
-            webspace: this.webspace,
-            segment: this.segment,
+            webspaceKey: this.webspace,
+            segmentKey: this.segment,
             token: this.token,
             provider: this.resourceKey,
             id: this.id,
-            targetGroup: this.targetGroup,
+            targetGroupId: this.targetGroup,
         });
 
         return Requester.post(route, {data}).then((response) => {
@@ -96,13 +96,13 @@ export default class PreviewStore {
 
     updateContext(type: string): Promise<string> {
         const route = generateRoute('update-context', {
-            webspace: this.webspace,
-            segment: this.segment,
+            webspaceKey: this.webspace,
+            segmentKey: this.segment,
             token: this.token,
             locale: this.locale,
             provider: this.resourceKey,
             id: this.id,
-            targetGroup: this.targetGroup,
+            targetGroupId: this.targetGroup,
         });
 
         return Requester.post(route, {context: {template: type}}).then((response) => {

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/stores/PreviewStore.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/stores/PreviewStore.js
@@ -73,7 +73,7 @@ export default class PreviewStore {
             targetGroup: this.targetGroup,
         });
 
-        return Requester.get(route).then((response) => {
+        return Requester.post(route).then((response) => {
             this.setToken(response.token);
         });
     }
@@ -113,6 +113,6 @@ export default class PreviewStore {
     stop(): Promise<*> {
         const route = generateRoute('stop', {token: this.token});
 
-        return Requester.get(route).then(this.setToken(null));
+        return Requester.post(route).then(this.setToken(null));
     }
 }

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/stores/PreviewStore.test.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/stores/PreviewStore.test.js
@@ -24,7 +24,7 @@ test('Should request server on start preview', () => {
     previewStore.start();
 
     return requestPromise.then(() => {
-        expect(Requester.post).toBeCalledWith('/start?id=123-123-123&locale=en&provider=pages&targetGroup=-1');
+        expect(Requester.post).toBeCalledWith('/start?id=123-123-123&locale=en&provider=pages&targetGroupId=-1');
     });
 });
 
@@ -37,7 +37,7 @@ test('Should request server on start preview with target group', () => {
     previewStore.start();
 
     return requestPromise.then(() => {
-        expect(Requester.post).toBeCalledWith('/start?id=123-123-123&locale=en&provider=pages&targetGroup=3');
+        expect(Requester.post).toBeCalledWith('/start?id=123-123-123&locale=en&provider=pages&targetGroupId=3');
     });
 });
 
@@ -54,7 +54,7 @@ test('Should request server on update preview', () => {
 
     return postPromise.then(() => {
         expect(Requester.post).toBeCalledWith(
-            '/update?id=123-123-123&locale=en&provider=pages&targetGroup=-1&webspace=sulu_io',
+            '/update?id=123-123-123&locale=en&provider=pages&targetGroupId=-1&webspaceKey=sulu_io',
             {data: {title: 'Sulu is aswesome'}}
         );
     });
@@ -74,7 +74,7 @@ test('Should request server on update preview with target group', () => {
 
     return postPromise.then(() => {
         expect(Requester.post).toBeCalledWith(
-            '/update?id=123-123-123&locale=en&provider=pages&targetGroup=2&webspace=sulu_io',
+            '/update?id=123-123-123&locale=en&provider=pages&targetGroupId=2&webspaceKey=sulu_io',
             {data: {title: 'Sulu is aswesome'}}
         );
     });
@@ -94,7 +94,7 @@ test('Should request server on update preview with segment', () => {
 
     return postPromise.then(() => {
         expect(Requester.post).toBeCalledWith(
-            '/update?id=123-123-123&locale=en&provider=pages&segment=w&targetGroup=-1&webspace=sulu_io',
+            '/update?id=123-123-123&locale=en&provider=pages&segmentKey=w&targetGroupId=-1&webspaceKey=sulu_io',
             {data: {title: 'Sulu is aswesome'}}
         );
     });
@@ -114,7 +114,7 @@ test('Should request server on update-context preview', () => {
     return postPromise.then(() => {
         expect(Requester.post)
             .toBeCalledWith(
-                '/update-context?id=123-123-123&locale=en&provider=pages&targetGroup=-1&webspace=sulu_io',
+                '/update-context?id=123-123-123&locale=en&provider=pages&targetGroupId=-1&webspaceKey=sulu_io',
                 {context: {template: 'default'}}
             );
     });
@@ -135,7 +135,7 @@ test('Should request server on update-context preview with target group', () => 
     return postPromise.then(() => {
         expect(Requester.post)
             .toBeCalledWith(
-                '/update-context?id=123-123-123&locale=en&provider=pages&targetGroup=6&webspace=sulu_io',
+                '/update-context?id=123-123-123&locale=en&provider=pages&targetGroupId=6&webspaceKey=sulu_io',
                 {context: {template: 'default'}}
             );
     });
@@ -156,7 +156,8 @@ test('Should request server on update-context preview with segment', () => {
     return postPromise.then(() => {
         expect(Requester.post)
             .toBeCalledWith(
-                '/update-context?id=123-123-123&locale=en&provider=pages&segment=s&targetGroup=-1&webspace=sulu_io',
+                '/update-context' +
+                '?id=123-123-123&locale=en&provider=pages&segmentKey=s&targetGroupId=-1&webspaceKey=sulu_io',
                 {context: {template: 'default'}}
             );
     });
@@ -171,7 +172,7 @@ test('Should request server on stop preview', () => {
     previewStore.stop();
 
     return postPromise.then(() => {
-        expect(Requester.post).toBeCalledWith('/start?id=123-123-123&locale=en&provider=pages&targetGroup=-1');
+        expect(Requester.post).toBeCalledWith('/start?id=123-123-123&locale=en&provider=pages&targetGroupId=-1');
         expect(Requester.post).toBeCalledWith('/stop');
     });
 });

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/stores/PreviewStore.test.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/stores/PreviewStore.test.js
@@ -19,12 +19,12 @@ test('Should request server on start preview', () => {
     const previewStore = new PreviewStore('pages', '123-123-123', 'en', 'sulu_io');
 
     const requestPromise = Promise.resolve({token: '123-123-123'});
-    Requester.get.mockReturnValue(requestPromise);
+    Requester.post.mockReturnValue(requestPromise);
 
     previewStore.start();
 
     return requestPromise.then(() => {
-        expect(Requester.get).toBeCalledWith('/start?id=123-123-123&locale=en&provider=pages&targetGroup=-1');
+        expect(Requester.post).toBeCalledWith('/start?id=123-123-123&locale=en&provider=pages&targetGroup=-1');
     });
 });
 
@@ -32,22 +32,19 @@ test('Should request server on start preview with target group', () => {
     const previewStore = new PreviewStore('pages', '123-123-123', 'en', 'sulu_io');
 
     const requestPromise = Promise.resolve({token: '123-123-123'});
-    Requester.get.mockReturnValue(requestPromise);
 
     previewStore.setTargetGroup(3);
     previewStore.start();
 
     return requestPromise.then(() => {
-        expect(Requester.get).toBeCalledWith('/start?id=123-123-123&locale=en&provider=pages&targetGroup=3');
+        expect(Requester.post).toBeCalledWith('/start?id=123-123-123&locale=en&provider=pages&targetGroup=3');
     });
 });
 
 test('Should request server on update preview', () => {
     const previewStore = new PreviewStore('pages', '123-123-123', 'en', 'sulu_io');
 
-    const getPromise = Promise.resolve({token: '123-123-123'});
     const postPromise = Promise.resolve({content: '<h1>Sulu is awesome</h1>'});
-    Requester.get.mockReturnValue(getPromise);
     Requester.post.mockReturnValue(postPromise);
 
     previewStore.start();
@@ -66,9 +63,7 @@ test('Should request server on update preview', () => {
 test('Should request server on update preview with target group', () => {
     const previewStore = new PreviewStore('pages', '123-123-123', 'en', 'sulu_io');
 
-    const getPromise = Promise.resolve({token: '123-123-123'});
     const postPromise = Promise.resolve({content: '<h1>Sulu is awesome</h1>'});
-    Requester.get.mockReturnValue(getPromise);
     Requester.post.mockReturnValue(postPromise);
 
     previewStore.setTargetGroup(2);
@@ -88,9 +83,7 @@ test('Should request server on update preview with target group', () => {
 test('Should request server on update preview with segment', () => {
     const previewStore = new PreviewStore('pages', '123-123-123', 'en', 'sulu_io');
 
-    const getPromise = Promise.resolve({token: '123-123-123'});
     const postPromise = Promise.resolve({content: '<h1>Sulu is awesome</h1>'});
-    Requester.get.mockReturnValue(getPromise);
     Requester.post.mockReturnValue(postPromise);
 
     previewStore.setSegment('w');
@@ -110,9 +103,7 @@ test('Should request server on update preview with segment', () => {
 test('Should request server on update-context preview', () => {
     const previewStore = new PreviewStore('pages', '123-123-123', 'en', 'sulu_io');
 
-    const getPromise = Promise.resolve({token: '123-123-123'});
     const postPromise = Promise.resolve({content: '<h1>Sulu is awesome</h1>'});
-    Requester.get.mockReturnValue(getPromise);
     Requester.post.mockReturnValue(postPromise);
 
     previewStore.start();
@@ -132,9 +123,7 @@ test('Should request server on update-context preview', () => {
 test('Should request server on update-context preview with target group', () => {
     const previewStore = new PreviewStore('pages', '123-123-123', 'en', 'sulu_io');
 
-    const getPromise = Promise.resolve({token: '123-123-123'});
     const postPromise = Promise.resolve({content: '<h1>Sulu is awesome</h1>'});
-    Requester.get.mockReturnValue(getPromise);
     Requester.post.mockReturnValue(postPromise);
 
     previewStore.setTargetGroup(6);
@@ -155,9 +144,7 @@ test('Should request server on update-context preview with target group', () => 
 test('Should request server on update-context preview with segment', () => {
     const previewStore = new PreviewStore('pages', '123-123-123', 'en', 'sulu_io');
 
-    const getPromise = Promise.resolve({token: '123-123-123'});
     const postPromise = Promise.resolve({content: '<h1>Sulu is awesome</h1>'});
-    Requester.get.mockReturnValue(getPromise);
     Requester.post.mockReturnValue(postPromise);
 
     previewStore.setSegment('s');
@@ -178,16 +165,14 @@ test('Should request server on update-context preview with segment', () => {
 test('Should request server on stop preview', () => {
     const previewStore = new PreviewStore('pages', '123-123-123', 'en', 'sulu_io');
 
-    const getPromise = Promise.resolve({token: '123-123-123'});
     const postPromise = Promise.resolve({content: '<h1>Sulu is awesome</h1>'});
-    Requester.get.mockReturnValue(getPromise);
 
     previewStore.start();
     previewStore.stop();
 
     return postPromise.then(() => {
-        expect(Requester.get).toBeCalledWith('/start?id=123-123-123&locale=en&provider=pages&targetGroup=-1');
-        expect(Requester.get).toBeCalledWith('/stop');
+        expect(Requester.post).toBeCalledWith('/start?id=123-123-123&locale=en&provider=pages&targetGroup=-1');
+        expect(Requester.post).toBeCalledWith('/stop');
     });
 });
 

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Controller/PreviewControllerTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Controller/PreviewControllerTest.php
@@ -71,14 +71,17 @@ class PreviewControllerTest extends TestCase
 
     public function testRender()
     {
-        $request = $this->prophesize(Request::class);
-        $request->get('token', null)->willReturn('test-token');
-        $request->get('webspace', null)->willReturn('sulu_io');
-        $request->get('locale', null)->willReturn('de');
-        $request->get('id', null)->willReturn('123-123-123');
-        $request->get('provider', null)->willReturn('test-provider');
-        $request->get('targetGroup', null)->willReturn(1);
-        $request->get('segment', null)->willReturn('w');
+        $request = new Request(
+            [
+                'token' => 'test-token',
+                'webspaceKey' => 'sulu_io',
+                'id' => '123-123-123',
+                'provider' => 'test-provider',
+                'locale' => 'de',
+                'targetGroupId' => 1,
+                'segmentKey' => 'w',
+            ]
+        );
 
         $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
         $this->preview->render(
@@ -86,20 +89,23 @@ class PreviewControllerTest extends TestCase
             ['targetGroupId' => 1, 'segmentKey' => 'w', 'webspaceKey' => 'sulu_io', 'locale' => 'de']
         )->shouldBeCalled()->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
 
-        $response = $this->previewController->renderAction($request->reveal());
+        $response = $this->previewController->renderAction($request);
         $this->assertEquals('<html><body><h1>SULU is awesome</h1></body></html>', $response->getContent());
     }
 
     public function testRenderInvalidToken()
     {
-        $request = $this->prophesize(Request::class);
-        $request->get('token', null)->willReturn('test-token');
-        $request->get('webspace', null)->willReturn('sulu_io');
-        $request->get('locale', null)->willReturn('de');
-        $request->get('id', null)->willReturn('123-123-123');
-        $request->get('provider', null)->willReturn('test-provider');
-        $request->get('targetGroup', null)->willReturn(1);
-        $request->get('segment', null)->willReturn('w');
+        $request = new Request(
+            [
+                'token' => 'test-token',
+                'webspaceKey' => 'sulu_io',
+                'id' => '123-123-123',
+                'provider' => 'test-provider',
+                'locale' => 'de',
+                'targetGroupId' => 1,
+                'segmentKey' => 'w',
+            ]
+        );
 
         $token = $this->prophesize(TokenInterface::class);
         $user = $this->prophesize(UserInterface::class);
@@ -119,20 +125,23 @@ class PreviewControllerTest extends TestCase
             ['targetGroupId' => 1, 'segmentKey' => 'w', 'webspaceKey' => 'sulu_io', 'locale' => 'de']
         )->shouldBeCalled()->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
 
-        $response = $this->previewController->renderAction($request->reveal());
+        $response = $this->previewController->renderAction($request);
         $this->assertEquals('<html><body><h1>SULU is awesome</h1></body></html>', $response->getContent());
     }
 
     public function testRenderWithATags()
     {
-        $request = $this->prophesize(Request::class);
-        $request->get('token', null)->willReturn('test-token');
-        $request->get('webspace', null)->willReturn('sulu_io');
-        $request->get('locale', null)->willReturn('de');
-        $request->get('id', null)->willReturn('123-123-123');
-        $request->get('provider', null)->willReturn('test-provider');
-        $request->get('targetGroup', null)->willReturn(1);
-        $request->get('segment', null)->willReturn('s');
+        $request = new Request(
+            [
+                'token' => 'test-token',
+                'webspaceKey' => 'sulu_io',
+                'id' => '123-123-123',
+                'provider' => 'test-provider',
+                'locale' => 'de',
+                'targetGroupId' => 1,
+                'segmentKey' => 's',
+            ]
+        );
 
         $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
         $this->preview->render(
@@ -140,21 +149,26 @@ class PreviewControllerTest extends TestCase
             ['targetGroupId' => 1, 'segmentKey' => 's', 'webspaceKey' => 'sulu_io', 'locale' => 'de']
         )->shouldBeCalled()->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
 
-        $response = $this->previewController->renderAction($request->reveal());
+        $response = $this->previewController->renderAction($request);
         $this->assertEquals('<html><body><h1>SULU is awesome</h1></body></html>', $response->getContent());
     }
 
     public function testUpdate()
     {
-        $request = $this->prophesize(Request::class);
-        $request->get('token', null)->willReturn('test-token');
-        $request->get('data', null)->willReturn(['title' => 'Sulu is awesome']);
-        $request->get('webspace', null)->willReturn('sulu_io');
-        $request->get('id', null)->willReturn('123-123-123');
-        $request->get('provider', null)->willReturn('test-provider');
-        $request->get('locale', null)->willReturn('de');
-        $request->get('targetGroup', null)->willReturn(1);
-        $request->get('segment', null)->willReturn('s');
+        $request = new Request(
+            [
+                'token' => 'test-token',
+                'webspaceKey' => 'sulu_io',
+                'id' => '123-123-123',
+                'provider' => 'test-provider',
+                'locale' => 'de',
+                'targetGroupId' => 1,
+                'segmentKey' => 's',
+            ],
+            [
+                'data' => ['title' => 'Sulu is awesome'],
+            ]
+        );
 
         $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
         $this->preview->update(
@@ -163,7 +177,7 @@ class PreviewControllerTest extends TestCase
             ['targetGroupId' => 1, 'segmentKey' => 's', 'webspaceKey' => 'sulu_io', 'locale' => 'de']
         )->shouldBeCalled()->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
 
-        $response = $this->previewController->updateAction($request->reveal());
+        $response = $this->previewController->updateAction($request);
 
         $this->assertEquals(
             \json_encode(['content' => '<html><body><h1>SULU is awesome</h1></body></html>'], $this->encodingOptions),
@@ -173,15 +187,20 @@ class PreviewControllerTest extends TestCase
 
     public function testUpdateWithATags()
     {
-        $request = $this->prophesize(Request::class);
-        $request->get('token', null)->willReturn('test-token');
-        $request->get('data', null)->willReturn(['title' => 'Sulu is awesome']);
-        $request->get('webspace', null)->willReturn('sulu_io');
-        $request->get('id', null)->willReturn('123-123-123');
-        $request->get('provider', null)->willReturn('test-provider');
-        $request->get('locale', null)->willReturn('de');
-        $request->get('targetGroup', null)->willReturn(1);
-        $request->get('segment', null)->willReturn('s');
+        $request = new Request(
+            [
+                'token' => 'test-token',
+                'webspaceKey' => 'sulu_io',
+                'id' => '123-123-123',
+                'provider' => 'test-provider',
+                'locale' => 'de',
+                'targetGroupId' => 1,
+                'segmentKey' => 's',
+            ],
+            [
+                'data' => ['title' => 'Sulu is awesome'],
+            ]
+        );
 
         $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
         $this->preview->update(
@@ -190,7 +209,7 @@ class PreviewControllerTest extends TestCase
             ['targetGroupId' => 1, 'segmentKey' => 's', 'webspaceKey' => 'sulu_io', 'locale' => 'de']
         )->shouldBeCalled()->willReturn('<html><body><a href="/test">SULU is awesome</a></body></html>');
 
-        $response = $this->previewController->updateAction($request->reveal());
+        $response = $this->previewController->updateAction($request);
         $this->assertEquals(
             \json_encode(
                 ['content' => '<html><body><a href="/test">SULU is awesome</a></body></html>'],
@@ -202,15 +221,20 @@ class PreviewControllerTest extends TestCase
 
     public function testUpdateContext()
     {
-        $request = $this->prophesize(Request::class);
-        $request->get('token', null)->willReturn('test-token');
-        $request->get('context', null)->willReturn(['template' => 'default']);
-        $request->get('webspace', null)->willReturn('sulu_io');
-        $request->get('id', null)->willReturn('123-123-123');
-        $request->get('provider', null)->willReturn('test-provider');
-        $request->get('locale', null)->willReturn('de');
-        $request->get('targetGroup', null)->willReturn(1);
-        $request->get('segment', null)->willReturn('s');
+        $request = new Request(
+            [
+                'token' => 'test-token',
+                'webspaceKey' => 'sulu_io',
+                'id' => '123-123-123',
+                'provider' => 'test-provider',
+                'locale' => 'de',
+                'targetGroupId' => 1,
+                'segmentKey' => 's',
+            ],
+            [
+                'context' => ['template' => 'default'],
+            ]
+        );
 
         $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
         $this->preview->updateContext(
@@ -219,7 +243,7 @@ class PreviewControllerTest extends TestCase
             ['targetGroupId' => 1, 'segmentKey' => 's', 'webspaceKey' => 'sulu_io', 'locale' => 'de']
         )->shouldBeCalled()->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
 
-        $response = $this->previewController->updateContextAction($request->reveal());
+        $response = $this->previewController->updateContextAction($request);
         $this->assertEquals(
             \json_encode(['content' => '<html><body><h1>SULU is awesome</h1></body></html>'], $this->encodingOptions),
             $response->getContent()
@@ -228,15 +252,20 @@ class PreviewControllerTest extends TestCase
 
     public function testUpdateContextWithATags()
     {
-        $request = $this->prophesize(Request::class);
-        $request->get('token', null)->willReturn('test-token');
-        $request->get('context', null)->willReturn(['template' => 'default']);
-        $request->get('webspace', null)->willReturn('sulu_io');
-        $request->get('id', null)->willReturn('123-123-123');
-        $request->get('provider', null)->willReturn('test-provider');
-        $request->get('locale', null)->willReturn('de');
-        $request->get('targetGroup', null)->willReturn(1);
-        $request->get('segment', null)->willReturn('w');
+        $request = new Request(
+            [
+                'token' => 'test-token',
+                'webspaceKey' => 'sulu_io',
+                'id' => '123-123-123',
+                'provider' => 'test-provider',
+                'locale' => 'de',
+                'targetGroupId' => 1,
+                'segmentKey' => 'w',
+            ],
+            [
+                'context' => ['template' => 'default'],
+            ]
+        );
 
         $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
         $this->preview->updateContext(
@@ -245,7 +274,7 @@ class PreviewControllerTest extends TestCase
             ['targetGroupId' => 1, 'segmentKey' => 'w', 'webspaceKey' => 'sulu_io', 'locale' => 'de']
         )->shouldBeCalled()->willReturn('<html><body><a href="/test">SULU is awesome</a></body></html>');
 
-        $response = $this->previewController->updateContextAction($request->reveal());
+        $response = $this->previewController->updateContextAction($request);
         $this->assertEquals(
             \json_encode(
                 ['content' => '<html><body><a href="/test">SULU is awesome</a></body></html>'],

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Controller/PreviewControllerTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Controller/PreviewControllerTest.php
@@ -63,9 +63,7 @@ class PreviewControllerTest extends TestCase
         $request->get('provider', null)->willReturn('test-provider');
         $request->get('locale', null)->willReturn('de');
 
-        $this->preview->start('test-provider', '123-123-123', 'de', 42)
-            ->shouldBeCalled()
-            ->willReturn('test-token');
+        $this->preview->start('test-provider', '123-123-123', 42)->shouldBeCalled()->willReturn('test-token');
 
         $response = $this->previewController->startAction($request->reveal());
         $this->assertEquals(\json_encode(['token' => 'test-token']), $response->getContent());
@@ -85,9 +83,7 @@ class PreviewControllerTest extends TestCase
         $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
         $this->preview->render(
             'test-token',
-            'sulu_io',
-            'de',
-            ['targetGroupId' => 1, 'segmentKey' => 'w']
+            ['targetGroupId' => 1, 'segmentKey' => 'w', 'webspaceKey' => 'sulu_io', 'locale' => 'de']
         )->shouldBeCalled()->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
 
         $response = $this->previewController->renderAction($request->reveal());
@@ -112,13 +108,15 @@ class PreviewControllerTest extends TestCase
         $user->getId()->willReturn(42);
 
         $this->preview->exists('test-token')->willReturn(false)->shouldBeCalled();
-        $this->preview->start('test-provider', '123-123-123', 'de', 42)
-            ->willReturn('test-token');
+        $this->preview->start(
+            'test-provider',
+            '123-123-123',
+            42,
+            ['webspaceKey' => 'sulu_io', 'locale' => 'de', 'segmentKey' => 'w', 'targetGroupId' => 1]
+        )->willReturn('test-token');
         $this->preview->render(
             'test-token',
-            'sulu_io',
-            'de',
-            ['targetGroupId' => 1, 'segmentKey' => 'w']
+            ['targetGroupId' => 1, 'segmentKey' => 'w', 'webspaceKey' => 'sulu_io', 'locale' => 'de']
         )->shouldBeCalled()->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
 
         $response = $this->previewController->renderAction($request->reveal());
@@ -139,9 +137,7 @@ class PreviewControllerTest extends TestCase
         $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
         $this->preview->render(
             'test-token',
-            'sulu_io',
-            'de',
-            ['targetGroupId' => 1, 'segmentKey' => 's']
+            ['targetGroupId' => 1, 'segmentKey' => 's', 'webspaceKey' => 'sulu_io', 'locale' => 'de']
         )->shouldBeCalled()->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
 
         $response = $this->previewController->renderAction($request->reveal());
@@ -163,9 +159,8 @@ class PreviewControllerTest extends TestCase
         $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
         $this->preview->update(
             'test-token',
-            'sulu_io',
             ['title' => 'Sulu is awesome'],
-            ['targetGroupId' => 1, 'segmentKey' => 's']
+            ['targetGroupId' => 1, 'segmentKey' => 's', 'webspaceKey' => 'sulu_io', 'locale' => 'de']
         )->shouldBeCalled()->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
 
         $response = $this->previewController->updateAction($request->reveal());
@@ -191,9 +186,8 @@ class PreviewControllerTest extends TestCase
         $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
         $this->preview->update(
             'test-token',
-            'sulu_io',
             ['title' => 'Sulu is awesome'],
-            ['targetGroupId' => 1, 'segmentKey' => 's']
+            ['targetGroupId' => 1, 'segmentKey' => 's', 'webspaceKey' => 'sulu_io', 'locale' => 'de']
         )->shouldBeCalled()->willReturn('<html><body><a href="/test">SULU is awesome</a></body></html>');
 
         $response = $this->previewController->updateAction($request->reveal());
@@ -221,9 +215,8 @@ class PreviewControllerTest extends TestCase
         $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
         $this->preview->updateContext(
             'test-token',
-            'sulu_io',
             ['template' => 'default'],
-            ['targetGroupId' => 1, 'segmentKey' => 's']
+            ['targetGroupId' => 1, 'segmentKey' => 's', 'webspaceKey' => 'sulu_io', 'locale' => 'de']
         )->shouldBeCalled()->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
 
         $response = $this->previewController->updateContextAction($request->reveal());
@@ -248,9 +241,8 @@ class PreviewControllerTest extends TestCase
         $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
         $this->preview->updateContext(
             'test-token',
-            'sulu_io',
             ['template' => 'default'],
-            ['targetGroupId' => 1, 'segmentKey' => 'w']
+            ['targetGroupId' => 1, 'segmentKey' => 'w', 'webspaceKey' => 'sulu_io', 'locale' => 'de']
         )->shouldBeCalled()->willReturn('<html><body><a href="/test">SULU is awesome</a></body></html>');
 
         $response = $this->previewController->updateContextAction($request->reveal());

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Controller/PreviewControllerTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Controller/PreviewControllerTest.php
@@ -83,9 +83,12 @@ class PreviewControllerTest extends TestCase
         $request->get('segment', null)->willReturn('w');
 
         $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
-        $this->preview->render('test-token', 'sulu_io', 'de', 1, 'w')
-            ->shouldBeCalled()
-            ->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
+        $this->preview->render(
+            'test-token',
+            'sulu_io',
+            'de',
+            ['targetGroupId' => 1, 'segmentKey' => 'w']
+        )->shouldBeCalled()->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
 
         $response = $this->previewController->renderAction($request->reveal());
         $this->assertEquals('<html><body><h1>SULU is awesome</h1></body></html>', $response->getContent());
@@ -111,9 +114,12 @@ class PreviewControllerTest extends TestCase
         $this->preview->exists('test-token')->willReturn(false)->shouldBeCalled();
         $this->preview->start('test-provider', '123-123-123', 'de', 42)
             ->willReturn('test-token');
-        $this->preview->render('test-token', 'sulu_io', 'de', 1, 'w')
-            ->shouldBeCalled()
-            ->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
+        $this->preview->render(
+            'test-token',
+            'sulu_io',
+            'de',
+            ['targetGroupId' => 1, 'segmentKey' => 'w']
+        )->shouldBeCalled()->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
 
         $response = $this->previewController->renderAction($request->reveal());
         $this->assertEquals('<html><body><h1>SULU is awesome</h1></body></html>', $response->getContent());
@@ -131,9 +137,12 @@ class PreviewControllerTest extends TestCase
         $request->get('segment', null)->willReturn('s');
 
         $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
-        $this->preview->render('test-token', 'sulu_io', 'de', 1, 's')
-            ->shouldBeCalled()
-            ->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
+        $this->preview->render(
+            'test-token',
+            'sulu_io',
+            'de',
+            ['targetGroupId' => 1, 'segmentKey' => 's']
+        )->shouldBeCalled()->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
 
         $response = $this->previewController->renderAction($request->reveal());
         $this->assertEquals('<html><body><h1>SULU is awesome</h1></body></html>', $response->getContent());
@@ -152,9 +161,12 @@ class PreviewControllerTest extends TestCase
         $request->get('segment', null)->willReturn('s');
 
         $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
-        $this->preview->update('test-token', 'sulu_io', ['title' => 'Sulu is awesome'], 1, 's')
-            ->shouldBeCalled()
-            ->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
+        $this->preview->update(
+            'test-token',
+            'sulu_io',
+            ['title' => 'Sulu is awesome'],
+            ['targetGroupId' => 1, 'segmentKey' => 's']
+        )->shouldBeCalled()->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
 
         $response = $this->previewController->updateAction($request->reveal());
 
@@ -177,9 +189,12 @@ class PreviewControllerTest extends TestCase
         $request->get('segment', null)->willReturn('s');
 
         $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
-        $this->preview->update('test-token', 'sulu_io', ['title' => 'Sulu is awesome'], 1, 's')
-            ->shouldBeCalled()
-            ->willReturn('<html><body><a href="/test">SULU is awesome</a></body></html>');
+        $this->preview->update(
+            'test-token',
+            'sulu_io',
+            ['title' => 'Sulu is awesome'],
+            ['targetGroupId' => 1, 'segmentKey' => 's']
+        )->shouldBeCalled()->willReturn('<html><body><a href="/test">SULU is awesome</a></body></html>');
 
         $response = $this->previewController->updateAction($request->reveal());
         $this->assertEquals(
@@ -204,9 +219,12 @@ class PreviewControllerTest extends TestCase
         $request->get('segment', null)->willReturn('s');
 
         $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
-        $this->preview->updateContext('test-token', 'sulu_io', ['template' => 'default'], 1, 's')
-            ->shouldBeCalled()
-            ->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
+        $this->preview->updateContext(
+            'test-token',
+            'sulu_io',
+            ['template' => 'default'],
+            ['targetGroupId' => 1, 'segmentKey' => 's']
+        )->shouldBeCalled()->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
 
         $response = $this->previewController->updateContextAction($request->reveal());
         $this->assertEquals(
@@ -228,9 +246,12 @@ class PreviewControllerTest extends TestCase
         $request->get('segment', null)->willReturn('w');
 
         $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
-        $this->preview->updateContext('test-token', 'sulu_io', ['template' => 'default'], 1, 'w')
-            ->shouldBeCalled()
-            ->willReturn('<html><body><a href="/test">SULU is awesome</a></body></html>');
+        $this->preview->updateContext(
+            'test-token',
+            'sulu_io',
+            ['template' => 'default'],
+            ['targetGroupId' => 1, 'segmentKey' => 'w']
+        )->shouldBeCalled()->willReturn('<html><body><a href="/test">SULU is awesome</a></body></html>');
 
         $response = $this->previewController->updateContextAction($request->reveal());
         $this->assertEquals(

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/PreviewTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/PreviewTest.php
@@ -223,8 +223,14 @@ class PreviewTest extends TestCase
         $this->provider->setValues($this->object->reveal(), $this->locale, $data)->shouldBeCalled();
         $this->provider->serialize($this->object->reveal())->willReturn($dataJson)->shouldBeCalled();
 
-        $this->renderer->render($this->object->reveal(), 1, $this->webspaceKey, $this->locale, true, null, null)
-            ->willReturn('<h1 property="title">SULU</h1>');
+        $this->renderer->render(
+            $this->object->reveal(),
+            1,
+            $this->webspaceKey,
+            $this->locale,
+            true,
+            []
+        )->willReturn('<h1 property="title">SULU</h1>');
 
         $this->cache->save(
             $token,
@@ -238,7 +244,7 @@ class PreviewTest extends TestCase
             $this->cacheLifeTime
         )->shouldBeCalled();
 
-        $result = $this->preview->update($token, $this->webspaceKey, $data, null, null);
+        $result = $this->preview->update($token, $this->webspaceKey, $data);
 
         $this->assertEquals(
             '<html><body><div id="content"><h1 property="title">SULU</h1></div></body></html>',
@@ -275,15 +281,12 @@ class PreviewTest extends TestCase
             $this->webspaceKey,
             $this->locale,
             true,
-            null,
-            null
-        )->willReturn(
-            '<h1 property="title">SULU</h1>'
-        );
+            []
+        )->willReturn('<h1 property="title">SULU</h1>');
 
         $this->cache->save(Argument::cetera())->shouldNotBeCalled();
 
-        $result = $this->preview->update($token, $this->webspaceKey, [], null, null);
+        $result = $this->preview->update($token, $this->webspaceKey, []);
 
         $this->assertEquals(
             '<html><body><div id="content"><h1 property="title">SULU</h1></div></body></html>',
@@ -304,10 +307,10 @@ class PreviewTest extends TestCase
         $this->provider->deserialize(Argument::cetera())->shouldNotBeCalled();
         $this->renderer->render(Argument::cetera())->shouldNotBeCalled();
 
-        $this->preview->update($token, $this->webspaceKey, ['title' => 'SULU'], null, null);
+        $this->preview->update($token, $this->webspaceKey, ['title' => 'SULU']);
     }
 
-    public function testUpdateWithTargetGroup()
+    public function testUpdateWithOptions()
     {
         $data = ['title' => 'Sulu'];
         $dataJson = \json_encode($data);
@@ -330,48 +333,23 @@ class PreviewTest extends TestCase
         $this->provider->setValues(Argument::cetera())->shouldNotBeCalled();
         $this->provider->serialize(Argument::cetera())->shouldNotBeCalled();
 
-        $this->renderer->render($this->object->reveal(), 1, $this->webspaceKey, $this->locale, true, 2, null)
-            ->willReturn('<h1 property="title">SULU</h1>');
+        $this->renderer->render(
+            $this->object->reveal(),
+            1,
+            $this->webspaceKey,
+            $this->locale,
+            true,
+            ['targetGroupId' => null, 'segmentKey' => 'w']
+        )->willReturn('<h1 property="title">SULU</h1>');
 
         $this->cache->save(Argument::cetera())->shouldNotBeCalled();
 
-        $result = $this->preview->update($token, $this->webspaceKey, [], 2, null);
-
-        $this->assertEquals(
-            '<html><body><div id="content"><h1 property="title">SULU</h1></div></body></html>',
-            $result
+        $result = $this->preview->update(
+            $token,
+            $this->webspaceKey,
+            [],
+            ['targetGroupId' => null, 'segmentKey' => 'w']
         );
-    }
-
-    public function testUpdateWithSegment()
-    {
-        $data = ['title' => 'Sulu'];
-        $dataJson = \json_encode($data);
-
-        $token = \md5(\sprintf('%s.%s.%s.%s', $this->providerKey, 1, $this->locale, 1));
-        $cacheData = [
-            'id' => '1',
-            'locale' => $this->locale,
-            'providerKey' => $this->providerKey,
-            'object' => $dataJson,
-            'objectClass' => \get_class($this->object->reveal()),
-            'userId' => 1,
-            'html' => '<html><body><div id="content"><!-- CONTENT-REPLACER --></div></body></html>',
-        ];
-
-        $this->cache->contains($token)->willReturn(true);
-        $this->cache->fetch($token)->willReturn(\json_encode($cacheData));
-
-        $this->provider->deserialize($cacheData['object'], $cacheData['objectClass'])->willReturn($this->object);
-        $this->provider->setValues(Argument::cetera())->shouldNotBeCalled();
-        $this->provider->serialize(Argument::cetera())->shouldNotBeCalled();
-
-        $this->renderer->render($this->object->reveal(), 1, $this->webspaceKey, $this->locale, true, null, 'w')
-            ->willReturn('<h1 property="title">SULU</h1>');
-
-        $this->cache->save(Argument::cetera())->shouldNotBeCalled();
-
-        $result = $this->preview->update($token, $this->webspaceKey, [], null, 'w');
 
         $this->assertEquals(
             '<html><body><div id="content"><h1 property="title">SULU</h1></div></body></html>',
@@ -422,14 +400,19 @@ class PreviewTest extends TestCase
             $this->webspaceKey,
             $this->locale,
             false,
-            null,
-            null
+            []
         )->willReturn(
             '<html><body><div id="content"><!-- CONTENT-REPLACER --><h1 property="title">SULU</h1><!-- CONTENT-REPLACER --></div></body></html>'
         );
 
-        $this->renderer->render($newObject->reveal(), 1, $this->webspaceKey, $this->locale, true, null, null)
-            ->willReturn('<h1 property="title">SULU</h1>');
+        $this->renderer->render(
+            $newObject->reveal(),
+            1,
+            $this->webspaceKey,
+            $this->locale,
+            true,
+            []
+        )->willReturn('<h1 property="title">SULU</h1>');
 
         $this->cache->save(
             $token,
@@ -443,7 +426,7 @@ class PreviewTest extends TestCase
             $this->cacheLifeTime
         )->shouldBeCalled();
 
-        $result = $this->preview->updateContext($token, $this->webspaceKey, $context, null, null);
+        $result = $this->preview->updateContext($token, $this->webspaceKey, $context);
 
         $this->assertEquals(
             '<html><body><div id="content"><h1 property="title">SULU</h1></div></body></html>',
@@ -486,13 +469,10 @@ class PreviewTest extends TestCase
             $this->webspaceKey,
             $this->locale,
             false,
-            null,
-            null
-        )->willReturn(
-            '<html><body><div id="content"><h1 property="title">SULU</h1></div></body></html>'
-        );
+            []
+        )->willReturn('<html><body><div id="content"><h1 property="title">SULU</h1></div></body></html>');
 
-        $this->preview->updateContext($token, $this->webspaceKey, $context, null, null);
+        $this->preview->updateContext($token, $this->webspaceKey, $context);
     }
 
     public function testUpdateContextNoContext()
@@ -527,15 +507,14 @@ class PreviewTest extends TestCase
             $this->webspaceKey,
             $this->locale,
             false,
-            null,
-            null
+            []
         )->willReturn(
             '<html><body><div id="content"><h1 property="title">SULU</h1></div></body></html>'
         );
 
         $this->cache->save(Argument::cetera())->shouldNotBeCalled();
 
-        $result = $this->preview->updateContext($token, $this->webspaceKey, $context, null, null);
+        $result = $this->preview->updateContext($token, $this->webspaceKey, $context, []);
 
         $this->assertEquals(
             '<html><body><div id="content"><h1 property="title">SULU</h1></div></body></html>',
@@ -543,7 +522,7 @@ class PreviewTest extends TestCase
         );
     }
 
-    public function testUpdateContextWithSegment()
+    public function testUpdateContextWithOptions()
     {
         $data = ['title' => 'Sulu', 'template' => 'default'];
         $dataJson = \json_encode($data);
@@ -586,14 +565,19 @@ class PreviewTest extends TestCase
             $this->webspaceKey,
             $this->locale,
             false,
-            null,
-            'w'
+            ['targetGroupId' => 2, 'segmentKey' => null]
         )->willReturn(
             '<html><body><div id="content"><!-- CONTENT-REPLACER --><h1 property="title">SULU</h1><!-- CONTENT-REPLACER --></div></body></html>'
         );
 
-        $this->renderer->render($newObject->reveal(), 1, $this->webspaceKey, $this->locale, true, null, 'w')
-            ->willReturn('<h1 property="title">SULU</h1>');
+        $this->renderer->render(
+            $newObject->reveal(),
+            1,
+            $this->webspaceKey,
+            $this->locale,
+            true,
+            ['targetGroupId' => 2, 'segmentKey' => null]
+        )->willReturn('<h1 property="title">SULU</h1>');
 
         $this->cache->save(
             $token,
@@ -607,71 +591,12 @@ class PreviewTest extends TestCase
             $this->cacheLifeTime
         )->shouldBeCalled();
 
-        $result = $this->preview->updateContext($token, $this->webspaceKey, $context, null, 'w');
-
-        $this->assertEquals(
-            '<html><body><div id="content"><h1 property="title">SULU</h1></div></body></html>',
-            $result
-        );
-    }
-
-    public function testUpdateContextWithTargetGroup()
-    {
-        $data = ['title' => 'Sulu', 'template' => 'default'];
-        $dataJson = \json_encode($data);
-
-        $context = ['template' => 'expert'];
-
-        $token = \md5(\sprintf('%s.%s.%s.%s', $this->providerKey, 1, $this->locale, 1));
-        $cacheData = [
-            'id' => '1',
-            'locale' => $this->locale,
-            'providerKey' => $this->providerKey,
-            'object' => $dataJson,
-            'objectClass' => \get_class($this->object->reveal()),
-            'userId' => 1,
-            'html' => '<html><body><div id="content"><!-- CONTENT-REPLACER --></div></body></html>',
-        ];
-
-        $newObject = $this->prophesize(\stdClass::class);
-        $expectedData = [
-            'id' => '1',
-            'locale' => $this->locale,
-            'providerKey' => $this->providerKey,
-            'object' => \json_encode(\array_merge($data, $context)),
-            'objectClass' => \get_class($newObject->reveal()),
-            'userId' => 1,
-            'html' => '<html><body><div id="content"><!-- CONTENT-REPLACER --></div></body></html>',
-        ];
-
-        $this->cache->contains($token)->willReturn(true);
-        $this->cache->fetch($token)->willReturn(\json_encode($cacheData));
-
-        $this->provider->deserialize($dataJson, $cacheData['objectClass'])->willReturn($this->object->reveal());
-        $this->provider->setContext($this->object->reveal(), $this->locale, $context)->willReturn($newObject->reveal());
-        $this->provider->setValues(Argument::cetera())->shouldNotBeCalled();
-        $this->provider->serialize($newObject->reveal())->willReturn($expectedData['object'])->shouldBeCalled();
-
-        $this->renderer->render($newObject->reveal(), 1, $this->webspaceKey, $this->locale, false, 2, null)->willReturn(
-            '<html><body><div id="content"><!-- CONTENT-REPLACER --><h1 property="title">SULU</h1><!-- CONTENT-REPLACER --></div></body></html>'
-        );
-
-        $this->renderer->render($newObject->reveal(), 1, $this->webspaceKey, $this->locale, true, 2, null)
-            ->willReturn('<h1 property="title">SULU</h1>');
-
-        $this->cache->save(
+        $result = $this->preview->updateContext(
             $token,
-            Argument::that(
-                function($json) use ($expectedData) {
-                    $this->assertEquals($expectedData, \json_decode($json, true));
-
-                    return true;
-                }
-            ),
-            $this->cacheLifeTime
-        )->shouldBeCalled();
-
-        $result = $this->preview->updateContext($token, $this->webspaceKey, $context, 2, null);
+            $this->webspaceKey,
+            $context,
+            ['targetGroupId' => 2, 'segmentKey' => null]
+        );
 
         $this->assertEquals(
             '<html><body><div id="content"><h1 property="title">SULU</h1></div></body></html>',
@@ -711,11 +636,23 @@ class PreviewTest extends TestCase
         $this->provider->setValues(Argument::cetera())->shouldNotBeCalled();
         $this->provider->serialize($this->object->reveal())->willReturn($dataJson)->shouldBeCalled();
 
-        $this->renderer->render($this->object->reveal(), 1, $this->webspaceKey, $this->locale, false, null, null)
-            ->willReturn('<html><body><div id="content"><!-- CONTENT-REPLACER --><h1 property="title">SULU</h1><!-- CONTENT-REPLACER --></div></body></html>');
+        $this->renderer->render(
+            $this->object->reveal(),
+            1,
+            $this->webspaceKey,
+            $this->locale,
+            false,
+            []
+        )->willReturn('<html><body><div id="content"><!-- CONTENT-REPLACER --><h1 property="title">SULU</h1><!-- CONTENT-REPLACER --></div></body></html>');
 
-        $this->renderer->render($this->object->reveal(), 1, $this->webspaceKey, $this->locale, true, null, null)
-            ->willReturn('<h1 property="title">SULU</h1>');
+        $this->renderer->render(
+            $this->object->reveal(),
+            1,
+            $this->webspaceKey,
+            $this->locale,
+            true,
+            []
+        )->shouldBeCalled()->willReturn('<h1 property="title">SULU</h1>');
 
         $this->cache->save(
             $token,
@@ -729,7 +666,7 @@ class PreviewTest extends TestCase
             $this->cacheLifeTime
         )->shouldBeCalled();
 
-        $result = $this->preview->render($token, $this->webspaceKey, $this->locale, null, null);
+        $result = $this->preview->render($token, $this->webspaceKey, $this->locale);
 
         $this->assertEquals(
             '<html><body><div id="content"><h1 property="title">SULU</h1></div></body></html>',
@@ -737,7 +674,7 @@ class PreviewTest extends TestCase
         );
     }
 
-    public function testRenderWithTargetGroup()
+    public function testRenderWithOptions()
     {
         $data = ['title' => 'Sulu'];
         $dataJson = \json_encode($data);
@@ -769,10 +706,23 @@ class PreviewTest extends TestCase
         $this->provider->setValues(Argument::cetera())->shouldNotBeCalled();
         $this->provider->serialize($this->object->reveal())->willReturn($dataJson)->shouldBeCalled();
 
-        $this->renderer->render($this->object->reveal(), 1, $this->webspaceKey, $this->locale, false, 2, null)
-            ->willReturn('<html><body><div id="content"><!-- CONTENT-REPLACER --><h1 property="title">SULU</h1><!-- CONTENT-REPLACER --></div></body></html>');
+        $this->renderer->render(
+            $this->object->reveal(),
+            1,
+            $this->webspaceKey,
+            $this->locale,
+            false,
+            ['targetGroupId' => null, 'segmentKey' => 's']
+        )->willReturn('<html><body><div id="content"><!-- CONTENT-REPLACER --><h1 property="title">SULU</h1><!-- CONTENT-REPLACER --></div></body></html>');
 
-        $this->renderer->render($this->object->reveal(), 1, $this->webspaceKey, $this->locale, true, 2, null)
+        $this->renderer->render(
+            $this->object->reveal(),
+            1,
+            $this->webspaceKey,
+            $this->locale,
+            true,
+            ['targetGroupId' => null, 'segmentKey' => 's']
+        )
             ->willReturn('<h1 property="title">SULU</h1>');
 
         $this->cache->save(
@@ -787,65 +737,12 @@ class PreviewTest extends TestCase
             $this->cacheLifeTime
         )->shouldBeCalled();
 
-        $result = $this->preview->render($token, $this->webspaceKey, $this->locale, 2, null);
-
-        $this->assertEquals(
-            '<html><body><div id="content"><h1 property="title">SULU</h1></div></body></html>',
-            $result
+        $result = $this->preview->render(
+            $token,
+            $this->webspaceKey,
+            $this->locale,
+            ['targetGroupId' => null, 'segmentKey' => 's']
         );
-    }
-
-    public function testRenderWithSegment()
-    {
-        $data = ['title' => 'Sulu'];
-        $dataJson = \json_encode($data);
-
-        $token = \md5(\sprintf('%s.%s.%s.%s', $this->providerKey, 1, $this->locale, 1));
-        $cacheData = [
-            'id' => '1',
-            'locale' => $this->locale,
-            'providerKey' => $this->providerKey,
-            'object' => $dataJson,
-            'objectClass' => \get_class($this->object->reveal()),
-            'userId' => 1,
-            'html' => null,
-        ];
-        $expectedData = [
-            'id' => '1',
-            'locale' => $this->locale,
-            'providerKey' => $this->providerKey,
-            'object' => $dataJson,
-            'objectClass' => \get_class($this->object->reveal()),
-            'userId' => 1,
-            'html' => '<html><body><div id="content"><!-- CONTENT-REPLACER --></div></body></html>',
-        ];
-
-        $this->cache->contains($token)->willReturn(true);
-        $this->cache->fetch($token)->willReturn(\json_encode($cacheData));
-
-        $this->provider->deserialize($cacheData['object'], $cacheData['objectClass'])->willReturn($this->object);
-        $this->provider->setValues(Argument::cetera())->shouldNotBeCalled();
-        $this->provider->serialize($this->object->reveal())->willReturn($dataJson)->shouldBeCalled();
-
-        $this->renderer->render($this->object->reveal(), 1, $this->webspaceKey, $this->locale, false, null, 's')
-            ->willReturn('<html><body><div id="content"><!-- CONTENT-REPLACER --><h1 property="title">SULU</h1><!-- CONTENT-REPLACER --></div></body></html>');
-
-        $this->renderer->render($this->object->reveal(), 1, $this->webspaceKey, $this->locale, true, null, 's')
-            ->willReturn('<h1 property="title">SULU</h1>');
-
-        $this->cache->save(
-            $token,
-            Argument::that(
-                function($json) use ($expectedData) {
-                    $this->assertEquals($expectedData, \json_decode($json, true));
-
-                    return true;
-                }
-            ),
-            $this->cacheLifeTime
-        )->shouldBeCalled();
-
-        $result = $this->preview->render($token, $this->webspaceKey, $this->locale, null, 's');
 
         $this->assertEquals(
             '<html><body><div id="content"><h1 property="title">SULU</h1></div></body></html>',

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/PreviewTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/PreviewTest.php
@@ -92,11 +92,10 @@ class PreviewTest extends TestCase
 
         $this->provider->serialize($this->object->reveal())->willReturn($dataJson);
 
-        $token = $this->preview->start($this->providerKey, 1, $this->locale, 1, $data);
+        $token = $this->preview->start($this->providerKey, 1, 1, $data, ['locale' => $this->locale]);
 
         $expectedData = [
             'id' => '1',
-            'locale' => $this->locale,
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
             'objectClass' => \get_class($this->object->reveal()),
@@ -127,11 +126,10 @@ class PreviewTest extends TestCase
 
         $this->provider->serialize($this->object->reveal())->willReturn($dataJson);
 
-        $token = $this->preview->start($this->providerKey, 1, $this->locale, 1);
+        $token = $this->preview->start($this->providerKey, 1, 1, [], ['locale' => $this->locale]);
 
         $expectedData = [
             'id' => '1',
-            'locale' => $this->locale,
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
             'objectClass' => \get_class($this->object->reveal()),
@@ -156,7 +154,7 @@ class PreviewTest extends TestCase
     {
         $this->expectException(ProviderNotFoundException::class);
 
-        $this->preview->start('xxx', 1, $this->locale, 1);
+        $this->preview->start('xxx', 1, 1, ['locale' => $this->locale]);
     }
 
     public function testStop()
@@ -196,10 +194,9 @@ class PreviewTest extends TestCase
         $data = ['title' => 'Sulu'];
         $dataJson = \json_encode($data);
 
-        $token = \md5(\sprintf('%s.%s.%s.%s', $this->providerKey, 1, $this->locale, 1));
+        $token = \md5(\sprintf('%s.%s.%s', $this->providerKey, 1, 1));
         $cacheData = [
             'id' => '1',
-            'locale' => $this->locale,
             'providerKey' => $this->providerKey,
             'object' => \json_encode(['title' => 'test']),
             'objectClass' => \get_class($this->object->reveal()),
@@ -208,7 +205,6 @@ class PreviewTest extends TestCase
         ];
         $expectedData = [
             'id' => '1',
-            'locale' => $this->locale,
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
             'objectClass' => \get_class($this->object->reveal()),
@@ -226,10 +222,8 @@ class PreviewTest extends TestCase
         $this->renderer->render(
             $this->object->reveal(),
             1,
-            $this->webspaceKey,
-            $this->locale,
             true,
-            []
+            ['webspaceKey' => $this->webspaceKey, 'locale' => $this->locale]
         )->willReturn('<h1 property="title">SULU</h1>');
 
         $this->cache->save(
@@ -244,7 +238,11 @@ class PreviewTest extends TestCase
             $this->cacheLifeTime
         )->shouldBeCalled();
 
-        $result = $this->preview->update($token, $this->webspaceKey, $data);
+        $result = $this->preview->update(
+            $token,
+            $data,
+            ['webspaceKey' => $this->webspaceKey, 'locale' => $this->locale]
+        );
 
         $this->assertEquals(
             '<html><body><div id="content"><h1 property="title">SULU</h1></div></body></html>',
@@ -257,10 +255,9 @@ class PreviewTest extends TestCase
         $data = ['title' => 'Sulu'];
         $dataJson = \json_encode($data);
 
-        $token = \md5(\sprintf('%s.%s.%s.%s', $this->providerKey, 1, $this->locale, 1));
+        $token = \md5(\sprintf('%s.%s.%s', $this->providerKey, 1, 1));
         $cacheData = [
             'id' => '1',
-            'locale' => $this->locale,
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
             'objectClass' => \get_class($this->object->reveal()),
@@ -278,15 +275,17 @@ class PreviewTest extends TestCase
         $this->renderer->render(
             $this->object->reveal(),
             1,
-            $this->webspaceKey,
-            $this->locale,
             true,
-            []
+            ['webspaceKey' => $this->webspaceKey, 'locale' => $this->locale]
         )->willReturn('<h1 property="title">SULU</h1>');
 
         $this->cache->save(Argument::cetera())->shouldNotBeCalled();
 
-        $result = $this->preview->update($token, $this->webspaceKey, []);
+        $result = $this->preview->update(
+            $token,
+            [],
+            ['webspaceKey' => $this->webspaceKey, 'locale' => $this->locale]
+        );
 
         $this->assertEquals(
             '<html><body><div id="content"><h1 property="title">SULU</h1></div></body></html>',
@@ -307,7 +306,7 @@ class PreviewTest extends TestCase
         $this->provider->deserialize(Argument::cetera())->shouldNotBeCalled();
         $this->renderer->render(Argument::cetera())->shouldNotBeCalled();
 
-        $this->preview->update($token, $this->webspaceKey, ['title' => 'SULU']);
+        $this->preview->update($token, ['title' => 'SULU'], ['webspaceKey' => $this->webspaceKey]);
     }
 
     public function testUpdateWithOptions()
@@ -315,10 +314,9 @@ class PreviewTest extends TestCase
         $data = ['title' => 'Sulu'];
         $dataJson = \json_encode($data);
 
-        $token = \md5(\sprintf('%s.%s.%s.%s', $this->providerKey, 1, $this->locale, 1));
+        $token = \md5(\sprintf('%s.%s.%s', $this->providerKey, 1, 1));
         $cacheData = [
             'id' => '1',
-            'locale' => $this->locale,
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
             'objectClass' => \get_class($this->object->reveal()),
@@ -336,19 +334,26 @@ class PreviewTest extends TestCase
         $this->renderer->render(
             $this->object->reveal(),
             1,
-            $this->webspaceKey,
-            $this->locale,
             true,
-            ['targetGroupId' => null, 'segmentKey' => 'w']
+            [
+                'targetGroupId' => null,
+                'segmentKey' => 'w',
+                'webspaceKey' => $this->webspaceKey,
+                'locale' => $this->locale,
+            ]
         )->willReturn('<h1 property="title">SULU</h1>');
 
         $this->cache->save(Argument::cetera())->shouldNotBeCalled();
 
         $result = $this->preview->update(
             $token,
-            $this->webspaceKey,
             [],
-            ['targetGroupId' => null, 'segmentKey' => 'w']
+            [
+                'targetGroupId' => null,
+                'segmentKey' => 'w',
+                'webspaceKey' => $this->webspaceKey,
+                'locale' => $this->locale,
+            ]
         );
 
         $this->assertEquals(
@@ -364,10 +369,9 @@ class PreviewTest extends TestCase
 
         $context = ['template' => 'expert'];
 
-        $token = \md5(\sprintf('%s.%s.%s.%s', $this->providerKey, 1, $this->locale, 1));
+        $token = \md5(\sprintf('%s.%s.%s', $this->providerKey, 1, 1));
         $cacheData = [
             'id' => '1',
-            'locale' => $this->locale,
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
             'objectClass' => \get_class($this->object->reveal()),
@@ -378,7 +382,6 @@ class PreviewTest extends TestCase
         $newObject = $this->prophesize(\stdClass::class);
         $expectedData = [
             'id' => '1',
-            'locale' => $this->locale,
             'providerKey' => $this->providerKey,
             'object' => \json_encode(\array_merge($data, $context)),
             'objectClass' => \get_class($newObject->reveal()),
@@ -397,10 +400,8 @@ class PreviewTest extends TestCase
         $this->renderer->render(
             $newObject->reveal(),
             1,
-            $this->webspaceKey,
-            $this->locale,
             false,
-            []
+            ['webspaceKey' => $this->webspaceKey, 'locale' => $this->locale]
         )->willReturn(
             '<html><body><div id="content"><!-- CONTENT-REPLACER --><h1 property="title">SULU</h1><!-- CONTENT-REPLACER --></div></body></html>'
         );
@@ -408,10 +409,8 @@ class PreviewTest extends TestCase
         $this->renderer->render(
             $newObject->reveal(),
             1,
-            $this->webspaceKey,
-            $this->locale,
             true,
-            []
+            ['webspaceKey' => $this->webspaceKey, 'locale' => $this->locale]
         )->willReturn('<h1 property="title">SULU</h1>');
 
         $this->cache->save(
@@ -426,7 +425,11 @@ class PreviewTest extends TestCase
             $this->cacheLifeTime
         )->shouldBeCalled();
 
-        $result = $this->preview->updateContext($token, $this->webspaceKey, $context);
+        $result = $this->preview->updateContext(
+            $token,
+            $context,
+            ['webspaceKey' => $this->webspaceKey, 'locale' => $this->locale]
+        );
 
         $this->assertEquals(
             '<html><body><div id="content"><h1 property="title">SULU</h1></div></body></html>',
@@ -447,7 +450,6 @@ class PreviewTest extends TestCase
         $token = \md5(\sprintf('%s.%s.%s.%s', $this->providerKey, 1, $this->locale, 1));
         $cacheData = [
             'id' => '1',
-            'locale' => $this->locale,
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
             'objectClass' => \get_class($this->object->reveal()),
@@ -466,13 +468,15 @@ class PreviewTest extends TestCase
         $this->renderer->render(
             $newObject->reveal(),
             1,
-            $this->webspaceKey,
-            $this->locale,
             false,
-            []
+            ['webspaceKey' => $this->webspaceKey, 'locale' => $this->locale]
         )->willReturn('<html><body><div id="content"><h1 property="title">SULU</h1></div></body></html>');
 
-        $this->preview->updateContext($token, $this->webspaceKey, $context);
+        $this->preview->updateContext(
+            $token,
+            $context,
+            ['webspaceKey' => $this->webspaceKey, 'locale' => $this->locale]
+        );
     }
 
     public function testUpdateContextNoContext()
@@ -482,10 +486,9 @@ class PreviewTest extends TestCase
 
         $context = [];
 
-        $token = \md5(\sprintf('%s.%s.%s.%s', $this->providerKey, 1, $this->locale, 1));
+        $token = \md5(\sprintf('%s.%s.%s', $this->providerKey, 1, 1));
         $cacheData = [
             'id' => '1',
-            'locale' => $this->locale,
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
             'objectClass' => \get_class($this->object->reveal()),
@@ -504,17 +507,19 @@ class PreviewTest extends TestCase
         $this->renderer->render(
             $this->object->reveal(),
             1,
-            $this->webspaceKey,
-            $this->locale,
             false,
-            []
+            ['webspaceKey' => $this->webspaceKey, 'locale' => $this->locale]
         )->willReturn(
             '<html><body><div id="content"><h1 property="title">SULU</h1></div></body></html>'
         );
 
         $this->cache->save(Argument::cetera())->shouldNotBeCalled();
 
-        $result = $this->preview->updateContext($token, $this->webspaceKey, $context, []);
+        $result = $this->preview->updateContext(
+            $token,
+            $context,
+            ['webspaceKey' => $this->webspaceKey, 'locale' => $this->locale]
+        );
 
         $this->assertEquals(
             '<html><body><div id="content"><h1 property="title">SULU</h1></div></body></html>',
@@ -529,10 +534,9 @@ class PreviewTest extends TestCase
 
         $context = ['template' => 'expert'];
 
-        $token = \md5(\sprintf('%s.%s.%s.%s', $this->providerKey, 1, $this->locale, 1));
+        $token = \md5(\sprintf('%s.%s.%s', $this->providerKey, 1, 1));
         $cacheData = [
             'id' => '1',
-            'locale' => $this->locale,
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
             'objectClass' => \get_class($this->object->reveal()),
@@ -543,7 +547,6 @@ class PreviewTest extends TestCase
         $newObject = $this->prophesize(\stdClass::class);
         $expectedData = [
             'id' => '1',
-            'locale' => $this->locale,
             'providerKey' => $this->providerKey,
             'object' => \json_encode(\array_merge($data, $context)),
             'objectClass' => \get_class($newObject->reveal()),
@@ -562,10 +565,8 @@ class PreviewTest extends TestCase
         $this->renderer->render(
             $newObject->reveal(),
             1,
-            $this->webspaceKey,
-            $this->locale,
             false,
-            ['targetGroupId' => 2, 'segmentKey' => null]
+            ['targetGroupId' => 2, 'segmentKey' => null, 'webspaceKey' => $this->webspaceKey, 'locale' => $this->locale]
         )->willReturn(
             '<html><body><div id="content"><!-- CONTENT-REPLACER --><h1 property="title">SULU</h1><!-- CONTENT-REPLACER --></div></body></html>'
         );
@@ -573,10 +574,8 @@ class PreviewTest extends TestCase
         $this->renderer->render(
             $newObject->reveal(),
             1,
-            $this->webspaceKey,
-            $this->locale,
             true,
-            ['targetGroupId' => 2, 'segmentKey' => null]
+            ['targetGroupId' => 2, 'segmentKey' => null, 'webspaceKey' => $this->webspaceKey, 'locale' => $this->locale]
         )->willReturn('<h1 property="title">SULU</h1>');
 
         $this->cache->save(
@@ -593,9 +592,8 @@ class PreviewTest extends TestCase
 
         $result = $this->preview->updateContext(
             $token,
-            $this->webspaceKey,
             $context,
-            ['targetGroupId' => 2, 'segmentKey' => null]
+            ['targetGroupId' => 2, 'segmentKey' => null, 'webspaceKey' => $this->webspaceKey, 'locale' => $this->locale]
         );
 
         $this->assertEquals(
@@ -609,10 +607,9 @@ class PreviewTest extends TestCase
         $data = ['title' => 'Sulu'];
         $dataJson = \json_encode($data);
 
-        $token = \md5(\sprintf('%s.%s.%s.%s', $this->providerKey, 1, $this->locale, 1));
+        $token = \md5(\sprintf('%s.%s.%s', $this->providerKey, 1, 1));
         $cacheData = [
             'id' => '1',
-            'locale' => $this->locale,
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
             'objectClass' => \get_class($this->object->reveal()),
@@ -621,7 +618,6 @@ class PreviewTest extends TestCase
         ];
         $expectedData = [
             'id' => '1',
-            'locale' => $this->locale,
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
             'objectClass' => \get_class($this->object->reveal()),
@@ -639,19 +635,15 @@ class PreviewTest extends TestCase
         $this->renderer->render(
             $this->object->reveal(),
             1,
-            $this->webspaceKey,
-            $this->locale,
             false,
-            []
+            ['webspaceKey' => $this->webspaceKey, 'locale' => $this->locale]
         )->willReturn('<html><body><div id="content"><!-- CONTENT-REPLACER --><h1 property="title">SULU</h1><!-- CONTENT-REPLACER --></div></body></html>');
 
         $this->renderer->render(
             $this->object->reveal(),
             1,
-            $this->webspaceKey,
-            $this->locale,
             true,
-            []
+            ['webspaceKey' => $this->webspaceKey, 'locale' => $this->locale]
         )->shouldBeCalled()->willReturn('<h1 property="title">SULU</h1>');
 
         $this->cache->save(
@@ -666,7 +658,7 @@ class PreviewTest extends TestCase
             $this->cacheLifeTime
         )->shouldBeCalled();
 
-        $result = $this->preview->render($token, $this->webspaceKey, $this->locale);
+        $result = $this->preview->render($token, ['webspaceKey' => $this->webspaceKey, 'locale' => $this->locale]);
 
         $this->assertEquals(
             '<html><body><div id="content"><h1 property="title">SULU</h1></div></body></html>',
@@ -679,10 +671,9 @@ class PreviewTest extends TestCase
         $data = ['title' => 'Sulu'];
         $dataJson = \json_encode($data);
 
-        $token = \md5(\sprintf('%s.%s.%s.%s', $this->providerKey, 1, $this->locale, 1));
+        $token = \md5(\sprintf('%s.%s.%s', $this->providerKey, 1, 1));
         $cacheData = [
             'id' => '1',
-            'locale' => $this->locale,
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
             'objectClass' => \get_class($this->object->reveal()),
@@ -691,7 +682,6 @@ class PreviewTest extends TestCase
         ];
         $expectedData = [
             'id' => '1',
-            'locale' => $this->locale,
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
             'objectClass' => \get_class($this->object->reveal()),
@@ -709,19 +699,25 @@ class PreviewTest extends TestCase
         $this->renderer->render(
             $this->object->reveal(),
             1,
-            $this->webspaceKey,
-            $this->locale,
             false,
-            ['targetGroupId' => null, 'segmentKey' => 's']
+            [
+                'targetGroupId' => null,
+                'segmentKey' => 's',
+                'webspaceKey' => $this->webspaceKey,
+                'locale' => $this->locale,
+            ]
         )->willReturn('<html><body><div id="content"><!-- CONTENT-REPLACER --><h1 property="title">SULU</h1><!-- CONTENT-REPLACER --></div></body></html>');
 
         $this->renderer->render(
             $this->object->reveal(),
             1,
-            $this->webspaceKey,
-            $this->locale,
             true,
-            ['targetGroupId' => null, 'segmentKey' => 's']
+            [
+                'targetGroupId' => null,
+                'segmentKey' => 's',
+                'webspaceKey' => $this->webspaceKey,
+                'locale' => $this->locale,
+            ]
         )
             ->willReturn('<h1 property="title">SULU</h1>');
 
@@ -739,9 +735,12 @@ class PreviewTest extends TestCase
 
         $result = $this->preview->render(
             $token,
-            $this->webspaceKey,
-            $this->locale,
-            ['targetGroupId' => null, 'segmentKey' => 's']
+            [
+                'targetGroupId' => null,
+                'segmentKey' => 's',
+                'webspaceKey' => $this->webspaceKey,
+                'locale' => $this->locale,
+            ]
         );
 
         $this->assertEquals(

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
@@ -235,10 +235,15 @@ class PreviewRendererTest extends TestCase
         $request = new Request();
         $this->requestStack->getCurrentRequest()->willReturn($request);
 
-        $this->httpKernel->handle(Argument::type(Request::class), HttpKernelInterface::MASTER_REQUEST, false)
-            ->shouldBeCalled()->willReturn(new Response('<title>Hallo</title>'));
+        $this->httpKernel->handle(
+            Argument::that(function(Request $request) {
+                return 2 == $request->headers->get('X-Sulu-Target-Group');
+            }),
+            HttpKernelInterface::MASTER_REQUEST,
+            false
+        )->shouldBeCalled()->willReturn(new Response('<title>Hallo</title>'));
 
-        $response = $this->renderer->render($object->reveal(), 1, 'sulu_io', 'de', true, 2);
+        $response = $this->renderer->render($object->reveal(), 1, 'sulu_io', 'de', true, ['targetGroupId' => 2]);
         $this->assertEquals('<title>Hallo</title>', $response);
     }
 
@@ -279,7 +284,7 @@ class PreviewRendererTest extends TestCase
             false
         )->shouldBeCalled()->willReturn(new Response('<title>Hallo</title>'));
 
-        $response = $this->renderer->render($object->reveal(), 1, 'sulu_io', 'de', true, 2, 'w');
+        $response = $this->renderer->render($object->reveal(), 1, 'sulu_io', 'de', true, ['segmentKey' => 'w']);
         $this->assertEquals('<title>Hallo</title>', $response);
     }
 

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
@@ -205,7 +205,7 @@ class PreviewRendererTest extends TestCase
 
         $this->requestStack->getCurrentRequest()->willReturn($request);
 
-        $response = $this->renderer->render($object->reveal(), 1, 'sulu_io', 'de', true);
+        $response = $this->renderer->render($object->reveal(), 1, true, ['webspaceKey' => 'sulu_io', 'locale' => 'de']);
         $this->assertEquals('<title>Hallo</title>', $response);
     }
 
@@ -243,7 +243,12 @@ class PreviewRendererTest extends TestCase
             false
         )->shouldBeCalled()->willReturn(new Response('<title>Hallo</title>'));
 
-        $response = $this->renderer->render($object->reveal(), 1, 'sulu_io', 'de', true, ['targetGroupId' => 2]);
+        $response = $this->renderer->render(
+            $object->reveal(),
+            1,
+            true,
+            ['webspaceKey' => 'sulu_io', 'locale' => 'de', 'targetGroupId' => 2]
+        );
         $this->assertEquals('<title>Hallo</title>', $response);
     }
 
@@ -284,7 +289,12 @@ class PreviewRendererTest extends TestCase
             false
         )->shouldBeCalled()->willReturn(new Response('<title>Hallo</title>'));
 
-        $response = $this->renderer->render($object->reveal(), 1, 'sulu_io', 'de', true, ['segmentKey' => 'w']);
+        $response = $this->renderer->render(
+            $object->reveal(),
+            1,
+            true,
+            ['webspaceKey' => 'sulu_io', 'locale' => 'de', 'segmentKey' => 'w']
+        );
         $this->assertEquals('<title>Hallo</title>', $response);
     }
 
@@ -313,7 +323,7 @@ class PreviewRendererTest extends TestCase
         $request = new Request();
         $this->requestStack->getCurrentRequest()->willReturn($request);
 
-        $response = $this->renderer->render($object->reveal(), 1, 'sulu_io', 'de', true);
+        $response = $this->renderer->render($object->reveal(), 1, true, ['webspaceKey' => 'sulu_io', 'locale' => 'de']);
 
         $this->assertEquals('<title>Hallo</title>', $response);
     }
@@ -333,7 +343,7 @@ class PreviewRendererTest extends TestCase
 
         $this->webspaceManager->findWebspaceByKey('not_existing')->willReturn(null);
 
-        $this->renderer->render($object, 1, 'not_existing', 'de', true);
+        $this->renderer->render($object, 1, true, ['webspaceKey' => 'not_existing', 'locale' => 'de']);
     }
 
     public function testRenderWebspaceLocalizationNotFound()
@@ -352,7 +362,7 @@ class PreviewRendererTest extends TestCase
         $webspace = new Webspace();
         $this->webspaceManager->findWebspaceByKey('sulu_io')->willReturn($webspace);
 
-        $this->renderer->render($object, 1, 'sulu_io', 'de', true);
+        $this->renderer->render($object, 1, true, ['webspaceKey' => 'sulu_io', 'locale' => 'de']);
     }
 
     public function testRenderRouteDefaultsProviderNotFound()
@@ -386,7 +396,7 @@ class PreviewRendererTest extends TestCase
         $request = new Request();
         $this->requestStack->getCurrentRequest()->willReturn($request);
 
-        $this->renderer->render($object->reveal(), 1, 'sulu_io', 'de', true);
+        $this->renderer->render($object->reveal(), 1, true, ['webspaceKey' => 'sulu_io', 'locale' => 'de']);
     }
 
     public function testRenderTwigError()
@@ -420,7 +430,7 @@ class PreviewRendererTest extends TestCase
         $request = new Request();
         $this->requestStack->getCurrentRequest()->willReturn($request);
 
-        $this->renderer->render($object->reveal(), 1, 'sulu_io', 'de', true);
+        $this->renderer->render($object->reveal(), 1, true, ['webspaceKey' => 'sulu_io', 'locale' => 'de']);
     }
 
     public function testRenderInvalidArgumentException()
@@ -454,7 +464,7 @@ class PreviewRendererTest extends TestCase
         $request = new Request();
         $this->requestStack->getCurrentRequest()->willReturn($request);
 
-        $this->renderer->render($object->reveal(), 1, 'sulu_io', 'de', true);
+        $this->renderer->render($object->reveal(), 1, true, ['webspaceKey' => 'sulu_io', 'locale' => 'de']);
     }
 
     public function testRenderHttpExceptionWithPreviousException()
@@ -490,7 +500,7 @@ class PreviewRendererTest extends TestCase
         $request = new Request();
         $this->requestStack->getCurrentRequest()->willReturn($request);
 
-        $this->renderer->render($object->reveal(), 1, 'sulu_io', 'de', true);
+        $this->renderer->render($object->reveal(), 1, true, ['webspaceKey' => 'sulu_io', 'locale' => 'de']);
     }
 
     public function testRenderHttpExceptionWithoutPreviousException()
@@ -526,7 +536,7 @@ class PreviewRendererTest extends TestCase
         $request = new Request();
         $this->requestStack->getCurrentRequest()->willReturn($request);
 
-        $this->renderer->render($object->reveal(), 1, 'sulu_io', 'de', true);
+        $this->renderer->render($object->reveal(), 1, true, ['webspaceKey' => 'sulu_io', 'locale' => 'de']);
     }
 
     public function testRenderRequestWithServerAttributes()
@@ -604,6 +614,6 @@ class PreviewRendererTest extends TestCase
         $request = new Request([], [], [], [], [], $server, []);
         $this->requestStack->getCurrentRequest()->willReturn($request);
 
-        $this->renderer->render($object->reveal(), 1, 'sulu_io', 'de', true);
+        $this->renderer->render($object->reveal(), 1, true, ['webspaceKey' => 'sulu_io', 'locale' => 'de']);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #5608
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR refactors some interfaces as described in https://github.com/sulu/sulu/pull/5608#issuecomment-734724110.

#### Why?

Because everytime we add some new option to the preview toolbar (this time it will be a `DatePicker` for previewing the block scheduling) we had to touch the `PreviewInterface` and some other classes.

#### BC Breaks/Deprecations

Some interfaces in the PreviewBundle will be changed, which is a BC break.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
