### PR TITLE
Adjust webpack configuration to prefer nearest node_modules folder when resolving packages

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,10 +67,10 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                     'vendor/friendsofsymfony/jsrouting-bundle/Resources/public/js'
                 ),
             },
-            modules: [nodeModulesPath, 'node_modules'],
+            modules: ['node_modules', nodeModulesPath],
         },
         resolveLoader: {
-            modules: [nodeModulesPath, 'node_modules'],
+            modules: ['node_modules', nodeModulesPath],
         },
         module: {
             rules: [


### PR DESCRIPTION
At the moment, webpack will prefer the `assets/admin/node_modules` directory over the `vendor/sulu/sulu/src/Sulu/Bundle/AdminBundle/Resources/js/node_modules` directory when resolving a package from a file inside of `vendor/sulu/sulu/src/Sulu/Bundle/AdminBundle/Resources/js`. See: https://webpack.js.org/configuration/resolve/#resolvemodules

The current behaviour leads to problems if the `assets/admin/node_modules` directory contains another version of a package than the `vendor/sulu/sulu/src/Sulu/Bundle/AdminBundle/Resources/js/node_modules` directory. We encounter this problem on the `2.x` branch after updating the `ajv` package in #5815