### PR TITLE
Allow to use is_array and implode in route schema

### DIFF
--- a/src/Sulu/Bundle/RouteBundle/Generator/SymfonyExpressionTokenProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Generator/SymfonyExpressionTokenProvider.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\RouteBundle\Generator;
 
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -42,7 +43,10 @@ class SymfonyExpressionTokenProvider implements TokenProviderInterface
         }
 
         $this->translator = $translator;
+
         $this->expressionLanguage = new ExpressionLanguage();
+        $this->expressionLanguage->addFunction(ExpressionFunction::fromPhp('implode'));
+        $this->expressionLanguage->addFunction(ExpressionFunction::fromPhp('is_array'));
     }
 
     public function provide($entity, $name)

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/SymfonyExpressionTokenProviderTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/SymfonyExpressionTokenProviderTest.php
@@ -51,6 +51,44 @@ class SymfonyExpressionTokenProviderTest extends TestCase
         $this->assertEquals('TEST', $provider->provide($entity, 'translator.trans("test-key")'));
     }
 
+    public function testResolveWithImplode()
+    {
+        $translator = $this->prophesize(Translator::class);
+        $translator->getLocale()->willReturn('de');
+        $translator->setLocale('de')->shouldBeCalled();
+
+        $entity = ['title', 'subtitle'];
+
+        $provider = new SymfonyExpressionTokenProvider($translator->reveal());
+
+        $this->assertEquals(
+            'events/title-subtitle',
+            $provider->provide($entity, '"events/" ~ implode("-", object)')
+        );
+    }
+
+    public function testResolveWithIsArray()
+    {
+        $translator = $this->prophesize(Translator::class);
+        $translator->getLocale()->willReturn('de');
+        $translator->setLocale('de')->shouldBeCalled();
+
+        $entity = new \stdClass();
+        $array = ['first-array-value'];
+
+        $provider = new SymfonyExpressionTokenProvider($translator->reveal());
+
+        $this->assertEquals(
+            'not-array',
+            $provider->provide($entity, 'is_array(object) ? object[0] : "not-array"')
+        );
+
+        $this->assertEquals(
+            'first-array-value',
+            $provider->provide($array, 'is_array(object) ? object[0] : "not-array"')
+        );
+    }
+
     public function testResolveNotExists()
     {
         $this->expectException(CannotEvaluateTokenException::class);


### PR DESCRIPTION
#### What's in this PR?

This PR allows to use the `is_array` and `implode` function inside of rout schemas:

```yml
sulu_route:
    mappings:
        App\Entity\Event:
            generator: schema
            options:
                route_schema: '/events/{is_array(object) ? implode("-", object) : object.getName()}'
```

#### Basics

There are two basic strategies when it comes to route generation at the moment.

##### Strategy 1: Live generation in Form based on `sulu.rlp.part` tag (used for pages)

In this strategy, properties that have a `sulu.rlp.part` tag are sent to the server via AJAX request when the form is edited. The value of the route is updated directly in the form, even without saving. On save, the already generated route-path is included in the data that sent to the API. This strategy is used for pages. 

##### Strategy 2: Generation based on entity (used for articles)

In this strategy, the route field in the form is updated only after save. When saving the form, the respective entity is persisted and the route bundle is used for generating the route-path for the persisted entity. The route bundle will generate the route-path by evaluating the configured route schema with the persisted entity. In contrast to strategy 1, this strategy allows to include the id of the entity in the route. Unfortunately, this strategy has considerable worse UX (see for example https://github.com/sulu/SuluArticleBundle/issues/514).

#### Usecase

When implementing a custom entity, I would like to use live generation for the route of the entity because it has better UX. 

This is already possible by the following steps:

1. Add a `sulu.rlp.part` tag to a property in the form of the entity. Now, if this property is changed, the ResourceLocator field-type will send an AJAX to the `RouteController::postAction`. The `RouteController` will generate the route-path by evaluating the configured route schema with the parts that were sent to the controller.

2. Because the `RouteController` will evaluate the configured route schema with the parts sent to the controller, we can now use a route schema like this:

```yml
sulu_route:
    mappings:
        App\Entity\Event:
            generator: schema
            options:
                route_schema: '/events/{object["title"]}-{object["subtitle"]}'
            resource_key: events
```

#### Problems

##### Problem 1: Need explicitly include all parts in the configured route schema

When generating the route-path for a page. The parts that are tagged with `sulu.rlp.part` are sorted by their priority and concatenated using `-` between parts. I cannot easily mimic this behaviour for a custom entity without explicitly including all parts in the route schema. By allowing to use `implode` in the route-schema, I can just use:

```yml
sulu_route:
    mappings:
        App\Entity\Event:
            generator: schema
            options:
                route_schema: '/events/{implode("-", object)}'
            resource_key: events
```

##### Problem 2: Error when route schema is evaluated with entity 

Depending on how the custom entity is implemented, there might be parts of the system that will try to evaluate the route schema using the entity (not with the `parts` array like the `RouteController`). For example, this can happen when using the `bin/console sulu:route:update` command. 

In these cases, the generation will fail because the route schema (`'/events/{object["title"]}'`) expects that `object` is an array. By allowing to use `is_array` in the route-schema, we can handle these cases with something like:

```yml
sulu_route:
    mappings:
        App\Entity\Event:
            generator: schema
            options:
                route_schema: '/events/{is_array(object) ? implode("-", object) : object.getName()}'
```

#### Conclusion

I am aware that this PR is not the complete solution for the inconsistencies and problems described above. To do this, we probably need a bigger refactoring inside of the `RouteBundle`. Because of this, I extracted parts of this description into #5676 for further discussion. 

That said, this PR should not hurt anything, does not break backwards compatibility and will reduce the pain when implementing a custom entity with a route significantly 🙂 