### PR TITLE
Change branch names

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,24 +1,30 @@
 | Q | A
 | --- | ---
-| Bug? | no
-| New Feature? | no
-| Sulu Version | Specific version or SHA of a commit
-| Browser Version | Browser name and version
+| Bug? | no yes
+| New Feature? | no yes
+| Sulu Version | <!-- Specific version or SHA of a commit (e.g.: 2.2.3) -->
+| PHP Version | <!-- Three digit PHP Version (e.g. 7.4.12) -->
+| DB Version | <!-- Three digit DB Version and Name (e.g. MySQL 5.7.35) -->
+| Browser Version | <!-- Browser name and version (e.g. Firefox 84.0.4 ) -->
 
 #### Actual Behavior
 
-How does Sulu behave at the moment? 
+<!-- How does Sulu behave at the moment? -->
 
 #### Expected Behavior
 
-What is the behavior you expect?
+<!-- What is the behavior you expect? -->
 
 #### Steps to Reproduce
 
+<!--
 What are the steps to reproduce this bug? Please add code examples,
 screenshots or links to GitHub repositories that reproduce the problem.
+-->
 
 #### Possible Solutions
 
+<!--
 If you have already ideas how to solve the issue, add them here.
 (remove this section if not needed)
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,37 +1,34 @@
 | Q | A
 | --- | ---
-| Bug fix? | no
-| New feature? | no
-| BC breaks? | no
-| Deprecations? | no
-| Fixed tickets | fixes #issuenum
-| Related issues/PRs | #issuenum
+| Bug fix? | no yes
+| New feature? | no yes
+| BC breaks? | no yes
+| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
+| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
+| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
 | License | MIT
-| Documentation PR | sulu/sulu-docs#prnum
+| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->
 
 #### What's in this PR?
 
-Explain the contents of the PR.
+<!-- Explain the contents of the PR. -->
 
 #### Why?
 
-Which problem does the PR fix? (remove this section if you linked an issue above)
+<!-- Which problem does the PR fix? (add some context and maybe link to an issue here) -->
 
 #### Example Usage
 
-~~~php
+<!--
+```php
 // If you added new features, show examples of how to use them here
-// (remove this section if not a new feature)
 
 $foo = new Foo();
 
 // Now we can do
 $foo->doSomething();
-~~~
-
-#### BC Breaks/Deprecations
-
-Describe BC breaks/deprecations here. (remove this section if not needed)
+```
+-->
 
 #### To Do
 

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -4,8 +4,8 @@ on:
     pull_request:
     push:
         branches:
-            - master
-            - release/**
+            - '[0-9]+.x'
+            - '[0-9]+.[0-9]+'
 
 jobs:
     php-cs-fixer:

--- a/composer.json
+++ b/composer.json
@@ -103,13 +103,5 @@
         "psr-0": {
             "Sulu\\": "tests/"
         }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-release/1.6": "1.6.x-dev",
-            "dev-release/2.1": "2.1.x-dev",
-            "dev-release/2.2": "2.2.x-dev",
-            "dev-master": "2.x-dev"
-        }
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

We did change the branch names from `release/*.*` to `*.*`.

#### Why?

That composer know which version we are using without the need to provide a branch alias.
