### PR TITLE
Use computed contentLocale from userStore instead of boxing value a single time

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {action, observable, toJS} from 'mobx';
+import {action, computed, observable, toJS} from 'mobx';
 import {observer} from 'mobx-react';
 import ResourceLocatorComponent from '../../../components/ResourceLocator';
 import ResourceLocatorHistory from '../../../containers/ResourceLocatorHistory';
@@ -146,7 +146,7 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
                     <ResourceLocatorComponent
                         disabled={!!disabled}
                         id={dataPath}
-                        locale={formInspector.locale ? formInspector.locale : observable.box(userStore.contentLocale)}
+                        locale={formInspector.locale ? formInspector.locale : computed(() => userStore.contentLocale)}
                         mode={this.mode}
                         onBlur={this.handleBlur}
                         onChange={onChange}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {computed, observable, intercept, toJS, reaction, isArrayLike} from 'mobx';
+import {computed, observable, toJS, reaction, isArrayLike} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import equals from 'fast-deep-equal';
 import {observer} from 'mobx-react';
@@ -138,13 +138,14 @@ class Selection extends React.Component<Props> {
                 }
             );
 
-            this.changeLocaleDisposer = intercept(this.locale, '', (change) => {
-                if (this.listStore) {
-                    this.listStore.sendRequestDisposer();
+            this.changeLocaleDisposer = reaction(
+                () => this.locale.get(),
+                () => {
+                    if (this.listStore) {
+                        this.listStore.sendRequestDisposer();
+                    }
                 }
-
-                return change;
-            });
+            );
         } else if (this.type === 'auto_complete') {
             this.autoCompleteSelectionStore = new MultiSelectionStore(
                 resourceKey,
@@ -220,7 +221,7 @@ class Selection extends React.Component<Props> {
     @computed get locale(): IObservableValue<string> {
         const {formInspector} = this.props;
 
-        return formInspector.locale ? formInspector.locale : observable.box(userStore.contentLocale);
+        return formInspector.locale ? formInspector.locale : computed(() => userStore.contentLocale);
     }
 
     @computed get type() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {computed, observable} from 'mobx';
+import {computed} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import jsonpointer from 'json-pointer';
 import log from 'loglevel';
@@ -89,7 +89,7 @@ export default class SingleSelection extends React.Component<Props>
     @computed get locale(): IObservableValue<string> {
         const {formInspector} = this.props;
 
-        return formInspector.locale ? formInspector.locale : observable.box(userStore.contentLocale);
+        return formInspector.locale ? formInspector.locale : computed(() => userStore.contentLocale);
     }
 
     @computed get viewName() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/TextEditor.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/TextEditor.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {observable} from 'mobx';
+import {computed} from 'mobx';
 import TextEditorContainer from '../../../containers/TextEditor';
 import type {FieldTypeProps} from '../../../types';
 import userStore from '../../../stores/userStore';
@@ -9,7 +9,7 @@ export default class TextEditor extends React.Component<FieldTypeProps<?string>>
     render() {
         const {disabled, formInspector, onChange, onFinish, schemaOptions, value} = this.props;
 
-        const locale = formInspector.locale ? formInspector.locale : observable.box(userStore.contentLocale);
+        const locale = formInspector.locale ? formInspector.locale : computed(() => userStore.contentLocale);
 
         return (
             <TextEditorContainer

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 import log from 'loglevel';
-import {extendObservable as mockExtendObservable, observable, toJS} from 'mobx';
+import {extendObservable as mockExtendObservable, observable} from 'mobx';
 import {mount, shallow} from 'enzyme';
 import fieldTypeDefaultProps from '../../../../utils/TestHelper/fieldTypeDefaultProps';
 import {translate} from '../../../../utils/Translator';
@@ -238,7 +238,7 @@ test('Should pass locale from userStore to MultiSelection component if form has 
 
     expect(translate).toBeCalledWith('sulu_snippet.selection_label', {count: 3});
 
-    expect(toJS(selection.find('MultiSelection').prop('locale'))).toEqual('de');
+    expect(selection.find('MultiSelection').prop('locale').get()).toEqual('de');
 });
 
 test('Should pass props with schema-options correctly to MultiSelection component', () => {
@@ -1028,7 +1028,7 @@ test('Should pass locale from userStore to listStore if form has no locale', () 
         />
     );
 
-    expect(toJS(selection.instance().listStore.locale)).toEqual('en');
+    expect(selection.instance().listStore.locale.get()).toEqual('en');
 });
 
 test('Should call onChange and onFinish prop when list selection changes', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
@@ -1,5 +1,5 @@
 // @flow
-import {action, autorun, computed, intercept, observable, untracked} from 'mobx';
+import {action, autorun, computed, intercept, observable, reaction, untracked} from 'mobx';
 import type {IObservableValue, IValueWillChange} from 'mobx';
 import equals from 'fast-deep-equal';
 import log from 'loglevel';
@@ -167,10 +167,14 @@ export default class ListStore {
 
         const {locale} = this.observableOptions;
         if (locale) {
-            this.localeDisposer = intercept(locale, '', (change: IValueWillChange<*>) => {
-                callResetForChangedObservable(change);
-                return change;
-            });
+            this.localeDisposer = reaction(
+                () => locale.get(),
+                () => {
+                    if (this.initialized) {
+                        this.reset();
+                    }
+                }
+            );
         }
 
         this.searchDisposer = intercept(this.searchTerm, '', (change: IValueWillChange<*>) => {

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/ruleTypes/SingleSelection.js
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/ruleTypes/SingleSelection.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {observable} from 'mobx';
+import {computed} from 'mobx';
 import {SingleSelection as SingleSelectionComponent} from 'sulu-admin-bundle/containers';
 import userStore from 'sulu-admin-bundle/stores/userStore';
 import type {RuleTypeProps} from '../types';
@@ -38,7 +38,7 @@ export default class SingleSelection extends React.Component<RuleTypeProps> {
                 emptyText={emptyText}
                 icon={icon}
                 listKey={resourceKey}
-                locale={observable.box(userStore.contentLocale)}
+                locale={computed(() => userStore.contentLocale)}
                 onChange={this.handleChange}
                 overlayTitle={overlayTitle}
                 resourceKey={resourceKey}

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/views/List/toolbarActions/AddMediaToolbarAction.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/views/List/toolbarActions/AddMediaToolbarAction.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {action, observable} from 'mobx';
+import {action, computed, observable} from 'mobx';
 import userStore from 'sulu-admin-bundle/stores/userStore';
 import {ResourceRequester} from 'sulu-admin-bundle/services';
 import {translate} from 'sulu-admin-bundle/utils';
@@ -17,7 +17,7 @@ class AddMediaToolbarAction extends AbstractListToolbarAction {
                 confirmLoading={this.patching}
                 excludedIds={this.resourceStore ? this.resourceStore.data.medias : []}
                 key="sulu_contact.add_media"
-                locale={observable.box(userStore.contentLocale)}
+                locale={computed(() => userStore.contentLocale)}
                 onClose={this.handleClose}
                 onConfirm={this.handleConfirm}
                 open={this.showOverlay}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/CKEditor5/plugins/InternalLinkPlugin/overlays/MediaInternalLinkTypeOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/CKEditor5/plugins/InternalLinkPlugin/overlays/MediaInternalLinkTypeOverlay.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {observable} from 'mobx';
+import {computed} from 'mobx';
 import {Dialog, Input, Form} from 'sulu-admin-bundle/components';
 import {userStore} from 'sulu-admin-bundle/stores';
 import {translate} from 'sulu-admin-bundle/utils';
@@ -35,7 +35,7 @@ export default class MediaInternalLinkTypeOverlay extends React.Component<Intern
                 <Form>
                     <Form.Field label={translate('sulu_admin.link_url')} required={true}>
                         <SingleMediaSelection
-                            locale={locale || observable.box(userStore.contentLocale)}
+                            locale={locale || computed(() => userStore.contentLocale)}
                             onChange={this.handleChange}
                             value={{displayOption: undefined, id}}
                         />

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
@@ -4,7 +4,7 @@ import {observer} from 'mobx-react';
 import log from 'loglevel';
 import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import userStore from 'sulu-admin-bundle/stores/userStore';
-import {computed, isArrayLike, observable} from 'mobx';
+import {computed, isArrayLike} from 'mobx';
 import {
     convertDisplayOptionsFromParams,
     convertMediaTypesFromParams,
@@ -101,7 +101,7 @@ class MediaSelection extends React.Component<FieldTypeProps<Value>> {
             } = {},
         } = schemaOptions;
 
-        const locale = formInspector.locale ? formInspector.locale : observable.box(userStore.contentLocale);
+        const locale = formInspector.locale ? formInspector.locale : computed(() => userStore.contentLocale);
 
         if (displayOptions !== undefined && displayOptions !== null && !Array.isArray(displayOptions)) {
             throw new Error('The "displayOptions" option has to be an Array if set.');

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaSelection.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {observer} from 'mobx-react';
 import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import userStore from 'sulu-admin-bundle/stores/userStore';
-import {computed, observable} from 'mobx';
+import {computed} from 'mobx';
 import {
     convertDisplayOptionsFromParams,
     convertMediaTypesFromParams,
@@ -87,7 +87,7 @@ class SingleMediaSelection extends React.Component<FieldTypeProps<Value>> {
                 value: mediaTypes,
             } = {},
         } = schemaOptions;
-        const locale = formInspector.locale ? formInspector.locale : observable.box(userStore.contentLocale);
+        const locale = formInspector.locale ? formInspector.locale : computed(() => userStore.contentLocale);
 
         if (displayOptions !== undefined && displayOptions !== null && !Array.isArray(displayOptions)) {
             throw new Error('The "displayOptions" option has to be an Array if set.');

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaUpload.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaUpload.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import userStore from 'sulu-admin-bundle/stores/userStore';
-import {observable} from 'mobx';
+import {computed} from 'mobx';
 import MediaUploadStore from '../../../stores/MediaUploadStore';
 import SingleMediaUploadComponent from '../../SingleMediaUpload';
 import type {Media} from '../../../types';
@@ -14,7 +14,7 @@ export default class SingleMediaUpload extends React.Component<FieldTypeProps<Me
         super(props);
 
         const {formInspector, value} = this.props;
-        const locale = formInspector.locale ? formInspector.locale : observable.box(userStore.contentLocale);
+        const locale = formInspector.locale ? formInspector.locale : computed(() => userStore.contentLocale);
 
         this.mediaUploadStore = new MediaUploadStore(value, locale);
     }

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/fields/TeaserSelection.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/fields/TeaserSelection.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {computed, observable} from 'mobx';
+import {computed} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import jsonpointer from 'json-pointer';
@@ -14,7 +14,7 @@ class TeaserSelection extends React.Component<FieldTypeProps<TeaserSelectionValu
     @computed get locale(): IObservableValue<string> {
         const {formInspector} = this.props;
 
-        return formInspector.locale ? formInspector.locale : observable.box(userStore.contentLocale);
+        return formInspector.locale ? formInspector.locale : computed(() => userStore.contentLocale);
     }
 
     handleItemClick = (itemId: string | number, item: ?TeaserItem) => {

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/PageList.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/PageList.js
@@ -1,5 +1,5 @@
 // @flow
-import {action, intercept, observable} from 'mobx';
+import {action, intercept, observable, reaction} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import React from 'react';
@@ -137,11 +137,12 @@ class PageList extends React.Component<Props> {
             return change;
         });
 
-        this.webspaceKeyDisposer = intercept(webspaceKey, '', (change) => {
-            this.listStore.destroy();
-            this.listStore.active.set(undefined);
-            return change;
-        });
+        this.webspaceKeyDisposer = reaction(
+            () => webspaceKey.get(),
+            () => {
+                this.listStore.destroy();
+                this.listStore.active.set(undefined);
+            });
     }
 
     componentWillUnmount() {

--- a/src/Sulu/Bundle/RouteBundle/Resources/js/containers/Form/fields/PageTreeRoute.js
+++ b/src/Sulu/Bundle/RouteBundle/Resources/js/containers/Form/fields/PageTreeRoute.js
@@ -2,7 +2,7 @@
 import React, {Component, Fragment} from 'react';
 import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import {observer} from 'mobx-react';
-import {action, observable} from 'mobx';
+import {action, computed, observable} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import {userStore} from 'sulu-admin-bundle/stores';
 import {Grid} from 'sulu-admin-bundle/components';
@@ -35,7 +35,7 @@ class PageTreeRoute extends Component<Props> {
     get locale(): IObservableValue<string> {
         const {formInspector} = this.props;
 
-        return formInspector.locale ? formInspector.locale : observable.box(userStore.contentLocale);
+        return formInspector.locale ? formInspector.locale : computed(() => userStore.contentLocale);
     }
 
     get pageValue(): ?string {


### PR DESCRIPTION
`computed(() => userStore.contentLocale)` will return an observable that is updated if the `userStore.contentLocale` is changed. 

I dont think this changes the behaviour anywhere, because `userStore.contentLocale` is only updated on view change. But we should still use the more appropriate method in my opinion 🙂 