### PR TITLE
Resolve absolute urls for sulu-link tags

### DIFF
--- a/src/Sulu/Bundle/MarkupBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MarkupBundle/Resources/config/services.xml
@@ -46,6 +46,7 @@
         <service id="sulu_markup.link_tag" class="Sulu\Bundle\MarkupBundle\Markup\LinkTag">
             <argument type="service" id="sulu_markup.link_tag.provider_pool"/>
             <argument type="expression">container.hasParameter('sulu.preview') ? parameter('sulu.preview') : false</argument>
+            <argument type="service" id="url_helper"/>
 
             <tag name="sulu_markup.tag" tag="link" type="html"/>
         </service>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #5702
| License | MIT
| Documentation PR | sulu/sulu-docs/pull/628

#### What's in this PR?

This PR adjusts the `LinkTag` service to use absolute urls when resolving a `<sulu-link>` tag.

#### Why?

Because relative urls will cause problems when used in emails. See #5702
