### PR TITLE
Return title of internal link instead of link destination in sulu_breadcrumb function

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationMapper.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationMapper.php
@@ -157,7 +157,7 @@ class NavigationMapper implements NavigationMapperInterface
         foreach ($contents as $content) {
             if ($this->inNavigation($content, $context)) {
                 $url = $content->getResourceLocator();
-                $title = $content->getNodeName();
+                $title = $content->getTitle();
                 $children = $recursive ? $this->generateChildNavigation($content, $webspace, $language, $flat, $context) : [];
 
                 if (false === $flat) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #5276
| License | MIT

#### What's in this PR?

This PR adjusts the `NavigationMapper::generateNavigation` method to return the title of the source page instead of the title of the destination page for internal links. The method is private and used only by the `NavigationMapper::getBreadcrumb` method. This affects the title that is returned by the `sulu_breadcrumb` twig function.

#### Why?

This makes the title returned by the `sulu_breadcrumb` twig function consistent the `sulu_navigation_*` functions. Furthermore, it makes the behaviour of the `NavigationMapper` consistent to the `ContentMapper`.