### PR TITLE
Fix tags auto_complete

### DIFF
--- a/src/Sulu/Bundle/TagBundle/Controller/TagController.php
+++ b/src/Sulu/Bundle/TagBundle/Controller/TagController.php
@@ -136,12 +136,13 @@ class TagController extends AbstractRestController implements ClassResourceInter
             $fieldDescriptors = $this->fieldDescriptorFactory->getFieldDescriptors('tags');
             $listBuilder = $this->listBuilderFactory->create($this->tagClass);
 
+            $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
+
             $names = \array_filter(\explode(',', $request->get('names', '')));
             if (\count($names) > 0) {
                 $listBuilder->in($fieldDescriptors['name'], $names);
+                $listBuilder->limit(\count($names));
             }
-
-            $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
 
             $list = new ListRepresentation(
                 $listBuilder->execute(),

--- a/src/Sulu/Bundle/TagBundle/Tests/Functional/Controller/TagControllerTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Functional/Controller/TagControllerTest.php
@@ -130,7 +130,7 @@ class TagControllerTest extends SuluTestCase
         $response = \json_decode($this->client->getResponse()->getContent());
 
         $this->assertEquals(1, $response->total);
-        $this->assertEquals(10, $response->limit);
+        $this->assertEquals(1, $response->limit);
         $this->assertEquals('tag1', $response->_embedded->tags[0]->name);
     }
 

--- a/src/Sulu/Bundle/TagBundle/Tests/Functional/Controller/TagControllerTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Functional/Controller/TagControllerTest.php
@@ -130,7 +130,29 @@ class TagControllerTest extends SuluTestCase
         $response = \json_decode($this->client->getResponse()->getContent());
 
         $this->assertEquals(1, $response->total);
+        $this->assertEquals(10, $response->limit);
         $this->assertEquals('tag1', $response->_embedded->tags[0]->name);
+    }
+
+    public function testListFilteredByMultipleNames()
+    {
+        $this->createTag('tag1');
+        $this->createTag('tag2');
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->client->jsonRequest(
+            'GET',
+            '/api/tags?flat=true&names=t1,t2,t3,t4,t5,t6,t7,t8,t9,t10,t11'
+        );
+
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+        $response = \json_decode($this->client->getResponse()->getContent());
+
+        $this->assertEquals(11, $response->total);
+        $this->assertEquals(11, $response->limit);
+        $this->assertEquals(1, $response->page);
+        $this->assertEquals(1, $response->pages);
     }
 
     public function testListSearch()

--- a/src/Sulu/Bundle/TagBundle/Tests/Functional/Controller/TagControllerTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Functional/Controller/TagControllerTest.php
@@ -136,21 +136,30 @@ class TagControllerTest extends SuluTestCase
 
     public function testListFilteredByMultipleNames()
     {
-        $this->createTag('tag1');
-        $this->createTag('tag2');
+        $this->createTag('t1');
+        $this->createTag('t2');
+        $this->createTag('t3');
+        $this->createTag('t4');
+        $this->createTag('t5');
+        $this->createTag('t6');
+        $this->createTag('t7');
+        $this->createTag('t8');
+        $this->createTag('t9');
+        $this->createTag('t10');
+        $this->createTag('t11');
         $this->em->flush();
         $this->em->clear();
 
         $this->client->jsonRequest(
             'GET',
-            '/api/tags?flat=true&names=t1,t2,t3,t4,t5,t6,t7,t8,t9,t10,t11'
+            '/api/tags?flat=true&names=t1,t2,t3,t4,t5,t6,t7,t8,t9,t10,t11,t12'
         );
 
         $this->assertHttpStatusCode(200, $this->client->getResponse());
         $response = \json_decode($this->client->getResponse()->getContent());
 
         $this->assertEquals(11, $response->total);
-        $this->assertEquals(11, $response->limit);
+        $this->assertEquals(12, $response->limit);
         $this->assertEquals(1, $response->page);
         $this->assertEquals(1, $response->pages);
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5828 
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

If specific tag names are passed to the `TagController::cgetAction`, the limit should be set to the amount of tags

#### Why?

Otherwise the autocomplete field in the admin will only show the first 10 tags
