### PR TITLE
Remove unused layershift library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
         "pulse00/ffmpeg-bundle": "^0.6",
         "oro/doctrine-extensions": "^1.0",
         "goodby/csv": "^1.3",
-        "layershifter/tld-extract": "^1.1",
         "mtdowling/cron-expression": "^1.1",
         "ramsey/uuid": "^3.1",
         "twig/twig": "^1.11 || ^2.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Remove unused layershift library.

#### Why?

The library is deprecated and not longer used by us: https://github.com/layershifter/TLDDatabase

EDIT:

Looks like the [`sulu_util_domain_info`](https://github.com/sulu/sulu/blob/aeae450baa0cab90c00239e5c00b0e077c1400d0/src/Sulu/Bundle/WebsiteBundle/Twig/Core/UtilTwigExtension.php#L29) provide the global `tld_extract` which is used in the https://github.com/sulu/sulu/blob/aeae450baa0cab90c00239e5c00b0e077c1400d0/src/Sulu/Bundle/WebsiteBundle/Resources/views/Sitemap/sitemap.xml.twig#L4. We will need to find a better way here.