### PR TITLE
Adjust data-format used by auto_complete type of single_selection to be consistent with other selections

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,80 @@
 # Upgrade
 
-## dev-master
+## 2.3
+
+### Changed data-format used by the single_account_selection field-type
+
+The `single_account_selection` field-type was adjusted to process an id instead of a serialized account entity.
+This makes the data-format used by the `single_account_selection` field-type consistent to all other `single_*_selection` field types.
+
+The data that is sent to the server by the field-type was changed like this:
+
+```diff
+{
+-    "single_account_selection_property": {
+-        "id": 1,
+-        "name": "Test Account",
+-        ...
+-    },
++    "single_account_selection_property": 1,
+}
+```
+
+If you have used the `single_account_selection` field-type in a form configuration for your custom entity,
+you should adjust the API of the custom entity to be compatible with the new data-format. 
+If you cannot adjust the API, you can use the `use_deprecated_object_data_format` param to bring back the old behaviour:
+
+```diff
+     <property name="single_account_selection_property" type="single_account_selection">
+         <!-- .. -->
++        <params>
++            <param name="use_deprecated_object_data_format" value="true" />
++        </params>
+     </property>
+```
+
+### Changed data-format used by the auto_complete type of single_selection field-type
+
+The `auto_complete` type of `single_selection` field-type was adjusted to process an id instead of a serialized object.
+This makes the data-format used by the `auto_complete` type consistent to all other `single_selection` types and therefore
+allows to switch between different types.
+
+If you have configured a `single_selection` field-type with the `auto_complete` type for your custom entity, 
+the data that is sent to the server by the field-type is changed like this:
+
+```diff
+{
+-    "auto_complete_single_selection_property": {
+-        "id": 1,
+-        "name": "...",
+-        ...
+-    },
++    "auto_complete_single_selection_property": 1,
+}
+```
+
+If you have used such a field-type in a form configuration for your custom entity, you should adjust the API of the 
+custom entity to be compatible with the new data-format.
+If you cannot adjust the API, you can use the `use_deprecated_object_data_format` param to bring back the old behaviour:
+
+```diff
+     <property name="auto_complete_single_selection_property" type="single_entity_selection">
+         <!-- .. -->
++        <params>
++            <param name="use_deprecated_object_data_format" value="true" />
++        </params>
+     </property>
+```
+
+### Adjusted SingleAutoComplete component to accept SingleSelectionStore
+
+The `SingleAutoComplete` container component was adjusted to accept a `SingleSelectionStore` instance via the `store` prop. 
+Furthermore, the `onChange`, `resourceKey` and `value` prop were replaced by the `store` prop and have been removed.
+This makes the implementation of the `SingleAutoComplete` consistent to the implementation of the `MultiAutoComplete`
+and makes it easier to reuse the component.
+
+If you are using the `SingleAutoComplete` container component in your custom javascript code, you need to adjust your 
+code to instantiate a `SingleSelectionStore` object and pass it to the `store` prop.
 
 ### conditionDataProvider interface changed
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/SingleAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/SingleAutoComplete.js
@@ -45,8 +45,7 @@ class SingleAutoComplete extends React.Component<Props> {
             value,
         } = this.props;
 
-        if (this.overrideValue || !equals(toJS(prevProps.value), toJS(value))){
-            this.overrideValue = false;
+        if (!equals(toJS(prevProps.value), toJS(value))){
             this.setInputValue(value ? value[displayProperty] : undefined);
         }
     }
@@ -74,8 +73,13 @@ class SingleAutoComplete extends React.Component<Props> {
     }, DEBOUNCE_TIME);
 
     handleSelect = (value: Object) => {
-        this.overrideValue = true;
-        this.props.onChange(value);
+        const {
+            displayProperty,
+            onChange,
+        } = this.props;
+
+        this.setInputValue(value ? value[displayProperty] : undefined);
+        onChange(value);
     };
 
     handleInputChange = (value: ?string) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/SingleAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/SingleAutoComplete.js
@@ -1,8 +1,9 @@
 // @flow
 import React from 'react';
+import equals from 'fast-deep-equal';
 import type {ElementRef} from 'react';
 import {observer} from 'mobx-react';
-import {action, computed, observable} from 'mobx';
+import {action, computed, observable, toJS} from 'mobx';
 import debounce from 'debounce';
 import Input from '../Input';
 import AutoCompletePopover from '../AutoCompletePopover';
@@ -38,12 +39,13 @@ class SingleAutoComplete extends React.Component<Props> {
 
     overrideValue: boolean = false;
 
-    componentDidUpdate() {
-        if (this.overrideValue) {
-            const {
-                displayProperty,
-                value,
-            } = this.props;
+    componentDidUpdate(prevProps: Props) {
+        const {
+            displayProperty,
+            value,
+        } = this.props;
+
+        if (this.overrideValue || !equals(toJS(prevProps.value), toJS(value))){
             this.overrideValue = false;
             this.setInputValue(value ? value[displayProperty] : undefined);
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/SingleAutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/SingleAutoComplete.test.js
@@ -122,3 +122,26 @@ test('Should call the onFinish callback when the Input lost focus', () => {
 
     expect(finishSpy).toBeCalledWith();
 });
+
+test('Should update value of Input when the value prop is updated', () => {
+    const finishSpy = jest.fn();
+    const suggestions = [
+        {id: 1, name: 'Suggestion 1'},
+    ];
+
+    const singleAutoComplete = shallow(
+        <SingleAutoComplete
+            displayProperty="name"
+            onChange={jest.fn()}
+            onFinish={finishSpy}
+            onSearch={jest.fn()}
+            searchProperties={['name']}
+            suggestions={suggestions}
+            value={{name: 'Test'}}
+        />
+    );
+
+    expect(singleAutoComplete.find('Input').prop('value')).toEqual('Test');
+    singleAutoComplete.setProps({value: {name: 'new value'}});
+    expect(singleAutoComplete.find('Input').prop('value')).toEqual('new value');
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/SingleAutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/SingleAutoComplete.test.js
@@ -49,7 +49,7 @@ test('SingleAutoComplete should be disabled when in disabled state', () => {
     expect(singleAutoComplete.find('input').prop('disabled')).toEqual(true);
 });
 
-test('Clicking on a suggestion should call the onChange handler with the value of the selected Suggestion', () => {
+test('Selecting suggestion should fire onChange callback and update value of Input with selected value', () => {
     const changeSpy = jest.fn();
 
     const suggestions = [
@@ -70,8 +70,11 @@ test('Clicking on a suggestion should call the onChange handler with the value o
         />
     );
 
+    expect(singleAutoComplete.find('Input').prop('value')).toEqual('Test');
+
     singleAutoComplete.find('Suggestion button').at(0).simulate('click');
 
+    expect(singleAutoComplete.find('Input').prop('value')).toEqual('Suggestion 1');
     expect(changeSpy).toHaveBeenCalledWith(suggestions[0]);
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
@@ -147,14 +147,15 @@ test('Pass correct options to SingleAutoComplete with deprecated data_path_to_au
 });
 
 test('Use locale from userStore and pass correct props with schema-options type to SingleAutoComplete', () => {
-    userStore.contentLocale = 'en';
-
     const formInspector = new FormInspector(
         new ResourceFormStore(
             new ResourceStore('test', undefined, undefined),
             'test'
         )
     );
+
+    // $FlowFixMe
+    userStore.contentLocale = 'en';
 
     const fieldTypeOptions = {
         default_type: 'list_overlay',
@@ -276,7 +277,7 @@ test('Handle object without warning when "use_deprecated_object_data_format" opt
             onChange={changeSpy}
             onFinish={finishSpy}
             schemaOptions={schemaOptions}
-            value={{id: 'old-entity-id'}}
+            value={({id: 'old-entity-id'}: any)}
         />
     );
 
@@ -554,7 +555,7 @@ test('Should log warning and use id of object if given value is an object instea
             disabled={true}
             fieldTypeOptions={fieldTypeOptions}
             formInspector={formInspector}
-            value={{id: 125}}
+            value={({id: 125}: any)}
         />
     );
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/MultiAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/MultiAutoComplete.js
@@ -38,7 +38,12 @@ class MultiAutoComplete extends React.Component<Props> {
             selectionStore,
         } = this.props;
 
-        this.searchStore = new SearchStore(selectionStore.resourceKey, searchProperties, options);
+        this.searchStore = new SearchStore(
+            selectionStore.resourceKey,
+            searchProperties,
+            options,
+            selectionStore.locale
+        );
     }
 
     handleChange = (value: Array<Object>) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/README.md
@@ -1,5 +1,5 @@
 This component uses the [`MultiAutoComplete` component](#multiautocomplete) and attaches it to a `MultiSelectionStore`.
-This store will contain the currently selected valued from the `MultiAutoComplete` container. The `displayProperty`
+This store will contain the currently selected values from the `MultiAutoComplete` container. The `displayProperty`
 indicates which of the properties of the items in the `MultiSelectionStore` will be used to display the items. The
 `idProperty` prop is the property of the object, that will be used to determine the unique identifier for an item. To
 define which properties will be searched by the `MultiAutoComplete` the `searchProperties` prop can be used.

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/tests/MultiAutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/tests/MultiAutoComplete.test.js
@@ -1,19 +1,23 @@
 // @flow
 import React from 'react';
 import {mount, shallow, render} from 'enzyme';
-import {extendObservable as mockExtendObservable} from 'mobx';
+import {extendObservable as mockExtendObservable, observable} from 'mobx';
 import MultiAutoComplete from '../MultiAutoComplete';
 import MultiAutoCompleteComponent from '../../../components/MultiAutoComplete';
 import SearchStore from '../../../stores/SearchStore';
 import MultiSelectionStore from '../../../stores/MultiSelectionStore';
 
 jest.mock('../../../stores/SearchStore', () => jest.fn());
-jest.mock('../../../stores/MultiSelectionStore', () => jest.fn(function(resourceKey) {
+jest.mock('../../../stores/MultiSelectionStore', () => jest.fn(function(resourceKey, selectedItemIds, locale) {
     this.resourceKey = resourceKey;
+    this.locale = locale;
     this.set = jest.fn();
     this.loading = false;
 
-    mockExtendObservable(this, {ids: [], items: []});
+    mockExtendObservable(this, {
+        ids: [],
+        items: [],
+    });
 }));
 
 test('Render in loading state', () => {
@@ -299,7 +303,8 @@ test('Construct SearchStore with correct parameters on mount', () => {
     // $FlowFixMe
     SearchStore.mockImplementation(function() {});
 
-    const selectionStore = new MultiSelectionStore('contact', []);
+    const locale = observable.box('de');
+    const selectionStore = new MultiSelectionStore('contact', [], locale);
 
     shallow(
         <MultiAutoComplete
@@ -312,5 +317,5 @@ test('Construct SearchStore with correct parameters on mount', () => {
         />
     );
 
-    expect(SearchStore).toBeCalledWith('contact', ['firstName', 'lastName'], {country: 'US'});
+    expect(SearchStore).toBeCalledWith('contact', ['firstName', 'lastName'], {country: 'US'}, locale);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/README.md
@@ -1,6 +1,4 @@
-This component uses the [`SingleAutoComplete` component](#singleautocomplete) and attaches it to one of the registered
-resources. The component will then read the suggestions from the resources with the given `resourceKey`. The `value` is
-the currently selected object. There are two properties describing which properties of the fields are used, the
-`displayProperty` describes which property from the object is read to the input field and the `searchProperties` define
-which fields of the object will be searched and displayed in the suggestion list. The `onChange` callback will be
-called with the selected object when a suggestion is selected.
+This component uses the [`SingleAutoComplete` component](#singleautocomplete) and attaches it to a `SingleSelectionStore`. 
+This store will contain the currently selected values of the `SingleAutoComplete` container.
+The `displayProperty` indicates which of the properties of the items in the `MultiSelectionStore` will be used to display the items.
+To define which properties will be searched by the `MultiAutoComplete` the `searchProperties` prop can be used.

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/SingleAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/SingleAutoComplete.js
@@ -3,16 +3,15 @@ import React from 'react';
 import {observer} from 'mobx-react';
 import SingleAutoCompleteComponent from '../../components/SingleAutoComplete';
 import SearchStore from '../../stores/SearchStore';
+import SingleSelectionStore from '../../stores/SingleSelectionStore';
 
 type Props = {|
     disabled: boolean,
     displayProperty: string,
     id?: string,
-    onChange: (value: ?Object) => void,
     options: Object,
-    resourceKey: string,
     searchProperties: Array<string>,
-    value: ?Object,
+    selectionStore: SingleSelectionStore<string | number>,
 |};
 
 @observer
@@ -27,13 +26,14 @@ class SingleAutoComplete extends React.Component<Props> {
     constructor(props: Props) {
         super(props);
 
-        const {options, resourceKey, searchProperties} = this.props;
+        const {options, selectionStore, searchProperties} = this.props;
 
-        this.searchStore = new SearchStore(resourceKey, searchProperties, options);
+        this.searchStore = new SearchStore(selectionStore.resourceKey, searchProperties, options);
     }
 
     handleChange = (value: ?Object) => {
-        this.props.onChange(value);
+        const {selectionStore} = this.props;
+        selectionStore.set(value);
         this.searchStore.clearSearchResults();
     };
 
@@ -47,8 +47,7 @@ class SingleAutoComplete extends React.Component<Props> {
             displayProperty,
             id,
             searchProperties,
-            value,
-
+            selectionStore,
         } = this.props;
 
         return (
@@ -56,12 +55,12 @@ class SingleAutoComplete extends React.Component<Props> {
                 disabled={disabled}
                 displayProperty={displayProperty}
                 id={id}
-                loading={this.searchStore.loading}
+                loading={this.searchStore.loading || selectionStore.loading}
                 onChange={this.handleChange}
                 onSearch={this.handleSearch}
                 searchProperties={searchProperties}
                 suggestions={this.searchStore.searchResults}
-                value={value}
+                value={selectionStore.item}
             />
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/SingleAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/SingleAutoComplete.js
@@ -28,7 +28,12 @@ class SingleAutoComplete<T: string | number> extends React.Component<Props<T>> {
 
         const {options, selectionStore, searchProperties} = this.props;
 
-        this.searchStore = new SearchStore(selectionStore.resourceKey, searchProperties, options);
+        this.searchStore = new SearchStore(
+            selectionStore.resourceKey,
+            searchProperties,
+            options,
+            selectionStore.locale
+        );
     }
 
     handleChange = (value: ?Object) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/SingleAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/SingleAutoComplete.js
@@ -5,17 +5,17 @@ import SingleAutoCompleteComponent from '../../components/SingleAutoComplete';
 import SearchStore from '../../stores/SearchStore';
 import SingleSelectionStore from '../../stores/SingleSelectionStore';
 
-type Props = {|
+type Props<T> = {|
     disabled: boolean,
     displayProperty: string,
     id?: string,
     options: Object,
     searchProperties: Array<string>,
-    selectionStore: SingleSelectionStore<string | number>,
+    selectionStore: SingleSelectionStore<T>,
 |};
 
 @observer
-class SingleAutoComplete extends React.Component<Props> {
+class SingleAutoComplete<T: string | number> extends React.Component<Props<T>> {
     static defaultProps = {
         disabled: false,
         options: {},
@@ -23,7 +23,7 @@ class SingleAutoComplete extends React.Component<Props> {
 
     searchStore: SearchStore;
 
-    constructor(props: Props) {
+    constructor(props: Props<T>) {
         super(props);
 
         const {options, selectionStore, searchProperties} = this.props;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/tests/SingleAutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/tests/SingleAutoComplete.test.js
@@ -96,7 +96,7 @@ test('Render with value of given SingleSelectionStore', () => {
     });
 
     const selectionStore = new SingleSelectionStore('tags');
-    selectionStore.item = {name: 'James Bond', number: '007'};
+    selectionStore.item = {id: 7, name: 'James Bond', number: '007'};
 
     expect(render(
         <SingleAutoComplete
@@ -115,7 +115,7 @@ test('Render in disabled state', () => {
     });
 
     const selectionStore = new SingleSelectionStore('tags');
-    selectionStore.item = {name: 'James Bond', number: '007'};
+    selectionStore.item = {id: 7, name: 'James Bond', number: '007'};
 
     expect(render(
         <SingleAutoComplete

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/tests/SingleAutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/tests/SingleAutoComplete.test.js
@@ -1,19 +1,20 @@
 // @flow
 import React from 'react';
 import {mount, shallow, render} from 'enzyme';
-import {extendObservable as mockExtendObservable} from 'mobx';
+import {extendObservable as mockExtendObservable, observable} from 'mobx';
 import SingleAutoComplete from '../SingleAutoComplete';
 import SingleAutoCompleteComponent from '../../../components/SingleAutoComplete';
 import SearchStore from '../../../stores/SearchStore';
 import SingleSelectionStore from '../../../stores/SingleSelectionStore';
 
 jest.mock('../../../stores/SearchStore', () => jest.fn());
-jest.mock('../../../stores/SingleSelectionStore', () => jest.fn(function(resourceKey) {
+jest.mock('../../../stores/SingleSelectionStore', () => jest.fn(function(resourceKey, selectedItemId, locale) {
     this.resourceKey = resourceKey;
+    this.locale = locale;
     this.set = jest.fn();
     this.loading = false;
 
-    mockExtendObservable(this, {item: undefined});
+    mockExtendObservable(this, {item: selectedItemId ? {id: selectedItemId} : undefined});
 }));
 
 test('Render in loading state when SearchStore is loading', () => {
@@ -188,7 +189,8 @@ test('Construct SearchStore with correct parameters on mount', () => {
         this.search = jest.fn();
     });
 
-    const selectionStore = new SingleSelectionStore('tags');
+    const locale = observable.box('cz');
+    const selectionStore = new SingleSelectionStore('tags', undefined, locale);
 
     shallow(
         <SingleAutoComplete
@@ -199,5 +201,5 @@ test('Construct SearchStore with correct parameters on mount', () => {
         />
     );
 
-    expect(SearchStore).toBeCalledWith('tags', ['firstName', 'lastName'], {country: 'US'});
+    expect(SearchStore).toBeCalledWith('tags', ['firstName', 'lastName'], {country: 'US'}, locale);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
@@ -33,39 +33,7 @@ exports[`Render in disabled state 1`] = `
 </div>
 `;
 
-exports[`Render in loading state 1`] = `
-<div
-  class="singleAutoComplete"
->
-  <label
-    class="input default left"
-  >
-    <div
-      class="prependedContainer default"
-    >
-      <div
-        class="spinner"
-        style="width:20px;height:20px"
-      >
-        <div
-          class="doubleBounce1"
-        />
-        <div
-          class="doubleBounce2"
-        />
-      </div>
-    </div>
-    <input
-      autocomplete="off"
-      class="mousetrap"
-      type="text"
-      value=""
-    />
-  </label>
-</div>
-`;
-
-exports[`Render with given value 1`] = `
+exports[`Render with value of given SingleSelectionStore 1`] = `
 <div
   class="singleAutoComplete"
 >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/SearchStore/SearchStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/SearchStore/SearchStore.js
@@ -1,18 +1,26 @@
 // @flow
 import {action, observable} from 'mobx';
+import type {IObservableValue} from 'mobx';
 import ResourceRequester from '../../services/ResourceRequester';
 
 export default class SearchStore {
     resourceKey: string;
     searchProperties: Array<string>;
     options: Object;
+    locale: ?IObservableValue<string>;
     @observable searchResults: Array<Object> = [];
     @observable loading: boolean = false;
 
-    constructor(resourceKey: string, searchProperties: Array<string>, options: Object = {}) {
+    constructor(
+        resourceKey: string,
+        searchProperties: Array<string>,
+        options: Object = {},
+        locale: ?IObservableValue<string>
+    ) {
         this.resourceKey = resourceKey;
         this.searchProperties = searchProperties;
         this.options = options;
+        this.locale = locale;
     }
 
     @action clearSearchResults = () => {
@@ -32,6 +40,7 @@ export default class SearchStore {
         return ResourceRequester.getList(resourceKey, {
             ...this.options,
             excludedIds,
+            locale: this.locale ? this.locale.get() : undefined,
             limit: 10,
             page: 1,
             searchFields: searchProperties,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/SearchStore/tests/SearchStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/SearchStore/tests/SearchStore.test.js
@@ -1,4 +1,5 @@
 // @flow
+import {observable} from 'mobx';
 import SearchStore from '../SearchStore';
 import ResourceRequester from '../../../services/ResourceRequester';
 
@@ -31,6 +32,34 @@ test('Send a request using the ResourceRequester when something is being searche
 
     return autoCompletePromise.then(() => {
         expect(ResourceRequester.getList).toBeCalledWith('accounts', {
+            locale: undefined,
+            limit: 10,
+            page: 1,
+            search: 'Sulu',
+            searchFields: ['name', 'number'],
+        });
+        expect(searchStore.searchResults).toEqual(searchResults);
+        expect(searchStore.loading).toEqual(false);
+    });
+});
+
+test('Send a request using the ResourceRequester with given locale when something is being searched', () => {
+    const searchStore = new SearchStore('accounts', ['name', 'number'], {}, observable.box('en'));
+    const searchResults = [{id: 1, name: 'Sulu'}];
+    const searchPromise = Promise.resolve({
+        _embedded: {
+            accounts: searchResults,
+        },
+    });
+
+    ResourceRequester.getList.mockReturnValue(searchPromise);
+
+    const autoCompletePromise = searchStore.search('Sulu');
+    expect(searchStore.loading).toEqual(true);
+
+    return autoCompletePromise.then(() => {
+        expect(ResourceRequester.getList).toBeCalledWith('accounts', {
+            locale: 'en',
             limit: 10,
             page: 1,
             search: 'Sulu',
@@ -58,6 +87,7 @@ test('Send a request using the ResourceRequester with given options when somethi
     return autoCompletePromise.then(() => {
         expect(ResourceRequester.getList).toBeCalledWith('accounts', {
             country: 'US',
+            locale: undefined,
             limit: 10,
             page: 1,
             search: 'Sulu',
@@ -85,6 +115,7 @@ test('Send a request using the ResourceRequester with excludedIds when something
     return autoCompletePromise.then(() => {
         expect(ResourceRequester.getList).toBeCalledWith('accounts', {
             excludedIds: [1, 4],
+            locale: undefined,
             limit: 10,
             page: 1,
             search: 'Sulu',

--- a/src/Sulu/Bundle/ContactBundle/Content/Types/SingleAccountSelection.php
+++ b/src/Sulu/Bundle/ContactBundle/Content/Types/SingleAccountSelection.php
@@ -59,7 +59,16 @@ class SingleAccountSelection extends ComplexContentType implements PreResolvable
     ) {
         $value = $property->getValue();
         if (null != $value) {
-            $node->setProperty($property->getName(), is_array($value) ? $value['id'] : $value);
+            if (\is_array($value)) {
+                @\trigger_error(
+                    'Passing a serialized account to the SingleAccountSelection deprecated. Please use an id instead.',
+                    \E_USER_DEPRECATED
+                );
+
+                $node->setProperty($property->getName(), $value['id']);
+            } else {
+                $node->setProperty($property->getName(), $value);
+            }
         } else {
             $this->remove($node, $property, $webspaceKey, $languageCode, $segmentKey);
         }

--- a/src/Sulu/Bundle/ContactBundle/Content/Types/SingleAccountSelection.php
+++ b/src/Sulu/Bundle/ContactBundle/Content/Types/SingleAccountSelection.php
@@ -18,6 +18,7 @@ use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\ComplexContentType;
 use Sulu\Component\Content\PreResolvableContentTypeInterface;
+use Sulu\Component\Rest\Exception\EntityNotFoundException;
 
 class SingleAccountSelection extends ComplexContentType implements PreResolvableContentTypeInterface
 {
@@ -90,7 +91,11 @@ class SingleAccountSelection extends ComplexContentType implements PreResolvable
             return null;
         }
 
-        return $this->accountManager->getById($id, $property->getStructure()->getLanguageCode());
+        try {
+            return $this->accountManager->getById($id, $property->getStructure()->getLanguageCode());
+        } catch (EntityNotFoundException $e) {
+            return null;
+        }
     }
 
     public function preResolve(PropertyInterface $property)

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/forms/account_details.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/forms/account_details.xml
@@ -47,6 +47,10 @@
                     <meta>
                         <title>sulu_contact.parent_company</title>
                     </meta>
+
+                    <params>
+                        <param name="use_deprecated_object_data_format" value="true" />
+                    </params>
                 </property>
 
                 <property name="uid" type="text_line" colspan="6">
@@ -62,6 +66,7 @@
 
                     <params>
                         <param name="type" value="auto_complete" />
+                        <param name="use_deprecated_object_data_format" value="true" />
                         <param name="data_path_to_auto_complete" type="collection">
                             <param name="id" value="accountId" />
                         </param>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/forms/contact_details.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/forms/contact_details.xml
@@ -86,6 +86,10 @@
                     <meta>
                         <title>sulu_contact.organization</title>
                     </meta>
+
+                    <params>
+                        <param name="use_deprecated_object_data_format" value="true" />
+                    </params>
                 </property>
 
                 <property

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/views/List/tests/toolbarActions/AddContactToolbarAction.test.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/views/List/tests/toolbarActions/AddContactToolbarAction.test.js
@@ -81,11 +81,11 @@ test('Reset fields if overlay is just closed', () => {
     let addContactOverlay = shallow(addContactToolbarAction.getNode());
     expect(addContactOverlay.instance().props.open).toEqual(true);
 
-    addContactOverlay.find('SingleAutoComplete').prop('onChange')({id: 3});
+    addContactOverlay.find('SingleAutoComplete').prop('selectionStore').set({id: 3});
     addContactOverlay.find('ResourceSingleSelect').prop('onChange')(5);
 
     addContactOverlay = shallow(addContactToolbarAction.getNode());
-    expect(addContactOverlay.find('SingleAutoComplete').prop('value')).toEqual({id: 3});
+    expect(addContactOverlay.find('SingleAutoComplete').prop('selectionStore').item).toEqual({id: 3});
     expect(addContactOverlay.find('ResourceSingleSelect').prop('value')).toEqual(5);
     addContactOverlay.instance().props.onClose();
 
@@ -94,7 +94,7 @@ test('Reset fields if overlay is just closed', () => {
 
     clickHandler();
     addContactOverlay = shallow(addContactToolbarAction.getNode());
-    expect(addContactOverlay.find('SingleAutoComplete').prop('value')).toEqual(undefined);
+    expect(addContactOverlay.find('SingleAutoComplete').prop('selectionStore').item).toEqual(undefined);
     expect(addContactOverlay.find('ResourceSingleSelect').prop('value')).toEqual(undefined);
 
     expect(ResourceRequester.put).not.toBeCalled();
@@ -113,7 +113,7 @@ test('Add selected contact to current account', () => {
     let addContactOverlay = shallow(addContactToolbarAction.getNode());
     expect(addContactOverlay.instance().props.open).toEqual(true);
     expect(addContactOverlay.instance().props.confirmDisabled).toEqual(true);
-    addContactOverlay.find('SingleAutoComplete').prop('onChange')({id: 3});
+    addContactOverlay.find('SingleAutoComplete').prop('selectionStore').set({id: 3});
 
     addContactOverlay = shallow(addContactToolbarAction.getNode());
     expect(addContactOverlay.instance().props.confirmDisabled).toEqual(false);
@@ -156,7 +156,7 @@ test('Add selected contact to current account with position', () => {
     clickHandler();
     let addContactOverlay = shallow(addContactToolbarAction.getNode());
     expect(addContactOverlay.instance().props.open).toEqual(true);
-    addContactOverlay.find('SingleAutoComplete').prop('onChange')({id: 3});
+    addContactOverlay.find('SingleAutoComplete').prop('selectionStore').set({id: 3});
     addContactOverlay.find('ResourceSingleSelect').prop('onChange')(5);
 
     addContactOverlay.instance().props.onConfirm();

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/SingleAccountSelectionTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/SingleAccountSelectionTest.php
@@ -75,19 +75,7 @@ class SingleAccountSelectionTest extends TestCase
         $this->node->hasProperty('account')->willReturn(true);
         $this->node->getPropertyValue('account')->willReturn(1);
 
-        $structure = $this->prophesize(StructureInterface::class);
-        $structure->getLanguageCode()->willReturn('de');
-
         $property = new Property('account', [], 'single_account_selection');
-        $property->setValue(['id' => 1]);
-        $property->setStructure($structure);
-
-        $this->account->getId()->willReturn(1);
-        $this->account->getName()->willReturn('Sulu');
-
-        $this->accountManager
-             ->getById(1, $property->getStructure()->getLanguageCode())
-             ->willReturn($this->account->reveal())->shouldBeCalled();
 
         $this->singleAccountSelection->read(
             $this->node->reveal(),
@@ -97,48 +85,30 @@ class SingleAccountSelectionTest extends TestCase
             ''
         );
 
-        $this->assertEquals(
-            [
-                'id' => 1,
-                'name' => 'Sulu',
-            ],
-            $property->getValue()
-        );
-    }
-
-    public function testReadWithNonExistingAccount()
-    {
-        $this->node->hasProperty('account')->willReturn(true);
-        $this->node->getPropertyValue('account')->willReturn(1);
-
-        $structure = $this->prophesize(StructureInterface::class);
-        $structure->getLanguageCode()->willReturn('de');
-
-        $property = new Property('account', [], 'single_account_selection');
-        $property->setValue(['id' => 1]);
-        $property->setStructure($structure);
-
-        $this->account->getId()->willReturn(1);
-        $this->account->getName()->willReturn('Sulu');
-
-        $this->accountManager
-             ->getById(1, $property->getStructure()->getLanguageCode())
-             ->willThrow(EntityNotFoundException::class)->shouldBeCalled();
-
-        $this->singleAccountSelection->read(
-            $this->node->reveal(),
-            $property,
-            'sulu',
-            'de',
-            ''
-        );
-
-        $this->assertNull($property->getValue());
+        $this->assertEquals(1, $property->getValue());
     }
 
     public function testWrite()
     {
         $this->node->setProperty('account', 1)->shouldBeCalled();
+
+        $property = new Property('account', [], 'single_account_selection');
+        $property->setValue(1);
+
+        $this->singleAccountSelection->write(
+            $this->node->reveal(),
+            $property,
+            1,
+            'sulu',
+            'de',
+            ''
+        );
+    }
+
+    public function testWriteObjectDeprecated()
+    {
+        $this->node->setProperty('account', 1)->shouldBeCalled();
+
         $property = new Property('account', [], 'single_account_selection');
         $property->setValue(['id' => 1]);
 
@@ -210,7 +180,7 @@ class SingleAccountSelectionTest extends TestCase
         $structure->getLanguageCode()->willReturn('de');
 
         $property = new Property('account', [], 'single_account_selection');
-        $property->setValue(['id' => 1]);
+        $property->setValue(1);
         $property->setStructure($structure);
 
         $this->accountManager
@@ -218,6 +188,22 @@ class SingleAccountSelectionTest extends TestCase
              ->willReturn($this->account->reveal())->shouldBeCalled();
 
         $this->assertEquals($this->account->reveal(), $this->singleAccountSelection->getContentData($property));
+    }
+
+    public function testContentDataWithNonExistingAccount()
+    {
+        $structure = $this->prophesize(StructureInterface::class);
+        $structure->getLanguageCode()->willReturn('de');
+
+        $property = new Property('account', [], 'single_account_selection');
+        $property->setValue(1);
+        $property->setStructure($structure);
+
+        $this->accountManager
+            ->getById(1, $property->getStructure()->getLanguageCode())
+            ->willThrow(EntityNotFoundException::class)->shouldBeCalled();
+
+        $this->assertNull($this->singleAccountSelection->getContentData($property));
     }
 
     public function testPreResolveEmpty()
@@ -243,7 +229,7 @@ class SingleAccountSelectionTest extends TestCase
     public function testPreResolve()
     {
         $property = new Property('account', [], 'single_account_selection');
-        $property->setValue(['id' => 22]);
+        $property->setValue(22);
 
         $this->accountReferenceStore->add(22)->shouldBeCalled();
 

--- a/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/LocationOverlay.js
+++ b/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/LocationOverlay.js
@@ -6,6 +6,7 @@ import {Form, Input, Number, Overlay} from 'sulu-admin-bundle/components';
 import {translate} from 'sulu-admin-bundle/utils';
 import {Map, Marker, TileLayer} from 'react-leaflet';
 import {SingleAutoComplete} from 'sulu-admin-bundle/containers';
+import SingleSelectionStore from 'sulu-admin-bundle/stores/SingleSelectionStore';
 import type {Location as LocationValue} from '../../types';
 import locationOverlayStyles from './locationOverlay.scss';
 
@@ -32,10 +33,19 @@ class LocationOverlay extends React.Component<Props> {
     @observable town: ?string;
     @observable country: ?string;
 
+    geolocatorSelectionStore: SingleSelectionStore<string>;
+    updateDataOnGeolocatorSelectDisposer: () => *;
     updateDataOnOpenDisposer: () => *;
 
     constructor(props: Props) {
         super(props);
+
+        this.geolocatorSelectionStore = new SingleSelectionStore('geolocator_locations');
+
+        this.updateDataOnGeolocatorSelectDisposer = reaction(
+            () => this.geolocatorSelectionStore.item,
+            this.handleAutoCompleteChange
+        );
 
         this.updateDataOnOpenDisposer = reaction(() => this.props.open, (newOpenValue) => {
             if (newOpenValue === true) {
@@ -57,6 +67,7 @@ class LocationOverlay extends React.Component<Props> {
     }
 
     componentWillUnmount() {
+        this.updateDataOnGeolocatorSelectDisposer();
         this.updateDataOnOpenDisposer();
     }
 
@@ -201,10 +212,8 @@ class LocationOverlay extends React.Component<Props> {
                         <Form.Field>
                             <SingleAutoComplete
                                 displayProperty="displayTitle"
-                                onChange={this.handleAutoCompleteChange}
-                                resourceKey="geolocator_locations"
                                 searchProperties={['displayTitle']}
-                                value={null}
+                                selectionStore={this.geolocatorSelectionStore}
                             />
                         </Form.Field>
 

--- a/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/LocationOverlay.test.js
+++ b/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/LocationOverlay.test.js
@@ -79,9 +79,7 @@ test('Should pass correct props the the SingleAutoComplete component', () => {
 
     expect(locationOverlay.find(SingleAutoComplete).props()).toEqual(expect.objectContaining({
         displayProperty: 'displayTitle',
-        resourceKey: 'geolocator_locations',
         searchProperties: ['displayTitle'],
-        value: null,
     }));
 });
 
@@ -195,7 +193,7 @@ test('Should pass correct props to the map, marker and input fields after auto-c
         country: 'new-country',
     };
 
-    locationOverlay.find(SingleAutoComplete).props().onChange(autoCompleteResult);
+    locationOverlay.find(SingleAutoComplete).props().selectionStore.set(autoCompleteResult);
     locationOverlay.update();
 
     expect(locationOverlay.find(Number).at(0).props().value).toEqual(autoCompleteResult.latitude); // lat
@@ -240,7 +238,7 @@ test('Should call onConfirm callback when the Overlay is confirmed after auto-co
         country: 'new-country',
     };
 
-    locationOverlay.find(SingleAutoComplete).props().onChange(autoCompleteResult);
+    locationOverlay.find(SingleAutoComplete).props().selectionStore.set(autoCompleteResult);
     locationOverlay.find(Overlay).props().onConfirm();
 
     expect(confirmSpy).toBeCalledWith(expect.objectContaining({


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | yes
| Deprecations? | yes
| Fixed tickets | fixes #4053, fixes #4960
| License | MIT

#### What's in this PR?

This PR adjusts the data-format used by the `auto_complete` type of the `single_selection` field-type to be consistent with other `single_selection` and `selection` types. Furthermore it adjusts the implementation of the `SingleAutoComplete` container to be consistent with other selection components. 

In practice, the changes adjust the data that is sent to the server when using a `single_account_selection` to be consistent with all other `single_*_selection` field-types:
```diff
{
     "other_property": null,
-    "single_account_selection_property": {
-        "id": 1,
-        "name": "Test Organisation",
-        ...
-    },
+    "single_account_selection_property": 1,
}
```
The old behaviour of the `single_account_selection` can be brought back by setting the `use_deprecated_object_data_format` param like this:
```diff
     <property name="single_account_selection_property" type="single_account_selection" colspan="6">
         <meta>
             <title>sulu_contact.organization</title>
         </meta>
+        <params>
+            <param name="use_deprecated_object_data_format" value="true" />
+        </params>
     </property>
```

#### Why?

Because the data-format that is used by the `single_selection` field type should be the same for all types. 