### PR TITLE
Use block visitors for hiding blocks in BlockContentType

### DIFF
--- a/src/Sulu/Bundle/AudienceTargetingBundle/Content/Types/Block/TargetGroupBlockVisitor.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Content/Types/Block/TargetGroupBlockVisitor.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AudienceTargetingBundle\Content\Types\Block;
+
+use Sulu\Bundle\AudienceTargetingBundle\TargetGroup\TargetGroupStoreInterface;
+use Sulu\Component\Content\Compat\Block\BlockPropertyType;
+use Sulu\Component\Content\Types\Block\BlockVisitorInterface;
+
+class TargetGroupBlockVisitor implements BlockVisitorInterface
+{
+    /**
+     * @var TargetGroupStoreInterface
+     */
+    private $targetGroupStore;
+
+    public function __construct(TargetGroupStoreInterface $targetGroupStore)
+    {
+        $this->targetGroupStore = $targetGroupStore;
+    }
+
+    public function visit(BlockPropertyType $block): ?BlockPropertyType
+    {
+        $blockPropertyTypeSettings = $block->getSettings();
+
+        if (\is_array($blockPropertyTypeSettings)
+            && isset($blockPropertyTypeSettings['target_groups_enabled'])
+            && $blockPropertyTypeSettings['target_groups_enabled']
+            && isset($blockPropertyTypeSettings['target_groups'])
+            && !\in_array($this->targetGroupStore->getTargetGroupId(), $blockPropertyTypeSettings['target_groups'])
+        ) {
+            return null;
+        } else {
+            return $block;
+        }
+    }
+}

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/services.xml
@@ -146,5 +146,13 @@
         <service id="sulu_audience_targeting.target_group_store"
                  class="Sulu\Bundle\AudienceTargetingBundle\TargetGroup\TargetGroupStore" public="true">
         </service>
+
+        <service
+            id="sulu_audience_targeting.target_group_block_visitor"
+            class="Sulu\Bundle\AudienceTargetingBundle\Content\Types\Block\TargetGroupBlockVisitor"
+        >
+            <argument type="service" id="sulu_audience_targeting.target_group_store"/>
+            <tag name="sulu_content.block_visitor" />
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Content/Types/Block/TargetGroupBlockVisitorTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Content/Types/Block/TargetGroupBlockVisitorTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Tests\Unit\Types\Block;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AudienceTargetingBundle\Content\Types\Block\TargetGroupBlockVisitor;
+use Sulu\Bundle\AudienceTargetingBundle\TargetGroup\TargetGroupStoreInterface;
+use Sulu\Component\Content\Compat\Block\BlockPropertyType;
+use Sulu\Component\Content\Compat\Metadata;
+
+class TargetGroupBlockVisitorTest extends TestCase
+{
+    /**
+     * @var TargetGroupStoreInterface
+     */
+    private $targetGroupStore;
+
+    /**
+     * @var TargetGroupBlockVisitor
+     */
+    private $targetGroupBlockVisitor;
+
+    public function setUp(): void
+    {
+        $this->targetGroupStore = $this->prophesize(TargetGroupStoreInterface::class);
+        $this->targetGroupBlockVisitor = new TargetGroupBlockVisitor($this->targetGroupStore->reveal());
+    }
+
+    public function testShouldNotSkipWithObjectAsSettings()
+    {
+        $blockPropertyType = new BlockPropertyType('type1', new Metadata([]));
+        $blockPropertyType->setSettings(new \stdClass());
+
+        $this->assertEquals($blockPropertyType, $this->targetGroupBlockVisitor->visit($blockPropertyType));
+    }
+
+    public function testShouldNotSkipWithEmptyArrayAsSettings()
+    {
+        $blockPropertyType = new BlockPropertyType('type1', new Metadata([]));
+        $blockPropertyType->setSettings([]);
+
+        $this->assertEquals($blockPropertyType, $this->targetGroupBlockVisitor->visit($blockPropertyType));
+    }
+
+    public function testShouldSkipWithOtherTargetGroup()
+    {
+        $blockPropertyType = new BlockPropertyType('type1', new Metadata([]));
+        $blockPropertyType->setSettings(['target_groups_enabled' => true, 'target_groups' => [1, 2]]);
+
+        $this->targetGroupStore->getTargetGroupId()->willReturn(3);
+
+        $this->assertNull($this->targetGroupBlockVisitor->visit($blockPropertyType));
+    }
+
+    public function testShouldNotSkipWithSameTargetGroup()
+    {
+        $blockPropertyType = new BlockPropertyType('type1', new Metadata([]));
+        $blockPropertyType->setSettings(['target_groups_enabled' => true, 'target_groups' => [1, 2, 3]]);
+
+        $this->targetGroupStore->getTargetGroupId()->willReturn(3);
+
+        $this->assertEquals($blockPropertyType, $this->targetGroupBlockVisitor->visit($blockPropertyType));
+    }
+
+    public function testShouldNotSkipWithoutTargetGroups()
+    {
+        $blockPropertyType = new BlockPropertyType('type1', new Metadata([]));
+        $blockPropertyType->setSettings(['target_groups_enabled' => true]);
+
+        $this->targetGroupStore->getTargetGroupId()->willReturn(3);
+
+        $this->assertEquals($blockPropertyType, $this->targetGroupBlockVisitor->visit($blockPropertyType));
+    }
+
+    public function testShouldNotSkipWithDisabledTargetGroups()
+    {
+        $blockPropertyType = new BlockPropertyType('type1', new Metadata([]));
+        $blockPropertyType->setSettings(['target_groups_enabled' => false, 'target_groups' => [1, 2]]);
+
+        $this->targetGroupStore->getTargetGroupId()->willReturn(3);
+
+        $this->assertEquals($blockPropertyType, $this->targetGroupBlockVisitor->visit($blockPropertyType));
+    }
+
+    public function testShouldNotSkipWithoutTargetGroupsFlag()
+    {
+        $blockPropertyType = new BlockPropertyType('type1', new Metadata([]));
+        $blockPropertyType->setSettings(['target_groups' => [1, 2]]);
+
+        $this->targetGroupStore->getTargetGroupId()->willReturn(3);
+
+        $this->assertEquals($blockPropertyType, $this->targetGroupBlockVisitor->visit($blockPropertyType));
+    }
+}

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -16,6 +16,7 @@ use Sulu\Bundle\ContactBundle\Entity\Account;
 use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
 use Sulu\Bundle\MediaBundle\Entity\Collection;
 use Sulu\Bundle\MediaBundle\Entity\CollectionInterface;
+use Sulu\Component\Content\Types\Block\BlockVisitorInterface;
 use Sulu\Component\HttpKernel\SuluKernel;
 use Sulu\Component\Rest\Csv\ObjectNotSupportedException;
 use Sulu\Component\Rest\DQL\Cast;
@@ -321,6 +322,9 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
         $loader->load('serializer.xml');
         $loader->load('request_analyzer.xml');
         $loader->load('doctrine.xml');
+
+        $container->registerForAutoconfiguration(BlockVisitorInterface::class)
+            ->addTag('sulu_content.block_visitor');
     }
 
     private function initWebspace(array $webspaceConfig, ContainerBuilder $container, XmlFileLoader $loader)

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
@@ -164,8 +164,24 @@
             <argument>%sulu.content.language.namespace%</argument>
             <argument type="service" id="sulu_core.webspace.request_analyzer" />
             <argument type="service" id="sulu_audience_targeting.target_group_store" on-invalid="null" />
+            <argument type="tagged" tag="sulu_content.block_visitor" />
             <tag name="sulu.content.type" alias="block"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
+        </service>
+
+        <service
+            id="sulu.content.type.block.hidden_visitor"
+            class="Sulu\Component\Content\Types\Block\HiddenBlockVisitor"
+        >
+            <tag name="sulu_content.block_visitor" />
+        </service>
+
+        <service
+            id="sulu.content.type.block.segment_visitor"
+            class="Sulu\Component\Content\Types\Block\SegmentBlockVisitor"
+        >
+            <argument type="service" id="sulu_core.webspace.request_analyzer" />
+            <tag name="sulu_content.block_visitor" />
         </service>
 
         <!-- content query -->

--- a/src/Sulu/Component/Content/Tests/Unit/Types/Block/HiddenBlockVisitorTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Types/Block/HiddenBlockVisitorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Tests\Unit\Types\Block;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Component\Content\Compat\Block\BlockPropertyType;
+use Sulu\Component\Content\Compat\Metadata;
+use Sulu\Component\Content\Types\Block\HiddenBlockVisitor;
+
+class HiddenBlockVisitorTest extends TestCase
+{
+    /**
+     * @var HiddenBlockVisitor
+     */
+    private $hiddenBlockVisitor;
+
+    public function setUp(): void
+    {
+        $this->hiddenBlockVisitor = new HiddenBlockVisitor();
+    }
+
+    public function testShouldNotSkipWithObjectAsSettings()
+    {
+        $blockPropertyType = new BlockPropertyType('type1', new Metadata([]));
+        $blockPropertyType->setSettings(new \stdClass());
+
+        $this->assertEquals($blockPropertyType, $this->hiddenBlockVisitor->visit($blockPropertyType));
+    }
+
+    public function testShouldNotSkipWithEmptyArrayAsSettings()
+    {
+        $blockPropertyType = new BlockPropertyType('type1', new Metadata([]));
+        $blockPropertyType->setSettings([]);
+
+        $this->assertEquals($blockPropertyType, $this->hiddenBlockVisitor->visit($blockPropertyType));
+    }
+
+    public function testShouldSkipWithHiddenSetting()
+    {
+        $blockPropertyType = new BlockPropertyType('type1', new Metadata([]));
+        $blockPropertyType->setSettings(['hidden' => true]);
+
+        $this->assertNull($this->hiddenBlockVisitor->visit($blockPropertyType));
+    }
+
+    public function testShouldNotSkipWithHiddenSetting()
+    {
+        $blockPropertyType = new BlockPropertyType('type1', new Metadata([]));
+        $blockPropertyType->setSettings(['hidden' => false]);
+
+        $this->assertEquals($blockPropertyType, $this->hiddenBlockVisitor->visit($blockPropertyType));
+    }
+}

--- a/src/Sulu/Component/Content/Tests/Unit/Types/Block/SegmentBlockVisitorTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Types/Block/SegmentBlockVisitorTest.php
@@ -1,0 +1,148 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Tests\Unit\Types\Block;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Component\Content\Compat\Block\BlockPropertyType;
+use Sulu\Component\Content\Compat\Metadata;
+use Sulu\Component\Content\Types\Block\SegmentBlockVisitor;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Segment;
+use Sulu\Component\Webspace\Webspace;
+
+class SegmentBlockVisitorTest extends TestCase
+{
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    /**
+     * @var SegmentBlockVisitor
+     */
+    private $segmentBlockVisitor;
+
+    public function setUp(): void
+    {
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $this->segmentBlockVisitor = new SegmentBlockVisitor($this->requestAnalyzer->reveal());
+    }
+
+    public function testShouldNotSkipWithObjectAsSettings()
+    {
+        $blockPropertyType = new BlockPropertyType('type1', new Metadata([]));
+        $blockPropertyType->setSettings(new \stdClass());
+
+        $this->assertEquals($blockPropertyType, $this->segmentBlockVisitor->visit($blockPropertyType));
+    }
+
+    public function testShouldNotSkipWithEmptyArrayAsSettings()
+    {
+        $blockPropertyType = new BlockPropertyType('type1', new Metadata([]));
+        $blockPropertyType->setSettings([]);
+
+        $this->assertEquals($blockPropertyType, $this->segmentBlockVisitor->visit($blockPropertyType));
+    }
+
+    public function testShouldSkipWithOtherSegment()
+    {
+        $blockPropertyType = new BlockPropertyType('type1', new Metadata([]));
+        $blockPropertyType->setSettings(['segment_enabled' => true, 'segments' => ['sulu_io' => 'w']]);
+
+        $webspace = new Webspace();
+        $webspace->setKey('sulu_io');
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $segment = new Segment();
+        $segment->setKey('s');
+        $this->requestAnalyzer->getSegment()->willReturn($segment);
+
+        $this->assertNull($this->segmentBlockVisitor->visit($blockPropertyType));
+    }
+
+    public function testShouldNotSkipWithSameSegment()
+    {
+        $blockPropertyType = new BlockPropertyType('type1', new Metadata([]));
+        $blockPropertyType->setSettings(['segment_enabled' => true, 'segments' => ['sulu_io' => 'w']]);
+
+        $webspace = new Webspace();
+        $webspace->setKey('sulu_io');
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $segment = new Segment();
+        $segment->setKey('w');
+        $this->requestAnalyzer->getSegment()->willReturn($segment);
+
+        $this->assertEquals($blockPropertyType, $this->segmentBlockVisitor->visit($blockPropertyType));
+    }
+
+    public function testShouldNotSkipWithoutSegment()
+    {
+        $blockPropertyType = new BlockPropertyType('type1', new Metadata([]));
+        $blockPropertyType->setSettings(['segment_enabled' => true, 'segments' => ['sulu_io' => 'w']]);
+
+        $webspace = new Webspace();
+        $webspace->setKey('sulu_io');
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
+        $this->requestAnalyzer->getSegment()->willReturn(null);
+
+        $this->assertEquals($blockPropertyType, $this->segmentBlockVisitor->visit($blockPropertyType));
+    }
+
+    public function testShouldNotSkipWithoutSegmentForWebspace()
+    {
+        $blockPropertyType = new BlockPropertyType('type1', new Metadata([]));
+        $blockPropertyType->setSettings(['segment_enabled' => true, 'segments' => ['sulu_io' => 'w']]);
+
+        $webspace = new Webspace();
+        $webspace->setKey('sulu_blog');
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $segment = new Segment();
+        $segment->setKey('s');
+        $this->requestAnalyzer->getSegment()->willReturn($segment);
+
+        $this->assertEquals($blockPropertyType, $this->segmentBlockVisitor->visit($blockPropertyType));
+    }
+
+    public function testShouldNotSkipWithDisabledSegment()
+    {
+        $blockPropertyType = new BlockPropertyType('type1', new Metadata([]));
+        $blockPropertyType->setSettings(['segment_enabled' => false, 'segments' => ['sulu_io' => 'w']]);
+
+        $webspace = new Webspace();
+        $webspace->setKey('sulu_io');
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $segment = new Segment();
+        $segment->setKey('s');
+        $this->requestAnalyzer->getSegment()->willReturn($segment);
+
+        $this->assertEquals($blockPropertyType, $this->segmentBlockVisitor->visit($blockPropertyType));
+    }
+
+    public function testShouldSkipWithoutSegmentEnabledFlag()
+    {
+        $blockPropertyType = new BlockPropertyType('type1', new Metadata([]));
+        $blockPropertyType->setSettings(['segments' => ['sulu_io' => 'w']]);
+
+        $webspace = new Webspace();
+        $webspace->setKey('sulu_io');
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $segment = new Segment();
+        $segment->setKey('s');
+        $this->requestAnalyzer->getSegment()->willReturn($segment);
+
+        $this->assertEquals($blockPropertyType, $this->segmentBlockVisitor->visit($blockPropertyType));
+    }
+}

--- a/src/Sulu/Component/Content/Types/Block/BlockVisitorInterface.php
+++ b/src/Sulu/Component/Content/Types/Block/BlockVisitorInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Types\Block;
+
+use Sulu\Component\Content\Compat\Block\BlockPropertyType;
+
+interface BlockVisitorInterface
+{
+    public function visit(BlockPropertyType $block): ?BlockPropertyType;
+}

--- a/src/Sulu/Component/Content/Types/Block/HiddenBlockVisitor.php
+++ b/src/Sulu/Component/Content/Types/Block/HiddenBlockVisitor.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Types\Block;
+
+use Sulu\Component\Content\Compat\Block\BlockPropertyType;
+
+class HiddenBlockVisitor implements BlockVisitorInterface
+{
+    public function visit(BlockPropertyType $block): ?BlockPropertyType
+    {
+        $blockPropertyTypeSettings = $block->getSettings();
+
+        return \is_array($blockPropertyTypeSettings) && !empty($blockPropertyTypeSettings['hidden'])
+            ? null
+            : $block;
+    }
+}

--- a/src/Sulu/Component/Content/Types/Block/SegmentBlockVisitor.php
+++ b/src/Sulu/Component/Content/Types/Block/SegmentBlockVisitor.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Types\Block;
+
+use Sulu\Component\Content\Compat\Block\BlockPropertyType;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+
+class SegmentBlockVisitor implements BlockVisitorInterface
+{
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    public function __construct(RequestAnalyzerInterface $requestAnalyzer)
+    {
+        $this->requestAnalyzer = $requestAnalyzer;
+    }
+
+    public function visit(BlockPropertyType $block): ?BlockPropertyType
+    {
+        $blockPropertyTypeSettings = $block->getSettings();
+
+        $webspace = $this->requestAnalyzer->getWebspace();
+        $webspaceKey = $webspace ? $webspace->getKey() : null;
+        $segment = $this->requestAnalyzer->getSegment();
+
+        if (\is_array($blockPropertyTypeSettings)
+            && $webspaceKey
+            && isset($blockPropertyTypeSettings['segment_enabled'])
+            && $blockPropertyTypeSettings['segment_enabled']
+            && isset($blockPropertyTypeSettings['segments'][$webspaceKey])
+            && $segment
+            && $blockPropertyTypeSettings['segments'][$webspaceKey] !== $segment->getKey()
+        ) {
+            return null;
+        } else {
+            return $block;
+        }
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Related issues/PRs | https://github.com/sulu/SuluHeadlessBundle/pull/63
| License | MIT

#### What's in this PR?

<!-- Explain the contents of the PR. -->

This PR backports the `BlockVisitor` pattern that was implemented for hiding blocks in https://github.com/sulu/sulu/pull/5608 to the `2.2` branch.

#### Why?

Because this makes it a lot easier to support this functionality in other places. For example, we need to reuse the functionality in the `HeadlessBundle`: https://github.com/sulu/SuluHeadlessBundle/pull/63
