### PR TITLE
Add security system permission-check to PageLinkProvider

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Markup/Link/PageLinkProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Markup/Link/PageLinkProvider.php
@@ -120,6 +120,10 @@ class PageLinkProvider implements LinkProviderInterface
             $security = $targetWebspace->getSecurity();
             $system = $security ? $security->getSystem() : null;
 
+            if (!$targetWebspace->hasWebsiteSecurity()) {
+                return true;
+            }
+
             $userPermissions = $this->accessControlManager->getUserPermissionByArray(
                 $content->getLocale(),
                 PageAdmin::SECURITY_CONTEXT_PREFIX . $webspaceKey,

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Markup/Link/PageLinkProviderTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Markup/Link/PageLinkProviderTest.php
@@ -364,7 +364,7 @@ class PageLinkProviderTest extends TestCase
             [1, 2, 3],
             $this->locale,
             Argument::that(
-                function(MappingInterface $mapping) {
+                function (MappingInterface $mapping) {
                     return $mapping->resolveUrl()
                         && !$mapping->shouldHydrateGhost()
                         && $mapping->onlyPublished()

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Markup/Link/PageLinkProviderTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Markup/Link/PageLinkProviderTest.php
@@ -253,13 +253,14 @@ class PageLinkProviderTest extends TestCase
         $this->assertEquals(!empty($contents[0]->getPropertyWithDefault('published')), $result[0]->isPublished());
     }
 
-    public function testPreloadWithSecurity()
+    public function testPreloadWithSecurityAndWebsiteSecurityEnabled()
     {
         $this->requestStack->getCurrentRequest()->willReturn($this->request->reveal());
         $webspace = new Webspace();
         $security = new Security();
         $security->setSystem('website');
         $webspace->setSecurity($security);
+        $security->setPermissionCheck(true);
         $this->webspaceManager->findWebspaceByKey('sulu_io')->willReturn($webspace);
 
         $user = new User();
@@ -312,6 +313,70 @@ class PageLinkProviderTest extends TestCase
         $result = $this->pageLinkProvider->preload([1, 2, 3], $this->locale, true);
 
         $this->assertCount(2, $result);
+
+        $this->assertEquals($contents[0]->getId(), $result[0]->getId());
+        $this->assertEquals($contents[2]->getId(), $result[2]->getId());
+    }
+
+    public function testPreloadWithSecurity()
+    {
+        $this->requestStack->getCurrentRequest()->willReturn($this->request->reveal());
+        $webspace = new Webspace();
+        $security = new Security();
+        $security->setSystem('website');
+        $webspace->setSecurity($security);
+        $this->webspaceManager->findWebspaceByKey('sulu_io')->willReturn($webspace);
+
+        $user = new User();
+        $token = $this->prophesize(TokenInterface::class);
+        $token->getUser()->willReturn($user);
+        $this->tokenStorage->getToken()->willReturn($token->reveal());
+
+        $contents = [
+            $this->createContent(1, 'Test 1', '/test-1', null, 'sulu.io', 'sulu_io', []),
+            $this->createContent(2, 'Test 2', '/test-2', null, 'sulu.io', 'sulu_io', [1 => ['view' => false]]),
+            $this->createContent(3, 'Test 3', '/test-3', null, 'sulu.io', 'sulu_io', [1 => ['view' => true]]),
+        ];
+
+        $this->accessControlManager
+            ->getUserPermissionByArray($this->locale, 'sulu.webspaces.sulu_io', [], $user, 'website')
+            ->willReturn([]);
+        $this->accessControlManager
+            ->getUserPermissionByArray(
+                $this->locale,
+                'sulu.webspaces.sulu_io',
+                [1 => ['view' => false]],
+                $user,
+                'website'
+            )
+            ->willReturn(['view' => false]);
+        $this->accessControlManager
+            ->getUserPermissionByArray(
+                $this->locale,
+                'sulu.webspaces.sulu_io',
+                [1 => ['view' => true]],
+                $user,
+                'website'
+            )
+            ->willReturn(['view' => true]);
+
+        $this->contentRepository->findByUuids(
+            [1, 2, 3],
+            $this->locale,
+            Argument::that(
+                function(MappingInterface $mapping) {
+                    return $mapping->resolveUrl()
+                        && !$mapping->shouldHydrateGhost()
+                        && $mapping->onlyPublished()
+                        && ['title', 'published'] === $mapping->getProperties();
+                }
+            )
+        )->shouldBeCalledTimes(1)->willReturn($contents);
+
+        /** @var LinkItem[] $result */
+        $result = $this->pageLinkProvider->preload([1, 2, 3], $this->locale, true);
+
+        $this->assertCount(3, $result);
 
         $this->assertEquals($contents[0]->getId(), $result[0]->getId());
         $this->assertEquals($contents[2]->getId(), $result[2]->getId());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

Currently the `PageLinkProvider` doesn't take into account, if the `permission-check` is enabled in a webspace.
This PR fixes this similar to the `ContentTwigExtension`

#### Why?

Because some features like the `sulu-link` weren't working as expected for anonymous users in a webspace with security enabled but the `permission-check` disabled.

The bug can be reproduced by the following:

Add a security system to your webspace:
```
    <security>
        <system>Website</system>
    </security>
```

Add a `sulu-link` to a twig file.
```
    <sulu-link href="810b7c99-060a-4294-af56-829d3806c4ad">Test Url</sulu-link>
```

Open the template in the browser and then check the resolved `sulu-link`.