### PR TITLE
Fix localizations for the TemplateAttributeResolver

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
@@ -89,15 +89,10 @@ class TemplateAttributeResolver implements TemplateAttributeResolverInterface
             $this->requestAnalyzerResolver->resolve($this->requestAnalyzer)
         );
 
-        // Generate Urls
-        if (!isset($customParameters['urls'])) {
-            $customParameters['urls'] = $this->getUrls();
-        }
-
         if (!isset($customParameters['localizations'])) {
             $localizations = [];
 
-            foreach ($customParameters['urls'] as $locale => $url) {
+            foreach ($this->getUrls() as $locale => $url) {
                 $localizations[$locale] = [
                     'locale' => $locale,
                     'url' => $url,
@@ -107,8 +102,15 @@ class TemplateAttributeResolver implements TemplateAttributeResolverInterface
             $customParameters['localizations'] = $localizations;
         }
 
-        if (isset($this->enabledTwigAttributes['urls']) && !$this->enabledTwigAttributes['urls']) {
-            unset($customParameters['urls']);
+        if ($this->enabledTwigAttributes['urls'] ?? true) {
+            @\trigger_error('Enabling the "urls" parameter is deprecated since Sulu 2.2', \E_USER_DEPRECATED);
+
+            if (!isset($customParameters['urls'])) {
+                $customParameters['urls'] = [];
+                foreach ($customParameters['localizations'] as $localization) {
+                    $customParameters['urls'][$localization['locale']] = $localization['url'];
+                }
+            }
         }
 
         return \array_merge(

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
@@ -91,8 +91,9 @@ class TemplateAttributeResolver implements TemplateAttributeResolverInterface
 
         if (!isset($customParameters['localizations'])) {
             $localizations = [];
+            $urls = $customParameters['urls'] ?? $this->getUrls();
 
-            foreach ($this->getUrls() as $locale => $url) {
+            foreach ($urls as $locale => $url) {
                 $localizations[$locale] = [
                     'locale' => $locale,
                     'url' => $url,

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
@@ -53,6 +53,11 @@ class TemplateAttributeResolver implements TemplateAttributeResolverInterface
     protected $environment;
 
     /**
+     * @var array
+     */
+    private $enabledTwigAttributes;
+
+    /**
      * TemplateAttributeResolver constructor.
      *
      * @param string $environment
@@ -63,7 +68,10 @@ class TemplateAttributeResolver implements TemplateAttributeResolverInterface
         WebspaceManagerInterface $webspaceManager,
         RouterInterface $router,
         RequestStack $requestStack,
-        $environment
+        $environment,
+        array $enabledTwigAttributes = [
+            'urls' => true,
+        ]
     ) {
         $this->requestAnalyzer = $requestAnalyzer;
         $this->requestAnalyzerResolver = $requestAnalyzerResolver;
@@ -71,6 +79,7 @@ class TemplateAttributeResolver implements TemplateAttributeResolverInterface
         $this->router = $router;
         $this->requestStack = $requestStack;
         $this->environment = $environment;
+        $this->enabledTwigAttributes = $enabledTwigAttributes;
     }
 
     public function resolve($customParameters = [])
@@ -83,6 +92,23 @@ class TemplateAttributeResolver implements TemplateAttributeResolverInterface
         // Generate Urls
         if (!isset($customParameters['urls'])) {
             $customParameters['urls'] = $this->getUrls();
+        }
+
+        if (!isset($customParameters['localizations'])) {
+            $localizations = [];
+
+            foreach ($customParameters['urls'] as $locale => $url) {
+                $localizations[$locale] = [
+                    'locale' => $locale,
+                    'url' => $url,
+                ];
+            }
+
+            $customParameters['localizations'] = $localizations;
+        }
+
+        if (isset($this->enabledTwigAttributes['urls']) && !$this->enabledTwigAttributes['urls']) {
+            unset($customParameters['urls']);
         }
 
         return \array_merge(

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -212,6 +212,7 @@
             <argument type="service" id="router"/>
             <argument type="service" id="request_stack"/>
             <argument>%kernel.environment%</argument>
+            <argument>%sulu_website.enabled_twig_attributes%</argument>
         </service>
 
         <service id="Sulu\Bundle\WebsiteBundle\Resolver\TemplateAttributeResolverInterface"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5697
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Add handling for `urls` and `loclzations` to the `TemplateAttributeResolver` which handles static routes.

#### Why?

It should have the same behaviour as the ParameterResolver which handles dynamic structure routes.


