### PR TITLE
Add phpstan, php-cs files to export-ignore in .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,9 @@ CHANGELOG.md export-ignore
 CONTRIBUTING.md export-ignore
 Gruntfile.js export-ignore
 phpunit.xml.dist export-ignore
+phpstan.neon export-ignore
+phpstan-baseline.neon export-ignore
+.php_cs.dist export-ignore
 README.md export-ignore
 UPGRADE.md export-ignore
 /src/Sulu/Bundle/*/Tests export-ignore


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add phpstan, php-cs files to export-ignore in .gitattributes file.

#### Why?

The phpstan-baseline.yaml is very big and should not be part of the exported package.
