### PR TITLE
Add category filter on contact, account and media list

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/SelectionFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/SelectionFieldFilterType.js
@@ -3,6 +3,7 @@ import React from 'react';
 import type {ElementRef} from 'react';
 import {action, autorun, computed, observable, toJS, untracked, when} from 'mobx';
 import equals from 'fast-deep-equal';
+import userStore from '../../../stores/userStore';
 import MultiSelectionStore from '../../../stores/MultiSelectionStore';
 import MultiAutoComplete from '../../MultiAutoComplete';
 import ResourceCheckboxGroup from '../../ResourceCheckboxGroup';
@@ -30,7 +31,11 @@ class SelectionFieldFilterType extends AbstractFieldFilterType<?Array<string | n
     ) {
         super(onChange, parameters, value);
 
-        this.selectionStore = new MultiSelectionStore(this.resourceKey, []);
+        this.selectionStore = new MultiSelectionStore(
+            this.resourceKey,
+            [],
+            computed(() => userStore.contentLocale)
+        );
 
         this.selectionStoreDisposer = autorun(() => {
             const {onChange, selectionStore} = this;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/SelectionFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/SelectionFieldFilterType.js
@@ -34,7 +34,7 @@ class SelectionFieldFilterType extends AbstractFieldFilterType<?Array<string | n
         this.selectionStore = new MultiSelectionStore(
             this.resourceKey,
             [],
-            computed(() => userStore.contentLocale)
+            observable.box(userStore.contentLocale)
         );
 
         this.selectionStoreDisposer = autorun(() => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/SelectionFieldFilterType.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/SelectionFieldFilterType.test.js
@@ -2,8 +2,10 @@
 import {extendObservable as mockExtendObservable} from 'mobx';
 import {shallow} from 'enzyme';
 import SelectionFieldFilterType from '../../fieldFilterTypes/SelectionFieldFilterType';
+import MultiSelectionStore from '../../../../stores/MultiSelectionStore';
+import userStore from '../../../../stores/userStore';
 
-jest.mock('../../../../stores/MultiSelectionStore', () => function() {
+jest.mock('../../../../stores/MultiSelectionStore', () => jest.fn(function() {
     this.loadItems = jest.fn();
     this.getById = jest.fn();
 
@@ -12,7 +14,9 @@ jest.mock('../../../../stores/MultiSelectionStore', () => function() {
         ids: [],
         items: [],
     });
-});
+}));
+
+jest.mock('../../../../stores/userStore', () => ({}));
 
 test.each([
     [undefined, 'parameters'],
@@ -23,17 +27,25 @@ test.each([
 });
 
 test('Pass correct props to MultiAutoComplete', () => {
+    // $FlowFixMe
+    userStore.contentLocale = 'ru';
+
     const selectionFieldFilterType = new SelectionFieldFilterType(
         jest.fn(),
         {displayProperty: 'name', resourceKey: 'accounts'},
         undefined
     );
 
+    expect(MultiSelectionStore).toBeCalledWith('accounts', [], expect.anything());
+    // $FlowFixMe
+    expect(MultiSelectionStore.mock.calls[0][2].get()).toEqual('ru');
+
     const selectionFieldFilterTypeForm = shallow(selectionFieldFilterType.getFormNode());
 
     expect(selectionFieldFilterTypeForm.find('MultiAutoComplete').props()).toEqual(expect.objectContaining({
         displayProperty: 'name',
         searchProperties: ['name'],
+        selectionStore: selectionFieldFilterType.selectionStore,
     }));
 });
 

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/lists/accounts.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/lists/accounts.xml
@@ -267,5 +267,30 @@
                 </params>
             </filter>
         </property>
+
+        <!-- categoryId property is only used for filtering and should never be included as column in a list -->
+        <!-- when used as column, the property will lead to duplicated rows for entities with multiple categories -->
+        <property
+            name="categoryId"
+            visibility="never"
+            translation="sulu_category.categories"
+        >
+            <field-name>id</field-name>
+            <entity-name>SuluCategoryBundle:Category</entity-name>
+
+            <joins>
+                <join>
+                    <entity-name>SuluCategoryBundle:Category</entity-name>
+                    <field-name>%sulu.model.account.class%.categories</field-name>
+                </join>
+            </joins>
+
+            <filter type="selection">
+                <params>
+                    <param name="displayProperty" value="name" />
+                    <param name="resourceKey" value="categories" />
+                </params>
+            </filter>
+        </property>
     </properties>
 </list>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
@@ -331,6 +331,31 @@
             </filter>
         </property>
 
+        <!-- categoryId property is only used for filtering and should never be included as column in a list -->
+        <!-- when used as column, the property will lead to duplicated rows for entities with multiple categories -->
+        <property
+            name="categoryId"
+            visibility="never"
+            translation="sulu_category.categories"
+        >
+            <field-name>id</field-name>
+            <entity-name>SuluCategoryBundle:Category</entity-name>
+
+            <joins>
+                <join>
+                    <entity-name>SuluCategoryBundle:Category</entity-name>
+                    <field-name>%sulu.model.contact.class%.categories</field-name>
+                </join>
+            </joins>
+
+            <filter type="selection">
+                <params>
+                    <param name="displayProperty" value="name" />
+                    <param name="resourceKey" value="categories" />
+                </params>
+            </filter>
+        </property>
+
         <property name="user" visibility="no" searchability="yes" translation="sulu_security.user_name">
             <field-name>username</field-name>
             <entity-name>%sulu.model.user.class%</entity-name>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/lists/media.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/lists/media.xml
@@ -273,6 +273,31 @@
             </filter>
         </property>
 
+        <!-- categoryId property is only used for filtering and should never be included as column in a list -->
+        <!-- when used as column, the property will lead to duplicated rows for entities with multiple categories -->
+        <property
+            name="categoryId"
+            visibility="never"
+            translation="sulu_category.categories"
+        >
+            <field-name>id</field-name>
+            <entity-name>SuluCategoryBundle:Category</entity-name>
+
+            <joins ref="fileVersion">
+                <join>
+                    <entity-name>SuluCategoryBundle:Category</entity-name>
+                    <field-name>SuluMediaBundle:FileVersion.categories</field-name>
+                </join>
+            </joins>
+
+            <filter type="selection">
+                <params>
+                    <param name="displayProperty" value="name" />
+                    <param name="resourceKey" value="categories" />
+                </params>
+            </filter>
+        </property>
+
         <property name="lft" visibility="never">
             <field-name>lft</field-name>
             <entity-name>%sulu.model.collection.class%</entity-name>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #5469
| Related issues/PRs | depends on #5805, depends on #5943
| License | MIT

#### What's in this PR?

This PR adds a tag filter on the list view for contacts, accounts and medias.

#### Why?

See #5469