### PR TITLE
Remove mandatory of user roles

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/forms/user_details.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/forms/user_details.xml
@@ -57,7 +57,7 @@
                 <title>sulu_security.permissions</title>
             </meta>
             <properties>
-                <property name="userRoles" mandatory="true" type="role_assignments">
+                <property name="userRoles" type="role_assignments">
                     <meta>
                         <title>sulu_security.roles</title>
                     </meta>

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/AdminControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/AdminControllerTest.php
@@ -52,7 +52,7 @@ class AdminControllerTest extends SuluTestCase
 
         $schema = $response->schema;
 
-        $this->assertEquals(['username', 'locale', 'userRoles'], $schema->allOf[0]->required);
+        $this->assertEquals(['username', 'locale'], $schema->allOf[0]->required);
         $this->assertEquals(['id'], $schema->allOf[1]->anyOf[0]->required);
         $this->assertEquals(['password'], $schema->allOf[1]->anyOf[1]->required);
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | part of #5886 <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove mandatory of user roles.

#### Why?

The user roles are not mandatory, currently they are marked as mandatory. There is another open issue that we should check why the role_assignement doesn't support mandatory, but I think its okay the user roles are not mandatory.

