### PR TITLE
Add new Toolbar.Popover component to display anything in a Toolbar

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Dropdown.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Dropdown.js
@@ -1,59 +1,20 @@
 // @flow
 import React from 'react';
-import type {ElementRef} from 'react';
-import {action, observable} from 'mobx';
 import {observer} from 'mobx-react';
-import classNames from 'classnames';
-import Popover from '../Popover';
 import type {DropdownOption, Dropdown as DropdownProps} from './types';
-import Button from './Button';
+import Popover from './Popover';
 import OptionList from './OptionList';
-import dropdownStyles from './dropdown.scss';
 
 @observer
 class Dropdown extends React.Component<DropdownProps> {
-    @observable open: boolean = false;
-
     static defaultProps = {
         showText: true,
-    };
-
-    @observable buttonRef: ?ElementRef<'button'>;
-
-    @action setButtonRef = (ref: ?ElementRef<'button'>) => {
-        if (ref) {
-            this.buttonRef = ref;
-        }
-    };
-
-    @action close = () => {
-        this.open = false;
-    };
-
-    @action toggle = () => {
-        this.open = !this.open;
-    };
-
-    componentDidUpdate() {
-        const {disabled} = this.props;
-
-        if (disabled) {
-            this.close();
-        }
-    }
-
-    handleButtonClick = () => {
-        this.toggle();
     };
 
     handleOptionListClick = (option: DropdownOption) => {
         if (option.onClick) {
             option.onClick();
         }
-    };
-
-    handleOptionListClose = () => {
-        this.close();
     };
 
     render() {
@@ -67,48 +28,27 @@ class Dropdown extends React.Component<DropdownProps> {
             loading,
             showText,
         } = this.props;
-        const dropdownClass = classNames(
-            dropdownStyles.dropdown,
-            {
-                [dropdownStyles[size]]: size,
-            }
-        );
 
         const allChildrenDisabled = options.every((option) => option.disabled);
 
         return (
-            <div className={dropdownClass}>
-                <Button
-                    active={this.open}
-                    buttonRef={this.setButtonRef}
-                    disabled={disabled || allChildrenDisabled}
-                    hasOptions={true}
-                    icon={icon}
-                    label={showText ? label : undefined}
-                    loading={loading}
-                    onClick={this.handleButtonClick}
-                    size={size}
-                    skin={skin}
-                />
-                <Popover
-                    anchorElement={this.buttonRef}
-                    onClose={this.handleOptionListClose}
-                    open={this.open}
-                >
-                    {
-                        (setPopoverElementRef, popoverStyle) => (
-                            <div ref={setPopoverElementRef} style={popoverStyle}>
-                                <OptionList
-                                    onClose={this.handleOptionListClose}
-                                    onOptionClick={this.handleOptionListClick}
-                                    options={options}
-                                    skin={skin}
-                                />
-                            </div>
-                        )
-                    }
-                </Popover>
-            </div>
+            <Popover
+                disabled={disabled || allChildrenDisabled}
+                icon={icon}
+                label={showText ? label : undefined}
+                loading={loading}
+                size={size}
+                skin={skin}
+            >
+                {(onClose) => (
+                    <OptionList
+                        onClose={onClose}
+                        onOptionClick={this.handleOptionListClick}
+                        options={options}
+                        skin={skin}
+                    />
+                )}
+            </Popover>
         );
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Popover.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Popover.js
@@ -1,0 +1,104 @@
+// @flow
+import React from 'react';
+import type {ElementRef} from 'react';
+import {action, observable} from 'mobx';
+import {observer} from 'mobx-react';
+import classNames from 'classnames';
+import PopoverComponent from '../Popover';
+import type {Popover as PopoverProps} from './types';
+import Button from './Button';
+import popoverStyles from './popover.scss';
+
+@observer
+class Popover extends React.Component<PopoverProps> {
+    @observable open: boolean = false;
+
+    static defaultProps = {
+        showText: true,
+    };
+
+    @observable buttonRef: ?ElementRef<'button'>;
+
+    @action setButtonRef = (ref: ?ElementRef<'button'>) => {
+        if (ref) {
+            this.buttonRef = ref;
+        }
+    };
+
+    @action close = () => {
+        this.open = false;
+    };
+
+    @action toggle = () => {
+        this.open = !this.open;
+    };
+
+    componentDidUpdate() {
+        const {disabled} = this.props;
+
+        if (disabled) {
+            this.close();
+        }
+    }
+
+    handleButtonClick = () => {
+        this.toggle();
+    };
+
+    handlePopoverClose = () => {
+        this.close();
+    };
+
+    render() {
+        const {
+            children,
+            className,
+            icon,
+            size,
+            skin,
+            label,
+            disabled,
+            loading,
+            showText,
+        } = this.props;
+        const popoverClass = classNames(
+            className,
+            popoverStyles.popover,
+            {
+                [popoverStyles[size]]: size,
+            }
+        );
+
+        return (
+            <div className={popoverClass}>
+                <Button
+                    active={this.open}
+                    buttonRef={this.setButtonRef}
+                    disabled={disabled}
+                    hasOptions={true}
+                    icon={icon}
+                    label={showText ? label : undefined}
+                    loading={loading}
+                    onClick={this.handleButtonClick}
+                    size={size}
+                    skin={skin}
+                />
+                <PopoverComponent
+                    anchorElement={this.buttonRef}
+                    onClose={this.handlePopoverClose}
+                    open={this.open}
+                >
+                    {
+                        (setPopoverElementRef, popoverStyle) => (
+                            <div ref={setPopoverElementRef} style={popoverStyle}>
+                                {children(this.close)}
+                            </div>
+                        )
+                    }
+                </PopoverComponent>
+            </div>
+        );
+    }
+}
+
+export default Popover;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Popover.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Popover.js
@@ -90,7 +90,7 @@ class Popover extends React.Component<PopoverProps> {
                 >
                     {
                         (setPopoverElementRef, popoverStyle) => (
-                            <div ref={setPopoverElementRef} style={popoverStyle}>
+                            <div className={popoverStyles[skin]} ref={setPopoverElementRef} style={popoverStyle}>
                                 {children(this.close)}
                             </div>
                         )

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/README.md
@@ -1,5 +1,6 @@
 The `Toolbar` component serves as container for `Controls`. The `Controls` component groups components which provide
-the user interaction like `Button`, `Select` or `Dropdown`.
+the user interaction like `Button`, `Toggler`, `Select` or `Dropdown`. Additionally the `Popover` component exists,
+which shows a button that hides the return value of the `children` prop and shows it on a click.
 
 ```javascript
 <Toolbar>
@@ -38,6 +39,9 @@ component you can group the items by using the `Items` component.
         </Toolbar.Items>
     </Toolbar.Controls>
     <Toolbar.Controls>
+        <Toolbar.Popover label="Show content">
+            {() => 'Content'}
+        </Toolbar.Popover>
         <Toolbar.Select 
             label="Chose an option" 
             onClick={() => null}
@@ -78,6 +82,9 @@ The appearance of the `Toolbar` can be changed by passing the attribute `skin`. 
         </Toolbar.Items>
     </Toolbar.Controls>
     <Toolbar.Controls>
+        <Toolbar.Popover label="Show content">
+            {() => 'Content'}
+        </Toolbar.Popover>
         <Toolbar.Select 
             label="Chose an option" 
             onClick={() => null}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Select.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Select.js
@@ -1,37 +1,15 @@
 // @flow
 import React from 'react';
-import type {ElementRef} from 'react';
-import {action, computed, observable} from 'mobx';
+import {computed} from 'mobx';
 import {observer} from 'mobx-react';
-import classNames from 'classnames';
-import Popover from '../Popover';
+import Popover from './Popover';
 import type {SelectOption, Select as SelectProps} from './types';
-import Button from './Button';
 import OptionList from './OptionList';
-import selectStyles from './select.scss';
 
 @observer
 class Select<T: ?string | number> extends React.Component<SelectProps<T>> {
-    @observable open: boolean = false;
-
     static defaultProps = {
         showText: true,
-    };
-
-    @observable buttonRef: ?ElementRef<'button'>;
-
-    @action setButtonRef = (ref: ?ElementRef<'button'>) => {
-        if (ref) {
-            this.buttonRef = ref;
-        }
-    };
-
-    @action close = () => {
-        this.open = false;
-    };
-
-    @action toggle = () => {
-        this.open = !this.open;
     };
 
     @computed get selectedOption(): ?Object {
@@ -40,85 +18,47 @@ class Select<T: ?string | number> extends React.Component<SelectProps<T>> {
         });
     }
 
-    componentDidUpdate() {
-        const {disabled} = this.props;
-
-        if (disabled) {
-            this.close();
-        }
-    }
-
-    handleButtonClick = () => {
-        this.toggle();
-    };
-
     handleOptionClick = (option: SelectOption<T>) => {
         this.props.onChange(option.value);
     };
 
-    handleOptionListClose = () => {
-        this.close();
-    };
-
     render() {
         const {
-            icon,
-            size,
-            value,
-            label,
-            options,
+            className,
             disabled,
+            icon,
+            label,
             loading,
-            className,
-            skin,
+            options,
             showText,
+            size,
+            skin,
+            value,
         } = this.props;
+
         const buttonValue = this.selectedOption ? this.selectedOption.label : label;
-        const selectClass = classNames(
-            className,
-            selectStyles.select,
-            {
-                [selectStyles[size]]: size,
-                [selectStyles[skin]]: skin,
-            }
-        );
 
         return (
-            <div className={selectClass}>
-                <Button
-                    active={this.open}
-                    buttonRef={this.setButtonRef}
-                    disabled={disabled}
-                    hasOptions={true}
-                    icon={icon}
-                    label={showText ? buttonValue : undefined}
-                    loading={loading}
-                    onClick={this.handleButtonClick}
-                    size={size}
-                    skin={skin}
-                />
-
-                <Popover
-                    anchorElement={this.buttonRef}
-                    onClose={this.handleOptionListClose}
-                    open={this.open}
-                >
-                    {
-                        (setPopoverElementRef, popoverStyle) => (
-                            <div ref={setPopoverElementRef} style={popoverStyle}>
-                                <OptionList
-                                    onClose={this.handleOptionListClose}
-                                    onOptionClick={this.handleOptionClick}
-                                    options={options}
-                                    size={size}
-                                    skin={skin}
-                                    value={value}
-                                />
-                            </div>
-                        )
-                    }
-                </Popover>
-            </div>
+            <Popover
+                className={className}
+                disabled={disabled}
+                icon={icon}
+                label={showText ? buttonValue : undefined}
+                loading={loading}
+                size={size}
+                skin={skin}
+            >
+                {(onClose) => (
+                    <OptionList
+                        onClose={onClose}
+                        onOptionClick={this.handleOptionClick}
+                        options={options}
+                        size={size}
+                        skin={skin}
+                        value={value}
+                    />
+                )}
+            </Popover>
         );
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Toolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Toolbar.js
@@ -7,6 +7,7 @@ import Controls from './Controls';
 import Dropdown from './Dropdown';
 import Items from './Items';
 import Icons from './Icons';
+import Popover from './Popover';
 import Toggler from './Toggler';
 import Select from './Select';
 import type {Skin} from './types';
@@ -25,8 +26,9 @@ export default class Toolbar extends React.PureComponent<Props> {
     static Button = Button;
     static Controls = Controls;
     static Dropdown = Dropdown;
-    static Items = Items;
     static Icons = Icons;
+    static Items = Items;
+    static Popover = Popover;
     static Select = Select;
     static Toggler = Toggler;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/dropdown.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/dropdown.scss
@@ -1,5 +1,0 @@
-@import '../../containers/Application/colors.scss';
-
-.dropdown {
-    position: relative;
-}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/popover.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/popover.scss
@@ -1,5 +1,5 @@
 @import '../../containers/Application/colors.scss';
 
-.select {
+.popover {
     position: relative;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/popover.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/popover.scss
@@ -1,5 +1,32 @@
 @import '../../containers/Application/colors.scss';
 
+$popoverBackgroundLightColor: $wildSand;
+$popoverBackgroundDarkColor: $mirage;
+$popoverTextLightColor: $blueZodiac;
+$popoverTextDarkColor: $white;
+$popoverTextLightColorDisabled: $silver;
+$popoverTextDarkColorDisabled: $stormGray;
+$popoverShadowColor: $silver;
+
 .popover {
     position: relative;
+}
+
+.light {
+    background-color: $popoverBackgroundLightColor;
+    color: $popoverTextLightColor;
+    box-shadow: 2px 6px 12px 0 rgba($popoverShadowColor, .5);
+
+    &:disabled {
+        color: $popoverTextLightColorDisabled;
+    }
+}
+
+.dark {
+    background-color: $popoverBackgroundDarkColor;
+    color: $popoverTextDarkColor;
+
+    &:disabled {
+        color: $popoverTextDarkColorDisabled;
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Dropdown.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Dropdown.test.js
@@ -144,9 +144,9 @@ test('No active options should disable dropdown', () => {
     const dropdown = mount(<Dropdown {...propsMock} />);
 
     expect(dropdown.find('button').instance().disabled).toBe(true);
-    expect(dropdown.instance().open).toBe(false);
+    expect(dropdown.find('OptionList')).toHaveLength(0);
 
     // click on button shouldn't open the options
     dropdown.find('button').simulate('click');
-    expect(dropdown.instance().open).toBe(false);
+    expect(dropdown.find('OptionList')).toHaveLength(0);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Popover.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Popover.test.js
@@ -1,0 +1,38 @@
+// @flow
+import React from 'react';
+import {mount, render} from 'enzyme';
+import Popover from '../Popover';
+
+test('Render a Popover', () => {
+    expect(render(
+        <Popover icon="su-calendar" label="Set time" size="small">{() => 'Child'}</Popover>
+    )).toMatchSnapshot();
+});
+
+test('Disable the Button if the Popover is disabled', () => {
+    const popover = mount(<Popover disabled={true} icon="su-calendar" label="Set time">{() => 'Child'}</Popover>);
+
+    expect(popover.find('button').prop('disabled')).toEqual(true);
+});
+
+test('Show a loader if the Popover is loading', () => {
+    const popover = mount(<Popover icon="su-calendar" label="Set time" loading={true}>{() => 'Child'}</Popover>);
+
+    expect(popover.find('Loader')).toHaveLength(1);
+});
+
+test('Open popover on click', () => {
+    const dropdown = mount(<Popover label="Set time">{() => <h1>Test</h1>}</Popover>);
+
+    expect(dropdown.find('h1').length).toBe(0);
+    dropdown.find('button').simulate('click');
+    expect(dropdown.find('h1').length).toBe(1);
+});
+
+test('Disabled popover does not open on click', () => {
+    const dropdown = mount(<Popover disabled={true} label="Set time">{() => <h1>Test</h1>}</Popover>);
+
+    expect(dropdown.find('h1').length).toBe(0);
+    dropdown.find('button').simulate('click');
+    expect(dropdown.find('h1').length).toBe(0);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Popover.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Popover.test.js
@@ -5,7 +5,7 @@ import Popover from '../Popover';
 
 test('Render a Popover', () => {
     expect(render(
-        <Popover icon="su-calendar" label="Set time" size="small">{() => 'Child'}</Popover>
+        <Popover icon="su-calendar" label="Set time" size="small" skin="light">{() => 'Child'}</Popover>
     )).toMatchSnapshot();
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Dropdown.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Dropdown.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Render disabled dropdown 1`] = `
 <div
-  class="dropdown"
+  class="popover"
 >
   <button
     class="button"
@@ -23,7 +23,7 @@ exports[`Render disabled dropdown 1`] = `
 
 exports[`Render dropdown 1`] = `
 <div
-  class="dropdown"
+  class="popover"
 >
   <button
     class="button"
@@ -43,7 +43,7 @@ exports[`Render dropdown 1`] = `
 
 exports[`Render dropdown with a different size 1`] = `
 <div
-  class="dropdown small"
+  class="popover small"
 >
   <button
     class="button small"
@@ -63,7 +63,7 @@ exports[`Render dropdown with a different size 1`] = `
 
 exports[`Render dropdown with a prepended icon 1`] = `
 <div
-  class="dropdown"
+  class="popover"
 >
   <button
     class="button"
@@ -87,7 +87,7 @@ exports[`Render dropdown with a prepended icon 1`] = `
 
 exports[`Render dropdown without text 1`] = `
 <div
-  class="dropdown"
+  class="popover"
 >
   <button
     class="button"
@@ -102,7 +102,7 @@ exports[`Render dropdown without text 1`] = `
 
 exports[`Render loading dropdown 1`] = `
 <div
-  class="dropdown"
+  class="popover"
 >
   <button
     class="button"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Popover.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Popover.test.js.snap
@@ -5,7 +5,7 @@ exports[`Render a Popover 1`] = `
   class="popover small"
 >
   <button
-    class="button small"
+    class="button small light"
   >
     <span
       aria-label="su-calendar"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Popover.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Popover.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Render a Popover 1`] = `
+<div
+  class="popover small"
+>
+  <button
+    class="button small"
+  >
+    <span
+      aria-label="su-calendar"
+      class="su-calendar icon"
+    />
+    <span
+      class="label"
+    >
+      Set time
+    </span>
+    <span
+      aria-label="su-angle-down"
+      class="su-angle-down dropdownIcon"
+    />
+  </button>
+</div>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Select.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Select.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Render disabled select 1`] = `
 <div
-  class="select"
+  class="popover"
 >
   <button
     class="button"
@@ -23,7 +23,7 @@ exports[`Render disabled select 1`] = `
 
 exports[`Render loading select 1`] = `
 <div
-  class="select"
+  class="popover"
 >
   <button
     class="button"
@@ -54,7 +54,7 @@ exports[`Render loading select 1`] = `
 
 exports[`Render select 1`] = `
 <div
-  class="select"
+  class="popover"
 >
   <button
     class="button"
@@ -74,7 +74,7 @@ exports[`Render select 1`] = `
 
 exports[`Render select with a different size 1`] = `
 <div
-  class="select small"
+  class="popover small"
 >
   <button
     class="button small"
@@ -94,7 +94,7 @@ exports[`Render select with a different size 1`] = `
 
 exports[`Render select with a prepended icon 1`] = `
 <div
-  class="select"
+  class="popover"
 >
   <button
     class="button"
@@ -118,7 +118,7 @@ exports[`Render select with a prepended icon 1`] = `
 
 exports[`Render select without text 1`] = `
 <div
-  class="select"
+  class="popover"
 >
   <button
     class="button"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/types.js
@@ -33,6 +33,18 @@ export type Button = {|
     success?: boolean,
 |};
 
+export type Popover = {|
+    children: (onClose: () => void) => Node,
+    className?: string,
+    disabled?: boolean,
+    icon?: string,
+    label?: string | number,
+    loading?: boolean,
+    showText?: boolean,
+    size?: string,
+    skin?: Skin,
+|};
+
 export type Toggler = {|
     disabled?: boolean,
     label: string,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
@@ -146,7 +146,7 @@ Array [
           </li>
           <li>
             <div
-              class="dropdown"
+              class="popover"
             >
               <button
                 class="button light"

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/__snapshots__/Preview.test.js.snap
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/__snapshots__/Preview.test.js.snap
@@ -38,7 +38,7 @@ exports[`Dont react or update preview when data is changed during formstore is l
         >
           <li>
             <div
-              class="select dark"
+              class="popover"
             >
               <button
                 class="button dark"
@@ -61,7 +61,7 @@ exports[`Dont react or update preview when data is changed during formstore is l
           </li>
           <li>
             <div
-              class="select dark"
+              class="popover"
             >
               <button
                 class="button dark"
@@ -155,7 +155,7 @@ exports[`Dont react or update preview when data is changed during preview-store 
         >
           <li>
             <div
-              class="select dark"
+              class="popover"
             >
               <button
                 class="button dark"
@@ -178,7 +178,7 @@ exports[`Dont react or update preview when data is changed during preview-store 
           </li>
           <li>
             <div
-              class="select dark"
+              class="popover"
             >
               <button
                 class="button dark"
@@ -271,7 +271,7 @@ exports[`React and update preview when data is changed 1`] = `
         >
           <li>
             <div
-              class="select dark"
+              class="popover"
             >
               <button
                 class="button dark"
@@ -294,7 +294,7 @@ exports[`React and update preview when data is changed 1`] = `
           </li>
           <li>
             <div
-              class="select dark"
+              class="popover"
             >
               <button
                 class="button dark"
@@ -391,7 +391,7 @@ exports[`Render correct preview 1`] = `
         >
           <li>
             <div
-              class="select dark"
+              class="popover"
             >
               <button
                 class="button dark"
@@ -414,7 +414,7 @@ exports[`Render correct preview 1`] = `
           </li>
           <li>
             <div
-              class="select dark"
+              class="popover"
             >
               <button
                 class="button dark"
@@ -432,7 +432,7 @@ exports[`Render correct preview 1`] = `
           </li>
           <li>
             <div
-              class="select dark"
+              class="popover"
             >
               <button
                 class="button dark"
@@ -523,7 +523,7 @@ exports[`Render correct preview with target groups 1`] = `
         >
           <li>
             <div
-              class="select dark"
+              class="popover"
             >
               <button
                 class="button dark"
@@ -546,7 +546,7 @@ exports[`Render correct preview with target groups 1`] = `
           </li>
           <li>
             <div
-              class="select dark"
+              class="popover"
             >
               <button
                 class="button dark"
@@ -564,7 +564,7 @@ exports[`Render correct preview with target groups 1`] = `
           </li>
           <li>
             <div
-              class="select dark"
+              class="popover"
             >
               <button
                 class="button dark"
@@ -655,7 +655,7 @@ exports[`Render nothing if separate window is opened and rerender if it is close
         >
           <li>
             <div
-              class="select dark"
+              class="popover"
             >
               <button
                 class="button dark"
@@ -678,7 +678,7 @@ exports[`Render nothing if separate window is opened and rerender if it is close
           </li>
           <li>
             <div
-              class="select dark"
+              class="popover"
             >
               <button
                 class="button dark"
@@ -769,7 +769,7 @@ exports[`Render nothing if separate window is opened and rerender if it is close
         >
           <li>
             <div
-              class="select dark"
+              class="popover"
             >
               <button
                 class="button dark"
@@ -792,7 +792,7 @@ exports[`Render nothing if separate window is opened and rerender if it is close
           </li>
           <li>
             <div
-              class="select dark"
+              class="popover"
             >
               <button
                 class="button dark"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds a new `Toolbar.Popover` component.

#### Why?

Because it allows to show anything after a button has been clicked in a `Popover` component, and that's exactly what we need for #5608, where we should show a `DatePicker` component in such a way.

#### Example Usage

```javascript
<Toolbar.Popover label="Show content">
    {() => 'Content'}
</Toolbar.Popover>
```