### PR TITLE
Fix format manager generated urls with multiple dots

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
@@ -176,8 +176,6 @@ class FormatManager implements FormatManagerInterface
 
     public function getFormats($id, $fileName, $version, $subVersion, $mimeType)
     {
-        $fileName = \pathinfo($fileName)['filename'];
-
         $formats = [];
 
         $extensions = $this->converter->getSupportedOutputImageFormats($mimeType);
@@ -191,7 +189,7 @@ class FormatManager implements FormatManagerInterface
             foreach ($extensions as $extension) {
                 $formatUrl = $this->formatCache->getMediaUrl(
                     $id,
-                    "$fileName.$extension",
+                    $this->replaceExtension($fileName, $extension),
                     $format['key'],
                     $version,
                     $subVersion

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
@@ -191,7 +191,7 @@ class FormatManager implements FormatManagerInterface
             foreach ($extensions as $extension) {
                 $formatUrl = $this->formatCache->getMediaUrl(
                     $id,
-                    $this->replaceExtension($fileName, $extension),
+                    "$fileName.$extension",
                     $format['key'],
                     $version,
                     $subVersion

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatManager/FormatManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatManager/FormatManagerTest.php
@@ -219,6 +219,22 @@ class FormatManagerTest extends TestCase
         $this->assertEquals([], $result);
     }
 
+    public function testGetFormatsWithMultipleDotsInFilename()
+    {
+        $this->formatCache->getMediaUrl(1, 'dummy.bak.jpg', '640x480', 1, 2)->shouldBeCalled();
+        $this->formatCache->getMediaUrl(1, 'dummy.bak.jpg', '50x50', 1, 2)->shouldBeCalled();
+
+        $this->imageConverter->getSupportedOutputImageFormats(Argument::any())->willReturn(['jpg'])->shouldBeCalled();
+
+        $this->formatManager->getFormats(
+            1,
+            'dummy.bak.jpg',
+            1,
+            2,
+            'jpg'
+        );
+    }
+
     public function testGetFormatDefinition()
     {
         $format = $this->formatManager->getFormatDefinition('640x480', 'en', ['my-option' => 'my-value']);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no 
| Deprecations? | no 
| Fixed tickets | 
| Related issues/PRs | 
| License | MIT
| Documentation PR | 

#### What's in this PR?

This PR removes the call to `replaceExtension` in the `FormatManager` of the MediaBundle, because it's not useful in the specific case.

#### Why?

`$fileName` is already without an extension, because it's read via `pathinfo`'s `filename` attribute, which doesn't include an extension. Calling `replaceExtension` removes normal filename parts containing dots. This lead to a wrong requested filename, when the original file had dots in the filename part (like `myfile.2000x1000.jpg`). 

Before this patch, `image.thumbnails['myname']` resulted in a filename without `.2000x1000`, which did render the image, but the file is always generated by sulu, because in `public/uploads/media` the file is saved *with* `.2000x1000` and therefore not directly served via the webserver.

