### PR TITLE
Include unpublished pages in preview when using teaser_selection

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Resources/config/teaser.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/teaser.xml
@@ -13,6 +13,7 @@
                  class="Sulu\Bundle\PageBundle\Teaser\PageTeaserProvider">
             <argument type="service" id="massive_search.search_manager"/>
             <argument type="service" id="translator"/>
+            <argument>%sulu_document_manager.show_drafts%</argument>
 
             <tag name="sulu.teaser.provider" alias="pages"/>
         </service>

--- a/src/Sulu/Bundle/PageBundle/Teaser/PageTeaserProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Teaser/PageTeaserProvider.php
@@ -32,10 +32,19 @@ class PageTeaserProvider implements TeaserProviderInterface
      */
     private $translator;
 
-    public function __construct(SearchManagerInterface $searchManager, TranslatorInterface $translator)
-    {
+    /**
+     * @var bool
+     */
+    private $showDrafts;
+
+    public function __construct(
+        SearchManagerInterface $searchManager,
+        TranslatorInterface $translator,
+        bool $showDrafts = false
+    ) {
         $this->searchManager = $searchManager;
         $this->translator = $translator;
+        $this->showDrafts = $showDrafts;
     }
 
     public function getConfiguration()
@@ -138,12 +147,21 @@ class PageTeaserProvider implements TeaserProviderInterface
      */
     private function getPageIndexes()
     {
-        return \array_filter(
+        $allPageIndexNames = \array_filter(
             $this->searchManager->getIndexNames(),
             function($index) {
-                return \preg_match('/page_(.*)_published/', $index) > 0;
+                return \preg_match('/page_(.+)/', $index) > 0;
             }
         );
+
+        $publishedPageIndexNames = \array_filter(
+            $allPageIndexNames,
+            function($index) {
+                return \preg_match('/page_(.+)_published/', $index) > 0;
+            }
+        );
+
+        return $this->showDrafts ? array_diff($allPageIndexNames, $publishedPageIndexNames) : $publishedPageIndexNames;
     }
 
     /**

--- a/src/Sulu/Bundle/PageBundle/Teaser/PageTeaserProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Teaser/PageTeaserProvider.php
@@ -161,7 +161,9 @@ class PageTeaserProvider implements TeaserProviderInterface
             }
         );
 
-        return $this->showDrafts ? array_diff($allPageIndexNames, $publishedPageIndexNames) : $publishedPageIndexNames;
+        return $this->showDrafts
+            ? \array_values(\array_diff($allPageIndexNames, $publishedPageIndexNames))
+            : \array_values($publishedPageIndexNames);
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4563
| License | MIT

#### What's in this PR?

This PR adjusts the behaviour of the `teaser_selection` content type in the administration interface to include unpublished pages. The overlay in the administration interface already allowed to select such pages, but they were dsiplayed with an empty title in the `teaser_selection` field and omitted in the preview.

Before:
![Screenshot 2020-12-22 at 16 35 23](https://user-images.githubusercontent.com/13310795/102905605-b5fb3880-4473-11eb-84d0-e58adec26d44.png)

After:
![Screenshot 2020-12-22 at 16 34 42](https://user-images.githubusercontent.com/13310795/102905556-9fed7800-4473-11eb-86a0-88f40f4ae37f.png)

#### Why?

This makes the behaviour of the `teaser_selection` consistent to the `smart_content` and `page_selection`. Both of these types will include unpublished pages in the preview too.
