### PR TITLE
Disable pagination in ResourceSingleSelect and ResourceMultiSelect

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceMultiSelect/ResourceMultiSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceMultiSelect/ResourceMultiSelect.js
@@ -51,11 +51,15 @@ class ResourceMultiSelect<T: string | number> extends React.Component<Props<T>> 
 
     @action createResourceListStore = () => {
         const {
+            idProperty,
             resourceKey,
             requestParameters,
         } = this.props;
 
-        this.resourceListStore = new ResourceListStore(resourceKey, requestParameters);
+        // sending an empty limit to the server will disable pagination
+        const parameters = {limit: '', ...requestParameters};
+
+        this.resourceListStore = new ResourceListStore(resourceKey, parameters, idProperty);
     };
 
     // TODO: Remove explicit type annotation when flow bug is fixed

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceMultiSelect/tests/ResourceMultiSelect.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceMultiSelect/tests/ResourceMultiSelect.test.js
@@ -43,7 +43,7 @@ test('Render with data', () => {
         />
     );
 
-    expect(ResourceListStore).toBeCalledWith('test', {});
+    expect(ResourceListStore).toBeCalledWith('test', {limit: ''}, 'id');
     expect(resourceMultiSelect.render()).toMatchSnapshot();
 });
 
@@ -75,7 +75,7 @@ test('Render in disabled state', () => {
         />
     );
 
-    expect(ResourceListStore).toBeCalledWith('test', {});
+    expect(ResourceListStore).toBeCalledWith('test', {limit: ''}, 'id');
     expect(resourceMultiSelect.find('MultiSelect').prop('disabled')).toEqual(true);
 });
 
@@ -133,7 +133,7 @@ test('Pass requestParameters', () => {
         />
     );
 
-    expect(ResourceListStore).toBeCalledWith('test', requestParameters);
+    expect(ResourceListStore).toBeCalledWith('test', {limit: '', testOption: 'testValue'}, 'id');
 });
 
 test('Pass requestParameters when requestParameters props changed', () => {
@@ -172,8 +172,8 @@ test('Pass requestParameters when requestParameters props changed', () => {
 
     // $FlowFixMe
     expect(ResourceListStore.mock.calls).toEqual([
-        ['test', requestParameters1],
-        ['test', requestParameters2],
+        ['test', {limit: ''}, 'id'],
+        ['test', {limit: '', testOption: 'testValue'}, 'id'],
     ]);
 });
 
@@ -190,20 +190,16 @@ test('Pass requestParameters when resourceKey props changed', () => {
         ];
     });
 
-    const requestParameters = {};
-
     const resourceMultiSelect = mount(
         <ResourceMultiSelect
             displayProperty="name"
             onChange={jest.fn()}
-            requestParameters={requestParameters}
             resourceKey="test1"
             values={undefined}
         />
     );
 
     resourceMultiSelect.setProps({
-        requestParameters,
         displayProperty: 'name',
         onChange: jest.fn(),
         resourceKey: 'test2',
@@ -212,8 +208,8 @@ test('Pass requestParameters when resourceKey props changed', () => {
 
     // $FlowFixMe
     expect(ResourceListStore.mock.calls).toEqual([
-        ['test1', requestParameters],
-        ['test2', requestParameters],
+        ['test1', {limit: ''}, 'id'],
+        ['test2', {limit: ''}, 'id'],
     ]);
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceSingleSelect/ResourceSingleSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceSingleSelect/ResourceSingleSelect.js
@@ -42,12 +42,15 @@ class ResourceSingleSelect<T: string | number> extends React.Component<Props<T>>
         super(props);
 
         const {
-            requestParameters,
             idProperty,
             resourceKey,
+            requestParameters,
         } = this.props;
 
-        this.resourceListStore = new ResourceListStore(resourceKey, requestParameters, idProperty);
+        // sending an empty limit to the server will disable pagination
+        const parameters = {limit: '', ...requestParameters};
+
+        this.resourceListStore = new ResourceListStore(resourceKey, parameters, idProperty);
     }
 
     handleReset = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceSingleSelect/tests/ResourceSingleSelect.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceSingleSelect/tests/ResourceSingleSelect.test.js
@@ -26,6 +26,8 @@ test('Render in loading state', () => {
             value={undefined}
         />
     )).toMatchSnapshot();
+
+    expect(ResourceListStore).toBeCalledWith('test', {limit: ''}, 'id');
 });
 
 test('Render in disabled state', () => {
@@ -166,7 +168,7 @@ test('Pass requestParameters to ResourceListStore', () => {
         />
     );
 
-    expect(ResourceListStore).toBeCalledWith('test', requestParameters, 'id');
+    expect(ResourceListStore).toBeCalledWith('test', {limit: '', flat: true}, 'id');
 });
 
 test('Trigger the change callback when the selection changes', () => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5680
| Related issues/PRs | #5691
| License | MIT

#### What's in this PR?

This PR adjusts the `ResourceSingleSelect` and `ResourceMultiSelect` to send an empty `limit` parameter to the server.

#### Why?

When sending an empty `limit` parameter, the `ListRestHelper` will not use the default limit of `10` and therefore will not paginate the response. We cannot paginate the response because the `ResourceSingleSelect` and `ResourceMultiSelect` do not provide a way to load the next page.