### PR TITLE
Allow toflar/psr6-symfony-http-cache-store version ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -104,7 +104,7 @@
         "symfony/twig-bundle": "^4.4 || ^5.0",
         "symfony/validator": "^4.4 || ^5.0",
         "symfony/yaml": "^4.4 || ^5.0",
-        "toflar/psr6-symfony-http-cache-store": "^1.1 || ^2.0",
+        "toflar/psr6-symfony-http-cache-store": "^1.1 || ^2.0 || ^3.0",
         "twig/twig": "^1.41 || ^2.10 || ^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no 
| Fixed tickets | fixes #
| Related issues/PRs | # 
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Allow toflar/psr6-symfony-http-cache-store version ^3.0

#### Why?

For PHP 8 compatibility #5646 
