### PR TITLE
Extract FormOverlay component from FormOverlayList view

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/FormOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/FormOverlay.js
@@ -8,6 +8,7 @@ import {translate} from '../../utils';
 import Snackbar from '../../components/Snackbar';
 import Form from '../Form';
 import type {FormStoreInterface} from '../Form/types';
+import type {ResourceFormStore} from '../Form';
 import type {Size} from '../../components/Overlay/types';
 import formOverlayStyles from './formOverlay.scss';
 
@@ -15,7 +16,7 @@ type Props = {|
     confirmDisabled: boolean,
     confirmLoading: boolean,
     confirmText: string,
-    formStore: FormStoreInterface,
+    formStore: FormStoreInterface | ResourceFormStore,
     onClose: () => void,
     onConfirm: () => void,
     open: boolean,
@@ -44,8 +45,7 @@ class FormOverlay extends React.Component<Props> {
         const {confirmLoading, formStore} = this.props;
 
         // disable confirm button while saving if formstore is instance of ResourceFormStore
-        // $FlowFixMe
-        const formStoreSaving = formStore.hasOwnProperty('saving') && formStore.saving;
+        const formStoreSaving = (typeof formStore.saving === 'boolean') && formStore.saving;
 
         return confirmLoading || formStoreSaving;
     }
@@ -74,7 +74,7 @@ class FormOverlay extends React.Component<Props> {
         } = this.props;
 
         // save data before calling onConfirm callback if formstore is instance of ResourceFormStore
-        if (formStore.hasOwnProperty('save')) {
+        if (typeof formStore.save === 'function') {
             // $FlowFixMe
             formStore.save()
                 .then(() => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/FormOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/FormOverlay.js
@@ -46,7 +46,10 @@ class FormOverlay extends React.Component<Props> {
 
     @computed get confirmLoading() {
         const {confirmLoading, formStore} = this.props;
-        const formStoreSaving = (formStore instanceof ResourceFormStore) ? formStore.saving : false;
+
+        // disable confirm button while saving if formstore is instance of ResourceFormStore
+        // $FlowFixMe
+        const formStoreSaving = (formStore && formStore.hasOwnProperty('saving')) ? formStore.saving : false;
 
         return confirmLoading || formStoreSaving;
     }
@@ -82,7 +85,9 @@ class FormOverlay extends React.Component<Props> {
             onConfirm,
         } = this.props;
 
-        if (formStore instanceof ResourceFormStore) {
+        // save data before calling onConfirm callback if formstore is instance of ResourceFormStore
+        if (formStore && formStore.hasOwnProperty('saving')) {
+            // $FlowFixMe
             formStore.save()
                 .then(() => {
                     onConfirm();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/FormOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/FormOverlay.js
@@ -1,0 +1,155 @@
+// @flow
+import React from 'react';
+import {action, computed, observable} from 'mobx';
+import type {ElementRef} from 'react';
+import {observer} from 'mobx-react';
+import Overlay from '../../components/Overlay';
+import {translate} from '../../utils';
+import Snackbar from '../../components/Snackbar';
+import Loader from '../../components/Loader';
+import Form, {ResourceFormStore} from '../Form';
+import type {FormStoreInterface} from '../Form/types';
+import type {Size} from '../../components/Overlay/types';
+import formOverlayStyles from './formOverlay.scss';
+
+type Props = {|
+    confirmDisabled: boolean,
+    confirmLoading: boolean,
+    confirmText: string,
+    formStore?: ?FormStoreInterface,
+    loading: boolean,
+    onClose: () => void,
+    onConfirm: () => void,
+    open: boolean,
+    size?: Size,
+    title: string,
+|};
+
+@observer
+class FormOverlay extends React.Component<Props> {
+    static defaultProps = {
+        confirmDisabled: false,
+        confirmLoading: false,
+        loading: false,
+    };
+
+    formRef: ?ElementRef<typeof Form>;
+
+    @observable formErrors: Array<string> = [];
+
+    @computed get confirmDisabled() {
+        const {confirmDisabled, formStore} = this.props;
+        const formStoreDirty = formStore ? formStore.dirty : false;
+
+        return confirmDisabled || !formStoreDirty;
+    }
+
+    @computed get confirmLoading() {
+        const {confirmLoading, formStore} = this.props;
+        const formStoreSaving = (formStore instanceof ResourceFormStore) ? formStore.saving : false;
+
+        return confirmLoading || formStoreSaving;
+    }
+
+    @action componentDidUpdate(prevProps: Props) {
+        const {open} = this.props;
+
+        if (prevProps.open === false && open === true) {
+            this.formErrors = [];
+        }
+    }
+
+    handleOverlayConfirm = () => {
+        if (!this.formRef) {
+            throw new Error('The Form ref has not been set! This should not happen and is likely a bug.');
+        }
+
+        // calling formRef.submit() will trigger either handleFormSubmit() or handleFormError()
+        this.formRef.submit();
+    };
+
+    handleOverlayClose = () => {
+        const {
+            onClose,
+        } = this.props;
+
+        onClose();
+    };
+
+    handleFormSubmit = () => {
+        const {
+            formStore,
+            onConfirm,
+        } = this.props;
+
+        if (formStore instanceof ResourceFormStore) {
+            formStore.save()
+                .then(() => {
+                    onConfirm();
+                })
+                .catch(action((error) => {
+                    this.formErrors.push(error.detail || error.title || translate('sulu_admin.form_save_server_error'));
+                }));
+        } else {
+            onConfirm();
+        }
+    };
+
+    handleFormError = () => {
+        this.formErrors.push(translate('sulu_admin.form_contains_invalid_values'));
+    };
+
+    @action handleErrorSnackbarClose = () => {
+        this.formErrors.pop();
+    };
+
+    setFormRef = (formRef: ?ElementRef<typeof Form>) => {
+        this.formRef = formRef;
+    };
+
+    render() {
+        const {
+            confirmText,
+            formStore,
+            loading,
+            open,
+            size,
+            title,
+        } = this.props;
+
+        return (
+            <Overlay
+                confirmDisabled={this.confirmDisabled}
+                confirmLoading={this.confirmLoading}
+                confirmText={confirmText}
+                onClose={this.handleOverlayClose}
+                onConfirm={this.handleOverlayConfirm}
+                open={open}
+                size={size}
+                title={title}
+            >
+                <Snackbar
+                    message={this.formErrors[this.formErrors.length - 1]}
+                    onCloseClick={this.handleErrorSnackbarClose}
+                    type="error"
+                    visible={!!this.formErrors.length}
+                />
+                <div className={formOverlayStyles.form}>
+                    {loading && (
+                        <Loader />
+                    )}
+                    {!loading && formStore && (
+                        <Form
+                            onError={this.handleFormError}
+                            onSubmit={this.handleFormSubmit}
+                            ref={this.setFormRef}
+                            store={formStore}
+                        />
+                    )}
+                </div>
+            </Overlay>
+        );
+    }
+}
+
+export default FormOverlay;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/FormOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/FormOverlay.js
@@ -6,8 +6,7 @@ import {observer} from 'mobx-react';
 import Overlay from '../../components/Overlay';
 import {translate} from '../../utils';
 import Snackbar from '../../components/Snackbar';
-import Loader from '../../components/Loader';
-import Form, {ResourceFormStore} from '../Form';
+import Form from '../Form';
 import type {FormStoreInterface} from '../Form/types';
 import type {Size} from '../../components/Overlay/types';
 import formOverlayStyles from './formOverlay.scss';
@@ -16,8 +15,7 @@ type Props = {|
     confirmDisabled: boolean,
     confirmLoading: boolean,
     confirmText: string,
-    formStore?: ?FormStoreInterface,
-    loading: boolean,
+    formStore: FormStoreInterface,
     onClose: () => void,
     onConfirm: () => void,
     open: boolean,
@@ -30,7 +28,6 @@ class FormOverlay extends React.Component<Props> {
     static defaultProps = {
         confirmDisabled: false,
         confirmLoading: false,
-        loading: false,
     };
 
     formRef: ?ElementRef<typeof Form>;
@@ -39,9 +36,8 @@ class FormOverlay extends React.Component<Props> {
 
     @computed get confirmDisabled() {
         const {confirmDisabled, formStore} = this.props;
-        const formStoreDirty = formStore ? formStore.dirty : false;
 
-        return confirmDisabled || !formStoreDirty;
+        return confirmDisabled || !formStore.dirty;
     }
 
     @computed get confirmLoading() {
@@ -49,7 +45,7 @@ class FormOverlay extends React.Component<Props> {
 
         // disable confirm button while saving if formstore is instance of ResourceFormStore
         // $FlowFixMe
-        const formStoreSaving = (formStore && formStore.hasOwnProperty('saving')) ? formStore.saving : false;
+        const formStoreSaving = formStore.hasOwnProperty('saving') && formStore.saving;
 
         return confirmLoading || formStoreSaving;
     }
@@ -71,14 +67,6 @@ class FormOverlay extends React.Component<Props> {
         this.formRef.submit();
     };
 
-    handleOverlayClose = () => {
-        const {
-            onClose,
-        } = this.props;
-
-        onClose();
-    };
-
     handleFormSubmit = () => {
         const {
             formStore,
@@ -86,7 +74,7 @@ class FormOverlay extends React.Component<Props> {
         } = this.props;
 
         // save data before calling onConfirm callback if formstore is instance of ResourceFormStore
-        if (formStore && formStore.hasOwnProperty('saving')) {
+        if (formStore.hasOwnProperty('save')) {
             // $FlowFixMe
             formStore.save()
                 .then(() => {
@@ -116,7 +104,7 @@ class FormOverlay extends React.Component<Props> {
         const {
             confirmText,
             formStore,
-            loading,
+            onClose,
             open,
             size,
             title,
@@ -127,7 +115,7 @@ class FormOverlay extends React.Component<Props> {
                 confirmDisabled={this.confirmDisabled}
                 confirmLoading={this.confirmLoading}
                 confirmText={confirmText}
-                onClose={this.handleOverlayClose}
+                onClose={onClose}
                 onConfirm={this.handleOverlayConfirm}
                 open={open}
                 size={size}
@@ -140,17 +128,12 @@ class FormOverlay extends React.Component<Props> {
                     visible={!!this.formErrors.length}
                 />
                 <div className={formOverlayStyles.form}>
-                    {loading && (
-                        <Loader />
-                    )}
-                    {!loading && formStore && (
-                        <Form
-                            onError={this.handleFormError}
-                            onSubmit={this.handleFormSubmit}
-                            ref={this.setFormRef}
-                            store={formStore}
-                        />
-                    )}
+                    <Form
+                        onError={this.handleFormError}
+                        onSubmit={this.handleFormSubmit}
+                        ref={this.setFormRef}
+                        store={formStore}
+                    />
                 </div>
             </Overlay>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/README.md
@@ -1,0 +1,5 @@
+This component displays a [`Form`](#form) inside of an [`Overlay`](#overlay). It expects a `FormStore` that contains 
+the data and the schema of the form that should be displayed. Additionally, it supports multiple parameters to
+adjust the [`Overlay`](#overlay) that contains the form.
+
+The component is used in various places to enable the input of data inside of an overlay.

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/formOverlay.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/formOverlay.scss
@@ -1,0 +1,7 @@
+@import '../Application/variables.scss';
+
+.form {
+    margin: $viewPaddingVertical $viewPaddingHorizontal;
+    overflow: hidden;
+    position: relative;
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/index.js
@@ -1,0 +1,4 @@
+// @flow
+import FormOverlay from './FormOverlay';
+
+export default FormOverlay;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/tests/FormOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/tests/FormOverlay.test.js
@@ -82,8 +82,8 @@ test('Should pass correct props to Overlay component', () => {
     const closeSpy = jest.fn();
 
     const formOverlay = shallow(<FormOverlay
-        confirmDisabled={false}
-        confirmLoading={false}
+        confirmDisabled={true}
+        confirmLoading={true}
         confirmText="confirm-text"
         formStore={formStore}
         onClose={closeSpy}
@@ -96,12 +96,40 @@ test('Should pass correct props to Overlay component', () => {
     const overlay = formOverlay.find(Overlay);
 
     expect(overlay.props()).toEqual(expect.objectContaining({
+        confirmDisabled: true,
+        confirmLoading: true,
+        confirmText: 'confirm-text',
+        onClose: closeSpy,
+        open: true,
+        size: 'small',
+        title: 'overlay-title',
+    }));
+});
+
+test('Should pass correct props to Overlay component when using default values', () => {
+    const formStore = new MemoryFormStore({}, {}, undefined, undefined);
+    formStore.dirty = true;
+
+    const closeSpy = jest.fn();
+
+    const formOverlay = shallow(<FormOverlay
+        confirmText="confirm-text"
+        formStore={formStore}
+        onClose={closeSpy}
+        onConfirm={jest.fn()}
+        open={true}
+        title="overlay-title"
+    />);
+
+    const overlay = formOverlay.find(Overlay);
+
+    expect(overlay.props()).toEqual(expect.objectContaining({
         confirmDisabled: false,
         confirmLoading: false,
         confirmText: 'confirm-text',
         onClose: closeSpy,
         open: true,
-        size: 'small',
+        size: undefined,
         title: 'overlay-title',
     }));
 });
@@ -128,7 +156,7 @@ test('Should pass correct props to Form component', () => {
     }));
 });
 
-test('Should disable confirm button if FromStore is not dirty', () => {
+test('Should disable confirm button if FormStore is not dirty', () => {
     const formStore = new MemoryFormStore({}, {}, undefined, undefined);
 
     const formOverlay = shallow(<FormOverlay
@@ -150,7 +178,7 @@ test('Should disable confirm button if FromStore is not dirty', () => {
     expect(formOverlay.find(Overlay).props().confirmDisabled).toEqual(false);
 });
 
-test('Should display confirm button as loading if FromStore is saving', () => {
+test('Should display confirm button as loading if FormStore is saving', () => {
     const formStore = new ResourceFormStore(new ResourceStore('test'), 'test');
 
     const formOverlay = shallow(<FormOverlay

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/tests/FormOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/tests/FormOverlay.test.js
@@ -1,0 +1,388 @@
+// @flow
+import mockReact from 'react';
+import {mount, shallow} from 'enzyme';
+import {extendObservable as mockExtendObservable} from 'mobx';
+import FormOverlay from '../FormOverlay';
+import Overlay from '../../../components/Overlay';
+import ResourceStore from '../../../stores/ResourceStore';
+import MemoryFormStore from '../../../containers/Form/stores/MemoryFormStore';
+import ResourceFormStore from '../../../containers/Form/stores/ResourceFormStore';
+import Form from '../../../containers/Form';
+import Snackbar from '../../../components/Snackbar';
+
+const React = mockReact;
+
+jest.mock('../../../containers/Form', () => class FormMock extends mockReact.Component<*> {
+    render() {
+        return <div>form container mock</div>;
+    }
+});
+
+jest.mock('../../../utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
+
+jest.mock('../../../stores/ResourceStore', () => jest.fn(
+    (resourceKey, itemId) => {
+        return {
+            id: itemId,
+        };
+    }
+));
+jest.mock('../../../containers/Form/stores/ResourceFormStore',
+    () => jest.fn(function(resourceStore, formKey, options, metadataOptions) {
+        this.id = resourceStore.id;
+        this.formKey = formKey;
+        this.options = options;
+        this.metadataOptions = metadataOptions;
+
+        this.save = jest.fn();
+
+        mockExtendObservable(this, {
+            dirty: false,
+            saving: false,
+        });
+    })
+);
+jest.mock('../../../containers/Form/stores/MemoryFormStore',
+    () => jest.fn(function(data, rawSchema, jsonSchema, locale) {
+        this.rawSchema = rawSchema;
+        this.jsonSchema = jsonSchema;
+        this.locale = locale;
+
+        mockExtendObservable(this, {
+            data,
+            dirty: false,
+        });
+    })
+);
+
+test('Component should render', () => {
+    const formStore = new MemoryFormStore({}, {}, undefined, undefined);
+
+    const formOverlay = mount(<FormOverlay
+        confirmDisabled={false}
+        confirmLoading={false}
+        confirmText="confirm-text"
+        formStore={formStore}
+        onClose={jest.fn()}
+        onConfirm={jest.fn()}
+        open={true}
+        size="small"
+        title="overlay-title"
+    />);
+
+    expect(formOverlay.render()).toMatchSnapshot();
+});
+
+test('Should pass correct props to Overlay component', () => {
+    const formStore = new MemoryFormStore({}, {}, undefined, undefined);
+    formStore.dirty = true;
+
+    const closeSpy = jest.fn();
+
+    const formOverlay = shallow(<FormOverlay
+        confirmDisabled={false}
+        confirmLoading={false}
+        confirmText="confirm-text"
+        formStore={formStore}
+        onClose={closeSpy}
+        onConfirm={jest.fn()}
+        open={true}
+        size="small"
+        title="overlay-title"
+    />);
+
+    const overlay = formOverlay.find(Overlay);
+
+    expect(overlay.props()).toEqual(expect.objectContaining({
+        confirmDisabled: false,
+        confirmLoading: false,
+        confirmText: 'confirm-text',
+        onClose: closeSpy,
+        open: true,
+        size: 'small',
+        title: 'overlay-title',
+    }));
+});
+
+test('Should pass correct props to Form component', () => {
+    const formStore = new MemoryFormStore({}, {}, undefined, undefined);
+
+    const formOverlay = shallow(<FormOverlay
+        confirmDisabled={false}
+        confirmLoading={false}
+        confirmText="confirm-text"
+        formStore={formStore}
+        onClose={jest.fn()}
+        onConfirm={jest.fn()}
+        open={true}
+        size="small"
+        title="overlay-title"
+    />);
+
+    const form = formOverlay.find(Form);
+
+    expect(form.props()).toEqual(expect.objectContaining({
+        store: formStore,
+    }));
+});
+
+test('Should disable confirm button if FromStore is not dirty', () => {
+    const formStore = new MemoryFormStore({}, {}, undefined, undefined);
+
+    const formOverlay = shallow(<FormOverlay
+        confirmDisabled={false}
+        confirmLoading={false}
+        confirmText="confirm-text"
+        formStore={formStore}
+        onClose={jest.fn()}
+        onConfirm={jest.fn()}
+        open={true}
+        size="small"
+        title="overlay-title"
+    />);
+
+    formStore.dirty = false;
+    expect(formOverlay.find(Overlay).props().confirmDisabled).toEqual(true);
+
+    formStore.dirty = true;
+    expect(formOverlay.find(Overlay).props().confirmDisabled).toEqual(false);
+});
+
+test('Should display confirm button as loading if FromStore is saving', () => {
+    const formStore = new ResourceFormStore(new ResourceStore('test'), 'test');
+
+    const formOverlay = shallow(<FormOverlay
+        confirmDisabled={false}
+        confirmLoading={false}
+        confirmText="confirm-text"
+        formStore={formStore}
+        onClose={jest.fn()}
+        onConfirm={jest.fn()}
+        open={true}
+        size="small"
+        title="overlay-title"
+    />);
+
+    // $FlowFixMe
+    formStore.saving = false;
+    expect(formOverlay.find(Overlay).props().confirmLoading).toEqual(false);
+
+    // $FlowFixMe
+    formStore.saving = true;
+    expect(formOverlay.find(Overlay).props().confirmLoading).toEqual(true);
+});
+
+test('Should submit Form container when Overlay is confirmed', () => {
+    const formStore = new MemoryFormStore({}, {}, undefined, undefined);
+
+    const formOverlay = mount(<FormOverlay
+        confirmDisabled={false}
+        confirmLoading={false}
+        confirmText="confirm-text"
+        formStore={formStore}
+        onClose={jest.fn()}
+        onConfirm={jest.fn()}
+        open={true}
+        size="small"
+        title="overlay-title"
+    />);
+
+    const submitSpy = jest.fn();
+    formOverlay.find(Form).instance().submit = submitSpy;
+
+    formOverlay.find(Overlay).props().onConfirm();
+
+    expect(submitSpy).toBeCalled();
+});
+
+test('Should save ResourceFormStore and call onConfirm callback on submit of Form', () => {
+    const formStore = new ResourceFormStore(new ResourceStore('test'), 'test');
+    const confirmSpy = jest.fn();
+
+    const formOverlay = shallow(<FormOverlay
+        confirmDisabled={false}
+        confirmLoading={false}
+        confirmText="confirm-text"
+        formStore={formStore}
+        onClose={jest.fn()}
+        onConfirm={confirmSpy}
+        open={true}
+        size="small"
+        title="overlay-title"
+    />);
+
+    const savePromise = Promise.resolve();
+    formStore.save.mockReturnValueOnce(savePromise);
+
+    formOverlay.find(Form).props().onSubmit();
+
+    return savePromise.finally(() => {
+        expect(formStore.save).toBeCalled();
+        expect(confirmSpy).toBeCalled();
+    });
+});
+
+test('Should call onConfirm callback directly in case of MemoryFormStore on submit of Form', () => {
+    const formStore = new MemoryFormStore({}, {}, undefined, undefined);
+    const confirmSpy = jest.fn();
+
+    const formOverlay = shallow(<FormOverlay
+        confirmDisabled={false}
+        confirmLoading={false}
+        confirmText="confirm-text"
+        formStore={formStore}
+        onClose={jest.fn()}
+        onConfirm={confirmSpy}
+        open={true}
+        size="small"
+        title="overlay-title"
+    />);
+
+    formOverlay.find(Form).props().onSubmit();
+
+    expect(confirmSpy).toBeCalled();
+});
+
+test('Should display Snackbar with generic message if an error happens while saving ResourceFormStore', (done) => {
+    const formStore = new ResourceFormStore(new ResourceStore('test'), 'test');
+    const confirmSpy = jest.fn();
+
+    const formOverlay = shallow(<FormOverlay
+        confirmDisabled={false}
+        confirmLoading={false}
+        confirmText="confirm-text"
+        formStore={formStore}
+        onClose={jest.fn()}
+        onConfirm={confirmSpy}
+        open={true}
+        size="small"
+        title="overlay-title"
+    />);
+
+    const savePromise = Promise.reject('error');
+    formStore.save.mockReturnValueOnce(savePromise);
+
+    formOverlay.find(Form).props().onSubmit();
+
+    // wait until rejection of savePromise was handled by component with setTimeout
+    setTimeout(() => {
+        expect(formStore.save).toBeCalled();
+        expect(confirmSpy).not.toBeCalled();
+
+        formOverlay.update();
+        expect(formOverlay.find(Snackbar).prop('visible')).toBeTruthy();
+        expect(formOverlay.find(Snackbar).prop('message')).toEqual('sulu_admin.form_save_server_error');
+
+        done();
+    });
+});
+
+test('Should display Snackbar with message from server if an error happens while saving ResourceFormStore', (done) => {
+    const formStore = new ResourceFormStore(new ResourceStore('test'), 'test');
+    const confirmSpy = jest.fn();
+
+    const formOverlay = shallow(<FormOverlay
+        confirmDisabled={false}
+        confirmLoading={false}
+        confirmText="confirm-text"
+        formStore={formStore}
+        onClose={jest.fn()}
+        onConfirm={confirmSpy}
+        open={true}
+        size="small"
+        title="overlay-title"
+    />);
+
+    const savePromise = Promise.reject({code: 100, detail: 'URL is already assigned to another page.'});
+    formStore.save.mockReturnValueOnce(savePromise);
+
+    formOverlay.find(Form).props().onSubmit();
+
+    // wait until rejection of savePromise was handled by component with setTimeout
+    setTimeout(() => {
+        expect(formStore.save).toBeCalled();
+        expect(confirmSpy).not.toBeCalled();
+
+        formOverlay.update();
+        expect(formOverlay.find(Snackbar).prop('visible')).toBeTruthy();
+        expect(formOverlay.find(Snackbar).prop('message')).toEqual('URL is already assigned to another page.');
+
+        done();
+    });
+});
+
+test('Should display Snackbar if a form is not valid', () => {
+    const formStore = new ResourceFormStore(new ResourceStore('test'), 'test');
+    const confirmSpy = jest.fn();
+
+    const formOverlay = shallow(<FormOverlay
+        confirmDisabled={false}
+        confirmLoading={false}
+        confirmText="confirm-text"
+        formStore={formStore}
+        onClose={jest.fn()}
+        onConfirm={confirmSpy}
+        open={true}
+        size="small"
+        title="overlay-title"
+    />);
+
+    formOverlay.find(Form).props().onError();
+    formOverlay.update();
+
+    expect(formOverlay.find(Snackbar).prop('visible')).toBeTruthy();
+    expect(formOverlay.find(Snackbar).prop('message')).toEqual('sulu_admin.form_contains_invalid_values');
+});
+
+test('Should hide Snackbar when closeClick callback of Snackbar is fired', () => {
+    const formStore = new ResourceFormStore(new ResourceStore('test'), 'test');
+    const confirmSpy = jest.fn();
+
+    const formOverlay = shallow(<FormOverlay
+        confirmDisabled={false}
+        confirmLoading={false}
+        confirmText="confirm-text"
+        formStore={formStore}
+        onClose={jest.fn()}
+        onConfirm={confirmSpy}
+        open={true}
+        size="small"
+        title="overlay-title"
+    />);
+
+    formOverlay.find(Form).props().onError();
+    formOverlay.update();
+    expect(formOverlay.find(Snackbar).prop('visible')).toBeTruthy();
+
+    formOverlay.find(Snackbar).props().onCloseClick();
+    formOverlay.update();
+    expect(formOverlay.find(Snackbar).props().visible).toBeFalsy();
+});
+
+test('Should clear old errors if Overlay is opened a second time', () => {
+    const formStore = new ResourceFormStore(new ResourceStore('test'), 'test');
+    const confirmSpy = jest.fn();
+
+    const formOverlay = shallow(<FormOverlay
+        confirmDisabled={false}
+        confirmLoading={false}
+        confirmText="confirm-text"
+        formStore={formStore}
+        onClose={jest.fn()}
+        onConfirm={confirmSpy}
+        open={true}
+        size="small"
+        title="overlay-title"
+    />);
+
+    formOverlay.find(Form).props().onError();
+    formOverlay.update();
+    expect(formOverlay.find(Snackbar).prop('visible')).toBeTruthy();
+
+    formOverlay.setProps({open: false});
+    formOverlay.setProps({open: true});
+
+    expect(formOverlay.find(Snackbar).props().visible).toBeFalsy();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/tests/__snapshots__/FormOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/tests/__snapshots__/FormOverlay.test.js.snap
@@ -1,0 +1,84 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component should render 1`] = `
+Array [
+  <div
+    class="backdrop visible fixed"
+    role="button"
+  />,
+  <div
+    class="container isDown"
+  >
+    <div
+      class="overlay small"
+    >
+      <section
+        class="content"
+      >
+        <header
+          class="header"
+        >
+          <h2>
+            overlay-title
+          </h2>
+          <span
+            aria-label="su-times"
+            class="su-times clickable icon"
+            role="button"
+            tabindex="0"
+          />
+        </header>
+        <article
+          class="article"
+        >
+          <div
+            class="snackbar error"
+            role="button"
+          >
+            <span
+              aria-label="su-exclamation-triangle"
+              class="su-exclamation-triangle icon"
+            />
+            <div
+              class="text"
+            >
+              <strong>
+                sulu_admin.error
+              </strong>
+               - 
+            </div>
+            <span
+              aria-label="su-times"
+              class="su-times clickable closeIcon"
+              role="button"
+              tabindex="0"
+            />
+          </div>
+          <div
+            class="form"
+          >
+            <div>
+              form container mock
+            </div>
+          </div>
+        </article>
+        <footer
+          class="footer"
+        >
+          <button
+            class="button primary"
+            disabled=""
+            type="button"
+          >
+            <span
+              class="buttonText"
+            >
+              confirm-text
+            </span>
+          </button>
+        </footer>
+      </section>
+    </div>
+  </div>,
+]
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ListOverlay/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ListOverlay/README.md
@@ -1,7 +1,7 @@
-This component uses a [`List`](#list) in an [`Overlay`](#overlay) to offer the possibility to select a few resources.
+This component displays a [`List`](#list) inside of an [`Overlay`](#overlay) to offer the possibility to select a few resources.
 The `onConfirm` callback is called with the selected IDs as soon as the confirm button is clicked. This component also
 gets a `ListStore` passed, and is not responsible for its creation. The `clearSelectionOnClose` prop defines whether or
 not the selection of the `List` should be cleared after the `Overlay` has been closed.
 
-This component mainly serves as base for the [`SingleListOverlay`](#singlelistoverlay) and
+The component mainly serves as base for the [`SingleListOverlay`](#singlelistoverlay) and
 [`MultiListOverlay`](#multilistoverlay) components.

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
@@ -129,19 +129,22 @@ class FormOverlayList extends React.Component<Props> {
 
     render() {
         const {
-            router: {
-                route: {
-                    options: {
-                        addOverlayTitle,
-                        editOverlayTitle,
-                        formKey,
-                        overlaySize,
+            formStore,
+            props: {
+                router: {
+                    route: {
+                        options: {
+                            addOverlayTitle,
+                            editOverlayTitle,
+                            formKey,
+                            overlaySize,
+                        },
                     },
                 },
             },
-        } = this.props;
+        } = this;
 
-        const overlayTitle = this.formStore && this.formStore.id
+        const overlayTitle = formStore && formStore.id
             ? translate(editOverlayTitle || 'sulu_admin.edit')
             : translate(addOverlayTitle || 'sulu_admin.create');
 
@@ -154,15 +157,17 @@ class FormOverlayList extends React.Component<Props> {
                     onItemClick={formKey && this.handleItemClick}
                     ref={this.setListRef}
                 />
-                <FormOverlay
-                    confirmText={translate('sulu_admin.save')}
-                    formStore={this.formStore}
-                    onClose={this.handleFormOverlayClose}
-                    onConfirm={this.handleFormOverlayConfirm}
-                    open={!!this.formStore}
-                    size={overlaySize ? overlaySize : 'small'}
-                    title={overlayTitle}
-                />
+                {!!formStore && (
+                    <FormOverlay
+                        confirmText={translate('sulu_admin.save')}
+                        formStore={formStore}
+                        onClose={this.handleFormOverlayClose}
+                        onConfirm={this.handleFormOverlayConfirm}
+                        open={!!formStore}
+                        size={overlaySize ? overlaySize : 'small'}
+                        title={overlayTitle}
+                    />
+                )}
             </Fragment>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/formOverlayList.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/formOverlayList.scss
@@ -1,9 +1,0 @@
-@import '../../containers/Application/variables.scss';
-@import '../../components/Overlay/variables.scss';
-@import '../../components/ColumnList/variables.scss';
-
-.form {
-    margin: $viewPaddingVertical $viewPaddingHorizontal;
-    overflow: hidden;
-    position: relative;
-}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/FormOverlayList.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/FormOverlayList.test.js
@@ -4,7 +4,6 @@ import {mount} from 'enzyme';
 import {observable} from 'mobx';
 import FormOverlayList from '../FormOverlayList';
 import List from '../../List';
-import Overlay from '../../../components/Overlay';
 import ResourceStore from '../../../stores/ResourceStore';
 import ResourceFormStore from '../../../containers/Form/stores/ResourceFormStore';
 import FormOverlay from '../../../containers/FormOverlay';
@@ -18,7 +17,7 @@ jest.mock('../../List', () => class ListMock extends mockReact.Component<*> {
     }
 });
 
-jest.mock('../../../containers/Form', () => class ListMock extends mockReact.Component<*> {
+jest.mock('../../../containers/Form', () => class FormMock extends mockReact.Component<*> {
     render() {
         return <div>form container mock</div>;
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/__snapshots__/FormOverlayList.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/__snapshots__/FormOverlayList.test.js.snap
@@ -16,7 +16,7 @@ Array [
     role="button"
   />,
   <div
-    class="container"
+    class="container isDown"
   >
     <div
       class="overlay small"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/__snapshots__/FormOverlayList.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/__snapshots__/FormOverlayList.test.js.snap
@@ -16,7 +16,7 @@ Array [
     role="button"
   />,
   <div
-    class="container isDown"
+    class="container"
   >
     <div
       class="overlay small"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Related issues/PRs | #5868, #5759
| License | MIT

#### What's in this PR?

This PR extracts a reusable `FormOverlay` from the `FormOverlayList` view.

#### Why?

As a preparation for fixing #5882 and #5759. We display a form inside of an overlay in various places of the administration interface. We should use a reusable component in these places to o keep things consistent.