### PR TITLE
Index embedded structures

### DIFF
--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/services.xml
@@ -85,6 +85,15 @@
             <tag name="sulu.context" context="admin"/>
         </service>
 
+        <service id="Sulu\Bundle\CategoryBundle\Search\Converter\CategoryConverter">
+            <argument type="service" id="sulu_category.category_manager"/>
+            <argument type="service" id="massive_search.search_manager"/>
+            <argument type="service" id="massive_search.object_to_document_converter"/>
+            <argument type="service" id="event_dispatcher"/>
+
+            <tag name="massive_search.converter" from="category" />
+        </service>
+
         <!--PERSISTENCE BUNDLE REPOSITORIES-->
         <service id="Sulu\Bundle\CategoryBundle\Entity\CategoryRepositoryInterface" alias="sulu.repository.category"/>
         <service id="Sulu\Bundle\CategoryBundle\Entity\CategoryMetaRepositoryInterface" alias="sulu.repository.category_meta"/>

--- a/src/Sulu/Bundle/CategoryBundle/Search/Converter/CategoryConverter.php
+++ b/src/Sulu/Bundle/CategoryBundle/Search/Converter/CategoryConverter.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CategoryBundle\Search\Converter;
+
+use Massive\Bundle\SearchBundle\Search\Converter\ConverterInterface;
+use Massive\Bundle\SearchBundle\Search\Document;
+use Massive\Bundle\SearchBundle\Search\Event\PreIndexEvent;
+use Massive\Bundle\SearchBundle\Search\Field;
+use Massive\Bundle\SearchBundle\Search\ObjectToDocumentConverter;
+use Massive\Bundle\SearchBundle\Search\SearchEvents;
+use Massive\Bundle\SearchBundle\Search\SearchManagerInterface;
+use Sulu\Bundle\CategoryBundle\Category\CategoryManagerInterface;
+use Sulu\Bundle\CategoryBundle\Exception\CategoryIdNotFoundException;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+class CategoryConverter implements ConverterInterface
+{
+    /**
+     * @var CategoryManagerInterface
+     */
+    private $categoryManager;
+
+    /**
+     * @var SearchManagerInterface
+     */
+    private $searchManager;
+
+    /**
+     * @var ObjectToDocumentConverter
+     */
+    private $objectToDocumentConverter;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    public function __construct(
+        CategoryManagerInterface $categoryManager,
+        SearchManagerInterface $searchManager,
+        ObjectToDocumentConverter $objectToDocumentConverter,
+        EventDispatcherInterface $eventDispatcher
+    ) {
+        $this->categoryManager = $categoryManager;
+        $this->searchManager = $searchManager;
+        $this->objectToDocumentConverter = $objectToDocumentConverter;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public function convert($value, Document $document = null)
+    {
+        if (null === $document) {
+            return $value;
+        }
+
+        $locale = $document->getLocale();
+
+        if (null === $value) {
+            return null;
+        }
+
+        $fields = [];
+
+        if (\is_integer($value)) {
+            $fields = $this->getFieldsById($value, $locale);
+        }
+
+        if (\is_array($value)) {
+            foreach ($value as $key => $item) {
+                if (null === $item || !\is_integer($item)) {
+                    continue;
+                }
+
+                foreach ($this->getFieldsById($item, $locale) as $field) {
+                    if (null === $field) {
+                        continue;
+                    }
+
+                    $field = clone $field;
+                    $field->setName($key . '#' . $field->getName());
+
+                    $fields[] = $field;
+                }
+            }
+        }
+
+        return [
+            'value' => $value,
+            'fields' => $fields,
+        ];
+    }
+
+    /**
+     * @return Field[]
+     */
+    private function getFieldsById(int $id, string $locale): ?array
+    {
+        try {
+            $category = $this->categoryManager->findById($id);
+            $categoryTranslation = $category->findTranslationByLocale($locale);
+
+            if (false === $categoryTranslation) {
+                return null;
+            }
+
+            $document = $this->convertObjectToDocument($categoryTranslation);
+
+            return $document->getFields();
+        } catch (CategoryIdNotFoundException $e) {
+            return null;
+        }
+    }
+
+    private function convertObjectToDocument(object $object): Document
+    {
+        $indexMetadata = $this->searchManager->getMetadata($object);
+        $defaultIndexMetadata = $indexMetadata->getIndexMetadata('_default');
+        $document = $this->objectToDocumentConverter->objectToDocument($defaultIndexMetadata, $object);
+        $evaluator = $this->objectToDocumentConverter->getFieldEvaluator();
+
+        $this->eventDispatcher->dispatch(
+            new PreIndexEvent($object, $document, $defaultIndexMetadata, $evaluator),
+            SearchEvents::PRE_INDEX
+        );
+
+        return $document;
+    }
+}

--- a/src/Sulu/Bundle/CategoryBundle/Search/Converter/CategoryConverter.php
+++ b/src/Sulu/Bundle/CategoryBundle/Search/Converter/CategoryConverter.php
@@ -58,15 +58,15 @@ class CategoryConverter implements ConverterInterface
 
     public function convert($value, Document $document = null)
     {
+        if (null === $value) {
+            return null;
+        }
+
         if (null === $document) {
             return $value;
         }
 
         $locale = $document->getLocale();
-
-        if (null === $value) {
-            return null;
-        }
 
         $fields = [];
 

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Search/Converter/CategoryConverterTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Search/Converter/CategoryConverterTest.php
@@ -1,0 +1,198 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CategoryBundle\Tests\Unit\Search\Converter;
+
+use Massive\Bundle\SearchBundle\Search\Document;
+use Massive\Bundle\SearchBundle\Search\Field;
+use Massive\Bundle\SearchBundle\Search\Metadata\ClassMetadata;
+use Massive\Bundle\SearchBundle\Search\Metadata\FieldEvaluator;
+use Massive\Bundle\SearchBundle\Search\Metadata\IndexMetadata;
+use Massive\Bundle\SearchBundle\Search\ObjectToDocumentConverter;
+use Massive\Bundle\SearchBundle\Search\SearchEvents;
+use Massive\Bundle\SearchBundle\Search\SearchManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\CategoryBundle\Category\CategoryManagerInterface;
+use Sulu\Bundle\CategoryBundle\Entity\Category;
+use Sulu\Bundle\CategoryBundle\Entity\CategoryTranslation;
+use Sulu\Bundle\CategoryBundle\Search\Converter\CategoryConverter;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+class CategoryConverterTest extends TestCase
+{
+    /**
+     * @var ObjectProphecy<CategoryManagerInterface>
+     */
+    private $categoryManager;
+
+    /**
+     * @var ObjectProphecy<SearchManagerInterface>
+     */
+    private $searchManager;
+
+    /**
+     * @var ObjectProphecy<ObjectToDocumentConverter>
+     */
+    private $objectToDocumentConverter;
+
+    /**
+     * @var ObjectProphecy<EventDispatcherInterface>
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var CategoryConverter
+     */
+    private $categoryConverter;
+
+    protected function setUp(): void
+    {
+        $this->categoryManager = $this->prophesize(CategoryManagerInterface::class);
+        $this->searchManager = $this->prophesize(SearchManagerInterface::class);
+        $this->objectToDocumentConverter = $this->prophesize(ObjectToDocumentConverter::class);
+        $this->eventDispatcher = $this->prophesize(EventDispatcherInterface::class);
+
+        $this->categoryConverter = new CategoryConverter(
+            $this->categoryManager->reveal(),
+            $this->searchManager->reveal(),
+            $this->objectToDocumentConverter->reveal(),
+            $this->eventDispatcher->reveal()
+        );
+    }
+
+    public function testConvertWithoutDocument()
+    {
+        $this->assertSame(1, $this->categoryConverter->convert(1));
+    }
+
+    public function testConvertNull()
+    {
+        $this->assertNull($this->categoryConverter->convert(null));
+    }
+
+    public function testConvertStringValue()
+    {
+        $id = 1;
+        $locale = 'en';
+
+        $document = $this->prophesize(Document::class);
+        $document->getLocale()->willReturn($locale);
+
+        $category = $this->prophesize(Category::class);
+        $object = $this->prophesize(CategoryTranslation::class);
+        $this->categoryManager->findById($id)->willReturn($category->reveal());
+        $category->findTranslationByLocale($locale)->willReturn($object->reveal());
+
+        $indexMetadata = $this->prophesize(ClassMetadata::class);
+        $this->searchManager->getMetadata($object->reveal())->willReturn($indexMetadata->reveal());
+
+        $defaultIndexMetadata = $this->prophesize(IndexMetadata::class);
+        $indexMetadata->getIndexMetadata('_default')->willReturn($defaultIndexMetadata->reveal());
+
+        $objectDocument = $this->prophesize(Document::class);
+        $this->objectToDocumentConverter->objectToDocument(
+            $defaultIndexMetadata->reveal(),
+            $object->reveal()
+        )->willReturn($objectDocument->reveal());
+
+        $fieldEvaluator = $this->prophesize(FieldEvaluator::class);
+        $this->objectToDocumentConverter->getFieldEvaluator()->willReturn($fieldEvaluator->reveal());
+
+        $this->eventDispatcher->dispatch(Argument::cetera(), SearchEvents::PRE_INDEX)->shouldBeCalled();
+
+        $fields = [
+            new Field('foo', 'abc'),
+            new Field('bar', 'xyz'),
+        ];
+        $objectDocument->getFields()->willReturn($fields);
+
+        $value = $this->categoryConverter->convert($id, $document->reveal());
+
+        $this->assertSame([
+            'value' => $id,
+            'fields' => $fields,
+        ], $value);
+    }
+
+    public function testConvertArrayValue()
+    {
+        $ids = [1, 2, 'invalid-value'];
+        $locale = 'en';
+
+        $document = $this->prophesize(Document::class);
+        $document->getLocale()->willReturn($locale);
+
+        $firstCategory = $this->prophesize(Category::class);
+        $firstObject = $this->prophesize(CategoryTranslation::class);
+        $firstCategory->findTranslationByLocale($locale)->willReturn($firstObject->reveal());
+        $this->categoryManager->findById($ids[0])->willReturn($firstCategory->reveal());
+
+        $secondCategory = $this->prophesize(Category::class);
+        $secondObject = $this->prophesize(CategoryTranslation::class);
+        $secondCategory->findTranslationByLocale($locale)->willReturn($secondObject->reveal());
+        $this->categoryManager->findById($ids[1])->willReturn($secondCategory->reveal());
+
+        $firstIndexMetadata = $this->prophesize(ClassMetadata::class);
+        $secondIndexMetadata = $this->prophesize(ClassMetadata::class);
+        $this->searchManager->getMetadata($firstObject->reveal())->willReturn($firstIndexMetadata->reveal());
+        $this->searchManager->getMetadata($secondObject->reveal())->willReturn($secondIndexMetadata->reveal());
+
+        $firstDefaultIndexMetadata = $this->prophesize(IndexMetadata::class);
+        $secondDefaultIndexMetadata = $this->prophesize(IndexMetadata::class);
+        $firstIndexMetadata->getIndexMetadata('_default')->willReturn($firstDefaultIndexMetadata->reveal());
+        $secondIndexMetadata->getIndexMetadata('_default')->willReturn($secondDefaultIndexMetadata->reveal());
+
+        $firstObjectDocument = $this->prophesize(Document::class);
+        $secondObjectDocument = $this->prophesize(Document::class);
+        $this->objectToDocumentConverter->objectToDocument(
+            $firstDefaultIndexMetadata->reveal(),
+            $firstObject->reveal()
+        )->willReturn($firstObjectDocument->reveal());
+        $this->objectToDocumentConverter->objectToDocument(
+            $secondDefaultIndexMetadata->reveal(),
+            $secondObject->reveal()
+        )->willReturn($secondObjectDocument->reveal());
+
+        $fieldEvaluator = $this->prophesize(FieldEvaluator::class);
+        $this->objectToDocumentConverter->getFieldEvaluator()->willReturn($fieldEvaluator->reveal());
+
+        $this->eventDispatcher->dispatch(Argument::cetera(), SearchEvents::PRE_INDEX)->shouldBeCalledTimes(2);
+
+        $firstFields = [
+            new Field('foo', 'abc'),
+            new Field('bar', 'xyz'),
+        ];
+        $secondFields = [
+            new Field('hello', 'world'),
+        ];
+        $firstObjectDocument->getFields()->willReturn($firstFields);
+        $secondObjectDocument->getFields()->willReturn($secondFields);
+
+        $value = $this->categoryConverter->convert($ids, $document->reveal());
+
+        $this->assertArrayHasKey('value', $value);
+        $this->assertSame($ids, $value['value']);
+
+        $this->assertArrayHasKey('fields', $value);
+        $this->assertCount(3, $value['fields']);
+
+        $this->assertSame('0#' . $firstFields[0]->getName(), $value['fields'][0]->getName());
+        $this->assertSame($firstFields[0]->getValue(), $value['fields'][0]->getValue());
+
+        $this->assertSame('0#' . $firstFields[1]->getName(), $value['fields'][1]->getName());
+        $this->assertSame($firstFields[1]->getValue(), $value['fields'][1]->getValue());
+
+        $this->assertSame('1#' . $secondFields[0]->getName(), $value['fields'][2]->getName());
+        $this->assertSame($secondFields[0]->getValue(), $value['fields'][2]->getValue());
+    }
+}

--- a/src/Sulu/Bundle/PageBundle/Content/templates/excerpt.xml
+++ b/src/Sulu/Bundle/PageBundle/Content/templates/excerpt.xml
@@ -45,7 +45,7 @@
                 <title lang="en">Categories</title>
             </meta>
 
-            <tag name="sulu.search.field" type="array"/>
+            <tag name="sulu.search.field" type="category"/>
         </property>
 
         <property name="audience_targeting_groups" type="target_group_selection" onInvalid="ignore">

--- a/src/Sulu/Bundle/SearchBundle/Resources/config/search.xml
+++ b/src/Sulu/Bundle/SearchBundle/Resources/config/search.xml
@@ -37,5 +37,14 @@
 
         <!-- Custom factory -->
         <service id="sulu_search.search.factory" class="%sulu_search.search.factory.class%"/>
+
+        <service id="Sulu\Bundle\SearchBundle\Search\Converter\StructureConverter">
+            <argument type="service" id="sulu_document_manager.document_manager"/>
+            <argument type="service" id="massive_search.search_manager"/>
+            <argument type="service" id="massive_search.object_to_document_converter"/>
+            <argument type="service" id="event_dispatcher"/>
+
+            <tag name="massive_search.converter" from="structure" />
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/SearchBundle/Search/Converter/StructureConverter.php
+++ b/src/Sulu/Bundle/SearchBundle/Search/Converter/StructureConverter.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SearchBundle\Search\Converter;
+
+use Massive\Bundle\SearchBundle\Search\Converter\ConverterInterface;
+use Massive\Bundle\SearchBundle\Search\Document;
+use Massive\Bundle\SearchBundle\Search\Event\PreIndexEvent;
+use Massive\Bundle\SearchBundle\Search\Field;
+use Massive\Bundle\SearchBundle\Search\ObjectToDocumentConverter;
+use Massive\Bundle\SearchBundle\Search\SearchEvents;
+use Massive\Bundle\SearchBundle\Search\SearchManagerInterface;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+class StructureConverter implements ConverterInterface
+{
+    /**
+     * @var DocumentManagerInterface
+     */
+    private $documentManager;
+
+    /**
+     * @var SearchManagerInterface
+     */
+    private $searchManager;
+
+    /**
+     * @var ObjectToDocumentConverter
+     */
+    private $objectToDocumentConverter;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    public function __construct(
+        DocumentManagerInterface $documentManager,
+        SearchManagerInterface $searchManager,
+        ObjectToDocumentConverter $objectToDocumentConverter,
+        EventDispatcherInterface $eventDispatcher
+    ) {
+        $this->documentManager = $documentManager;
+        $this->searchManager = $searchManager;
+        $this->objectToDocumentConverter = $objectToDocumentConverter;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public function convert($value, Document $document = null)
+    {
+        if (null === $document) {
+            return $value;
+        }
+
+        $locale = $document->getLocale();
+
+        if (null === $value) {
+            return null;
+        }
+
+        $fields = [];
+
+        if (\is_string($value)) {
+            $fields = $this->getFieldsById($value, $locale);
+        }
+
+        if (\is_array($value)) {
+            foreach ($value as $key => $item) {
+                if (null === $item || !\is_string($item)) {
+                    continue;
+                }
+
+                foreach ($this->getFieldsById($item, $locale) as $field) {
+                    if (null === $field) {
+                        continue;
+                    }
+
+                    $field = clone $field;
+                    $field->setName($key . '#' . $field->getName());
+
+                    $fields[] = $field;
+                }
+            }
+        }
+
+        return [
+            'value' => $value,
+            'fields' => $fields,
+        ];
+    }
+
+    /**
+     * @return Field[]
+     */
+    private function getFieldsById(string $id, string $locale): ?array
+    {
+        try {
+            $object = $this->documentManager->find($id, $locale);
+            $document = $this->convertObjectToDocument($object);
+
+            return $document->getFields();
+        } catch (DocumentManagerException $e) {
+            return null;
+        }
+    }
+
+    private function convertObjectToDocument(object $object): Document
+    {
+        $indexMetadata = $this->searchManager->getMetadata($object);
+        $defaultIndexMetadata = $indexMetadata->getIndexMetadata('_default');
+        $document = $this->objectToDocumentConverter->objectToDocument($defaultIndexMetadata, $object);
+        $evaluator = $this->objectToDocumentConverter->getFieldEvaluator();
+
+        $this->eventDispatcher->dispatch(
+            new PreIndexEvent($object, $document, $defaultIndexMetadata, $evaluator),
+            SearchEvents::PRE_INDEX
+        );
+
+        return $document;
+    }
+}

--- a/src/Sulu/Bundle/SearchBundle/Search/Converter/StructureConverter.php
+++ b/src/Sulu/Bundle/SearchBundle/Search/Converter/StructureConverter.php
@@ -60,16 +60,15 @@ class StructureConverter implements ConverterInterface
 
     public function convert($value, Document $document = null)
     {
+        if (null === $value) {
+            return null;
+        }
+
         if (null === $document) {
             return $value;
         }
 
         $locale = $document->getLocale();
-
-        if (null === $value) {
-            return null;
-        }
-
         $fields = [];
 
         if (\is_string($value)) {

--- a/src/Sulu/Bundle/SearchBundle/Tests/Unit/Search/Converter/StructureConverterTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Unit/Search/Converter/StructureConverterTest.php
@@ -1,0 +1,190 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SearchBundle\Tests\Unit\Search\Converter;
+
+use Massive\Bundle\SearchBundle\Search\Document;
+use Massive\Bundle\SearchBundle\Search\Field;
+use Massive\Bundle\SearchBundle\Search\Metadata\ClassMetadata;
+use Massive\Bundle\SearchBundle\Search\Metadata\FieldEvaluator;
+use Massive\Bundle\SearchBundle\Search\Metadata\IndexMetadata;
+use Massive\Bundle\SearchBundle\Search\ObjectToDocumentConverter;
+use Massive\Bundle\SearchBundle\Search\SearchEvents;
+use Massive\Bundle\SearchBundle\Search\SearchManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\PageBundle\Document\BasePageDocument;
+use Sulu\Bundle\SearchBundle\Search\Converter\StructureConverter;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+class StructureConverterTest extends TestCase
+{
+    /**
+     * @var ObjectProphecy<DocumentManagerInterface>
+     */
+    private $documentManager;
+
+    /**
+     * @var ObjectProphecy<SearchManagerInterface>
+     */
+    private $searchManager;
+
+    /**
+     * @var ObjectProphecy<ObjectToDocumentConverter>
+     */
+    private $objectToDocumentConverter;
+
+    /**
+     * @var ObjectProphecy<EventDispatcherInterface>
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var StructureConverter
+     */
+    private $structureConverter;
+
+    protected function setUp(): void
+    {
+        $this->documentManager = $this->prophesize(DocumentManagerInterface::class);
+        $this->searchManager = $this->prophesize(SearchManagerInterface::class);
+        $this->objectToDocumentConverter = $this->prophesize(ObjectToDocumentConverter::class);
+        $this->eventDispatcher = $this->prophesize(EventDispatcherInterface::class);
+
+        $this->structureConverter = new StructureConverter(
+            $this->documentManager->reveal(),
+            $this->searchManager->reveal(),
+            $this->objectToDocumentConverter->reveal(),
+            $this->eventDispatcher->reveal()
+        );
+    }
+
+    public function testConvertWithoutDocument()
+    {
+        $this->assertSame('abcd', $this->structureConverter->convert('abcd'));
+    }
+
+    public function testConvertNull()
+    {
+        $this->assertNull($this->structureConverter->convert(null));
+    }
+
+    public function testConvertStringValue()
+    {
+        $uuid = 'abcd';
+        $locale = 'en';
+
+        $document = $this->prophesize(Document::class);
+        $document->getLocale()->willReturn($locale);
+
+        $object = $this->prophesize(BasePageDocument::class);
+        $this->documentManager->find($uuid, $locale)->willReturn($object->reveal());
+
+        $indexMetadata = $this->prophesize(ClassMetadata::class);
+        $this->searchManager->getMetadata($object->reveal())->willReturn($indexMetadata->reveal());
+
+        $defaultIndexMetadata = $this->prophesize(IndexMetadata::class);
+        $indexMetadata->getIndexMetadata('_default')->willReturn($defaultIndexMetadata->reveal());
+
+        $objectDocument = $this->prophesize(Document::class);
+        $this->objectToDocumentConverter->objectToDocument(
+            $defaultIndexMetadata->reveal(),
+            $object->reveal()
+        )->willReturn($objectDocument->reveal());
+
+        $fieldEvaluator = $this->prophesize(FieldEvaluator::class);
+        $this->objectToDocumentConverter->getFieldEvaluator()->willReturn($fieldEvaluator->reveal());
+
+        $this->eventDispatcher->dispatch(Argument::cetera(), SearchEvents::PRE_INDEX)->shouldBeCalled();
+
+        $fields = [
+            new Field('foo', 'abc'),
+            new Field('bar', 'xyz'),
+        ];
+        $objectDocument->getFields()->willReturn($fields);
+
+        $value = $this->structureConverter->convert($uuid, $document->reveal());
+
+        $this->assertSame([
+            'value' => $uuid,
+            'fields' => $fields,
+        ], $value);
+    }
+
+    public function testConvertArrayValue()
+    {
+        $uuids = ['abcd', 'efgh', ['invalid-value']];
+        $locale = 'en';
+
+        $document = $this->prophesize(Document::class);
+        $document->getLocale()->willReturn($locale);
+
+        $firstObject = $this->prophesize(BasePageDocument::class);
+        $secondObject = $this->prophesize(BasePageDocument::class);
+        $this->documentManager->find($uuids[0], $locale)->willReturn($firstObject->reveal());
+        $this->documentManager->find($uuids[1], $locale)->willReturn($secondObject->reveal());
+
+        $firstIndexMetadata = $this->prophesize(ClassMetadata::class);
+        $secondIndexMetadata = $this->prophesize(ClassMetadata::class);
+        $this->searchManager->getMetadata($firstObject->reveal())->willReturn($firstIndexMetadata->reveal());
+        $this->searchManager->getMetadata($secondObject->reveal())->willReturn($secondIndexMetadata->reveal());
+
+        $firstDefaultIndexMetadata = $this->prophesize(IndexMetadata::class);
+        $secondDefaultIndexMetadata = $this->prophesize(IndexMetadata::class);
+        $firstIndexMetadata->getIndexMetadata('_default')->willReturn($firstDefaultIndexMetadata->reveal());
+        $secondIndexMetadata->getIndexMetadata('_default')->willReturn($secondDefaultIndexMetadata->reveal());
+
+        $firstObjectDocument = $this->prophesize(Document::class);
+        $secondObjectDocument = $this->prophesize(Document::class);
+        $this->objectToDocumentConverter->objectToDocument(
+            $firstDefaultIndexMetadata->reveal(),
+            $firstObject->reveal()
+        )->willReturn($firstObjectDocument->reveal());
+        $this->objectToDocumentConverter->objectToDocument(
+            $secondDefaultIndexMetadata->reveal(),
+            $secondObject->reveal()
+        )->willReturn($secondObjectDocument->reveal());
+
+        $fieldEvaluator = $this->prophesize(FieldEvaluator::class);
+        $this->objectToDocumentConverter->getFieldEvaluator()->willReturn($fieldEvaluator->reveal());
+
+        $this->eventDispatcher->dispatch(Argument::cetera(), SearchEvents::PRE_INDEX)->shouldBeCalledTimes(2);
+
+        $firstFields = [
+            new Field('foo', 'abc'),
+            new Field('bar', 'xyz'),
+        ];
+        $secondFields = [
+            new Field('hello', 'world'),
+        ];
+        $firstObjectDocument->getFields()->willReturn($firstFields);
+        $secondObjectDocument->getFields()->willReturn($secondFields);
+
+        $value = $this->structureConverter->convert($uuids, $document->reveal());
+
+        $this->assertArrayHasKey('value', $value);
+        $this->assertSame($uuids, $value['value']);
+
+        $this->assertArrayHasKey('fields', $value);
+        $this->assertCount(3, $value['fields']);
+
+        $this->assertSame('0#' . $firstFields[0]->getName(), $value['fields'][0]->getName());
+        $this->assertSame($firstFields[0]->getValue(), $value['fields'][0]->getValue());
+
+        $this->assertSame('0#' . $firstFields[1]->getName(), $value['fields'][1]->getName());
+        $this->assertSame($firstFields[1]->getValue(), $value['fields'][1]->getValue());
+
+        $this->assertSame('1#' . $secondFields[0]->getName(), $value['fields'][2]->getName());
+        $this->assertSame($secondFields[0]->getValue(), $value['fields'][2]->getValue());
+    }
+}

--- a/src/Sulu/Bundle/TagBundle/Search/TagsConverter.php
+++ b/src/Sulu/Bundle/TagBundle/Search/TagsConverter.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\TagBundle\Search;
 
 use Massive\Bundle\SearchBundle\Search\Converter\ConverterInterface;
+use Massive\Bundle\SearchBundle\Search\Document;
 use Massive\Bundle\SearchBundle\Search\Field;
 use Sulu\Bundle\TagBundle\Tag\TagManagerInterface;
 
@@ -32,7 +33,11 @@ class TagsConverter implements ConverterInterface
 
     public function convert($value/*, Document $document = null*/)
     {
-        if (\count(\func_get_args()) < 2 || false === \func_get_arg(1) || null === \func_get_arg(1)) {
+        if (null === $value) {
+            return null;
+        }
+
+        if (\func_num_args() < 2 || !(\func_get_arg(1) instanceof Document)) {
             // Preserve backward compatibility
             return $this->tagManager->resolveTagNames($value);
         }

--- a/src/Sulu/Bundle/TagBundle/Search/TagsConverter.php
+++ b/src/Sulu/Bundle/TagBundle/Search/TagsConverter.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\TagBundle\Search;
 
 use Massive\Bundle\SearchBundle\Search\Converter\ConverterInterface;
+use Massive\Bundle\SearchBundle\Search\Field;
 use Sulu\Bundle\TagBundle\Tag\TagManagerInterface;
 
 /**
@@ -29,8 +30,44 @@ class TagsConverter implements ConverterInterface
         $this->tagManager = $tagManager;
     }
 
-    public function convert($value)
+    public function convert($value/*, Document $document = null*/)
     {
-        return $this->tagManager->resolveTagNames($value);
+        if (\count(\func_get_args()) < 2 || false === \func_get_arg(1) || null === \func_get_arg(1)) {
+            // Preserve backward compatibility
+            return $this->tagManager->resolveTagNames($value);
+        }
+
+        $resultValue = null;
+        $fields = [];
+
+        if (\is_string($value)) {
+            $tag = $this->tagManager->findByName($value);
+            $resultValue = $tag->getId();
+
+            $fields = [
+                new Field('id', $tag->getId()),
+                new Field('name', $tag->getName()),
+            ];
+        }
+
+        if (\is_array($value)) {
+            $ids = $this->tagManager->resolveTagNames($value);
+            $resultValue = $ids;
+            $tags = \array_combine($ids, $value);
+
+            if (false !== $tags) {
+                $index = 0;
+                foreach ($tags as $id => $tagName) {
+                    $fields[] = new Field($index . '#id', $id);
+                    $fields[] = new Field($index . '#name', $tagName);
+                    ++$index;
+                }
+            }
+        }
+
+        return [
+            'value' => $resultValue,
+            'fields' => $fields,
+        ];
     }
 }

--- a/src/Sulu/Bundle/TagBundle/Tests/Unit/Search/TagsConverterTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Unit/Search/TagsConverterTest.php
@@ -11,7 +11,10 @@
 
 namespace Sulu\Bundle\TagBundle\Tests\Unit\Search;
 
+use Massive\Bundle\SearchBundle\Search\Document;
+use Massive\Bundle\SearchBundle\Search\Field;
 use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\TagBundle\Entity\Tag;
 use Sulu\Bundle\TagBundle\Search\TagsConverter;
 use Sulu\Bundle\TagBundle\Tag\TagManager;
 
@@ -19,12 +22,100 @@ class TagsConverterTest extends TestCase
 {
     public function testConvert()
     {
-        $manager = $this->prophesize(TagManager::class);
-        $manager->resolveTagNames(['Tag1', 'Tag2', 'Tag3'])->willReturn([1, 2, 3]);
+        $tagManager = $this->prophesize(TagManager::class);
+        $tagsConverter = new TagsConverter($tagManager->reveal());
 
-        $converter = new TagsConverter($manager->reveal());
+        $tagManager->resolveTagNames(['Tag1', 'Tag2', 'Tag3'])->willReturn([1, 2, 3]);
 
-        $this->assertEquals([1, 2, 3], $converter->convert(['Tag1', 'Tag2', 'Tag3']));
-        $manager->resolveTagNames(['Tag1', 'Tag2', 'Tag3'])->shouldBeCalled();
+        $this->assertEquals([1, 2, 3], $tagsConverter->convert(['Tag1', 'Tag2', 'Tag3']));
+    }
+
+    public function testConvertNull()
+    {
+        $tagManager = $this->prophesize(TagManager::class);
+        $tagsConverter = new TagsConverter($tagManager->reveal());
+
+        $this->assertNull(
+            $tagsConverter->convert(null)
+        );
+    }
+
+    public function testConvertWithDocumentAndNull()
+    {
+        $tagManager = $this->prophesize(TagManager::class);
+        $tagsConverter = new TagsConverter($tagManager->reveal());
+
+        $this->assertNull(
+            $tagsConverter->convert(null, $this->prophesize(Document::class)->reveal())
+        );
+    }
+
+    public function testConvertWithDocumentAndStringValue()
+    {
+        $tagManager = $this->prophesize(TagManager::class);
+        $tagsConverter = new TagsConverter($tagManager->reveal());
+
+        $originalValue = 'Tag1';
+
+        $tag = new Tag();
+        $tag->setId(1);
+        $tag->setName($originalValue);
+        $tagManager->findByName($originalValue)->willReturn($tag);
+
+        $value = $tagsConverter->convert($originalValue, $this->prophesize(Document::class)->reveal());
+
+        $this->assertArrayHasKey('value', $value);
+        $this->assertSame($tag->getId(), $value['value']);
+
+        $this->assertArrayHasKey('fields', $value);
+        $this->assertCount(2, $value['fields']);
+
+        /** @var Field $idField */
+        $idField = $value['fields'][0];
+        $this->assertSame('id', $idField->getName());
+        $this->assertSame($tag->getId(), $idField->getValue());
+
+        /** @var Field $nameField */
+        $nameField = $value['fields'][1];
+        $this->assertSame('name', $nameField->getName());
+        $this->assertSame($tag->getName(), $nameField->getValue());
+    }
+
+    public function testConvertWithDocumentAndArrayValue()
+    {
+        $tagManager = $this->prophesize(TagManager::class);
+        $tagsConverter = new TagsConverter($tagManager->reveal());
+
+        $originalValue = ['Tag1', 'Tag2'];
+        $ids = [1, 2];
+        $tagManager->resolveTagNames($originalValue)->willReturn($ids);
+
+        $value = $tagsConverter->convert($originalValue, $this->prophesize(Document::class)->reveal());
+
+        $this->assertArrayHasKey('value', $value);
+        $this->assertSame($ids, $value['value']);
+
+        $this->assertArrayHasKey('fields', $value);
+        $this->assertCount(4, $value['fields']);
+
+        /** @var Field $firstIdField */
+        $firstIdField = $value['fields'][0];
+        $this->assertSame('0#id', $firstIdField->getName());
+        $this->assertSame($ids[0], $firstIdField->getValue());
+
+        /** @var Field $firstNameField */
+        $firstNameField = $value['fields'][1];
+        $this->assertSame('0#name', $firstNameField->getName());
+        $this->assertSame($originalValue[0], $firstNameField->getValue());
+
+        /** @var Field $secondIdField */
+        $secondIdField = $value['fields'][2];
+        $this->assertSame('1#id', $secondIdField->getName());
+        $this->assertSame($ids[1], $secondIdField->getValue());
+
+        /** @var Field $secondNameField */
+        $secondNameField = $value['fields'][3];
+        $this->assertSame('1#name', $secondNameField->getName());
+        $this->assertSame($originalValue[1], $secondNameField->getValue());
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4073
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#629

#### What's in this PR?

This pull request adds massive search converters to properly index embedded tags, categories and structure (pages, snippets, ...)

#### Why?

Until this, snippet content could never be indexed inside a page.

#### Example Usage

~~~xml
<property name="snippet" type="single_snippet_selection">
    <tag name="sulu.search.field" type="structure"/>
</property>

<property name="pages" type="page_selection">
    <tag name="sulu.search.field" type="structure"/>
</property>

<property name="category" type="single_category_selection">
    <tag name="sulu.search.field" type="category"/>
</property>

<property name="categories" type="category_selection">
    <tag name="sulu.search.field" type="category"/>
</property>

<property name="tags" type="tag_selection">
    <tag name="sulu.search.field" type="tags"/>
</property>
~~~

#### To Do

- [x] Create a documentation PR
