### PR TITLE
Display helpful error message if uploaded media is blocked or exceeds maximum filesize

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
@@ -168,8 +168,6 @@ class CollectionController extends AbstractRestController implements ClassResour
             );
         } catch (CollectionNotFoundException $cnf) {
             $view = $this->view($cnf->toArray(), 404);
-        } catch (MediaException $e) {
-            $view = $this->view($e->toArray(), 400);
         }
 
         return $this->handleView($view);
@@ -245,8 +243,6 @@ class CollectionController extends AbstractRestController implements ClassResour
             $view = $this->view($list, 200);
         } catch (CollectionNotFoundException $cnf) {
             $view = $this->view($cnf->toArray(), 404);
-        } catch (MediaException $me) {
-            $view = $this->view($me->toArray(), 400);
         }
 
         return $this->handleView($view);
@@ -290,8 +286,6 @@ class CollectionController extends AbstractRestController implements ClassResour
                 $this->collectionManager->delete($id);
             } catch (CollectionNotFoundException $cnf) {
                 throw new EntityNotFoundException(self::$entityName, $id); // will throw 404 Entity not found
-            } catch (MediaException $me) {
-                throw new RestException($me->getMessage(), $me->getCode()); // will throw 400 Bad Request
             }
         };
 
@@ -383,8 +377,6 @@ class CollectionController extends AbstractRestController implements ClassResour
             $view = $this->view($collection, 200);
         } catch (CollectionNotFoundException $e) {
             $view = $this->view($e->toArray(), 404);
-        } catch (MediaException $e) {
-            $view = $this->view($e->toArray(), 400);
         }
 
         return $this->handleView($view);

--- a/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
@@ -18,7 +18,6 @@ use Sulu\Bundle\MediaBundle\Api\RootCollection;
 use Sulu\Bundle\MediaBundle\Collection\Manager\CollectionManagerInterface;
 use Sulu\Bundle\MediaBundle\Entity\Collection as CollectionEntity;
 use Sulu\Bundle\MediaBundle\Media\Exception\CollectionNotFoundException;
-use Sulu\Bundle\MediaBundle\Media\Exception\MediaException;
 use Sulu\Component\Media\SystemCollections\SystemCollectionManagerInterface;
 use Sulu\Component\Rest\AbstractRestController;
 use Sulu\Component\Rest\Exception\EntityNotFoundException;

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
@@ -17,7 +17,6 @@ use HandcraftedInTheAlps\RestRoutingBundle\Routing\ClassResourceInterface;
 use Sulu\Bundle\MediaBundle\Entity\Collection;
 use Sulu\Bundle\MediaBundle\Entity\CollectionRepositoryInterface;
 use Sulu\Bundle\MediaBundle\Entity\Media;
-use Sulu\Bundle\MediaBundle\Media\Exception\MediaException;
 use Sulu\Bundle\MediaBundle\Media\Exception\MediaNotFoundException;
 use Sulu\Bundle\MediaBundle\Media\FormatManager\FormatManagerInterface;
 use Sulu\Bundle\MediaBundle\Media\ListBuilderFactory\MediaListBuilderFactory;

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
@@ -207,8 +207,6 @@ class MediaController extends AbstractMediaController implements
             );
         } catch (MediaNotFoundException $e) {
             $view = $this->view($e->toArray(), 404);
-        } catch (MediaException $e) {
-            $view = $this->view($e->toArray(), 400);
         }
 
         return $this->handleView($view);
@@ -437,8 +435,6 @@ class MediaController extends AbstractMediaController implements
                 $this->mediaManager->delete($id, true);
             } catch (MediaNotFoundException $e) {
                 throw new EntityNotFoundException($this->mediaClass, $id); // will throw 404 Entity not found
-            } catch (MediaException $e) {
-                throw new RestException($e->getMessage(), $e->getCode()); // will throw 400 Bad Request
             }
         };
 
@@ -539,8 +535,6 @@ class MediaController extends AbstractMediaController implements
             $view = $this->view($media, 200);
         } catch (MediaNotFoundException $e) {
             $view = $this->view($e->toArray(), 404);
-        } catch (MediaException $e) {
-            $view = $this->view($e->toArray(), 400);
         }
 
         return $this->handleView($view);
@@ -562,8 +556,6 @@ class MediaController extends AbstractMediaController implements
             $view = $this->view($media, 200);
         } catch (MediaNotFoundException $e) {
             $view = $this->view($e->toArray(), 404);
-        } catch (MediaException $e) {
-            $view = $this->view($e->toArray(), 400);
         }
 
         return $this->handleView($view);

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaPreviewController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaPreviewController.php
@@ -100,8 +100,6 @@ class MediaPreviewController extends AbstractMediaController implements ClassRes
             $view = $this->view($media, 200);
         } catch (MediaNotFoundException $e) {
             $view = $this->view($e->toArray(), 404);
-        } catch (MediaException $e) {
-            $view = $this->view($e->toArray(), 400);
         }
 
         return $this->handleView($view);
@@ -135,8 +133,6 @@ class MediaPreviewController extends AbstractMediaController implements ClassRes
             $view = $this->view($media, 200);
         } catch (MediaNotFoundException $e) {
             $view = $this->view($e->toArray(), 404);
-        } catch (MediaException $e) {
-            $view = $this->view($e->toArray(), 400);
         }
 
         return $this->handleView($view);

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaPreviewController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaPreviewController.php
@@ -16,7 +16,6 @@ use FOS\RestBundle\View\ViewHandlerInterface;
 use HandcraftedInTheAlps\RestRoutingBundle\Controller\Annotations\RouteResource;
 use HandcraftedInTheAlps\RestRoutingBundle\Routing\ClassResourceInterface;
 use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
-use Sulu\Bundle\MediaBundle\Media\Exception\MediaException;
 use Sulu\Bundle\MediaBundle\Media\Exception\MediaNotFoundException;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
 use Sulu\Component\Media\SystemCollections\SystemCollectionManagerInterface;

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -19,6 +19,7 @@ use Sulu\Bundle\MediaBundle\Entity\Collection;
 use Sulu\Bundle\MediaBundle\Media\Exception\FileVersionNotFoundException;
 use Sulu\Bundle\MediaBundle\Media\Exception\FormatNotFoundException;
 use Sulu\Bundle\MediaBundle\Media\Exception\FormatOptionsMissingParameterException;
+use Sulu\Bundle\MediaBundle\Media\Exception\MediaException;
 use Sulu\Bundle\MediaBundle\Media\Exception\MediaNotFoundException;
 use Sulu\Bundle\MediaBundle\Media\Storage\StorageInterface;
 use Sulu\Bundle\PersistenceBundle\DependencyInjection\PersistenceExtensionTrait;
@@ -115,6 +116,7 @@ class SuluMediaExtension extends Extension implements PrependExtensionInterface
                             FileVersionNotFoundException::class => 404,
                             FormatNotFoundException::class => 404,
                             FormatOptionsMissingParameterException::class => 400,
+                            MediaException::class => 400,
                         ],
                     ],
                 ]

--- a/src/Sulu/Bundle/MediaBundle/Media/Exception/InvalidFileException.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Exception/InvalidFileException.php
@@ -11,7 +11,9 @@
 
 namespace Sulu\Bundle\MediaBundle\Media\Exception;
 
-class InvalidFileException extends UploadFileException
+use Sulu\Component\Rest\Exception\TranslationErrorMessageExceptionInterface;
+
+class InvalidFileException extends UploadFileException implements TranslationErrorMessageExceptionInterface
 {
     /**
      * @param string $message
@@ -19,5 +21,15 @@ class InvalidFileException extends UploadFileException
     public function __construct($message)
     {
         parent::__construct($message, self::EXCEPTION_CODE_UPLOAD_ERROR);
+    }
+
+    public function getMessageTranslationKey(): string
+    {
+        return 'sulu_media.file_upload_error';
+    }
+
+    public function getMessageTranslationParameters(): array
+    {
+        return [];
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Media/Exception/InvalidFileTypeException.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Exception/InvalidFileTypeException.php
@@ -11,7 +11,9 @@
 
 namespace Sulu\Bundle\MediaBundle\Media\Exception;
 
-class InvalidFileTypeException extends UploadFileException
+use Sulu\Component\Rest\Exception\TranslationErrorMessageExceptionInterface;
+
+class InvalidFileTypeException extends UploadFileException implements TranslationErrorMessageExceptionInterface
 {
     /**
      * @param string $message
@@ -19,5 +21,15 @@ class InvalidFileTypeException extends UploadFileException
     public function __construct($message, \Throwable $previous = null)
     {
         parent::__construct($message, self::EXCEPTION_CODE_BLOCKED_FILE_TYPE, $previous);
+    }
+
+    public function getMessageTranslationKey(): string
+    {
+        return 'sulu_media.upload_filetype_blocked';
+    }
+
+    public function getMessageTranslationParameters(): array
+    {
+        return [];
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Media/Exception/MaxFileSizeExceededException.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Exception/MaxFileSizeExceededException.php
@@ -11,7 +11,9 @@
 
 namespace Sulu\Bundle\MediaBundle\Media\Exception;
 
-class MaxFileSizeExceededException extends UploadFileException
+use Sulu\Component\Rest\Exception\TranslationErrorMessageExceptionInterface;
+
+class MaxFileSizeExceededException extends UploadFileException implements TranslationErrorMessageExceptionInterface
 {
     /**
      * @param string $message
@@ -19,5 +21,15 @@ class MaxFileSizeExceededException extends UploadFileException
     public function __construct($message)
     {
         parent::__construct($message, self::EXCEPTION_CODE_MAX_FILE_SIZE);
+    }
+
+    public function getMessageTranslationKey(): string
+    {
+        return 'sulu_media.upload_exceeds_max_filesize';
+    }
+
+    public function getMessageTranslationParameters(): array
+    {
+        return [];
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Media/Exception/UploadFileNotSetException.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Exception/UploadFileNotSetException.php
@@ -11,7 +11,9 @@
 
 namespace Sulu\Bundle\MediaBundle\Media\Exception;
 
-class UploadFileNotSetException extends UploadFileException
+use Sulu\Component\Rest\Exception\TranslationErrorMessageExceptionInterface;
+
+class UploadFileNotSetException extends UploadFileException implements TranslationErrorMessageExceptionInterface
 {
     /**
      * @param string $message
@@ -19,5 +21,15 @@ class UploadFileNotSetException extends UploadFileException
     public function __construct($message)
     {
         parent::__construct($message, self::EXCEPTION_CODE_UPLOADED_FILE_NOT_FOUND);
+    }
+
+    public function getMessageTranslationKey(): string
+    {
+        return 'sulu_media.upload_file_not_found';
+    }
+
+    public function getMessageTranslationParameters(): array
+    {
+        return [];
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -21,7 +21,7 @@ type Props = {|
     mediaListStore: ListStore,
     onCollectionNavigate: (collectionId: ?string | number) => void,
     onMediaNavigate?: (mediaId: string | number) => void,
-    onUploadError?: (errorResponses: Array<string>) => void,
+    onUploadError?: (errors: Array<Object>) => void,
     onUploadOverlayClose: () => void,
     onUploadOverlayOpen: () => void,
     overlayType: OverlayType,
@@ -63,7 +63,7 @@ class MediaCollection extends React.Component<Props> {
         );
     };
 
-    @action handleUploadError = (errorResponses: Array<string>) => {
+    @action handleUploadError = (errorResponses: Array<Object>) => {
         const {mediaListStore, onUploadError} = this.props;
 
         if (onUploadError) {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
@@ -617,9 +617,23 @@ test('Reload medias and fire onUploadError callback if an error happens while up
 
     expect(onUploadErrorSpy).not.toBeCalled();
 
-    mediaCollection.find('MultiMediaDropzone').props().onUploadError(['wrong-file-extension-error']);
+    mediaCollection.find('MultiMediaDropzone').props().onUploadError(
+        [
+            {
+                'code': 5003,
+                'detail': 'The uploaded file exceeds the configured maximum filesize.',
+            },
+        ]
+    );
 
-    expect(onUploadErrorSpy).toBeCalledWith(['wrong-file-extension-error']);
+    expect(onUploadErrorSpy).toBeCalledWith(
+        [
+            {
+                'code': 5003,
+                'detail': 'The uploaded file exceeds the configured maximum filesize.',
+            },
+        ]
+    );
     expect(mediaListStore.reset).toBeCalled();
     expect(mediaListStore.reload).toBeCalled();
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
@@ -17,7 +17,7 @@ type Props = {
     onClose: () => void,
     onOpen: () => void,
     onUpload: (media: Array<Object>) => void,
-    onUploadError: (errorResponses: Array<string>) => void,
+    onUploadError: (errors: Array<Object>) => void,
     open: boolean,
 };
 
@@ -91,7 +91,11 @@ class MultiMediaDropzone extends React.Component<Props> {
                 if (result.status === 'fulfilled') {
                     uploadedMedias.push(result.value);
                 } else {
-                    errorResponses.push(result.reason);
+                    try {
+                        errorResponses.push(JSON.parse(result.reason));
+                    } catch (e) {
+                        errorResponses.push(result);
+                    }
                 }
             });
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
@@ -91,11 +91,7 @@ class MultiMediaDropzone extends React.Component<Props> {
                 if (result.status === 'fulfilled') {
                     uploadedMedias.push(result.value);
                 } else {
-                    try {
-                        errorResponses.push(JSON.parse(result.reason));
-                    } catch (e) {
-                        errorResponses.push(result);
-                    }
+                    errorResponses.push(result.reason);
                 }
             });
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/tests/MultiMediaDropzone.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/tests/MultiMediaDropzone.test.js
@@ -22,7 +22,10 @@ jest.mock('sulu-admin-bundle/utils', () => ({
 jest.mock('../../../stores/MediaUploadStore', () => jest.fn(function() {
     this.create = jest.fn((_, file) => {
         if (file.name === 'invalid-file') {
-            return Promise.reject('error-while-uploading-file');
+            return Promise.reject({
+                'code': 5003,
+                'detail': 'The uploaded file exceeds the configured maximum filesize.',
+            });
         }
 
         return Promise.resolve({
@@ -172,6 +175,7 @@ test('Should fire onClose and onUploadError callback if an error happens when up
     const dropPromise = multiMediaDropzone.find('Dropzone').props().onDrop([
         new File([''], 'fileA'),
         new File([''], 'invalid-file'),
+        new File([''], 'invalid-file'),
     ]);
 
     expect(closeSpy).not.toBeCalled();
@@ -181,7 +185,18 @@ test('Should fire onClose and onUploadError callback if an error happens when up
 
         expect(closeSpy).toBeCalledWith();
         expect(multiMediaDropzone.instance().mediaUploadStores.length).toBe(0);
-        expect(uploadErrorSpy).toBeCalledWith(['error-while-uploading-file']);
+        expect(uploadErrorSpy).toBeCalledWith(
+            [
+                {
+                    'code': 5003,
+                    'detail': 'The uploaded file exceeds the configured maximum filesize.',
+                },
+                {
+                    'code': 5003,
+                    'detail': 'The uploaded file exceeds the configured maximum filesize.',
+                },
+            ]
+        );
     });
 });
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/MediaUploadStore.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/MediaUploadStore.js
@@ -174,13 +174,18 @@ export default class MediaUploadStore {
             xhr.open('POST', url);
 
             xhr.onload = (event: any) => {
+                // mimic ok property of fetch response: https://developer.mozilla.org/en-US/docs/Web/API/Response/ok
                 if (event.target.status >= 200 && event.target.status <= 299) {
                     resolve(JSON.parse(event.target.response));
                 } else {
-                    reject(event.target.response);
+                    try {
+                        reject(JSON.parse(event.target.response));
+                    } catch (e) {
+                        reject(event.target);
+                    }
                 }
             };
-            xhr.onerror = (event: any) => reject(event.target.response);
+            xhr.onerror = (event: any) => reject(event.target);
 
             if (xhr.upload) {
                 xhr.upload.onprogress = (event) => this.setProgress(event.loaded / event.total * 100);

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/tests/MediaUploadStore.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/tests/MediaUploadStore.test.js
@@ -94,9 +94,14 @@ test('Promise returned by "update" method should be rejected if request has erro
 
     const updatePromise = mediaUploadStore.update(fileData);
 
-    window.XMLHttpRequest.mock.instances[0].onload({target: {status: 400, response: 'invalid-format'}});
+    window.XMLHttpRequest.mock.instances[0].onload({
+        target: {
+            status: 400,
+            response: '{"code":5003,"message":"Bad Request"}',
+        },
+    });
 
-    return expect(updatePromise).rejects.toEqual('invalid-format');
+    return expect(updatePromise).rejects.toEqual({code: 5003, message: 'Bad Request'});
 });
 
 test('Promise returned by "update" method should be rejected if request is not successful', () => {
@@ -118,9 +123,9 @@ test('Promise returned by "update" method should be rejected if request is not s
 
     const updatePromise = mediaUploadStore.update(fileData);
 
-    window.XMLHttpRequest.mock.instances[0].onerror({target: {response: 'network-error'}});
+    window.XMLHttpRequest.mock.instances[0].onerror({target: {status: 'network-error'}});
 
-    return expect(updatePromise).rejects.toEqual('network-error');
+    return expect(updatePromise).rejects.toEqual({status: 'network-error'});
 });
 
 test('Calling the "create" method should make a "POST" request to the media update api', () => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -144,8 +144,21 @@ class MediaOverview extends React.Component<ViewProps> {
         this.collectionId.set(collectionId);
     };
 
-    @action handleUploadError= () => {
-        this.errors.push(translate('sulu_media.upload_server_error'));
+    @action handleUploadError= (errors: Array<Object>) => {
+        let errorMessageKey = 'sulu_media.upload_server_error';
+
+        if (errors.length === 1) {
+            switch (errors[0].code) {
+                case 5003:
+                    errorMessageKey = 'sulu_media.upload_exceeds_max_filesize';
+                    break;
+                case 5004:
+                    errorMessageKey = 'sulu_media.upload_filetype_blocked';
+                    break;
+            }
+        }
+
+        this.errors.push(translate(errorMessageKey));
     };
 
     @action handleUploadOverlayOpen = () => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -145,31 +145,10 @@ class MediaOverview extends React.Component<ViewProps> {
     };
 
     @action handleUploadError= (errors: Array<Object>) => {
-        if (errors.length !== 1) {
+        if (errors.length === 1) {
+            this.errors.push(errors[0].detail || errors[0].title || translate('sulu_media.upload_server_error'));
+        } else {
             this.errors.push(translate('sulu_media.upload_server_error'));
-
-            return;
-        }
-
-        switch (errors[0].code) {
-            case 5001:
-                this.errors.push(translate('sulu_media.file_upload_error'));
-                break;
-
-            case 5002:
-                this.errors.push(translate('sulu_media.upload_file_not_found'));
-                break;
-
-            case 5003:
-                this.errors.push(translate('sulu_media.upload_exceeds_max_filesize'));
-                break;
-
-            case 5004:
-                this.errors.push(translate('sulu_media.upload_filetype_blocked'));
-                break;
-
-            default:
-                this.errors.push(translate('sulu_media.upload_server_error'));
         }
     };
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -145,20 +145,32 @@ class MediaOverview extends React.Component<ViewProps> {
     };
 
     @action handleUploadError= (errors: Array<Object>) => {
-        let errorMessageKey = 'sulu_media.upload_server_error';
+        if (errors.length !== 1) {
+            this.errors.push(translate('sulu_media.upload_server_error'));
 
-        if (errors.length === 1) {
-            switch (errors[0].code) {
-                case 5003:
-                    errorMessageKey = 'sulu_media.upload_exceeds_max_filesize';
-                    break;
-                case 5004:
-                    errorMessageKey = 'sulu_media.upload_filetype_blocked';
-                    break;
-            }
+            return;
         }
 
-        this.errors.push(translate(errorMessageKey));
+        switch (errors[0].code) {
+            case 5001:
+                this.errors.push(translate('sulu_media.file_upload_error'));
+                break;
+
+            case 5002:
+                this.errors.push(translate('sulu_media.upload_file_not_found'));
+                break;
+
+            case 5003:
+                this.errors.push(translate('sulu_media.upload_exceeds_max_filesize'));
+                break;
+
+            case 5004:
+                this.errors.push(translate('sulu_media.upload_filetype_blocked'));
+                break;
+
+            default:
+                this.errors.push(translate('sulu_media.upload_server_error'));
+        }
     };
 
     @action handleUploadOverlayOpen = () => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -687,7 +687,7 @@ test('Media should be moved when overlay is confirmed', () => {
     });
 });
 
-test('Should show error if upload via MediaCollection fails', () => {
+test('Should show generic error if upload of multiple files fails in MediaCollection', () => {
     const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
     const MediaOverview = require('../MediaOverview').default;
     const toolbarFunction = findWithHighOrderFunction(withToolbar, MediaOverview);
@@ -715,7 +715,60 @@ test('Should show error if upload via MediaCollection fails', () => {
 
     expect(toolbarFunction.call(mediaOverview.instance()).errors).toEqual([]);
 
-    mediaOverview.find('MediaCollection').props().onUploadError(['invalid-file']);
+    mediaOverview.find('MediaCollection').props().onUploadError(
+        [
+            {
+                'code': 5003,
+                'detail': 'The uploaded file exceeds the configured maximum filesize.',
+            },
+            {
+                'code': 5003,
+                'detail': 'The uploaded file exceeds the configured maximum filesize.',
+            },
+        ]
+    );
 
     expect(toolbarFunction.call(mediaOverview.instance()).errors).toEqual(['sulu_media.upload_server_error']);
+});
+
+test('Should show error message from serve if upload of a single files fails in MediaCollection', () => {
+    const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
+    const MediaOverview = require('../MediaOverview').default;
+    const toolbarFunction = findWithHighOrderFunction(withToolbar, MediaOverview);
+
+    const router = {
+        restore: jest.fn(),
+        bind: jest.fn(),
+        route: {
+            options: {
+                locales: ['de'],
+                permissions: {
+                    add: true,
+                    delete: true,
+                    edit: true,
+                },
+            },
+        },
+        attributes: {
+            id: 4,
+        },
+    };
+    const mediaOverview = mount(<MediaOverview router={router} />);
+    mediaOverview.instance().collectionId.set(4);
+    mediaOverview.instance().locale.set('de');
+
+    expect(toolbarFunction.call(mediaOverview.instance()).errors).toEqual([]);
+
+    mediaOverview.find('MediaCollection').props().onUploadError(
+        [
+            {
+                'code': 5003,
+                'detail': 'The uploaded file exceeds the configured maximum filesize.',
+            },
+        ]
+    );
+
+    expect(toolbarFunction.call(mediaOverview.instance()).errors).toEqual(
+        ['The uploaded file exceeds the configured maximum filesize.']
+    );
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
@@ -44,6 +44,8 @@
     "sulu_media.all_collections": "Alle Kollektionen",
     "sulu_media.move_media": "Medien verschieben",
     "sulu_media.upload_server_error": "Beim Upload einer oder mehrerer Dateien ist ein Fehler aufgetreten.",
+    "sulu_media.file_upload_error": "Die Datei konnte nicht auf den Server geladen werden. Die Ursache könnte ein Größenlimit für Uploads zum Servers sein.",
+    "sulu_media.upload_file_not_found": "Die hochgeladene Date wurde vom Server nicht gefunden. Die Ursache könnte ein Größenlimit für Uploads zum Servers sein.",
     "sulu_media.upload_exceeds_max_filesize": "Die hochgeladene Datei überschreitet die konfigurierte maximale Dateigröße.",
     "sulu_media.upload_filetype_blocked": "Der Dateityp der hochgeladenen Datei ist als blockiert konfiguriert.",
     "sulu_media.set_focus_point": "Fokuspunkt setzen",

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
@@ -44,6 +44,8 @@
     "sulu_media.all_collections": "Alle Kollektionen",
     "sulu_media.move_media": "Medien verschieben",
     "sulu_media.upload_server_error": "Beim Upload einer oder mehrerer Dateien ist ein Fehler aufgetreten.",
+    "sulu_media.upload_exceeds_max_filesize": "Die hochgeladene Datei überschreitet die konfigurierte maximale Dateigröße.",
+    "sulu_media.upload_filetype_blocked": "Der Dateityp der hochgeladenen Datei ist als blockiert konfiguriert.",
     "sulu_media.set_focus_point": "Fokuspunkt setzen",
     "sulu_media.define_crops": "Ausschnitte festlegen",
     "sulu_media.upload_preview_image": "Vorschaubild hochladen",

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
@@ -44,6 +44,8 @@
     "sulu_media.all_collections": "All collections",
     "sulu_media.move_media": "Move media",
     "sulu_media.upload_server_error": "There was an error while uploading one or multiple files to the server.",
+    "sulu_media.upload_exceeds_max_filesize": "The uploaded file exceeds the configured maximum filesize.",
+    "sulu_media.upload_filetype_blocked": "The filetype of the uploaded file is configured to be blocked.",
     "sulu_media.set_focus_point": "Set focus point",
     "sulu_media.define_crops": "Define crops",
     "sulu_media.upload_preview_image": "Upload preview image",

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
@@ -44,6 +44,8 @@
     "sulu_media.all_collections": "All collections",
     "sulu_media.move_media": "Move media",
     "sulu_media.upload_server_error": "There was an error while uploading one or multiple files to the server.",
+    "sulu_media.file_upload_error": "The file could not be uploaded to the server. This might be caused by a filesize limit for uploads on the server.",
+    "sulu_media.upload_file_not_found": "The uploaded file was not found on the server. This might be caused by a filesize limit for uploads on the server.",
     "sulu_media.upload_exceeds_max_filesize": "The uploaded file exceeds the configured maximum filesize.",
     "sulu_media.upload_filetype_blocked": "The filetype of the uploaded file is configured to be blocked.",
     "sulu_media.set_focus_point": "Set focus point",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #5417
| License | MIT

#### What's in this PR?

This PR adjusts the `MediaOverview` view to display helpful error messages if the upload of a file fails.

Builds upon https://github.com/sulu/sulu/pull/5799