### PR TITLE
Add hint about using current date to datetime input in preview

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/field.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/field.scss
@@ -62,6 +62,10 @@ $errorLabelHeight: 20px;
     font-size: 10px;
     line-height: $errorLabelHeight;
     height: $errorLabelHeight;
+
+    .dark & {
+        color: $labelDarkColor;
+    }
 }
 
 .error-label {

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -178,5 +178,6 @@
     "sulu_admin.sunday": "Sonntag",
     "sulu_admin.start": "Start",
     "sulu_admin.end": "Ende",
-    "sulu_admin.preview_date_time": "Zeit/Datum für Seitenvorschau"
+    "sulu_admin.preview_date_time": "Zeit/Datum für Seitenvorschau",
+    "sulu_admin.preview_date_time_description": "Eingabeld löschen um das aktuelle Datum zu verwenden."
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -179,5 +179,6 @@
     "sulu_admin.sunday": "Sunday",
     "sulu_admin.start": "Start",
     "sulu_admin.end": "End",
-    "sulu_admin.preview_date_time": "Time/Date for page preview"
+    "sulu_admin.preview_date_time": "Time/Date for page preview",
+    "sulu_admin.preview_date_time_description": "Clear input to use the current date."
 }

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
@@ -312,7 +312,10 @@ class Preview extends React.Component<Props> {
                                 {() => (
                                     <div className={previewStyles.dateTimeForm}>
                                         <Form skin="dark">
-                                            <Form.Field label={translate('sulu_admin.preview_date_time')}>
+                                            <Form.Field
+                                                description={translate('sulu_admin.preview_date_time_description')}
+                                                label={translate('sulu_admin.preview_date_time')}
+                                            >
                                                 <DatePicker
                                                     onChange={this.handleDateTimeChange}
                                                     options={{dateFormat: true, timeFormat: true}}


### PR DESCRIPTION
This PR adds a hint to the datetime input in the preview toolbar that explains how to reset the selected date. The hint is displayed as `info_text` of the field. 

![Screenshot 2020-12-23 at 12 06 38](https://user-images.githubusercontent.com/13310795/102990242-5b1b1d00-4517-11eb-8d53-7de88712bb96.png)

(The padding between toolbar and popover is already documented in a separate issue: https://github.com/sulu/sulu/issues/5718)
