### PR TITLE
Display title of internal link instead of link destination in webspace overview

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,13 @@
 # Upgrade
 
+## 2.1.10
+
+### Changed ContentRepository to return title of source instead of link destination for internal link pages
+
+The `ContentRepository` service was changed to return the title of the source page instead of the title of the destination
+page for internal links. This makes the behaviour consistent with external links and the `ContentMapper` service. 
+This change only affects you if you are using the `ContentRepository` service with a mapping that includes the `title` property.
+
 ## 2.1.9
 
 ### A new argument `$requestStack` has been added to the `ContentTwigExtension`

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/ContentRepositoryTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/ContentRepositoryTest.php
@@ -266,7 +266,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertCount(3, $result);
 
         $this->assertEquals('test-1', $result[0]['title']);
-        $this->assertEquals('test-1', $result[1]['title']);
+        $this->assertEquals('test-2', $result[1]['title']);
         $this->assertEquals(RedirectType::INTERNAL, $result[1]->getNodeType());
         $this->assertEquals('test-3', $result[2]['title']);
     }
@@ -289,7 +289,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertCount(3, $result);
 
         $this->assertEquals('test-1', $result[0]['title']);
-        $this->assertEquals('test-1', $result[1]['title']);
+        $this->assertEquals('test-2', $result[1]['title']);
         $this->assertEquals(RedirectType::INTERNAL, $result[1]->getNodeType());
         $this->assertEmpty($result[1]['published']);
         $this->assertEquals('test-3', $result[2]['title']);
@@ -335,7 +335,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertCount(3, $result);
 
         $this->assertEquals('test-1', $result[0]['title']);
-        $this->assertEquals('test-1', $result[1]['title']);
+        $this->assertEquals('test-2', $result[1]['title']);
         $this->assertEquals(RedirectType::INTERNAL, $result[1]->getNodeType());
         $this->assertEquals('test-3', $result[2]['title']);
     }
@@ -452,7 +452,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertCount(3, $result);
 
         $this->assertEquals('test-1', $result[0]['title']);
-        $this->assertEquals('test-1', $result[1]['title']);
+        $this->assertEquals('test-2', $result[1]['title']);
         $this->assertEquals('test-3', $result[2]['title']);
     }
 
@@ -471,7 +471,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertCount(3, $result);
 
         $this->assertEquals('test-1', $result[0]['title']);
-        $this->assertEquals('test-1', $result[1]['title']);
+        $this->assertEquals('test-2', $result[1]['title']);
         $this->assertEquals('test-3', $result[2]['title']);
     }
 
@@ -563,7 +563,7 @@ class ContentRepositoryTest extends SuluTestCase
 
         $this->assertEquals($page->getUuid(), $result->getId());
         $this->assertEquals('/test-2', $result->getPath());
-        $this->assertEquals('test-1', $result['title']);
+        $this->assertEquals('test-2', $result['title']);
     }
 
     public function testFindWithEmptyInternalLink()
@@ -626,7 +626,7 @@ class ContentRepositoryTest extends SuluTestCase
 
         $this->assertEquals($page->getUuid(), $result->getId());
         $this->assertEquals('/test-2', $result->getPath());
-        $this->assertEquals('test-1', $result['title']);
+        $this->assertEquals('test-2', $result['title']);
     }
 
     public function testFindWithNonFallbackProperties()
@@ -685,7 +685,7 @@ class ContentRepositoryTest extends SuluTestCase
 
         $this->assertEquals($page->getUuid(), $result->getId());
         $this->assertEquals('/test-2', $result->getPath());
-        $this->assertEquals('test-1', $result['title']);
+        $this->assertEquals('test-2', $result['title']);
     }
 
     public function testFindPermissions()

--- a/src/Sulu/Component/Content/Repository/ContentRepository.php
+++ b/src/Sulu/Component/Content/Repository/ContentRepository.php
@@ -715,7 +715,8 @@ class ContentRepository implements ContentRepositoryInterface
         $data = $linkedContent->getData();
 
         // return value of source node instead of link destination for title and non-fallback-properties
-        $sourceNodeValueProperties = array_merge(['title'], self::$nonFallbackProperties);
+        $sourceNodeValueProperties = self::$nonFallbackProperties;
+        $sourceNodeValueProperties[] = 'title';
         $properties = \array_intersect($sourceNodeValueProperties, \array_keys($data));
         foreach ($properties as $property) {
             $data[$property] = $this->resolveProperty($row, $property, $locale);

--- a/src/Sulu/Component/Content/Repository/ContentRepository.php
+++ b/src/Sulu/Component/Content/Repository/ContentRepository.php
@@ -714,9 +714,9 @@ class ContentRepository implements ContentRepositoryInterface
         $linkedContent = $this->find($row->getValue('internalLink'), $locale, $webspaceKey, $mapping);
         $data = $linkedContent->getData();
 
-        // properties which are in the intersection of the data and non
-        // fallback properties should be handled on the original row.
-        $properties = \array_intersect(self::$nonFallbackProperties, \array_keys($data));
+        // return value of source node instead of link destination for title and non-fallback-properties
+        $sourceNodeValueProperties = array_merge(['title'], self::$nonFallbackProperties);
+        $properties = \array_intersect($sourceNodeValueProperties, \array_keys($data));
         foreach ($properties as $property) {
             $data[$property] = $this->resolveProperty($row, $property, $locale);
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Fixed tickets | fixes #3721, fixes #3877
| License | MIT

#### What's in this PR?

This PR adjusts the `ContentRepository` service to return the title of the source page instead of the title of the destination page for internal links. This affects the title that is displayed for internal links in the webspace overview.

#### Why?

This makes the displayed title consistent to the title returned by the `sulu_navigation_*` functions. Furthermore, it makes the behaviour of the `ContentRepository` consistent to the `ContentMapper`.
