### PR TITLE
Fix list padding and disabled input field for safari and firefox

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Chip/chip.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Chip/chip.scss
@@ -5,6 +5,7 @@ $chipPrimaryColor: $white;
 $chipSecondaryBackgroundColor: $wildSand;
 $chipSecondaryColor: $black;
 $chipDisabledBackgroundColor: $silver;
+$chipDisabledColor: $gray;
 
 .chip {
     border: none;
@@ -31,6 +32,7 @@ $chipDisabledBackgroundColor: $silver;
 
 .disabled {
     background-color: $chipDisabledBackgroundColor;
+    color: $chipDisabledColor;
 }
 
 .primary {
@@ -44,6 +46,10 @@ $chipDisabledBackgroundColor: $silver;
     &.chip {
         background-color: $chipSecondaryBackgroundColor;
         color: $chipSecondaryColor;
+
+        &.disabled {
+            color: $chipDisabledColor;
+        }
     }
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/input.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/input.scss
@@ -56,6 +56,7 @@ $darkIconColor: $doveGray;
         &:disabled {
             color: $inputDisabledColor;
             background-color: $inputDisabledBackgroundColor;
+            -webkit-text-fill-color: $inputDisabledColor; /* Necessary for Safari and iOS */
         }
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/TextArea/textArea.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/TextArea/textArea.scss
@@ -26,6 +26,6 @@ $textareaColor: $black;
     &.disabled {
         color: $textareaDisabledColor;
         background-color: $textareaDisabledBackgroundColor;
-        -webkit-text-fill-color: $inputDisabledColor; /* Necessary for Safari and iOS */
+        -webkit-text-fill-color: $textareaDisabledColor; /* Necessary for Safari and iOS */
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/TextArea/textArea.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/TextArea/textArea.scss
@@ -26,5 +26,6 @@ $textareaColor: $black;
     &.disabled {
         color: $textareaDisabledColor;
         background-color: $textareaDisabledBackgroundColor;
+        -webkit-text-fill-color: $inputDisabledColor; /* Necessary for Safari and iOS */
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/url.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/url.scss
@@ -39,6 +39,7 @@ $urlInputDisabledBackgroundColor: $wildSand;
         &:disabled {
             color: $urlInputDisabledColor;
             background-color: $urlInputDisabledBackgroundColor;
+            -webkit-text-fill-color: $urlInputDisabledColor; /* Necessary for Safari and iOS */
         }
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/url.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/url.scss
@@ -5,7 +5,8 @@ $urlBorderColor: $silver;
 $urlButtonColor: $dustyGray;
 $urlInputColor: $black;
 $urlErrorBorderColor: $persianRed;
-
+$urlHeight: 30px;
+$urlBorderWidth: 1px;
 $urlInputDisabledColor: $gray;
 $urlInputDisabledBackgroundColor: $wildSand;
 
@@ -13,9 +14,9 @@ $urlInputDisabledBackgroundColor: $wildSand;
     display: flex;
     align-items: center;
     width: 100%;
-    height: 30px;
+    height: $urlHeight;
     border-radius: 3px;
-    border: 1px solid $urlBorderColor;
+    border: $urlBorderWidth solid $urlBorderColor;
     background-color: $urlBackgroundColor;
     font-size: 12px;
     overflow: hidden;
@@ -35,6 +36,7 @@ $urlInputDisabledBackgroundColor: $wildSand;
         border: none;
         padding: 0 10px;
         width: 0;
+        height: calc($urlHeight - 2 * $urlBorderWidth);
 
         &:disabled {
             color: $urlInputDisabledColor;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/application.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/application.scss
@@ -41,11 +41,11 @@
 }
 
 .view-container {
-    display: flex;
-    flex-direction: column;
-    flex-grow: 1;
+    display: block;
+    width: 100%;
+    height: 100%;
     overflow-y: auto;
-    padding: $viewPaddingVertical $viewPaddingHorizontal;
+    padding: $viewPaddingVertical $viewPaddingHorizontal 0;
 }
 
 .main {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/list.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/list.scss
@@ -1,12 +1,13 @@
 @import 'sulu-admin-bundle/containers/Application/colors.scss';
 
 $listToolbarHeight: 30px;
-$listHeaderMarginBottom: 40px;
+$listMarginBottom: 40px;
 
 .list-container {
     display: flex;
     flex-direction: column;
     flex-grow: 1;
+    padding-bottom: $listMarginBottom;
 }
 
 .list {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fixes `padding-bottom` for lists in Safari and Firefox.
Fixes disabled input fields for Safari.

#### Why?

Sulu GUI should look the same in all browsers.
