### PR TITLE
Allow newer version of oro doctrine extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "massive/build-bundle": "^0.3 || ^0.4 || ^0.5",
         "massive/search-bundle": "^2.0",
         "ocramius/proxy-manager": "^2.1",
-        "oro/doctrine-extensions": "^1.0",
+        "oro/doctrine-extensions": "^1.0 || ^2.0",
         "pagerfanta/pagerfanta": "^1.0.4 || ^2.0",
         "php-http/client-common": "^1.1.0 || ^2.0",
         "php-http/guzzle6-adapter": "^1.1 || ^2.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Allow newer version of oro doctrine extensions

#### Why?

Allow newer version for library and php updates in future.