### PR TITLE
Remove not longer needed conflict with doctrine/doctrine-bundle 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -143,7 +143,6 @@
     "conflict": {
         "doctrine/dbal": "2.7.0",
         "doctrine/lexer": "1.0.0",
-        "doctrine/doctrine-bundle": "2.3.0",
         "doctrine/doctrine-cache-bundle": "<1.3.1",
         "jackalope/jackalope": "< 1.3.4",
         "jackalope/jackalope-doctrine-dbal": "< 1.3.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove not longer needed conflict with doctrine/doctrine-bundle 2.3

#### Why?

New version of gedmo released which fixes the compatibility to doctrine-bundle 2.3.0: https://github.com/doctrine-extensions/DoctrineExtensions/releases/tag/v3.0.4