### PR TITLE
Improve to build 1.6 admin

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/.gitignore
+++ b/src/Sulu/Bundle/AdminBundle/.gitignore
@@ -1,4 +1,5 @@
 /node_modules/
+/bower_components/
 /vendor/
 /composer.phar
 /composer.lock

--- a/src/Sulu/Bundle/AdminBundle/package.json
+++ b/src/Sulu/Bundle/AdminBundle/package.json
@@ -2,9 +2,11 @@
   "name": "suluadmin",
   "scripts": {
     "build": "grunt build",
-    "watch": "grunt watch"
+    "watch": "grunt watch",
+    "postinstall": "bower update"
   },
   "devDependencies": {
+    "bower": "^1.8.12",
     "grunt": "0.4.*",
     "grunt-bower-task": "~0.4.0",
     "grunt-cli": "^1.2.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Improve to build 1.6 admin.

#### Why?

That:

```
bin/build-bundles.sh
```

Install before also the newest bower dependencies.

