### PR TITLE
Fix deprecated uksort implementation

### DIFF
--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
@@ -132,7 +132,7 @@ class WebspaceCollectionBuilder
             \uksort(
                 $this->portalInformations[$environment],
                 function ($a, $b) {
-                    return \strlen($a) < \strlen($b);
+                    return \strlen($a) < \strlen($b) ? 1 : -1;
                 }
             );
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

With PHP8 there is a deprecation warning with this function. Since PHP7 is deprecated to return bool in the callback. It should return a int 

