### PR TITLE
Add repository interface as alias for persistence bundle service ids

### DIFF
--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/services.xml
@@ -146,5 +146,10 @@
         <service id="sulu_audience_targeting.target_group_store"
                  class="Sulu\Bundle\AudienceTargetingBundle\TargetGroup\TargetGroupStore" public="true">
         </service>
+        <!--PERSISTENCE BUNDLE REPOSITORIES-->
+        <service id="Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupRepositoryInterface" alias="sulu.repository.target_group"/>
+        <service id="Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupConditionRepositoryInterface" alias="sulu.repository.target_group_condition"/>
+        <service id="Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupRuleRepositoryInterface" alias="sulu.repository.target_group_rule"/>
+        <service id="Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupWebspaceRepositoryInterface" alias="sulu.repository.target_group_webspace"/>
     </services>
 </container>

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/services.xml
@@ -84,5 +84,11 @@
 
             <tag name="sulu.context" context="admin"/>
         </service>
+
+        <!--PERSISTENCE BUNDLE REPOSITORIES-->
+        <service id="Sulu\Bundle\CategoryBundle\Entity\CategoryRepositoryInterface" alias="sulu.repository.category"/>
+        <service id="Sulu\Bundle\CategoryBundle\Entity\CategoryMetaRepositoryInterface" alias="sulu.repository.category_meta"/>
+        <service id="Sulu\Bundle\CategoryBundle\Entity\CategoryTranslationRepositoryInterface" alias="sulu.repository.category_translation"/>
+        <service id="Sulu\Bundle\CategoryBundle\Entity\KeywordRepositoryInterface" alias="sulu.repository.keyword"/>
     </services>
 </container>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
@@ -199,5 +199,9 @@
         >
             <tag name="sulu_core.list_builder_filter_type" alias="country" />
         </service>
+
+        <!--PERSISTENCE BUNDLE REPOSITORIES-->
+        <service id="Sulu\Bundle\ContactBundle\Entity\ContactRepositoryInterface" alias="sulu.repository.contact"/>
+        <service id="Sulu\Bundle\ContactBundle\Entity\AccountRepositoryInterface" alias="sulu.repository.account"/>
     </services>
 </container>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -425,5 +425,8 @@
         <service id="sulu_media.fixtures.media_types" class="Sulu\Bundle\MediaBundle\DataFixtures\ORM\LoadMediaTypes">
             <tag name="doctrine.fixture.orm"/>
         </service>
+
+        <!--PERSISTENCE BUNDLE REPOSITORIES-->
+        <service id="Sulu\Bundle\MediaBundle\Entity\MediaRepositoryInterface" alias="sulu.repository.media"/>
     </services>
 </container>

--- a/src/Sulu/Bundle/RouteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/RouteBundle/Resources/config/services.xml
@@ -50,5 +50,8 @@
 
             <tag name="sulu.context" context="admin"/>
         </service>
+
+        <!--PERSISTENCE BUNDLE REPOSITORIES-->
+        <service id="Sulu\Bundle\RouteBundle\Entity\RouteRepositoryInterface" alias="sulu.repository.route"/>
     </services>
 </container>

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -298,5 +298,11 @@
             <tag name="kernel.event_subscriber"/>
             <tag name="sulu.context" context="admin"/>
         </service>
+
+        <!--PERSISTENCE BUNDLE REPOSITORIES-->
+        <service id="Sulu\Component\Security\Authentication\UserRepositoryInterface" alias="sulu.repository.user"/>
+        <service id="Sulu\Component\Security\Authentication\RoleRepositoryInterface" alias="sulu.repository.role"/>
+        <service id="Sulu\Component\Security\Authentication\RoleSettingRepositoryInterface" alias="sulu.repository.role_setting"/>
+        <service id="Sulu\Component\Security\Authorization\AccessControl\AccessControlRepositoryInterface" alias="sulu.repository.access_control"/>
     </services>
 </container>

--- a/src/Sulu/Bundle/TagBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/TagBundle/Resources/config/services.xml
@@ -60,5 +60,8 @@
 
             <tag name="sulu.context" context="admin"/>
         </service>
+
+        <!--PERSISTENCE BUNDLE REPOSITORIES-->
+        <service id="Sulu\Bundle\TagBundle\Tag\TagRepositoryInterface" alias="sulu.repository.tag"/>
     </services>
 </container>


### PR DESCRIPTION
Makes the built in repositories autowireable via their interface.