### PR TITLE
Fix PHP version for github actions

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -16,6 +16,10 @@ jobs:
               uses: actions/checkout@v1
             - name: Create downloads directory
               run: mkdir downloads
+            - name: Install and configure PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '7.4'
             - name: Get downloads path
               id: php-cs-fixer-dir
               run: echo "::set-output name=dir::downloads"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

GitHub actions seems to use PHP 8 as default version now, and php-cs-fixer does not seem to support that yet.