### PR TITLE
Fix constructors to allow MetadataProviderInterface instead of implementation

### DIFF
--- a/src/Sulu/Bundle/SnippetBundle/Content/SnippetDataProvider.php
+++ b/src/Sulu/Bundle/SnippetBundle/Content/SnippetDataProvider.php
@@ -13,8 +13,8 @@ namespace Sulu\Bundle\SnippetBundle\Content;
 
 use ProxyManager\Factory\LazyLoadingValueHolderFactory;
 use ProxyManager\Proxy\LazyLoadingInterface;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataProvider;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
 use Sulu\Bundle\SnippetBundle\Admin\SnippetAdmin;
 use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
@@ -77,7 +77,7 @@ class SnippetDataProvider implements DataProviderInterface
     private $hasAudienceTargeting;
 
     /**
-     * @var FormMetadataProvider|null
+     * @var MetadataProviderInterface|null
      */
     private $formMetadataProvider;
 
@@ -94,7 +94,7 @@ class SnippetDataProvider implements DataProviderInterface
         DocumentManagerInterface $documentManager,
         ReferenceStoreInterface $referenceStore,
         bool $hasAudienceTargeting = false,
-        FormMetadataProvider $formMetadataProvider = null,
+        MetadataProviderInterface $formMetadataProvider = null,
         TokenStorageInterface $tokenStorage = null
     ) {
         $this->contentQueryExecutor = $contentQueryExecutor;

--- a/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
+++ b/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
@@ -15,8 +15,8 @@ use PHPCR\ItemNotFoundException;
 use PHPCR\SessionInterface;
 use ProxyManager\Factory\LazyLoadingValueHolderFactory;
 use ProxyManager\Proxy\LazyLoadingInterface;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataProvider;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
 use Sulu\Bundle\PageBundle\Admin\PageAdmin;
 use Sulu\Bundle\PageBundle\Document\PageDocument;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
@@ -85,7 +85,7 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
     private $hasAudienceTargeting;
 
     /**
-     * @var FormMetadataProvider|null
+     * @var MetadataProviderInterface|null
      */
     private $formMetadataProvider;
 
@@ -103,7 +103,7 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
         ReferenceStoreInterface $referenceStore,
         $showDrafts,
         bool $hasAudienceTargeting = false,
-        FormMetadataProvider $formMetadataProvider = null,
+        MetadataProviderInterface $formMetadataProvider = null,
         TokenStorageInterface $tokenStorage = null
     ) {
         $this->contentQueryBuilder = $contentQueryBuilder;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no yes
| New feature? | no yes
| BC breaks? | no yes
| Deprecations? | no 
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the constructor arguments of serveral services to allow injecting by the interface instead of the implementation.

#### Why?

Else the service cannot be decorated.
