### PR TITLE
Fix ImageMapContentType on null value

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Content/Types/ImageMapContentType.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/ImageMapContentType.php
@@ -390,7 +390,8 @@ class ImageMapContentType extends ComplexContentType implements ContentTypeExpor
             'hotspots' => [],
         ];
 
-        foreach ($value['hotspots'] as $i => $hotspot) {
+        $hotspots = $value['hotspots'] ?? [];
+        foreach ($hotspots as $i => $hotspot) {
             $hotspotData = [];
 
             $propertyType = $property->initProperties($i, $hotspot['type']);

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/ImageMapContentTypeTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/ImageMapContentTypeTest.php
@@ -954,7 +954,7 @@ class ImageMapContentTypeTest extends TestCase
         );
 
         $this->singleMediaSelectionContentType->getContentData(
-            Argument::that(function ($property) {
+            Argument::that(function($property) {
                 return $property instanceof Property
                     && 'image' === $property->getName()
                     && $property->getValue() === ['id' => null];

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/ImageMapContentTypeTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/ImageMapContentTypeTest.php
@@ -935,6 +935,37 @@ class ImageMapContentTypeTest extends TestCase
         $this->assertNull($this->imageMapContentType->getContentData($property));
     }
 
+    public function testGetContentDataNullValue(): void
+    {
+        $value = null;
+
+        $property = new Property(
+            'imageMap',
+            '',
+            'image_map',
+            false,
+            true,
+            1,
+            1,
+            [],
+            [],
+            null,
+            'text'
+        );
+
+        $this->singleMediaSelectionContentType->getContentData(
+            Argument::that(function ($property) {
+                return $property instanceof Property
+                    && 'image' === $property->getName()
+                    && $property->getValue() === ['id' => null];
+            })
+        )->willReturn(null)->shouldBeCalled();
+
+        $property->setValue($value);
+
+        $this->assertNull($this->imageMapContentType->getContentData($property));
+    }
+
     public function testGetViewData(): void
     {
         $types = [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Adds a default value for `hotspots`. The default value is used, when the `value` of the `property` is null.

#### Why?

Because in the preview it was possible for the frontend to send a `update` request in the preview, without proper values for the image map. In this case, now the default value for the `hotspots` is used in the `ImageMapContentType`.
