### PR TITLE
Changed the guzzle client for the symfony httpclient

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,11 @@
 
 ## dev-master
 
+### Deprecated service `sulu_location.geolocator.guzzle.client` and parameter `sulu_location.guzzle.client.class`
+
+Because `NominatimGeolocator` and `GoogleGeolocator` now use the symfony http client the `sulu_location.geolocator.guzzle.client` is now deprecated
+as is the parameter `sulu_location.guzzle.client.class`.
+
 ### The constructor of the `NominatimGeolocator` and `GoogleGeolocator` requires a `Symfony\Contracts\HttpClient\HttpClientInterface` for the `$client` argument
 
 Constructing `NominatimGeolocator` and `GoogleGeolocator` with the previous `GuzzleHttp\ClientInterface` is deprecated. 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,10 @@
 
 ## dev-master
 
+### The constructor of the `NominatimGeolocator` and `GoogleGeolocator` requires a `Symfony\Contracts\HttpClient\HttpClientInterface` for the `$client` argument
+
+Constructing `NominatimGeolocator` and `GoogleGeolocator` with the previous `GuzzleHttp\ClientInterface` is deprecated. 
+
 ### conditionDataProvider interface changed
 
 The interface of `conditionDataProviders` changed its arguments. In order to make these providers even more powerful,

--- a/src/Sulu/Bundle/LocationBundle/Geolocator/Service/GoogleGeolocator.php
+++ b/src/Sulu/Bundle/LocationBundle/Geolocator/Service/GoogleGeolocator.php
@@ -11,11 +11,11 @@
 
 namespace Sulu\Bundle\LocationBundle\Geolocator\Service;
 
-use GuzzleHttp\ClientInterface;
 use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorInterface;
 use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorLocation;
 use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * Geolocator which uses the google geocoding API.
@@ -27,24 +27,26 @@ class GoogleGeolocator implements GeolocatorInterface
     const ENDPOINT = 'https://maps.googleapis.com/maps/api/geocode/json';
 
     /**
-     * @var ClientInterface
+     * @var HttpClientInterface
      */
-    protected $client;
+    protected $httpClient;
 
     /**
      * @var string
      */
     protected $apiKey;
 
-    public function __construct(ClientInterface $client, string $apiKey)
-    {
-        $this->client = $client;
+    public function __construct(
+        HttpClientInterface $httpClient,
+        string $apiKey
+    ) {
+        $this->httpClient = $httpClient;
         $this->apiKey = $apiKey;
     }
 
     public function locate(string $query): GeolocatorResponse
     {
-        $response = $this->client->request(
+        $response = $this->httpClient->request(
             'GET',
             self::ENDPOINT,
             [
@@ -66,7 +68,7 @@ class GoogleGeolocator implements GeolocatorInterface
             );
         }
 
-        $googleResponse = \json_decode($response->getBody(), true);
+        $googleResponse = $response->toArray();
         $response = new GeolocatorResponse();
         if ('OK' != $googleResponse['status']) {
             return $response;

--- a/src/Sulu/Bundle/LocationBundle/Geolocator/Service/NominatimGeolocator.php
+++ b/src/Sulu/Bundle/LocationBundle/Geolocator/Service/NominatimGeolocator.php
@@ -16,6 +16,7 @@ use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorInterface;
 use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorLocation;
 use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * Geolocator which uses the open street maps nominatim service.
@@ -25,9 +26,9 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 class NominatimGeolocator implements GeolocatorInterface
 {
     /**
-     * @var ClientInterface
+     * @var HttpClientInterface
      */
-    protected $client;
+    protected $httpClient;
 
     /**
      * @var string
@@ -39,16 +40,19 @@ class NominatimGeolocator implements GeolocatorInterface
      */
     private $key;
 
-    public function __construct(ClientInterface $client, string $baseUrl, string $key)
-    {
-        $this->client = $client;
+    public function __construct(
+        HttpClientInterface $httpClient,
+        string $baseUrl,
+        string $key
+    ) {
+        $this->httpClient = $httpClient;
         $this->baseUrl = $baseUrl;
         $this->key = $key;
     }
 
     public function locate(string $query): GeolocatorResponse
     {
-        $response = $this->client->request(
+        $response = $this->httpClient->request(
             'GET',
             $this->baseUrl,
             [
@@ -72,7 +76,7 @@ class NominatimGeolocator implements GeolocatorInterface
             );
         }
 
-        $results = \json_decode($response->getBody(), true);
+        $results = $response->toArray();
         $response = new GeolocatorResponse();
         foreach ($results as $result) {
             $location = new GeolocatorLocation();

--- a/src/Sulu/Bundle/LocationBundle/Resources/config/geolocator.xml
+++ b/src/Sulu/Bundle/LocationBundle/Resources/config/geolocator.xml
@@ -10,14 +10,14 @@
         <!-- Geolocator services -->
         <!-- * Nominatim * -->
         <service id="sulu_location.geolocator.service.nominatim" class="%sulu_location.geolocator.nominatim.class%">
-            <argument type="service" id="Symfony\Contracts\HttpClient\HttpClientInterface" />
+            <argument type="service" id="http_client" />
             <argument>%sulu_location.geolocator.service.nominatim.endpoint%</argument>
             <argument>%sulu_location.geolocator.service.nominatim.api_key%</argument>
         </service>
 
         <!-- * Google * -->
         <service id="sulu_location.geolocator.service.google" class="%sulu_location.geolocator.google.class%">
-            <argument type="service" id="Symfony\Contracts\HttpClient\HttpClientInterface" />
+            <argument type="service" id="http_client" />
             <argument>%sulu_location.geolocator.service.google.api_key%</argument>
         </service>
     </services>

--- a/src/Sulu/Bundle/LocationBundle/Resources/config/geolocator.xml
+++ b/src/Sulu/Bundle/LocationBundle/Resources/config/geolocator.xml
@@ -9,10 +9,9 @@
 
     <services>
         <!-- Guzzle client -->
-        <service id="sulu_location.geolocator.guzzle.client" alias="sulu_location.geolocator.guzzle.client_deprecated">
+        <service id=""sulu_location.geolocator.guzzle.client" class="%sulu_location.guzzle.client.class%">
             <deprecated />
         </service>
-        <service id="sulu_location.geolocator.guzzle.client_deprecated" class="%sulu_location.guzzle.client.class%"/>
 
         <!-- Geolocator services -->
         <!-- * Nominatim * -->

--- a/src/Sulu/Bundle/LocationBundle/Resources/config/geolocator.xml
+++ b/src/Sulu/Bundle/LocationBundle/Resources/config/geolocator.xml
@@ -2,11 +2,18 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
+        <parameter key="sulu_location.guzzle.client.class">GuzzleHttp\Client</parameter>
         <parameter key="sulu_location.geolocator.nominatim.class">Sulu\Bundle\LocationBundle\Geolocator\Service\NominatimGeolocator</parameter>
         <parameter key="sulu_location.geolocator.google.class">Sulu\Bundle\LocationBundle\Geolocator\Service\GoogleGeolocator</parameter>
     </parameters>
 
     <services>
+        <!-- Guzzle client -->
+        <service id="sulu_location.geolocator.guzzle.client" alias="sulu_location.geolocator.guzzle.client_deprecated">
+            <deprecated />
+        </service>
+        <service id="sulu_location.geolocator.guzzle.client_deprecated" class="%sulu_location.guzzle.client.class%"/>
+
         <!-- Geolocator services -->
         <!-- * Nominatim * -->
         <service id="sulu_location.geolocator.service.nominatim" class="%sulu_location.geolocator.nominatim.class%">

--- a/src/Sulu/Bundle/LocationBundle/Resources/config/geolocator.xml
+++ b/src/Sulu/Bundle/LocationBundle/Resources/config/geolocator.xml
@@ -2,26 +2,22 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
-        <parameter key="sulu_location.guzzle.client.class">GuzzleHttp\Client</parameter>
         <parameter key="sulu_location.geolocator.nominatim.class">Sulu\Bundle\LocationBundle\Geolocator\Service\NominatimGeolocator</parameter>
         <parameter key="sulu_location.geolocator.google.class">Sulu\Bundle\LocationBundle\Geolocator\Service\GoogleGeolocator</parameter>
     </parameters>
 
     <services>
-        <!-- Guzzle client -->
-        <service id="sulu_location.geolocator.guzzle.client" class="%sulu_location.guzzle.client.class%"/>
-
         <!-- Geolocator services -->
         <!-- * Nominatim * -->
         <service id="sulu_location.geolocator.service.nominatim" class="%sulu_location.geolocator.nominatim.class%">
-            <argument type="service" id="sulu_location.geolocator.guzzle.client" />
+            <argument type="service" id="Symfony\Contracts\HttpClient\HttpClientInterface" />
             <argument>%sulu_location.geolocator.service.nominatim.endpoint%</argument>
             <argument>%sulu_location.geolocator.service.nominatim.api_key%</argument>
         </service>
 
         <!-- * Google * -->
         <service id="sulu_location.geolocator.service.google" class="%sulu_location.geolocator.google.class%">
-            <argument type="service" id="sulu_location.geolocator.guzzle.client" />
+            <argument type="service" id="Symfony\Contracts\HttpClient\HttpClientInterface" />
             <argument>%sulu_location.geolocator.service.google.api_key%</argument>
         </service>
     </services>

--- a/src/Sulu/Bundle/LocationBundle/Resources/config/geolocator.xml
+++ b/src/Sulu/Bundle/LocationBundle/Resources/config/geolocator.xml
@@ -9,7 +9,7 @@
 
     <services>
         <!-- Guzzle client -->
-        <service id=""sulu_location.geolocator.guzzle.client" class="%sulu_location.guzzle.client.class%">
+        <service id="sulu_location.geolocator.guzzle.client" class="%sulu_location.guzzle.client.class%">
             <deprecated />
         </service>
 

--- a/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/Service/NominatimGeolocatorTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/Service/NominatimGeolocatorTest.php
@@ -11,12 +11,10 @@
 
 namespace Sulu\Bundle\LocationBundle\Tests\Unit\Geolocator\Service;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\LocationBundle\Geolocator\Service\NominatimGeolocator;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 
 class NominatimGeolocatorTest extends TestCase
 {
@@ -47,10 +45,10 @@ class NominatimGeolocatorTest extends TestCase
     {
         $fixtureName = __DIR__ . '/responses/' . \md5($query) . '.json';
         $fixture = \file_get_contents($fixtureName);
-        $mockHandler = new MockHandler([new Response(200, [], $fixture)]);
+        $mockResponse = new MockResponse($fixture);
 
-        $client = new Client(['handler' => HandlerStack::create($mockHandler)]);
-        $geolocator = new NominatimGeolocator($client, '', '');
+        $httpClient = new MockHttpClient($mockResponse);
+        $geolocator = new NominatimGeolocator($httpClient, 'https://example.org', 'key');
 
         $results = $geolocator->locate($query);
         $this->assertCount($expectedCount, $results);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Changed the guzzle client for the httpclient of symfony in the Locationbundle

#### Why?

It seems easier to update a standard symfony component and now the guzzle client could be dropped as a dependency for the LocationBundle. 

#### BC Breaks/Deprecations?

The constructor of the `NominatimGeolocator` and `GoogleGeolocator` requires a `Symfony\Contracts\HttpClient\HttpClientInterface` for the `$client` argument

Constructing `NominatimGeolocator` and `GoogleGeolocator` with the previous `GuzzleHttp\ClientInterface` is deprecated. 

updated UPGRADE.md