### PR TITLE
Fix correct cache adapter for collabration

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
@@ -51,7 +51,7 @@ class SuluAdminExtension extends Extension implements PrependExtensionInterface
                     'cache' => [
                         'pools' => [
                             'sulu_admin.collaboration_cache' => [
-                                'adapter' => 'cache.adapter.filesystem',
+                                'adapter' => 'cache.app',
                             ],
                         ],
                     ],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Use the `cache.app` adapter for collabration cache.

#### Why?

The `cache.app` adapter is the one which is configured to be shared over the system in a multi server setup. Sulu itself should only specify if a cache pool is a `app` (shared) or a `system` (local) cache not which specific adapter it should use.
