### PR TITLE
Fix PHP 8 compatibility in AccessControlManager

### DIFF
--- a/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
@@ -62,7 +62,7 @@ class AccessControlManager implements AccessControlManagerInterface
         MaskConverterInterface $maskConverter,
         EventDispatcherInterface $eventDispatcher,
         SystemStoreInterface $systemStore,
-        iterable $descendantProviders = [],
+        iterable $descendantProviders,
         RoleRepositoryInterface $roleRepository
     ) {
         $this->maskConverter = $maskConverter;


### PR DESCRIPTION
…clared before required parameter.

| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets |
| Related issues/PRs | 
| License | MIT
| Documentation PR |

#### What's in this PR?

PHP Deprecated:  Required parameter $roleRepository follows optional parameter $descendantProviders in /home/domain/domains/domain_name.com/vendor/sulu/sulu/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php on line 61


#### Why?

Fix deprecation notices for optional function parameters declared before required parameter.