### PR TITLE
Allow to set mode of route field type via param in XML template

### DIFF
--- a/src/Sulu/Bundle/RouteBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/RouteBundle/Resources/js/index.js
@@ -2,8 +2,8 @@
 import {resourceRouteRegistry} from 'sulu-admin-bundle/services/ResourceRequester';
 import {fieldRegistry, ResourceLocator} from 'sulu-admin-bundle/containers';
 import initializer from 'sulu-admin-bundle/services/initializer';
+import type {FieldTypeProps} from '../../../AdminBundle/Resources/js/containers/Form/types';
 import PageTreeRoute from './containers/Form/fields/PageTreeRoute';
-import type {FieldTypeProps} from "../../../AdminBundle/Resources/js/containers/Form/types";
 
 initializer.addUpdateConfigHook('sulu_admin', (config: Object, initialized: boolean) => {
     if (initialized) {

--- a/src/Sulu/Bundle/RouteBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/RouteBundle/Resources/js/index.js
@@ -3,6 +3,7 @@ import {resourceRouteRegistry} from 'sulu-admin-bundle/services/ResourceRequeste
 import {fieldRegistry, ResourceLocator} from 'sulu-admin-bundle/containers';
 import initializer from 'sulu-admin-bundle/services/initializer';
 import PageTreeRoute from './containers/Form/fields/PageTreeRoute';
+import type {FieldTypeProps} from "../../../AdminBundle/Resources/js/containers/Form/types";
 
 initializer.addUpdateConfigHook('sulu_admin', (config: Object, initialized: boolean) => {
     if (initialized) {
@@ -16,8 +17,16 @@ initializer.addUpdateConfigHook('sulu_admin', (config: Object, initialized: bool
         ResourceLocator,
         {
             historyResourceKey: 'routes',
-            modeResolver: () => {
-                return Promise.resolve('full');
+            modeResolver: (props: FieldTypeProps<?string>) => {
+                const {
+                    schemaOptions: {
+                        mode: {
+                            value: mode = 'full',
+                        } = {},
+                    },
+                } = props;
+
+                return Promise.resolve(mode);
             },
             generationUrl: routeGenerationUrl,
             options: {history: true},


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Related issues/PRs | #5932
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/641

#### What's in this PR?

This PR adjusts the `route` field type to allow for configuring the `mode` of the rendered `ResourceLocator` component in the XML template like this:

```xml
<property name="routePath" type="route">
    <meta>
        <title lang="en">Resourcelocator</title>
    </meta>

    <params>
        <param name="mode" value="leaf"/>
    </params>
</property>
```

This will result in the following input field in the administration interface:

![Screenshot 2021-04-12 at 09 25 32](https://user-images.githubusercontent.com/13310795/114356572-0f958900-9b71-11eb-88f2-774945083d49.png)

#### Why?

Because it might be useful to use the `leaf` mode in some cases (see #5932). See the following part of the documenation for the difference between the `full` mode and the `leaf` mode:
https://docs.sulu.io/en/latest/book/webspaces.html#resource-locator-optional
