### PR TITLE
 Referencing controllers with a single colon is deprecated

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/config/routing.yml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/routing.yml
@@ -1,22 +1,22 @@
 sulu_admin:
     path:  /
     defaults:
-        _controller: sulu_admin.admin_controller:indexAction
+        _controller: sulu_admin.admin_controller::indexAction
 
 sulu_admin.config:
     path: /config
     defaults:
-        _controller: sulu_admin.admin_controller:configAction
+        _controller: sulu_admin.admin_controller::configAction
 
 sulu_admin.metadata:
     path: /metadata/{type}/{key}
     defaults:
-        _controller: sulu_admin.admin_controller:metadataAction
+        _controller: sulu_admin.admin_controller::metadataAction
 
 sulu_admin.translation:
     path: /translations
     defaults:
-        _controller: sulu_admin.admin_controller:translationsAction
+        _controller: sulu_admin.admin_controller::translationsAction
 
 sulu_admin.login_check:
     path: /login
@@ -26,4 +26,4 @@ sulu_admin.logout:
 
 sulu_admin.reset:
     path: /reset/{token}
-    defaults: { _controller: SuluAdminBundle:Security:reset }
+    defaults: { _controller: SuluAdminBundle::Security:reset }

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/routing.yml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/routing.yml
@@ -23,7 +23,3 @@ sulu_admin.login_check:
 
 sulu_admin.logout:
     path: /logout
-
-sulu_admin.reset:
-    path: /reset/{token}
-    defaults: { _controller: SuluAdminBundle::Security:reset }

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/routing_website.yml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/routing_website.yml
@@ -1,9 +1,9 @@
 sulu_audience_targeting.target_group:
     path: "%sulu_audience_targeting.url%"
     defaults:
-        _controller: sulu_audience_targeting.target_group_evaluation_controller:targetGroupAction
+        _controller: sulu_audience_targeting.target_group_evaluation_controller::targetGroupAction
 
 sulu_audience_targeting.target_group_hit:
     path: "%sulu_audience_targeting.hit.url%"
     defaults:
-        _controller: sulu_audience_targeting.target_group_evaluation_controller:targetGroupHitAction
+        _controller: sulu_audience_targeting.target_group_evaluation_controller::targetGroupHitAction

--- a/src/Sulu/Bundle/LocationBundle/Resources/config/routing.yml
+++ b/src/Sulu/Bundle/LocationBundle/Resources/config/routing.yml
@@ -1,3 +1,3 @@
 sulu_location.geolocator_query:
     path: /geolocator
-    defaults: { _controller: sulu_location.controller.geolocator:queryAction }
+    defaults: { _controller: sulu_location.controller.geolocator::queryAction }

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/routing.yml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/routing.yml
@@ -1,3 +1,3 @@
 sulu_media.redirect:
     path: /redirect/media/{id}
-    defaults: { _controller: sulu_media.media_redirect_controller:redirectAction }
+    defaults: { _controller: sulu_media.media_redirect_controller::redirectAction }

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/routing_api.yml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/routing_api.yml
@@ -7,7 +7,7 @@ sulu_media.post_collection_trigger:
     path: /collections/{id}.{_format}
     methods: POST
     defaults:
-        _controller: sulu_media.collection_controller:postTriggerAction
+        _controller: sulu_media.collection_controller::postTriggerAction
         _format: json
 
 sulu_media.media:
@@ -19,7 +19,7 @@ sulu_media.post_media_trigger:
     path: /media/{id}.{_format}
     methods: POST
     defaults:
-        _controller: sulu_media.media_controller:postTriggerAction
+        _controller: sulu_media.media_controller::postTriggerAction
         _format: json
 
 sulu_media.media_preview:
@@ -32,7 +32,7 @@ sulu_media.post_media_preview:
     path: /media/{id}/preview.{_format}
     methods: POST
     defaults:
-        _controller: sulu_media.media_preview_controller:postAction
+        _controller: sulu_media.media_preview_controller::postAction
         _format: json
 
 sulu_media.format:

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/routing_website.yml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/routing_website.yml
@@ -1,7 +1,7 @@
 sulu_media.website.image.proxy:
     path: "%sulu_media.format_cache.media_proxy_path%"
     defaults:
-        _controller: sulu_media.media_stream_controller:getImageAction
+        _controller: sulu_media.media_stream_controller::getImageAction
         _requestAnalyzer: false
     requirements:
         slug: .*
@@ -9,7 +9,7 @@ sulu_media.website.image.proxy:
 sulu_media.website.media.download:
     path: "%sulu_media.media_manager.media_download_path%"
     defaults:
-        _controller: sulu_media.media_stream_controller:downloadAction
+        _controller: sulu_media.media_stream_controller::downloadAction
         _requestAnalyzer: false
     requirements:
         id: "\\d+"

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/routing.yml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/routing.yml
@@ -1,25 +1,25 @@
 sulu_preview.start:
     path: "/start"
     defaults:
-        _controller: sulu_preview.preview_controller:startAction
+        _controller: sulu_preview.preview_controller::startAction
 
 sulu_preview.render:
     path: "/render"
     defaults:
-        _controller: sulu_preview.preview_controller:renderAction
+        _controller: sulu_preview.preview_controller::renderAction
 
 sulu_preview.update:
     path: "/update"
     methods: [POST]
     defaults:
-        _controller: sulu_preview.preview_controller:updateAction
+        _controller: sulu_preview.preview_controller::updateAction
 
 sulu_preview.update-context:
     path: "/update-context"
     defaults:
-        _controller: sulu_preview.preview_controller:updateContextAction
+        _controller: sulu_preview.preview_controller::updateContextAction
 
 sulu_preview.stop:
     path: "/stop"
     defaults:
-        _controller: sulu_preview.preview_controller:stopAction
+        _controller: sulu_preview.preview_controller::stopAction

--- a/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
@@ -221,7 +221,7 @@ class RouteProvider implements RouteProviderInterface
             return new Route(
                 $routePath,
                 [
-                    '_controller' => 'sulu_website.redirect_controller:redirectAction',
+                    '_controller' => 'sulu_website.redirect_controller::redirectAction',
                     'url' => $request->getSchemeAndHttpHost()
                         . $attributes->getAttribute('resourceLocatorPrefix')
                         . $route->getTarget()->getPath()

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Routing/RouteProviderTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Routing/RouteProviderTest.php
@@ -339,7 +339,7 @@ class RouteProviderTest extends TestCase
 
         $this->assertEquals('/de/test', $routes[0]->getPath());
         $this->assertEquals(
-            ['_controller' => 'sulu_website.redirect_controller:redirectAction', 'url' => 'http://www.sulu.io/de/test-2?test=1'],
+            ['_controller' => 'sulu_website.redirect_controller::redirectAction', 'url' => 'http://www.sulu.io/de/test-2?test=1'],
             $routes[0]->getDefaults()
         );
     }
@@ -383,7 +383,7 @@ class RouteProviderTest extends TestCase
 
         $this->assertEquals('/de/test', $routes[0]->getPath());
         $this->assertEquals(
-            ['_controller' => 'sulu_website.redirect_controller:redirectAction', 'url' => 'http://www.sulu.io/de/test-2'],
+            ['_controller' => 'sulu_website.redirect_controller::redirectAction', 'url' => 'http://www.sulu.io/de/test-2'],
             $routes[0]->getDefaults()
         );
     }

--- a/src/Sulu/Bundle/SearchBundle/Resources/config/routing.yml
+++ b/src/Sulu/Bundle/SearchBundle/Resources/config/routing.yml
@@ -1,7 +1,7 @@
 sulu_search_indexes:
     path: /indexes
-    defaults: { _controller: "sulu_search.controller.search:indexesAction", _format: json }
+    defaults: { _controller: "sulu_search.controller.search::indexesAction", _format: json }
 
 sulu_search_search:
     path: /query
-    defaults: { _controller: "sulu_search.controller.search:searchAction", _format: json }
+    defaults: { _controller: "sulu_search.controller.search::searchAction", _format: json }

--- a/src/Sulu/Bundle/SearchBundle/Resources/config/routing_website.yml
+++ b/src/Sulu/Bundle/SearchBundle/Resources/config/routing_website.yml
@@ -1,5 +1,5 @@
 sulu_search.website_search:
     path: "/search.{_format}"
     defaults:
-        _controller: sulu_search.controller.website_search:queryAction
+        _controller: sulu_search.controller.website_search::queryAction
         _format: html

--- a/src/Sulu/Bundle/SearchBundle/Tests/Resources/TestBundle/Resources/config/routing.yml
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Resources/TestBundle/Resources/config/routing.yml
@@ -1,3 +1,3 @@
 test_search:
     path: /{locale}/search
-    defaults: { _controller: sulu_test.search_controller:queryAction }
+    defaults: { _controller: sulu_test.search_controller::queryAction }

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/routing.yml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/routing.yml
@@ -1,9 +1,9 @@
 sulu_security.reset_password.email:
     path: reset/email
     defaults:
-        _controller: sulu_security.resetting_controller:sendEmailAction
+        _controller: sulu_security.resetting_controller::sendEmailAction
 
 sulu_security.reset_password.reset:
     path: reset
     defaults:
-        _controller: sulu_security.resetting_controller:resetAction
+        _controller: sulu_security.resetting_controller::resetAction

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/routing_api.yml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/routing_api.yml
@@ -7,7 +7,7 @@ sulu_snippet.post_snippet_trigger:
     path: /snippets/{id}.{_format}
     methods: POST
     defaults:
-        _controller: sulu_snippet.controller.snippet:postTriggerAction
+        _controller: sulu_snippet.controller.snippet::postTriggerAction
         _format: json
 
 sulu_snippet.snippet-areas:

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/routing.yml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/routing.yml
@@ -1,4 +1,4 @@
 sulu_website.cache.remove:
     path: /cache
-    defaults: { _controller: sulu_website.cache_controller:clearAction }
+    defaults: { _controller: sulu_website.cache_controller::clearAction }
     methods: [DELETE]

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
@@ -251,7 +251,7 @@ class ContentRouteProvider implements RouteProviderInterface
         return new Route(
             $this->decodePathInfo($request->getPathInfo()),
             [
-                '_controller' => 'sulu_website.redirect_controller:redirectAction',
+                '_controller' => 'sulu_website.redirect_controller::redirectAction',
                 'url' => $url . $formatSuffix,
             ],
             [],

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/ContentRouteProviderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/ContentRouteProviderTest.php
@@ -464,7 +464,7 @@ class ContentRouteProviderTest extends TestCase
 
         $this->assertCount(1, $routes);
         $route = $routes->getIterator()->current();
-        $this->assertEquals('sulu_website.redirect_controller:redirectAction', $route->getDefaults()['_controller']);
+        $this->assertEquals('sulu_website.redirect_controller::redirectAction', $route->getDefaults()['_controller']);
         $this->assertEquals('sulu.io/de/other-test', $route->getDefaults()['url']);
     }
 
@@ -522,7 +522,7 @@ class ContentRouteProviderTest extends TestCase
 
         $this->assertCount(1, $routes);
         $route = $routes->getIterator()->current();
-        $this->assertEquals('sulu_website.redirect_controller:redirectAction', $route->getDefaults()['_controller']);
+        $this->assertEquals('sulu_website.redirect_controller::redirectAction', $route->getDefaults()['_controller']);
         $this->assertEquals('sulu.io/de/other-test?test1=value1', $route->getDefaults()['url']);
     }
 
@@ -560,7 +560,7 @@ class ContentRouteProviderTest extends TestCase
 
         $this->assertCount(1, $routes);
         $route = $routes->getIterator()->current();
-        $this->assertEquals('sulu_website.redirect_controller:redirectAction', $route->getDefaults()['_controller']);
+        $this->assertEquals('sulu_website.redirect_controller::redirectAction', $route->getDefaults()['_controller']);
         $this->assertEquals('/de/new-test.json', $route->getDefaults()['url']);
     }
 
@@ -607,7 +607,7 @@ class ContentRouteProviderTest extends TestCase
 
         $this->assertCount(1, $routes);
         $route = $routes->getIterator()->current();
-        $this->assertEquals('sulu_website.redirect_controller:redirectAction', $route->getDefaults()['_controller']);
+        $this->assertEquals('sulu_website.redirect_controller::redirectAction', $route->getDefaults()['_controller']);
         $this->assertEquals('http://www.example.org', $route->getDefaults()['url']);
     }
 
@@ -645,7 +645,7 @@ class ContentRouteProviderTest extends TestCase
 
         $this->assertCount(1, $routes);
         $route = $routes->getIterator()->current();
-        $this->assertEquals('sulu_website.redirect_controller:redirectAction', $route->getDefaults()['_controller']);
+        $this->assertEquals('sulu_website.redirect_controller::redirectAction', $route->getDefaults()['_controller']);
         $this->assertEquals('/de/new-test', $route->getDefaults()['url']);
     }
 
@@ -738,7 +738,7 @@ class ContentRouteProviderTest extends TestCase
 
         $this->assertCount(1, $routes);
         $route = $routes->getIterator()->current();
-        $this->assertEquals('sulu_website.redirect_controller:redirectAction', $route->getDefaults()['_controller']);
+        $this->assertEquals('sulu_website.redirect_controller::redirectAction', $route->getDefaults()['_controller']);
         $this->assertEquals('/de/qwertz', $route->getDefaults()['url']);
     }
 
@@ -782,7 +782,7 @@ class ContentRouteProviderTest extends TestCase
         $routes = $this->contentRouteProvider->getRouteCollectionForRequest($request);
         $this->assertCount(1, $routes);
         $route = $routes->getIterator()->current();
-        $this->assertEquals('sulu_website.redirect_controller:redirectAction', $route->getDefaults()['_controller']);
+        $this->assertEquals('sulu_website.redirect_controller::redirectAction', $route->getDefaults()['_controller']);
         $this->assertEquals('/de/foo?bar=baz', $route->getDefaults()['url']);
     }
 
@@ -822,7 +822,7 @@ class ContentRouteProviderTest extends TestCase
 
         $this->assertCount(1, $routes);
         $route = $routes->getIterator()->current();
-        $this->assertEquals('sulu_website.redirect_controller:redirectAction', $route->getDefaults()['_controller']);
+        $this->assertEquals('sulu_website.redirect_controller::redirectAction', $route->getDefaults()['_controller']);
         $this->assertEquals('/qwertz', $route->getDefaults()['url']);
     }
 
@@ -864,7 +864,7 @@ class ContentRouteProviderTest extends TestCase
 
         $this->assertCount(1, $routes);
         $route = $routes->getIterator()->current();
-        $this->assertEquals('sulu_website.redirect_controller:redirectAction', $route->getDefaults()['_controller']);
+        $this->assertEquals('sulu_website.redirect_controller::redirectAction', $route->getDefaults()['_controller']);
         $this->assertEquals('/de', $route->getDefaults()['url']);
     }
 

--- a/src/Sulu/Component/CustomUrl/Routing/CustomUrlRouteProvider.php
+++ b/src/Sulu/Component/CustomUrl/Routing/CustomUrlRouteProvider.php
@@ -149,7 +149,7 @@ class CustomUrlRouteProvider implements RouteProviderInterface
             new Route(
                 $this->decodePathInfo($request->getPathInfo()),
                 [
-                    '_controller' => 'sulu_website.redirect_controller:redirectAction',
+                    '_controller' => 'sulu_website.redirect_controller::redirectAction',
                     '_finalized' => true,
                     'url' => $url,
                 ],

--- a/src/Sulu/Component/CustomUrl/Routing/Enhancers/ExternalLinkEnhancer.php
+++ b/src/Sulu/Component/CustomUrl/Routing/Enhancers/ExternalLinkEnhancer.php
@@ -35,7 +35,7 @@ class ExternalLinkEnhancer implements RouteEnhancerInterface
         return \array_merge(
             $defaults,
             [
-                '_controller' => 'sulu_website.redirect_controller:redirectAction',
+                '_controller' => 'sulu_website.redirect_controller::redirectAction',
                 'url' => $structure->getResourceLocator(),
             ]
         );

--- a/src/Sulu/Component/CustomUrl/Routing/Enhancers/RedirectEnhancer.php
+++ b/src/Sulu/Component/CustomUrl/Routing/Enhancers/RedirectEnhancer.php
@@ -58,7 +58,7 @@ class RedirectEnhancer extends AbstractEnhancer
         $queryStringSuffix = $queryString ? '?' . $queryString : '';
 
         return [
-            '_controller' => 'sulu_website.redirect_controller:redirectAction',
+            '_controller' => 'sulu_website.redirect_controller::redirectAction',
             'url' => $url . $requestFormatSuffix . $queryStringSuffix,
         ];
     }

--- a/src/Sulu/Component/CustomUrl/Routing/Enhancers/TrailingHTMLEnhancer.php
+++ b/src/Sulu/Component/CustomUrl/Routing/Enhancers/TrailingHTMLEnhancer.php
@@ -32,7 +32,7 @@ class TrailingHTMLEnhancer extends AbstractEnhancer
 
         return [
             '_finalized' => true,
-            '_controller' => 'sulu_website.redirect_controller:redirectAction',
+            '_controller' => 'sulu_website.redirect_controller::redirectAction',
             'url' => \substr($request->getUri(), 0, -5),
         ];
     }

--- a/src/Sulu/Component/CustomUrl/Routing/Enhancers/TrailingSlashEnhancer.php
+++ b/src/Sulu/Component/CustomUrl/Routing/Enhancers/TrailingSlashEnhancer.php
@@ -32,7 +32,7 @@ class TrailingSlashEnhancer extends AbstractEnhancer
 
         return [
             '_finalized' => true,
-            '_controller' => 'sulu_website.redirect_controller:redirectAction',
+            '_controller' => 'sulu_website.redirect_controller::redirectAction',
             'url' => \substr($request->getUri(), 0, -1),
         ];
     }

--- a/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/CustomUrlRouteProviderTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/CustomUrlRouteProviderTest.php
@@ -135,7 +135,7 @@ class CustomUrlRouteProviderTest extends TestCase
         if ($history) {
             $this->assertEquals(
                 [
-                    '_controller' => 'sulu_website.redirect_controller:redirectAction',
+                    '_controller' => 'sulu_website.redirect_controller::redirectAction',
                     '_finalized' => true,
                     'url' => 'http://' . $expectedHistoryRedirectUrl,
                 ],

--- a/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/Enhancers/ExternalLinkEnhancerTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/Enhancers/ExternalLinkEnhancerTest.php
@@ -32,7 +32,7 @@ class ExternalLinkEnhancerTest extends TestCase
         $this->assertEquals(
             [
                 '_structure' => $structure->reveal(),
-                '_controller' => 'sulu_website.redirect_controller:redirectAction',
+                '_controller' => 'sulu_website.redirect_controller::redirectAction',
                 'url' => '/test',
             ],
             $defaults

--- a/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/Enhancers/RedirectEnhancerTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/Enhancers/RedirectEnhancerTest.php
@@ -62,7 +62,7 @@ class RedirectEnhancerTest extends TestCase
                 '_custom_url' => $customUrl->reveal(),
                 '_webspace' => $webspace->reveal(),
                 '_environment' => 'prod',
-                '_controller' => 'sulu_website.redirect_controller:redirectAction',
+                '_controller' => 'sulu_website.redirect_controller::redirectAction',
                 'url' => 'sulu.io/test',
             ],
             $defaults
@@ -110,7 +110,7 @@ class RedirectEnhancerTest extends TestCase
                 '_custom_url' => $customUrl->reveal(),
                 '_webspace' => $webspace->reveal(),
                 '_environment' => 'prod',
-                '_controller' => 'sulu_website.redirect_controller:redirectAction',
+                '_controller' => 'sulu_website.redirect_controller::redirectAction',
                 'url' => 'sulu.io/test?param=1',
             ],
             $defaults
@@ -158,7 +158,7 @@ class RedirectEnhancerTest extends TestCase
                 '_custom_url' => $customUrl->reveal(),
                 '_webspace' => $webspace->reveal(),
                 '_environment' => 'prod',
-                '_controller' => 'sulu_website.redirect_controller:redirectAction',
+                '_controller' => 'sulu_website.redirect_controller::redirectAction',
                 'url' => 'sulu.io/test.json?param=1',
             ],
             $defaults

--- a/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/Enhancers/TrailingHTMLEnhancerTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/Enhancers/TrailingHTMLEnhancerTest.php
@@ -40,7 +40,7 @@ class TrailingHTMLEnhancerTest extends TestCase
                 '_custom_url' => $customUrl->reveal(),
                 '_webspace' => $webspace->reveal(),
                 '_finalized' => true,
-                '_controller' => 'sulu_website.redirect_controller:redirectAction',
+                '_controller' => 'sulu_website.redirect_controller::redirectAction',
                 'url' => 'sulu.io/test',
             ],
             $defaults

--- a/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/Enhancers/TrailingSlashEnhancerTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/Enhancers/TrailingSlashEnhancerTest.php
@@ -40,7 +40,7 @@ class TrailingSlashEnhancerTest extends TestCase
                 '_custom_url' => $customUrl->reveal(),
                 '_webspace' => $webspace->reveal(),
                 '_finalized' => true,
-                '_controller' => 'sulu_website.redirect_controller:redirectAction',
+                '_controller' => 'sulu_website.redirect_controller::redirectAction',
                 'url' => 'sulu.io/test',
             ],
             $defaults


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| License | MIT

#### What's in this PR?
symfony/http-kernel 5.1 return deprecation warning

#### Why?

Change : to ::
