### PR TITLE
Refactor visibleCondition and disabledCondition to allow different blocks having different evaluations

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,32 @@
 
 ## dev-master
 
+### conditionDataProvider interface changed
+
+The interface of `conditionDataProviders` changed its arguments. In order to make these providers even more powerful,
+they now also get the `dataPath` passed. Also, instead of the `options` and `metadataOptions` a `formInspector` instance
+is passed, which allows accessing both of the properties.
+
+```javascript
+// before
+function (data: {[string]: any}, options: {[string]: any}, metadataOptions: {[string]: any}) {
+    const webspaceKey = data.webspace || options.webspace || (metadataOptions && metadataOptions.webspace);
+}
+
+// after
+function (data: {[string]: any}, dataPath: ?string, formInspector: FormInspector) {
+    const {options, metadataOptions} = formInspector;
+    const webspaceKey = data.webspace || options.webspace || (metadataOptions && metadataOptions.webspace);
+}
+```
+
+### Props of Renderer component changed
+
+The [`Renderer` React component](https://github.com/sulu/sulu/blob/release/2.2/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js)
+has changed its interface to support better evaluation of the `disbledCondition` and `visibleCondition`. Therefore it
+needs the data of the entire form being passed to the `data` prop and the data for the fields rendered by the
+`Renderer` need to be passed to the `value` prop.
+
 ### Deprecated path variable in twig
 
 The `path` twig variable was deprecated because it was confused with the `url` property by many new developers.

--- a/config/templates/pages/example.xml
+++ b/config/templates/pages/example.xml
@@ -447,7 +447,7 @@
                                 <title lang="de">Titel</title>
                             </meta>
                         </property>
-                        <property name="description" type="text_area">
+                        <property name="description" type="text_area" visibleCondition="title == 'Test'">
                             <meta>
                                 <title lang="en">Description</title>
                                 <title lang="de">Beschreibung</title>

--- a/config/templates/pages/example.xml
+++ b/config/templates/pages/example.xml
@@ -447,7 +447,7 @@
                                 <title lang="de">Titel</title>
                             </meta>
                         </property>
-                        <property name="description" type="text_area" visibleCondition="title == 'Test'">
+                        <property name="description" type="text_area">
                             <meta>
                                 <title lang="en">Description</title>
                                 <title lang="de">Beschreibung</title>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -146,7 +146,7 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
 
             const blockSettingsTag = schemaEntry.tags.find((tag) => tag.name === SETTINGS_TAG);
 
-            if (blockSettingsTag && schemaEntry.visible !== false) {
+            if (blockSettingsTag) {
                 iconsMapping[SETTINGS_PREFIX + schemaKey] = blockSettingsTag.attributes.icon;
             }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -246,6 +246,7 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
 
     renderExpandedBlockContent = (value: Object, type: string, index: number) => {
         const {
+            data,
             dataPath,
             error,
             formInspector,
@@ -261,7 +262,7 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
 
         return (
             <FieldRenderer
-                data={value}
+                data={data}
                 dataPath={dataPath + '/' + index}
                 errors={errors && errors.length > index && errors[index] ? errors[index] : undefined}
                 formInspector={formInspector}
@@ -273,6 +274,7 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
                 schema={blockSchemaType.form}
                 schemaPath={schemaPath + '/types/' + type + '/form'}
                 showAllErrors={showAllErrors}
+                value={value}
             />
         );
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldRenderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldRenderer.js
@@ -18,6 +18,7 @@ type Props = {|
     schema: Schema,
     schemaPath: string,
     showAllErrors: boolean,
+    value: Object,
 |};
 
 export default class FieldRenderer extends React.Component<Props> {
@@ -42,6 +43,7 @@ export default class FieldRenderer extends React.Component<Props> {
             schema,
             schemaPath,
             showAllErrors,
+            value,
         } = this.props;
 
         return (
@@ -57,6 +59,7 @@ export default class FieldRenderer extends React.Component<Props> {
                 schema={schema}
                 schemaPath={schemaPath}
                 showAllErrors={showAllErrors}
+                value={value}
             />
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
@@ -106,7 +106,6 @@ test('Render collapsed blocks with block previews', () => {
                 {attributes: {icon: 'su-eye'}, name: 'sulu.block_setting_icon'},
             ],
             type: 'checkbox',
-            visibleCondition: 'false',
         },
         section: {
             items: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
@@ -71,7 +71,6 @@ test('Render collapsed blocks with block previews', () => {
                         {name: 'sulu.block_preview'},
                     ],
                     type: 'text_line',
-                    visible: true,
                 },
                 text2: {
                     label: 'Text 2',
@@ -79,7 +78,6 @@ test('Render collapsed blocks with block previews', () => {
                         {name: 'sulu.block_preview'},
                     ],
                     type: 'text_line',
-                    visible: true,
                 },
                 something: {
                     label: 'Something',
@@ -87,12 +85,10 @@ test('Render collapsed blocks with block previews', () => {
                         {name: 'sulu.block_preview'},
                     ],
                     type: 'text_area',
-                    visible: true,
                 },
                 nothing: {
                     label: 'Nothing',
                     type: 'text_line',
-                    visible: true,
                 },
             },
         },
@@ -198,7 +194,6 @@ test('Render collapsed blocks with block previews and sections', () => {
                                 {name: 'sulu.block_preview'},
                             ],
                             type: 'text_line',
-                            visible: true,
                         },
                         text2: {
                             label: 'Text 2',
@@ -206,7 +201,6 @@ test('Render collapsed blocks with block previews and sections', () => {
                                 {name: 'sulu.block_preview'},
                             ],
                             type: 'text_line',
-                            visible: true,
                         },
                         something: {
                             label: 'Something',
@@ -214,12 +208,10 @@ test('Render collapsed blocks with block previews and sections', () => {
                                 {name: 'sulu.block_preview'},
                             ],
                             type: 'text_area',
-                            visible: true,
                         },
                         nothing: {
                             label: 'Nothing',
                             type: 'text_line',
-                            visible: true,
                         },
                     },
                 },
@@ -299,22 +291,18 @@ test('Render collapsed blocks with block previews without tags and with sections
                         nothing: {
                             label: 'Nothing',
                             type: 'phone',
-                            visible: true,
                         },
                         text1: {
                             label: 'Text 1',
                             type: 'text_line',
-                            visible: true,
                         },
                         text2: {
                             label: 'Text 2',
                             type: 'media_selection',
-                            visible: true,
                         },
                         something: {
                             label: 'Text 3',
                             type: 'text_editor',
-                            visible: true,
                         },
                     },
                 },
@@ -412,22 +400,18 @@ test('Render collapsed blocks with block previews without tags', () => {
                 nothing: {
                     label: 'Nothing',
                     type: 'phone',
-                    visible: true,
                 },
                 text1: {
                     label: 'Text 1',
                     type: 'text_line',
-                    visible: true,
                 },
                 text2: {
                     label: 'Text 2',
                     type: 'media_selection',
-                    visible: true,
                 },
                 something: {
                     label: 'Text 3',
                     type: 'text_editor',
-                    visible: true,
                 },
             },
         },
@@ -526,7 +510,6 @@ test('Render collapsed blocks with block previews', () => {
                         {name: 'sulu.block_preview', priority: -100},
                     ],
                     type: 'text_line',
-                    visible: true,
                 },
                 text2: {
                     label: 'Text 2',
@@ -534,7 +517,6 @@ test('Render collapsed blocks with block previews', () => {
                         {name: 'sulu.block_preview'},
                     ],
                     type: 'text_line',
-                    visible: true,
                 },
                 something: {
                     label: 'Text 3',
@@ -542,7 +524,6 @@ test('Render collapsed blocks with block previews', () => {
                         {name: 'sulu.block_preview', priority: 100},
                     ],
                     type: 'text_line',
-                    visible: true,
                 },
             },
         },
@@ -608,12 +589,10 @@ test('Render block with schema', () => {
                 text1: {
                     label: 'Text 1',
                     type: 'text_line',
-                    visible: true,
                 },
                 text2: {
                     label: 'Text 2',
                     type: 'text_line',
-                    visible: true,
                 },
             },
         },
@@ -668,12 +647,10 @@ test('Call not onChange on componentDidUpdate when new types are the same', () =
                         text1: {
                             label: 'Text 1',
                             type: 'text_line',
-                            visible: true,
                         },
                         text2: {
                             label: 'Text 2',
                             type: 'text_line',
-                            visible: true,
                         },
                     },
                 },
@@ -714,12 +691,10 @@ test('Call not onChange on componentDidUpdate when new types are the same', () =
                     text1: {
                         label: 'Text 1 a',
                         type: 'text_line',
-                        visible: true,
                     },
                     text2: {
                         label: 'Text 2 b',
                         type: 'text_line',
-                        visible: true,
                     },
                 },
             },
@@ -748,12 +723,10 @@ test('Call onChange on componentDidUpdate when type not longer exist', () => {
                         text1: {
                             label: 'Text 1',
                             type: 'text_line',
-                            visible: true,
                         },
                         text2: {
                             label: 'Text 2',
                             type: 'text_line',
-                            visible: true,
                         },
                     },
                 },
@@ -794,12 +767,10 @@ test('Call onChange on componentDidUpdate when type not longer exist', () => {
                     text1: {
                         label: 'Text 1',
                         type: 'text_line',
-                        visible: true,
                     },
                     text2: {
                         label: 'Text 2',
                         type: 'text_line',
-                        visible: true,
                     },
                 },
             },
@@ -830,7 +801,6 @@ test('Render block with schema and error on fields already being modified', () =
                 text: {
                     label: 'Text',
                     type: 'text_line',
-                    visible: true,
                 },
             },
         },
@@ -902,7 +872,6 @@ test('Render block with schema and error on fields already being modified', () =
                 text: {
                     label: 'Text',
                     type: 'text_line',
-                    visible: true,
                 },
             },
         },
@@ -972,7 +941,6 @@ test('Should correctly pass props to the BlockCollection', () => {
                 text: {
                     label: 'Text',
                     type: 'text_line',
-                    visible: true,
                 },
             },
         },
@@ -1015,7 +983,6 @@ test('Should pass new value to the BlockCollection if value prop is updated', ()
                 text: {
                     label: 'Text',
                     type: 'text_line',
-                    visible: true,
                 },
             },
         },
@@ -1046,6 +1013,61 @@ test('Should pass new value to the BlockCollection if value prop is updated', ()
     expect(fieldBlocks.find('BlockCollection').props().value).toEqual([{type: 'default', text: 'Three'}]);
 });
 
+test('Should pass correct data and value and router to FieldRenderer', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+    const router = new Router();
+
+    const types = {
+        default: {
+            title: 'Default',
+            form: {
+                text: {
+                    type: 'text_line',
+                },
+            },
+        },
+    };
+    formInspector.getSchemaEntryByPath.mockReturnValue({types});
+
+    const data = {
+        title: 'Test',
+    };
+
+    const value = [
+        {
+            title: 'Test 1',
+            type: 'default',
+        },
+        {
+            title: 'Test 2',
+            type: 'default',
+        },
+    ];
+
+    const fieldBlocks = mount(
+        <FieldBlocks
+            {...fieldTypeDefaultProps}
+            data={data}
+            dataPath=""
+            defaultType="editor"
+            formInspector={formInspector}
+            router={router}
+            schemaPath=""
+            types={types}
+            value={value}
+        />
+    );
+
+    fieldBlocks.find('SortableBlockList').prop('onExpand')(0);
+    fieldBlocks.find('SortableBlockList').prop('onExpand')(1);
+    fieldBlocks.update();
+
+    expect(fieldBlocks.find('FieldRenderer').at(0).prop('data')).toEqual(data);
+    expect(fieldBlocks.find('FieldRenderer').at(0).prop('value')).toEqual(value[0]);
+    expect(fieldBlocks.find('FieldRenderer').at(1).prop('data')).toEqual(data);
+    expect(fieldBlocks.find('FieldRenderer').at(1).prop('value')).toEqual(value[1]);
+});
+
 test('Should pass correct schemaPath and router to FieldRenderer', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
     const router = new Router();
@@ -1056,7 +1078,6 @@ test('Should pass correct schemaPath and router to FieldRenderer', () => {
             form: {
                 text: {
                     type: 'text_line',
-                    visible: true,
                 },
             },
         },
@@ -1096,7 +1117,6 @@ test('Should call onFinish when a field from the child renderer has finished edi
                 text: {
                     label: 'Text',
                     type: 'text_line',
-                    visible: true,
                 },
             },
         },
@@ -1135,7 +1155,6 @@ test ('Should set nested properties in handleBlockChange and call onChange with 
                 text: {
                     label: 'Text',
                     type: 'text_line',
-                    visible: true,
                 },
             },
         },
@@ -1178,7 +1197,6 @@ test('Should call onFinish when the order of the blocks has changed', () => {
                 text: {
                     label: 'Text',
                     type: 'text_line',
-                    visible: true,
                 },
             },
         },
@@ -1212,7 +1230,6 @@ test('Should open and close block settings overlay close button is clicked', () 
                 text: {
                     label: 'Text',
                     type: 'text_line',
-                    visible: true,
                 },
             },
         },
@@ -1250,7 +1267,6 @@ test('Should open and close block settings overlay when confirm button is clicke
                 text: {
                     label: 'Text',
                     type: 'text_line',
-                    visible: true,
                 },
             },
         },
@@ -1310,7 +1326,6 @@ test('Should open and close block settings overlay when confirm button is clicke
                 text: {
                     label: 'Text',
                     type: 'text_line',
-                    visible: true,
                 },
             },
         },
@@ -1374,7 +1389,6 @@ test('Should update block settings on submit and immediately show the icon', () 
                         {name: 'sulu.block_preview'},
                     ],
                     type: 'text_line',
-                    visible: true,
                 },
             },
         },
@@ -1437,7 +1451,6 @@ test('Destroy store on unmount', () => {
                 text: {
                     label: 'Text',
                     type: 'text_line',
-                    visible: true,
                 },
             },
         },
@@ -1472,7 +1485,6 @@ test('Should show correct value in type select after type is changed', () => {
                 text: {
                     label: 'Text',
                     type: 'text_line',
-                    visible: true,
                 },
             },
         },
@@ -1482,7 +1494,6 @@ test('Should show correct value in type select after type is changed', () => {
                 other_text: {
                     label: 'Other Text',
                     type: 'text_line',
-                    visible: true,
                 },
             },
         },
@@ -1674,7 +1685,6 @@ test('Throw error if passed settings_form_key schema option is not a string', ()
                 nothing: {
                     label: 'Nothing',
                     type: 'phone',
-                    visible: true,
                 },
             },
         },
@@ -1702,7 +1712,6 @@ test('Throw error if passed add_button_text schema option is not a string', () =
                 nothing: {
                     label: 'Nothing',
                     type: 'phone',
-                    visible: true,
                 },
             },
         },

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldRenderer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldRenderer.test.js
@@ -19,9 +19,16 @@ jest.mock('../../../stores/ResourceStore', () => jest.fn());
 test('Should pass props correctly to Renderer', () => {
     const fieldFinishSpy = jest.fn();
     const successSpy = jest.fn();
+
+    const value = {
+        title: 'Test',
+    };
+
     const data = {
         content: 'test',
+        block: value,
     };
+
     const errors = {
         content: {
             keyword: 'minLength',
@@ -47,6 +54,7 @@ test('Should pass props correctly to Renderer', () => {
             router={router}
             schema={schema}
             schemaPath="/test"
+            value={value}
         />
     );
 
@@ -61,6 +69,7 @@ test('Should pass props correctly to Renderer', () => {
         schema,
         schemaPath: '/test',
         showAllErrors: false,
+        value,
     }));
 });
 
@@ -80,6 +89,7 @@ test('Should pass showAllErrors prop to Renderer', () => {
             schema={{}}
             schemaPath=""
             showAllErrors={true}
+            value={{}}
         />
     );
 
@@ -102,6 +112,7 @@ test('Should call onChange callback with correct index', () => {
             router={undefined}
             schema={{}}
             schemaPath=""
+            value={{}}
         />
     );
 
@@ -126,6 +137,7 @@ test('Should call onFieldFinish when some subfield finishes editing', () => {
             router={undefined}
             schema={{}}
             schemaPath=""
+            value={{}}
         />
     );
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
@@ -785,7 +785,12 @@ exports[`Render collapsed blocks with block previews 1`] = `
         >
           <div
             class="icons"
-          />
+          >
+            <span
+              aria-label="su-eye"
+              class="su-eye"
+            />
+          </div>
           <div
             class="type"
           >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
@@ -3,15 +3,18 @@ import React from 'react';
 import {computed} from 'mobx';
 import {observer} from 'mobx-react';
 import log from 'loglevel';
+import jexl from 'jexl';
 import Router from '../../services/Router';
 import {translate} from '../../utils';
-import FieldComponent from '../../components/Form/Field';
+import Form from '../../components/Form';
+import conditionDataProviderRegistry from './registries/conditionDataProviderRegistry';
 import fieldRegistry from './registries/fieldRegistry';
 import fieldStyles from './field.scss';
 import FormInspector from './FormInspector';
 import type {Error, ErrorCollection, SchemaEntry} from './types';
 
 type Props = {|
+    data: Object,
     dataPath: string,
     error?: Error | ErrorCollection,
     formInspector: FormInspector,
@@ -32,10 +35,42 @@ class Field extends React.Component<Props> {
         showAllErrors: false,
     };
 
-    handleChange = (value: *) => {
-        const {name, onChange, schema} = this.props;
+    @computed get conditionData() {
+        const {data, formInspector} = this.props;
+        const {locale, metadataOptions, options} = formInspector;
 
-        if (schema.disabled) {
+        return conditionDataProviderRegistry.getAll().reduce(
+            function(data, conditionDataProvider) {
+                return {...data, ...conditionDataProvider(data, options, metadataOptions)};
+            },
+            {...data, __locale: locale}
+        );
+    }
+
+    @computed get disabled() {
+        const {schema} = this.props;
+
+        if (!schema.disabledCondition) {
+            return false;
+        }
+
+        return jexl.evalSync(schema.disabledCondition, this.conditionData);
+    }
+
+    @computed get visible() {
+        const {schema} = this.props;
+
+        if (!schema.visibleCondition) {
+            return true;
+        }
+
+        return jexl.evalSync(schema.visibleCondition, this.conditionData);
+    }
+
+    handleChange = (value: *) => {
+        const {name, onChange} = this.props;
+
+        if (this.disabled) {
             return;
         }
 
@@ -87,6 +122,10 @@ class Field extends React.Component<Props> {
     }
 
     render() {
+        if (!this.visible) {
+            return null;
+        }
+
         const {
             dataPath,
             error,
@@ -103,7 +142,6 @@ class Field extends React.Component<Props> {
         const {
             defaultType,
             description,
-            disabled,
             label,
             maxOccurs,
             minOccurs,
@@ -125,7 +163,7 @@ class Field extends React.Component<Props> {
             log.error(e);
 
             return (
-                <FieldComponent
+                <Form.Field
                     colSpan={schema.colSpan}
                     spaceAfter={schema.spaceAfter}
                 >
@@ -140,7 +178,7 @@ class Field extends React.Component<Props> {
                             </div>
                         </div>
                     </div>
-                </FieldComponent>
+                </Form.Field>
             );
         }
         const fieldTypeOptions = fieldRegistry.getOptions(type);
@@ -148,7 +186,7 @@ class Field extends React.Component<Props> {
         const errorKeyword = this.findErrorKeyword(error);
 
         return (
-            <FieldComponent
+            <Form.Field
                 colSpan={schema.colSpan}
                 description={description}
                 error={errorKeyword ? translate('sulu_admin.error_' + errorKeyword.toLowerCase()) : undefined}
@@ -162,7 +200,7 @@ class Field extends React.Component<Props> {
                         <FieldType
                             dataPath={dataPath}
                             defaultType={defaultType}
-                            disabled={disabled}
+                            disabled={this.disabled}
                             error={error}
                             fieldTypeOptions={fieldTypeOptions}
                             formInspector={formInspector}
@@ -181,7 +219,7 @@ class Field extends React.Component<Props> {
                         />
                     </div>
                 </div>
-            </FieldComponent>
+            </Form.Field>
         );
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
@@ -36,14 +36,13 @@ class Field extends React.Component<Props> {
     };
 
     @computed get conditionData() {
-        const {data, formInspector} = this.props;
-        const {locale, metadataOptions, options} = formInspector;
+        const {data, dataPath, formInspector} = this.props;
 
         return conditionDataProviderRegistry.getAll().reduce(
             function(data, conditionDataProvider) {
-                return {...data, ...conditionDataProvider(data, options, metadataOptions)};
+                return {...data, ...conditionDataProvider(data, dataPath, formInspector)};
             },
-            {...data, __locale: locale}
+            {...data}
         );
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
@@ -127,6 +127,7 @@ class Field extends React.Component<Props> {
         }
 
         const {
+            data,
             dataPath,
             error,
             formInspector,
@@ -198,6 +199,7 @@ class Field extends React.Component<Props> {
                 <div className={fieldStyles.fieldContainer}>
                     <div className={fieldStyles.field}>
                         <FieldType
+                            data={data}
                             dataPath={dataPath}
                             defaultType={defaultType}
                             disabled={this.disabled}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
@@ -194,6 +194,7 @@ class Form extends React.Component<Props> {
                         schema={store.schema}
                         schemaPath=""
                         showAllErrors={this.showAllErrors}
+                        value={store.data}
                     />
                 }
             </Fragment>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
@@ -8,6 +8,7 @@ import Form from '../../components/Form';
 import Router from '../../services/Router';
 import Field from './Field';
 import FormInspector from './FormInspector';
+import Section from './Section';
 import type {ErrorCollection, Schema, SchemaEntry} from './types';
 
 type Props = {|
@@ -39,13 +40,15 @@ class Renderer extends React.Component<Props> {
     };
 
     renderSection(schemaField: SchemaEntry, schemaKey: string, schemaPath: string) {
-        const {colSpan, label, items} = schemaField;
+        const {data, formInspector} = this.props;
+        const {items} = schemaField;
+
         return (
-            <Form.Section colSpan={colSpan} key={schemaKey} label={label}>
+            <Section data={data} formInspector={formInspector} key={schemaKey} name={schemaKey} schema={schemaField}>
                 {!!items &&
                     Object.keys(items).map((key) => this.renderItem(items[key], key, schemaPath + '/items/' + key))
                 }
-            </Form.Section>
+            </Section>
         );
     }
 
@@ -59,6 +62,7 @@ class Renderer extends React.Component<Props> {
 
         return (
             <Field
+                data={data}
                 dataPath={itemDataPath}
                 error={error}
                 formInspector={formInspector}
@@ -80,11 +84,7 @@ class Renderer extends React.Component<Props> {
         schemaField: SchemaEntry,
         schemaKey: string,
         schemaPath: string
-    ): ?Element<typeof Field | typeof Form.Section> {
-        if (schemaField.visible === false) {
-            return null;
-        }
-
+    ): ?Element<typeof Field | typeof Section> {
         if (schemaField.type === 'section') {
             return this.renderSection(schemaField, schemaKey, schemaPath);
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
@@ -23,6 +23,7 @@ type Props = {|
     schema: Schema,
     schemaPath: string,
     showAllErrors: boolean,
+    value: Object,
 |};
 
 @observer
@@ -53,7 +54,7 @@ class Renderer extends React.Component<Props> {
     }
 
     renderField(schemaField: SchemaEntry, schemaKey: string, schemaPath: string) {
-        const {data, dataPath, errors, formInspector, onChange, onSuccess, router, showAllErrors} = this.props;
+        const {data, dataPath, errors, formInspector, onChange, onSuccess, router, showAllErrors, value} = this.props;
         const itemDataPath = dataPath + '/' + schemaKey;
 
         const error = (showAllErrors || formInspector.isFieldModified(itemDataPath)) && errors && errors[schemaKey]
@@ -75,7 +76,7 @@ class Renderer extends React.Component<Props> {
                 schema={schemaField}
                 schemaPath={schemaPath}
                 showAllErrors={showAllErrors}
-                value={jsonpointer.has(data, '/' + schemaKey) ? jsonpointer.get(data, '/' + schemaKey) : undefined}
+                value={jsonpointer.has(value, '/' + schemaKey) ? jsonpointer.get(value, '/' + schemaKey) : undefined}
             />
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Section.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Section.js
@@ -1,0 +1,61 @@
+// @flow
+import React from 'react';
+import type {ChildrenArray, Element} from 'react';
+import {computed} from 'mobx';
+import {observer} from 'mobx-react';
+import jexl from 'jexl';
+import Form from '../../components/Form';
+import conditionDataProviderRegistry from './registries/conditionDataProviderRegistry';
+import FormInspector from './FormInspector';
+import Field from './Field';
+import type {SchemaEntry} from './types';
+
+type Props = {|
+    children: false | ChildrenArray<?Element<typeof Field | typeof Section>>,
+    data: Object,
+    formInspector: FormInspector,
+    name: string,
+    schema: SchemaEntry,
+|};
+
+@observer
+class Section extends React.Component<Props> {
+    @computed get conditionData() {
+        const {data, formInspector} = this.props;
+        const {locale, metadataOptions, options} = formInspector;
+
+        return conditionDataProviderRegistry.getAll().reduce(
+            function(data, conditionDataProvider) {
+                return {...data, ...conditionDataProvider(data, options, metadataOptions)};
+            },
+            {...data, __locale: locale}
+        );
+    }
+
+    @computed get visible() {
+        const {schema} = this.props;
+
+        if (!schema.visibleCondition) {
+            return true;
+        }
+
+        return jexl.evalSync(schema.visibleCondition, this.conditionData);
+    }
+
+    render() {
+        if (!this.visible) {
+            return null;
+        }
+
+        const {children, name, schema} = this.props;
+        const {colSpan, label} = schema;
+
+        return (
+            <Form.Section colSpan={colSpan} key={name} label={label}>
+                {children}
+            </Form.Section>
+        );
+    }
+}
+
+export default Section;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Section.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Section.js
@@ -22,13 +22,12 @@ type Props = {|
 class Section extends React.Component<Props> {
     @computed get conditionData() {
         const {data, formInspector} = this.props;
-        const {locale, metadataOptions, options} = formInspector;
 
         return conditionDataProviderRegistry.getAll().reduce(
             function(data, conditionDataProvider) {
-                return {...data, ...conditionDataProvider(data, options, metadataOptions)};
+                return {...data, ...conditionDataProvider(data, undefined, formInspector)};
             },
-            {...data, __locale: locale}
+            {...data}
         );
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/conditionDataProviders/localeConditionDataProvider.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/conditionDataProviders/localeConditionDataProvider.js
@@ -1,0 +1,6 @@
+// @flow
+import FormInspector from '../FormInspector';
+
+export default function(data: Object, dataPath: ?string, formInspector: FormInspector): {[string]: any} {
+    return {__locale: formInspector.locale?.get()};
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/conditionDataProviders/parentConditionDataProvider.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/conditionDataProviders/parentConditionDataProvider.js
@@ -1,0 +1,10 @@
+// @flow
+import jsonpointer from 'json-pointer';
+
+export default function(data: Object, dataPath: ?string): {[string]: any} {
+    if (!dataPath) {
+        return {__parent: data};
+    }
+
+    return {__parent: jsonpointer.get(data, dataPath.substring(0, dataPath.lastIndexOf('/')))};
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/index.js
@@ -2,6 +2,7 @@
 import Form from './Form';
 import FormInspector from './FormInspector';
 import bundlesConditionDataProvider from './conditionDataProviders/bundlesConditionDataProvider';
+import localeConditionDataProvider from './conditionDataProviders/localeConditionDataProvider';
 import conditionDataProviderRegistry from './registries/conditionDataProviderRegistry';
 import fieldRegistry from './registries/fieldRegistry';
 import MemoryFormStore from './stores/MemoryFormStore';
@@ -34,6 +35,7 @@ import type {FormStoreInterface, Schema, Types} from './types';
 
 export {
     bundlesConditionDataProvider,
+    localeConditionDataProvider,
     conditionDataProviderRegistry,
     fieldRegistry,
     Selection,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/index.js
@@ -3,6 +3,7 @@ import Form from './Form';
 import FormInspector from './FormInspector';
 import bundlesConditionDataProvider from './conditionDataProviders/bundlesConditionDataProvider';
 import localeConditionDataProvider from './conditionDataProviders/localeConditionDataProvider';
+import parentConditionDataProvider from './conditionDataProviders/parentConditionDataProvider';
 import conditionDataProviderRegistry from './registries/conditionDataProviderRegistry';
 import fieldRegistry from './registries/fieldRegistry';
 import MemoryFormStore from './stores/MemoryFormStore';
@@ -36,6 +37,7 @@ import type {FormStoreInterface, Schema, Types} from './types';
 export {
     bundlesConditionDataProvider,
     localeConditionDataProvider,
+    parentConditionDataProvider,
     conditionDataProviderRegistry,
     fieldRegistry,
     Selection,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
@@ -105,7 +105,6 @@ export default class AbstractFormStore
     +loading: boolean;
     +locale: ?IObservableValue<string>;
     schema: Schema;
-    @observable evaluatedSchema: Schema = {};
     modifiedFields: Array<string> = [];
     @observable errors: Object = {};
     validator: ?(data: Object) => boolean;
@@ -164,10 +163,6 @@ export default class AbstractFormStore
         }
 
         return true;
-    }
-
-    @action setEvaluatedSchema(evaluatedSchema: Schema) {
-        this.evaluatedSchema = evaluatedSchema;
     }
 
     getValueByPath = (path: string): mixed => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
@@ -104,7 +104,7 @@ export default class AbstractFormStore
     +metadataOptions: ?{[string]: any};
     +loading: boolean;
     +locale: ?IObservableValue<string>;
-    @observable schema: Schema;
+    schema: Schema;
     @observable evaluatedSchema: Schema = {};
     modifiedFields: Array<string> = [];
     @observable errors: Object = {};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/MemoryFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/MemoryFormStore.js
@@ -1,9 +1,9 @@
 // @flow
-import {action, autorun, observable} from 'mobx';
+import {action, observable} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import Ajv from 'ajv';
 import jsonpointer from 'json-pointer';
-import type {FormStoreInterface, RawSchema, SchemaType} from '../types';
+import type {FormStoreInterface, Schema, SchemaType} from '../types';
 import AbstractFormStore from './AbstractFormStore';
 
 const ajv = new Ajv({allErrors: true, jsonPointers: true});
@@ -15,11 +15,10 @@ export default class MemoryFormStore extends AbstractFormStore implements FormSt
     @observable data: {[string]: any};
     @observable dirty: boolean = false;
     @observable types: {[key: string]: SchemaType} = {};
-    updateFieldPathEvaluationsDisposer: ?() => void;
 
     constructor(
         data: {[string]: any},
-        rawSchema: RawSchema,
+        schema: Schema,
         jsonSchema: ?Object,
         locale: ?IObservableValue<string>,
         metadataOptions: ?{[string]: any}
@@ -28,13 +27,11 @@ export default class MemoryFormStore extends AbstractFormStore implements FormSt
 
         this.data = data;
         this.loading = false;
-        this.rawSchema = rawSchema;
+        this.schema = schema;
         this.locale = locale;
         this.addMissingSchemaProperties();
         this.validator = jsonSchema ? ajv.compile(jsonSchema) : undefined;
         this.metadataOptions = metadataOptions;
-
-        this.updateFieldPathEvaluationsDisposer = autorun(this.updateFieldPathEvaluations);
     }
 
     @action change(path: string, value: mixed) {
@@ -48,17 +45,9 @@ export default class MemoryFormStore extends AbstractFormStore implements FormSt
 
     @action setMultiple(data: Object) {
         this.data = {...this.data, ...data};
-
-        super.setMultiple();
     }
 
     setType() {
         throw new Error('The MemoryFormStore cannot handle types');
-    }
-
-    destroy() {
-        if (this.updateFieldPathEvaluationsDisposer) {
-            this.updateFieldPathEvaluationsDisposer();
-        }
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
@@ -4,7 +4,7 @@ import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
 import Ajv from 'ajv';
 import jsonpointer from 'json-pointer';
 import ResourceStore from '../../../stores/ResourceStore';
-import type {FormStoreInterface, RawSchema, SchemaEntry, SchemaType, SchemaTypes} from '../types';
+import type {FormStoreInterface, Schema, SchemaEntry, SchemaType, SchemaTypes} from '../types';
 import AbstractFormStore from './AbstractFormStore';
 import metadataStore from './metadataStore';
 
@@ -23,7 +23,6 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
     @observable typesLoading: boolean = true;
     schemaDisposer: ?() => void;
     typeDisposer: ?() => void;
-    updateFieldPathEvaluationsDisposer: ?() => void;
     metadataOptions: ?{[string]: any};
 
     constructor(resourceStore: ResourceStore, formKey: string, options: Object = {}, metadataOptions: ?Object) {
@@ -45,10 +44,6 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
 
         if (this.typeDisposer) {
             this.typeDisposer();
-        }
-
-        if (this.updateFieldPathEvaluationsDisposer) {
-            this.updateFieldPathEvaluationsDisposer();
         }
     }
 
@@ -92,15 +87,13 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
         });
     };
 
-    @action handleSchemaResponse = ([schema, jsonSchema]: [RawSchema, Object]) => {
+    @action handleSchemaResponse = ([schema, jsonSchema]: [Schema, Object]) => {
         this.validator = jsonSchema ? ajv.compile(jsonSchema) : undefined;
         this.pathsByTag = {};
 
-        this.rawSchema = schema;
+        this.schema = schema;
         this.addMissingSchemaProperties();
         this.setSchemaLoading(false);
-
-        this.updateFieldPathEvaluationsDisposer = autorun(this.updateFieldPathEvaluations);
     };
 
     @computed get hasTypes(): boolean {
@@ -154,8 +147,6 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
 
     setMultiple(data: Object) {
         this.resourceStore.setMultiple(data);
-
-        super.setMultiple();
     }
 
     change(name: string, value: mixed) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/SchemaFormStoreDecorator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/SchemaFormStoreDecorator.js
@@ -1,13 +1,13 @@
 // @flow
 import {action, computed, observable} from 'mobx';
-import type {FormStoreInterface, RawSchema, Schema, SchemaEntry} from '../types';
+import type {FormStoreInterface, Schema, SchemaEntry} from '../types';
 import metadataStore from './metadataStore';
 
 export default class SchemaFormStoreDecorator implements FormStoreInterface {
     @observable innerFormStore: ?FormStoreInterface;
 
     constructor(
-        initializer: (schema: RawSchema, jsonSchema: Object) => FormStoreInterface,
+        initializer: (schema: Schema, jsonSchema: Object) => FormStoreInterface,
         formKey: string,
         type: ?string,
         metadataOptions: ?{[string]: any}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/memoryFormStoreFactory.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/memoryFormStoreFactory.js
@@ -1,6 +1,6 @@
 // @flow
 import type {IObservableValue} from 'mobx';
-import type {RawSchema} from '../types';
+import type {Schema} from '../types';
 import MemoryFormStore from './MemoryFormStore';
 import SchemaFormStoreDecorator from './SchemaFormStoreDecorator';
 
@@ -20,7 +20,7 @@ class MemoryFormStoreFactory {
         );
     }
 
-    createFromSchema(schema: RawSchema, jsonSchema: Object, data: Object = {}) {
+    createFromSchema(schema: Schema, jsonSchema: Object, data: Object = {}) {
         return new MemoryFormStore(data, schema, jsonSchema);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/metadataStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/metadataStore.js
@@ -1,6 +1,6 @@
 // @flow
 import metadataStore from '../../../stores/metadataStore';
-import type {RawSchema, SchemaTypes} from '../types';
+import type {Schema, SchemaTypes} from '../types';
 
 const FORM_TYPE = 'form';
 
@@ -28,7 +28,7 @@ class MetadataStore {
             });
     }
 
-    getSchema(formKey: string, type: ?string, metadataOptions: ?Object): Promise<RawSchema> {
+    getSchema(formKey: string, type: ?string, metadataOptions: ?Object): Promise<Schema> {
         return metadataStore.loadMetadata(FORM_TYPE, formKey, metadataOptions)
             .then((configuration) => {
                 const typeConfiguration = this.getTypeConfiguration(configuration, type, formKey);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
@@ -338,44 +338,6 @@ test('Do not render anything if visibleCondition evaluates to false', () => {
     expect(field.find('Field')).toHaveLength(1);
 });
 
-test('Render the field if visibleCondition with locale evaluates to true', () => {
-    const formInspector = new FormInspector(
-        new ResourceFormStore(
-            new ResourceStore('snippets', undefined, {locale: 'en'}),
-            'snippets'
-        )
-    );
-
-    fieldRegistry.get.mockReturnValue(function Text() {
-        return <input type="date" />;
-    });
-
-    const schema = {
-        label: 'Text',
-        type: 'text_line',
-        visibleCondition: '__locale == "en"',
-    };
-
-    const field = shallow(
-        <Field
-            data={{}}
-            dataPath="/block/0/text"
-            formInspector={formInspector}
-            name="text"
-            onChange={jest.fn()}
-            onFinish={jest.fn()}
-            onSuccess={undefined}
-            router={undefined}
-            schema={schema}
-            schemaPath="/text"
-            showAllErrors={true}
-            value="test"
-        />
-    );
-
-    expect(field.find('Field')).toHaveLength(1);
-});
-
 test('Render the field if visibleCondition with conditionDataProvider evaluates to true', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('snippets'), 'snippets'));
 
@@ -447,44 +409,6 @@ test('Pass disabled flag to FieldType if disabledCondition evaluates to true', (
 
     data.title = 'Change title!';
     expect(field.find('Text').prop('disabled')).toEqual(false);
-});
-
-test('Pass disabled flag to FieldType if disabledCondition with locale evaluates to true', () => {
-    const formInspector = new FormInspector(
-        new ResourceFormStore(
-            new ResourceStore('snippets', undefined, {locale: 'en'}),
-            'snippets'
-        )
-    );
-
-    fieldRegistry.get.mockReturnValue(function Text() {
-        return <input type="date" />;
-    });
-
-    const schema = {
-        disabledCondition: '__locale == "en"',
-        label: 'Text',
-        type: 'text_line',
-    };
-
-    const field = shallow(
-        <Field
-            data={{}}
-            dataPath="/block/0/text"
-            formInspector={formInspector}
-            name="text"
-            onChange={jest.fn()}
-            onFinish={jest.fn()}
-            onSuccess={undefined}
-            router={undefined}
-            schema={schema}
-            schemaPath="/text"
-            showAllErrors={true}
-            value="test"
-        />
-    );
-
-    expect(field.find('Text').prop('disabled')).toEqual(true);
 });
 
 test('Pass disabled flag to FieldType if disabledCondition with conditionDataProvider evaluates to true', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
@@ -261,9 +261,14 @@ test('Pass correct props to FieldType', () => {
         type: 'text_line',
         types: {},
     };
+
+    const data = {
+        title: 'Test',
+    };
+
     const field = shallow(
         <Field
-            data={{}}
+            data={data}
             dataPath="/block/0/text"
             formInspector={formInspector}
             name="text"
@@ -279,6 +284,7 @@ test('Pass correct props to FieldType', () => {
     );
 
     expect(field.find('Text').props()).toEqual(expect.objectContaining({
+        data,
         dataPath: '/block/0/text',
         disabled: false,
         formInspector,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
@@ -1,17 +1,32 @@
 // @flow
 import {render, shallow} from 'enzyme';
 import React from 'react';
+import {observable} from 'mobx';
 import ResourceStore from '../../../stores/ResourceStore';
 import Router from '../../../services/Router';
+import conditionDataProviderRegistry from '../registries/conditionDataProviderRegistry';
 import Field from '../Field';
 import fieldRegistry from '../registries/fieldRegistry';
 import FormInspector from '../FormInspector';
 import ResourceFormStore from '../stores/ResourceFormStore';
 
+beforeEach(() => {
+    conditionDataProviderRegistry.clear();
+});
+
 jest.mock('../../../services/Router/Router', () => jest.fn());
-jest.mock('../../../stores/ResourceStore', () => jest.fn());
-jest.mock('../FormInspector', () => jest.fn());
-jest.mock('../stores/ResourceFormStore', () => jest.fn());
+
+jest.mock('../../../stores/ResourceStore', () => jest.fn(function(resourceKey, id, observableOptions) {
+    this.locale = observableOptions?.locale;
+}));
+
+jest.mock('../FormInspector', () => jest.fn(function(resourceFormStore) {
+    this.locale = resourceFormStore.locale;
+}));
+
+jest.mock('../stores/ResourceFormStore', () => jest.fn(function(resourceStore) {
+    this.locale = resourceStore.locale;
+}));
 
 jest.mock('../registries/fieldRegistry', () => ({
     get: jest.fn(),
@@ -31,6 +46,7 @@ test('Render correct label with correct field type', () => {
     });
     expect(render(
         <Field
+            data={{}}
             dataPath=""
             formInspector={formInspector}
             name="test"
@@ -38,7 +54,7 @@ test('Render correct label with correct field type', () => {
             onFinish={jest.fn()}
             onSuccess={successSpy}
             router={undefined}
-            schema={{label: 'label1', type: 'text', visible: true}}
+            schema={{label: 'label1', type: 'text'}}
             schemaPath=""
         />
     )).toMatchSnapshot();
@@ -48,6 +64,7 @@ test('Render correct label with correct field type', () => {
     });
     expect(render(
         <Field
+            data={{}}
             dataPath=""
             formInspector={formInspector}
             name="test"
@@ -55,7 +72,7 @@ test('Render correct label with correct field type', () => {
             onFinish={jest.fn()}
             onSuccess={successSpy}
             router={undefined}
-            schema={{label: 'label2', type: 'datetime', visible: true}}
+            schema={{label: 'label2', type: 'datetime'}}
             schemaPath=""
         />
     )).toMatchSnapshot();
@@ -69,6 +86,7 @@ test('Render field with correct values for grid', () => {
     });
     expect(render(
         <Field
+            data={{}}
             dataPath=""
             formInspector={formInspector}
             name="test"
@@ -76,7 +94,7 @@ test('Render field with correct values for grid', () => {
             onFinish={jest.fn()}
             onSuccess={undefined}
             router={undefined}
-            schema={{label: 'label1', type: 'text', colSpan: 8, spaceAfter: 3, visible: true}}
+            schema={{label: 'label1', type: 'text', colSpan: 8, spaceAfter: 3}}
             schemaPath=""
         />
     )).toMatchSnapshot();
@@ -90,6 +108,7 @@ test('Render a required field with correct field type', () => {
     });
     expect(render(
         <Field
+            data={{}}
             dataPath=""
             formInspector={formInspector}
             name="test"
@@ -97,7 +116,7 @@ test('Render a required field with correct field type', () => {
             onFinish={jest.fn()}
             onSuccess={undefined}
             router={undefined}
-            schema={{label: 'label1', required: true, type: 'text', visible: true}}
+            schema={{label: 'label1', required: true, type: 'text'}}
             schemaPath=""
         />
     )).toMatchSnapshot();
@@ -108,6 +127,7 @@ test('Render a field without a label', () => {
 
     expect(render(
         <Field
+            data={{}}
             dataPath=""
             formInspector={formInspector}
             name="test"
@@ -115,7 +135,7 @@ test('Render a field without a label', () => {
             onFinish={jest.fn()}
             onSuccess={undefined}
             router={undefined}
-            schema={{type: 'text', visible: true}}
+            schema={{type: 'text'}}
             schemaPath=""
         />
     )).toMatchSnapshot();
@@ -126,6 +146,7 @@ test('Render a field with a description', () => {
 
     expect(render(
         <Field
+            data={{}}
             dataPath=""
             formInspector={formInspector}
             name="test"
@@ -137,7 +158,6 @@ test('Render a field with a description', () => {
                 description: 'Small description describing the field',
                 label: 'label1',
                 type: 'text',
-                visible: true,
             }}
             schemaPath=""
         />
@@ -153,6 +173,7 @@ test('Render a field with an error', () => {
     expect(
         render(
             <Field
+                data={{}}
                 dataPath=""
                 error={{keyword: 'minLength', parameters: {}}}
                 formInspector={formInspector}
@@ -161,7 +182,7 @@ test('Render a field with an error', () => {
                 onFinish={jest.fn()}
                 onSuccess={undefined}
                 router={undefined}
-                schema={{label: 'label1', type: 'text', visible: true}}
+                schema={{label: 'label1', type: 'text'}}
                 schemaPath=""
             />
         )
@@ -177,6 +198,7 @@ test('Render a field without a const error', () => {
     expect(
         render(
             <Field
+                data={{}}
                 dataPath=""
                 error={{keyword: 'const', parameters: {}}}
                 formInspector={formInspector}
@@ -185,7 +207,7 @@ test('Render a field without a const error', () => {
                 onFinish={jest.fn()}
                 onSuccess={undefined}
                 router={undefined}
-                schema={{label: 'label1', type: 'text', visible: true}}
+                schema={{label: 'label1', type: 'text'}}
                 schemaPath=""
             />
         )
@@ -207,6 +229,7 @@ test('Render a field with a error collection', () => {
     expect(
         render(
             <Field
+                data={{}}
                 dataPath=""
                 error={error}
                 formInspector={formInspector}
@@ -215,7 +238,7 @@ test('Render a field with a error collection', () => {
                 onFinish={jest.fn()}
                 onSuccess={undefined}
                 router={undefined}
-                schema={{label: 'label1', type: 'text', visible: true}}
+                schema={{label: 'label1', type: 'text'}}
                 schemaPath=""
             />
         )
@@ -237,10 +260,10 @@ test('Pass correct props to FieldType', () => {
         minOccurs: 2,
         type: 'text_line',
         types: {},
-        visible: true,
     };
     const field = shallow(
         <Field
+            data={{}}
             dataPath="/block/0/text"
             formInspector={formInspector}
             name="text"
@@ -257,7 +280,7 @@ test('Pass correct props to FieldType', () => {
 
     expect(field.find('Text').props()).toEqual(expect.objectContaining({
         dataPath: '/block/0/text',
-        disabled: undefined,
+        disabled: false,
         formInspector,
         label: 'Text',
         maxOccurs: 4,
@@ -271,7 +294,7 @@ test('Pass correct props to FieldType', () => {
     }));
 });
 
-test('Pass disabled flag to disabled FieldType', () => {
+test('Do not render anything if visibleCondition evaluates to false', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('snippets'), 'snippets'));
 
     fieldRegistry.get.mockReturnValue(function Text() {
@@ -279,16 +302,16 @@ test('Pass disabled flag to disabled FieldType', () => {
     });
 
     const schema = {
-        disabled: true,
         label: 'Text',
-        maxOccurs: 4,
-        minOccurs: 2,
         type: 'text_line',
-        types: {},
-        visible: true,
+        visibleCondition: 'title != "Test"',
     };
+
+    const data = observable({title: 'Test'});
+
     const field = shallow(
         <Field
+            data={data}
             dataPath="/block/0/text"
             formInspector={formInspector}
             name="text"
@@ -303,18 +326,194 @@ test('Pass disabled flag to disabled FieldType', () => {
         />
     );
 
-    expect(field.find('Text').props()).toEqual(expect.objectContaining({
-        dataPath: '/block/0/text',
-        disabled: true,
-        formInspector,
+    expect(field.find('Field')).toHaveLength(0);
+
+    data.title = 'Changed title!';
+    expect(field.find('Field')).toHaveLength(1);
+});
+
+test('Render the field if visibleCondition with locale evaluates to true', () => {
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            new ResourceStore('snippets', undefined, {locale: 'en'}),
+            'snippets'
+        )
+    );
+
+    fieldRegistry.get.mockReturnValue(function Text() {
+        return <input type="date" />;
+    });
+
+    const schema = {
         label: 'Text',
-        maxOccurs: 4,
-        minOccurs: 2,
-        schemaPath: '/text',
-        showAllErrors: true,
-        types: {},
-        value: 'test',
-    }));
+        type: 'text_line',
+        visibleCondition: '__locale == "en"',
+    };
+
+    const field = shallow(
+        <Field
+            data={{}}
+            dataPath="/block/0/text"
+            formInspector={formInspector}
+            name="text"
+            onChange={jest.fn()}
+            onFinish={jest.fn()}
+            onSuccess={undefined}
+            router={undefined}
+            schema={schema}
+            schemaPath="/text"
+            showAllErrors={true}
+            value="test"
+        />
+    );
+
+    expect(field.find('Field')).toHaveLength(1);
+});
+
+test('Render the field if visibleCondition with conditionDataProvider evaluates to true', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('snippets'), 'snippets'));
+
+    conditionDataProviderRegistry.add((data) => ({__test: data.test}));
+
+    fieldRegistry.get.mockReturnValue(function Text() {
+        return <input type="date" />;
+    });
+
+    const schema = {
+        label: 'Text',
+        type: 'text_line',
+        visibleCondition: '__test == "Test"',
+    };
+
+    const field = shallow(
+        <Field
+            data={{test: 'Test'}}
+            dataPath="/block/0/text"
+            formInspector={formInspector}
+            name="text"
+            onChange={jest.fn()}
+            onFinish={jest.fn()}
+            onSuccess={undefined}
+            router={undefined}
+            schema={schema}
+            schemaPath="/text"
+            showAllErrors={true}
+            value="test"
+        />
+    );
+
+    expect(field.find('Field')).toHaveLength(1);
+});
+
+test('Pass disabled flag to FieldType if disabledCondition evaluates to true', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('snippets'), 'snippets'));
+
+    fieldRegistry.get.mockReturnValue(function Text() {
+        return <input type="date" />;
+    });
+
+    const schema = {
+        disabledCondition: 'title == "Test"',
+        label: 'Text',
+        type: 'text_line',
+    };
+
+    const data = observable({title: 'Test'});
+
+    const field = shallow(
+        <Field
+            data={data}
+            dataPath="/block/0/text"
+            formInspector={formInspector}
+            name="text"
+            onChange={jest.fn()}
+            onFinish={jest.fn()}
+            onSuccess={undefined}
+            router={undefined}
+            schema={schema}
+            schemaPath="/text"
+            showAllErrors={true}
+            value="test"
+        />
+    );
+
+    expect(field.find('Text').prop('disabled')).toEqual(true);
+
+    data.title = 'Change title!';
+    expect(field.find('Text').prop('disabled')).toEqual(false);
+});
+
+test('Pass disabled flag to FieldType if disabledCondition with locale evaluates to true', () => {
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            new ResourceStore('snippets', undefined, {locale: 'en'}),
+            'snippets'
+        )
+    );
+
+    fieldRegistry.get.mockReturnValue(function Text() {
+        return <input type="date" />;
+    });
+
+    const schema = {
+        disabledCondition: '__locale == "en"',
+        label: 'Text',
+        type: 'text_line',
+    };
+
+    const field = shallow(
+        <Field
+            data={{}}
+            dataPath="/block/0/text"
+            formInspector={formInspector}
+            name="text"
+            onChange={jest.fn()}
+            onFinish={jest.fn()}
+            onSuccess={undefined}
+            router={undefined}
+            schema={schema}
+            schemaPath="/text"
+            showAllErrors={true}
+            value="test"
+        />
+    );
+
+    expect(field.find('Text').prop('disabled')).toEqual(true);
+});
+
+test('Pass disabled flag to FieldType if disabledCondition with conditionDataProvider evaluates to true', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('snippets'), 'snippets'));
+
+    conditionDataProviderRegistry.add((data) => ({__test: data.test}));
+
+    fieldRegistry.get.mockReturnValue(function Text() {
+        return <input type="date" />;
+    });
+
+    const schema = {
+        disabledCondition: '__test == "Test"',
+        label: 'Text',
+        type: 'text_line',
+    };
+
+    const field = shallow(
+        <Field
+            data={{test: 'Test'}}
+            dataPath="/block/0/text"
+            formInspector={formInspector}
+            name="text"
+            onChange={jest.fn()}
+            onFinish={jest.fn()}
+            onSuccess={undefined}
+            router={undefined}
+            schema={schema}
+            schemaPath="/text"
+            showAllErrors={true}
+            value="test"
+        />
+    );
+
+    expect(field.find('Text').prop('disabled')).toEqual(true);
 });
 
 test('Merge with options from fieldRegistry before passing props to FieldType', () => {
@@ -336,10 +535,10 @@ test('Merge with options from fieldRegistry before passing props to FieldType', 
         },
         type: 'text_line',
         types: {},
-        visible: true,
     };
     const field = shallow(
         <Field
+            data={{}}
             dataPath=""
             formInspector={formInspector}
             name="text"
@@ -379,6 +578,7 @@ test('Call onChange callback when value of Field changes', () => {
     const changeSpy = jest.fn();
     const field = shallow(
         <Field
+            data={{}}
             dataPath=""
             formInspector={formInspector}
             name="test"
@@ -386,7 +586,7 @@ test('Call onChange callback when value of Field changes', () => {
             onFinish={jest.fn()}
             onSuccess={undefined}
             router={undefined}
-            schema={{label: 'label', type: 'text', visible: true}}
+            schema={{label: 'label', type: 'text'}}
             schemaPath=""
         />
     );
@@ -406,6 +606,7 @@ test('Do not call onChange callback when value of disabled Field changes', () =>
     const changeSpy = jest.fn();
     const field = shallow(
         <Field
+            data={{title: 'Test'}}
             dataPath=""
             formInspector={formInspector}
             name="test"
@@ -413,7 +614,7 @@ test('Do not call onChange callback when value of disabled Field changes', () =>
             onFinish={jest.fn()}
             onSuccess={undefined}
             router={undefined}
-            schema={{label: 'label', type: 'text', disabled: true}}
+            schema={{label: 'label', type: 'text', disabledCondition: 'title == "Test"'}}
             schemaPath=""
         />
     );
@@ -433,6 +634,7 @@ test('Call onFinish callback after editing the field has finished', () => {
     const finishSpy = jest.fn();
     const field = shallow(
         <Field
+            data={{}}
             dataPath="/block/0/test"
             formInspector={formInspector}
             name="test"
@@ -440,7 +642,7 @@ test('Call onFinish callback after editing the field has finished', () => {
             onFinish={finishSpy}
             onSuccess={undefined}
             router={undefined}
-            schema={{label: 'label', type: 'text', visible: true}}
+            schema={{label: 'label', type: 'text'}}
             schemaPath="/test"
         />
     );
@@ -460,6 +662,7 @@ test('Call onSuccess callback when field calls onSuccess', () => {
     const finishSpy = jest.fn();
     const field = shallow(
         <Field
+            data={{}}
             dataPath="/block/0/test"
             formInspector={formInspector}
             name="test"
@@ -467,7 +670,7 @@ test('Call onSuccess callback when field calls onSuccess', () => {
             onFinish={finishSpy}
             onSuccess={successSpy}
             router={undefined}
-            schema={{label: 'label', type: 'text', visible: true}}
+            schema={{label: 'label', type: 'text'}}
             schemaPath="/test"
         />
     );
@@ -486,6 +689,7 @@ test('Do not render anything if field does not exist and onInvalid is set to ign
 
     const field = shallow(
         <Field
+            data={{}}
             dataPath="/test"
             formInspector={formInspector}
             name="test"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Form.test.js
@@ -328,6 +328,7 @@ test('Should pass data, onSuccess, router and schema to Renderer', () => {
         onSuccess: successSpy,
         router,
         schema: store.schema,
+        value: store.data,
     }));
 
     const formInspector = form.find('Renderer').prop('formInspector');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Renderer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Renderer.test.js
@@ -36,12 +36,10 @@ test('Should call onFieldFinish callback when editing a field has finished', () 
         text: {
             label: 'Text',
             type: 'text_line',
-            visible: true,
         },
         datetime: {
             label: 'Datetime',
             type: 'datetime',
-            visible: true,
         },
     };
     const fieldFinishSpy = jest.fn();
@@ -58,6 +56,7 @@ test('Should call onFieldFinish callback when editing a field has finished', () 
             router={undefined}
             schema={schema}
             schemaPath=""
+            value={{}}
         />
     );
 
@@ -73,12 +72,10 @@ test('Should render field types based on schema', () => {
         text: {
             label: 'Text',
             type: 'text_line',
-            visible: true,
         },
         datetime: {
             label: 'Datetime',
             type: 'datetime',
-            visible: true,
         },
     };
 
@@ -97,6 +94,7 @@ test('Should render field types based on schema', () => {
             router={undefined}
             schema={schema}
             schemaPath=""
+            value={{}}
         />
     );
 
@@ -108,12 +106,10 @@ test('Should render nested field types with based on schema', () => {
         'test/text': {
             label: 'Text',
             type: 'text_line',
-            visible: true,
         },
         'test/datetime': {
             label: 'Datetime',
             type: 'datetime',
-            visible: true,
         },
     };
 
@@ -139,6 +135,7 @@ test('Should render nested field types with based on schema', () => {
             router={undefined}
             schema={schema}
             schemaPath=""
+            value={data}
         />
     );
 
@@ -182,13 +179,15 @@ test('Should not render fields when the schema contains a visibleCondition evalu
         },
     };
 
+    const data = {test: 'Test'};
+
     const changeSpy = jest.fn();
 
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('snippets'), 'snippets'));
 
     const renderer = render(
         <Renderer
-            data={{test: 'Test'}}
+            data={data}
             dataPath=""
             formInspector={formInspector}
             onChange={changeSpy}
@@ -197,31 +196,28 @@ test('Should not render fields when the schema contains a visibleCondition evalu
             router={undefined}
             schema={schema}
             schemaPath=""
+            value={data}
         />
     );
 
     expect(renderer).toMatchSnapshot();
 });
 
-test('Should pass correct schemaPath to fields', () => {
+test('Should pass correct dataPath and schemaPath to fields', () => {
     const schema = {
         highlight: {
             items: {
                 title: {
                     type: 'text_line',
-                    visible: true,
                 },
                 url: {
                     type: 'text_line',
-                    visible: true,
                 },
             },
             type: 'section',
-            visible: true,
         },
         article: {
             type: 'text_line',
-            visible: true,
         },
     };
 
@@ -238,6 +234,7 @@ test('Should pass correct schemaPath to fields', () => {
             router={undefined}
             schema={schema}
             schemaPath="/test"
+            value={{}}
         />
     );
 
@@ -249,17 +246,69 @@ test('Should pass correct schemaPath to fields', () => {
     expect(renderer.find('Field').at(2).prop('dataPath')).toEqual('/block/0/article');
 });
 
+test('Should pass correct data and value to fields', () => {
+    const schema = {
+        highlight: {
+            items: {
+                title: {
+                    type: 'text_line',
+                },
+                url: {
+                    type: 'text_line',
+                },
+            },
+            type: 'section',
+        },
+        article: {
+            type: 'text_line',
+        },
+    };
+
+    const value = {
+        title: 'Some title',
+        url: 'some-url',
+        article: 'Some article',
+    };
+
+    const data = {
+        title: 'Page title',
+        block: value,
+    };
+
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('snippets'), 'snippets'));
+
+    const renderer = shallow(
+        <Renderer
+            data={data}
+            dataPath="/block/0"
+            formInspector={formInspector}
+            onChange={jest.fn()}
+            onFieldFinish={jest.fn()}
+            onSuccess={undefined}
+            router={undefined}
+            schema={schema}
+            schemaPath="/test"
+            value={value}
+        />
+    );
+
+    expect(renderer.find('Field').at(0).prop('data')).toEqual(data);
+    expect(renderer.find('Field').at(0).prop('value')).toEqual('Some title');
+    expect(renderer.find('Field').at(1).prop('data')).toEqual(data);
+    expect(renderer.find('Field').at(1).prop('value')).toEqual('some-url');
+    expect(renderer.find('Field').at(2).prop('data')).toEqual(data);
+    expect(renderer.find('Field').at(2).prop('value')).toEqual('Some article');
+});
+
 test('Should pass name, schema and formInspector to fields', () => {
     const schema = {
         text: {
             label: 'Text',
             type: 'text_line',
-            visible: true,
         },
         datetime: {
             label: 'Datetime',
             type: 'datetime',
-            visible: true,
         },
     };
 
@@ -280,6 +329,7 @@ test('Should pass name, schema and formInspector to fields', () => {
             router={undefined}
             schema={schema}
             schemaPath=""
+            value={{}}
         />
     );
 
@@ -305,12 +355,10 @@ test('Should pass router to fields if given', () => {
         text: {
             label: 'Text',
             type: 'text_line',
-            visible: true,
         },
         datetime: {
             label: 'Datetime',
             type: 'datetime',
-            visible: true,
         },
     };
 
@@ -332,6 +380,7 @@ test('Should pass router to fields if given', () => {
             router={router}
             schema={schema}
             schemaPath=""
+            value={{}}
         />
     );
 
@@ -346,12 +395,10 @@ test('Should pass errors to fields that have already been modified at least once
         text: {
             label: 'Text',
             type: 'text_line',
-            visible: true,
         },
         datetime: {
             label: 'Datetime',
             type: 'datetime',
-            visible: true,
         },
     };
 
@@ -387,6 +434,7 @@ test('Should pass errors to fields that have already been modified at least once
             router={undefined}
             schema={schema}
             schemaPath=""
+            value={{}}
         />
     );
 
@@ -401,12 +449,10 @@ test('Should pass all errors to fields if showAllErrors is set to true', () => {
         text: {
             label: 'Text',
             type: 'text_line',
-            visible: true,
         },
         datetime: {
             label: 'Datetime',
             type: 'datetime',
-            visible: true,
         },
     };
 
@@ -440,6 +486,7 @@ test('Should pass all errors to fields if showAllErrors is set to true', () => {
             schema={schema}
             schemaPath=""
             showAllErrors={true}
+            value={{}}
         />
     );
 
@@ -462,15 +509,12 @@ test('Should render nested sections', () => {
                 item11: {
                     label: 'Item 1.1',
                     type: 'text_line',
-                    visible: true,
                 },
                 section11: {
                     label: 'Section 1.1',
                     type: 'section',
-                    visible: true,
                 },
             },
-            visible: true,
         },
         section2: {
             label: 'Section 2',
@@ -479,10 +523,8 @@ test('Should render nested sections', () => {
                 item21: {
                     label: 'Item 2.1',
                     type: 'text_line',
-                    visible: true,
                 },
             },
-            visible: true,
         },
     };
 
@@ -499,6 +541,7 @@ test('Should render nested sections', () => {
             router={undefined}
             schema={schema}
             schemaPath=""
+            value={{}}
         />
     )).toMatchSnapshot();
 });
@@ -515,10 +558,8 @@ test('Should render sections with colSpan', () => {
                 item11: {
                     label: 'Item 1.1',
                     type: 'text_line',
-                    visible: true,
                 },
             },
-            visible: true,
         },
         section2: {
             label: 'Section 2',
@@ -528,10 +569,8 @@ test('Should render sections with colSpan', () => {
                 item21: {
                     label: 'Item 2.1',
                     type: 'text_line',
-                    visible: true,
                 },
             },
-            visible: true,
         },
     };
 
@@ -548,6 +587,7 @@ test('Should render sections with colSpan', () => {
             router={undefined}
             schema={schema}
             schemaPath=""
+            value={{}}
         />
     )).toMatchSnapshot();
 });
@@ -563,10 +603,8 @@ test('Should render sections without label', () => {
                 item11: {
                     label: 'Item 1.1',
                     type: 'text_line',
-                    visible: true,
                 },
             },
-            visible: true,
         },
         section2: {
             label: 'Section 2',
@@ -576,10 +614,8 @@ test('Should render sections without label', () => {
                 item21: {
                     label: 'Item 2.1',
                     type: 'text_line',
-                    visible: true,
                 },
             },
-            visible: true,
         },
     };
 
@@ -596,6 +632,7 @@ test('Should render sections without label', () => {
             router={undefined}
             schema={schema}
             schemaPath=""
+            value={{}}
         />
     )).toMatchSnapshot();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Renderer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Renderer.test.js
@@ -145,31 +145,31 @@ test('Should render nested field types with based on schema', () => {
     expect(renderer).toMatchSnapshot();
 });
 
-test('Should not render fields when the schema contains a visible flag of false', () => {
+test('Should not render fields when the schema contains a visibleCondition evaluating false', () => {
     const schema = {
         highlight: {
             items: {
                 title: {
                     type: 'text_line',
-                    visible: true,
+                    visibleCondition: 'test == "Test"',
                 },
                 url: {
                     type: 'text_line',
-                    visible: false,
+                    visibleCondition: 'test == false',
                 },
             },
             type: 'section',
-            visible: true,
+            visibleCondition: 'test == "Test"',
         },
         highlight2: {
             items: {
                 title: {
                     type: 'text_line',
-                    visible: true,
+                    visibleCondition: 'test == "Test"',
                 },
             },
             type: 'section',
-            visible: false,
+            visibleCondition: 'test == false',
         },
         text: {
             label: 'Text',
@@ -178,7 +178,7 @@ test('Should not render fields when the schema contains a visible flag of false'
         datetime: {
             label: 'Datetime',
             type: 'datetime',
-            visible: false,
+            visibleCondition: 'test == false',
         },
     };
 
@@ -188,7 +188,7 @@ test('Should not render fields when the schema contains a visible flag of false'
 
     const renderer = render(
         <Renderer
-            data={{}}
+            data={{test: 'Test'}}
             dataPath=""
             formInspector={formInspector}
             onChange={changeSpy}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Section.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Section.test.js
@@ -90,44 +90,6 @@ test('Do not render anything if visibleCondition evaluates to false', () => {
     expect(section.find('Section')).toHaveLength(1);
 });
 
-test('Render the section if visibleCondition with locale evaluates to true', () => {
-    const formInspector = new FormInspector(
-        new ResourceFormStore(
-            new ResourceStore('snippets', undefined, {locale: 'en'}),
-            'snippets'
-        )
-    );
-
-    fieldRegistry.get.mockReturnValue(function Text() {
-        return <input type="date" />;
-    });
-
-    const schema = {
-        label: 'Text',
-        type: 'text_line',
-        visibleCondition: '__locale == "en"',
-    };
-
-    const section = shallow(
-        <Section data={{}} formInspector={formInspector} name="section" schema={schema}>
-            <Field
-                data={{}}
-                dataPath=""
-                formInspector={formInspector}
-                name="test"
-                onChange={jest.fn()}
-                onFinish={jest.fn()}
-                onSuccess={jest.fn()}
-                router={undefined}
-                schema={{label: 'label1', type: 'text'}}
-                schemaPath=""
-            />
-        </Section>
-    );
-
-    expect(section.find('Section')).toHaveLength(1);
-});
-
 test('Render the section if visibleCondition with conditionDataProvider evaluates to true', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('snippets'), 'snippets'));
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Section.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Section.test.js
@@ -1,0 +1,166 @@
+// @flow
+import React from 'react';
+import {observable} from 'mobx';
+import {shallow, render} from 'enzyme';
+import ResourceStore from '../../../stores/ResourceStore';
+import Field from '../Field';
+import Section from '../Section';
+import FormInspector from '../FormInspector';
+import conditionDataProviderRegistry from '../registries/conditionDataProviderRegistry';
+import fieldRegistry from '../registries/fieldRegistry';
+import ResourceFormStore from '../stores/ResourceFormStore';
+
+jest.mock('../../../stores/ResourceStore', () => jest.fn(function(resourceKey, id, observableOptions) {
+    this.locale = observableOptions?.locale;
+}));
+
+jest.mock('../FormInspector', () => jest.fn(function(resourceFormStore) {
+    this.locale = resourceFormStore.locale;
+}));
+
+jest.mock('../stores/ResourceFormStore', () => jest.fn(function(resourceStore) {
+    this.locale = resourceStore.locale;
+}));
+
+jest.mock('../registries/fieldRegistry', () => ({
+    get: jest.fn(),
+    getOptions: jest.fn(),
+}));
+
+test('Render section with children', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('snippets'), 'snippets'));
+
+    fieldRegistry.get.mockReturnValue(function Text() {
+        return <input type="text" />;
+    });
+
+    expect(render(
+        <Section data={{}} formInspector={formInspector} name="section" schema={{label: 'Section', type: 'section'}}>
+            <Field
+                data={{}}
+                dataPath=""
+                formInspector={formInspector}
+                name="test"
+                onChange={jest.fn()}
+                onFinish={jest.fn()}
+                onSuccess={jest.fn()}
+                router={undefined}
+                schema={{label: 'label1', type: 'text'}}
+                schemaPath=""
+            />
+        </Section>
+    )).toMatchSnapshot();
+});
+
+test('Do not render anything if visibleCondition evaluates to false', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('snippets'), 'snippets'));
+
+    fieldRegistry.get.mockReturnValue(function Text() {
+        return <input type="date" />;
+    });
+
+    const schema = {
+        label: 'Text',
+        type: 'text_line',
+        visibleCondition: 'title != "Test"',
+    };
+
+    const data = observable({title: 'Test'});
+
+    const section = shallow(
+        <Section data={data} formInspector={formInspector} name="section" schema={schema}>
+            <Field
+                data={data}
+                dataPath=""
+                formInspector={formInspector}
+                name="test"
+                onChange={jest.fn()}
+                onFinish={jest.fn()}
+                onSuccess={jest.fn()}
+                router={undefined}
+                schema={{label: 'label1', type: 'text'}}
+                schemaPath=""
+            />
+        </Section>
+    );
+
+    expect(section.find('Section')).toHaveLength(0);
+
+    data.title = 'Changed title!';
+    expect(section.find('Section')).toHaveLength(1);
+});
+
+test('Render the section if visibleCondition with locale evaluates to true', () => {
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            new ResourceStore('snippets', undefined, {locale: 'en'}),
+            'snippets'
+        )
+    );
+
+    fieldRegistry.get.mockReturnValue(function Text() {
+        return <input type="date" />;
+    });
+
+    const schema = {
+        label: 'Text',
+        type: 'text_line',
+        visibleCondition: '__locale == "en"',
+    };
+
+    const section = shallow(
+        <Section data={{}} formInspector={formInspector} name="section" schema={schema}>
+            <Field
+                data={{}}
+                dataPath=""
+                formInspector={formInspector}
+                name="test"
+                onChange={jest.fn()}
+                onFinish={jest.fn()}
+                onSuccess={jest.fn()}
+                router={undefined}
+                schema={{label: 'label1', type: 'text'}}
+                schemaPath=""
+            />
+        </Section>
+    );
+
+    expect(section.find('Section')).toHaveLength(1);
+});
+
+test('Render the section if visibleCondition with conditionDataProvider evaluates to true', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('snippets'), 'snippets'));
+
+    conditionDataProviderRegistry.add((data) => ({__test: data.test}));
+
+    fieldRegistry.get.mockReturnValue(function Text() {
+        return <input type="date" />;
+    });
+
+    const schema = {
+        label: 'Text',
+        type: 'text_line',
+        visibleCondition: '__test == "Test"',
+    };
+
+    const data = {test: 'Test'};
+
+    const section = shallow(
+        <Section data={data} formInspector={formInspector} name="section" schema={schema}>
+            <Field
+                data={data}
+                dataPath=""
+                formInspector={formInspector}
+                name="test"
+                onChange={jest.fn()}
+                onFinish={jest.fn()}
+                onSuccess={jest.fn()}
+                router={undefined}
+                schema={{label: 'label1', type: 'text'}}
+                schemaPath=""
+            />
+        </Section>
+    );
+
+    expect(section.find('Section')).toHaveLength(1);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Renderer.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Renderer.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Should not render fields when the schema contains a visible flag of false 1`] = `
+exports[`Should not render fields when the schema contains a visibleCondition evaluating false 1`] = `
 <div
   class="grid grid"
 >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Section.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Section.test.js.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Render section with children 1`] = `
+<div
+  class="section gridSection colSpan colSpan-12 space-before-0 space-after-0"
+>
+  <div
+    class="item dividerContainer colSpan colSpan-12 space-before-0 space-after-0"
+  >
+    <div
+      class="divider"
+    >
+      Section
+    </div>
+  </div>
+  <div
+    class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
+  >
+    <div
+      class="field"
+    >
+      <label
+        class="label"
+        for=""
+      >
+        label1
+      </label>
+      <div
+        class="fieldContainer"
+      >
+        <div
+          class="field"
+        >
+          <input
+            type="text"
+          />
+        </div>
+      </div>
+      <label
+        class="errorLabel"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/conditionDataProviders/localeConditionDataProvider.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/conditionDataProviders/localeConditionDataProvider.test.js
@@ -1,0 +1,33 @@
+// @flow
+import {observable} from 'mobx';
+import ResourceStore from '../../../../stores/ResourceStore';
+import ResourceFormStore from '../../stores/ResourceFormStore';
+import FormInspector from '../../FormInspector';
+import localeConditionDataProvider from '../../conditionDataProviders/localeConditionDataProvider';
+
+jest.mock(
+    '../../stores/ResourceFormStore',
+    () => jest.fn(function(resourceStore) {
+        this.locale = resourceStore.locale;
+    })
+);
+
+jest.mock('../../../../stores/ResourceStore', () => jest.fn(function(resourceStore, id, observableOptions) {
+    this.locale = observableOptions?.locale;
+}));
+
+test('Return locale from FormInspector', () => {
+    const formInspector = new FormInspector(
+        new ResourceFormStore(new ResourceStore('test'), 'test', {webspace: 'test'})
+    );
+
+    expect(localeConditionDataProvider({}, '/test', formInspector)).toEqual({__locale: undefined});
+});
+
+test('Return locale from FormInspector', () => {
+    const formInspector = new FormInspector(
+        new ResourceFormStore(new ResourceStore('test', 5, {locale: observable.box('en')}), 'test', {webspace: 'test'})
+    );
+
+    expect(localeConditionDataProvider({}, '/test', formInspector)).toEqual({__locale: 'en'});
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/conditionDataProviders/localeConditionDataProvider.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/conditionDataProviders/localeConditionDataProvider.test.js
@@ -16,7 +16,7 @@ jest.mock('../../../../stores/ResourceStore', () => jest.fn(function(resourceSto
     this.locale = observableOptions?.locale;
 }));
 
-test('Return locale from FormInspector', () => {
+test('Return undefined if FormInspector has no locale', () => {
     const formInspector = new FormInspector(
         new ResourceFormStore(new ResourceStore('test'), 'test', {webspace: 'test'})
     );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/conditionDataProviders/parentConditionDataProvider.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/conditionDataProviders/parentConditionDataProvider.test.js
@@ -36,6 +36,7 @@ test('Return parent for nested second block', () => {
         title: 'Title',
         blocks: [
             {
+                title: 'Block title',
                 blocks: [
                     {title: 'Block title 1'},
                     {title: 'Block title 2'},
@@ -47,6 +48,7 @@ test('Return parent for nested second block', () => {
     expect(parentConditionDataProvider(data, '/blocks/0/blocks/1/title')).toEqual({
         __parent: {
             __parent: {
+                title: 'Block title',
                 blocks: [
                     {title: 'Block title 1'},
                     {title: 'Block title 2'},

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/conditionDataProviders/parentConditionDataProvider.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/conditionDataProviders/parentConditionDataProvider.test.js
@@ -2,67 +2,57 @@
 import parentConditionDataProvider from '../../conditionDataProviders/parentConditionDataProvider';
 
 test('Return parent for root level', () => {
-    const data = {
-        title: 'Test',
-    };
+    const data = {title: 'Test'};
 
-    expect(parentConditionDataProvider(data, '/title')).toEqual({__parent: data});
+    expect(parentConditionDataProvider(data, '/title')).toEqual({__parent: {title: 'Test'}});
 });
 
 test('Return parent for first block', () => {
-    const blocks = [
-        {
-            title: 'Block title 1',
-        },
-        {
-            title: 'Block title 2',
-        },
-    ];
-
     const data = {
         title: 'Title',
-        blocks,
+        blocks: [
+            {title: 'Block title 1'},
+            {title: 'Block title 2'},
+        ],
     };
 
-    expect(parentConditionDataProvider(data, '/blocks/0/title')).toEqual({__parent: blocks[0]});
+    expect(parentConditionDataProvider(data, '/blocks/0/title')).toEqual({__parent: {title: 'Block title 1'}});
 });
 
 test('Return parent for second block', () => {
-    const blocks = [
-        {
-            title: 'Block title 1',
-        },
-        {
-            title: 'Block title 2',
-        },
-    ];
-
     const data = {
         title: 'Title',
-        blocks,
+        blocks: [
+            {title: 'Block title 1'},
+            {title: 'Block title 2'},
+        ],
     };
 
-    expect(parentConditionDataProvider(data, '/blocks/1/title')).toEqual({__parent: blocks[1]});
+    expect(parentConditionDataProvider(data, '/blocks/1/title')).toEqual({__parent: {title: 'Block title 2'}});
 });
 
 test('Return parent for nested second block', () => {
-    const nestedBlocks = [
-        {
-            title: 'Block title 1',
-        },
-        {
-            title: 'Block title 2',
-        },
-    ];
-
     const data = {
         title: 'Title',
         blocks: [
             {
-                blocks: nestedBlocks,
+                blocks: [
+                    {title: 'Block title 1'},
+                    {title: 'Block title 2'},
+                ],
             },
         ],
     };
 
-    expect(parentConditionDataProvider(data, '/blocks/0/blocks/1/title')).toEqual({__parent: nestedBlocks[1]});
+    expect(parentConditionDataProvider(data, '/blocks/0/blocks/1/title')).toEqual({
+        __parent: {
+            __parent: {
+                blocks: [
+                    {title: 'Block title 1'},
+                    {title: 'Block title 2'},
+                ],
+            },
+            title: 'Block title 2',
+        },
+    });
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/conditionDataProviders/parentConditionDataProvider.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/conditionDataProviders/parentConditionDataProvider.test.js
@@ -1,0 +1,68 @@
+// @flow
+import parentConditionDataProvider from '../../conditionDataProviders/parentConditionDataProvider';
+
+test('Return parent for root level', () => {
+    const data = {
+        title: 'Test',
+    };
+
+    expect(parentConditionDataProvider(data, '/title')).toEqual({__parent: data});
+});
+
+test('Return parent for first block', () => {
+    const blocks = [
+        {
+            title: 'Block title 1',
+        },
+        {
+            title: 'Block title 2',
+        },
+    ];
+
+    const data = {
+        title: 'Title',
+        blocks,
+    };
+
+    expect(parentConditionDataProvider(data, '/blocks/0/title')).toEqual({__parent: blocks[0]});
+});
+
+test('Return parent for second block', () => {
+    const blocks = [
+        {
+            title: 'Block title 1',
+        },
+        {
+            title: 'Block title 2',
+        },
+    ];
+
+    const data = {
+        title: 'Title',
+        blocks,
+    };
+
+    expect(parentConditionDataProvider(data, '/blocks/1/title')).toEqual({__parent: blocks[1]});
+});
+
+test('Return parent for nested second block', () => {
+    const nestedBlocks = [
+        {
+            title: 'Block title 1',
+        },
+        {
+            title: 'Block title 2',
+        },
+    ];
+
+    const data = {
+        title: 'Title',
+        blocks: [
+            {
+                blocks: nestedBlocks,
+            },
+        ],
+    };
+
+    expect(parentConditionDataProvider(data, '/blocks/0/blocks/1/title')).toEqual({__parent: nestedBlocks[1]});
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/MemoryFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/MemoryFormStore.test.js
@@ -35,7 +35,6 @@ test('Create data object for schema', () => {
             },
         },
     });
-    memoryFormStore.destroy();
 });
 
 test('Create data object for schema while keeping existing data', () => {
@@ -58,7 +57,6 @@ test('Create data object for schema while keeping existing data', () => {
         title: 'Test',
         description: undefined,
     });
-    memoryFormStore.destroy();
 });
 
 test('Create data object for schema with sections', () => {
@@ -95,293 +93,38 @@ test('Create data object for schema with sections', () => {
         item11: undefined,
         item21: undefined,
     });
-    memoryFormStore.destroy();
-});
-
-test('Evaluate all disabledConditions and visibleConditions for schema', () => {
-    const schema = {
-        item1: {
-            type: 'text_line',
-        },
-        item2: {
-            type: 'text_line',
-            disabledCondition: 'item1 != "item2"',
-            visibleCondition: 'item1 == "item2"',
-        },
-        section: {
-            items: {
-                item31: {
-                    type: 'text_line',
-                },
-                item32: {
-                    type: 'text_line',
-                    disabledCondition: 'item1 != "item32"',
-                    visibleCondition: 'item1 == "item32"',
-                },
-            },
-            type: 'section',
-            disabledCondition: 'item1 != "section"',
-            visibleCondition: 'item1 == "section"',
-        },
-        block: {
-            type: 'block',
-            types: {
-                text_line: {
-                    title: 'item41',
-                    form: {
-                        item41: {
-                            type: 'text_line',
-                            disabledCondition: 'item1 != "item41"',
-                            visibleCondition: 'item1 == "item41"',
-                        },
-                        item42: {
-                            type: 'text_line',
-                        },
-                    },
-                },
-            },
-        },
-    };
-
-    const memoryFormStore = new MemoryFormStore({}, schema);
-
-    setTimeout(() => {
-        const sectionItems1 = memoryFormStore.schema.section.items;
-        if (!sectionItems1) {
-            throw new Error('Section items should be defined!');
-        }
-        const blockTypes1 = memoryFormStore.schema.block.types;
-        if (!blockTypes1) {
-            throw new Error('Block types should be defined!');
-        }
-
-        expect(memoryFormStore.schema.item2.disabled).toEqual(true);
-        expect(memoryFormStore.schema.item2.visible).toEqual(false);
-        expect(sectionItems1.item32.disabled).toEqual(true);
-        expect(sectionItems1.item32.visible).toEqual(false);
-        expect(memoryFormStore.schema.section.disabled).toEqual(true);
-        expect(memoryFormStore.schema.section.visible).toEqual(false);
-        expect(blockTypes1.text_line.form.item41.disabled).toEqual(true);
-        expect(blockTypes1.text_line.form.item41.visible).toEqual(false);
-
-        memoryFormStore.data = observable({item1: 'item2'});
-        expect(memoryFormStore.schema.item2.disabled).toEqual(true);
-        expect(memoryFormStore.schema.item2.visible).toEqual(false);
-
-        memoryFormStore.finishField('/item1');
-        const sectionItems2 = memoryFormStore.schema.section.items;
-        if (!sectionItems2) {
-            throw new Error('Section items should be defined!');
-        }
-        const blockTypes2 = memoryFormStore.schema.block.types;
-        if (!blockTypes2) {
-            throw new Error('Block types should be defined!');
-        }
-
-        expect(memoryFormStore.schema.item2.disabled).toEqual(false);
-        expect(memoryFormStore.schema.item2.visible).toEqual(true);
-        expect(sectionItems2.item32.disabled).toEqual(true);
-        expect(sectionItems2.item32.visible).toEqual(false);
-        expect(memoryFormStore.schema.section.disabled).toEqual(true);
-        expect(memoryFormStore.schema.section.visible).toEqual(false);
-        expect(blockTypes2.text_line.form.item41.disabled).toEqual(true);
-        expect(blockTypes2.text_line.form.item41.visible).toEqual(false);
-
-        memoryFormStore.data = observable({item1: 'item32'});
-
-        memoryFormStore.finishField('/item1');
-        const sectionItems3 = memoryFormStore.schema.section.items;
-        if (!sectionItems3) {
-            throw new Error('Section items should be defined!');
-        }
-        const blockTypes3 = memoryFormStore.schema.block.types;
-        if (!blockTypes3) {
-            throw new Error('Block types should be defined!');
-        }
-
-        expect(memoryFormStore.schema.item2.disabled).toEqual(true);
-        expect(memoryFormStore.schema.item2.visible).toEqual(false);
-        expect(sectionItems3.item32.disabled).toEqual(false);
-        expect(sectionItems3.item32.visible).toEqual(true);
-        expect(memoryFormStore.schema.section.disabled).toEqual(true);
-        expect(memoryFormStore.schema.section.visible).toEqual(false);
-        expect(blockTypes3.text_line.form.item41.disabled).toEqual(true);
-        expect(blockTypes3.text_line.form.item41.visible).toEqual(false);
-
-        memoryFormStore.data = observable({item1: 'section'});
-        memoryFormStore.finishField('/item1');
-
-        const sectionItems4 = memoryFormStore.schema.section.items;
-        if (!sectionItems4) {
-            throw new Error('Section items should be defined!');
-        }
-        const blockTypes4 = memoryFormStore.schema.block.types;
-        if (!blockTypes4) {
-            throw new Error('Block types should be defined!');
-        }
-
-        expect(memoryFormStore.schema.item2.disabled).toEqual(true);
-        expect(memoryFormStore.schema.item2.visible).toEqual(false);
-        expect(sectionItems4.item32.disabled).toEqual(true);
-        expect(sectionItems4.item32.visible).toEqual(false);
-        expect(memoryFormStore.schema.section.disabled).toEqual(false);
-        expect(memoryFormStore.schema.section.visible).toEqual(true);
-        expect(blockTypes4.text_line.form.item41.disabled).toEqual(true);
-        expect(blockTypes4.text_line.form.item41.visible).toEqual(false);
-
-        memoryFormStore.data = observable({item1: 'item41'});
-        memoryFormStore.finishField('/item1');
-        const sectionItems5 = memoryFormStore.schema.section.items;
-        if (!sectionItems5) {
-            throw new Error('Section items should be defined!');
-        }
-        const blockTypes5 = memoryFormStore.schema.block.types;
-        if (!blockTypes5) {
-            throw new Error('Block types should be defined!');
-        }
-
-        expect(memoryFormStore.schema.item2.disabled).toEqual(true);
-        expect(memoryFormStore.schema.item2.visible).toEqual(false);
-        expect(sectionItems5.item32.disabled).toEqual(true);
-        expect(sectionItems5.item32.visible).toEqual(false);
-        expect(memoryFormStore.schema.section.disabled).toEqual(true);
-        expect(memoryFormStore.schema.section.visible).toEqual(false);
-        expect(blockTypes5.text_line.form.item41.disabled).toEqual(false);
-        expect(blockTypes5.text_line.form.item41.visible).toEqual(true);
-
-        memoryFormStore.destroy();
-    }, 0);
-});
-
-test('Evaluate all disabledConditions and visibleConditions after calling setMultiple', () => {
-    const schema = {
-        item1: {
-            type: 'text_line',
-        },
-        item2: {
-            type: 'text_line',
-            disabledCondition: 'item1 != "item2"',
-            visibleCondition: 'item1 == "item2"',
-        },
-    };
-
-    const memoryFormStore = new MemoryFormStore({}, schema);
-
-    setTimeout(() => {
-        expect(memoryFormStore.schema.item2.disabled).toEqual(true);
-        expect(memoryFormStore.schema.item2.visible).toEqual(false);
-
-        memoryFormStore.setMultiple({item1: 'item2'});
-
-        expect(memoryFormStore.schema.item2.disabled).toEqual(false);
-        expect(memoryFormStore.schema.item2.visible).toEqual(true);
-
-        memoryFormStore.destroy();
-    }, 0);
-});
-
-test('Evaluate disabledConditions and visibleConditions for schema with locale', (done) => {
-    const schema = {
-        item: {
-            type: 'text_line',
-            disabledCondition: '__locale == "en"',
-            visibleCondition: '__locale == "de"',
-        },
-    };
-
-    const memoryFormStore = new MemoryFormStore({}, schema, {}, observable.box('en'));
-
-    setTimeout(() => {
-        expect(memoryFormStore.schema.item.disabled).toEqual(true);
-        expect(memoryFormStore.schema.item.visible).toEqual(false);
-        memoryFormStore.destroy();
-        done();
-    });
-});
-
-test('Evaluate disabledConditions and visibleConditions when changing locale', (done) => {
-    const schema = {
-        item: {
-            type: 'text_line',
-            disabledCondition: '__locale == "en"',
-            visibleCondition: '__locale == "de"',
-        },
-    };
-
-    const locale = observable.box('en');
-    const memoryFormStore = new MemoryFormStore({}, schema, {}, locale);
-
-    setTimeout(() => {
-        expect(memoryFormStore.schema.item.disabled).toEqual(true);
-        expect(memoryFormStore.schema.item.visible).toEqual(false);
-
-        locale.set('de');
-        setTimeout(() => {
-            expect(memoryFormStore.schema.item.disabled).toEqual(false);
-            expect(memoryFormStore.schema.item.visible).toEqual(true);
-            memoryFormStore.destroy();
-            done();
-        }, 0);
-    }, 0);
-});
-
-test('Evaluate disabledConditions and visibleConditions for schema with conditionDataProvider', (done) => {
-    const schema = {
-        item: {
-            type: 'text_line',
-            disabledCondition: '__test == "value1"',
-            visibleCondition: '__test == "value2"',
-        },
-    };
-
-    conditionDataProviderRegistry.add((data) => ({__test: data.test}));
-
-    const memoryFormStore = new MemoryFormStore({test: 'value1'}, schema, {}, observable.box('en'));
-
-    setTimeout(() => {
-        expect(memoryFormStore.schema.item.disabled).toEqual(true);
-        expect(memoryFormStore.schema.item.visible).toEqual(false);
-        memoryFormStore.destroy();
-        done();
-    });
 });
 
 test('Asking for resourceKey should return undefined', () => {
     const memoryFormStore = new MemoryFormStore({}, {});
     expect(memoryFormStore.resourceKey).toBeUndefined();
-    memoryFormStore.destroy();
 });
 
 test('Asking for resourceKey should return undefined', () => {
     const memoryFormStore = new MemoryFormStore({}, {});
     expect(memoryFormStore.resourceKey).toBeUndefined();
-    memoryFormStore.destroy();
 });
 
 test('Asking for id should return undefined', () => {
     const memoryFormStore = new MemoryFormStore({}, {});
     expect(memoryFormStore.id).toBeUndefined();
-    memoryFormStore.destroy();
 });
 
 test('Read dirty flag', () => {
     const memoryFormStore = new MemoryFormStore({}, {});
     expect(memoryFormStore.dirty).toEqual(false);
-    memoryFormStore.destroy();
 });
 
 test('Set dirty flag', () => {
     const memoryFormStore = new MemoryFormStore({}, {});
     memoryFormStore.change('test', 'test');
     expect(memoryFormStore.dirty).toEqual(true);
-    memoryFormStore.destroy();
 });
 
 test('Set nested value', () => {
     const memoryFormStore = new MemoryFormStore({}, {});
     memoryFormStore.change('test1/test2', 'test');
     expect(memoryFormStore.data).toEqual({test1: {test2: 'test'}});
-    memoryFormStore.destroy();
 });
 
 test('Set multiple values', () => {
@@ -391,13 +134,11 @@ test('Set multiple values', () => {
     memoryFormStore.setMultiple({key2: 'newValue2', key3: 'value3'});
 
     expect(memoryFormStore.data).toEqual({key1: 'value1', key2: 'newValue2', key3: 'value3'});
-    memoryFormStore.destroy();
 });
 
 test('Loading flag should always be false', () => {
     const memoryFormStore = new MemoryFormStore({}, {});
     expect(memoryFormStore.loading).toEqual(false);
-    memoryFormStore.destroy();
 });
 
 test('Data attribute should return the data', () => {
@@ -408,16 +149,6 @@ test('Data attribute should return the data', () => {
     const memoryFormStore = new MemoryFormStore(data, {});
 
     expect(memoryFormStore.data).toBe(data);
-    memoryFormStore.destroy();
-});
-
-test('Destroying the store should call all the disposers', () => {
-    const memoryFormStore = new MemoryFormStore({}, {});
-    memoryFormStore.updateFieldPathEvaluationsDisposer = jest.fn();
-
-    memoryFormStore.destroy();
-
-    expect(memoryFormStore.updateFieldPathEvaluationsDisposer).toBeCalled();
 });
 
 test('Should return value for property path', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {isObservable, observable, observable as mockObservable, toJS, when} from 'mobx';
+import {observable, observable as mockObservable, toJS, when} from 'mobx';
 import ResourceFormStore from '../../stores/ResourceFormStore';
 import ResourceStore from '../../../../stores/ResourceStore';
 import metadataStore from '../../stores/metadataStore';
@@ -75,318 +75,6 @@ test('Create data object for schema', (done) => {
             },
         });
         resourceFormStore.destroy();
-        done();
-    }, 0);
-});
-
-test('Evaluate all disabledConditions and visibleConditions for schema', () => {
-    const metadata = {
-        item1: {
-            type: 'text_line',
-        },
-        item2: {
-            type: 'text_line',
-            disabledCondition: 'item1 != "item2"',
-            visibleCondition: 'item1 == "item2"',
-        },
-        section: {
-            items: {
-                item31: {
-                    type: 'text_line',
-                },
-                item32: {
-                    type: 'text_line',
-                    disabledCondition: 'item1 != "item32"',
-                    visibleCondition: 'item1 == "item32"',
-                },
-            },
-            type: 'section',
-            disabledCondition: 'item1 != "section"',
-            visibleCondition: 'item1 == "section"',
-        },
-        block: {
-            types: {
-                text_line: {
-                    form: {
-                        item41: {
-                            type: 'text_line',
-                            disabledCondition: 'item1 != "item41"',
-                            visibleCondition: 'item1 == "item41"',
-                        },
-                        item42: {
-                            type: 'text_line',
-                        },
-                    },
-                },
-            },
-        },
-    };
-
-    const metadataPromise = Promise.resolve(metadata);
-    metadataStore.getSchema.mockReturnValue(metadataPromise);
-
-    const resourceStore = new ResourceStore('snippets', '1');
-    const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets');
-
-    setTimeout(() => {
-        expect(isObservable(resourceFormStore.schema)).toBe(false);
-        const sectionItems1 = resourceFormStore.schema.section.items;
-        if (!sectionItems1) {
-            throw new Error('Section items should be defined!');
-        }
-        const blockTypes1 = resourceFormStore.schema.block.types;
-        if (!blockTypes1) {
-            throw new Error('Block types should be defined!');
-        }
-
-        expect(resourceFormStore.schema.item2.disabled).toEqual(true);
-        expect(resourceFormStore.schema.item2.visible).toEqual(false);
-        expect(sectionItems1.item32.disabled).toEqual(true);
-        expect(sectionItems1.item32.visible).toEqual(false);
-        expect(resourceFormStore.schema.section.disabled).toEqual(true);
-        expect(resourceFormStore.schema.section.visible).toEqual(false);
-        expect(blockTypes1.text_line.form.item41.disabled).toEqual(true);
-        expect(blockTypes1.text_line.form.item41.visible).toEqual(false);
-
-        resourceStore.data = observable({item1: 'item2'});
-        expect(resourceFormStore.schema.item2.disabled).toEqual(true);
-        expect(resourceFormStore.schema.item2.visible).toEqual(false);
-
-        resourceFormStore.finishField('/item1');
-        const sectionItems2 = resourceFormStore.schema.section.items;
-        if (!sectionItems2) {
-            throw new Error('Section items should be defined!');
-        }
-        const blockTypes2 = resourceFormStore.schema.block.types;
-        if (!blockTypes2) {
-            throw new Error('Block types should be defined!');
-        }
-
-        expect(resourceFormStore.schema.item2.disabled).toEqual(false);
-        expect(resourceFormStore.schema.item2.visible).toEqual(true);
-        expect(sectionItems2.item32.disabled).toEqual(true);
-        expect(sectionItems2.item32.visible).toEqual(false);
-        expect(resourceFormStore.schema.section.disabled).toEqual(true);
-        expect(resourceFormStore.schema.section.visible).toEqual(false);
-        expect(blockTypes2.text_line.form.item41.disabled).toEqual(true);
-        expect(blockTypes2.text_line.form.item41.visible).toEqual(false);
-
-        resourceStore.data = observable({item1: 'item32'});
-        resourceFormStore.finishField('/item1');
-        const sectionItems3 = resourceFormStore.schema.section.items;
-        if (!sectionItems3) {
-            throw new Error('Section items should be defined!');
-        }
-        const blockTypes3 = resourceFormStore.schema.block.types;
-        if (!blockTypes3) {
-            throw new Error('Block types should be defined!');
-        }
-
-        expect(resourceFormStore.schema.item2.disabled).toEqual(true);
-        expect(resourceFormStore.schema.item2.visible).toEqual(false);
-        expect(sectionItems3.item32.disabled).toEqual(false);
-        expect(sectionItems3.item32.visible).toEqual(true);
-        expect(resourceFormStore.schema.section.disabled).toEqual(true);
-        expect(resourceFormStore.schema.section.visible).toEqual(false);
-        expect(blockTypes3.text_line.form.item41.disabled).toEqual(true);
-        expect(blockTypes3.text_line.form.item41.visible).toEqual(false);
-
-        resourceStore.data = observable({item1: 'section'});
-        resourceFormStore.finishField('/item1');
-        const sectionItems4 = resourceFormStore.schema.section.items;
-        if (!sectionItems4) {
-            throw new Error('Section items should be defined!');
-        }
-        const blockTypes4 = resourceFormStore.schema.block.types;
-        if (!blockTypes4) {
-            throw new Error('Block types should be defined!');
-        }
-
-        expect(resourceFormStore.schema.item2.disabled).toEqual(true);
-        expect(resourceFormStore.schema.item2.visible).toEqual(false);
-        expect(sectionItems4.item32.disabled).toEqual(true);
-        expect(sectionItems4.item32.visible).toEqual(false);
-        expect(resourceFormStore.schema.section.disabled).toEqual(false);
-        expect(resourceFormStore.schema.section.visible).toEqual(true);
-        expect(blockTypes4.text_line.form.item41.disabled).toEqual(true);
-        expect(blockTypes4.text_line.form.item41.visible).toEqual(false);
-
-        resourceStore.data = observable({item1: 'item41'});
-        resourceFormStore.finishField('/item1');
-        const sectionItems5 = resourceFormStore.schema.section.items;
-        if (!sectionItems5) {
-            throw new Error('Section items should be defined!');
-        }
-        const blockTypes5 = resourceFormStore.schema.block.types;
-        if (!blockTypes5) {
-            throw new Error('Block types should be defined!');
-        }
-
-        expect(resourceFormStore.schema.item2.disabled).toEqual(true);
-        expect(resourceFormStore.schema.item2.visible).toEqual(false);
-        expect(sectionItems5.item32.disabled).toEqual(true);
-        expect(sectionItems5.item32.visible).toEqual(false);
-        expect(resourceFormStore.schema.section.disabled).toEqual(true);
-        expect(resourceFormStore.schema.section.visible).toEqual(false);
-        expect(blockTypes5.text_line.form.item41.disabled).toEqual(false);
-        expect(blockTypes5.text_line.form.item41.visible).toEqual(true);
-
-        resourceFormStore.destroy();
-    }, 0);
-});
-
-test('Evaluate all disabledConditions and visibleConditions for schema after calling setMultiple', () => {
-    const metadata = {
-        item1: {
-            type: 'text_line',
-        },
-        item2: {
-            type: 'text_line',
-            disabledCondition: 'item1 != "item2"',
-            visibleCondition: 'item1 == "item2"',
-        },
-    };
-
-    const metadataPromise = Promise.resolve(metadata);
-    metadataStore.getSchema.mockReturnValue(metadataPromise);
-
-    const resourceStore = new ResourceStore('snippets', '1');
-    const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets');
-
-    setTimeout(() => {
-        expect(isObservable(resourceFormStore.schema)).toBe(false);
-
-        resourceFormStore.setMultiple({item1: 'item2'});
-        expect(resourceFormStore.schema.item2.disabled).toEqual(false);
-        expect(resourceFormStore.schema.item2.visible).toEqual(true);
-
-        resourceFormStore.destroy();
-    }, 0);
-});
-
-test('Evaluate disabledConditions and visibleConditions for schema with locale', (done) => {
-    const metadata = {
-        item: {
-            type: 'text_line',
-            disabledCondition: '__locale == "en"',
-            visibleCondition: '__locale == "de"',
-        },
-    };
-
-    const metadataPromise = Promise.resolve(metadata);
-    metadataStore.getSchema.mockReturnValue(metadataPromise);
-
-    const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box('en')});
-    const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets');
-
-    setTimeout(() => {
-        expect(resourceFormStore.schema.item.disabled).toEqual(true);
-        expect(resourceFormStore.schema.item.visible).toEqual(false);
-        done();
-    }, 0);
-});
-
-test('Evaluate disabledConditions and visibleConditions when changing locale', (done) => {
-    const metadata = {
-        item: {
-            type: 'text_line',
-            disabledCondition: '__locale == "en"',
-            visibleCondition: '__locale == "de"',
-        },
-    };
-
-    const metadataPromise = Promise.resolve(metadata);
-    metadataStore.getSchema.mockReturnValue(metadataPromise);
-
-    const locale = observable.box('en');
-    const resourceStore = new ResourceStore('snippets', '1', {locale});
-    const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets');
-
-    setTimeout(() => {
-        expect(resourceFormStore.schema.item.disabled).toEqual(true);
-        expect(resourceFormStore.schema.item.visible).toEqual(false);
-
-        locale.set('de');
-        setTimeout(() => {
-            expect(resourceFormStore.schema.item.disabled).toEqual(false);
-            expect(resourceFormStore.schema.item.visible).toEqual(true);
-            done();
-        });
-    });
-});
-
-test('Evaluate disabledConditions and visibleConditions for schema from data', (done) => {
-    const metadata = {
-        item: {
-            type: 'text_line',
-            disabledCondition: '__test == "value1"',
-            visibleCondition: '__test == "value2"',
-        },
-    };
-
-    conditionDataProviderRegistry.add((data) => ({__test: data.test}));
-
-    const metadataPromise = Promise.resolve(metadata);
-    metadataStore.getSchema.mockReturnValue(metadataPromise);
-
-    const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box('en')});
-    const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets');
-
-    resourceStore.data = observable({test: 'value1'});
-
-    setTimeout(() => {
-        expect(resourceFormStore.schema.item.disabled).toEqual(true);
-        expect(resourceFormStore.schema.item.visible).toEqual(false);
-        done();
-    }, 0);
-});
-
-test('Evaluate disabledConditions and visibleConditions for schema from options', (done) => {
-    const metadata = {
-        item: {
-            type: 'text_line',
-            disabledCondition: '__test == "value1"',
-            visibleCondition: '__test == "value2"',
-        },
-    };
-
-    conditionDataProviderRegistry.add((data, options) => ({__test: options.test}));
-
-    const metadataPromise = Promise.resolve(metadata);
-    metadataStore.getSchema.mockReturnValue(metadataPromise);
-
-    const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box('en')});
-    const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets', {test: 'value1'});
-
-    setTimeout(() => {
-        expect(resourceFormStore.schema.item.disabled).toEqual(true);
-        expect(resourceFormStore.schema.item.visible).toEqual(false);
-        done();
-    }, 0);
-});
-
-test('Evaluate disabledConditions and visibleConditions for schema from metadatOptions', (done) => {
-    const metadata = {
-        item: {
-            type: 'text_line',
-            disabledCondition: '__test == "value1"',
-            visibleCondition: '__test == "value2"',
-        },
-    };
-
-    conditionDataProviderRegistry.add(
-        (data, options, metadataOptions) => ({__test: metadataOptions && metadataOptions.test})
-    );
-
-    const metadataPromise = Promise.resolve(metadata);
-    metadataStore.getSchema.mockReturnValue(metadataPromise);
-
-    const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box('en')});
-    const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets', {}, {test: 'value1'});
-
-    setTimeout(() => {
-        expect(resourceFormStore.schema.item.disabled).toEqual(true);
-        expect(resourceFormStore.schema.item.visible).toEqual(false);
         done();
     }, 0);
 });
@@ -575,7 +263,7 @@ test('Change type should update schema and data', (done) => {
     const cachedPathsByTag = resourceFormStore.pathsByTag;
 
     setTimeout(() => {
-        expect(resourceFormStore.rawSchema).toEqual(sidebarMetadata);
+        expect(resourceFormStore.schema).toEqual(sidebarMetadata);
         expect(resourceFormStore.pathsByTag).not.toBe(cachedPathsByTag);
         expect(resourceFormStore.data).toEqual({
             title: 'Title',
@@ -1143,13 +831,11 @@ test('Destroying the store should call all the disposers', () => {
     const resourceFormStore = new ResourceFormStore(new ResourceStore('snippets', '2'), 'snippets');
     resourceFormStore.schemaDisposer = jest.fn();
     resourceFormStore.typeDisposer = jest.fn();
-    resourceFormStore.updateFieldPathEvaluationsDisposer = jest.fn();
 
     resourceFormStore.destroy();
 
     expect(resourceFormStore.schemaDisposer).toBeCalled();
     expect(resourceFormStore.typeDisposer).toBeCalled();
-    expect(resourceFormStore.updateFieldPathEvaluationsDisposer).toBeCalled();
 });
 
 test('Destroying the store should not fail if no disposers are available', () => {
@@ -1178,7 +864,7 @@ test('Return all the values for a given tag', () => {
     });
 
     const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets');
-    resourceFormStore.rawSchema = {
+    resourceFormStore.schema = {
         title: {
             tags: [
                 {name: 'sulu.resource_locator_part'},
@@ -1211,7 +897,7 @@ test('Return all the values for a given tag sorted by priority', () => {
     });
 
     const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets');
-    resourceFormStore.rawSchema = {
+    resourceFormStore.schema = {
         title: {
             tags: [
                 {name: 'sulu.resource_locator_part', priority: 10},
@@ -1242,7 +928,7 @@ test('Return all the values for a given tag within sections', () => {
     });
 
     const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets');
-    resourceFormStore.rawSchema = {
+    resourceFormStore.schema = {
         highlight: {
             items: {
                 title: {
@@ -1282,7 +968,7 @@ test('Return all the values for a given tag with empty blocks', () => {
     });
 
     const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets');
-    resourceFormStore.rawSchema = {
+    resourceFormStore.schema = {
         title: {
             tags: [
                 {name: 'sulu.resource_locator_part'},
@@ -1334,7 +1020,7 @@ test('Return all the values for a given tag within blocks', () => {
     });
 
     const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets');
-    resourceFormStore.rawSchema = {
+    resourceFormStore.schema = {
         title: {
             tags: [
                 {name: 'sulu.resource_locator_part'},
@@ -1454,7 +1140,7 @@ test('Return SchemaEntry for given schemaPath', (done) => {
 
 test('Remember fields being finished as modified fields and forget about them after saving', () => {
     const resourceFormStore = new ResourceFormStore(new ResourceStore('test'), 'snippets');
-    resourceFormStore.rawSchema = {};
+    resourceFormStore.schema = {};
     resourceFormStore.finishField('/block/0/text');
     resourceFormStore.finishField('/block/0/text');
     resourceFormStore.finishField('/block/1/text');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -107,6 +107,7 @@ export interface FormStoreInterface {
 }
 
 export type FieldTypeProps<T> = {|
+    data: Object,
     dataPath: string,
     defaultType: ?string,
     disabled: ?boolean,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -73,8 +73,8 @@ export type SaveHandler = (action: ?string | {[string]: any}) => void;
 
 export type ConditionDataProvider = (
     data: {[string]: any},
-    options: {[string]: any},
-    metadataOptions: ?{[string]: any}
+    dataPath: ?string,
+    formInspector: FormInspector,
 ) => {[string]: any};
 
 export interface FormStoreInterface {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -19,18 +19,9 @@ export type Tag = {
     priority?: number,
 };
 
-type BaseType = {
-    title: string,
-};
-
-export type RawType = BaseType & {
-    form: RawSchema,
-};
-
-export type RawTypes = {[key: string]: RawType};
-
-export type Type = BaseType & {
+export type Type = {
     form: Schema,
+    title: string,
 };
 
 export type Types = {[key: string]: Type};
@@ -55,10 +46,12 @@ export type SchemaOption = {
 
 export type SchemaOptions = {[key: string]: SchemaOption | typeof undefined};
 
-type BaseSchemaEntry = {
+export type SchemaEntry = {
     colSpan?: ColSpan,
     defaultType?: string,
     description?: string,
+    disabledCondition?: string,
+    items?: Schema,
     label?: string,
     maxOccurs?: number,
     minOccurs?: number,
@@ -68,23 +61,9 @@ type BaseSchemaEntry = {
     spaceAfter?: ColSpan,
     tags?: Array<Tag>,
     type: string,
-};
-
-export type RawSchemaEntry = BaseSchemaEntry & {
-    disabledCondition?: string,
-    items?: RawSchema,
-    types?: RawTypes,
+    types?: Types,
     visibleCondition?: string,
 };
-
-export type SchemaEntry = BaseSchemaEntry & {
-    disabled?: boolean,
-    items?: Schema,
-    types?: Types,
-    visible?: boolean,
-};
-
-export type RawSchema = {[string]: RawSchemaEntry};
 
 export type Schema = {[string]: SchemaEntry};
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -79,6 +79,7 @@ import {
     fieldRegistry,
     Heading,
     Input,
+    localeConditionDataProvider,
     Select,
     Number,
     PasswordConfirmation,
@@ -160,6 +161,7 @@ initializer.addUpdateConfigHook('sulu_admin', (config: Object, initialized: bool
         registerViews();
 
         conditionDataProviderRegistry.add(bundlesConditionDataProvider);
+        conditionDataProviderRegistry.add(localeConditionDataProvider);
     }
 
     processConfig(config);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -82,6 +82,7 @@ import {
     localeConditionDataProvider,
     Select,
     Number,
+    parentConditionDataProvider,
     PasswordConfirmation,
     Phone,
     Selection,
@@ -162,6 +163,7 @@ initializer.addUpdateConfigHook('sulu_admin', (config: Object, initialized: bool
 
         conditionDataProviderRegistry.add(bundlesConditionDataProvider);
         conditionDataProviderRegistry.add(localeConditionDataProvider);
+        conditionDataProviderRegistry.add(parentConditionDataProvider);
     }
 
     processConfig(config);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/TestHelper/fieldTypeDefaultProps.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/TestHelper/fieldTypeDefaultProps.js
@@ -1,6 +1,7 @@
 // @flow
 
 const fieldTypeDefaultProps = {
+    data: {},
     dataPath: '/',
     defaultType: undefined,
     disabled: undefined,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/ImageMap/FieldRenderer.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/ImageMap/FieldRenderer.js
@@ -18,6 +18,7 @@ type Props = {|
     schema: Schema,
     schemaPath: string,
     showAllErrors: boolean,
+    value: Object,
 |};
 
 export default class FieldRenderer extends React.Component<Props> {
@@ -42,6 +43,7 @@ export default class FieldRenderer extends React.Component<Props> {
             schema,
             schemaPath,
             showAllErrors,
+            value,
         } = this.props;
 
         return (
@@ -57,6 +59,7 @@ export default class FieldRenderer extends React.Component<Props> {
                 schema={schema}
                 schemaPath={schemaPath}
                 showAllErrors={showAllErrors}
+                value={value}
             />
         );
     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/ImageMap/ImageMap.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/ImageMap/ImageMap.js
@@ -95,6 +95,7 @@ class ImageMap extends React.Component<FieldTypeProps<Value>> {
 
     renderHotspotForm: RenderHotspotFormCallback = (value: Object, type: string, index: number) => {
         const {
+            data,
             dataPath,
             error,
             formInspector,
@@ -110,7 +111,7 @@ class ImageMap extends React.Component<FieldTypeProps<Value>> {
 
         return (
             <FieldRenderer
-                data={value}
+                data={data}
                 dataPath={dataPath + '/' + index}
                 errors={errors && errors.length > index && errors[index] ? errors[index] : undefined}
                 formInspector={formInspector}
@@ -122,6 +123,7 @@ class ImageMap extends React.Component<FieldTypeProps<Value>> {
                 schema={hotspotFormSchemaType.form}
                 schemaPath={schemaPath + '/types/' + type + '/form'}
                 showAllErrors={showAllErrors}
+                value={value}
             />
         );
     };

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/ImageMap.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/ImageMap.test.js
@@ -66,7 +66,6 @@ test('Pass correct props to SingleMediaSelection component', () => {
                 text: {
                     label: 'Text',
                     type: 'text_line',
-                    visible: true,
                 },
             },
         },
@@ -106,7 +105,6 @@ test('Pass correct default value to ImageMapContainer', () => {
                 text: {
                     label: 'Text',
                     type: 'text_line',
-                    visible: true,
                 },
             },
         },
@@ -140,7 +138,6 @@ test('Pass content-locale of user to SingleMediaSelection if locale is not prese
                 text: {
                     label: 'Text',
                     type: 'text_line',
-                    visible: true,
                 },
             },
         },
@@ -177,7 +174,6 @@ test('Should call onChange and onFinish if the value changes', () => {
                 text: {
                     label: 'Text',
                     type: 'text_line',
-                    visible: true,
                 },
             },
         },

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/conditionDataProviders/webspaceConditionDataProvider.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/conditionDataProviders/webspaceConditionDataProvider.js
@@ -1,12 +1,14 @@
 // @flow
 import {toJS} from 'mobx';
+import {FormInspector} from 'sulu-admin-bundle/containers';
 import webspaceStore from '../../../stores/webspaceStore';
 
 export default function(
     data: {[string]: any},
-    options: {[string]: any},
-    metadataOptions: ?{[string]: any}
+    dataPath: ?string,
+    formInspector: FormInspector
 ): {[string]: any} {
+    const {options, metadataOptions} = formInspector;
     const webspaceKey = data.webspace || options.webspace || (metadataOptions && metadataOptions.webspace);
 
     const conditionData = {};

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/tests/conditionDataProviders/webspaceConditionDataProvider.test.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/tests/conditionDataProviders/webspaceConditionDataProvider.test.js
@@ -1,9 +1,25 @@
 // @flow
+import {FormInspector, ResourceFormStore} from 'sulu-admin-bundle/containers';
+import {ResourceStore} from 'sulu-admin-bundle/stores';
 import defaultWebspace from 'sulu-admin-bundle/utils/TestHelper/defaultWebspace';
 import webspaceStore from '../../../../stores/webspaceStore';
 import webspaceConditionDataProvider from '../../conditionDataProviders/webspaceConditionDataProvider';
 
+jest.mock(
+    'sulu-admin-bundle/containers/Form/stores/ResourceFormStore',
+    () => jest.fn(function(resourceStore, formKey, options, metadataOptions) {
+        this.options = options;
+        this.metadataOptions = metadataOptions;
+    })
+);
+
+jest.mock('sulu-admin-bundle/stores/ResourceStore/ResourceStore', () => jest.fn());
+
 test('Return webspace from data', () => {
+    const formInspector = new FormInspector(
+        new ResourceFormStore(new ResourceStore('test'), 'test', {webspace: 'test'})
+    );
+
     const webspace1 = {
         ...defaultWebspace,
         key: 'test',
@@ -18,11 +34,15 @@ test('Return webspace from data', () => {
     const webspaces = [webspace1, webspace2];
     webspaceStore.setWebspaces(webspaces);
 
-    expect(webspaceConditionDataProvider({webspace: 'sulu'}, {webspace: 'test'}, {}))
+    expect(webspaceConditionDataProvider({webspace: 'sulu'}, '/test', formInspector))
         .toEqual({__webspace: webspace2, __webspaces: webspaces});
 });
 
 test('Return webspace from options', () => {
+    const formInspector = new FormInspector(
+        new ResourceFormStore(new ResourceStore('test'), 'test', {webspace: 'sulu'}, {webspace: 'test'})
+    );
+
     const webspace1 = {
         ...defaultWebspace,
         key: 'test',
@@ -38,11 +58,15 @@ test('Return webspace from options', () => {
 
     webspaceStore.setWebspaces(webspaces);
 
-    expect(webspaceConditionDataProvider({}, {webspace: 'sulu'}, {webspace: 'test'}))
+    expect(webspaceConditionDataProvider({}, '/test', formInspector))
         .toEqual({__webspace: webspace2, __webspaces: webspaces});
 });
 
 test('Return webspace from metadataOptions', () => {
+    const formInspector = new FormInspector(
+        new ResourceFormStore(new ResourceStore('test'), 'test', {}, {webspace: 'test'})
+    );
+
     const webspace1 = {
         ...defaultWebspace,
         key: 'test',
@@ -58,11 +82,15 @@ test('Return webspace from metadataOptions', () => {
 
     webspaceStore.setWebspaces(webspaces);
 
-    expect(webspaceConditionDataProvider({}, {}, {webspace: 'test'}))
+    expect(webspaceConditionDataProvider({}, '/test', formInspector))
         .toEqual({__webspace: webspace1, __webspaces: webspaces});
 });
 
 test('Return empty data if webspace does not exist', () => {
+    const formInspector = new FormInspector(
+        new ResourceFormStore(new ResourceStore('test'), 'test', {}, {})
+    );
+
     const webspace1 = {
         ...defaultWebspace,
         key: 'test',
@@ -73,10 +101,14 @@ test('Return empty data if webspace does not exist', () => {
 
     webspaceStore.setWebspaces(webspaces);
 
-    expect(webspaceConditionDataProvider({webspace: 'sulu'}, {}, {})).toEqual({__webspaces: webspaces});
+    expect(webspaceConditionDataProvider({webspace: 'sulu'}, '/test', formInspector)).toEqual({__webspaces: webspaces});
 });
 
 test('Return empty data if no webspace prop exists on data', () => {
+    const formInspector = new FormInspector(
+        new ResourceFormStore(new ResourceStore('test'), 'test', {}, {})
+    );
+
     const webspace1 = {
         ...defaultWebspace,
         key: 'test',
@@ -87,5 +119,5 @@ test('Return empty data if no webspace prop exists on data', () => {
 
     webspaceStore.setWebspaces(webspaces);
 
-    expect(webspaceConditionDataProvider({}, {}, {})).toEqual({__webspaces: webspaces});
+    expect(webspaceConditionDataProvider({}, '/test', formInspector)).toEqual({__webspaces: webspaces});
 });

--- a/src/Sulu/Bundle/RouteBundle/Resources/js/containers/Form/fields/PageTreeRoute.js
+++ b/src/Sulu/Bundle/RouteBundle/Resources/js/containers/Form/fields/PageTreeRoute.js
@@ -96,6 +96,7 @@ class PageTreeRoute extends Component<Props> {
         }
 
         const {
+            data,
             dataPath,
             defaultType,
             disabled,
@@ -130,6 +131,7 @@ class PageTreeRoute extends Component<Props> {
 
                     <Grid.Item colSpan={7}>
                         <ResourceLocator
+                            data={data}
                             dataPath={dataPath}
                             defaultType={defaultType}
                             disabled={disabled}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5291
| Related issues/PRs | ---
| License | MIT
| Documentation PR | sulu/sulu-docs#609

#### What's in this PR?

This PR will allow to have different evaluations of multiple blocks.

#### BC Breaks/Deprecations

TODO

#### To Do

- [x] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md
- [x] Implement `visibleCondition` for sections
- [x] `Renderer` should retrieve all data via the `data` prop and only the current one via `value`, so that the same semantics as before the refactoring can be established
- [x] Double check if no `visible` and `disabled` flags are used anymore in the tests
- [x] Support multiple nesting levels like `__parent.__parent.__parent.title`