### PR TITLE
Allow to use custom-url redirects with other request-formats than html

### DIFF
--- a/src/Sulu/Bundle/CustomUrlBundle/Request/CustomUrlRequestProcessor.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Request/CustomUrlRequestProcessor.php
@@ -61,10 +61,17 @@ class CustomUrlRequestProcessor implements RequestProcessorInterface
 
     public function process(Request $request, RequestAttributes $requestAttributes)
     {
-        $url = $this->decodeUrl(\rtrim(\sprintf('%s%s', $request->getHost(), $request->getRequestUri()), '/'));
-        if ('.html' === \substr($url, -5, 5)) {
-            $url = \substr($url, 0, -5);
+        $pathInfo = $request->getPathInfo();
+        if (\strrpos($pathInfo, '.')) {
+            $pathInfo = \substr($pathInfo, 0, \strrpos($pathInfo, '.'));
         }
+
+        $queryString = $request->getQueryString();
+        if (!empty($queryString)) {
+            $queryString = '?' . $queryString;
+        }
+
+        $url = $this->decodeUrl(\rtrim(\sprintf('%s%s%s', $request->getHost(), $pathInfo, $queryString), '/'));
         $portalInformations = $this->webspaceManager->findPortalInformationsByUrl($url, $this->environment);
 
         if (0 === \count($portalInformations)) {

--- a/src/Sulu/Component/CustomUrl/Routing/CustomUrlRouteProvider.php
+++ b/src/Sulu/Component/CustomUrl/Routing/CustomUrlRouteProvider.php
@@ -139,7 +139,10 @@ class CustomUrlRouteProvider implements RouteProviderInterface
             $this->getRoutesPath($webspaceKey)
         );
 
-        $url = \sprintf('%s://%s', $request->getScheme(), $resourceSegment);
+        $requestFormat = $request->getRequestFormat(null);
+        $requestFormatSuffix = $requestFormat ? '.' . $requestFormat : '';
+
+        $url = \sprintf('%s://%s%s', $request->getScheme(), $resourceSegment, $requestFormatSuffix);
 
         $collection->add(
             \uniqid('custom_url_route_', true),

--- a/src/Sulu/Component/CustomUrl/Routing/Enhancers/RedirectEnhancer.php
+++ b/src/Sulu/Component/CustomUrl/Routing/Enhancers/RedirectEnhancer.php
@@ -59,7 +59,7 @@ class RedirectEnhancer extends AbstractEnhancer
 
         return [
             '_controller' => 'sulu_website.redirect_controller:redirectAction',
-            'url' => $url . $requestFormatSuffix . $queryString,
+            'url' => $url . $requestFormatSuffix . $queryStringSuffix,
         ];
     }
 

--- a/src/Sulu/Component/CustomUrl/Routing/Enhancers/RedirectEnhancer.php
+++ b/src/Sulu/Component/CustomUrl/Routing/Enhancers/RedirectEnhancer.php
@@ -51,13 +51,15 @@ class RedirectEnhancer extends AbstractEnhancer
             $request->getScheme()
         );
 
-        if ($request->getQueryString()) {
-            $url .= '?' . $request->getQueryString();
-        }
+        $requestFormat = $request->getRequestFormat(null);
+        $requestFormatSuffix = $requestFormat ? '.' . $requestFormat : '';
+
+        $queryString = $request->getQueryString();
+        $queryStringSuffix = $queryString ? '?' . $queryString : '';
 
         return [
             '_controller' => 'sulu_website.redirect_controller:redirectAction',
-            'url' => $url,
+            'url' => $url . $requestFormatSuffix . $queryString,
         ];
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Related issues/PRs | https://github.com/sulu/SuluHeadlessBundle/issues/67
| License | MIT

#### What's in this PR?

This PR adjusts a few classes related to the custom-url feature to be compatible with other request-formats than `.html`.

#### Why?

At the moment, when a custom-url (with enabled `redirect` option) is accessed in the `.json` request-format, the `.json` suffix is lost after the redirect. This makes the custom-url feature incompatible with the SuluHeadlessBundle (see https://github.com/sulu/SuluHeadlessBundle/issues/67).
