### PR TITLE
Prevent duplicated requests when block with list_overlay selection is changed 

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/MultiListOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/MultiListOverlay.js
@@ -50,7 +50,10 @@ class MultiListOverlay extends React.Component<Props> {
     constructor(props: Props) {
         super(props);
 
-        const excludedIds = computed(() => this.props.excludedIds.length ? this.props.excludedIds : undefined);
+        const excludedIds = computed(
+            () => this.props.excludedIds.length ? this.props.excludedIds : undefined,
+            {equals: comparer.structural}
+        );
         this.excludedIdsDisposer = excludedIds.observe(() => this.listStore.clear());
 
         const {listKey, locale, options, preloadSelectedItems, preSelectedItems, resourceKey} = this.props;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/tests/MultiListOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/tests/MultiListOverlay.test.js
@@ -115,6 +115,54 @@ test('Should not update options of ListStore if new value of options prop is equ
     expect(multiListOverlay.instance().listStore.reset).not.toBeCalled();
 });
 
+test('Should clear ListStore if the excludedIds prop is changed', () => {
+    const multiListOverlay = shallow(
+        <MultiListOverlay
+            adapter="table"
+            excludedIds={['id-1', 'id-2']}
+            listKey="snippets_list"
+            locale={observable.box('en')}
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+            open={false}
+            resourceKey="snippets"
+            title="Selection"
+        />
+    );
+
+    expect(multiListOverlay.instance().listStore.clear).not.toBeCalled();
+
+    multiListOverlay.setProps({
+        excludedIds: ['id-3'],
+    });
+
+    expect(multiListOverlay.instance().listStore.clear).toBeCalled();
+});
+
+test('Should not clear ListStore if new value of excludedIds prop is equal to old value', () => {
+    const multiListOverlay = shallow(
+        <MultiListOverlay
+            adapter="table"
+            excludedIds={['id-1', 'id-2']}
+            listKey="snippets_list"
+            locale={observable.box('en')}
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+            open={false}
+            resourceKey="snippets"
+            title="Selection"
+        />
+    );
+
+    expect(multiListOverlay.instance().listStore.clear).not.toBeCalled();
+
+    multiListOverlay.setProps({
+        excludedIds: ['id-1', 'id-2'],
+    });
+
+    expect(multiListOverlay.instance().listStore.clear).not.toBeCalled();
+});
+
 test('Should instantiate the ListStore without locale, excluded-ids and options', () => {
     const multiListOverlay = shallow(
         <MultiListOverlay

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/SingleListOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/SingleListOverlay.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {autorun, computed, observable} from 'mobx';
+import {autorun, comparer, computed, observable} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import ListStore from '../../containers/List/stores/ListStore';
@@ -48,7 +48,10 @@ class SingleListOverlay extends React.Component<Props> {
     constructor(props: Props) {
         super(props);
 
-        const excludedIds = computed(() => this.props.excludedIds.length ? this.props.excludedIds : undefined);
+        const excludedIds = computed(
+            () => this.props.excludedIds.length ? this.props.excludedIds : undefined,
+            {equals: comparer.structural}
+        );
         this.excludedIdsDisposer = excludedIds.observe(() => this.listStore.clear());
 
         const {listKey, locale, metadataOptions, options, preSelectedItem, resourceKey} = this.props;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/tests/SingleListOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/tests/SingleListOverlay.test.js
@@ -346,6 +346,52 @@ test('Should only select a single item at a time', () => {
     expect(singleListOverlay.instance().listStore.select).toBeCalledWith({id: 5});
 });
 
+test('Should clear ListStore if the excludedIds prop is changed', () => {
+    const singleListOverlay = shallow(
+        <SingleListOverlay
+            adapter="table"
+            excludedIds={['id-1', 'id-2']}
+            listKey="snippets"
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+            open={true}
+            resourceKey="snippets"
+            title="test"
+        />
+    );
+
+    expect(singleListOverlay.instance().listStore.clear).not.toBeCalled();
+
+    singleListOverlay.setProps({
+        excludedIds: ['id-3'],
+    });
+
+    expect(singleListOverlay.instance().listStore.clear).toBeCalled();
+});
+
+test('Should not clear ListStore if new value of excludedIds prop is equal to old value', () => {
+    const singleListOverlay = shallow(
+        <SingleListOverlay
+            adapter="table"
+            excludedIds={['id-1', 'id-2']}
+            listKey="snippets"
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+            open={true}
+            resourceKey="snippets"
+            title="test"
+        />
+    );
+
+    expect(singleListOverlay.instance().listStore.clear).not.toBeCalled();
+
+    singleListOverlay.setProps({
+        excludedIds: ['id-1', 'id-2'],
+    });
+
+    expect(singleListOverlay.instance().listStore.clear).not.toBeCalled();
+});
+
 test('Should destroy listStore and autorun when unmounted', () => {
     const singleListOverlay = shallow(
         <SingleListOverlay

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelectionOverlay/MultiMediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelectionOverlay/MultiMediaSelectionOverlay.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {computed, observable} from 'mobx';
+import {comparer, computed, observable} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import {ListStore} from 'sulu-admin-bundle/containers';
@@ -32,7 +32,10 @@ class MultiMediaSelectionOverlay extends React.Component<Props> {
     constructor(props: Props) {
         super(props);
 
-        const excludedIds = computed(() => this.props.excludedIds.length ? this.props.excludedIds : undefined);
+        const excludedIds = computed(
+            () => this.props.excludedIds.length ? this.props.excludedIds : undefined,
+            {equals: comparer.structural}
+        );
         this.excludedIdsDisposer = excludedIds.observe(() => this.mediaListStore.clear());
 
         this.mediaListStore = MediaSelectionOverlay.createMediaListStore(

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelectionOverlay/tests/MultiMediaSelectionOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelectionOverlay/tests/MultiMediaSelectionOverlay.test.js
@@ -116,6 +116,46 @@ test('Should pass correct props to media-selection-overlay', () => {
     expect(mediaSelectionOverlay.prop('onConfirm')).toEqual(onConfirm);
 });
 
+test('Should clear media ListStore if the excludedIds prop is changed', () => {
+    const multiMediaSelectionOverlay = shallow(
+        <MultiMediaSelectionOverlay
+            excludedIds={[11, 22]}
+            locale={observable.box('en')}
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+            open={true}
+        />
+    );
+
+    expect(multiMediaSelectionOverlay.instance().mediaListStore.clear).not.toBeCalled();
+
+    multiMediaSelectionOverlay.setProps({
+        excludedIds: [33],
+    });
+
+    expect(multiMediaSelectionOverlay.instance().mediaListStore.clear).toBeCalled();
+});
+
+test('Should not clear media ListStore if new value of excludedIds prop is equal to old value', () => {
+    const multiMediaSelectionOverlay = shallow(
+        <MultiMediaSelectionOverlay
+            excludedIds={[11, 22]}
+            locale={observable.box('en')}
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+            open={true}
+        />
+    );
+
+    expect(multiMediaSelectionOverlay.instance().mediaListStore.clear).not.toBeCalled();
+
+    multiMediaSelectionOverlay.setProps({
+        excludedIds: [11, 22],
+    });
+
+    expect(multiMediaSelectionOverlay.instance().mediaListStore.clear).not.toBeCalled();
+});
+
 test('Should destroy list-stores on unmount', () => {
     const multiMediaSelectionOverlay = shallow(
         <MultiMediaSelectionOverlay

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelectionOverlay/SingleMediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelectionOverlay/SingleMediaSelectionOverlay.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {autorun, computed, observable} from 'mobx';
+import {autorun, comparer, computed, observable} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import {ListStore} from 'sulu-admin-bundle/containers';
@@ -31,7 +31,10 @@ class SingleMediaSelectionOverlay extends React.Component<Props> {
     constructor(props: Props) {
         super(props);
 
-        const excludedIds = computed(() => this.props.excludedIds.length ? this.props.excludedIds : undefined);
+        const excludedIds = computed(
+            () => this.props.excludedIds.length ? this.props.excludedIds : undefined,
+            {equals: comparer.structural}
+        );
         this.excludedIdsDisposer = excludedIds.observe(() => this.mediaListStore.clear());
 
         this.mediaListStore = MediaSelectionOverlay.createMediaListStore(

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelectionOverlay/tests/SingleMediaSelectionOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelectionOverlay/tests/SingleMediaSelectionOverlay.test.js
@@ -134,6 +134,46 @@ test('Should pass correct props to media-selection-overlay', () => {
     expect(mediaSelectionOverlay.prop('onClose')).toEqual(onClose);
 });
 
+test('Should clear media ListStore if the excludedIds prop is changed', () => {
+    const singleMediaSelectionOverlay = shallow(
+        <SingleMediaSelectionOverlay
+            excludedIds={[11, 22]}
+            locale={mockObservable.box('en')}
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+            open={true}
+        />
+    );
+
+    expect(singleMediaSelectionOverlay.instance().mediaListStore.clear).not.toBeCalled();
+
+    singleMediaSelectionOverlay.setProps({
+        excludedIds: [33],
+    });
+
+    expect(singleMediaSelectionOverlay.instance().mediaListStore.clear).toBeCalled();
+});
+
+test('Should not clear media ListStore if new value of excludedIds prop is equal to old value', () => {
+    const singleMediaSelectionOverlay = shallow(
+        <SingleMediaSelectionOverlay
+            excludedIds={[11, 22]}
+            locale={mockObservable.box('en')}
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+            open={true}
+        />
+    );
+
+    expect(singleMediaSelectionOverlay.instance().mediaListStore.clear).not.toBeCalled();
+
+    singleMediaSelectionOverlay.setProps({
+        excludedIds: [11, 22],
+    });
+
+    expect(singleMediaSelectionOverlay.instance().mediaListStore.clear).not.toBeCalled();
+});
+
 test('Should destroy list-stores on unmount', () => {
     const singleMediaSelectionOverlay = shallow(
         <SingleMediaSelectionOverlay


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5743
| License | MIT

#### What's in this PR?

This PR adjust the `ListOverlay` components to only update the `excludedIds` that are passed to the `ListStore` if the value is changed.

#### Why?

I am using the `SingleMediaSelection` as example. The same issue can occur for other components that use a `ListOverlay` component with a `excludedIds` prop.

The `SingleMediaSelection` passes the currently selected id to the `excludedIds` prop of the `SingleMediaSelectionOverlay`. The array that is passed to the `excludedIds` prop is created in the `SingleMediaSelection::render` method. This means that it will pass a different array reference (with the same content) on each render:
https://github.com/sulu/sulu/blob/3b41b627fbc1cf93be7f98eb3e3d4ebe35883b35/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/SingleMediaSelection.js#L173

 At the moment, this different array reference will update the `observableOptions` object that is passed to the `ListStore` by the `SingleMediaSelectionOverlay`. This will then trigger a new request even if the content of the `excludedIds` array has not changed.

With this PR, the `SingleMediaSelectionOverlay` will check the content of the `excludedIds` prop and only update the `observableOptions` object if there was an actual change. 
