### PR TITLE
Include schema defined in XML template in StructureFormMetadataLoader

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/FormMetadata/FormXmlLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/FormMetadata/FormXmlLoader.php
@@ -111,9 +111,9 @@ class FormXmlLoader extends AbstractLoader
         $form->setItems($this->formMetadataMapper->mapChildren($formMetadata->getChildren(), $locale));
 
         $schema = $this->formMetadataMapper->mapSchema($formMetadata->getProperties());
-        $formSchema = $formMetadata->getSchema();
-        if ($formSchema) {
-            $schema = $schema->merge($formSchema);
+        $xmlSchema = $formMetadata->getSchema();
+        if ($xmlSchema) {
+            $schema = $schema->merge($xmlSchema);
         }
 
         $form->setSchema($schema);

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
@@ -150,7 +150,14 @@ class StructureFormMetadataLoader implements FormMetadataLoaderInterface, CacheW
             $form->setName($structureMetadata->getName());
             $form->setTitle($structureMetadata->getTitle($locale) ?? \ucfirst($structureMetadata->getName()));
             $form->setItems($this->formMetadataMapper->mapChildren($structureMetadata->getChildren(), $locale));
-            $form->setSchema($this->formMetadataMapper->mapSchema($structureMetadata->getProperties()));
+
+            $schema = $this->formMetadataMapper->mapSchema($structureMetadata->getProperties());
+            $xmlSchema = $structureMetadata->getSchema();
+            if ($xmlSchema) {
+                $schema = $schema->merge($xmlSchema);
+            }
+
+            $form->setSchema($schema);
 
             $typedForm->addForm($structureMetadata->getName(), $form);
         }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/default.xml
@@ -20,6 +20,21 @@
     <tag name="test2" test="test-value2"/>
     <tag name="test3" value="test-value"/>
 
+    <schema>
+        <anyOf>
+            <schema>
+                <properties>
+                    <property name="blog" mandatory="true"/>
+                </properties>
+            </schema>
+            <schema>
+                <properties>
+                    <property name="localized_blog" mandatory="true"/>
+                </properties>
+            </schema>
+        </anyOf>
+    </schema>
+
     <properties>
         <property name="title" type="text_line" mandatory="true">
             <meta>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
@@ -52,6 +52,10 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
         $this->assertNotNull($overviewForm->getSchema());
         $this->assertInstanceOf(SchemaMetadata::class, $overviewForm->getSchema());
 
+        $overviewFormSchema = $overviewForm->getSchema()->toJsonSchema();
+        $this->assertArrayNotHasKey('anyOf', $overviewFormSchema);
+        $this->assertArrayNotHasKey('allOf', $overviewFormSchema);
+
         $defaultForm = $typedForm->getForms()['default'];
         $this->assertInstanceOf(FormMetadata::class, $defaultForm);
         $this->assertEquals('default', $defaultForm->getName());
@@ -60,6 +64,12 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
         $this->assertCount(3, $defaultForm->getTags());
         $this->assertNotNull($defaultForm->getSchema());
         $this->assertInstanceOf(SchemaMetadata::class, $defaultForm->getSchema());
+
+        // default template has <schema> node in xml, therefore the metadata should contain 2 schemas in allOf
+        $defaultFormSchema = $defaultForm->getSchema()->toJsonSchema();
+        $this->assertArrayNotHasKey('anyOf', $defaultFormSchema);
+        $this->assertArrayHasKey('allOf', $defaultFormSchema);
+        $this->assertCount(2, $defaultFormSchema['allOf']);
     }
 
     public function testGetMetadataGerman()

--- a/src/Sulu/Bundle/RouteBundle/Command/UpdateRouteCommand.php
+++ b/src/Sulu/Bundle/RouteBundle/Command/UpdateRouteCommand.php
@@ -67,7 +67,7 @@ class UpdateRouteCommand extends Command
     {
         $this->addArgument('entity', InputArgument::REQUIRED)
             ->addArgument('locale', InputArgument::REQUIRED)
-            ->addOption('batch-size', null, InputOption::VALUE_REQUIRED, '', 1000)
+            ->addOption('batch-size', null, InputOption::VALUE_REQUIRED, '', '1000')
             ->setDescription('Update the routes for all entities.')
             ->setHelp(
                 <<<'EOT'
@@ -82,7 +82,7 @@ EOT
     {
         $this->translator->setLocale($input->getArgument('locale'));
 
-        $batchSize = $input->getOption('batch-size');
+        $batchSize = (int) $input->getOption('batch-size');
 
         /** @var EntityRepository $repository */
         $repository = $this->entityManager->getRepository($input->getArgument('entity'));


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

This PR adjusts the `StructureFormMetadataLoader` to include the schema that is defined in the `<schema>` node inside of the XML template. This is already implemented in the `FormXmlLoader` and therefore works for non-template forms such as the [`analytic_details.xml`](https://github.com/sulu/sulu/blob/2.x/src/Sulu/Bundle/WebsiteBundle/Resources/config/forms/analytic_details.xml#L8-L56). 

#### Why?

Because it might be useful to use this inside of page template for something like shown below. Also, the template XML schema already allows to define a `<schema>` node, but content of the node is ignored at the moment. 

```xml
<schema>
    <!-- template is valid if at least one of the firstProperty and secondProperty is set -->
    <anyOf>
        <schema>
            <properties>
                <property name="firstProperty" mandatory="true"/>
            </properties>
        </schema>
        <schema>
            <properties>
                <property name="secondProperty" mandatory="true"/>
            </properties>
        </schema>
    </anyOf>
</schema>
```
