### PR TITLE
Fix media caching with security

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Content/MediaSelectionContainer.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/MediaSelectionContainer.php
@@ -110,9 +110,9 @@ class MediaSelectionContainer implements ArrayableInterface
     {
         if (!empty($this->ids)) {
             return $this->mediaManager->getByIds($this->ids, $locale, $this->permission);
-        } else {
-            return [];
         }
+
+        return [];
     }
 
     /**
@@ -161,7 +161,7 @@ class MediaSelectionContainer implements ArrayableInterface
                 return $this->getTypes();
         }
 
-        return;
+        return null;
     }
 
     public function __isset($name)

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -238,7 +238,7 @@ class MediaManager implements MediaManagerInterface
             ['pagination' => false, 'ids' => $ids],
             null,
             null,
-            $this->getCurrentUser(),
+            $permission ? $this->getCurrentUser() : null,
             $permission
         );
         $this->count = \count($mediaEntities);
@@ -260,7 +260,7 @@ class MediaManager implements MediaManagerInterface
             $filter,
             $limit,
             $offset,
-            $this->getCurrentUser(),
+            $permission ? $this->getCurrentUser() : null,
             $permission
         );
         $this->count = $this->mediaRepository->count($filter);
@@ -912,8 +912,6 @@ class MediaManager implements MediaManagerInterface
         if ($user instanceof UserInterface) {
             return $user;
         }
-
-        return;
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -142,6 +142,8 @@ class MediaManager implements MediaManagerInterface
 
     /**
      * @var array
+     *
+     * @deprecated
      */
     private $permissions;
 
@@ -197,6 +199,7 @@ class MediaManager implements MediaManagerInterface
         $this->tokenStorage = $tokenStorage;
         $this->securityChecker = $securityChecker;
         $this->ffprobe = $ffprobe;
+        // TODO permissions are deprecated and should be removed in 2.3
         $this->permissions = $permissions;
         $this->downloadPath = $downloadPath;
         $this->maxFileSize = $maxFileSize;
@@ -895,23 +898,25 @@ class MediaManager implements MediaManagerInterface
     /**
      * Returns current user or null if no user is loggedin.
      *
-     * @return UserInterface|void
+     * @return UserInterface|null
      */
     protected function getCurrentUser()
     {
         if (!$this->tokenStorage) {
-            return;
+            return null;
         }
 
         $token = $this->tokenStorage->getToken();
         if (!$token) {
-            return;
+            return null;
         }
 
         $user = $token->getUser();
         if ($user instanceof UserInterface) {
             return $user;
         }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

Prevents accessing the `currentUser` if no permissions are given. Trying to get the `user` results in a session and thus the response header is automatically set to `private` by symfony.

#### Why?

Activating a security context (without `check-permission`) results in non cacheable response.

#### To Do

- [ ] Write a test for this behaviour
