### PR TITLE
Prevent doubleclick of item while ordering column list

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Item.js
@@ -60,7 +60,11 @@ class Item extends React.Component<Props> {
     };
 
     handleDoubleClick = () => {
-        const {onDoubleClick, id} = this.props;
+        const {onDoubleClick, id, showOrderField} = this.props;
+
+        if (showOrderField) {
+            return;
+        }
 
         if (onDoubleClick) {
             onDoubleClick(id);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Item.js
@@ -127,6 +127,7 @@ class Item extends React.Component<Props> {
                 [itemStyles.active]: active,
                 [itemStyles.disabled]: disabled,
                 [itemStyles.selected]: selected,
+                [itemStyles.orderFieldShown]: showOrderField,
             }
         );
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/item.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/item.scss
@@ -30,6 +30,10 @@ $itemHeight: 40px;
         color: $itemColorDisabled;
     }
 
+    &.order-field-shown {
+        cursor: default;
+    }
+
     &:hover {
         background: $itemBackgroundColorHover;
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/Item.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/Item.test.js
@@ -34,6 +34,26 @@ test('Should render item with order input', () => {
         .toMatchSnapshot();
 });
 
+test('Should call onDoubleClick', () => {
+    const doubleClickSpy = jest.fn();
+
+    const item = shallow(<Item id={2} onDoubleClick={doubleClickSpy}>Test with indicators</Item>);
+
+    item.find('div.item').simulate('doubleclick');
+
+    expect(doubleClickSpy).toBeCalled();
+});
+
+test('Should not call onDoubleClick if order field is shown', () => {
+    const doubleClickSpy = jest.fn();
+
+    const item = shallow(<Item id={2} onDoubleClick={doubleClickSpy} showOrderField={true}>Test with indicators</Item>);
+
+    item.find('div.item').simulate('doubleclick');
+
+    expect(doubleClickSpy).not.toBeCalled();
+});
+
 test('Should call onOrderChange callback when order has changed', () => {
     const orderChangePromise = Promise.resolve(true);
     const orderChangeSpy = jest.fn().mockReturnValue(orderChangePromise);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/Item.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/Item.test.js.snap
@@ -188,7 +188,7 @@ exports[`Should render item with indicators 1`] = `
 
 exports[`Should render item with order input 1`] = `
 <div
-  class="item"
+  class="item orderFieldShown"
   role="button"
 >
   <div


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5838
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Prevent doubleclick of item while ordering column list