### PR TITLE
Fix category not found and fallback to default locale for category converter

### DIFF
--- a/src/Sulu/Bundle/CategoryBundle/Search/Converter/CategoryConverter.php
+++ b/src/Sulu/Bundle/CategoryBundle/Search/Converter/CategoryConverter.php
@@ -102,21 +102,25 @@ class CategoryConverter implements ConverterInterface
     /**
      * @return Field[]
      */
-    private function getFieldsById(int $id, string $locale): ?array
+    private function getFieldsById(int $id, string $locale): array
     {
         try {
             $category = $this->categoryManager->findById($id);
             $categoryTranslation = $category->findTranslationByLocale($locale);
 
             if (false === $categoryTranslation) {
-                return null;
+                $categoryTranslation = $category->findTranslationByLocale($category->getDefaultLocale());
+            }
+
+            if (false === $categoryTranslation) {
+                return [];
             }
 
             $document = $this->convertObjectToDocument($categoryTranslation);
 
             return $document->getFields();
         } catch (CategoryIdNotFoundException $e) {
-            return null;
+            return [];
         }
     }
 

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Search/Converter/CategoryConverterTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Search/Converter/CategoryConverterTest.php
@@ -213,7 +213,7 @@ class CategoryConverterTest extends TestCase
             ->willReturn('de')
             ->shouldBeCalled();
         $category->findTranslationByLocale('de')
-            ->willReturn($object)
+            ->willReturn($object->reveal())
             ->shouldBeCalled();
 
         $indexMetadata = $this->prophesize(ClassMetadata::class);

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Search/Converter/CategoryConverterTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Search/Converter/CategoryConverterTest.php
@@ -25,6 +25,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\CategoryBundle\Category\CategoryManagerInterface;
 use Sulu\Bundle\CategoryBundle\Entity\Category;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryTranslation;
+use Sulu\Bundle\CategoryBundle\Exception\CategoryIdNotFoundException;
 use Sulu\Bundle\CategoryBundle\Search\Converter\CategoryConverter;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -194,5 +195,79 @@ class CategoryConverterTest extends TestCase
 
         $this->assertSame('1#' . $secondFields[0]->getName(), $value['fields'][2]->getName());
         $this->assertSame($secondFields[0]->getValue(), $value['fields'][2]->getValue());
+    }
+
+    public function testConvertDefaultCategory()
+    {
+        $id = 1;
+        $locale = 'en';
+
+        $document = $this->prophesize(Document::class);
+        $document->getLocale()->willReturn($locale);
+
+        $category = $this->prophesize(Category::class);
+        $object = $this->prophesize(CategoryTranslation::class);
+        $this->categoryManager->findById($id)->willReturn($category->reveal());
+        $category->findTranslationByLocale($locale)->willReturn(false);
+        $category->getDefaultLocale()
+            ->willReturn('de')
+            ->shouldBeCalled();
+        $category->findTranslationByLocale('de')
+            ->willReturn($object)
+            ->shouldBeCalled();
+
+        $indexMetadata = $this->prophesize(ClassMetadata::class);
+        $this->searchManager->getMetadata($object->reveal())->willReturn($indexMetadata->reveal());
+
+        $defaultIndexMetadata = $this->prophesize(IndexMetadata::class);
+        $indexMetadata->getIndexMetadata('_default')->willReturn($defaultIndexMetadata->reveal());
+
+        $objectDocument = $this->prophesize(Document::class);
+        $this->objectToDocumentConverter->objectToDocument(
+            $defaultIndexMetadata->reveal(),
+            $object->reveal()
+        )->willReturn($objectDocument->reveal());
+
+        $fieldEvaluator = $this->prophesize(FieldEvaluator::class);
+        $this->objectToDocumentConverter->getFieldEvaluator()->willReturn($fieldEvaluator->reveal());
+
+        $this->eventDispatcher->dispatch(Argument::cetera(), SearchEvents::PRE_INDEX)->shouldBeCalled();
+
+        $fields = [
+            new Field('foo', 'abc'),
+            new Field('bar', 'xyz'),
+        ];
+        $objectDocument->getFields()->willReturn($fields);
+
+        $value = $this->categoryConverter->convert($id, $document->reveal());
+
+        $this->assertSame([
+            'value' => $id,
+            'fields' => $fields,
+        ], $value);
+    }
+
+    public function testConvertCategoryNotFound()
+    {
+        $ids = [1];
+        $locale = 'en';
+
+        $document = $this->prophesize(Document::class);
+        $document->getLocale()->willReturn($locale);
+
+        $this->categoryManager->findById(Argument::any())
+            ->willThrow(new CategoryIdNotFoundException(1));
+
+        $firstIndexMetadata = $this->prophesize(ClassMetadata::class);
+        $firstDefaultIndexMetadata = $this->prophesize(IndexMetadata::class);
+        $firstIndexMetadata->getIndexMetadata('_default')->willReturn($firstDefaultIndexMetadata->reveal());
+
+        $value = $this->categoryConverter->convert($ids, $document->reveal());
+
+        $this->assertArrayHasKey('value', $value);
+        $this->assertSame($ids, $value['value']);
+
+        $this->assertArrayHasKey('fields', $value);
+        $this->assertCount(0, $value['fields']);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix category not found and fallback to default locale for category converter when category does not exist in this locale, because categories like media fallback to there default locale when not exist in the requested locale. 

#### Why?

Article bundle currently fails when the category does not longer exists: https://github.com/sulu/SuluArticleBundle/pull/546/checks?check_run_id=1961281832

#### Example Usage

 - Create a page with a category.
 - Remove the category.
 - Reindex page

Or run test case with:

```bash
bin/runtests -t CategoryBundle -C --flags="--filter='CategoryConverterTest'"
```
