### PR TITLE
Fallback to unlocalized toLowerCase if locale is not BCP 47 in ResourceLocator

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
@@ -76,7 +76,12 @@ class ResourceLocator extends React.Component<Props> {
         const {mode, onChange, locale} = this.props;
 
         if (value) {
-            value = value.toLocaleLowerCase(locale.get());
+            try {
+                value = value.toLocaleLowerCase(locale.get());
+            } catch (e) {
+                // fallback to unlocalized toLowerCase if locale is not a valid BCP 47 code
+                value = value.toLowerCase();
+            }
 
             if (mode === 'leaf') {
                 value = value.replace(/\//g, '-');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
@@ -79,7 +79,7 @@ class ResourceLocator extends React.Component<Props> {
             try {
                 value = value.toLocaleLowerCase(locale.get());
             } catch (e) {
-                // fallback to unlocalized toLowerCase if locale is not a valid BCP 47 code
+                // fallback to toLowerCase if toLocaleLowerCase fails because given locale is not a valid BCP 47 code
                 value = value.toLowerCase();
             }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/tests/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/tests/ResourceLocator.test.js
@@ -241,6 +241,17 @@ test('ResourceLocator should replace capital letters with lower case in full mod
     expect(onChange).toBeCalledWith('/parent/child');
 });
 
+test('ResourceLocator should replace capital letters even when given locale is not a valid BCP 47 code', () => {
+    const onChange = jest.fn();
+    const value = '/parent/child';
+    const locale = observable.box('de_CH');
+    const resourceLocator = mount(
+        <ResourceLocator locale={locale} mode="leaf" onBlur={jest.fn()} onChange={onChange} value={value} />
+    );
+    resourceLocator.find('Input').props().onChange('CHILD');
+    expect(onChange).toBeCalledWith('/parent/child');
+});
+
 test('ResourceLocator should call the onChange callback when a slash is typed in full mode', () => {
     const onChange = jest.fn();
     const value = '/parent/child';


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### Why?

Right now, the `ResourceLocator` component crashes if the given `locale` prop is not a valid BCP 47 code. For example, this happens when `de_ch` is used as locale.
