### PR TITLE
Throw error when can not create symlink

### DIFF
--- a/symlink-vendor-directory.js
+++ b/symlink-vendor-directory.js
@@ -36,7 +36,7 @@ if (
 ) {
     exec('npx symlink-dir ' + from + ' ' + to, (error) => {
         if (error) {
-            console.error('Error occured while creating symlink: ' + error); // eslint-disable-line no-console
+            throw new Error('Error occured while creating symlink: ' + error);
         }
     });
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Throw error when can not create symlink.

#### Why?

Try to use node 8 or older the symlink script will not work and fail. This should cancel the installation.

#### Example Usage

In skeleton:

```php
cd assets/admin
fnm use 8
npm install
```
