### PR TITLE
Add visible property to NavigationItem to allow for hiding navigation items

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItem.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItem.php
@@ -75,7 +75,14 @@ class NavigationItem implements \Iterator
      *
      * @var bool
      */
-    protected $disabled;
+    protected $disabled = false;
+
+    /**
+     * Defines if item is visible in the navigation.
+     *
+     * @var bool
+     */
+    protected $visible = true;
 
     /**
      * @param string $name The name of the item
@@ -83,7 +90,6 @@ class NavigationItem implements \Iterator
     public function __construct($name)
     {
         $this->name = $name;
-        $this->disabled = false;
     }
 
     /**
@@ -247,6 +253,22 @@ class NavigationItem implements \Iterator
     }
 
     /**
+     * @param bool $visible
+     */
+    public function setVisible($visible)
+    {
+        $this->visible = $visible;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getVisible()
+    {
+        return $this->visible;
+    }
+
+    /**
      * Returns a copy of this navigation item without its children.
      *
      * @return NavigationItem
@@ -400,6 +422,7 @@ class NavigationItem implements \Iterator
             'icon' => $this->getIcon(),
             'view' => $this->getView(),
             'disabled' => $this->getDisabled(),
+            'visible' => $this->getVisible(),
             'id' => (null != $this->getId()) ? $this->getId() : \str_replace('.', '', \uniqid('', true)), //FIXME don't use uniqid()
         ];
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/Navigation.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/Navigation.js
@@ -87,21 +87,21 @@ class Navigation extends React.Component<Props> {
                 userImage={this.userImage}
                 username={this.username}
             >
-                {navigationItems.map((navigationItem: NavigationItem) => (
+                {navigationItems.filter((item: NavigationItem) => item.visible).map((item: NavigationItem) => (
                     <NavigationComponent.Item
-                        active={this.isItemActive(navigationItem)}
-                        icon={navigationItem.icon}
-                        key={navigationItem.id}
-                        title={navigationItem.label}
-                        value={navigationItem.id}
+                        active={this.isItemActive(item)}
+                        icon={item.icon}
+                        key={item.id}
+                        title={item.label}
+                        value={item.id}
                     >
-                        {Array.isArray(navigationItem.items) &&
-                            navigationItem.items.map((subNavigationItem) => (
+                        {Array.isArray(item.items) &&
+                            item.items.filter((subItem: NavigationItem) => subItem.visible).map((subItem) => (
                                 <NavigationComponent.Item
-                                    active={this.isItemActive(subNavigationItem)}
-                                    key={subNavigationItem.id}
-                                    title={subNavigationItem.label}
-                                    value={subNavigationItem.id}
+                                    active={this.isItemActive(subItem)}
+                                    key={subItem.id}
+                                    title={subItem.label}
+                                    value={subItem.id}
                                 />
                             ))
                         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/Navigation.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/Navigation.js
@@ -41,13 +41,14 @@ class Navigation extends React.Component<Props> {
 
     handleNavigationItemClick = (value: string) => {
         const navigationItem = navigationRegistry.get(value);
+        const view = navigationItem.view;
 
-        if (!navigationItem.view) {
+        if (!view) {
             return;
         }
 
-        this.props.router.navigate(navigationItem.view);
-        this.props.onNavigate(navigationItem.view);
+        this.props.router.navigate(view);
+        this.props.onNavigate(view);
     };
 
     handleProfileEditClick = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/tests/Navigation.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/tests/Navigation.test.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {render, mount} from 'enzyme';
 import Navigation from '../Navigation';
 import Router, {Route} from '../../../services/Router';
+import type {NavigationItem} from '../types';
 
 jest.mock('../../../services/Router/Router', () => jest.fn(function() {
     this.navigate = jest.fn();
@@ -10,48 +11,76 @@ jest.mock('../../../services/Router/Router', () => jest.fn(function() {
 
 jest.mock('../registries/navigationRegistry', () => ({
     get: jest.fn().mockReturnValue(
-        {
+        ({
             id: '111-111',
             title: 'Test Navigation',
+            label: '',
             icon: 'su-options',
             view: 'returned_main_route',
-        }
+            visible: true,
+        }: NavigationItem)
     ),
-    getAll: jest.fn().mockReturnValue([
+    getAll: jest.fn().mockReturnValue(([
         {
             id: '111-111',
             title: 'Test Navigation',
+            label: '',
             icon: 'su-options',
             view: 'sulu_admin.form_tab',
+            visible: true,
         },
         {
             id: '222-222',
             title: 'Test Navigation 2',
+            label: '',
             icon: 'su-article',
             view: 'sulu_article.list',
             childViews: ['sulu_article.form', 'sulu_article.form'],
+            visible: true,
+        },
+        {
+            id: '111-222',
+            title: 'Hidden Navigation Item',
+            label: '',
+            icon: 'su-options',
+            view: 'sulu_admin.form_tab',
+            visible: false,
         },
         {
             id: '333-333',
             title: 'Test Navigation with Children',
+            label: '',
             icon: 'su-options',
+            visible: true,
             items: [
                 {
                     id: '333-child1',
                     title: 'Test Navigation Child 1',
+                    label: '',
                     icon: 'su-options',
                     view: 'sulu_admin.form_tab',
+                    visible: true,
                 },
                 {
                     id: '333-child2',
                     title: 'Test Navigation Child 2',
+                    label: '',
                     icon: 'su-article',
                     view: 'sulu_article.list',
                     childViews: ['sulu_article.form', 'sulu_article.form'],
+                    visible: true,
+                },
+                {
+                    id: '333-child3',
+                    title: 'Test Navigation Child 1',
+                    label: '',
+                    icon: 'su-options',
+                    view: 'sulu_admin.form_tab',
+                    visible: false,
                 },
             ],
         },
-    ]),
+    ]: Array<NavigationItem>)),
 }));
 
 test('Should render navigation', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/tests/registries/NavigationRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/tests/registries/NavigationRegistry.test.js
@@ -13,18 +13,21 @@ test('Set and clear all from NavigationRegistry', () => {
                 label: 'Test 1',
                 icon: 'su-webspace',
                 view: 'sulu_page.webspaces',
+                visible: true,
             },
             {
                 id: '222',
                 label: 'Test 2',
                 icon: 'su-webspace',
                 view: 'sulu_page.webspaces',
+                visible: true,
             },
             {
                 id: '333',
                 label: 'Test 3',
                 icon: 'su-webspace',
                 view: 'sulu_page.webspaces',
+                visible: true,
             },
         ]
     );
@@ -41,18 +44,21 @@ test('Set and get all from NavigationRegistry', () => {
             label: 'Test 1',
             icon: 'su-webspace',
             view: 'sulu_page.webspaces',
+            visible: true,
         },
         {
             id: '222',
             label: 'Test 2',
             icon: 'su-webspace',
             view: 'sulu_page.webspaces',
+            visible: true,
         },
         {
             id: '333',
             label: 'Test 3',
             icon: 'su-webspace',
             view: 'sulu_page.webspaces',
+            visible: true,
         },
     ];
 
@@ -68,30 +74,35 @@ test('Get should return the correct item', () => {
             label: 'Test 1',
             icon: 'su-webspace',
             view: 'sulu_page.webspaces',
+            visible: true,
         },
         {
             id: '222',
             label: 'Test 2',
             icon: 'su-webspace',
             view: 'sulu_page.webspaces',
+            visible: true,
         },
         {
             id: '333',
             label: 'Test 3',
             icon: 'su-webspace',
             view: 'sulu_page.webspaces',
+            visible: true,
             items: [
                 {
                     id: '444',
                     label: 'Test 4',
                     icon: 'su-webspace',
                     view: 'sulu_page.webspaces',
+                    visible: true,
                 },
                 {
                     id: '555',
                     label: 'Test 5',
                     icon: 'su-webspace',
                     view: 'sulu_page.webspaces',
+                    visible: true,
                 },
             ],
         },

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/types.js
@@ -5,6 +5,6 @@ export type NavigationItem = {
     id: string,
     items?: Array<NavigationItem>,
     label: string,
-    view: string,
+    view?: string,
     visible: boolean,
 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/types.js
@@ -6,4 +6,5 @@ export type NavigationItem = {
     items?: Array<NavigationItem>,
     label: string,
     view: string,
+    visible: boolean,
 };

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Navigation/NavigationItemTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Navigation/NavigationItemTest.php
@@ -72,10 +72,40 @@ class NavigationItemTest extends TestCase
         $this->assertEquals('OtherNavigationItem', $this->navigationItem->getName());
     }
 
+    public function testLabel()
+    {
+        $this->navigationItem->setLabel('label');
+        $this->assertEquals('label', $this->navigationItem->getLabel());
+    }
+
     public function testIcon()
     {
         $this->navigationItem->setIcon('icon');
         $this->assertEquals('icon', $this->navigationItem->getIcon());
+    }
+
+    public function testView()
+    {
+        $this->navigationItem->setView('view');
+        $this->assertEquals('view', $this->navigationItem->getView());
+    }
+
+    public function testPosition()
+    {
+        $this->navigationItem->setPosition(110);
+        $this->assertEquals(110, $this->navigationItem->getPosition());
+    }
+
+    public function testDisabled()
+    {
+        $this->navigationItem->setDisabled(true);
+        $this->assertEquals(true, $this->navigationItem->getDisabled());
+    }
+
+    public function testVisible()
+    {
+        $this->navigationItem->setVisible(false);
+        $this->assertEquals(false, $this->navigationItem->getVisible());
     }
 
     public function testChildren()
@@ -136,6 +166,25 @@ class NavigationItemTest extends TestCase
         $array = $this->item2->toArray();
 
         $this->assertNotContains('header', \array_keys($array));
+    }
+
+    public function testToArrayWithoutChildre()
+    {
+        $item = new NavigationItem('Navigation Item');
+        $item->setId('test-id');
+        $item->setLabel('test-label');
+        $item->setIcon('test-icon');
+        $item->setView('test-view');
+
+        $this->assertEquals([
+            'title' => 'Navigation Item',
+            'label' => 'test-label',
+            'icon' => 'test-icon',
+            'view' => 'test-view',
+            'id' => 'test-id',
+            'disabled' => false,
+            'visible' => true,
+        ], $item->toArray());
     }
 
     public function testToArrayWithPosition()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

This PR adds a `visible` property to the `NavigationItem` class and adjusts the `Navigation` component to only render items that should be visible.

#### Why?

This allows to hide specific navigation items in a project by registering an `Admin` class like this:

```php
<?php

declare(strict_types=1);

namespace App\Admin;

use Sulu\Bundle\AdminBundle\Admin\Admin;
use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
use Sulu\Bundle\ContactBundle\Admin\ContactAdmin;

class AppAdmin extends Admin
{
    public function configureNavigationItems(NavigationItemCollection $navigationItemCollection): void
    {
        $navigationItemCollection->get('sulu_contact.contacts')->setVisible(false);
    }

    public static function getPriority(): int
    {
        return ContactAdmin::getPriority() - 1;
    }
}
```
