### PR TITLE
Validate Webspaces with SuluThemeBundle

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Resources/config/command.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/command.xml
@@ -54,7 +54,8 @@
             <argument type="service" id="sulu.content.structure_manager"/>
             <argument type="service" id="sulu.content.webspace_structure_provider"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
-            <argument type="service" id="liip_theme.active_theme" on-invalid="null"/>
+            <argument type="service" id="Sylius\Bundle\ThemeBundle\Repository\ThemeRepositoryInterface" on-invalid="null"/>
+            <argument type="service" id="Sylius\Bundle\ThemeBundle\Context\ThemeContextInterface" on-invalid="null"/>
 
             <tag name="console.command"/>
         </service>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

With SuluThemeBundle 3.0 validation webspace fails due to old config

#### Why?

Because we want to validate all templates in themes with
```
bin/console sulu:content:validate:webspaces
```

