### PR TITLE
Add conflict to failing jms/serializer-bundle and doctrine/doctrine-bundle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -138,10 +138,12 @@
     "conflict": {
         "doctrine/dbal": "2.7.0",
         "doctrine/lexer": "1.0.0",
+        "doctrine/doctrine-bundle": "2.3.0",
         "doctrine/doctrine-cache-bundle": "<1.3.1",
         "jackalope/jackalope": "< 1.3.4",
         "jackalope/jackalope-doctrine-dbal": "< 1.3.0",
         "jackalope/jackalope-jackrabbit": "< 1.3.0",
+        "jms/serializer-bundle": "3.9.0",
         "php-http/discovery": "< 1.8.0",
         "phpcr/phpcr-utils": "1.2.0 - 1.2.10 || 1.3.0 - 1.3.2",
         "phpdocumentor/reflection-docblock": "5.0.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #5889
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add conflict to failing jms/serializer-bundle and doctrine/doctrine-bundle version.

#### Why?

See: https://github.com/schmittjoh/JMSSerializerBundle/issues/844 (introduced with 3.9.0 jms serializer bundle release)
See: https://github.com/doctrine/DoctrineBundle/issues/1305 (introduced with 2.3.0 doctrine bundle release)

The linked issues are not related to each other just did occur now because both bundles had a new release which a bc break in it.

#### Example Usage

Add following to your composer.json:

```json
    "conflict": {
        "doctrine/doctrine-bundle": "2.3.0",
        "jms/serializer-bundle": "3.9.0"
    }
```

