### PR TITLE
Allow to pass included properties to sulu_content_load

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
@@ -45,7 +45,7 @@ class StructureResolver implements StructureResolverInterface
 
     public function resolve(StructureInterface $structure, bool $loadExcerpt = true/*, array $includedProperties = null*/)
     {
-        $includedProperties = (\func_num_args() > 2) ? null : \func_get_arg(2);
+        $includedProperties = (\func_num_args() > 2) ? \func_get_arg(2) : null;
 
         $data = [
             'view' => [],

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
@@ -43,7 +43,7 @@ class StructureResolver implements StructureResolverInterface
         $this->extensionManager = $structureManager;
     }
 
-    public function resolve(StructureInterface $structure, bool $loadExcerpt = true)
+    public function resolve(StructureInterface $structure, bool $loadExcerpt = true, array $includedProperties = null)
     {
         $data = [
             'view' => [],
@@ -96,17 +96,21 @@ class StructureResolver implements StructureResolverInterface
 
         // pre-resolve content-types
         foreach ($structure->getProperties(true) as $property) {
-            $contentType = $this->contentTypeManager->get($property->getContentTypeName());
+            if ($includedProperties === null || in_array($property->getName(), $includedProperties)) {
+                $contentType = $this->contentTypeManager->get($property->getContentTypeName());
 
-            if ($contentType instanceof PreResolvableContentTypeInterface) {
-                $contentType->preResolve($property);
+                if ($contentType instanceof PreResolvableContentTypeInterface) {
+                    $contentType->preResolve($property);
+                }
             }
         }
 
         foreach ($structure->getProperties(true) as $property) {
-            $contentType = $this->contentTypeManager->get($property->getContentTypeName());
-            $data['view'][$property->getName()] = $contentType->getViewData($property);
-            $data['content'][$property->getName()] = $contentType->getContentData($property);
+            if ($includedProperties === null || in_array($property->getName(), $includedProperties)) {
+                $contentType = $this->contentTypeManager->get($property->getContentTypeName());
+                $data['view'][$property->getName()] = $contentType->getViewData($property);
+                $data['content'][$property->getName()] = $contentType->getContentData($property);
+            }
         }
 
         return $data;

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
@@ -43,8 +43,10 @@ class StructureResolver implements StructureResolverInterface
         $this->extensionManager = $structureManager;
     }
 
-    public function resolve(StructureInterface $structure, bool $loadExcerpt = true, array $includedProperties = null)
+    public function resolve(StructureInterface $structure, bool $loadExcerpt = true/*, array $includedProperties = null*/)
     {
+        $includedProperties = (\func_num_args() > 2) ? null : \func_get_arg(2);
+
         $data = [
             'view' => [],
             'content' => [],

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
@@ -96,7 +96,7 @@ class StructureResolver implements StructureResolverInterface
 
         // pre-resolve content-types
         foreach ($structure->getProperties(true) as $property) {
-            if ($includedProperties === null || in_array($property->getName(), $includedProperties)) {
+            if (null === $includedProperties || \in_array($property->getName(), $includedProperties)) {
                 $contentType = $this->contentTypeManager->get($property->getContentTypeName());
 
                 if ($contentType instanceof PreResolvableContentTypeInterface) {
@@ -106,7 +106,7 @@ class StructureResolver implements StructureResolverInterface
         }
 
         foreach ($structure->getProperties(true) as $property) {
-            if ($includedProperties === null || in_array($property->getName(), $includedProperties)) {
+            if (null === $includedProperties || \in_array($property->getName(), $includedProperties)) {
                 $contentType = $this->contentTypeManager->get($property->getContentTypeName());
                 $data['view'][$property->getName()] = $contentType->getViewData($property);
                 $data['content'][$property->getName()] = $contentType->getContentData($property);

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolverInterface.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolverInterface.php
@@ -26,5 +26,5 @@ interface StructureResolverInterface
      *
      * @return array
      */
-    public function resolve(StructureInterface $structure, bool $loadExcerpt = true, array $includedProperties = null);
+    public function resolve(StructureInterface $structure, bool $loadExcerpt = true/*, array $includedProperties = null*/);
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolverInterface.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolverInterface.php
@@ -26,5 +26,5 @@ interface StructureResolverInterface
      *
      * @return array
      */
-    public function resolve(StructureInterface $structure, bool $loadExcerpt = true);
+    public function resolve(StructureInterface $structure, bool $loadExcerpt = true, array $includedProperties = null);
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Resolver/StructureResolverTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Resolver/StructureResolverTest.php
@@ -61,7 +61,6 @@ class StructureResolverTest extends TestCase
     public function testResolve()
     {
         $this->contentTypeManager->get('content_type')->willReturn($this->contentType);
-
         $this->contentType->getViewData(Argument::any())->willReturn('view');
         $this->contentType->getContentData(Argument::any())->willReturn('content');
 
@@ -69,15 +68,19 @@ class StructureResolverTest extends TestCase
         $excerptExtension->getContentData(['test1' => 'test1'])->willReturn(['test1' => 'test1']);
         $this->extensionManager->getExtension('test', 'excerpt')->willReturn($excerptExtension);
 
-        $property = $this->prophesize('Sulu\Component\Content\Compat\PropertyInterface');
-        $property->getName()->willReturn('property');
-        $property->getContentTypeName()->willReturn('content_type');
+        $property1 = $this->prophesize('Sulu\Component\Content\Compat\PropertyInterface');
+        $property1->getName()->willReturn('property-1');
+        $property1->getContentTypeName()->willReturn('content_type');
+
+        $property2 = $this->prophesize('Sulu\Component\Content\Compat\PropertyInterface');
+        $property2->getName()->willReturn('property-2');
+        $property2->getContentTypeName()->willReturn('content_type');
 
         $structure = $this->prophesize('Sulu\Component\Content\Compat\Structure\PageBridge');
         $structure->getKey()->willReturn('test');
         $structure->getExt()->willReturn(new ExtensionContainer(['excerpt' => ['test1' => 'test1']]));
         $structure->getUuid()->willReturn('some-uuid');
-        $structure->getProperties(true)->willReturn([$property->reveal()]);
+        $structure->getProperties(true)->willReturn([$property1->reveal(), $property2->reveal()]);
         $structure->getCreator()->willReturn(1);
         $structure->getChanger()->willReturn(1);
         $structure->getCreated()->willReturn('date');
@@ -103,10 +106,12 @@ class StructureResolverTest extends TestCase
             'id' => 'some-uuid',
             'uuid' => 'some-uuid',
             'view' => [
-                'property' => 'view',
+                'property-1' => 'view',
+                'property-2' => 'view',
             ],
             'content' => [
-                'property' => 'content',
+                'property-1' => 'content',
+                'property-2' => 'content',
             ],
             'creator' => 1,
             'changer' => 1,
@@ -187,5 +192,75 @@ class StructureResolverTest extends TestCase
         ];
 
         $this->assertEquals($expected, $this->structureResolver->resolve($structure->reveal(), false));
+    }
+
+    public function testResolveWithIncludedProperties()
+    {
+        $this->contentTypeManager->get('content_type')->willReturn($this->contentType);
+        $this->contentType->getViewData(Argument::any())->willReturn('view');
+        $this->contentType->getContentData(Argument::any())->willReturn('content');
+
+        $excerptExtension = $this->prophesize('Sulu\Component\Content\Extension\ExtensionInterface');
+        $excerptExtension->getContentData(['test1' => 'test1'])->willReturn(['test1' => 'test1']);
+        $this->extensionManager->getExtension('test', 'excerpt')->willReturn($excerptExtension);
+
+        $property1 = $this->prophesize('Sulu\Component\Content\Compat\PropertyInterface');
+        $property1->getName()->willReturn('property-1');
+        $property1->getContentTypeName()->willReturn('content_type');
+
+        $property2 = $this->prophesize('Sulu\Component\Content\Compat\PropertyInterface');
+        $property2->getName()->willReturn('property-2');
+        $property2->getContentTypeName()->willReturn('content_type');
+
+        $structure = $this->prophesize('Sulu\Component\Content\Compat\Structure\PageBridge');
+        $structure->getKey()->willReturn('test');
+        $structure->getExt()->willReturn(new ExtensionContainer(['excerpt' => ['test1' => 'test1']]));
+        $structure->getUuid()->willReturn('some-uuid');
+        $structure->getProperties(true)->willReturn([$property1->reveal(), $property2->reveal()]);
+        $structure->getCreator()->willReturn(1);
+        $structure->getChanger()->willReturn(1);
+        $structure->getCreated()->willReturn('date');
+        $structure->getChanged()->willReturn('date');
+        $structure->getPublished()->willReturn('date');
+        $structure->getPath()->willReturn('test-path');
+        $structure->getUrls()->willReturn(['en' => '/description', 'de' => '/beschreibung', 'es' => null]);
+        $structure->getShadowBaseLanguage()->willReturn('en');
+        $structure->getWebspaceKey()->willReturn('test');
+
+        $authored = new \DateTime();
+
+        $document = $this->prophesize()->willImplement(LocalizedAuthorBehavior::class);
+        $document->willImplement(ExtensionBehavior::class);
+        $structure->getDocument()->willReturn($document->reveal());
+        $document->getAuthored()->willReturn($authored);
+        $document->getAuthor()->willReturn(1);
+
+        $expected = [
+            'extension' => [
+                'excerpt' => ['test1' => 'test1'],
+            ],
+            'id' => 'some-uuid',
+            'uuid' => 'some-uuid',
+            'view' => [
+                'property-2' => 'view',
+            ],
+            'content' => [
+                'property-2' => 'content',
+            ],
+            'creator' => 1,
+            'changer' => 1,
+            'created' => 'date',
+            'changed' => 'date',
+            'published' => 'date',
+            'template' => 'test',
+            'urls' => ['en' => '/description', 'de' => '/beschreibung', 'es' => null],
+            'path' => 'test-path',
+            'shadowBaseLocale' => 'en',
+            'authored' => $authored,
+            'author' => 1,
+            'webspaceKey' => 'test',
+        ];
+
+        $this->assertEquals($expected, $this->structureResolver->resolve($structure->reveal(), true, ['property-2']));
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/ContentTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/ContentTwigExtensionTest.php
@@ -15,16 +15,12 @@ use PHPCR\NodeInterface;
 use PHPCR\SessionInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\LoggerInterface;
-use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolver;
 use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;
 use Sulu\Bundle\WebsiteBundle\Twig\Content\ContentTwigExtension;
-use Sulu\Component\Content\Compat\Property;
 use Sulu\Component\Content\Compat\Structure\StructureBridge;
-use Sulu\Component\Content\ContentTypeManagerInterface;
-use Sulu\Component\Content\Extension\ExtensionManagerInterface;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
-use Sulu\Component\Content\Types\TextLine;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
@@ -34,57 +30,47 @@ use Sulu\Component\Webspace\Webspace;
 class ContentTwigExtensionTest extends TestCase
 {
     /**
-     * @var StructureResolverInterface
+     * @var StructureResolverInterface|ObjectProphecy
      */
     private $structureResolver;
 
     /**
-     * @var ContentMapperInterface
+     * @var ContentMapperInterface|ObjectProphecy
      */
     private $contentMapper;
 
     /**
-     * @var RequestAnalyzerInterface
+     * @var RequestAnalyzerInterface|ObjectProphecy
      */
     private $requestAnalyzer;
 
     /**
-     * @var ExtensionManagerInterface
-     */
-    private $extensionManager;
-
-    /**
-     * @var ContentTypeManagerInterface
-     */
-    private $contentTypeManager;
-
-    /**
-     * @var SessionManagerInterface
+     * @var SessionManagerInterface|ObjectProphecy
      */
     private $sessionManager;
 
     /**
-     * @var SessionInterface
+     * @var SessionInterface|ObjectProphecy
      */
     private $session;
 
     /**
-     * @var NodeInterface
+     * @var NodeInterface|ObjectProphecy
      */
     private $node;
 
     /**
-     * @var NodeInterface
+     * @var NodeInterface|ObjectProphecy
      */
     private $parentNode;
 
     /**
-     * @var NodeInterface
+     * @var NodeInterface|ObjectProphecy
      */
     private $startPageNode;
 
     /**
-     * @var LoggerInterface
+     * @var LoggerInterface|ObjectProphecy
      */
     private $logger;
 
@@ -97,10 +83,9 @@ class ContentTwigExtensionTest extends TestCase
     {
         parent::setUp();
 
+        $this->structureResolver = $this->prophesize(StructureResolverInterface::class);
         $this->contentMapper = $this->prophesize(ContentMapperInterface::class);
         $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
-        $this->contentTypeManager = $this->prophesize(ContentTypeManagerInterface::class);
-        $this->extensionManager = $this->prophesize(ExtensionManagerInterface::class);
         $this->sessionManager = $this->prophesize(SessionManagerInterface::class);
         $this->session = $this->prophesize(SessionInterface::class);
         $this->node = $this->prophesize(NodeInterface::class);
@@ -118,8 +103,6 @@ class ContentTwigExtensionTest extends TestCase
         $this->requestAnalyzer->getWebspace()->willReturn($webspace);
         $this->requestAnalyzer->getCurrentLocalization()->willReturn($locale);
 
-        $this->contentTypeManager->get('text_line')->willReturn(new TextLine(''));
-
         $this->sessionManager->getSession()->willReturn($this->session->reveal());
         $this->sessionManager->getContentNode('sulu_test')->willReturn($this->startPageNode->reveal());
 
@@ -135,52 +118,166 @@ class ContentTwigExtensionTest extends TestCase
 
         $this->startPageNode->getDepth()->willReturn(3);
 
-        $this->structureResolver = new StructureResolver(
-            $this->contentTypeManager->reveal(),
-            $this->extensionManager->reveal()
-        );
-
         $this->extension = new ContentTwigExtension(
             $this->contentMapper->reveal(),
-            $this->structureResolver,
+            $this->structureResolver->reveal(),
             $this->sessionManager->reveal(),
             $this->requestAnalyzer->reveal()
         );
     }
 
-    public function testLoad()
+    public function testLoadWithoutProperties()
     {
         $testStructure = $this->prophesize(StructureBridge::class);
-        $testStructure->getKey()->willReturn('test');
-        $testStructure->getPath()->willReturn(null);
-        $testStructure->getUuid()->willReturn('123-123-123');
-        $testStructure->getCreator()->willReturn(1);
-        $testStructure->getChanger()->willReturn(1);
-        $testStructure->getCreated()->willReturn(null);
-        $testStructure->getChanged()->willReturn(null);
-        $testStructure->getDocument()->willReturn(null);
 
-        $titleProperty = new Property('title', [], 'text_line');
-        $titleProperty->setValue('test');
-        $testStructure->getProperties(true)->willReturn([$titleProperty]);
+        $this->contentMapper->load('123-123-123', 'sulu_test', 'en_us')
+            ->willReturn($testStructure->reveal());
 
-        $this
-            ->contentMapper
-            ->load('123-123-123', 'sulu_test', 'en_us')
-            ->willReturn($testStructure);
+        $resolvedStructure = [
+            'id' => 'some-uuid',
+            'template' => 'test',
+            'view' => [
+                'property-1' => 'view',
+                'property-2' => 'view',
+            ],
+            'content' => [
+                'property-1' => 'content',
+                'property-2' => 'content',
+            ],
+            'extension' => [
+                'excerpt' => ['test1' => 'test1'],
+            ],
+        ];
+        $this->structureResolver->resolve($testStructure->reveal())->willReturn($resolvedStructure);
 
         $result = $this->extension->load('123-123-123');
 
-        // uuid
-        $this->assertEquals('123-123-123', $result['uuid']);
+        $this->assertSame($resolvedStructure, $result);
+    }
 
-        // metadata
-        $this->assertEquals(1, $result['creator']);
-        $this->assertEquals(1, $result['changer']);
+    public function testLoadWithProperties()
+    {
+        $testStructure = $this->prophesize(StructureBridge::class);
 
-        // content
-        $this->assertEquals(['title' => 'test'], $result['content']);
-        $this->assertEquals(['title' => []], $result['view']);
+        $this->contentMapper->load('123-123-123', 'sulu_test', 'en_us')
+            ->willReturn($testStructure->reveal());
+
+        $this->structureResolver->resolve(
+            $testStructure->reveal(),
+            false,
+            ['property-1']
+        )->willReturn([
+            'id' => 'some-uuid',
+            'template' => 'test',
+            'view' => [
+                'property-1' => 'view',
+            ],
+            'content' => [
+                'property-1' => 'content',
+            ],
+        ]);
+
+        $result = $this->extension->load('123-123-123', ['property-1']);
+
+        $this->assertSame(
+            [
+                'id' => 'some-uuid',
+                'template' => 'test',
+                'view' => [
+                    'property-1' => 'view',
+                ],
+                'content' => [
+                    'property-1' => 'content',
+                ],
+            ],
+            $result
+        );
+    }
+
+    public function testLoadWithPropertiesWithKeys()
+    {
+        $testStructure = $this->prophesize(StructureBridge::class);
+
+        $this->contentMapper->load('123-123-123', 'sulu_test', 'en_us')
+            ->willReturn($testStructure->reveal());
+
+        $this->structureResolver->resolve(
+            $testStructure->reveal(),
+            false,
+            ['property-1']
+        )->willReturn([
+            'id' => 'some-uuid',
+            'template' => 'test',
+            'view' => [
+                'property-1' => 'view',
+            ],
+            'content' => [
+                'property-1' => 'content',
+            ],
+        ]);
+
+        $result = $this->extension->load('123-123-123', ['property-1' => 'myTemplateTitle']);
+
+        $this->assertSame(
+            [
+                'id' => 'some-uuid',
+                'template' => 'test',
+                'view' => [
+                    'myTemplateTitle' => 'view',
+                ],
+                'content' => [
+                    'myTemplateTitle' => 'content',
+                ],
+            ],
+            $result
+        );
+    }
+
+    public function testLoadWithPropertiesIncludingExcerpt()
+    {
+        $testStructure = $this->prophesize(StructureBridge::class);
+
+        $this->contentMapper->load('123-123-123', 'sulu_test', 'en_us')
+            ->willReturn($testStructure->reveal());
+
+        $this->structureResolver->resolve(
+            $testStructure->reveal(),
+            true,
+            ['property-1']
+        )->willReturn([
+            'id' => 'some-uuid',
+            'template' => 'test',
+            'view' => [
+                'property-1' => 'view',
+            ],
+            'content' => [
+                'property-1' => 'content',
+            ],
+            'extension' => [
+                'excerpt' => ['title' => 'test-title', 'description' => 'test-description'],
+            ],
+        ]);
+
+        $result = $this->extension->load(
+            '123-123-123',
+            ['property-1' => 'myTemplateTitle', 'excerpt.title' => 'excerptTitle']
+        );
+
+        $this->assertSame(
+            [
+                'id' => 'some-uuid',
+                'template' => 'test',
+                'view' => [
+                    'myTemplateTitle' => 'view',
+                    'excerptTitle' => [],
+                ],
+                'content' => [
+                    'myTemplateTitle' => 'content',
+                    'excerptTitle' => 'test-title',
+                ],
+            ],
+            $result
+        );
     }
 
     public function testLoadNull()
@@ -206,39 +303,76 @@ class ContentTwigExtensionTest extends TestCase
         $this->assertNull($this->extension->load('999-999-999'));
     }
 
-    public function testLoadParent()
+    public function testLoadParentWithoutProperties()
     {
         $testStructure = $this->prophesize(StructureBridge::class);
-        $testStructure->getKey()->willReturn('test');
-        $testStructure->getPath()->willReturn(null);
-        $testStructure->getUuid()->willReturn('321-321-321');
-        $testStructure->getCreator()->willReturn(1);
-        $testStructure->getChanger()->willReturn(1);
-        $testStructure->getCreated()->willReturn(null);
-        $testStructure->getChanged()->willReturn(null);
-        $testStructure->getDocument()->willReturn(null);
 
-        $titleProperty = new Property('title', [], 'text_line');
-        $titleProperty->setValue('test');
-        $testStructure->getProperties(true)->willReturn([$titleProperty]);
-
-        $this
-            ->contentMapper
-            ->load('321-321-321', 'sulu_test', 'en_us')
+        $this->contentMapper->load('321-321-321', 'sulu_test', 'en_us')
             ->willReturn($testStructure);
+
+        $resolvedStructure = [
+            'id' => 'some-uuid',
+            'template' => 'test',
+            'view' => [
+                'property-1' => 'view',
+                'property-2' => 'view',
+            ],
+            'content' => [
+                'property-1' => 'content',
+                'property-2' => 'content',
+            ],
+            'extension' => [
+                'excerpt' => ['test1' => 'test1'],
+            ],
+        ];
+        $this->structureResolver->resolve($testStructure->reveal())->willReturn($resolvedStructure);
 
         $result = $this->extension->loadParent('123-123-123');
 
-        // uuid
-        $this->assertEquals('321-321-321', $result['uuid']);
+        $this->assertSame($resolvedStructure, $result);
+    }
 
-        // metadata
-        $this->assertEquals(1, $result['creator']);
-        $this->assertEquals(1, $result['changer']);
+    public function testLoadParentWithProperties()
+    {
+        $testStructure = $this->prophesize(StructureBridge::class);
 
-        // content
-        $this->assertEquals(['title' => 'test'], $result['content']);
-        $this->assertEquals(['title' => []], $result['view']);
+        $this->contentMapper->load('321-321-321', 'sulu_test', 'en_us')
+            ->willReturn($testStructure);
+
+        $this->structureResolver->resolve($testStructure->reveal(), true, ['property-1'])->willReturn([
+            'id' => 'some-uuid',
+            'template' => 'test',
+            'view' => [
+                'property-1' => 'view',
+            ],
+            'content' => [
+                'property-1' => 'content',
+            ],
+            'extension' => [
+                'excerpt' => ['title' => 'test-title', 'description' => 'test-description'],
+            ],
+        ]);
+
+        $result = $this->extension->loadParent(
+            '123-123-123',
+            ['property-1' => 'myTemplateTitle', 'excerpt.title' => 'excerptTitle']
+        );
+
+        $this->assertSame(
+            [
+                'id' => 'some-uuid',
+                'template' => 'test',
+                'view' => [
+                    'myTemplateTitle' => 'view',
+                    'excerptTitle' => [],
+                ],
+                'content' => [
+                    'myTemplateTitle' => 'content',
+                    'excerptTitle' => 'test-title',
+                ],
+            ],
+            $result
+        );
     }
 
     public function testLoadParentStartPage()

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/ContentTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/ContentTwigExtensionTest.php
@@ -165,7 +165,7 @@ class ContentTwigExtensionTest extends TestCase
         $this->structureResolver->resolve(
             $testStructure->reveal(),
             false,
-            ['property-1']
+            ['property-1', 'invalid-property-name']
         )->willReturn([
             'id' => 'some-uuid',
             'template' => 'test',
@@ -177,7 +177,7 @@ class ContentTwigExtensionTest extends TestCase
             ],
         ]);
 
-        $result = $this->extension->load('123-123-123', ['property-1']);
+        $result = $this->extension->load('123-123-123', ['property-1', 'invalid-property-name']);
 
         $this->assertSame(
             [
@@ -204,7 +204,7 @@ class ContentTwigExtensionTest extends TestCase
         $this->structureResolver->resolve(
             $testStructure->reveal(),
             false,
-            ['property-1']
+            ['property-1', 'invalid-property-name']
         )->willReturn([
             'id' => 'some-uuid',
             'template' => 'test',
@@ -216,17 +216,20 @@ class ContentTwigExtensionTest extends TestCase
             ],
         ]);
 
-        $result = $this->extension->load('123-123-123', ['property-1' => 'myTemplateTitle']);
+        $result = $this->extension->load(
+            '123-123-123',
+            ['myTemplateProperty' => 'property-1', 'invalidProperty' => 'invalid-property-name']
+        );
 
         $this->assertSame(
             [
                 'id' => 'some-uuid',
                 'template' => 'test',
                 'view' => [
-                    'myTemplateTitle' => 'view',
+                    'myTemplateProperty' => 'view',
                 ],
                 'content' => [
-                    'myTemplateTitle' => 'content',
+                    'myTemplateProperty' => 'content',
                 ],
             ],
             $result
@@ -260,7 +263,7 @@ class ContentTwigExtensionTest extends TestCase
 
         $result = $this->extension->load(
             '123-123-123',
-            ['property-1' => 'myTemplateTitle', 'excerpt.title' => 'excerptTitle']
+            ['myTemplateProperty' => 'property-1', 'excerptTitle' => 'excerpt.title']
         );
 
         $this->assertSame(
@@ -268,11 +271,11 @@ class ContentTwigExtensionTest extends TestCase
                 'id' => 'some-uuid',
                 'template' => 'test',
                 'view' => [
-                    'myTemplateTitle' => 'view',
+                    'myTemplateProperty' => 'view',
                     'excerptTitle' => [],
                 ],
                 'content' => [
-                    'myTemplateTitle' => 'content',
+                    'myTemplateProperty' => 'content',
                     'excerptTitle' => 'test-title',
                 ],
             ],
@@ -355,7 +358,7 @@ class ContentTwigExtensionTest extends TestCase
 
         $result = $this->extension->loadParent(
             '123-123-123',
-            ['property-1' => 'myTemplateTitle', 'excerpt.title' => 'excerptTitle']
+            ['myTemplateProperty' => 'property-1', 'excerptTitle' => 'excerpt.title']
         );
 
         $this->assertSame(
@@ -363,11 +366,11 @@ class ContentTwigExtensionTest extends TestCase
                 'id' => 'some-uuid',
                 'template' => 'test',
                 'view' => [
-                    'myTemplateTitle' => 'view',
+                    'myTemplateProperty' => 'view',
                     'excerptTitle' => [],
                 ],
                 'content' => [
-                    'myTemplateTitle' => 'content',
+                    'myTemplateProperty' => 'content',
                     'excerptTitle' => 'test-title',
                 ],
             ],

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
@@ -126,35 +126,35 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
         $contentProperties = [];
         $extensionProperties = [];
 
-        foreach ($properties as $sourceProperty => $targetProperty) {
-            if (!\is_string($sourceProperty)) {
-                $sourceProperty = $targetProperty;
+        foreach ($properties as $targetProperty => $sourceProperty) {
+            if (!\is_string($targetProperty)) {
+                $targetProperty = $sourceProperty;
             }
 
             if (!\strpos($sourceProperty, '.')) {
-                $contentProperties[$sourceProperty] = $targetProperty;
+                $contentProperties[$targetProperty] = $sourceProperty;
             } else {
-                $extensionProperties[$sourceProperty] = $targetProperty;
+                $extensionProperties[$targetProperty] = $sourceProperty;
             }
         }
 
         $resolvedStructure = $this->structureResolver->resolve(
             $contentStructure,
             !empty($extensionProperties),
-            \array_keys($contentProperties)
+            \array_values($contentProperties)
         );
 
-        foreach ($contentProperties as $sourceProperty => $targetProperty) {
-            if ($sourceProperty !== $targetProperty) {
+        foreach ($contentProperties as $targetProperty => $sourceProperty) {
+            if (isset($resolvedStructure['content'][$sourceProperty]) && $sourceProperty !== $targetProperty) {
                 $resolvedStructure['content'][$targetProperty] = $resolvedStructure['content'][$sourceProperty];
-                $resolvedStructure['view'][$targetProperty] = $resolvedStructure['view'][$sourceProperty];
+                $resolvedStructure['view'][$targetProperty] = $resolvedStructure['view'][$sourceProperty] ?? [];
 
                 unset($resolvedStructure['content'][$sourceProperty]);
                 unset($resolvedStructure['view'][$sourceProperty]);
             }
         }
 
-        foreach ($extensionProperties as $sourceProperty => $targetProperty) {
+        foreach ($extensionProperties as $targetProperty => $sourceProperty) {
             [$extensionName, $propertyName] = \explode('.', $sourceProperty);
             $propertyValue = $resolvedStructure['extension'][$extensionName][$propertyName];
 

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
@@ -77,7 +77,7 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
         ];
     }
 
-    public function load($uuid)
+    public function load($uuid, bool $includeExtensions = true, array $includedProperties = null)
     {
         if (!$uuid) {
             return;
@@ -90,7 +90,7 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
                 $this->requestAnalyzer->getCurrentLocalization()->getLocale()
             );
 
-            return $this->structureResolver->resolve($contentStructure);
+            return $this->structureResolver->resolve($contentStructure, $includeExtensions, $includedProperties);
         } catch (DocumentNotFoundException $e) {
             $this->logger->error((string) $e);
 
@@ -98,7 +98,7 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
         }
     }
 
-    public function loadParent($uuid)
+    public function loadParent($uuid, bool $includeExtensions = true, array $includedProperties = null)
     {
         $session = $this->sessionManager->getSession();
         $contentsNode = $this->sessionManager->getContentNode($this->requestAnalyzer->getWebspace()->getKey());
@@ -108,6 +108,6 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
             throw new ParentNotFoundException($uuid);
         }
 
-        return $this->load($node->getParent()->getIdentifier());
+        return $this->load($node->getParent()->getIdentifier(), $includeExtensions, $includedProperties);
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
@@ -90,40 +90,50 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
                 $this->requestAnalyzer->getCurrentLocalization()->getLocale()
             );
 
-            if ($properties === null) {
+            if (null === $properties) {
                 return $this->structureResolver->resolve($contentStructure);
-            } else {
-                $contentProperties = [];
-                $extensionProperties = [];
-                foreach ($properties as $targetProperty => $sourceProperty) {
-                    if (!\is_string($targetProperty)) {
-                        $targetProperty = $sourceProperty;
-                    }
-
-                    if (strpos($sourceProperty, '.')) {
-                        $extensionProperties[$targetProperty] = $sourceProperty;
-                    } else {
-                        $contentProperties[$targetProperty] = $sourceProperty;
-                    }
-                }
-
-                $resolvedStructure = $this->structureResolver->resolve(
-                    $contentStructure,
-                    !empty($extensionProperties),
-                    array_values($contentProperties)
-                );
-
-                foreach ($extensionProperties as $targetProperty => $sourceProperty) {
-                    [$extensionName, $propertyName] = explode('.', $sourceProperty);
-                    $propertyValue = $resolvedStructure['extension'][$extensionName][$propertyName];
-
-                    $resolvedStructure['content'][$targetProperty] =  $propertyValue;
-                    $resolvedStructure['view'][$targetProperty] = [];
-                }
-                unset($resolvedStructure['extension']);
-
-                return $resolvedStructure;
             }
+
+            $contentProperties = [];
+            $extensionProperties = [];
+            foreach ($properties as $sourceProperty => $targetProperty) {
+                if (!\is_string($sourceProperty)) {
+                    $sourceProperty = $targetProperty;
+                }
+
+                if (!\strpos($sourceProperty, '.')) {
+                    $contentProperties[$sourceProperty] = $targetProperty;
+                } else {
+                    $extensionProperties[$sourceProperty] = $targetProperty;
+                }
+            }
+
+            $resolvedStructure = $this->structureResolver->resolve(
+                $contentStructure,
+                !empty($extensionProperties),
+                \array_keys($contentProperties)
+            );
+
+            foreach ($contentProperties as $sourceProperty => $targetProperty) {
+                if ($sourceProperty !== $targetProperty) {
+                    $resolvedStructure['content'][$targetProperty] = $resolvedStructure['content'][$sourceProperty];
+                    $resolvedStructure['view'][$targetProperty] = $resolvedStructure['view'][$sourceProperty];
+
+                    unset($resolvedStructure['content'][$sourceProperty]);
+                    unset($resolvedStructure['view'][$sourceProperty]);
+                }
+            }
+
+            foreach ($extensionProperties as $sourceProperty => $targetProperty) {
+                [$extensionName, $propertyName] = \explode('.', $sourceProperty);
+                $propertyValue = $resolvedStructure['extension'][$extensionName][$propertyName];
+
+                $resolvedStructure['content'][$targetProperty] = $propertyValue;
+                $resolvedStructure['view'][$targetProperty] = [];
+            }
+            unset($resolvedStructure['extension']);
+
+            return $resolvedStructure;
         } catch (DocumentNotFoundException $e) {
             $this->logger->error((string) $e);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Related issues/PRs | #4576
| License | MIT
| Documentation PR | sulu/sulu-docs#627

#### What's in this PR?

This PR adds an additional `properties` parameter to the `sulu_content_load` and `sulu_content_load_parent` twig function that allows to set the properties of the target that should be resolved. The added parameter behaves the same as the `properties` param of the `page_selection` content type.

#### Why?

The `sulu_content_load` and `sulu_content_load_parent` twig function are used to render specific properties (eg the title and the description) of a page in most cases. At the moment, the functions **load an resolve all extensions and all properties of the page**. This is an expensive operation that is not necessary in most cases. We even [warn about using the function in out documentation](https://docs.sulu.io/en/2.2/reference/twig-extensions/functions/sulu_content_load.html). 

While some usecases can be implemented by using the [`<sulu-link>` tag](https://docs.sulu.io/en/2.2/bundles/markup/link.html) instead of the `sulu_content_load` function, there are cases where there is no alternative to using these functions. This change allows to improve performance in these cases by specifying the properties that are needed.

#### Example Usage

```twig
{# old behaviour #}
sulu_content_load(content.single_page_selection)

{# new behaviour #}
sulu_content_load(content.single_page_selection, ['title'])
sulu_content_load(content.single_page_selection, {'title': 'title', 'excerptTitle': 'excerpt.title'})
```
