### PR TITLE
Remove download-language script from test workflow

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -188,7 +188,3 @@ jobs:
             - name: Execute test cases
               run: time composer test
               env: ${{ matrix.env }}
-
-            - name: Test download-language script
-              run: bin/console sulu:admin:download-language nl
-              env: ${{ matrix.env }}


### PR DESCRIPTION
We need to test the script in the `sulu/skeleton` repository. Executing the script in this repository will always lead to the [following output](https://github.com/sulu/sulu/runs/1680477063):
```
Language: nl
------------


                                                                                                                        
 [WARNING] Translation for language "nl" does not exist yet. Reach out to the Sulu team via https://sulu.io/contact-us  
           if you are interested in creating it. Your contribution is highly appreciated!                               
                                                                                                                        
```

The reason for this is that the script does not detect relevant packages when it is executed in this repository:
https://github.com/sulu/sulu/blob/5792ba7765bfb0b88dad6bea433c743cc3b20f56/src/Sulu/Bundle/AdminBundle/Command/DownloadLanguageCommand.php#L103-L107