### PR TITLE
Fix query for filtering template types

### DIFF
--- a/src/Sulu/Component/Content/SmartContent/QueryBuilder.php
+++ b/src/Sulu/Component/Content/SmartContent/QueryBuilder.php
@@ -329,7 +329,7 @@ class QueryBuilder extends ContentQueryBuilder
     {
         $sql2Where = [];
         foreach ($types as $type) {
-            $sql2Where[] = \sprintf("page.[i18n:%s-template] = '%s'", $languageCode, $type);
+            $sql2Where[] = \sprintf('page.[i18n:%s-template] = \'%s\'', $languageCode, $type);
         }
 
         if (\count($sql2Where) > 0) {

--- a/src/Sulu/Component/Content/SmartContent/QueryBuilder.php
+++ b/src/Sulu/Component/Content/SmartContent/QueryBuilder.php
@@ -329,7 +329,7 @@ class QueryBuilder extends ContentQueryBuilder
     {
         $sql2Where = [];
         foreach ($types as $type) {
-            $sql2Where[] = 'page.[i18n:' . $languageCode . '-template] = ' . $type;
+            $sql2Where[] = \sprintf("page.[i18n:%s-template] = '%s'", $languageCode, $type);
         }
 
         if (\count($sql2Where) > 0) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

This PR fixes an query error from the SmartContent Templatetype filter that accourse if you use phpcr in combination with jackrabbit. Example:

```SQL
HTTP 400: Query:
SELECT page.*
FROM [nt:unstructured] AS page
WHERE (page.[jcr:mixinTypes] = "sulu:page" OR page.[jcr:mixinTypes] = "sulu:home")
AND (ISCHILDNODE(page, '/cmf/medela-intranet/contents/test-projektueersicht') AND (page.[i18n:en-template] = intranet(*)-default-detail) AND (NOT page.[jcr:uuid] = '7e1d4d0c-4d3f-4109-989e-18dfbb011ae5'))
ORDER BY page.[sulu:order] ASC; expected: static operand
``` 

#### Why?

With this fix, SmartContent is able to load pages again when filtered by template type in combination with jackrabbit.
