### PR TITLE
Fix route generation with correct translator locale

### DIFF
--- a/src/Sulu/Bundle/RouteBundle/Generator/RouteGenerator.php
+++ b/src/Sulu/Bundle/RouteBundle/Generator/RouteGenerator.php
@@ -48,7 +48,7 @@ class RouteGenerator implements RouteGeneratorInterface
 
         foreach ($tokenNames as $index => $name) {
             $tokenName = '{' . $name . '}';
-            $tokenValue = $this->tokenProvider->provide($entity, $name);
+            $tokenValue = $this->tokenProvider->provide($entity, $name, $options);
 
             $tokens[$tokenName] = $this->slugifier->slugify($tokenValue);
         }
@@ -59,7 +59,7 @@ class RouteGenerator implements RouteGeneratorInterface
                 \sprintf(
                     'Generated path "%s" for object "%s" has to start with a slash',
                     $path,
-                    \get_class($entity)
+                    \is_object($entity) ? \get_class($entity) : \json_encode($entity)
                 )
             );
         }

--- a/src/Sulu/Bundle/RouteBundle/Generator/RouteGeneratorInterface.php
+++ b/src/Sulu/Bundle/RouteBundle/Generator/RouteGeneratorInterface.php
@@ -21,7 +21,8 @@ interface RouteGeneratorInterface
     /**
      * Generates route by route-schema for given entity.
      *
-     * @param object $entity
+     * @param object|mixed[] $entity
+     * @param mixed[] $options
      *
      * @return string
      */
@@ -29,6 +30,8 @@ interface RouteGeneratorInterface
 
     /**
      * Returns options-resolver for validating options.
+     *
+     * @param mixed[] $options
      *
      * @return OptionsResolver
      */

--- a/src/Sulu/Bundle/RouteBundle/Generator/TokenProviderInterface.php
+++ b/src/Sulu/Bundle/RouteBundle/Generator/TokenProviderInterface.php
@@ -19,11 +19,12 @@ interface TokenProviderInterface
     /**
      * Returns resolved token for entity.
      *
+     * @param object|mixed[] $entity
      * @param string $name
      *
      * @return string
      *
      * @throws CannotEvaluateTokenException
      */
-    public function provide($entity, $name);
+    public function provide($entity, $name/*, array $options = [] */);
 }

--- a/src/Sulu/Bundle/RouteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/RouteBundle/Resources/config/services.xml
@@ -47,6 +47,7 @@
             <argument type="service" id="sulu_route.generator.route_generator"/>
             <argument>%sulu_route.resource_key_mappings%</argument>
             <argument type="service" id="sulu_route.manager.conflict_resolver.auto_increment"/>
+            <argument type="service" id="translator"/>
 
             <tag name="sulu.context" context="admin"/>
         </service>

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/RouteGeneratorTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/RouteGeneratorTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\RouteBundle\Tests\Unit\Generator;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Sulu\Bundle\RouteBundle\Generator\RouteGenerator;
 use Sulu\Bundle\RouteBundle\Generator\TokenProviderInterface;
 use Sulu\Bundle\RouteBundle\Model\RoutableInterface;
@@ -46,8 +47,8 @@ class RouteGeneratorTest extends TestCase
     {
         $entity = $this->prophesize(RoutableInterface::class);
 
-        $this->tokenProvider->provide($entity->reveal(), 'object.getTitle()')->willReturn('Test Title');
-        $this->tokenProvider->provide($entity->reveal(), 'object.getId()')->willReturn(1);
+        $this->tokenProvider->provide($entity->reveal(), 'object.getTitle()', Argument::any())->willReturn('Test Title');
+        $this->tokenProvider->provide($entity->reveal(), 'object.getId()', Argument::any())->willReturn(1);
 
         $this->slugifier->slugify('Test Title')->willReturn('test-title');
         $this->slugifier->slugify(1)->willReturn('1');

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/SymfonyExpressionTokenProviderTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/SymfonyExpressionTokenProviderTest.php
@@ -67,6 +67,27 @@ class SymfonyExpressionTokenProviderTest extends TestCase
         );
     }
 
+    public function testResolveWithLocale(): void
+    {
+        $translator = $this->prophesize(Translator::class);
+        $translator->getLocale()->willReturn('de');
+        $translator->setLocale('de')->shouldBeCalled();
+        $translator->setLocale('es')->shouldBeCalled();
+        $translator->trans('test-key')->willReturn('TEST');
+
+        $entity = [
+            'title',
+            'subtitle',
+        ];
+
+        $provider = new SymfonyExpressionTokenProvider($translator->reveal());
+
+        $this->assertEquals(
+            'TEST',
+            $provider->provide($entity, 'translator.trans("test-key")', ['locale' => 'es'])
+        );
+    }
+
     public function testResolveWithIsArray()
     {
         $translator = $this->prophesize(Translator::class);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes https://sulu-io.slack.com/archives/C0430GGCV/p1617448633344600
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the generation of localized routes by setting the locale to the translator in the RouteContoller

#### Why?

See discussion in slack https://sulu-io.slack.com/archives/C0430GGCV/p1617448633344600

#### To Do

- [ ] Add Tests