### PR TITLE
Fallback to content-locale of user in ResourceLocator field-type

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
@@ -6,8 +6,8 @@ import ResourceLocatorComponent from '../../../components/ResourceLocator';
 import ResourceLocatorHistory from '../../../containers/ResourceLocatorHistory';
 import Requester from '../../../services/Requester';
 import type {FieldTypeProps} from '../../../types';
+import userStore from '../../../stores/userStore';
 import resourceLocatorStyles from './resourceLocator.scss';
-import userStore from "../../../stores/userStore";
 
 const PART_TAG = 'sulu.rlp.part';
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
@@ -7,6 +7,7 @@ import ResourceLocatorHistory from '../../../containers/ResourceLocatorHistory';
 import Requester from '../../../services/Requester';
 import type {FieldTypeProps} from '../../../types';
 import resourceLocatorStyles from './resourceLocator.scss';
+import userStore from "../../../stores/userStore";
 
 const PART_TAG = 'sulu.rlp.part';
 
@@ -93,7 +94,7 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
                 {
                     parts: Object.fromEntries(partEntries),
                     resourceKey: formInspector.resourceKey,
-                    locale: formInspector.locale ? formInspector.locale.get() : undefined,
+                    locale: formInspector.locale ? formInspector.locale.get() : userStore.contentLocale,
                     ...requestOptions,
                 }
             ).then((response) => {
@@ -145,7 +146,7 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
                     <ResourceLocatorComponent
                         disabled={!!disabled}
                         id={dataPath}
-                        locale={formInspector.locale}
+                        locale={formInspector.locale ? formInspector.locale : observable.box(userStore.contentLocale)}
                         mode={this.mode}
                         onBlur={this.handleBlur}
                         onChange={onChange}
@@ -157,7 +158,7 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
                         <ResourceLocatorHistory
                             id={formInspector.id}
                             options={{
-                                locale: formInspector.locale,
+                                locale: formInspector.locale ? formInspector.locale.get() : userStore.contentLocale,
                                 resourceKey: formInspector.resourceKey,
                                 webspace: formInspector.options.webspace,
                                 ...options,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adjusts the `ResourceLocator` field-type to use the `userStore.contentLocale` if a form is not localized.

#### Why?

Because the `ResourceLocator` components expects a non-null locale. Also, the API that is called in the `ResourceLocatorHistory` expects a non-null locale. Because of this, the `ResourceLocator` field-type is not usable for unlocalized entities at the moment (see https://github.com/sulu/sulu-demo/pull/87 for example).

We used the same fallback strategy in multiple other field-types including the `SingleSelection`, `TextEditor`, `MediaSelection` and `TeaserSelection`.