### PR TITLE
Fix DeviceDetectorSubscriber with newer matomo device detector version

### DIFF
--- a/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/DeviceDetectorSubscriber.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/DeviceDetectorSubscriber.php
@@ -39,7 +39,7 @@ class DeviceDetectorSubscriber implements EventSubscriberInterface
 
     public function setUserAgent(RequestEvent $event)
     {
-        $this->deviceDetector->setUserAgent($event->getRequest()->headers->get('User-Agent'));
+        $this->deviceDetector->setUserAgent($event->getRequest()->headers->get('User-Agent') ?? '');
         $this->deviceDetector->parse();
     }
 }

--- a/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/DeviceDetectorSubscriber.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/DeviceDetectorSubscriber.php
@@ -39,7 +39,7 @@ class DeviceDetectorSubscriber implements EventSubscriberInterface
 
     public function setUserAgent(RequestEvent $event)
     {
-        $this->deviceDetector->setUserAgent($event->getRequest()->headers->get('User-Agent') ?? '');
+        $this->deviceDetector->setUserAgent($event->getRequest()->headers->get('User-Agent', ''));
         $this->deviceDetector->parse();
     }
 }

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Functional/EventListener/DeviceDetectorSubscriberTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Functional/EventListener/DeviceDetectorSubscriberTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AudienceTargetingBundle\Tests\Functional\EventListener;
+
+use App\Kernel;
+use DeviceDetector\DeviceDetector;
+use Sulu\Bundle\AudienceTargetingBundle\EventListener\DeviceDetectorSubscriber;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+
+class DeviceDetectorSubscriberTest extends SuluTestCase
+{
+    /**
+     * @var DeviceDetector
+     */
+    private $deviceDetector;
+
+    /**
+     * @var DeviceDetectorSubscriber
+     */
+    private $deviceDetectorSubscriber;
+
+    protected function setUp(): void
+    {
+        $this->deviceDetector = new DeviceDetector();
+        $this->deviceDetectorSubscriber = new DeviceDetectorSubscriber($this->deviceDetector);
+    }
+
+    public function testSetUserAgent(): void
+    {
+        $kernel = $this->prophesize(Kernel::class);
+        $request = new Request();
+        $request->headers->add(['User-Agent' => 'Test-Agent']);
+
+        $requestEvent = new RequestEvent($kernel->reveal(), $request, null);
+
+        $this->deviceDetectorSubscriber->setUserAgent($requestEvent);
+
+        $this->assertSame('Test-Agent', $this->deviceDetector->getUserAgent());
+    }
+
+    public function testSetUserAgentNull(): void
+    {
+        $kernel = $this->prophesize(Kernel::class);
+        $request = new Request();
+        $request->headers->add([]);
+
+        $requestEvent = new RequestEvent($kernel->reveal(), $request, null);
+
+        $this->deviceDetectorSubscriber->setUserAgent($requestEvent);
+
+        $this->assertSame('', $this->deviceDetector->getUserAgent());
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

The method `deviceDetector->setUserAgent(..)` expects a string, if no `User-Agent` was set in the request-header an exception is thrown because null is not allowed to set.

#### Why?

The exception should not be thrown on missing `User-Agent` headers.