### PR TITLE
Remove requirement to layershifter/tld-extract

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,6 @@
         "imagine/imagine": "^0.6.1 || ^0.7.0 || ^1.0",
         "jms/serializer": "^3.0",
         "jms/serializer-bundle": "^3.0",
-        "layershifter/tld-extract": "^1.1 || ^2.0",
         "massive/build-bundle": "^0.3 || ^0.4 || ^0.5",
         "massive/search-bundle": "^2.0",
         "ocramius/proxy-manager": "^2.1",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -34,3 +34,4 @@ parameters:
     ignoreErrors:
         - '#has invalid typehint type Symfony\\Bundle\\FrameworkBundle\\Controller\\ControllerNameParser#'
         - '#has invalid typehint type Symfony\\Bundle\\TwigBundle\\Controller\\ExceptionController#'
+        - '#Function tld_extract not found.#'

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Sitemap/sitemap.xml.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Sitemap/sitemap.xml.twig
@@ -1,12 +1,10 @@
 {% apply spaceless %}
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns:xhtml="http://www.w3.org/1999/xhtml" {% block namespaces %}xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"{% endblock %}>
-    {% set registrableDomain = sulu_util_domain_info(domain).registrableDomain %}
-
     {% for entry in entries %}
         {% set location = entry.loc %}
 
-        {% if sulu_util_domain_info(location).registrableDomain == registrableDomain %}
+        {% if domain in location %}
             <url>
                 {% block url %}
                     <loc>{{ location }}</loc>
@@ -25,7 +23,7 @@
                     {% if entry.alternateLinks|length > 1 %}
                         {% for alternateLink in entry.alternateLinks %}
                             {% set href = alternateLink.href %}
-                            {% if href is not empty and sulu_util_domain_info(href).registrableDomain == registrableDomain %}
+                            {% if href is not empty and domain in href %}
                                 <xhtml:link rel="alternate" hreflang="{{ alternateLink.locale|replace({'_': '-'}) }}" href="{{ href }}"/>
                                 {% set amount = amount + 1 %}
                                 {% if entry.defaultLocale == alternateLink.locale %}

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Core/UtilTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Core/UtilTwigExtension.php
@@ -26,14 +26,33 @@ class UtilTwigExtension extends AbstractExtension
         return [
             new TwigFilter('sulu_util_multisort', 'Sulu\Component\Util\SortUtils::multisort'),
             new TwigFilter('sulu_util_filter', 'Sulu\Component\Util\ArrayUtils::filter'),
-            new TwigFilter('sulu_util_domain_info', 'tld_extract'),
+            new TwigFilter('sulu_util_domain_info', [$this, 'extract']),
         ];
     }
 
     public function getFunctions()
     {
         return [
-            new TwigFunction('sulu_util_domain_info', 'tld_extract'),
+            new TwigFunction('sulu_util_domain_info', [$this, 'extract']),
         ];
+    }
+
+    /**
+     * @deprecated The "sulu_util_domain_info" is deprecated and will be removed with Sulu 3.0.
+     */
+    public function extract($url, $mode = null)
+    {
+        @\trigger_error(
+            'The "sulu_util_domain_info" is deprecated and will be removed with Sulu 3.0.',
+            \E_USER_DEPRECATED
+        );
+
+        if (\function_exists('tld_extract')) {
+            return \tld_extract($url, $mode);
+        }
+
+        throw new \LogicException(
+            'The "sulu_util_domain_info" requires "layershifter/tld-extract" package to be installed.'
+        );
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove requirement to layershifter/tld-extract.

#### Why?

The package is deprecated and we do not longer need it for the sitemap provider. I removed there the check.