### PR TITLE
Sort items returned by server to march order of selected ids in MultiSelectionStore

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MultiSelectionStore/MultiSelectionStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MultiSelectionStore/MultiSelectionStore.js
@@ -72,7 +72,11 @@ export default class MultiSelectionStore<T = string | number, U: {id: T} = Objec
             limit: undefined,
             page: 1,
         }).then(action((data) => {
-            this.set(data._embedded[this.resourceKey]);
+            const items = data._embedded[this.resourceKey];
+            // TODO use metadata instead of hardcoded id
+            items.sort((item1, item2) => itemIds.indexOf(item1.id) - itemIds.indexOf(item2.id));
+
+            this.set(items);
             this.setLoading(false);
         }));
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MultiSelectionStore/tests/MultiSelectionStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MultiSelectionStore/tests/MultiSelectionStore.test.js
@@ -80,6 +80,45 @@ test('Should return undefined if the given ID does not exist', () => {
     expect(selectionStore.getById(5)).toEqual(undefined);
 });
 
+test('Should sort items to match order of given ids after loading items when being constructed', () => {
+    const listPromise = Promise.resolve({
+        _embedded: {
+            snippets: [
+                {id: 1},
+                {id: 2},
+                {id: 3},
+            ],
+        },
+    });
+
+    ResourceRequester.getList.mockReturnValue(listPromise);
+
+    const selectionStore = new MultiSelectionStore(
+        'snippets',
+        [3, 1, 2],
+        observable.box('en'),
+        'ids'
+    );
+
+    expect(ResourceRequester.getList).toBeCalledWith(
+        'snippets',
+        {
+            ids: '3,1,2',
+            limit: undefined,
+            locale: 'en',
+            page: 1,
+        }
+    );
+
+    return listPromise.then(() => {
+        expect(toJS(selectionStore.items)).toEqual([
+            {id: 3},
+            {id: 1},
+            {id: 2},
+        ]);
+    });
+});
+
 test('Should load items with different filterParameter when being constructed', () => {
     const listPromise = Promise.resolve({
         _embedded: {
@@ -226,19 +265,19 @@ test('Should remove an item from the store', () => {
         _embedded: {
             snippets: [
                 {id: 1},
-                {id: 2},
+                {id: 3},
             ],
         },
     });
 
     ResourceRequester.getList.mockReturnValue(listPromise);
 
-    const selectionStore = new MultiSelectionStore('snippets', [1, 3, 4], observable.box('en'));
+    const selectionStore = new MultiSelectionStore('snippets', [1, 3], observable.box('en'));
 
     expect(ResourceRequester.getList).toBeCalledWith(
         'snippets',
         {
-            ids: '1,3,4',
+            ids: '1,3',
             limit: undefined,
             locale: 'en',
             page: 1,
@@ -248,12 +287,12 @@ test('Should remove an item from the store', () => {
     return listPromise.then(() => {
         expect(toJS(selectionStore.items)).toEqual([
             {id: 1},
-            {id: 2},
+            {id: 3},
         ]);
 
         selectionStore.removeById(1);
 
-        expect(toJS(selectionStore.items)).toEqual([{id: 2}]);
+        expect(toJS(selectionStore.items)).toEqual([{id: 3}]);
     });
 });
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #5728
| License | MIT

#### What's in this PR?

This PR adjust the `MultiSelectionStore` to sort the items returned by the server so match the order of the given `ids`.

#### Why?

At the moment, the `MultiSelectionStore` expects the server to respect the order if the ids in the `ids` query parameter. If the server does not respect this order, the store will contain the items in the wrong order and therefore the `MultiSelection` and `MultiMediaSelection` will display its items in the wrong order.

This is a common pitfall for new developers when implementing a `selection` field type for their custom entity. (see #5728).


