### PR TITLE
Don't remove trailing zeroes when parsing values in Router.js

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -38,7 +38,7 @@ function tryParse(value: ?string) {
         }
     }
 
-    if (isNaN(value)) {
+    if (isNaN(value) || (value && value.match(/0+[^.].*/))) {
         return value;
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -38,7 +38,11 @@ function tryParse(value: ?string) {
         }
     }
 
-    if (isNaN(value) || (value && value.match(/0+[^.].*/))) {
+    if (isNaN(value)) {
+        return value;
+    }
+
+    if (value && value.match(/0+[^.].*/)) {
         return value;
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -42,8 +42,8 @@ function tryParse(value: ?string) {
         return value;
     }
 
-    if (value && value.match(/0+[^.].*/)) {
-        return value;
+    if (value && value.match(/0[^.].*/)) {
+        return value; // do not parse as number if string starts with 0 and does not contain a dot
     }
 
     return parseFloat(value);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
@@ -600,15 +600,28 @@ test('Navigate to route using a number with leading zeroes', () => {
         page: new Route({
             name: 'page',
             type: 'form',
-            path: '/pages/:uuid',
+            path: '/pages/:code',
         }),
     });
 
     const history = createMemoryHistory();
     const router = new Router(history);
 
-    router.navigate('page', {uuid: '012345'});
+    router.navigate('page', {code: '12345'});
+    expect(history.location.pathname).toBe('/pages/12345');
+    expect(router.attributes.code).toBe(12345);
+
+    router.navigate('page', {code: '012345'});
     expect(history.location.pathname).toBe('/pages/012345');
+    expect(router.attributes.code).toBe('012345');
+
+    router.navigate('page', {code: '0.12345'});
+    expect(history.location.pathname).toBe('/pages/0.12345');
+    expect(router.attributes.code).toBe(0.12345);
+
+    router.navigate('page', {code: '00.12345'});
+    expect(history.location.pathname).toBe('/pages/00.12345');
+    expect(router.attributes.code).toBe('00.12345');
 });
 
 test('Navigate to route changing only parameters', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
@@ -595,6 +595,22 @@ test('Navigate to route using URL with search parameters', () => {
     expect(history.location.search).toBe('?page=1&sort=date');
 });
 
+test('Navigate to route using a number with leading zeroes', () => {
+    routeRegistry.getAll.mockReturnValue({
+        page: new Route({
+            name: 'page',
+            type: 'form',
+            path: '/pages/:uuid',
+        }),
+    });
+
+    const history = createMemoryHistory();
+    const router = new Router(history);
+
+    router.navigate('page', {uuid: '012345'});
+    expect(history.location.pathname).toBe('/pages/012345');
+});
+
 test('Navigate to route changing only parameters', () => {
     routeRegistry.getAll.mockReturnValue({
         page: new Route({


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Added an extra check to see if a value is a number with trailing zeroes and if so, return it as a string instead of parsing it as a number/float and getting rid of those zeroes.

#### Why?

Route generation is stripping trailing zeroes, which leads to 404 errors when trying to edit an object.

Before: `/admin/#/products/9771/details`
After:   `/admin/#/products/09771/details`

This is only a problem when the id is saved in the database as a string and not a zerofilled integer.

It might also be possible to not check if the value is a number and return the value early, or parse values starting with `.` only. For now the commit only handles values starting with `0` and not followed by a `.`.