### PR TITLE
Conflict not working symfony/framework-bundle 5.2.6 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -154,6 +154,7 @@
         "phpstan/phpstan": "0.12.26",
         "rokka/imagine-vips": "<0.9.2",
         "symfony/doctrine-bridge": "< 3.4.0",
+        "symfony/framework-bundle": "5.2.6",
         "symfony/http-foundation": "4.3.4"
     },
     "replace": {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Conflict not working symfony/framework-bundle 5.2.6 version and ends with:

> Fatal error: Uncaught LogicException: Cannot retrieve the container from a non-booted kernel. in /Sulu-cms/sulu-develop.localhost/vendor/symfony/http-kernel/Kernel.php:307 Stack trace: #0 /sulu-cms/sulu-develop.localhost/vendor/symfony/framework-bundle/HttpCache/HttpCache.php(68): Symfony\Component\HttpKernel\Kernel->getContainer() #1 /sulu-cms/sulu-develop.localhost/vendor/friendsofsymfony/http-cache/src/SymfonyCache/EventDispatchingHttpCache.php(103): Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true) #2 /sulu-cms/sulu-develop.localhost/public/index.php(66): Sulu\Bundle\HttpCacheBundle\Cache\SuluHttpCache->handle(Object(Symfony\Component\HttpFoundation\Request)) #3 {main} thrown in /Users/sulu-cms/sulu-develop.localhost/vendor/symfony/http-kernel/Kernel.php on line 307

Caused by https://github.com/symfony/symfony/pull/40497 the http foundation implemented a BC break which did crash the Prod Http Cache. 

Related Issues:

 - https://github.com/symfony/symfony/issues/40624 -> Fix: https://github.com/symfony/symfony/pull/40619
    - https://github.com/symfony/symfony/issues/40618

#### Why?

So Sulu can work again.
