### PR TITLE
Add tag and category filter on contact, account and media list

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/SelectionFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/SelectionFieldFilterType.js
@@ -3,6 +3,7 @@ import React from 'react';
 import type {ElementRef} from 'react';
 import {action, autorun, computed, observable, toJS, untracked, when} from 'mobx';
 import equals from 'fast-deep-equal';
+import userStore from '../../../stores/userStore';
 import MultiSelectionStore from '../../../stores/MultiSelectionStore';
 import MultiAutoComplete from '../../MultiAutoComplete';
 import ResourceCheckboxGroup from '../../ResourceCheckboxGroup';
@@ -30,7 +31,11 @@ class SelectionFieldFilterType extends AbstractFieldFilterType<?Array<string | n
     ) {
         super(onChange, parameters, value);
 
-        this.selectionStore = new MultiSelectionStore(this.resourceKey, []);
+        this.selectionStore = new MultiSelectionStore(
+            this.resourceKey,
+            [],
+            computed(() => userStore.contentLocale)
+        );
 
         this.selectionStoreDisposer = autorun(() => {
             const {onChange, selectionStore} = this;

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -391,6 +391,7 @@ class AccountController extends AbstractRestController implements ClassResourceI
         if ('true' == $request->get('flat')) {
             $fieldDescriptors = $this->getFieldDescriptors();
             $listBuilder = $this->generateFlatListBuilder();
+            $listBuilder->distinct(true);
             $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
             $this->applyRequestParameters($request, $listBuilder);
 

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -389,9 +389,9 @@ class AccountController extends AbstractRestController implements ClassResourceI
         $locale = $this->getUser()->getLocale();
 
         if ('true' == $request->get('flat')) {
-            $fieldDescriptors = $this->getFieldDescriptors();
             $listBuilder = $this->generateFlatListBuilder();
             $listBuilder->distinct(true);
+            $fieldDescriptors = $this->getFieldDescriptors();
             $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
             $this->applyRequestParameters($request, $listBuilder);
 

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -390,7 +390,6 @@ class AccountController extends AbstractRestController implements ClassResourceI
 
         if ('true' == $request->get('flat')) {
             $listBuilder = $this->generateFlatListBuilder();
-            $listBuilder->distinct(true);
             $fieldDescriptors = $this->getFieldDescriptors();
             $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
             $this->applyRequestParameters($request, $listBuilder);

--- a/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
@@ -296,9 +296,10 @@ class ContactController extends AbstractRestController implements ClassResourceI
      */
     private function getList(Request $request, $locale)
     {
-        $fieldDescriptors = $this->getFieldDescriptors();
+        /** @var DoctrineListBuilder $listBuilder */
         $listBuilder = $this->listBuilderFactory->create($this->contactClass);
         $listBuilder->distinct(true);
+        $fieldDescriptors = $this->getFieldDescriptors();
         $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
 
         $account = $request->get('accountId');

--- a/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
@@ -298,6 +298,7 @@ class ContactController extends AbstractRestController implements ClassResourceI
     {
         $fieldDescriptors = $this->getFieldDescriptors();
         $listBuilder = $this->listBuilderFactory->create($this->contactClass);
+        $listBuilder->distinct(true);
         $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
 
         $account = $request->get('accountId');

--- a/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
@@ -298,7 +298,6 @@ class ContactController extends AbstractRestController implements ClassResourceI
     {
         /** @var DoctrineListBuilder $listBuilder */
         $listBuilder = $this->listBuilderFactory->create($this->contactClass);
-        $listBuilder->distinct(true);
         $fieldDescriptors = $this->getFieldDescriptors();
         $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
 

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/lists/accounts.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/lists/accounts.xml
@@ -265,5 +265,28 @@
                 </params>
             </filter>
         </property>
+
+        <property
+            name="categoryId"
+            visibility="never"
+            translation="sulu_category.categories"
+        >
+            <field-name>id</field-name>
+            <entity-name>SuluCategoryBundle:Category</entity-name>
+
+            <joins>
+                <join>
+                    <entity-name>SuluCategoryBundle:Category</entity-name>
+                    <field-name>%sulu.model.account.class%.categories</field-name>
+                </join>
+            </joins>
+
+            <filter type="selection">
+                <params>
+                    <param name="displayProperty" value="name" />
+                    <param name="resourceKey" value="categories" />
+                </params>
+            </filter>
+        </property>
     </properties>
 </list>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/lists/accounts.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/lists/accounts.xml
@@ -22,6 +22,13 @@
         </join>
     </joins>
 
+    <joins name="tags">
+        <join>
+            <entity-name>SuluTagBundle:Tag</entity-name>
+            <field-name>%sulu.model.account.class%.tags</field-name>
+        </join>
+    </joins>
+
     <properties>
         <property name="logo" visibility="always" translation="sulu_contact.logo" sortable="false">
             <field-name>id</field-name>
@@ -238,12 +245,25 @@
             <field-name>id</field-name>
             <entity-name>SuluTagBundle:Tag</entity-name>
 
-            <joins>
-                <join>
-                    <entity-name>SuluTagBundle:Tag</entity-name>
-                    <field-name>%sulu.model.account.class%.tags</field-name>
-                </join>
-            </joins>
+            <joins ref="tags"/>
         </group-concat-property>
+
+        <property
+            name="tagId"
+            visibility="never"
+            translation="sulu_tag.tags"
+        >
+            <field-name>id</field-name>
+            <entity-name>SuluTagBundle:Tag</entity-name>
+
+            <joins ref="tags"/>
+
+            <filter type="selection">
+                <params>
+                    <param name="displayProperty" value="name" />
+                    <param name="resourceKey" value="tags" />
+                </params>
+            </filter>
+        </property>
     </properties>
 </list>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/lists/accounts.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/lists/accounts.xml
@@ -248,6 +248,8 @@
             <joins ref="tags"/>
         </group-concat-property>
 
+        <!-- tagId property is only used for filtering and should never be included as column in a list -->
+        <!-- when as as column, the property will lead to duplicated rows for entities with multiple tags -->
         <property
             name="tagId"
             visibility="never"
@@ -266,6 +268,8 @@
             </filter>
         </property>
 
+        <!-- categoryId property is only used for filtering and should never be included as column in a list -->
+        <!-- when used as column, the property will lead to duplicated rows for entities with multiple categories -->
         <property
             name="categoryId"
             visibility="never"

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/lists/accounts.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/lists/accounts.xml
@@ -249,7 +249,7 @@
         </group-concat-property>
 
         <!-- tagId property is only used for filtering and should never be included as column in a list -->
-        <!-- when as as column, the property will lead to duplicated rows for entities with multiple tags -->
+        <!-- when used as column, the property will lead to duplicated rows for entities with multiple tags -->
         <property
             name="tagId"
             visibility="never"

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
@@ -35,6 +35,13 @@
         </join>
     </joins>
 
+    <joins name="tags">
+        <join>
+            <entity-name>SuluTagBundle:Tag</entity-name>
+            <field-name>%sulu.model.contact.class%.tags</field-name>
+        </join>
+    </joins>
+
     <properties>
         <property
             name="avatar"
@@ -301,13 +308,26 @@
             <field-name>id</field-name>
             <entity-name>SuluTagBundle:Tag</entity-name>
 
-            <joins>
-                <join>
-                    <entity-name>SuluTagBundle:Tag</entity-name>
-                    <field-name>%sulu.model.contact.class%.tags</field-name>
-                </join>
-            </joins>
+            <joins ref="tags"/>
         </group-concat-property>
+
+        <property
+            name="tagId"
+            visibility="never"
+            translation="sulu_tag.tags"
+        >
+            <field-name>id</field-name>
+            <entity-name>SuluTagBundle:Tag</entity-name>
+
+            <joins ref="tags"/>
+
+            <filter type="selection">
+                <params>
+                    <param name="displayProperty" value="name" />
+                    <param name="resourceKey" value="tags" />
+                </params>
+            </filter>
+        </property>
 
         <property name="user" visibility="no" searchability="yes" translation="sulu_security.user_name">
             <field-name>username</field-name>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
@@ -311,6 +311,8 @@
             <joins ref="tags"/>
         </group-concat-property>
 
+        <!-- tagId property is only used for filtering and should never be included as column in a list -->
+        <!-- when as as column, the property will lead to duplicated rows for entities with multiple tags -->
         <property
             name="tagId"
             visibility="never"
@@ -329,6 +331,8 @@
             </filter>
         </property>
 
+        <!-- categoryId property is only used for filtering and should never be included as column in a list -->
+        <!-- when used as column, the property will lead to duplicated rows for entities with multiple categories -->
         <property
             name="categoryId"
             visibility="never"

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
@@ -329,6 +329,29 @@
             </filter>
         </property>
 
+        <property
+            name="categoryId"
+            visibility="never"
+            translation="sulu_category.categories"
+        >
+            <field-name>id</field-name>
+            <entity-name>SuluCategoryBundle:Category</entity-name>
+
+            <joins>
+                <join>
+                    <entity-name>SuluCategoryBundle:Category</entity-name>
+                    <field-name>%sulu.model.contact.class%.categories</field-name>
+                </join>
+            </joins>
+
+            <filter type="selection">
+                <params>
+                    <param name="displayProperty" value="name" />
+                    <param name="resourceKey" value="categories" />
+                </params>
+            </filter>
+        </property>
+
         <property name="user" visibility="no" searchability="yes" translation="sulu_security.user_name">
             <field-name>username</field-name>
             <entity-name>%sulu.model.user.class%</entity-name>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
@@ -312,7 +312,7 @@
         </group-concat-property>
 
         <!-- tagId property is only used for filtering and should never be included as column in a list -->
-        <!-- when as as column, the property will lead to duplicated rows for entities with multiple tags -->
+        <!-- when used as column, the property will lead to duplicated rows for entities with multiple tags -->
         <property
             name="tagId"
             visibility="never"

--- a/src/Sulu/Bundle/MediaBundle/Media/ListRepresentationFactory/MediaListRepresentationFactory.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ListRepresentationFactory/MediaListRepresentationFactory.php
@@ -42,6 +42,7 @@ class MediaListRepresentationFactory
         array $parameters
     ): ListRepresentation {
         $listBuilder->setParameter('locale', $locale);
+        $listBuilder->distinct(true);
         $listResponse = $listBuilder->execute();
 
         for ($i = 0, $length = \count($listResponse); $i < $length; ++$i) {

--- a/src/Sulu/Bundle/MediaBundle/Media/ListRepresentationFactory/MediaListRepresentationFactory.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ListRepresentationFactory/MediaListRepresentationFactory.php
@@ -42,7 +42,6 @@ class MediaListRepresentationFactory
         array $parameters
     ): ListRepresentation {
         $listBuilder->setParameter('locale', $locale);
-        $listBuilder->distinct(true);
         $listResponse = $listBuilder->execute();
 
         for ($i = 0, $length = \count($listResponse); $i < $length; ++$i) {

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/lists/media.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/lists/media.xml
@@ -248,6 +248,8 @@
             <joins ref="fileVersionMeta"/>
         </property>
 
+        <!-- tagId property is only used for filtering and should never be included as column in a list -->
+        <!-- when as as column, the property will lead to duplicated rows for entities with multiple tags -->
         <property
             name="tagId"
             visibility="never"
@@ -271,6 +273,8 @@
             </filter>
         </property>
 
+        <!-- categoryId property is only used for filtering and should never be included as column in a list -->
+        <!-- when used as column, the property will lead to duplicated rows for entities with multiple categories -->
         <property
             name="categoryId"
             visibility="never"

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/lists/media.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/lists/media.xml
@@ -248,6 +248,29 @@
             <joins ref="fileVersionMeta"/>
         </property>
 
+        <property
+            name="tagId"
+            visibility="never"
+            translation="sulu_tag.tags"
+        >
+            <field-name>id</field-name>
+            <entity-name>SuluTagBundle:Tag</entity-name>
+
+            <joins ref="fileVersion">
+                <join>
+                    <entity-name>SuluTagBundle:Tag</entity-name>
+                    <field-name>SuluMediaBundle:FileVersion.tags</field-name>
+                </join>
+            </joins>
+
+            <filter type="selection">
+                <params>
+                    <param name="displayProperty" value="name" />
+                    <param name="resourceKey" value="tags" />
+                </params>
+            </filter>
+        </property>
+
         <property name="lft" visibility="never">
             <field-name>lft</field-name>
             <entity-name>%sulu.model.collection.class%</entity-name>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/lists/media.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/lists/media.xml
@@ -271,6 +271,29 @@
             </filter>
         </property>
 
+        <property
+            name="categoryId"
+            visibility="never"
+            translation="sulu_category.categories"
+        >
+            <field-name>id</field-name>
+            <entity-name>SuluCategoryBundle:Category</entity-name>
+
+            <joins ref="fileVersion">
+                <join>
+                    <entity-name>SuluCategoryBundle:Category</entity-name>
+                    <field-name>SuluMediaBundle:FileVersion.categories</field-name>
+                </join>
+            </joins>
+
+            <filter type="selection">
+                <params>
+                    <param name="displayProperty" value="name" />
+                    <param name="resourceKey" value="categories" />
+                </params>
+            </filter>
+        </property>
+
         <property name="lft" visibility="never">
             <field-name>lft</field-name>
             <entity-name>%sulu.model.collection.class%</entity-name>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/lists/media.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/lists/media.xml
@@ -249,7 +249,7 @@
         </property>
 
         <!-- tagId property is only used for filtering and should never be included as column in a list -->
-        <!-- when as as column, the property will lead to duplicated rows for entities with multiple tags -->
+        <!-- when used as column, the property will lead to duplicated rows for entities with multiple tags -->
         <property
             name="tagId"
             visibility="never"

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -226,7 +226,7 @@ class DoctrineListBuilder extends AbstractListBuilder
         );
 
         // now select all data
-        $this->assignJoins($this->queryBuilder);
+        $this->assignJoins($this->queryBuilder, $this->getJoins(false));
 
         // use ids previously selected ids for query
         $select = $this->idField->getSelect();
@@ -362,12 +362,18 @@ class DoctrineListBuilder extends AbstractListBuilder
     /**
      * Returns all the joins required for the query.
      *
+     * @param bool $includeFilterFields Define if joins of filtering FieldDescriptors should be returned
+     *
      * @return DoctrineJoinDescriptor[]
      */
-    protected function getJoins()
+    protected function getJoins($includeFilterFields = true)
     {
         $joins = [];
-        $fields = \array_merge($this->sortFields, $this->selectFields, $this->searchFields, $this->expressionFields);
+        $fields = \array_merge($this->sortFields, $this->selectFields);
+
+        if ($includeFilterFields) {
+            $fields = \array_merge($fields, $this->searchFields, $this->expressionFields);
+        }
 
         foreach ($fields as $field) {
             $joins = \array_merge($joins, $field->getJoins());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #5469
| Related issues/PRs | depends on #5805, depends on #5943
| License | MIT

#### What's in this PR?

This PR implements a POC for adding a tag filter and a category filter on the list view for contacts, accounts and medias:
![Screenshot 2021-04-14 at 17 23 19](https://user-images.githubusercontent.com/13310795/114736149-23deaf00-9d46-11eb-9684-6fe36e9abca3.png)

#### Why?

See #5469
