### PR TITLE
Add sulu_category_url_remove and sulu_category_url_toggle twig functions

### DIFF
--- a/src/Sulu/Bundle/CategoryBundle/Twig/CategoryTwigExtension.php
+++ b/src/Sulu/Bundle/CategoryBundle/Twig/CategoryTwigExtension.php
@@ -62,6 +62,8 @@ class CategoryTwigExtension extends AbstractExtension
             new TwigFunction('sulu_categories', [$this, 'getCategoriesFunction']),
             new TwigFunction('sulu_category_url', [$this, 'setCategoryUrlFunction']),
             new TwigFunction('sulu_category_url_append', [$this, 'appendCategoryUrlFunction']),
+            new TwigFunction('sulu_category_url_remove', [$this, 'removeCategoryUrlFunction']),
+            new TwigFunction('sulu_category_url_toggle', [$this, 'toggleCategoryUrlFunction']),
             new TwigFunction('sulu_category_url_clear', [$this, 'clearCategoryUrlFunction']),
         ];
     }
@@ -102,6 +104,32 @@ class CategoryTwigExtension extends AbstractExtension
     public function appendCategoryUrlFunction($category, $categoriesParameter = 'categories')
     {
         return $this->categoryRequestHandler->appendCategoryToUrl($category, $categoriesParameter);
+    }
+
+    /**
+     * Removes given category from current url.
+     *
+     * @param array $category will be removed from the URL
+     * @param string $categoriesParameter GET parameter name
+     *
+     * @return string
+     */
+    public function removeCategoryUrlFunction($category, $categoriesParameter = 'categories')
+    {
+        return $this->categoryRequestHandler->removeCategoryFromUrl($category, $categoriesParameter);
+    }
+
+    /**
+     * Toggles given category in current URL.
+     *
+     * @param array $category will be toggled in the URL
+     * @param string $categoriesParameter GET parameter name
+     *
+     * @return string
+     */
+    public function toggleCategoryUrlFunction($category, $categoriesParameter = 'categories')
+    {
+        return $this->categoryRequestHandler->toggleCategoryInUrl($category, $categoriesParameter);
     }
 
     /**

--- a/src/Sulu/Component/Category/Request/CategoryRequestHandler.php
+++ b/src/Sulu/Component/Category/Request/CategoryRequestHandler.php
@@ -68,6 +68,66 @@ class CategoryRequestHandler implements CategoryRequestHandlerInterface
         return $request->getPathInfo() . (\strlen($queryString) > 0 ? '?' . $queryString : '');
     }
 
+    public function removeCategoryFromUrl($category, $categoriesParameter = 'categories')
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (!(\is_array($category) && \array_key_exists('id', $category))) {
+            return;
+        }
+
+        $id = $category['id'];
+
+        // extend comma separated list
+        $categories = $request->get($categoriesParameter, '');
+        $categoriesArray = \array_filter(\explode(',', $categories), function($categoryId) use ($id) {
+            return $categoryId && $categoryId != $id;
+        });
+        $categories = \implode(',', \array_unique($categoriesArray));
+
+        // get all parameter and extend with new tags string
+        $query = $request->query->all();
+        $query = \array_merge($query, [$categoriesParameter => $categories]);
+
+        $queryString = \http_build_query($query);
+
+        return $request->getPathInfo() . (\strlen($queryString) > 0 ? '?' . $queryString : '');
+    }
+
+    public function toggleCategoryInUrl($category, $categoriesParameter = 'categories')
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (!(\is_array($category) && \array_key_exists('id', $category))) {
+            return;
+        }
+
+        $id = $category['id'];
+
+        // extend comma separated list
+        $categories = $request->get($categoriesParameter, '');
+        $categoriesArray = \explode(',', $categories);
+
+        if (\in_array($id, $categoriesArray)) {
+            $categoriesArray = \array_filter($categoriesArray, function($categoryId) use ($id) {
+                return $categoryId != $id;
+            });
+        } else {
+            $categoriesArray = \array_merge($categoriesArray, [$id]);
+        }
+
+        $categoriesArray = \array_filter($categoriesArray);
+        $categories = \implode(',', \array_unique($categoriesArray));
+
+        // get all parameter and extend with new tags string
+        $query = $request->query->all();
+        $query = \array_merge($query, [$categoriesParameter => $categories]);
+
+        $queryString = \http_build_query($query);
+
+        return $request->getPathInfo() . (\strlen($queryString) > 0 ? '?' . $queryString : '');
+    }
+
     public function setCategoryToUrl($category, $categoriesParameter = 'categories')
     {
         $request = $this->requestStack->getCurrentRequest();

--- a/src/Sulu/Component/Category/Request/CategoryRequestHandlerInterface.php
+++ b/src/Sulu/Component/Category/Request/CategoryRequestHandlerInterface.php
@@ -38,6 +38,26 @@ interface CategoryRequestHandlerInterface
     public function appendCategoryToUrl($category, $categoriesParameter = 'categories');
 
     /**
+     * Removes given category from current URL.
+     *
+     * @param array|CategoryInterface $category will be removed from the URL
+     * @param string $categoriesParameter GET parameter name
+     *
+     * @return string
+     */
+    public function removeCategoryFromUrl($category, $categoriesParameter = 'categories');
+
+    /**
+     * Toggles given category in current URL.
+     *
+     * @param array|CategoryInterface $category will be toggled in the URL
+     * @param string $categoriesParameter GET parameter name
+     *
+     * @return string
+     */
+    public function toggleCategoryInUrl($category, $categoriesParameter = 'categories');
+
+    /**
      * Set category to current URL.
      *
      * @param array|CategoryInterface $category will be included in the URL

--- a/src/Sulu/Component/Category/Tests/Unit/Request/CategoryRequestHandlerTest.php
+++ b/src/Sulu/Component/Category/Tests/Unit/Request/CategoryRequestHandlerTest.php
@@ -103,7 +103,7 @@ class CategoryRequestHandlerTest extends TestCase
     /**
      * @dataProvider removeSingleProvider
      */
-    public function testRemoveToUrl($parameter, $url, $queryString, $expected)
+    public function testRemoveSingleFromUrl($parameter, $url, $queryString, $expected)
     {
         $category = ['id' => 3, 'name' => 'test'];
 

--- a/src/Sulu/Component/Category/Tests/Unit/Request/CategoryRequestHandlerTest.php
+++ b/src/Sulu/Component/Category/Tests/Unit/Request/CategoryRequestHandlerTest.php
@@ -86,6 +86,78 @@ class CategoryRequestHandlerTest extends TestCase
         $this->assertEquals($url . '?' . $parameter . '=' . \urlencode($expected), $result);
     }
 
+    public function removeProvider()
+    {
+        return [
+            ['c', '/test', '1,2,3', '1,2'],
+            ['c', '/asdf', '1,2', '1,2'],
+            ['c', '/asdf', '3', ''],
+            ['categories', '/asdf', '1,2', '1,2'],
+            ['categories', '/test', '1,3,2', '1,2'],
+            ['categories', '/test', '3,1', '1'],
+            ['categories', '/test', '1,3', '1'],
+            ['categories', '/test', '', ''],
+        ];
+    }
+
+    /**
+     * @dataProvider removeProvider
+     */
+    public function testRemoveToUrl($parameter, $url, $queryString, $expected)
+    {
+        $category = ['id' => 3, 'name' => 'test'];
+
+        $requestStack = $this->prophesize(RequestStack::class);
+        $request = $this->prophesize(Request::class);
+
+        $requestReveal = $request->reveal();
+        $requestReveal->query = new ParameterBag([$parameter => $queryString]);
+        $requestStack->getCurrentRequest()->willReturn($requestReveal);
+        $request->get($parameter, '')->willReturn($queryString);
+        $request->getPathInfo()->willReturn($url);
+
+        $handler = new CategoryRequestHandler($requestStack->reveal());
+        $result = $handler->removeCategoryFromUrl($category, $parameter);
+
+        $this->assertEquals($url . '?' . $parameter . '=' . \urlencode($expected), $result);
+    }
+
+    public function toggleProvider()
+    {
+        return [
+            ['c', '/test', '1,2', '1,2,3'],
+            ['c', '/asdf', '1,3', '1'],
+            ['c', '/asdf', '2,1', '2,1,3'],
+            ['categories', '/asdf', '1,2', '1,2,3'],
+            ['categories', '/test', '3,2', '2'],
+            ['categories', '/test', '1,3', '1'],
+            ['categories', '/test', '3', ''],
+            ['categories', '/test', '', '3'],
+        ];
+    }
+
+    /**
+     * @dataProvider toggleProvider
+     */
+    public function testToggleToUrl($parameter, $url, $queryString, $expected)
+    {
+        $category = ['id' => 3, 'name' => 'test'];
+
+        $requestStack = $this->prophesize(RequestStack::class);
+        $request = $this->prophesize(Request::class);
+
+        $requestReveal = $request->reveal();
+        $requestReveal->query = new ParameterBag([$parameter => $queryString]);
+        $requestStack->getCurrentRequest()->willReturn($requestReveal);
+        $request->get($parameter, '')->willReturn($queryString);
+        $request->getPathInfo()->willReturn($url);
+
+        $handler = new CategoryRequestHandler($requestStack->reveal());
+        $result = $handler->toggleCategoryInUrl($category, $parameter);
+
+        $this->assertEquals($url . '?' . $parameter . '=' . \urlencode($expected), $result);
+    }
+
     public function setProvider()
     {
         return [

--- a/src/Sulu/Component/Category/Tests/Unit/Request/CategoryRequestHandlerTest.php
+++ b/src/Sulu/Component/Category/Tests/Unit/Request/CategoryRequestHandlerTest.php
@@ -86,7 +86,7 @@ class CategoryRequestHandlerTest extends TestCase
         $this->assertEquals($url . '?' . $parameter . '=' . \urlencode($expected), $result);
     }
 
-    public function removeProvider()
+    public function removeSingleProvider()
     {
         return [
             ['c', '/test', '1,2,3', '1,2'],
@@ -101,7 +101,7 @@ class CategoryRequestHandlerTest extends TestCase
     }
 
     /**
-     * @dataProvider removeProvider
+     * @dataProvider removeSingleProvider
      */
     public function testRemoveToUrl($parameter, $url, $queryString, $expected)
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add `sulu_category_url_remove` and `sulu_category_url_toggle` twig functions

#### Why?

Because there is just a `sulu_category_url_append` function and no way to remove a category from the url

#### To Do

- [ ] Create a documentation PR
