### PR TITLE
Display 'Recently added' headline when no collection is selected in media library

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -6,7 +6,7 @@ import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
 import {observer} from 'mobx-react';
 import {Divider} from 'sulu-admin-bundle/components';
 import {List, ListStore} from 'sulu-admin-bundle/containers';
-import {translate} from "sulu-admin-bundle/utils/Translator";
+import {translate} from 'sulu-admin-bundle/utils/Translator';
 import CollectionStore from '../../stores/CollectionStore';
 import MultiMediaDropzone from '../MultiMediaDropzone';
 import type {OverlayType} from './types';

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -6,12 +6,12 @@ import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
 import {observer} from 'mobx-react';
 import {Divider} from 'sulu-admin-bundle/components';
 import {List, ListStore} from 'sulu-admin-bundle/containers';
+import {translate} from "sulu-admin-bundle/utils/Translator";
 import CollectionStore from '../../stores/CollectionStore';
 import MultiMediaDropzone from '../MultiMediaDropzone';
 import type {OverlayType} from './types';
 import CollectionSection from './CollectionSection';
 import MediaSection from './MediaSection';
-import {translate} from "sulu-admin-bundle/utils/Translator";
 
 type Props = {|
     collectionListStore: ListStore,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -11,6 +11,7 @@ import MultiMediaDropzone from '../MultiMediaDropzone';
 import type {OverlayType} from './types';
 import CollectionSection from './CollectionSection';
 import MediaSection from './MediaSection';
+import {translate} from "sulu-admin-bundle/utils/Translator";
 
 type Props = {|
     collectionListStore: ListStore,
@@ -118,7 +119,7 @@ class MediaCollection extends React.Component<Props> {
                     resourceStore={collectionStore.resourceStore}
                     securable={securable}
                 />
-                <Divider />
+                <Divider>{collectionStore.id ? undefined : translate('sulu_media.recently_added') }</Divider>
                 <div>
                     <MediaSection
                         adapters={mediaListAdapters}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
@@ -769,7 +769,9 @@ exports[`Render the MediaCollection for all media 1`] = `
   </div>
   <div
     class="divider"
-  />
+  >
+    sulu_media.recently_added
+  </div>
   <div>
     <div
       class="listContainer"

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
@@ -55,6 +55,7 @@
     "sulu_media.cropped": "Zugeschnitten",
     "sulu_media.double_click_crop_and_maximize": "Mit Doppelklick wird der Ausschnitt maximiert und zentriert",
     "sulu_media.min_size_notification": "Minimalgröße erreicht",
+    "sulu_media.recently_added": "Zuletzt hinzugefügt",
     "sulu_media.left_top": "Links oben",
     "sulu_media.top": "Oben",
     "sulu_media.right_top": "Rechts oben",

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
@@ -55,6 +55,7 @@
     "sulu_media.cropped": "Cropped",
     "sulu_media.double_click_crop_and_maximize": "A double-click maximizes and centers the area",
     "sulu_media.min_size_notification": "Minimal size reached",
+    "sulu_media.recently_added": "Recently added",
     "sulu_media.left_top": "Left top",
     "sulu_media.top": "Top",
     "sulu_media.right_top": "Right top",


### PR DESCRIPTION
I noticed that the initial design for the media library includes a `Recently added` headline. I think it would be nice to display this headline if no collection is selected to explain that area below will show all recently added medias:

![Screenshot 2021-04-02 at 14 11 27](https://user-images.githubusercontent.com/13310795/113414450-5212d500-93bd-11eb-9012-4f5e86f71274.png)
