### PR TITLE
Add json schema validation for teaser_selection field type

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -17,7 +17,11 @@ The metadata classes in the `Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata` na
 
 * Various new metadata classes (like `ObjectMetadata`, `StringMetadata`, `NumberMetadata`, ...) have been introduced to allow better schema definitions of a property.
 
-### The constructor of the `MediaSelectionContentType` requires a new `$propertyMetadataMinMaxValueResolver` for full functionality
+### The constructor of the `TeaserContentType` requires a new `$propertyMetadataMinMaxValueResolver` argument for full functionality
+
+Without this service, `min` and `max` parameters of a `teaser_selection` property will not work.
+
+### The constructor of the `MediaSelectionContentType` requires a new `$propertyMetadataMinMaxValueResolver` argument for full functionality
 
 Without this service, `min` and `max` parameters of a `media_selection` property will not work.
 

--- a/config/templates/pages/example.xml
+++ b/config/templates/pages/example.xml
@@ -282,6 +282,26 @@
                 <title lang="en">Teaser Selection</title>
                 <title lang="de">Anreiser</title>
             </meta>
+
+            <params>
+                <param name="min" value="1"/>
+                <param name="max" value="1"/>
+
+                <param name="present_as" type="collection">
+                    <param name="three-columns">
+                        <meta>
+                            <title lang="en">3 Columns</title>
+                            <title lang="de">3 Spalten</title>
+                        </meta>
+                    </param>
+                    <param name="five-columns">
+                        <meta>
+                            <title lang="en">5 Columns</title>
+                            <title lang="de">5 Spalten</title>
+                        </meta>
+                    </param>
+                </param>
+            </params>
         </property>
 
         <property name="smart_content" type="smart_content">
@@ -331,6 +351,11 @@
                 <title lang="en">Media Selection</title>
                 <title lang="de">Medien</title>
             </meta>
+
+            <params>
+                <param name="min" value="2"/>
+                <param name="max" value="3"/>
+            </params>
         </property>
 
         <property name="single_account_selection" type="single_account_selection">

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/button.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/button.scss
@@ -35,6 +35,7 @@ $buttonMargin: 2px;
         }
 
         &.has-label {
+            align-items: center;
             display: flex;
             padding: 0 10px;
             width: auto;

--- a/src/Sulu/Bundle/PageBundle/Resources/config/teaser.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/teaser.xml
@@ -27,9 +27,11 @@
             <argument type="service" id="sulu_page.teaser.provider_pool"/>
             <argument type="service" id="sulu_page.teaser.manager"/>
             <argument type="service" id="sulu_website.reference_store_pool"/>
+            <argument type="service" id="sulu_admin.property_metadata_min_max_value_resolver" on-invalid="null"/>
 
             <tag name="sulu.content.type" alias="teaser_selection"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
+            <tag name="sulu_admin.property_metadata_mapper" type="teaser_selection" />
         </service>
 
         <!-- serialization -->

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/fields/TeaserSelection.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/fields/TeaserSelection.js
@@ -39,8 +39,15 @@ class TeaserSelection extends React.Component<FieldTypeProps<TeaserSelectionValu
         );
     };
 
+    handleTeaserSelectionChange = (value: TeaserSelectionValue) => {
+        const {onChange, onFinish} = this.props;
+
+        onChange(value);
+        onFinish();
+    };
+
     render() {
-        const {disabled, onChange, schemaOptions = {}, value} = this.props;
+        const {disabled, schemaOptions = {}, value} = this.props;
 
         const {
             present_as: {
@@ -75,7 +82,7 @@ class TeaserSelection extends React.Component<FieldTypeProps<TeaserSelectionValu
             <TeaserSelectionComponent
                 disabled={disabled === null ? undefined : disabled}
                 locale={this.locale}
-                onChange={onChange}
+                onChange={this.handleTeaserSelectionChange}
                 onItemClick={this.handleItemClick}
                 presentations={presentations.length > 0 ? presentations : undefined}
                 value={value === null ? undefined : value}

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/tests/fields/TeaserSelection.test.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/tests/fields/TeaserSelection.test.js
@@ -6,6 +6,7 @@ import {FormInspector, ResourceFormStore} from 'sulu-admin-bundle/containers';
 import {ResourceStore, userStore} from 'sulu-admin-bundle/stores';
 import {fieldTypeDefaultProps} from 'sulu-admin-bundle/utils/TestHelper';
 import {Router} from 'sulu-admin-bundle/services';
+import Selection from 'sulu-admin-bundle/containers/Form/fields/Selection';
 import TeaserSelection from '../../fields/TeaserSelection';
 import TeaserSelectionComponent from '../../../../containers/TeaserSelection';
 import teaserProviderRegistry from '../../../../containers/TeaserSelection/registries/teaserProviderRegistry';
@@ -68,7 +69,6 @@ test('Pass props correctly to component', () => {
 
     expect(field.find(TeaserSelectionComponent).prop('disabled')).toEqual(false);
     expect(field.find(TeaserSelectionComponent).prop('locale').get()).toEqual('en');
-    expect(field.find(TeaserSelectionComponent).prop('onChange')).toBe(changeSpy);
     expect(field.find(TeaserSelectionComponent).prop('presentations')).toBe(undefined);
     expect(field.find(TeaserSelectionComponent).prop('value')).toBe(value);
 });
@@ -195,4 +195,33 @@ test('Throw error if present_as schemaOption is from wrong type', () => {
             <TeaserSelection {...fieldTypeDefaultProps} formInspector={formInspector} schemaOptions={schemaOptions} />
         )
     ).toThrow(/present_as/);
+});
+
+test('Should call onChange and onFinish callback when TeaserSelection container fires onChange callback', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'snippets'));
+    // $FlowFixMe
+    userStore.contentLocale = 'de';
+
+    const changeSpy = jest.fn();
+    const finishSpy = jest.fn();
+
+    const field = shallow(
+        <TeaserSelection
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            onChange={changeSpy}
+            onFinish={finishSpy}
+        />
+    );
+
+    field.find(TeaserSelectionComponent).prop('onChange')({
+        presentAs: undefined,
+        items: [],
+    });
+
+    expect(changeSpy).toBeCalledWith({
+        presentAs: undefined,
+        items: [],
+    });
+    expect(finishSpy).toBeCalledWith();
 });

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/tests/fields/TeaserSelection.test.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/tests/fields/TeaserSelection.test.js
@@ -6,7 +6,6 @@ import {FormInspector, ResourceFormStore} from 'sulu-admin-bundle/containers';
 import {ResourceStore, userStore} from 'sulu-admin-bundle/stores';
 import {fieldTypeDefaultProps} from 'sulu-admin-bundle/utils/TestHelper';
 import {Router} from 'sulu-admin-bundle/services';
-import Selection from 'sulu-admin-bundle/containers/Form/fields/Selection';
 import TeaserSelection from '../../fields/TeaserSelection';
 import TeaserSelectionComponent from '../../../../containers/TeaserSelection';
 import teaserProviderRegistry from '../../../../containers/TeaserSelection/registries/teaserProviderRegistry';

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Teaser/TeaserContentTypeTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Teaser/TeaserContentTypeTest.php
@@ -192,6 +192,36 @@ class TeaserContentTypeTest extends TestCase
         ];
     }
 
+    private function getTeaserItemSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'id' => [
+                    'type' => 'string',
+                    'name' => 'id',
+                ],
+                'type' => [
+                    'type' => 'string',
+                    'name' => 'type',
+                ],
+                'title' => [
+                    'type' => 'string',
+                    'name' => 'title',
+                ],
+                'description' => [
+                    'type' => 'string',
+                    'name' => 'description',
+                ],
+                'mediaId' => [
+                    'type' => 'number',
+                    'name' => 'mediaId',
+                ],
+            ],
+            'required' => ['id', 'type'],
+        ];
+    }
+
     public function testMapPropertyMetadata(): void
     {
         $propertyMetadata = new PropertyMetadata();
@@ -211,32 +241,7 @@ class TeaserContentTypeTest extends TestCase
                                 $this->getEmptyArraySchema(),
                                 [
                                     'type' => 'array',
-                                    'items' => [
-                                        'type' => 'object',
-                                        'properties' => [
-                                            'id' => [
-                                                'type' => 'string',
-                                                'name' => 'id',
-                                            ],
-                                            'type' => [
-                                                'type' => 'string',
-                                                'name' => 'type',
-                                            ],
-                                            'title' => [
-                                                'type' => 'string',
-                                                'name' => 'title',
-                                            ],
-                                            'description' => [
-                                                'type' => 'string',
-                                                'name' => 'description',
-                                            ],
-                                            'mediaId' => [
-                                                'type' => 'number',
-                                                'name' => 'mediaId',
-                                            ],
-                                        ],
-                                        'required' => ['id', 'type'],
-                                    ],
+                                    'items' => $this->getTeaserItemSchema(),
                                     'uniqueItems' => true,
                                 ],
                             ],
@@ -265,37 +270,18 @@ class TeaserContentTypeTest extends TestCase
             'type' => 'object',
             'properties' => [
                 'items' => [
-                    'type' => 'object',
-                    'properties' => [
-                        'id' => [
-                            'type' => 'string',
-                            'name' => 'id',
-                        ],
-                        'type' => [
-                            'type' => 'string',
-                            'name' => 'type',
-                        ],
-                        'title' => [
-                            'type' => 'string',
-                            'name' => 'title',
-                        ],
-                        'description' => [
-                            'type' => 'string',
-                            'name' => 'description',
-                        ],
-                        'mediaId' => [
-                            'type' => 'number',
-                            'name' => 'mediaId',
-                        ],
-                    ],
-                    'required' => ['id', 'type'],
+                    'type' => 'array',
+                    'items' => $this->getTeaserItemSchema(),
+                    'minItems' => 1,
+                    'uniqueItems' => true,
+                    'name' => 'items',
                 ],
                 'presentAs' => [
                     'type' => 'string',
                     'name' => 'presentAs',
                 ],
             ],
-            'required' => ['ids'],
+            'required' => ['items'],
         ], $jsonSchema);
     }
 
@@ -322,32 +308,7 @@ class TeaserContentTypeTest extends TestCase
                                 $this->getEmptyArraySchema(),
                                 [
                                     'type' => 'array',
-                                    'items' => [
-                                        'type' => 'object',
-                                        'properties' => [
-                                            'id' => [
-                                                'type' => 'string',
-                                                'name' => 'id',
-                                            ],
-                                            'type' => [
-                                                'type' => 'string',
-                                                'name' => 'type',
-                                            ],
-                                            'title' => [
-                                                'type' => 'string',
-                                                'name' => 'title',
-                                            ],
-                                            'description' => [
-                                                'type' => 'string',
-                                                'name' => 'description',
-                                            ],
-                                            'mediaId' => [
-                                                'type' => 'number',
-                                                'name' => 'mediaId',
-                                            ],
-                                        ],
-                                        'required' => ['id', 'type'],
-                                    ],
+                                    'items' => $this->getTeaserItemSchema(),
                                     'minItems' => 2,
                                     'maxItems' => 3,
                                     'uniqueItems' => true,
@@ -387,32 +348,7 @@ class TeaserContentTypeTest extends TestCase
                                 $this->getEmptyArraySchema(),
                                 [
                                     'type' => 'array',
-                                    'items' => [
-                                        'type' => 'object',
-                                        'properties' => [
-                                            'id' => [
-                                                'type' => 'string',
-                                                'name' => 'id',
-                                            ],
-                                            'type' => [
-                                                'type' => 'string',
-                                                'name' => 'type',
-                                            ],
-                                            'title' => [
-                                                'type' => 'string',
-                                                'name' => 'title',
-                                            ],
-                                            'description' => [
-                                                'type' => 'string',
-                                                'name' => 'description',
-                                            ],
-                                            'mediaId' => [
-                                                'type' => 'number',
-                                                'name' => 'mediaId',
-                                            ],
-                                        ],
-                                        'required' => ['id', 'type'],
-                                    ],
+                                    'items' => $this->getTeaserItemSchema(),
                                     'minItems' => 2,
                                     'uniqueItems' => true,
                                 ],
@@ -451,32 +387,7 @@ class TeaserContentTypeTest extends TestCase
                                 $this->getEmptyArraySchema(),
                                 [
                                     'type' => 'array',
-                                    'items' => [
-                                        'type' => 'object',
-                                        'properties' => [
-                                            'id' => [
-                                                'type' => 'string',
-                                                'name' => 'id',
-                                            ],
-                                            'type' => [
-                                                'type' => 'string',
-                                                'name' => 'type',
-                                            ],
-                                            'title' => [
-                                                'type' => 'string',
-                                                'name' => 'title',
-                                            ],
-                                            'description' => [
-                                                'type' => 'string',
-                                                'name' => 'description',
-                                            ],
-                                            'mediaId' => [
-                                                'type' => 'number',
-                                                'name' => 'mediaId',
-                                            ],
-                                        ],
-                                        'required' => ['id', 'type'],
-                                    ],
+                                    'items' => $this->getTeaserItemSchema(),
                                     'maxItems' => 2,
                                     'uniqueItems' => true,
                                 ],
@@ -516,32 +427,7 @@ class TeaserContentTypeTest extends TestCase
                                 $this->getEmptyArraySchema(),
                                 [
                                     'type' => 'array',
-                                    'items' => [
-                                        'type' => 'object',
-                                        'properties' => [
-                                            'id' => [
-                                                'type' => 'string',
-                                                'name' => 'id',
-                                            ],
-                                            'type' => [
-                                                'type' => 'string',
-                                                'name' => 'type',
-                                            ],
-                                            'title' => [
-                                                'type' => 'string',
-                                                'name' => 'title',
-                                            ],
-                                            'description' => [
-                                                'type' => 'string',
-                                                'name' => 'description',
-                                            ],
-                                            'mediaId' => [
-                                                'type' => 'number',
-                                                'name' => 'mediaId',
-                                            ],
-                                        ],
-                                        'required' => ['id', 'type'],
-                                    ],
+                                    'items' => $this->getTeaserItemSchema(),
                                     'minItems' => 2,
                                     'maxItems' => 3,
                                     'uniqueItems' => true,

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Teaser/TeaserContentTypeTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Teaser/TeaserContentTypeTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\PageBundle\Tests\Unit\Teaser;
 
 use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMinMaxValueResolver;
 use Sulu\Bundle\PageBundle\Teaser\Configuration\TeaserConfiguration;
 use Sulu\Bundle\PageBundle\Teaser\Provider\TeaserProviderPoolInterface;
 use Sulu\Bundle\PageBundle\Teaser\Teaser;
@@ -23,6 +24,7 @@ use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStorePoolInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Content\Compat\StructureInterface;
+use Sulu\Component\Content\Metadata\PropertyMetadata;
 
 class TeaserContentTypeTest extends TestCase
 {
@@ -63,7 +65,8 @@ class TeaserContentTypeTest extends TestCase
         $this->contentType = new TeaserContentType(
             $this->teaserProviderPool->reveal(),
             $this->teaserManager->reveal(),
-            $this->referenceStorePool->reveal()
+            $this->referenceStorePool->reveal(),
+            new PropertyMetadataMinMaxValueResolver()
         );
     }
 
@@ -171,5 +174,468 @@ class TeaserContentTypeTest extends TestCase
 
         $articleStore->add(1)->shouldBeCalled();
         $contentStore->add(3)->shouldBeCalled();
+    }
+
+    private function getNullSchema(): array
+    {
+        return [
+            'type' => 'null',
+        ];
+    }
+
+    private function getEmptyArraySchema(): array
+    {
+        return [
+            'type' => 'array',
+            'items' => ['required' => []],
+            'maxItems' => 0,
+        ];
+    }
+
+    public function testMapPropertyMetadata(): void
+    {
+        $propertyMetadata = new PropertyMetadata();
+        $propertyMetadata->setName('property-name');
+
+        $jsonSchema = $this->contentType->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+
+        $this->assertEquals([
+            'name' => 'property-name',
+            'anyOf' => [
+                $this->getNullSchema(),
+                [
+                    'type' => 'object',
+                    'properties' => [
+                        'items' => [
+                            'anyOf' => [
+                                $this->getEmptyArraySchema(),
+                                [
+                                    'type' => 'array',
+                                    'items' => [
+                                        'type' => 'object',
+                                        'properties' => [
+                                            'id' => [
+                                                'type' => 'string',
+                                                'name' => 'id',
+                                            ],
+                                            'type' => [
+                                                'type' => 'string',
+                                                'name' => 'type',
+                                            ],
+                                            'title' => [
+                                                'type' => 'string',
+                                                'name' => 'title',
+                                            ],
+                                            'description' => [
+                                                'type' => 'string',
+                                                'name' => 'description',
+                                            ],
+                                            'mediaId' => [
+                                                'type' => 'number',
+                                                'name' => 'mediaId',
+                                            ],
+                                        ],
+                                        'required' => ['id', 'type'],
+                                    ],
+                                    'uniqueItems' => true,
+                                ],
+                            ],
+                            'name' => 'items',
+                        ],
+                        'presentAs' => [
+                            'type' => 'string',
+                            'name' => 'presentAs',
+                        ],
+                    ],
+                ],
+            ],
+        ], $jsonSchema);
+    }
+
+    public function testMapPropertyMetadataRequired(): void
+    {
+        $propertyMetadata = new PropertyMetadata();
+        $propertyMetadata->setName('property-name');
+        $propertyMetadata->setRequired(true);
+
+        $jsonSchema = $this->contentType->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+
+        $this->assertEquals([
+            'name' => 'property-name',
+            'type' => 'object',
+            'properties' => [
+                'items' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'id' => [
+                            'type' => 'string',
+                            'name' => 'id',
+                        ],
+                        'type' => [
+                            'type' => 'string',
+                            'name' => 'type',
+                        ],
+                        'title' => [
+                            'type' => 'string',
+                            'name' => 'title',
+                        ],
+                        'description' => [
+                            'type' => 'string',
+                            'name' => 'description',
+                        ],
+                        'mediaId' => [
+                            'type' => 'number',
+                            'name' => 'mediaId',
+                        ],
+                    ],
+                    'required' => ['id', 'type'],
+                ],
+                'presentAs' => [
+                    'type' => 'string',
+                    'name' => 'presentAs',
+                ],
+            ],
+            'required' => ['ids'],
+        ], $jsonSchema);
+    }
+
+    public function testMapPropertyMetadataMinAndMax(): void
+    {
+        $propertyMetadata = new PropertyMetadata();
+        $propertyMetadata->setName('property-name');
+        $propertyMetadata->setParameters([
+            ['name' => 'min', 'value' => 2],
+            ['name' => 'max', 'value' => 3],
+        ]);
+
+        $jsonSchema = $this->contentType->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+
+        $this->assertEquals([
+            'name' => 'property-name',
+            'anyOf' => [
+                $this->getNullSchema(),
+                [
+                    'type' => 'object',
+                    'properties' => [
+                        'items' => [
+                            'anyOf' => [
+                                $this->getEmptyArraySchema(),
+                                [
+                                    'type' => 'array',
+                                    'items' => [
+                                        'type' => 'object',
+                                        'properties' => [
+                                            'id' => [
+                                                'type' => 'string',
+                                                'name' => 'id',
+                                            ],
+                                            'type' => [
+                                                'type' => 'string',
+                                                'name' => 'type',
+                                            ],
+                                            'title' => [
+                                                'type' => 'string',
+                                                'name' => 'title',
+                                            ],
+                                            'description' => [
+                                                'type' => 'string',
+                                                'name' => 'description',
+                                            ],
+                                            'mediaId' => [
+                                                'type' => 'number',
+                                                'name' => 'mediaId',
+                                            ],
+                                        ],
+                                        'required' => ['id', 'type'],
+                                    ],
+                                    'minItems' => 2,
+                                    'maxItems' => 3,
+                                    'uniqueItems' => true,
+                                ],
+                            ],
+                            'name' => 'items',
+                        ],
+                        'presentAs' => [
+                            'type' => 'string',
+                            'name' => 'presentAs',
+                        ],
+                    ],
+                ],
+            ],
+        ], $jsonSchema);
+    }
+
+    public function testMapPropertyMetadataMinAndMaxMinOnly(): void
+    {
+        $propertyMetadata = new PropertyMetadata();
+        $propertyMetadata->setName('property-name');
+        $propertyMetadata->setParameters([
+            ['name' => 'min', 'value' => 2],
+        ]);
+
+        $jsonSchema = $this->contentType->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+
+        $this->assertEquals([
+            'name' => 'property-name',
+            'anyOf' => [
+                $this->getNullSchema(),
+                [
+                    'type' => 'object',
+                    'properties' => [
+                        'items' => [
+                            'anyOf' => [
+                                $this->getEmptyArraySchema(),
+                                [
+                                    'type' => 'array',
+                                    'items' => [
+                                        'type' => 'object',
+                                        'properties' => [
+                                            'id' => [
+                                                'type' => 'string',
+                                                'name' => 'id',
+                                            ],
+                                            'type' => [
+                                                'type' => 'string',
+                                                'name' => 'type',
+                                            ],
+                                            'title' => [
+                                                'type' => 'string',
+                                                'name' => 'title',
+                                            ],
+                                            'description' => [
+                                                'type' => 'string',
+                                                'name' => 'description',
+                                            ],
+                                            'mediaId' => [
+                                                'type' => 'number',
+                                                'name' => 'mediaId',
+                                            ],
+                                        ],
+                                        'required' => ['id', 'type'],
+                                    ],
+                                    'minItems' => 2,
+                                    'uniqueItems' => true,
+                                ],
+                            ],
+                            'name' => 'items',
+                        ],
+                        'presentAs' => [
+                            'type' => 'string',
+                            'name' => 'presentAs',
+                        ],
+                    ],
+                ],
+            ],
+        ], $jsonSchema);
+    }
+
+    public function testMapPropertyMetadataMinAndMaxMaxOnly(): void
+    {
+        $propertyMetadata = new PropertyMetadata();
+        $propertyMetadata->setName('property-name');
+        $propertyMetadata->setParameters([
+            ['name' => 'max', 'value' => 2],
+        ]);
+
+        $jsonSchema = $this->contentType->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+
+        $this->assertEquals([
+            'name' => 'property-name',
+            'anyOf' => [
+                $this->getNullSchema(),
+                [
+                    'type' => 'object',
+                    'properties' => [
+                        'items' => [
+                            'anyOf' => [
+                                $this->getEmptyArraySchema(),
+                                [
+                                    'type' => 'array',
+                                    'items' => [
+                                        'type' => 'object',
+                                        'properties' => [
+                                            'id' => [
+                                                'type' => 'string',
+                                                'name' => 'id',
+                                            ],
+                                            'type' => [
+                                                'type' => 'string',
+                                                'name' => 'type',
+                                            ],
+                                            'title' => [
+                                                'type' => 'string',
+                                                'name' => 'title',
+                                            ],
+                                            'description' => [
+                                                'type' => 'string',
+                                                'name' => 'description',
+                                            ],
+                                            'mediaId' => [
+                                                'type' => 'number',
+                                                'name' => 'mediaId',
+                                            ],
+                                        ],
+                                        'required' => ['id', 'type'],
+                                    ],
+                                    'maxItems' => 2,
+                                    'uniqueItems' => true,
+                                ],
+                            ],
+                            'name' => 'items',
+                        ],
+                        'presentAs' => [
+                            'type' => 'string',
+                            'name' => 'presentAs',
+                        ],
+                    ],
+                ],
+            ],
+        ], $jsonSchema);
+    }
+
+    public function testMapPropertyMetadataMinAndMaxWithIntegerishValues(): void
+    {
+        $propertyMetadata = new PropertyMetadata();
+        $propertyMetadata->setName('property-name');
+        $propertyMetadata->setParameters([
+            ['name' => 'min', 'value' => '2'],
+            ['name' => 'max', 'value' => '3'],
+        ]);
+
+        $jsonSchema = $this->contentType->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+
+        $this->assertEquals([
+            'name' => 'property-name',
+            'anyOf' => [
+                $this->getNullSchema(),
+                [
+                    'type' => 'object',
+                    'properties' => [
+                        'items' => [
+                            'anyOf' => [
+                                $this->getEmptyArraySchema(),
+                                [
+                                    'type' => 'array',
+                                    'items' => [
+                                        'type' => 'object',
+                                        'properties' => [
+                                            'id' => [
+                                                'type' => 'string',
+                                                'name' => 'id',
+                                            ],
+                                            'type' => [
+                                                'type' => 'string',
+                                                'name' => 'type',
+                                            ],
+                                            'title' => [
+                                                'type' => 'string',
+                                                'name' => 'title',
+                                            ],
+                                            'description' => [
+                                                'type' => 'string',
+                                                'name' => 'description',
+                                            ],
+                                            'mediaId' => [
+                                                'type' => 'number',
+                                                'name' => 'mediaId',
+                                            ],
+                                        ],
+                                        'required' => ['id', 'type'],
+                                    ],
+                                    'minItems' => 2,
+                                    'maxItems' => 3,
+                                    'uniqueItems' => true,
+                                ],
+                            ],
+                            'name' => 'items',
+                        ],
+                        'presentAs' => [
+                            'type' => 'string',
+                            'name' => 'presentAs',
+                        ],
+                    ],
+                ],
+            ],
+        ], $jsonSchema);
+    }
+
+    public function testMapPropertyMetadataMinAndMaxMinInvalidType(): void
+    {
+        $this->expectExceptionMessage('Parameter "min" of property "property-name" needs to be either null or of type int');
+
+        $propertyMetadata = new PropertyMetadata();
+        $propertyMetadata->setName('property-name');
+        $propertyMetadata->setParameters([
+            ['name' => 'min', 'value' => 'invalid-value'],
+        ]);
+
+        $this->contentType->mapPropertyMetadata($propertyMetadata);
+    }
+
+    public function testMapPropertyMetadataMinAndMaxMinTooLow(): void
+    {
+        $this->expectExceptionMessage('Parameter "min" of property "property-name" needs to be greater than or equal "0"');
+
+        $propertyMetadata = new PropertyMetadata();
+        $propertyMetadata->setName('property-name');
+        $propertyMetadata->setParameters([
+            ['name' => 'min', 'value' => -1],
+        ]);
+
+        $this->contentType->mapPropertyMetadata($propertyMetadata);
+    }
+
+    public function testMapPropertyMetadataMinAndMaxMandatoryMinTooLow(): void
+    {
+        $this->expectExceptionMessage('Because property "property-name" is mandatory, parameter "min" needs to be greater than or equal "1"');
+
+        $propertyMetadata = new PropertyMetadata();
+        $propertyMetadata->setName('property-name');
+        $propertyMetadata->setRequired(true);
+        $propertyMetadata->setParameters([
+            ['name' => 'min', 'value' => 0],
+        ]);
+
+        $this->contentType->mapPropertyMetadata($propertyMetadata);
+    }
+
+    public function testMapPropertyMetadataMinAndMaxMaxInvalidType(): void
+    {
+        $this->expectExceptionMessage('Parameter "max" of property "property-name" needs to be either null or of type int');
+
+        $propertyMetadata = new PropertyMetadata();
+        $propertyMetadata->setName('property-name');
+        $propertyMetadata->setParameters([
+            ['name' => 'max', 'value' => 'invalid-value'],
+        ]);
+
+        $this->contentType->mapPropertyMetadata($propertyMetadata);
+    }
+
+    public function testMapPropertyMetadataMinAndMaxMaxTooLow(): void
+    {
+        $this->expectExceptionMessage('Parameter "max" of property "property-name" needs to be greater than or equal "1"');
+
+        $propertyMetadata = new PropertyMetadata();
+        $propertyMetadata->setName('property-name');
+        $propertyMetadata->setParameters([
+            ['name' => 'max', 'value' => 0],
+        ]);
+
+        $this->contentType->mapPropertyMetadata($propertyMetadata);
+    }
+
+    public function testMapPropertyMetadataMinAndMaxMaxLowerThanMin(): void
+    {
+        $this->expectExceptionMessage('Because parameter "min" of property "property-name" has value "2", parameter "max" needs to be greater than or equal "2"');
+
+        $propertyMetadata = new PropertyMetadata();
+        $propertyMetadata->setName('property-name');
+        $propertyMetadata->setParameters([
+            ['name' => 'min', 'value' => 2],
+            ['name' => 'max', 'value' => 1],
+        ]);
+
+        $this->contentType->mapPropertyMetadata($propertyMetadata);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add json schema validation for `min` and `max` parameters of the `teaser_selection` field type
