### PR TITLE
Do not remove margin of divider of child-sections

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/grid.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/grid.scss
@@ -11,7 +11,7 @@
     margin-bottom: -$fieldMarginBottom;
 
     &:first-child {
-        .divider-container {
+        > .divider-container {
             margin-top: -$dividerTopMargin;
         }
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### Why?

We remove the margin of the divider of the section, if a section is the first child of its parent (see https://github.com/sulu/sulu/issues/4786). At the moment, the code unintentionally removes the margin of all child-sections of this section too.

##### Example Template:

```xml
<properties>
    <section name="parent">
        <meta>
            <title>parent section</title>
        </meta>
        <properties>
            <property name="title" type="text_line" mandatory="true">
                <meta>
                    <title>title</title>
                </meta>

                <tag name="sulu.rlp.part"/>
            </property>
            <section name="child">
                <meta>
                    <title>child section</title>
                </meta>
                <properties>
                    <property name="url" type="resource_locator" mandatory="true">
                        <meta>
                            <title>url</title>
                        </meta>

                        <tag name="sulu.rlp"/>
                    </property>
                </properties>
            </section>
        </properties>
    </section>
</properties>
```

##### Before:

![Screenshot 2021-01-07 at 13 57 44](https://user-images.githubusercontent.com/13310795/103895220-57c78a00-50f0-11eb-8c03-696154f23207.png)

##### After:

![Screenshot 2021-01-07 at 13 58 17](https://user-images.githubusercontent.com/13310795/103895263-69a92d00-50f0-11eb-8d79-bf61ee41cdbf.png)
