### PR TITLE
Add twig blocks to admin twig template

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/views/Admin/main.html.twig
+++ b/src/Sulu/Bundle/AdminBundle/Resources/views/Admin/main.html.twig
@@ -16,7 +16,7 @@
 
     <script>
         {%- set config = {
-            initialLoginState: is_granted('IS_AUTHENTICATED_REMEMBERED') ? 'true' : 'false',
+            initialLoginState: is_granted('IS_AUTHENTICATED_REMEMBERED'),
             translations: translations,
             fallbackLocale: fallback_locale,
             endpoints: endpoints,

--- a/src/Sulu/Bundle/AdminBundle/Resources/views/Admin/main.html.twig
+++ b/src/Sulu/Bundle/AdminBundle/Resources/views/Admin/main.html.twig
@@ -1,30 +1,37 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <title>SULU</title>
-
-        {# We do not preload the files because of problems with big files on http push in Chrome #}
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>SULU</title>
+    {% block style %}
+        {#- We do not preload the files because of problems with big files on http push in Chrome -#}
         <link rel="stylesheet" href="{{ asset('main.css', 'sulu_admin') }}">
-    </head>
-    <body>
-        <div id="application">
-        </div>
-        <script>
-            {% autoescape false %}
-            const SULU_CONFIG = Object.freeze({
-                initialLoginState: {{ is_granted('IS_AUTHENTICATED_REMEMBERED') ? 'true' : 'false' }},
-                translations: {{ translations|json_encode }},
-                fallbackLocale: '{{ fallback_locale }}',
-                endpoints: {{ endpoints|json_encode }},
-                suluVersion: '{{ sulu_version }}',
-                appVersion: '{{ app_version }}'
-            });
-            {% endautoescape %}
-        </script>
+    {%- endblock ~%}
+</head>
+<body>
+    {% block application -%}
+        <div id="application"></div>
+    {% endblock %}
 
-        {# We do not preload the files because of problems with big files on http push in Chrome #}
+    <script>
+        {%- set config = {
+            initialLoginState: is_granted('IS_AUTHENTICATED_REMEMBERED') ? 'true' : 'false',
+            translations: translations,
+            fallbackLocale: fallback_locale,
+            endpoints: endpoints,
+            suluVersion: sulu_version,
+            appVersion: app_version,
+        } -%}
+
+        {%- block config -%}
+            const SULU_CONFIG = Object.freeze({{ config|json_encode(constant('JSON_PRETTY_PRINT'))|raw }});
+        {%- endblock -%}
+    </script>
+
+    {% block javascript %}
+        {#- We do not preload the files because of problems with big files on http push in Chrome -#}
         <script src="{{ asset('main.js', 'sulu_admin') }}"></script>
-    </body>
+    {%- endblock %}
+</body>
 </html>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
@@ -1,3 +1,9 @@
+# Required vendor routes
+fos_js_routing:
+    prefix: /admin
+    resource: "@FOSJsRoutingBundle/Resources/config/routing/routing.xml"
+
+# Sulu Routes
 sulu_admin:
     resource: "@SuluAdminBundle/Resources/config/routing.yml"
     prefix: /admin
@@ -6,6 +12,10 @@ sulu_admin_api:
     resource: "@SuluAdminBundle/Resources/config/routing_api.yml"
     type: rest
     prefix: /admin/api
+
+sulu_security:
+    resource: "@SuluSecurityBundle/Resources/config/routing.yml"
+    prefix: /admin/security
 
 sulu_security_api:
     type: rest

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/public/build/admin/manifest.json
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/public/build/admin/manifest.json
@@ -1,0 +1,4 @@
+{
+  "main.css": "build/admin/main.DUMMY.css",
+  "main.js": "build/admin/main.DUMMY.js"
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? yes 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add blocks to twig templates.

#### Why?

This allows use to move the [`observer` of the sulu demo](https://github.com/sulu/sulu-demo/blob/8140793ba355f3f2ef3a2934c9ff4e7d03311803/assets/admin/index.js#L25-L43) into that template. And use the build provided by sulu/skeleton repository.