### PR TITLE
Log helpful error messages when invalid values are passed to Selection fields

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
@@ -38,26 +38,27 @@ class MediaSelection extends React.Component<FieldTypeProps<Value>> {
             );
         }
 
-        if (!this.value === undefined) {
+        if (this.value === undefined) {
             onChange({ids: [], displayOption: defaultDisplayOption});
         }
     }
 
     @computed get value(): ?Value {
-        let {value} = this.props;
+        const {value, dataPath} = this.props;
 
         if (value && isArrayLike(value)) {
             log.warn(
-                'The "MediaSelection" field expects an object with an "ids" property as value but received '
-                + 'an array instead. Is it possible that your API returns an array of ids or an array serialized '
-                + 'objects?'
+                'The "MediaSelection" field with the path "' + dataPath + '" expects an object with an "ids" '
+                + 'property as value but received an array instead. Is it possible that your API returns an array of '
+                + 'ids or an array serialized objects?'
                 + '\n\nThe Sulu form view expects that your API returns the data in the same format as it is sent '
                 + 'to the server when submitting the form. '
                 + '\nSulu will try to extract the required data from the given array heuristically. '
                 + 'This decreases performance and might lead to errors or other unexpected behaviour.'
             );
 
-            value = {ids: value.map((item) => item && typeof item === 'object' ? item.id : item)};
+            // $FlowFixMe: flow does recognize that isArrayLike(value) means that value is an array
+            return {ids: value.map((item) => item && typeof item === 'object' ? item.id : item)};
         }
 
         if (value && (typeof value !== 'object' || !isArrayLike(value.ids))) {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaSelection.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {observer} from 'mobx-react';
 import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import userStore from 'sulu-admin-bundle/stores/userStore';
-import {observable} from 'mobx';
+import {computed, observable} from 'mobx';
 import {
     convertDisplayOptionsFromParams,
     convertMediaTypesFromParams,
@@ -18,7 +18,7 @@ class SingleMediaSelection extends React.Component<FieldTypeProps<Value>> {
     constructor(props: FieldTypeProps<Value>) {
         super(props);
 
-        const {onChange, schemaOptions, value} = this.props;
+        const {onChange, schemaOptions} = this.props;
 
         const {
             defaultDisplayOption: {
@@ -37,9 +37,22 @@ class SingleMediaSelection extends React.Component<FieldTypeProps<Value>> {
             );
         }
 
-        if (value === undefined) {
+        if (this.value === undefined) {
             onChange({id: undefined, displayOption: defaultDisplayOption});
         }
+    }
+
+    @computed get value(): ?Value {
+        const {value} = this.props;
+
+        if (value && typeof value !== 'object') {
+            throw new Error(
+                'The "SingleMediaSelection" field expects an object with an "id" property and '
+                + 'an optional "displayOption" property as value.'
+            );
+        }
+
+        return value;
     }
 
     handleChange = (value: Value) => {
@@ -62,7 +75,7 @@ class SingleMediaSelection extends React.Component<FieldTypeProps<Value>> {
     };
 
     render() {
-        const {disabled, error, formInspector, schemaOptions, value} = this.props;
+        const {disabled, error, formInspector, schemaOptions} = this.props;
         const {
             displayOptions: {
                 value: displayOptions,
@@ -94,7 +107,7 @@ class SingleMediaSelection extends React.Component<FieldTypeProps<Value>> {
                 onItemClick={this.handleItemClick}
                 types={mediaTypeValues}
                 valid={!error}
-                value={value ? value : undefined}
+                value={this.value ? this.value : undefined}
             />
         );
     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaSelection.js
@@ -43,12 +43,15 @@ class SingleMediaSelection extends React.Component<FieldTypeProps<Value>> {
     }
 
     @computed get value(): ?Value {
-        const {value} = this.props;
+        const {value, dataPath} = this.props;
 
         if (value && typeof value !== 'object') {
             throw new Error(
-                'The "SingleMediaSelection" field expects an object with an "id" property and '
-                + 'an optional "displayOption" property as value.'
+                'The "SingleMediaSelection" field with the path "' + dataPath + '" expects an object with an "id" '
+                + 'property and an optional "displayOption" property as value. Is it possible that your API returns '
+                + 'something else?'
+                + '\n\nThe Sulu form view expects that your API returns the data in the same format as it is sent '
+                + 'to the server when submitting the form.'
             );
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/SingleMediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/SingleMediaSelection.test.js
@@ -231,6 +231,23 @@ test('Should call onItemClick if item is clicked', () => {
     expect(router.navigate).toBeCalledWith('sulu_media.form', {id: 6, locale: 'de'});
 });
 
+test('Should throw an error if given value is not an object', () => {
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            new ResourceStore('test', undefined, {locale: observable.box('en')}),
+            'test'
+        )
+    );
+
+    expect(() => shallow(
+        <SingleMediaSelection
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            value={(55: any)}
+        />
+    )).toThrow(/expects an object with an "id" property/);
+});
+
 test('Should throw an error if displayOptions schemaOption is given but not an array', () => {
     const formInspector = new FormInspector(
         new ResourceFormStore(

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/package.json
@@ -7,6 +7,7 @@
         "classnames": "^2.2.5",
         "copy-to-clipboard": "^3.0.8",
         "fast-deep-equal": "^3.1.1",
+        "loglevel": "^1.4.1",
         "mousetrap": "^1.6.1",
         "react-clipboard.js": "^2.0.16",
         "react-dropzone": "^10.2.2",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

This PR adjusts the `Selection`, `SingleSelection`, `MediaSelection` and `SingleMediaSelection` field to log helpful error messages when an invalid value is passed to them.

Additionally, it adjusts these fields to extract the expected data and log a warning if a serialized object is passed instead of an id.

#### Why?

Because it is a common pitfall for new developers to return the data for these fields in the wrong format. 
In most cases, the developer return a serialized object instead of an id from their API.
