### PR TITLE
Skip json schema "type" validation errors

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
@@ -216,6 +216,7 @@ export default class AbstractFormStore
             // $FlowFixMe
             for (const error of validator.errors) {
                 switch (error.keyword) {
+                    case 'type':
                     case 'oneOf':
                     case 'anyOf':
                         // these errors are not shown in the leaf field, e.g. in blocks and similar constructs

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -30,7 +30,6 @@
     "sulu_admin.error_minlength": "Die minimale Länge dieses Feldes wurde unterschritten",
     "sulu_admin.error_minitems": "Dieses Feld hat zu wenig Zuweisungen",
     "sulu_admin.error_maxitems": "Dieses Feld hat zu viele Zuweisungen",
-    "sulu_admin.error_type": "Ein Fehler ist aufgetreten",
     "sulu_admin.welcome": "Willkommen",
     "sulu_admin.reset_password": "Passwort zurücksetzen",
     "sulu_admin.reset_password_error": "Die Passwörter stimmen nicht überein",

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -30,7 +30,6 @@
     "sulu_admin.error_minlength": "The minimal length of this field was undershot",
     "sulu_admin.error_minitems": "This field has too few selections",
     "sulu_admin.error_maxitems": "This field has too many selections",
-    "sulu_admin.error_type": "An error occurred",
     "sulu_admin.welcome": "Welcome",
     "sulu_admin.reset_password": "Reset password",
     "sulu_admin.reset_password_error": "The passwords do not match",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Skip json schema "type" validation errors.

#### Why?

Because there is always a more specific error behind the `type` error
