### PR TITLE
Add upload button to media selection

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/Button.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/Button.js
@@ -91,12 +91,19 @@ export default class Button<T> extends React.PureComponent<Props<T>> {
                 {icon &&
                     <Icon className={iconClass} name={icon} />
                 }
+
+                {icon && children && (
+                    <span className={buttonStyles.spacer} />
+                )}
+
                 {children &&
                     <span className={buttonStyles.buttonText}>{children}</span>
                 }
+
                 {showDropdownIcon &&
                     <Icon className={buttonStyles.dropdownIcon} name="su-angle-down" />
                 }
+
                 {loading &&
                     <div className={buttonStyles.loader}>
                         <Loader size={LOADER_SIZE} />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/button.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/button.scss
@@ -114,6 +114,10 @@ $iconColorActive: $white;
     }
 }
 
+.spacer {
+    margin: auto 5px;
+}
+
 .text {
     padding: 0;
     border: 0;
@@ -146,7 +150,7 @@ $iconColorActive: $white;
     color: $iconBorderColor;
     cursor: pointer;
     font-size: $iconFontSize;
-    padding: 0 5px;
+    padding: 0 10px;
 
     &:hover:not(:disabled) {
         background-color: $silver;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
@@ -38,6 +38,7 @@ type Props = {|
     adapters: Array<string>,
     allowActivateForDisabledItems: boolean,
     copyable: boolean,
+    customButtons?: Array<Node>,
     deletable: boolean,
     disabled: boolean,
     disabledIds: Array<string | number>,
@@ -65,6 +66,7 @@ class List extends React.Component<Props> {
     static defaultProps = {
         allowActivateForDisabledItems: true,
         copyable: true,
+        customButtons: [],
         deletable: true,
         disabled: false,
         disabledIds: [],

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
@@ -515,6 +515,7 @@ class List extends React.Component<Props> {
             adapterOptions,
             adapters,
             copyable,
+            customButtons,
             deletable,
             disabled,
             header,
@@ -601,7 +602,7 @@ class List extends React.Component<Props> {
                             </Fragment>
                         }
 
-                        {this.props.customButtons}
+                        {customButtons}
 
                         <AdapterSwitch
                             adapters={adapters}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
@@ -598,6 +598,9 @@ class List extends React.Component<Props> {
                                 />
                             </Fragment>
                         }
+
+                        {this.props.customButtons}
+
                         <AdapterSwitch
                             adapters={adapters}
                             currentAdapter={this.currentAdapterKey}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
@@ -37,8 +37,8 @@ type Props = {|
     adapterOptions?: {[adapterKey: string]: {[key: string]: mixed}},
     adapters: Array<string>,
     allowActivateForDisabledItems: boolean,
+    buttons?: Array<Node>,
     copyable: boolean,
-    customButtons?: Array<Node>,
     deletable: boolean,
     disabled: boolean,
     disabledIds: Array<string | number>,
@@ -65,8 +65,8 @@ const USER_SETTING_ADAPTER = 'adapter';
 class List extends React.Component<Props> {
     static defaultProps = {
         allowActivateForDisabledItems: true,
+        buttons: [],
         copyable: true,
-        customButtons: [],
         deletable: true,
         disabled: false,
         disabledIds: [],
@@ -514,8 +514,8 @@ class List extends React.Component<Props> {
         const {
             adapterOptions,
             adapters,
+            buttons,
             copyable,
-            customButtons,
             deletable,
             disabled,
             header,
@@ -602,7 +602,7 @@ class List extends React.Component<Props> {
                             </Fragment>
                         }
 
-                        {customButtons}
+                        {buttons}
 
                         <AdapterSwitch
                             adapters={adapters}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
@@ -22,12 +22,11 @@ type Props = {
     listStore: ListStore,
     locale: IObservableValue<string>,
     onCollectionNavigate: (collectionId: ?string | number) => void,
+    onOpenDropZone: () => void,
     overlayType: OverlayType,
     resourceStore: ResourceStore,
     securable: boolean,
-
     uploadable: boolean,
-    onOpenDropZone: () => void,
 };
 
 @observer
@@ -196,11 +195,11 @@ class CollectionSection extends React.Component<Props> {
             editable,
             listStore,
             locale,
+            onOpenDropZone,
             overlayType,
             resourceStore,
             securable,
             uploadable,
-            onOpenDropZone,
         } = this.props;
 
         const operationType = this.openedCollectionOperationOverlayType;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
@@ -25,6 +25,9 @@ type Props = {
     overlayType: OverlayType,
     resourceStore: ResourceStore,
     securable: boolean,
+
+    uploadable: boolean,
+    onOpenDropZone: () => void,
 };
 
 @observer
@@ -196,6 +199,8 @@ class CollectionSection extends React.Component<Props> {
             overlayType,
             resourceStore,
             securable,
+            uploadable,
+            onOpenDropZone,
         } = this.props;
 
         const operationType = this.openedCollectionOperationOverlayType;
@@ -216,6 +221,11 @@ class CollectionSection extends React.Component<Props> {
                                 {addable &&
                                     <Button icon="su-plus" onClick={this.handleAddCollectionClick} />
                                 }
+
+                                {uploadable && (
+                                    <Button icon="su-upload" onClick={onOpenDropZone} />
+                                )}
+
                                 {!!resourceStore.id && (editable || deletable || editable || securable) &&
                                     <DropdownButton icon="su-cog">
                                         {editable &&

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
@@ -22,11 +22,9 @@ type Props = {
     listStore: ListStore,
     locale: IObservableValue<string>,
     onCollectionNavigate: (collectionId: ?string | number) => void,
-    onOpenDropZone: () => void,
     overlayType: OverlayType,
     resourceStore: ResourceStore,
     securable: boolean,
-    uploadable: boolean,
 };
 
 @observer
@@ -195,11 +193,9 @@ class CollectionSection extends React.Component<Props> {
             editable,
             listStore,
             locale,
-            onOpenDropZone,
             overlayType,
             resourceStore,
             securable,
-            uploadable,
         } = this.props;
 
         const operationType = this.openedCollectionOperationOverlayType;
@@ -218,13 +214,10 @@ class CollectionSection extends React.Component<Props> {
                         <div className={collectionSectionStyles.right}>
                             <ButtonGroup>
                                 {addable &&
-                                    <Button icon="su-plus" onClick={this.handleAddCollectionClick} />
+                                    <Button icon="su-plus" onClick={this.handleAddCollectionClick}>
+                                        Add folder
+                                    </Button>
                                 }
-
-                                {uploadable && (
-                                    <Button icon="su-upload" onClick={onOpenDropZone} />
-                                )}
-
                                 {!!resourceStore.id && (editable || deletable || editable || securable) &&
                                     <DropdownButton icon="su-cog">
                                         {editable &&

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
@@ -215,7 +215,7 @@ class CollectionSection extends React.Component<Props> {
                             <ButtonGroup>
                                 {addable &&
                                     <Button icon="su-plus" onClick={this.handleAddCollectionClick}>
-                                        Add folder
+                                        {translate('sulu_media.add_collection')}
                                     </Button>
                                 }
                                 {!!resourceStore.id && (editable || deletable || editable || securable) &&

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -97,6 +97,8 @@ class MediaCollection extends React.Component<Props> {
         const securable = !locked
             && (permissions.security !== undefined ? permissions.security : MediaCollection.securable);
 
+        const hasCollectionId = ['string', 'number'].includes(typeof collectionStore.id);
+
         return (
             <MultiMediaDropzone
                 collectionId={addable ? collectionStore.id : undefined}
@@ -117,6 +119,9 @@ class MediaCollection extends React.Component<Props> {
                     overlayType={overlayType}
                     resourceStore={collectionStore.resourceStore}
                     securable={securable}
+
+                    uploadable={addable && hasCollectionId}
+                    onOpenDropZone={onUploadOverlayOpen}
                 />
                 <Divider />
                 <div>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -116,12 +116,11 @@ class MediaCollection extends React.Component<Props> {
                     listStore={collectionListStore}
                     locale={locale}
                     onCollectionNavigate={this.handleCollectionNavigate}
+                    onOpenDropZone={onUploadOverlayOpen}
                     overlayType={overlayType}
                     resourceStore={collectionStore.resourceStore}
                     securable={securable}
-
                     uploadable={addable && hasCollectionId}
-                    onOpenDropZone={onUploadOverlayOpen}
                 />
                 <Divider />
                 <div>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -116,11 +116,9 @@ class MediaCollection extends React.Component<Props> {
                     listStore={collectionListStore}
                     locale={locale}
                     onCollectionNavigate={this.handleCollectionNavigate}
-                    onOpenDropZone={onUploadOverlayOpen}
                     overlayType={overlayType}
                     resourceStore={collectionStore.resourceStore}
                     securable={securable}
-                    uploadable={addable && hasCollectionId}
                 />
                 <Divider />
                 <div>
@@ -129,6 +127,8 @@ class MediaCollection extends React.Component<Props> {
                         listStore={mediaListStore}
                         mediaListRef={mediaListRef}
                         onMediaClick={this.handleMediaClick}
+                        onUploadOverlayOpen={onUploadOverlayOpen}
+                        uploadable={addable && hasCollectionId}
                     />
                 </div>
             </MultiMediaDropzone>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -97,7 +97,9 @@ class MediaCollection extends React.Component<Props> {
         const securable = !locked
             && (permissions.security !== undefined ? permissions.security : MediaCollection.securable);
 
-        const hasCollectionId = ['string', 'number'].includes(typeof collectionStore.id);
+        const onUploadClick = (addable && collectionStore.id)
+            ? onUploadOverlayOpen
+            : null;
 
         return (
             <MultiMediaDropzone
@@ -127,8 +129,7 @@ class MediaCollection extends React.Component<Props> {
                         listStore={mediaListStore}
                         mediaListRef={mediaListRef}
                         onMediaClick={this.handleMediaClick}
-                        onUploadOverlayOpen={onUploadOverlayOpen}
-                        uploadable={addable && hasCollectionId}
+                        onUploadClick={onUploadClick}
                     />
                 </div>
             </MultiMediaDropzone>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaSection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaSection.js
@@ -30,8 +30,7 @@ export default class MediaSection extends React.PureComponent<Props> {
         return (
             <List
                 adapters={adapters}
-                customButtons={[
-                    uploadable && (
+                buttons={[
                         <ButtonGroup key="upload-media">
                             <Button icon="su-upload" onClick={onUploadOverlayOpen}>
                                 Upload File

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaSection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaSection.js
@@ -24,16 +24,12 @@ export default class MediaSection extends React.PureComponent<Props> {
             listStore,
             mediaListRef,
             onUploadOverlayOpen,
-            uploadable
+            uploadable,
         } = this.props;
 
         return (
             <List
                 adapters={adapters}
-                onItemClick={this.handleMediaClick}
-                ref={mediaListRef}
-                store={listStore}
-
                 customButtons={[
                     uploadable && (
                         <ButtonGroup key="upload-media">
@@ -41,8 +37,12 @@ export default class MediaSection extends React.PureComponent<Props> {
                                 Upload File
                             </Button>
                         </ButtonGroup>
-                    )
+                    ),
                 ]}
+
+                onItemClick={this.handleMediaClick}
+                ref={mediaListRef}
+                store={listStore}
             />
         );
     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaSection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaSection.js
@@ -2,12 +2,15 @@
 import React from 'react';
 import type {ElementRef} from 'react';
 import {List, ListStore} from 'sulu-admin-bundle/containers';
+import {Button, ButtonGroup} from 'sulu-admin-bundle/components';
 
 type Props = {|
     adapters: Array<string>,
     listStore: ListStore,
     mediaListRef?: (?ElementRef<typeof List>) => void,
     onMediaClick: (mediaId: string | number) => void,
+    onUploadOverlayOpen: () => void,
+    uploadable: boolean,
 |};
 
 export default class MediaSection extends React.PureComponent<Props> {
@@ -20,6 +23,8 @@ export default class MediaSection extends React.PureComponent<Props> {
             adapters,
             listStore,
             mediaListRef,
+            onUploadOverlayOpen,
+            uploadable
         } = this.props;
 
         return (
@@ -28,6 +33,16 @@ export default class MediaSection extends React.PureComponent<Props> {
                 onItemClick={this.handleMediaClick}
                 ref={mediaListRef}
                 store={listStore}
+
+                customButtons={[
+                    uploadable && (
+                        <ButtonGroup key="upload-media">
+                            <Button icon="su-upload" onClick={onUploadOverlayOpen}>
+                                Upload File
+                            </Button>
+                        </ButtonGroup>
+                    )
+                ]}
             />
         );
     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaSection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaSection.js
@@ -29,17 +29,20 @@ export default class MediaSection extends React.PureComponent<Props> {
             adapters,
             listStore,
             mediaListRef,
+            onUploadClick,
         } = this.props;
 
         return (
             <List
                 adapters={adapters}
                 buttons={[
-                    <ButtonGroup key="upload-media">
-                        <Button icon="su-upload" onClick={this.handleUploadClick}>
-                            {translate('sulu_media.upload')}
-                        </Button>
-                    </ButtonGroup>,
+                    onUploadClick && (
+                        <ButtonGroup key="upload-media">
+                            <Button icon="su-upload" onClick={this.handleUploadClick}>
+                                {translate('sulu_media.upload')}
+                            </Button>
+                        </ButtonGroup>
+                    ),
                 ]}
 
                 onItemClick={this.handleMediaClick}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaSection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaSection.js
@@ -3,14 +3,14 @@ import React from 'react';
 import type {ElementRef} from 'react';
 import {List, ListStore} from 'sulu-admin-bundle/containers';
 import {Button, ButtonGroup} from 'sulu-admin-bundle/components';
+import {translate} from 'sulu-admin-bundle/utils';
 
 type Props = {|
     adapters: Array<string>,
     listStore: ListStore,
     mediaListRef?: (?ElementRef<typeof List>) => void,
     onMediaClick: (mediaId: string | number) => void,
-    onUploadOverlayOpen: () => void,
-    uploadable: boolean,
+    onUploadClick: (() => void) | null,
 |};
 
 export default class MediaSection extends React.PureComponent<Props> {
@@ -18,25 +18,28 @@ export default class MediaSection extends React.PureComponent<Props> {
         this.props.onMediaClick(mediaId);
     };
 
+    handleUploadClick = () => {
+        if (this.props.onUploadClick) {
+            this.props.onUploadClick();
+        }
+    };
+
     render() {
         const {
             adapters,
             listStore,
             mediaListRef,
-            onUploadOverlayOpen,
-            uploadable,
         } = this.props;
 
         return (
             <List
                 adapters={adapters}
                 buttons={[
-                        <ButtonGroup key="upload-media">
-                            <Button icon="su-upload" onClick={onUploadOverlayOpen}>
-                                Upload File
-                            </Button>
-                        </ButtonGroup>
-                    ),
+                    <ButtonGroup key="upload-media">
+                        <Button icon="su-upload" onClick={this.handleUploadClick}>
+                            {translate('sulu_media.upload')}
+                        </Button>
+                    </ButtonGroup>,
                 ]}
 
                 onItemClick={this.handleMediaClick}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/DropzoneOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/DropzoneOverlay.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import type {ChildrenArray, Element} from 'react';
+import type {ChildrenArray, Element, ElementRef} from 'react';
 import {observer} from 'mobx-react';
 import Mousetrap from 'mousetrap';
 import {Portal} from 'react-portal';
@@ -78,8 +78,12 @@ class DropzoneOverlay extends React.Component<Props> {
                 <div
                     className={dropzoneOverlayStyles.dropzoneOverlay}
                     onClick={this.handleClose}
-                    onDragLeave={onDragLeave}
                     role="button"
+
+                    onDragLeave={(e) => {
+                        console.log('onDragLeave', e.target)
+                        onDragLeave();
+                    }}
                 >
                     <div className={dropzoneOverlayStyles.dropArea}>
                         <div className={dropzoneOverlayStyles.uploadInfoContainer}>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/DropzoneOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/DropzoneOverlay.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import type {ChildrenArray, Element, ElementRef} from 'react';
+import type {ChildrenArray, Element} from 'react';
 import {observer} from 'mobx-react';
 import Mousetrap from 'mousetrap';
 import {Portal} from 'react-portal';
@@ -78,12 +78,8 @@ class DropzoneOverlay extends React.Component<Props> {
                 <div
                     className={dropzoneOverlayStyles.dropzoneOverlay}
                     onClick={this.handleClose}
+                    onDragLeave={onDragLeave}
                     role="button"
-
-                    onDragLeave={(e) => {
-                        console.log('onDragLeave', e.target)
-                        onDragLeave();
-                    }}
                 >
                     <div className={dropzoneOverlayStyles.dropArea}>
                         <div className={dropzoneOverlayStyles.uploadInfoContainer}>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #5039 <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #5039 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

<!-- Explain the contents of the PR. -->

Added the ability to open the `MultiMediaDropzone` by clicking the newly added upload button.

#### Why?

Because it kinda confused me, that I am only able to upload new medias in the media collection and not in the media selection. Until I realized, you **can** upload in the media section, but only by dragging a file inside the modal.

<!-- Which problem does the PR fix? (add some context and maybe link to an issue here) -->

I added an `uploadable` boolean to the `CollectionSection` component. Basing on the investigation I made in the `MultiMediaDropzone`, you can upload a file if addable is true and a collectionId is defined.

Then I passed the onUploadOverlayOpen to the `CollectionSection` component, to trigger the overlay open state.

#### Example Usage

<!--
```php
// If you added new features, show examples of how to use them here

$foo = new Foo();

// Now we can do
$foo->doSomething();
```
-->

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
