### PR TITLE
Prepare PHP 8 compatibility for 2.2

### DIFF
--- a/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
@@ -103,12 +103,12 @@ class DataProviderRepositoryTraitTest extends TestCase
                 $this->queryBuilder = $queryBuilder;
             }
 
-            public function createQueryBuilder()
+            public function createQueryBuilder($alias, $indexBy = null)
             {
                 return $this->queryBuilder;
             }
 
-            public function appendJoins()
+            public function appendJoins(QueryBuilder $queryBuilder, $alias, $locale)
             {
             }
         };


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? |  yes
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Prepare PHP 8 compatibility for 2.2.

#### Why?

To support PHP 8 soon.


Wait: https://github.com/sulu/sulu/pull/5817