### PR TITLE
Fix original media download link in the admin UI

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Media/ListRepresentationFactory/MediaListRepresentationFactory.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ListRepresentationFactory/MediaListRepresentationFactory.php
@@ -63,6 +63,12 @@ class MediaListRepresentationFactory
                 $listResponse[$i]['version']
             );
 
+            $listResponse[$i]['adminUrl'] = $this->mediaManager->getAdminUrl(
+                $listResponse[$i]['id'],
+                $listResponse[$i]['name'],
+                $listResponse[$i]['version']
+            );
+
             if ($locale !== $listResponse[$i]['locale']) {
                 $listResponse[$i]['ghostLocale'] = $listResponse[$i]['locale'];
             }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/adapters/MediaCardAdapter.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/adapters/MediaCardAdapter.js
@@ -31,9 +31,10 @@ class MediaCardAdapter extends React.Component<Props> {
         const baseURL = window.location.origin;
         const {thumbnails} = item;
         const imageSizes = [];
+        const adminUrl = item.adminUrl || item.url;
 
         imageSizes.push({
-            url: baseURL + item.adminUrl,
+            url: baseURL + adminUrl,
             label: translate('sulu_media.copy_masterfile_url'),
         });
 
@@ -55,7 +56,7 @@ class MediaCardAdapter extends React.Component<Props> {
             imageSizes,
             onDownload: this.handleDownload,
             downloadCopyText: translate('sulu_media.copy_url'),
-            downloadUrl: baseURL + item.adminUrl,
+            downloadUrl: baseURL + adminUrl,
             downloadText: translate('sulu_media.download_masterfile'),
         };
     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/MediaCardAdapter.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/MediaCardAdapter.test.js
@@ -53,6 +53,43 @@ test('Render a basic Masonry view with MediaCards', () => {
     expect(mediaCardAdapter).toMatchSnapshot();
 });
 
+test('AdminUrl should fallback to url on undefined', () => {
+    const data = [
+        {
+            id: 1,
+            title: 'Test 1',
+            mimeType: 'image/png',
+            size: 12345,
+            url: '/media/1/download/test1.svg',
+            adminUrl: '/admin/media/1/download/test1.svg',
+        },
+        {
+            ghostLocale: 'en',
+            id: 2,
+            title: 'Test 2',
+            mimeType: 'image/jpeg',
+            size: 54321,
+            url: '/media/2/download/test2.svg',
+        },
+    ];
+
+    const mediaCardAdapter = shallow(
+        <MediaCardAdapter
+            {...listAdapterDefaultProps}
+            data={data}
+            icon="su-pen"
+            onItemSelectionChange={jest.fn()}
+            page={1}
+            pageCount={7}
+        />
+    );
+
+    expect(mediaCardAdapter.find('MediaCard').get(0).props.downloadUrl)
+        .toBe('http://localhost/admin/media/1/download/test1.svg');
+    expect(mediaCardAdapter.find('MediaCard').get(1).props.downloadUrl)
+        .toBe('http://localhost/media/2/download/test2.svg');
+});
+
 test('MediaCard should call the the appropriate handler', () => {
     const mediaCardSelectionChangeSpy = jest.fn();
     const thumbnails = {

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
@@ -473,6 +473,7 @@ class MediaControllerTest extends SuluTestCase
         $this->assertEquals('2', $response['downloadCounter']);
         $this->assertEquals($this->mediaDefaultDescription, $response['description']);
         $this->assertNotEmpty($response['url']);
+        $this->assertNotEmpty($response['adminUrl']);
         $this->assertNotEmpty($response['thumbnails']);
         $this->assertNull($response['previewImageId']);
 
@@ -525,6 +526,24 @@ class MediaControllerTest extends SuluTestCase
 
         $this->assertNotEmpty($response);
         $this->assertEquals(2, $response->total);
+    }
+
+    public function testCgetAdminUrl()
+    {
+        $media = $this->createMedia('photo');
+
+        $this->client->jsonRequest(
+            'GET',
+            '/api/media?locale=en-gb'
+        );
+
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+        $response = \json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertSame(
+            '/admin/media/' . $media->getId() . '/download/photo.jpeg?v=1',
+            $response['_embedded']['media'][0]['adminUrl']
+        );
     }
 
     public function testCgetWithPreview()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixe
| Related issues/PRs |
| License | MIT

#### What's in this PR?

The `adminUrl` generation was missing in `MediaListRepresentationFactory` for images. Thus downloading the original image in the admin UI was not possible due to an `undefined` url.

#### Why?

Downloading the original image was not possible in the admin UI.