### PR TITLE
Allow newer version of flysystem azure adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,7 +114,7 @@
         "jackalope/jackalope-doctrine-dbal": "^1.3",
         "league/flysystem": "^1.0",
         "league/flysystem-aws-s3-v3": "^1.0.1",
-        "league/flysystem-azure-blob-storage": "^0.1",
+        "league/flysystem-azure-blob-storage": "^0.1 || ^1.0",
         "matthiasnoback/symfony-config-test": "^4.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "microsoft/azure-storage-blob": "^1.2",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no 
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Allow newer version of flysystem azure adapter

#### Why?

To avoid conflicts with others libraries and support newer php versions

