### PR TITLE
Prepare PHP 8 compatibility

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/MediaImageExtractorTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/MediaImageExtractorTest.php
@@ -55,7 +55,12 @@ class MediaImageExtractorTest extends TestCase
         // bug with aws s3 unseekable resources: https://github.com/sulu/sulu/issues/5468
         // if this test fail the createUnseekableResource is maybe wrong
         $this->expectWarning();
-        $this->expectWarningMessage('mime_content_type(): stream does not support seeking');
+
+        if (\PHP_VERSION_ID >= 80000) {
+            $this->expectWarningMessage('mime_content_type(): Stream does not support seeking');
+        } else {
+            $this->expectWarningMessage('mime_content_type(): stream does not support seeking');
+        }
 
         $this->mediaImageExtractor->extract($resource);
     }

--- a/src/Sulu/Bundle/RouteBundle/Generator/SymfonyExpressionTokenProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Generator/SymfonyExpressionTokenProvider.php
@@ -54,7 +54,7 @@ class SymfonyExpressionTokenProvider implements TokenProviderInterface
         $locale = $this->translator->getLocale();
 
         try {
-            if (\method_exists($entity, 'getLocale')) {
+            if (\is_object($entity) && \method_exists($entity, 'getLocale')) {
                 $this->translator->setLocale($entity->getLocale());
             }
 

--- a/src/Sulu/Component/Rest/RestControllerTrait.php
+++ b/src/Sulu/Component/Rest/RestControllerTrait.php
@@ -214,7 +214,7 @@ trait RestControllerTrait
         // FIXME: this is just a hack to avoid relations that start with index != 0
         // FIXME: otherwise deserialization process will parse relations as object instead of an array
         // reindex entities
-        if (\count($entities) > 0 && \method_exists($entities, 'getValues')) {
+        if (\count($entities) > 0 && \is_object($entities) && \method_exists($entities, 'getValues')) {
             $newEntities = $entities->getValues();
             $entities->clear();
             foreach ($newEntities as $value) {

--- a/src/Sulu/Component/Util/SuluNodeHelper.php
+++ b/src/Sulu/Component/Util/SuluNodeHelper.php
@@ -250,7 +250,8 @@ class SuluNodeHelper
         $newPath = PathHelper::getParentPath($path);
         $newPath = \substr($newPath, \strlen($snippetsPath));
 
-        if (false === $newPath) {
+        // $newPath can be false or empty because of return difference of substr depending on php version (<= 7.4, 8.0)
+        if (!$newPath) {
             throw new \InvalidArgumentException(
                 \sprintf(
                     'Cannot extract snippet template type from path "%s"',

--- a/src/Sulu/Component/Util/Tests/Unit/SortUtilsTest.php
+++ b/src/Sulu/Component/Util/Tests/Unit/SortUtilsTest.php
@@ -105,16 +105,26 @@ class SortUtilsTest extends TestCase
                 '[foo]', ['2', '1', '3'],
             ],
 
-            // multi dimensional array missing key
+            // multi dimensional array missing key asc
             [
                 [
                     ['foo' => '1', 'baz' => ['bar' => 'bbb']],
                     ['foo' => '2', 'baz' => ['sad' => 'aaa']],
-                    ['foo' => '3', 'baz' => ['bad' => 'ccc']],
                 ],
                 '[baz][bar]',
                 'asc',
-                '[foo]', ['3', '2', '1'],
+                '[foo]', ['2', '1'],
+            ],
+
+            // multi dimensional array missing key desc
+            [
+                [
+                    ['foo' => '1', 'baz' => ['bar' => 'bbb']],
+                    ['foo' => '2', 'baz' => ['sad' => 'aaa']],
+                ],
+                '[baz][bar]',
+                'desc',
+                '[foo]', ['1', '2'],
             ],
         ];
     }

--- a/src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
+++ b/src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
@@ -179,6 +179,7 @@ class SuluNodeHelperTest extends TestCase
         return [
             ['/cmf/snippets/foobar/snippet1', 'foobar'],
             ['/cmf/snippets/bar-foo/snippet2', 'bar-foo'],
+            ['/cmf', null, false],
             ['/cmf/snippets', null, false],
             ['/cmf/snippets/bar', null, false],
             ['/cmf/snippets/animal/elephpant', 'animal'],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | yes
| BC breaks? | no 
| Deprecations? | no 
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add PHP 8 compatibility

#### Why?

This fixes codes which are needed for the PHP 8 compatibility to be changed. See also #5757

