### PR TITLE
Add missing hint about the changed default value of the single_select to UPGRADE.md

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -65,6 +65,12 @@ ALTER TABLE `se_roles` CHANGE `anonymous` `anonymous` TINYINT(1) NOT NULL DEFAUL
 
 ## 2.2.0-RC1
 
+### Changed default value for single_select properties from empty string to null
+
+The default value for properties with the type `single_select` was changed from an empty string (`''`) to `null` to
+be consistent with the `*_single_selection` property types. If you depend on the default value being an empty string
+in your twig template, you need to adjust your template.
+
 ### CKeditor update
 
 Due to the update of the CKEditor you have to make sure that you are also using the latest ckeditor packages in your


### PR DESCRIPTION
The default value was changed here: https://github.com/sulu/sulu/commit/8c23932a4d8e1abc7d17f066e27c91726c588d48#diff-1e15a373c38c17902d5b054e3dbf4f248995c2e3ea494ffb861a1981e065b073L25