### PR TITLE
Add UploadToolbarAction

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/BytesFieldTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/BytesFieldTransformer.js
@@ -1,6 +1,7 @@
 // @flow
 import type {Node} from 'react';
 import type {FieldTransformer} from '../types';
+import {transformBytesToReadableString} from '../../../utils';
 
 export default class BytesFieldTransformer implements FieldTransformer {
     transform(value: *): Node {
@@ -8,14 +9,6 @@ export default class BytesFieldTransformer implements FieldTransformer {
             return null;
         }
 
-        if (value === 0) {
-            return '0 Byte';
-        }
-
-        const k = 1000;
-        const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
-        const i = Math.floor(Math.log(value) / Math.log(k));
-
-        return (value / Math.pow(k, i)).toFixed(2) + ' ' + sizes[i];
+        return transformBytesToReadableString(value);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -28,6 +28,7 @@ import List, {
     DeleteToolbarAction as ListDeleteToolbarAction,
     MoveToolbarAction as ListMoveToolbarAction,
     ExportToolbarAction as ListExportToolbarAction,
+    UploadToolbarAction as ListUploadToolbarAction,
 } from './views/List';
 import Tabs from './views/Tabs';
 import CKEditor5 from './containers/TextEditor/adapters/CKEditor5';
@@ -309,6 +310,7 @@ function registerListToolbarActions() {
     listToolbarActionRegistry.add('sulu_admin.delete', ListDeleteToolbarAction);
     listToolbarActionRegistry.add('sulu_admin.move', ListMoveToolbarAction);
     listToolbarActionRegistry.add('sulu_admin.export', ListExportToolbarAction);
+    listToolbarActionRegistry.add('sulu_admin.upload', ListUploadToolbarAction);
 }
 
 function processConfig(config: Object) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Bytes/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Bytes/index.js
@@ -1,0 +1,4 @@
+// @flow
+import transformBytesToReadableString from './transformBytesToReadableString';
+
+export {transformBytesToReadableString};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Bytes/tests/transformBytesToReadableString.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Bytes/tests/transformBytesToReadableString.test.js
@@ -1,0 +1,18 @@
+// @flow
+import transformBytesToReadableString from '../transformBytesToReadableString';
+
+test('Test example 0', () => {
+    expect(transformBytesToReadableString(0)).toBe('0 Byte');
+});
+
+test('Test example MB', () => {
+    expect(transformBytesToReadableString(12312312)).toBe('12.31 MB');
+});
+
+test('Test example KB', () => {
+    expect(transformBytesToReadableString(55500)).toBe('55.50 KB');
+});
+
+test('Test example Bytes', () => {
+    expect(transformBytesToReadableString(521)).toBe('521.00 Bytes');
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Bytes/transformBytesToReadableString.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Bytes/transformBytesToReadableString.js
@@ -1,0 +1,15 @@
+// @flow
+
+const transformBytesToReadableString = (bytes: number): string => {
+    if (bytes === 0) {
+        return '0 Byte';
+    }
+
+    const k = 1000;
+    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+    return (bytes / Math.pow(k, i)).toFixed(2) + ' ' + sizes[i];
+};
+
+export default transformBytesToReadableString;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/index.js
@@ -1,10 +1,12 @@
 // @flow
 import arrayMove from 'array-move';
 import {buildQueryString} from './Request';
+import {transformBytesToReadableString} from './Bytes';
 import {translate} from './Translator';
 
 export {
     arrayMove,
     buildQueryString,
+    transformBytesToReadableString,
     translate,
 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DropdownToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DropdownToolbarAction.js
@@ -78,7 +78,7 @@ export default class DropdownToolbarAction extends AbstractFormToolbarAction {
         }
 
         if (typeof icon !== 'string') {
-            throw new Error('The "label" option must be a string!');
+            throw new Error('The "icon" option must be a string!');
         }
 
         const options: Array<DropdownOption> = this.toolbarActions

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/index.js
@@ -9,6 +9,7 @@ import AddToolbarAction from './toolbarActions/AddToolbarAction';
 import DeleteToolbarAction from './toolbarActions/DeleteToolbarAction';
 import MoveToolbarAction from './toolbarActions/MoveToolbarAction';
 import ExportToolbarAction from './toolbarActions/ExportToolbarAction';
+import UploadToolbarAction from './toolbarActions/UploadToolbarAction';
 
 export default List;
 
@@ -22,4 +23,5 @@ export {
     LinkItemAction,
     MoveToolbarAction,
     ExportToolbarAction,
+    UploadToolbarAction,
 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/toolbarActions/UploadToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/toolbarActions/UploadToolbarAction.test.js
@@ -14,7 +14,7 @@ jest.mock('../../../../utils/Translator', () => ({
 }));
 
 jest.mock('../../../../containers/List/stores/ListStore', () => jest.fn(function() {
-    this.setShouldReload = jest.fn();
+    this.reload = jest.fn();
 }));
 
 jest.mock('../../../../views/List/List', () => jest.fn(function() {
@@ -127,7 +127,7 @@ test('Should make xhr request on confirm', () => {
     }));
 
     return promise.then(() => {
-        expect(uploadToolbarAction.listStore.setShouldReload).toBeCalledWith(true);
+        expect(uploadToolbarAction.listStore.reload).toBeCalled();
     });
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/toolbarActions/UploadToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/toolbarActions/UploadToolbarAction.test.js
@@ -1,0 +1,320 @@
+// @flow
+import {render} from 'enzyme';
+import {observable} from 'mobx';
+import {act} from 'react-dom/test-utils';
+import SymfonyRouting from 'fos-jsrouting/router';
+import ListStore from '../../../../containers/List/stores/ListStore';
+import Router from '../../../../services/Router';
+import ResourceStore from '../../../../stores/ResourceStore';
+import List from '../../../../views/List';
+import UploadToolbarAction from '../../toolbarActions/UploadToolbarAction';
+
+jest.mock('../../../../utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
+
+jest.mock('../../../../containers/List/stores/ListStore', () => jest.fn(function() {
+    this.setShouldReload = jest.fn();
+}));
+
+jest.mock('../../../../views/List/List', () => jest.fn(function() {
+    this.errors = [];
+}));
+
+jest.mock('../../../../services/Router', () => jest.fn(function() {
+    this.attributes = {
+        locale: 'en',
+    };
+}));
+
+function createUploadToolbarAction(options = {}) {
+    const router = new Router({});
+    const listStore = new ListStore('test', 'test', 'test', {page: observable.box(1)});
+    const list = new List({
+        route: router.route,
+        router,
+    });
+    const locales = [];
+    const resourceStore = new ResourceStore('test');
+
+    return new UploadToolbarAction(listStore, list, router, locales, resourceStore, options);
+}
+
+test('Should correctly render node', () => {
+    const uploadToolbarAction = createUploadToolbarAction({
+        label: 'foo',
+        icon: 'su-times',
+        routeName: 'foo',
+        requestParameters: {
+            foo: 'bar',
+            baz: 'foo',
+        },
+        routerAttributesToRequest: {
+            '0': 'locale',
+            'locale': 'locale2',
+        },
+        errorMapping: {
+            '400': 'sulu_admin.bad_request',
+        },
+        accept: ['text/csv'],
+        minSize: 1000,
+        maxSize: 9999,
+        maxFiles: 1,
+    });
+
+    expect(render(uploadToolbarAction.getNode())).toMatchSnapshot();
+});
+
+test('Should return config for toolbar item', () => {
+    const uploadToolbarAction = createUploadToolbarAction();
+
+    expect(uploadToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        icon: 'su-upload',
+        label: 'sulu_admin.upload',
+        type: 'button',
+    }));
+});
+
+test('Should return custom config for toolbar item', () => {
+    const uploadToolbarAction = createUploadToolbarAction({
+        label: 'foo',
+        icon: 'bar',
+    });
+
+    expect(uploadToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        icon: 'bar',
+        label: 'foo',
+        type: 'button',
+    }));
+});
+
+test('Should make xhr request on confirm', () => {
+    const promise = Promise.resolve({
+        status: 200,
+        statusText: '',
+        ok: true,
+    });
+
+    // eslint-disable-next-line no-undef
+    global.fetch = jest.fn(() => promise);
+
+    SymfonyRouting.generate.mockImplementation((routeName, params) => {
+        return routeName + '?' + Object.keys(params).map((key) => key + '=' + params[key]).join('&');
+    });
+
+    const uploadToolbarAction = createUploadToolbarAction({
+        routeName: 'foo',
+        requestParameters: {
+            foo: 'bar',
+            baz: 'foo',
+        },
+        routerAttributesToRequest: {
+            '0': 'locale',
+            'locale': 'locale2',
+        },
+    });
+
+    const toolbarItemConfig = uploadToolbarAction.getToolbarItemConfig();
+    act(() => {
+        toolbarItemConfig.onClick();
+    });
+
+    uploadToolbarAction.handleConfirm([new File(['foo'], 'foo.jpg')]);
+
+    expect(fetch).toBeCalledWith('foo?locale=en&locale2=en&foo=bar&baz=foo', expect.objectContaining({
+        method: 'POST',
+        body: expect.any(FormData),
+    }));
+
+    return promise.then(() => {
+        expect(uploadToolbarAction.listStore.setShouldReload).toBeCalledWith(true);
+    });
+});
+
+test('Should display errors if dropzone error occurs', () => {
+    const uploadToolbarAction = createUploadToolbarAction({
+        routeName: 'foo',
+        maxFiles: 2,
+        minSize: 3000,
+        maxSize: 4000,
+    });
+
+    const toolbarItemConfig = uploadToolbarAction.getToolbarItemConfig();
+    act(() => {
+        toolbarItemConfig.onClick();
+    });
+
+    uploadToolbarAction.handleError([
+        {
+            file: {
+                name: 'file-invalid-type.jpg',
+            },
+            errors: [
+                {
+                    code: 'file-invalid-type',
+                },
+                {
+                    code: 'too-many-files',
+                },
+            ],
+        },
+        {
+            file: {
+                name: 'file-too-large.jpg',
+            },
+            errors: [
+                {
+                    code: 'file-too-large',
+                },
+                {
+                    code: 'too-many-files',
+                },
+            ],
+        },
+        {
+            file: {
+                name: 'file-too-small.jpg',
+            },
+            errors: [
+                {
+                    code: 'file-too-small',
+                },
+                {
+                    code: 'too-many-files',
+                },
+            ],
+        },
+        {
+            file: {
+                name: 'not-existing-code.jpg',
+            },
+            errors: [
+                {
+                    code: 'not-existing-code',
+                },
+                {
+                    code: 'too-many-files',
+                },
+            ],
+        },
+    ]);
+
+    expect(uploadToolbarAction.errors).toEqual([
+        'sulu_admin.dropzone_error_file-invalid-type',
+        'sulu_admin.dropzone_error_file-too-large',
+        'sulu_admin.dropzone_error_file-too-small',
+        'sulu_admin.an_error_occurred',
+        'sulu_admin.dropzone_error_too-many-files',
+    ]);
+
+    expect(uploadToolbarAction.list.errors).toEqual([
+        'sulu_admin.dropzone_error_file-invalid-type',
+        'sulu_admin.dropzone_error_file-too-large',
+        'sulu_admin.dropzone_error_file-too-small',
+        'sulu_admin.an_error_occurred',
+        'sulu_admin.dropzone_error_too-many-files',
+    ]);
+
+    uploadToolbarAction.setDropzoneRef({open: jest.fn()});
+    uploadToolbarAction.handleClick();
+
+    expect(uploadToolbarAction.errors).toEqual([]);
+    expect(uploadToolbarAction.list.errors).toEqual([]);
+});
+
+test('Should display error if server error occurs', () => {
+    const promise = Promise.resolve({
+        status: 400,
+        statusText: '',
+        ok: false,
+    });
+
+    // eslint-disable-next-line no-undef
+    global.fetch = jest.fn(() => promise);
+
+    SymfonyRouting.generate.mockImplementation((routeName, params) => {
+        return routeName + '?' + Object.keys(params).map((key) => key + '=' + params[key]).join('&');
+    });
+
+    const uploadToolbarAction = createUploadToolbarAction({
+        routeName: 'foo',
+    });
+
+    const toolbarItemConfig = uploadToolbarAction.getToolbarItemConfig();
+    act(() => {
+        toolbarItemConfig.onClick();
+    });
+
+    uploadToolbarAction.handleConfirm([new File(['foo'], 'foo.jpg')]);
+
+    expect(fetch).toBeCalledWith('foo?', expect.objectContaining({
+        method: 'POST',
+        body: expect.any(FormData),
+    }));
+
+    return promise.then(() => {
+        expect(uploadToolbarAction.errors).toEqual([
+            'sulu_admin.an_error_occurred',
+        ]);
+
+        expect(uploadToolbarAction.list.errors).toEqual([
+            'sulu_admin.an_error_occurred',
+        ]);
+
+        uploadToolbarAction.setDropzoneRef({open: jest.fn()});
+        uploadToolbarAction.handleClick();
+
+        expect(uploadToolbarAction.errors).toEqual([]);
+        expect(uploadToolbarAction.list.errors).toEqual([]);
+    });
+});
+
+test('Should display custom error if server error occurs', () => {
+    const promise = Promise.resolve({
+        status: 400,
+        statusText: '',
+        ok: false,
+    });
+
+    // eslint-disable-next-line no-undef
+    global.fetch = jest.fn(() => promise);
+
+    SymfonyRouting.generate.mockImplementation((routeName, params) => {
+        return routeName + '?' + Object.keys(params).map((key) => key + '=' + params[key]).join('&');
+    });
+
+    const uploadToolbarAction = createUploadToolbarAction({
+        routeName: 'foo',
+        errorMapping: {
+            '400': 'sulu_admin.bad_request',
+        },
+    });
+
+    const toolbarItemConfig = uploadToolbarAction.getToolbarItemConfig();
+    act(() => {
+        toolbarItemConfig.onClick();
+    });
+
+    uploadToolbarAction.handleConfirm([new File(['foo'], 'foo.jpg')]);
+
+    expect(fetch).toBeCalledWith('foo?', expect.objectContaining({
+        method: 'POST',
+        body: expect.any(FormData),
+    }));
+
+    return promise.then(() => {
+        expect(uploadToolbarAction.errors).toEqual([
+            'sulu_admin.bad_request',
+        ]);
+
+        expect(uploadToolbarAction.list.errors).toEqual([
+            'sulu_admin.bad_request',
+        ]);
+
+        uploadToolbarAction.setDropzoneRef({open: jest.fn()});
+        uploadToolbarAction.handleClick();
+
+        expect(uploadToolbarAction.errors).toEqual([]);
+        expect(uploadToolbarAction.list.errors).toEqual([]);
+    });
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/toolbarActions/UploadToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/toolbarActions/UploadToolbarAction.test.js
@@ -59,7 +59,7 @@ test('Should correctly render node', () => {
         accept: ['text/csv'],
         minSize: 1000,
         maxSize: 9999,
-        maxFiles: 1,
+        multiple: false,
     });
 
     expect(render(uploadToolbarAction.getNode())).toMatchSnapshot();
@@ -134,7 +134,7 @@ test('Should make xhr request on confirm', () => {
 test('Should display errors if dropzone error occurs', () => {
     const uploadToolbarAction = createUploadToolbarAction({
         routeName: 'foo',
-        maxFiles: 2,
+        multiple: true,
         minSize: 3000,
         maxSize: 4000,
     });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/toolbarActions/UploadToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/toolbarActions/UploadToolbarAction.test.js
@@ -53,7 +53,7 @@ test('Should correctly render node', () => {
             '0': 'locale',
             'locale': 'locale2',
         },
-        errorMapping: {
+        errorCodeMapping: {
             '400': 'sulu_admin.bad_request',
         },
         accept: ['text/csv'],
@@ -203,7 +203,7 @@ test('Should display errors if dropzone error occurs', () => {
         'sulu_admin.dropzone_error_file-invalid-type',
         'sulu_admin.dropzone_error_file-too-large',
         'sulu_admin.dropzone_error_file-too-small',
-        'sulu_admin.an_error_occurred',
+        'sulu_admin.unexpected_upload_error',
         'sulu_admin.dropzone_error_too-many-files',
     ]);
 
@@ -211,7 +211,7 @@ test('Should display errors if dropzone error occurs', () => {
         'sulu_admin.dropzone_error_file-invalid-type',
         'sulu_admin.dropzone_error_file-too-large',
         'sulu_admin.dropzone_error_file-too-small',
-        'sulu_admin.an_error_occurred',
+        'sulu_admin.unexpected_upload_error',
         'sulu_admin.dropzone_error_too-many-files',
     ]);
 
@@ -254,11 +254,11 @@ test('Should display error if server error occurs', () => {
 
     return promise.then(() => {
         expect(uploadToolbarAction.errors).toEqual([
-            'sulu_admin.an_error_occurred',
+            'sulu_admin.unexpected_upload_error',
         ]);
 
         expect(uploadToolbarAction.list.errors).toEqual([
-            'sulu_admin.an_error_occurred',
+            'sulu_admin.unexpected_upload_error',
         ]);
 
         uploadToolbarAction.setDropzoneRef({open: jest.fn()});
@@ -285,7 +285,7 @@ test('Should display custom error if server error occurs', () => {
 
     const uploadToolbarAction = createUploadToolbarAction({
         routeName: 'foo',
-        errorMapping: {
+        errorCodeMapping: {
             '400': 'sulu_admin.bad_request',
         },
     });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/toolbarActions/__snapshots__/UploadToolbarAction.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/toolbarActions/__snapshots__/UploadToolbarAction.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Should correctly render node 1`] = `
+<div>
+  <input
+    accept="text/csv"
+    autocomplete="off"
+    style="display:none"
+    tabindex="-1"
+    type="file"
+  />
+</div>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/UploadToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/UploadToolbarAction.js
@@ -80,27 +80,25 @@ export default class UploadToolbarAction extends AbstractListToolbarAction {
     };
 
     @action handleConfirm = (files: File[]) => {
+        const formData = new FormData();
+
         for (const file of files) {
-            const formData = new FormData();
-            formData.append('redirectRoutes', file);
-
-            fetch(this.url, {
-                method: 'POST',
-                body: formData,
-            })
-                .then((response) => {
-                    if (!response.ok) {
-                        const error = this.errorMapping[response.status] || 'sulu_admin.an_error_occurred';
-                        this.addError(translate(error, {
-                            statusText: response.statusText,
-                        }));
-
-                        return;
-                    }
-
-                    this.listStore.setShouldReload(true);
-                });
+            formData.append('files[]', file);
         }
+
+        fetch(this.url, {method: 'POST', body: formData}).then((response) => {
+            if (!response.ok) {
+                this.addError(
+                    translate(this.errorMapping[response.status] || 'sulu_admin.an_error_occurred', {
+                        statusText: response.statusText,
+                    })
+                );
+
+                return;
+            }
+
+            this.listStore.setShouldReload(true);
+        });
     };
 
     @computed get label(): string {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/UploadToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/UploadToolbarAction.js
@@ -104,7 +104,7 @@ export default class UploadToolbarAction extends AbstractListToolbarAction {
                 return;
             }
 
-            this.listStore.setShouldReload(true);
+            this.listStore.reload();
         });
     };
 
@@ -173,7 +173,7 @@ export default class UploadToolbarAction extends AbstractListToolbarAction {
                 const requestAttributeKey = routerAttributesToRequest[routerAttributeKey];
 
                 if (typeof requestAttributeKey !== 'string') {
-                    throw new Error('The values "routerAttributesToRequest" must be strings!');
+                    throw new Error('The "routerAttributesToRequest" option must contain strings!');
                 }
 
                 const attributeName = isNaN(routerAttributeKey)
@@ -182,9 +182,8 @@ export default class UploadToolbarAction extends AbstractListToolbarAction {
 
                 requestParameters[requestAttributeKey] = routerAttributes[attributeName];
             });
-        requestParameters = {...requestParameters, ...attributesToRequest};
 
-        return requestParameters;
+        return {...requestParameters, ...attributesToRequest};
     }
 
     @computed get accept(): ?$ReadOnlyArray<any> {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/UploadToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/UploadToolbarAction.js
@@ -1,0 +1,294 @@
+// @flow
+import React from 'react';
+import {action, computed, observable} from 'mobx';
+import Dropzone, {DropzoneRef, FileRejection} from 'react-dropzone';
+import symfonyRouting from 'fos-jsrouting/router';
+import {translate} from '../../../utils/Translator';
+import AbstractListToolbarAction from './AbstractListToolbarAction';
+
+export default class UploadToolbarAction extends AbstractListToolbarAction {
+    @observable dropzoneRef: ?DropzoneRef;
+    @observable errors: string[] = [];
+
+    @action setDropzoneRef = (ref: ?DropzoneRef) => {
+        this.dropzoneRef = ref;
+    };
+
+    @action handleClick = () => {
+        const {dropzoneRef} = this;
+
+        if (dropzoneRef) {
+            dropzoneRef.open();
+            this.removeErrors();
+        }
+    };
+
+    removeErrors = () => {
+        for (const error of this.errors) {
+            this.removeError(error);
+        }
+    };
+
+    @action removeError = (errorToRemove: string) => {
+        this.errors = this.errors.filter((existingError) => errorToRemove !== existingError);
+        this.list.errors = this.list.errors.filter((existingError) => errorToRemove !== existingError);
+    };
+
+    @action addError = (error: string) => {
+        this.removeError(error);
+
+        this.errors = [...this.errors, error];
+        this.list.errors = [...this.list.errors, error];
+    };
+
+    handleError = (fileRejections: FileRejection[]) => {
+        for (const fileRejection of fileRejections) {
+            for (const {code} of fileRejection.errors) {
+                let error;
+                switch (code) {
+                    case 'file-invalid-type':
+                        error = translate('sulu_admin.dropzone_error_file-invalid-type', {
+                            fileName: fileRejection.file.name,
+                            allowedTypes: this.accept ? this.accept.join(', ') : undefined,
+                        });
+                        break;
+                    case 'file-too-large':
+                        error = translate('sulu_admin.dropzone_error_file-too-large', {
+                            fileName: fileRejection.file.name,
+                            maxSize: this.maxSize ? this.getReadableFileSizeString(this.maxSize) : undefined,
+                        });
+                        break;
+                    case 'file-too-small':
+                        error = translate('sulu_admin.dropzone_error_file-too-small', {
+                            fileName: fileRejection.file.name,
+                            minSize: this.minSize ? this.getReadableFileSizeString(this.minSize) : undefined,
+                        });
+                        break;
+                    case 'too-many-files':
+                        error = translate('sulu_admin.dropzone_error_too-many-files', {
+                            fileName: fileRejection.file.name,
+                            maxFiles: this.maxFiles,
+                        });
+                        break;
+                    default:
+                        error = translate('sulu_admin.an_error_occurred');
+                }
+
+                this.addError(error);
+            }
+        }
+    };
+
+    @action handleConfirm = (files: File[]) => {
+        for (const file of files) {
+            const formData = new FormData();
+            formData.append('redirectRoutes', file);
+
+            fetch(this.url, {
+                method: 'POST',
+                body: formData,
+            })
+                .then((response) => {
+                    if (!response.ok) {
+                        const error = this.errorMapping[response.status] || 'sulu_admin.an_error_occurred';
+                        this.addError(translate(error, {
+                            statusText: response.statusText,
+                        }));
+
+                        return;
+                    }
+
+                    this.listStore.setShouldReload(true);
+                });
+        }
+    };
+
+    @computed get label(): string {
+        const {label = 'sulu_admin.upload'} = this.options;
+
+        if (typeof label !== 'string') {
+            throw new Error('The "label" option must be a string!');
+        }
+
+        return translate(label);
+    }
+
+    @computed get icon(): string {
+        const {icon = 'su-upload'} = this.options;
+
+        if (typeof icon !== 'string') {
+            throw new Error('The "icon" option must be a string!');
+        }
+
+        return icon;
+    }
+
+    @computed get url(): string {
+        const {routeName} = this.options;
+
+        if (typeof routeName !== 'string') {
+            throw new Error('The "routeName" option must be a string!');
+        }
+
+        return symfonyRouting.generate(routeName, this.requestParameters);
+    }
+
+    @computed get errorMapping(): $ReadOnly<Object> {
+        const {errorMapping = {}} = this.options;
+
+        if (typeof errorMapping !== 'object') {
+            throw new Error('The "errorMapping" option must be an object!');
+        }
+
+        return errorMapping;
+    }
+
+    @computed get requestParameters(): $ReadOnly<Object> {
+        const {
+            options: {
+                requestParameters: attributesToRequest = {},
+                routerAttributesToRequest = {},
+            },
+            router: {
+                attributes: routerAttributes,
+            },
+        } = this;
+
+        if (!attributesToRequest || typeof attributesToRequest !== 'object') {
+            throw new Error('The "attributesToRequest" option must be an object!');
+        }
+
+        if (!routerAttributesToRequest || typeof routerAttributesToRequest !== 'object') {
+            throw new Error('The "routerAttributesToRequest" option must be an object!');
+        }
+
+        let requestParameters = {};
+        Object.keys(routerAttributesToRequest)
+            .forEach((routerAttributeKey) => {
+                const requestAttributeKey = routerAttributesToRequest[routerAttributeKey];
+
+                if (typeof requestAttributeKey !== 'string') {
+                    throw new Error('The values "routerAttributesToRequest" must be strings!');
+                }
+
+                const attributeName = isNaN(routerAttributeKey)
+                    ? routerAttributeKey
+                    : requestAttributeKey;
+
+                requestParameters[requestAttributeKey] = routerAttributes[attributeName];
+            });
+        requestParameters = {...requestParameters, ...attributesToRequest};
+
+        return requestParameters;
+    }
+
+    @computed get accept(): ?$ReadOnlyArray<any> {
+        const {accept} = this.options;
+
+        if (accept === undefined || accept === null) {
+            return undefined;
+        }
+
+        if (!Array.isArray(accept)) {
+            throw new Error('The "accept" option must be an array!');
+        }
+
+        return accept;
+    }
+
+    @computed get minSize(): ?number {
+        const {minSize} = this.options;
+
+        if (minSize === undefined || minSize === null) {
+            return undefined;
+        }
+
+        if (typeof minSize !== 'number') {
+            throw new Error('The "minSize" option must be a number!');
+        }
+
+        return minSize;
+    }
+
+    @computed get maxSize(): ?number {
+        const {maxSize} = this.options;
+
+        if (maxSize === undefined || maxSize === null) {
+            return undefined;
+        }
+
+        if (typeof maxSize !== 'number') {
+            throw new Error('The "maxSize" option must be a number!');
+        }
+
+        return maxSize;
+    }
+
+    @computed get maxFiles(): ?number {
+        const {maxFiles} = this.options;
+
+        if (maxFiles === undefined || maxFiles === null) {
+            return undefined;
+        }
+
+        if (typeof maxFiles !== 'number') {
+            throw new Error('The "maxFiles" option must be a number!');
+        }
+
+        return maxFiles;
+    }
+
+    @computed get multiple(): boolean {
+        const {maxFiles} = this;
+
+        return maxFiles !== 1;
+    }
+
+    getToolbarItemConfig() {
+        return {
+            type: 'button',
+            label: this.label,
+            icon: this.icon,
+            onClick: this.handleClick,
+        };
+    }
+
+    getNode() {
+        return (
+            <Dropzone
+                accept={this.accept}
+                key="sulu_admin.upload"
+                maxFiles={this.maxFiles}
+                maxSize={this.maxSize}
+                minSize={this.minSize}
+                multiple={this.multiple}
+                noClick={true}
+                noDrag={true}
+                noKeyboard={true}
+                onDropAccepted={this.handleConfirm}
+                onDropRejected={this.handleError}
+                ref={this.setDropzoneRef}
+            >
+                {({getRootProps, getInputProps}) => {
+                    return (
+                        <div {...getRootProps()}>
+                            <input {...getInputProps()} />
+                        </div>
+                    );
+                }}
+            </Dropzone>
+        );
+    }
+
+    // Method copied from https://stackoverflow.com/q/10420352/7733374
+    getReadableFileSizeString = (fileSizeInBytes: number): string => {
+        var i = -1;
+        var byteUnits = [' kB', ' MB', ' GB', ' TB', ' PB', ' EB', ' ZB', ' YB'];
+        do {
+            fileSizeInBytes = fileSizeInBytes / 1024;
+            i++;
+        } while (fileSizeInBytes > 1024);
+
+        return Math.max(fileSizeInBytes, 0.1).toFixed(1) + byteUnits[i];
+    };
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -162,7 +162,7 @@
     "sulu_admin.missing_type_dialog_title": "Neues Template auswählen",
     "sulu_admin.missing_type_dialog_description": "Das Template der kopierten Seite steht in diesem Webspace nicht zur Verfügung.",
     "sulu_admin.upload": "Hochladen",
-    "sulu_admin.an_error_occurred": "Ein Fehler ist aufgetreten",
+    "sulu_admin.unexpected_upload_error": "Unerwarteter Fehler beim Hochladen {fileName, select, undefined{einer Datei} other{von {fileName}}} auf den Server.",
     "sulu_admin.dropzone_error_file-invalid-type": "Dateityp{fileName, select, undefined{} other{ von {fileName}}} ist nicht erlaubt{allowedTypes, select, undefined{} other{. Erlaubt sind ({allowedTypes})}}",
     "sulu_admin.dropzone_error_file-too-large": "{fileName, select, undefined{Datei} other{{fileName}}} ist {maxSize, select, undefined{zu groß} other{größer als {maxSize}}}",
     "sulu_admin.dropzone_error_file-too-small": "{fileName, select, undefined{Datei} other{{fileName}}} ist {minSize, select, undefined{zu klein} other{kleiner als {minSize}}}",

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -160,5 +160,11 @@
     "sulu_admin.hide_block": "Verstecke diesen Block auf der Webseite",
     "sulu_admin.segment": "Segment",
     "sulu_admin.missing_type_dialog_title": "Neues Template auswählen",
-    "sulu_admin.missing_type_dialog_description": "Das Template der kopierten Seite steht in diesem Webspace nicht zur Verfügung."
+    "sulu_admin.missing_type_dialog_description": "Das Template der kopierten Seite steht in diesem Webspace nicht zur Verfügung.",
+    "sulu_admin.upload": "Hochladen",
+    "sulu_admin.an_error_occurred": "Ein Fehler ist aufgetreten",
+    "sulu_admin.dropzone_error_file-invalid-type": "Dateityp{fileName, select, undefined{} other{ von {fileName}}} ist nicht erlaubt{allowedTypes, select, undefined{} other{. Erlaubt sind ({allowedTypes})}}",
+    "sulu_admin.dropzone_error_file-too-large": "{fileName, select, undefined{Datei} other{{fileName}}} ist {maxSize, select, undefined{zu groß} other{größer als {maxSize}}}",
+    "sulu_admin.dropzone_error_file-too-small": "{fileName, select, undefined{Datei} other{{fileName}}} ist {minSize, select, undefined{zu klein} other{kleiner als {minSize}}}",
+    "sulu_admin.dropzone_error_too-many-files": "Zu viele Dateien{maxFiles, select, undefined{} other{. Maximale Anzahl Dateien: {maxFiles}}}"
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -162,7 +162,7 @@
     "sulu_admin.missing_type_dialog_title": "Choose new template",
     "sulu_admin.missing_type_dialog_description": "The template for the copied page does not exist in this webspace.",
     "sulu_admin.upload": "Upload",
-    "sulu_admin.an_error_occurred": "An error occurred",
+    "sulu_admin.unexpected_upload_error": "Unexpected error while uploading {fileName, select, undefined{a file} other{the file {fileName}}} to the server.",
     "sulu_admin.dropzone_error_file-invalid-type": "{fileName, select, undefined{File} other{{fileName}}} has invalid type{allowedTypes, select, undefined{} other{. Allowed types are ({allowedTypes})}}",
     "sulu_admin.dropzone_error_file-too-large": "{fileName, select, undefined{File} other{{fileName}}} is {maxSize, select, undefined{too large} other{larger than {maxSize}}}",
     "sulu_admin.dropzone_error_file-too-small": "{fileName, select, undefined{File} other{{fileName}}} is {minSize, select, undefined{too small} other{smaller than {minSize}}}",

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -160,5 +160,11 @@
     "sulu_admin.hide_block": "Hide this block on website",
     "sulu_admin.segment": "Segment",
     "sulu_admin.missing_type_dialog_title": "Choose new template",
-    "sulu_admin.missing_type_dialog_description": "The template for the copied page does not exist in this webspace."
+    "sulu_admin.missing_type_dialog_description": "The template for the copied page does not exist in this webspace.",
+    "sulu_admin.upload": "Upload",
+    "sulu_admin.an_error_occurred": "An error occurred",
+    "sulu_admin.dropzone_error_file-invalid-type": "{fileName, select, undefined{File} other{{fileName}}} has invalid type{allowedTypes, select, undefined{} other{. Allowed types are ({allowedTypes})}}",
+    "sulu_admin.dropzone_error_file-too-large": "{fileName, select, undefined{File} other{{fileName}}} is {maxSize, select, undefined{too large} other{larger than {maxSize}}}",
+    "sulu_admin.dropzone_error_file-too-small": "{fileName, select, undefined{File} other{{fileName}}} is {minSize, select, undefined{too small} other{smaller than {minSize}}}",
+    "sulu_admin.dropzone_error_too-many-files": "Too many files{maxFiles, select, undefined{} other{. Maximum allowed files: {maxFiles}}}"
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | https://github.com/sulu/SuluRedirectBundle/issues/33
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add UploadToolbarAction

#### Why?

SuluRedirectBundle needs this to import redirects

#### Example Usage

~~~php
new ToolbarAction('sulu_admin.upload', [
    'label' => 'sulu_redirect.import',
    'icon' => 'su-upload',
    'routeName' => 'sulu_redirect.import',
    'requestParameters' => [
        'foo' => 'bar',
        'bar' => 'baz',
    ],
    'routerAttributesToRequest' => [
        'locale' => 'locale',
    ],
    'multiple' => true,
    'requestPropertyName' => 'files',
    'minSize' => 1000,
    'maxSize' => 2000,
    'accept' => ['text/csv'],
    'errorCodeMapping' => [
        400 => 'sulu_redirect.error_bad_request',
        500 => 'sulu_redirect.error_internal_server_error',
    ],
]);
~~~

#### To Do

- [ ] Create a documentation PR
