### PR TITLE
Adjust smart_content sortBy migration to not check for limitResult key

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version202005250917.php
+++ b/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version202005250917.php
@@ -45,7 +45,7 @@ class Version202005250917 implements VersionInterface, ContainerAwareInterface
     {
         $queryManager = $session->getWorkspace()->getQueryManager();
 
-        $query = 'SELECT * FROM [nt:unstructured] WHERE ([jcr:mixinTypes] = "sulu:snippet" or [jcr:mixinTypes] = "sulu:page")';
+        $query = 'SELECT * FROM [nt:unstructured] WHERE ([jcr:mixinTypes] = "sulu:snippet" OR [jcr:mixinTypes] = "sulu:page") OR [jcr:mixinTypes] = "sulu:home"';
         $rows = $queryManager->createQuery($query, 'JCR-SQL2')->execute();
 
         foreach ($rows as $row) {
@@ -54,8 +54,9 @@ class Version202005250917 implements VersionInterface, ContainerAwareInterface
             foreach ($node->getProperties() as $property) {
                 if (\is_string($property->getValue())) {
                     $propertyValue = \json_decode($property->getValue(), true);
-                    if (\is_array($propertyValue) && \array_key_exists('presentAs', $propertyValue) &&
-                        \array_key_exists('limitResult', $propertyValue) && \array_key_exists('sortBy', $propertyValue)) {
+
+                    // decide if property is of type smart_content type by checking for presentAs and sortBy
+                    if (\is_array($propertyValue) && \array_key_exists('presentAs', $propertyValue) && \array_key_exists('sortBy', $propertyValue)) {
                         if (\is_array($propertyValue['sortBy'])) {
                             $propertyValue['sortBy'] = \count($propertyValue['sortBy']) > 0 ? $propertyValue['sortBy'][0] : null;
                         }
@@ -71,7 +72,7 @@ class Version202005250917 implements VersionInterface, ContainerAwareInterface
     {
         $queryManager = $session->getWorkspace()->getQueryManager();
 
-        $query = 'SELECT * FROM [nt:unstructured] WHERE ([jcr:mixinTypes] = "sulu:snippet" or [jcr:mixinTypes] = "sulu:page")';
+        $query = 'SELECT * FROM [nt:unstructured] WHERE ([jcr:mixinTypes] = "sulu:snippet" OR [jcr:mixinTypes] = "sulu:page") OR [jcr:mixinTypes] = "sulu:home"';
         $rows = $queryManager->createQuery($query, 'JCR-SQL2')->execute();
 
         foreach ($rows as $row) {
@@ -80,9 +81,10 @@ class Version202005250917 implements VersionInterface, ContainerAwareInterface
             foreach ($node->getProperties() as $property) {
                 if (\is_string($property->getValue())) {
                     $propertyValue = \json_decode($property->getValue(), true);
-                    if (\is_array($propertyValue) && \array_key_exists('presentAs', $propertyValue) &&
-                        \array_key_exists('limitResult', $propertyValue) && \array_key_exists('sortBy', $propertyValue)) {
-                        if (\is_array($propertyValue['sortBy'])) {
+
+                    // decide if property is of type smart_content type by checking for presentAs and sortBy
+                    if (\is_array($propertyValue) && \array_key_exists('presentAs', $propertyValue) && \array_key_exists('sortBy', $propertyValue)) {
+                        if (!\is_array($propertyValue['sortBy'])) {
                             $propertyValue['sortBy'] = [$propertyValue['sortBy']];
                         }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| License | MIT

#### Why?

There we two independent reports that the check for `limitResult` caused problems when updating a project from 1.6 to 2.0 in our Slack channel. Also, the migration does not migrate `smart_content` properties on the homepage at the moment.