### PR TITLE
Allow to access locale in expression in form configuration

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
+++ b/src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
@@ -152,7 +152,7 @@ class FormMetadataMapper
         $option->setName($parameter['name']);
         $option->setType($parameter['type']);
 
-        if ('collection' === $parameter['type']) {
+        if (OptionMetadata::TYPE_COLLECTION === $parameter['type']) {
             foreach ($parameter['value'] as $parameterName => $parameterValue) {
                 $valueOption = new OptionMetadata();
                 $valueOption->setName($parameterValue['name']);
@@ -162,7 +162,7 @@ class FormMetadataMapper
 
                 $option->addValueOption($valueOption);
             }
-        } elseif ('string' === $parameter['type'] || 'expression' === $parameter['type']) {
+        } elseif (OptionMetadata::TYPE_STRING === $parameter['type'] || OptionMetadata::TYPE_EXPRESSION === $parameter['type']) {
             $option->setValue($parameter['value']);
             $this->mapOptionMeta($parameter, $locale, $option);
         } else {

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
@@ -49,11 +49,12 @@ class FormMetadataProvider implements MetadataProviderInterface
             throw new MetadataNotFoundException('form', $key);
         }
 
+        $expressionContext = array_merge(['locale' => $locale], $metadataOptions);
         if ($form instanceof FormMetadata) {
-            $this->evaluateFormItemExpressions($form->getItems(), $metadataOptions);
+            $this->evaluateFormItemExpressions($form->getItems(), $expressionContext);
         } elseif ($form instanceof TypedFormMetadata) {
             foreach ($form->getForms() as $formType) {
-                $this->evaluateFormItemExpressions($formType->getItems(), $metadataOptions);
+                $this->evaluateFormItemExpressions($formType->getItems(), $expressionContext);
             }
 
             if (\array_key_exists('tags', $metadataOptions)) {
@@ -108,21 +109,21 @@ class FormMetadataProvider implements MetadataProviderInterface
     /**
      * @param ItemMetadata[] $items
      */
-    private function evaluateFormItemExpressions(array $items, array $metadataOptions)
+    private function evaluateFormItemExpressions(array $items, array $context)
     {
         foreach ($items as $item) {
             if ($item instanceof SectionMetadata) {
-                $this->evaluateFormItemExpressions($item->getItems(), $metadataOptions);
+                $this->evaluateFormItemExpressions($item->getItems(), $context);
             }
 
             if ($item instanceof FieldMetadata) {
                 foreach ($item->getTypes() as $type) {
-                    $this->evaluateFormItemExpressions($type->getItems(), $metadataOptions);
+                    $this->evaluateFormItemExpressions($type->getItems(), $context);
                 }
 
                 foreach ($item->getOptions() as $option) {
                     if (OptionMetadata::TYPE_EXPRESSION === $option->getType()) {
-                        $option->setValue($this->expressionLanguage->evaluate($option->getValue(), $metadataOptions));
+                        $option->setValue($this->expressionLanguage->evaluate($option->getValue(), $context));
                     }
                 }
             }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
@@ -49,7 +49,7 @@ class FormMetadataProvider implements MetadataProviderInterface
             throw new MetadataNotFoundException('form', $key);
         }
 
-        $expressionContext = array_merge(['locale' => $locale], $metadataOptions);
+        $expressionContext = \array_merge(['locale' => $locale], $metadataOptions);
         if ($form instanceof FormMetadata) {
             $this->evaluateFormItemExpressions($form->getItems(), $expressionContext);
         } elseif ($form instanceof TypedFormMetadata) {

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/forms/form_with_locale_expression_param.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/forms/form_with_locale_expression_param.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<form xmlns="http://schemas.sulu.io/template/template"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd"
+>
+    <key>form_with_locale_expression_param</key>
+
+    <properties>
+        <property name="name" type="text_line">
+            <params>
+                <param name="id" type="expression" value="locale" />
+            </params>
+        </property>
+    </properties>
+</form>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
@@ -44,7 +44,7 @@ class FormMetadataProviderTest extends KernelTestCase
         $this->assertCount(2, \array_keys($schema));
     }
 
-    public function testGetMetadataWithExpressions()
+    public function testGetMetadataWithExpression()
     {
         $form = $this->formMetadataProvider->getMetadata(
             'form_with_webspace_expression_param',
@@ -54,6 +54,17 @@ class FormMetadataProviderTest extends KernelTestCase
         $this->assertInstanceOf(FormMetadata::class, $form);
 
         $this->assertEquals('sulu_io', $form->getItems()['name']->getOptions()['id']->getValue());
+    }
+
+    public function testGetMetadataWithLocaleInExpression()
+    {
+        $form = $this->formMetadataProvider->getMetadata(
+            'form_with_locale_expression_param',
+            'en'
+        );
+        $this->assertInstanceOf(FormMetadata::class, $form);
+
+        $this->assertEquals('en', $form->getItems()['name']->getOptions()['id']->getValue());
     }
 
     public function testGetMetadataFromStructureLoader()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adds the locale to the context that is used for evaluating expressions in form configurations. For example, these expressions can be used to display values from a service in a `single_select` property: https://docs.sulu.io/en/2.2/cookbook/select-values-service.html

#### Why?

Because metadata is always evaluated for a specific locale. At the moment, I need to access the locale of the user inside of my service. With this PR, I can pass the locale to the service like this:

```xml
<property name="eventType" type="single_select">
    <meta>
        <title lang="en">Event Type</title>
    </meta>

    <params>
        <param name="values" type="expression" value="service('App\\Content\\Select\\EventTypeSelect').getValues(locale)"/>
    </params>
</property>
```