### PR TITLE
Update locale of preview when switching locale of form

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
@@ -1,6 +1,6 @@
 // @flow
 import {action, autorun, computed, get, observable, when} from 'mobx';
-import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
+import type {IObservableValue} from 'mobx';
 import jsonpointer from 'json-pointer';
 import {createAjv} from '../../../utils/Ajv';
 import ResourceStore from '../../../stores/ResourceStore';

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
@@ -74,20 +74,10 @@ class Preview extends React.Component<Props> {
 
         const {
             formStore,
-            router: {
-                attributes: {
-                    locale,
-                },
-            },
         } = this.props;
 
-        if (locale !== undefined && typeof locale !== 'string') {
-            throw new Error('The "locale" router attribute must be a string if set!');
-        }
-
         if (Preview.audienceTargeting) {
-            const targetGroupsStore = new ResourceListStore('target_groups');
-            this.targetGroupsStore = targetGroupsStore;
+            this.targetGroupsStore = new ResourceListStore('target_groups');
         }
 
         this.webspaceOptions = webspaceStore.grantedWebspaces.map((webspace): Object => ({
@@ -98,7 +88,7 @@ class Preview extends React.Component<Props> {
         this.previewStore = new PreviewStore(
             formStore.resourceKey,
             formStore.id,
-            locale,
+            formStore.locale,
             this.webspaceKey,
             this.segments.find((segment) => segment.default === true)?.key
         );

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/stores/PreviewStore.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/stores/PreviewStore.js
@@ -3,6 +3,7 @@ import queryString from 'query-string';
 import {action, computed, observable} from 'mobx';
 import {Requester} from 'sulu-admin-bundle/services';
 import {transformDateForUrl} from 'sulu-admin-bundle/utils';
+import type {IObservableValue} from 'mobx';
 import type {PreviewRouteName} from './../types';
 
 const generateRoute = (name: PreviewRouteName, options: Object): string => {
@@ -19,7 +20,7 @@ export default class PreviewStore {
 
     resourceKey: string;
     id: ?string | number;
-    locale: ?string;
+    locale: ?IObservableValue<string>;
     @observable webspace: string;
     @observable segment: ?string;
     @observable targetGroup: number = -1;
@@ -27,7 +28,17 @@ export default class PreviewStore {
 
     @observable token: ?string;
 
-    constructor(resourceKey: string, id: ?string | number, locale: ?string, webspace: string, segment: ?string) {
+    constructor(
+        resourceKey: string,
+        id: ?string | number,
+        locale: ?IObservableValue<string>,
+        webspace: string,
+        segment: ?string
+    ) {
+        // keep backwards compatibility to previous versions where locale was passed as string
+        if (typeof locale === 'string') {
+            locale = observable.box(locale);
+        }
         this.resourceKey = resourceKey;
         this.id = id;
         this.locale = locale;

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/stores/PreviewStore.test.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/stores/PreviewStore.test.js
@@ -1,5 +1,6 @@
 // @flow
 import {Requester} from 'sulu-admin-bundle/services';
+import {observable} from 'mobx';
 import PreviewStore from '../../stores/PreviewStore';
 
 PreviewStore.endpoints = {
@@ -16,7 +17,8 @@ jest.mock('sulu-admin-bundle/services/Requester', () => ({
 }));
 
 test('Should request server on start preview', () => {
-    const previewStore = new PreviewStore('pages', '123-123-123', 'en', 'sulu_io');
+    const locale = observable.box('en');
+    const previewStore = new PreviewStore('pages', '123-123-123', locale, 'sulu_io');
 
     const requestPromise = Promise.resolve({token: '123-123-123'});
     Requester.post.mockReturnValue(requestPromise);
@@ -28,8 +30,22 @@ test('Should request server on start preview', () => {
     });
 });
 
+test('Should request server without locale on start preview', () => {
+    const previewStore = new PreviewStore('pages', '123-123-123', undefined, 'sulu_io');
+
+    const requestPromise = Promise.resolve({token: '123-123-123'});
+    Requester.post.mockReturnValue(requestPromise);
+
+    previewStore.start();
+
+    return requestPromise.then(() => {
+        expect(Requester.post).toBeCalledWith('/start?id=123-123-123&provider=pages');
+    });
+});
+
 test('Should request server on update preview', () => {
-    const previewStore = new PreviewStore('pages', '123-123-123', 'en', 'sulu_io');
+    const locale = observable.box('en');
+    const previewStore = new PreviewStore('pages', '123-123-123', locale, 'sulu_io');
 
     const postPromise = Promise.resolve({content: '<h1>Sulu is awesome</h1>'});
     Requester.post.mockReturnValue(postPromise);
@@ -48,7 +64,8 @@ test('Should request server on update preview', () => {
 });
 
 test('Should request server on update preview with target group', () => {
-    const previewStore = new PreviewStore('pages', '123-123-123', 'en', 'sulu_io');
+    const locale = observable.box('en');
+    const previewStore = new PreviewStore('pages', '123-123-123', locale, 'sulu_io');
 
     const postPromise = Promise.resolve({content: '<h1>Sulu is awesome</h1>'});
     Requester.post.mockReturnValue(postPromise);
@@ -68,7 +85,8 @@ test('Should request server on update preview with target group', () => {
 });
 
 test('Should request server on update preview with date time', () => {
-    const previewStore = new PreviewStore('pages', '123-123-123', 'en', 'sulu_io');
+    const locale = observable.box('en');
+    const previewStore = new PreviewStore('pages', '123-123-123', locale, 'sulu_io');
 
     const postPromise = Promise.resolve({content: '<h1>Sulu is awesome</h1>'});
     Requester.post.mockReturnValue(postPromise);
@@ -89,7 +107,8 @@ test('Should request server on update preview with date time', () => {
 });
 
 test('Should request server on update preview with segment', () => {
-    const previewStore = new PreviewStore('pages', '123-123-123', 'en', 'sulu_io');
+    const locale = observable.box('en');
+    const previewStore = new PreviewStore('pages', '123-123-123', locale, 'sulu_io');
 
     const postPromise = Promise.resolve({content: '<h1>Sulu is awesome</h1>'});
     Requester.post.mockReturnValue(postPromise);
@@ -109,7 +128,8 @@ test('Should request server on update preview with segment', () => {
 });
 
 test('Should request server on update-context preview', () => {
-    const previewStore = new PreviewStore('pages', '123-123-123', 'en', 'sulu_io');
+    const locale = observable.box('en');
+    const previewStore = new PreviewStore('pages', '123-123-123', locale, 'sulu_io');
 
     const postPromise = Promise.resolve({content: '<h1>Sulu is awesome</h1>'});
     Requester.post.mockReturnValue(postPromise);
@@ -129,7 +149,8 @@ test('Should request server on update-context preview', () => {
 });
 
 test('Should request server on update-context preview with target group', () => {
-    const previewStore = new PreviewStore('pages', '123-123-123', 'en', 'sulu_io');
+    const locale = observable.box('en');
+    const previewStore = new PreviewStore('pages', '123-123-123', locale, 'sulu_io');
 
     const postPromise = Promise.resolve({content: '<h1>Sulu is awesome</h1>'});
     Requester.post.mockReturnValue(postPromise);
@@ -150,7 +171,8 @@ test('Should request server on update-context preview with target group', () => 
 });
 
 test('Should request server on update-context preview with datetime', () => {
-    const previewStore = new PreviewStore('pages', '123-123-123', 'en', 'sulu_io');
+    const locale = observable.box('en');
+    const previewStore = new PreviewStore('pages', '123-123-123', locale, 'sulu_io');
 
     const postPromise = Promise.resolve({content: '<h1>Sulu is awesome</h1>'});
     Requester.post.mockReturnValue(postPromise);
@@ -172,7 +194,8 @@ test('Should request server on update-context preview with datetime', () => {
 });
 
 test('Should request server on update-context preview with segment', () => {
-    const previewStore = new PreviewStore('pages', '123-123-123', 'en', 'sulu_io');
+    const locale = observable.box('en');
+    const previewStore = new PreviewStore('pages', '123-123-123', locale, 'sulu_io');
 
     const postPromise = Promise.resolve({content: '<h1>Sulu is awesome</h1>'});
     Requester.post.mockReturnValue(postPromise);
@@ -194,7 +217,8 @@ test('Should request server on update-context preview with segment', () => {
 });
 
 test('Should request server on stop preview', () => {
-    const previewStore = new PreviewStore('pages', '123-123-123', 'en', 'sulu_io');
+    const locale = observable.box('en');
+    const previewStore = new PreviewStore('pages', '123-123-123', locale, 'sulu_io');
 
     const postPromise = Promise.resolve({content: '<h1>Sulu is awesome</h1>'});
 
@@ -208,7 +232,8 @@ test('Should request server on stop preview', () => {
 });
 
 test('Should set webspace', () => {
-    const previewStore = new PreviewStore('pages', '123-123-123', 'en', 'sulu_io');
+    const locale = observable.box('en');
+    const previewStore = new PreviewStore('pages', '123-123-123', locale, 'sulu_io');
     expect(previewStore.webspace).toEqual('sulu_io');
 
     previewStore.setWebspace('example');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #5084
| Related issues/PRs | #5665
| License | MIT

#### What's in this PR?

This PR adjusts the `Preview` container to pass the observable locale of the form to the `PreviewStore` instead of reading to locale from the router a single time.

This PR requires #5665 to handle the new locale on the server side the locale. Without #5665 the new locale will be sent to the server, but the server will ignore the locale of the request and [use the outdated locale from the cache](https://github.com/sulu/sulu/pull/5665/files#diff-4e58f16c1677e0b707c7193da31bfed39b335555747cf84d89ce00042a35e572R100). 

#### Why?

At the moment, if the user switches the locale of the form, the locale of the `PreviewStore` is not updated (see #5084). 

