### PR TITLE
Add resolveConflict parameter to createOrUpdateByAttributes method of RouteManager

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,16 @@
 # Upgrade
 
+## dev-master
+
+### Added resolveConflict parameter to RouteManagerInterface::createOrUpdateByAttributes
+
+The `createOrUpdateByAttributes` method of the `RouteManagerInterface` was adjusted to include a `resolveConflict`
+parameter. This makes the available parameters consistent to the `RouteManagerInterface::create` method and the
+`RouteManagerInterface::update` method.
+
+If you have implemented this interface in your project, you need to add the parameter to the 
+`createOrUpdateByAttributes` method of your implementation.
+
 ## 2.2.2
 
 ### Added default value to anonymous column of se_roles table

--- a/src/Sulu/Bundle/RouteBundle/Manager/RouteManagerInterface.php
+++ b/src/Sulu/Bundle/RouteBundle/Manager/RouteManagerInterface.php
@@ -45,5 +45,11 @@ interface RouteManagerInterface
     /**
      * Creates a new route and handles the histories if the route has changed.
      */
-    public function createOrUpdateByAttributes(string $entityClass, string $id, string $locale, string $path): RouteInterface;
+    public function createOrUpdateByAttributes(
+        string $entityClass,
+        string $id,
+        string $locale,
+        string $path,
+        $resolveConflict = true
+    ): RouteInterface;
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| New feature? | yes
| Fixed tickets | fixes #5579
| License | MIT

#### What's in this PR?

This PR adds a `resolveConflict` parameter to the `RouteManagerInterface::createOrUpdateByAttributes` method. This makes the available parameter consistent to the `RouteManagerInterface::create` and `RouteManagerInterface::update`.

#### Why?

When using the `RouteBundle` for a custom entity, it is not possible to implement the `RoutableInterface` in some cases (eg for unlocalized entities or when using the SuluContentBundle). You need to use the `RouteManagerInterface::createOrUpdateByAttributes` method for these entities. We should allow to resolve possible conflicts in these cases too.
