### PR TITLE
Not analyze route if doesn't match

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/RouterListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/RouterListener.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\WebsiteBundle\EventListener;
 
+use Sulu\Component\Webspace\Analyzer\Exception\UrlMatchNotFoundException;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
@@ -56,7 +57,11 @@ class RouterListener implements EventSubscriberInterface
         $this->requestAnalyzer->analyze($request);
         $this->baseRouteListener->onKernelRequest($event);
         if (false !== $request->attributes->getBoolean(static::REQUEST_ANALYZER, true)) {
-            $this->requestAnalyzer->validate($request);
+            try {
+                $this->requestAnalyzer->validate($request);
+            } catch (UrlMatchNotFoundException $exception) {
+                $request->attributes->set(self::REQUEST_ANALYZER, false);
+            }
         }
     }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/RouterListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/RouterListenerTest.php
@@ -13,6 +13,7 @@ namespace Unit\Sulu\Bundle\WebsiteBundle\EventListener;
 
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\WebsiteBundle\EventListener\RouterListener;
+use Sulu\Component\Webspace\Analyzer\Exception\UrlMatchNotFoundException;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -91,6 +92,18 @@ class RouterListenerTest extends TestCase
         $this->requestAnalyzer->validate($request)->shouldBeCalled();
 
         $this->routerListener->onKernelRequest($event);
+    }
+
+    public function testDisableAnalyzerIfUrlNotMatch(): void
+    {
+        $request = new Request([], [], ['_requestAnalyzer' => true]);
+        $event = $this->createRequestEvent($request);
+
+        $this->requestAnalyzer->analyze($request)->shouldBeCalled();
+        $this->requestAnalyzer->validate($request)->willThrow(UrlMatchNotFoundException::class);
+
+        $this->routerListener->onKernelRequest($event);
+        $this->assertFalse($request->attributes->get('_requestAnalyzer'));
     }
 
     private function createRequestEvent(Request $request): RequestEvent


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no 
| Deprecations? | -
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

After symfony route match a 404 or redirect route, some routes are analyzed and throw a UrlMatchNotFoundException showing a basic 404 symfony error. 

This should solve this kind or error https://sulu.rocks/fdsafd.txt ( Sulu error page must be shown )

#### Why?

Because we want to show a sulu error page or redirect

