### PR TITLE
Allow to define empty option for single_select property in form configuration

### DIFF
--- a/config/templates/pages/example.xml
+++ b/config/templates/pages/example.xml
@@ -116,19 +116,25 @@
 
             <params>
                 <param name="values" type="collection">
+                    <param name="">
+                        <meta>
+                            <title lang="en">No selection</title>
+                            <title lang="de">Keine Auswahl</title>
+                        </meta>
+                    </param>
                     <param name="value-1">
                         <meta>
                             <title lang="en">Value 1</title>
                             <title lang="de">Wert 1</title>
                         </meta>
                     </param>
-                    <param name="value-2" value="Value 2">
+                    <param name="value-2">
                         <meta>
                             <title lang="en">Value 2</title>
                             <title lang="de">Wert 2</title>
                         </meta>
                     </param>
-                    <param name="value-3" value="Value 3">
+                    <param name="value-3">
                         <meta>
                             <title lang="en">Value 3</title>
                             <title lang="de">Wert 3</title>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
@@ -16,7 +16,7 @@ export default class SingleSelect extends React.Component<FieldTypeProps<string 
             } = {},
         } = schemaOptions;
 
-        if (defaultValue === undefined || defaultValue === null) {
+        if (defaultValue === undefined || defaultValue === null || defaultValue === '') {
             return;
         }
 
@@ -41,7 +41,7 @@ export default class SingleSelect extends React.Component<FieldTypeProps<string 
         const values = toJS(schemaOptions.values);
 
         if (!values || !Array.isArray(values.value)) {
-            throw new Error('The "values" option has to be set for the SingleSelect FieldType');
+            throw new Error('The "values" schema option of the SingleSelect field-type must be an array!');
         }
 
         return (
@@ -51,8 +51,12 @@ export default class SingleSelect extends React.Component<FieldTypeProps<string 
                         throw new Error('The children of "values" must only contain values of type string or number!');
                     }
 
+                    // it is not possible to define a param without a name in a form xml. to allow for creating an
+                    // empty option, we use undefined as value if the name of a param is an empty string in the xml
+                    const normalizedValue = value === '' ? undefined : value;
+
                     return (
-                        <SingleSelectComponent.Option key={value} value={value}>
+                        <SingleSelectComponent.Option key={value} value={normalizedValue}>
                             {title || value}
                         </SingleSelectComponent.Option>
                     );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelect.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelect.test.js
@@ -84,6 +84,41 @@ test('Pass value if no title is given to SingleSelect', () => {
     }));
 });
 
+test('Pass undefined as option-value if value with empty name is given to SingleSelect', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+    const schemaOptions = observable({
+        values: {
+            name: 'values',
+            value: [
+                {
+                    name: '',
+                    title: 'No Selection',
+                },
+                {
+                    name: 'ms',
+                    title: 'Miss',
+                },
+            ],
+        },
+    });
+    const singleSelect = shallow(
+        <SingleSelect
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            schemaOptions={schemaOptions}
+        />
+    );
+
+    expect(singleSelect.find('Option').at(0).props()).toEqual(expect.objectContaining({
+        value: undefined,
+        children: 'No Selection',
+    }));
+    expect(singleSelect.find('Option').at(1).props()).toEqual(expect.objectContaining({
+        value: 'ms',
+        children: 'Miss',
+    }));
+});
+
 test('Should throw an exception if defaultValue is of wrong type', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
     const schemaOptions = {
@@ -175,7 +210,7 @@ test('Should call onFinish callback on every onChange', () => {
     expect(finishSpy).toBeCalledWith();
 });
 
-test('Set default value of null should not call onChange', () => {
+test('Default value of null should not call onChange', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
     const changeSpy = jest.fn();
     const schemaOptions = {
@@ -190,9 +225,35 @@ test('Set default value of null should not call onChange', () => {
                     name: 'mr',
                     title: 'Mister',
                 },
+            ],
+        },
+    };
+    shallow(
+        <SingleSelect
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            onChange={changeSpy}
+            schemaOptions={schemaOptions}
+        />
+    );
+
+    expect(changeSpy).not.toBeCalled();
+});
+
+test('Default value of empty string should not call onChange', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+    const changeSpy = jest.fn();
+    const schemaOptions = {
+        default_value: {
+            name: 'default_value',
+            value: '',
+        },
+        values: {
+            name: 'values',
+            value: [
                 {
-                    name: 'ms',
-                    title: 'Miss',
+                    name: 'mr',
+                    title: 'Mister',
                 },
             ],
         },
@@ -277,7 +338,7 @@ test('Set default value to a number of 0 should work', () => {
     expect(changeSpy).toBeCalledWith(0);
 });
 
-test('Throw error if no value option is passed', () => {
+test('Throw error if no values option is passed', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
     expect(() => shallow(
         <SingleSelect
@@ -287,7 +348,7 @@ test('Throw error if no value option is passed', () => {
     ).toThrow(/"values"/);
 });
 
-test('Throw error if value option with wrong is passed', () => {
+test('Throw error if values option with wrong type is passed', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
     expect(() => shallow(
         <SingleSelect


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adjusts the `SingleSelect` field-type to allow for defining an empty option in the form configuration xml like shown below. The empty option will appear as selected when a new page is created and allows to "unselect" the selected option later on.

```xml
<property name="single_select" type="single_select">
    <meta>
        <title lang="en">Single Select</title>
        <title lang="de">Einzelauswahl</title>
    </meta>

    <params>
        <param name="values" type="collection">
            <param name="">
                <meta>
                    <title lang="en">No selection</title>
                    <title lang="de">Keine Auswahl</title>
                </meta>
            </param>
            <param name="value-1">
                <meta>
                    <title lang="en">Value 1</title>
                    <title lang="de">Wert 1</title>
                </meta>
            </param>
            <param name="value-2">
                <meta>
                    <title lang="en">Value 2</title>
                    <title lang="de">Wert 2</title>
                </meta>
            </param>
        </param>
    </params>
</property>
```

#### Why?

At the moment, it is not possible to define an empty option in the form configuration xml. The `single_select` property will always show `Please choose` for new pages if no default value is set.