### PR TITLE
Fix ordering in ContactSelection and AccountSelection

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Content/Types/AccountSelection.php
+++ b/src/Sulu/Bundle/ContactBundle/Content/Types/AccountSelection.php
@@ -53,7 +53,7 @@ class AccountSelection extends SimpleContentType implements PreResolvableContent
         $accounts = $this->accountManager->getByIds($ids, $property->getStructure()->getLanguageCode());
 
         foreach ($accounts as $account) {
-            $contacts[\array_search($account->getId(), $ids)] = $account;
+            $accounts[\array_search($account->getId(), $ids)] = $account;
         }
 
         return $accounts;

--- a/src/Sulu/Bundle/ContactBundle/Content/Types/AccountSelection.php
+++ b/src/Sulu/Bundle/ContactBundle/Content/Types/AccountSelection.php
@@ -52,9 +52,10 @@ class AccountSelection extends SimpleContentType implements PreResolvableContent
 
         $accounts = $this->accountManager->getByIds($ids, $property->getStructure()->getLanguageCode());
 
-        foreach ($accounts as $account) {
-            $accounts[\array_search($account->getId(), $ids)] = $account;
-        }
+        $idPositions = \array_flip($ids);
+        \usort($accounts, function(Account $a, Account $b) use ($idPositions) {
+            return $idPositions[$a->getId()] - $idPositions[$b->getId()];
+        });
 
         return $accounts;
     }

--- a/src/Sulu/Bundle/ContactBundle/Content/Types/AccountSelection.php
+++ b/src/Sulu/Bundle/ContactBundle/Content/Types/AccountSelection.php
@@ -50,7 +50,13 @@ class AccountSelection extends SimpleContentType implements PreResolvableContent
             return [];
         }
 
-        return $this->accountManager->getByIds($ids, $property->getStructure()->getLanguageCode());
+        $accounts = $this->accountManager->getByIds($ids, $property->getStructure()->getLanguageCode());
+
+        foreach ($accounts as $account) {
+            $contacts[\array_search($account->getId(), $ids)] = $account;
+        }
+
+        return $accounts;
     }
 
     public function preResolve(PropertyInterface $property)

--- a/src/Sulu/Bundle/ContactBundle/Content/Types/ContactSelection.php
+++ b/src/Sulu/Bundle/ContactBundle/Content/Types/ContactSelection.php
@@ -52,9 +52,10 @@ class ContactSelection extends SimpleContentType implements PreResolvableContent
 
         $contacts = $this->contactRepository->findByIds($ids);
 
-        foreach ($contacts as $contact) {
-            $contacts[\array_search($contact->getId(), $ids)] = $contact;
-        }
+        $idPositions = \array_flip($ids);
+        \usort($contacts, function(ContactInterface $a, ContactInterface $b) use ($idPositions) {
+            return $idPositions[$a->getId()] - $idPositions[$b->getId()];
+        });
 
         return $contacts;
     }

--- a/src/Sulu/Bundle/ContactBundle/Content/Types/ContactSelection.php
+++ b/src/Sulu/Bundle/ContactBundle/Content/Types/ContactSelection.php
@@ -50,7 +50,13 @@ class ContactSelection extends SimpleContentType implements PreResolvableContent
             return [];
         }
 
-        return $this->contactRepository->findByIds($ids);
+        $contacts = $this->contactRepository->findByIds($ids);
+
+        foreach ($contacts as $contact) {
+            $contacts[\array_search($contact->getId(), $ids)] = $contact;
+        }
+
+        return $contacts;
     }
 
     public function preResolve(PropertyInterface $property)

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/ContactSelectionTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/ContactSelectionTest.php
@@ -64,7 +64,9 @@ class ContactSelectionTest extends TestCase
         $this->contactRepository = $this->prophesize(ContactRepositoryInterface::class);
         $this->contactReferenceStore = $this->prophesize(ReferenceStore::class);
         $this->contact1 = $this->prophesize(ContactInterface::class);
+        $this->contact1->getId()->willReturn(123);
         $this->contact2 = $this->prophesize(ContactInterface::class);
+        $this->contact2->getId()->willReturn(789);
         $this->node = $this->prophesize(NodeInterface::class);
         $this->property = $this->prophesize(PropertyInterface::class);
         $this->contactSelection = new ContactSelection(
@@ -78,7 +80,7 @@ class ContactSelectionTest extends TestCase
         $this->node->hasProperty('contacts')->willReturn(true);
         $this->node->getPropertyValue('contacts')->willReturn([123, 789]);
 
-        $this->assertEquals(
+        $this->assertSame(
             [123, 789],
             $this->contactSelection->read(
                 $this->node->reveal(),
@@ -128,7 +130,7 @@ class ContactSelectionTest extends TestCase
 
     public function testDefaultParams()
     {
-        $this->assertEquals(
+        $this->assertSame(
             [],
             $this->contactSelection->getDefaultParams(new Property('contacts', [], 'contact_selection'))
         );
@@ -136,7 +138,7 @@ class ContactSelectionTest extends TestCase
 
     public function testViewDataEmpty()
     {
-        $this->assertEquals(
+        $this->assertSame(
             [],
             $this->contactSelection->getViewData(new Property('contacts', [], 'contact_selection'))
         );
@@ -147,7 +149,7 @@ class ContactSelectionTest extends TestCase
         $property = new Property('contacts', [], 'contact_selection');
         $property->setValue([123, 789]);
 
-        $this->assertEquals(
+        $this->assertSame(
             [],
             $this->contactSelection->getViewData($property)
         );
@@ -155,7 +157,7 @@ class ContactSelectionTest extends TestCase
 
     public function testContentDataEmpty()
     {
-        $this->assertEquals(
+        $this->assertSame(
             [],
             $this->contactSelection->getContentData(new Property('contacts', [], 'contact_selection'))
         );
@@ -169,7 +171,21 @@ class ContactSelectionTest extends TestCase
         $result = [$this->contact1->reveal(), $this->contact2->reveal()];
         $this->contactRepository->findByIds([123, 789])->willReturn($result);
 
-        $this->assertEquals($result, $this->contactSelection->getContentData($property));
+        $this->assertSame($result, $this->contactSelection->getContentData($property));
+    }
+
+    public function testContentDataWithSorting()
+    {
+        $property = new Property('contacts', [], 'contact_selection');
+        $property->setValue([789, 123]);
+
+        $this->contactRepository->findByIds([789, 123])
+            ->willReturn([$this->contact1->reveal(), $this->contact2->reveal()]);
+
+        $this->assertSame(
+            [$this->contact2->reveal(), $this->contact1->reveal()],
+            $this->contactSelection->getContentData($property)
+        );
     }
 
     public function testPreResolveEmpty()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no 
| Deprecations? | no
| Fixed tickets | fixes #5857
| Related issues/PRs | #5857
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

This PR fixes the sorting in ContactSelection and AccountSelection. 

#### Why?

The list of contacts or accounts should be received in the same order as in Admin.

