### PR TITLE
Add resourceTitleLocale to DomainEvent

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,7 +4,7 @@
 
 ### Added resourceTitleLocale field to EventRecord
 
-Becase a new `resourceTitleLocale` field has been added to the `EventRecord` entity,
+Because a new `resourceTitleLocale` field has been added to the `EventRecord` entity,
 you need to update your database schema:
 
 ```sql

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,15 @@
 
 ## 2.3
 
+### Added resourceTitleLocale field to EventRecord
+
+Becase a new `resourceTitleLocale` field has been added to the `EventRecord` entity,
+you need to update your database schema:
+
+```sql
+ALTER TABLE el_event_records ADD resourceTitleLocale VARCHAR(191) DEFAULT NULL;
+```
+
 ### Changed constructor of multiple services to integrate them with the SuluEventLogBundle
 
 To integrate the `SuluEventLogBundle` with the existing services, the constructor of the following services was 

--- a/src/Sulu/Bundle/CategoryBundle/Category/CategoryManager.php
+++ b/src/Sulu/Bundle/CategoryBundle/Category/CategoryManager.php
@@ -267,11 +267,12 @@ class CategoryManager implements CategoryManagerInterface
             }
         }
 
-        $defaultTranslation = $entity->findTranslationByLocale($entity->getDefaultLocale());
+        $defaultLocale = $entity->getDefaultLocale();
+        $defaultTranslation = $entity->findTranslationByLocale($defaultLocale);
         $categoryName = $defaultTranslation ? $defaultTranslation->getTranslation() : null;
 
         $this->em->remove($entity);
-        $this->domainEventCollector->collect(new CategoryRemovedEvent($id, $categoryName));
+        $this->domainEventCollector->collect(new CategoryRemovedEvent($id, $categoryName, $defaultLocale));
         $this->em->flush();
 
         // throw a category.delete event

--- a/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryCreatedEvent.php
+++ b/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryCreatedEvent.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\CategoryBundle\Domain\Event;
 use Sulu\Bundle\CategoryBundle\Admin\CategoryAdmin;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\EventLogBundle\Domain\Event\DomainEvent;
+use Webmozart\Assert\Assert;
 
 class CategoryCreatedEvent extends DomainEvent
 {
@@ -79,14 +80,12 @@ class CategoryCreatedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $translation = $this->category->findTranslationByLocale($this->getResourceTitleLocale());
+        $resourceTitleLocale = $this->getResourceTitleLocale();
+        Assert::notNull($resourceTitleLocale);
+
+        $translation = $this->category->findTranslationByLocale($resourceTitleLocale);
 
         return $translation ? $translation->getTranslation() : null;
-    }
-
-    public function getResourceTitleLocale(): string
-    {
-        return $this->getResourceLocale();
     }
 
     public function getResourceSecurityContext(): ?string

--- a/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryCreatedEvent.php
+++ b/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryCreatedEvent.php
@@ -72,16 +72,21 @@ class CategoryCreatedEvent extends DomainEvent
         return (string) $this->category->getId();
     }
 
-    public function getResourceLocale(): ?string
+    public function getResourceLocale(): string
     {
         return $this->locale;
     }
 
     public function getResourceTitle(): ?string
     {
-        $translation = $this->category->findTranslationByLocale($this->locale);
+        $translation = $this->category->findTranslationByLocale($this->getResourceTitleLocale());
 
         return $translation ? $translation->getTranslation() : null;
+    }
+
+    public function getResourceTitleLocale(): string
+    {
+        return $this->getResourceLocale();
     }
 
     public function getResourceSecurityContext(): ?string

--- a/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryCreatedEvent.php
+++ b/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryCreatedEvent.php
@@ -14,7 +14,6 @@ namespace Sulu\Bundle\CategoryBundle\Domain\Event;
 use Sulu\Bundle\CategoryBundle\Admin\CategoryAdmin;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\EventLogBundle\Domain\Event\DomainEvent;
-use Webmozart\Assert\Assert;
 
 class CategoryCreatedEvent extends DomainEvent
 {
@@ -80,10 +79,7 @@ class CategoryCreatedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $resourceTitleLocale = $this->getResourceTitleLocale();
-        Assert::notNull($resourceTitleLocale);
-
-        $translation = $this->category->findTranslationByLocale($resourceTitleLocale);
+        $translation = $this->category->findTranslationByLocale($this->locale);
 
         return $translation ? $translation->getTranslation() : null;
     }

--- a/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryKeywordCreatedEvent.php
+++ b/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryKeywordCreatedEvent.php
@@ -15,7 +15,6 @@ use Sulu\Bundle\CategoryBundle\Admin\CategoryAdmin;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\CategoryBundle\Entity\KeywordInterface;
 use Sulu\Bundle\EventLogBundle\Domain\Event\DomainEvent;
-use Webmozart\Assert\Assert;
 
 class CategoryKeywordCreatedEvent extends DomainEvent
 {
@@ -79,10 +78,7 @@ class CategoryKeywordCreatedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $resourceTitleLocale = $this->getResourceTitleLocale();
-        Assert::notNull($resourceTitleLocale);
-
-        $translation = $this->category->findTranslationByLocale($resourceTitleLocale);
+        $translation = $this->category->findTranslationByLocale($this->keyword->getLocale());
 
         return $translation ? $translation->getTranslation() : null;
     }

--- a/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryKeywordCreatedEvent.php
+++ b/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryKeywordCreatedEvent.php
@@ -15,6 +15,7 @@ use Sulu\Bundle\CategoryBundle\Admin\CategoryAdmin;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\CategoryBundle\Entity\KeywordInterface;
 use Sulu\Bundle\EventLogBundle\Domain\Event\DomainEvent;
+use Webmozart\Assert\Assert;
 
 class CategoryKeywordCreatedEvent extends DomainEvent
 {
@@ -78,14 +79,12 @@ class CategoryKeywordCreatedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $translation = $this->category->findTranslationByLocale($this->getResourceTitleLocale());
+        $resourceTitleLocale = $this->getResourceTitleLocale();
+        Assert::notNull($resourceTitleLocale);
+
+        $translation = $this->category->findTranslationByLocale($resourceTitleLocale);
 
         return $translation ? $translation->getTranslation() : null;
-    }
-
-    public function getResourceTitleLocale(): string
-    {
-        return $this->getResourceLocale();
     }
 
     public function getResourceSecurityContext(): ?string

--- a/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryKeywordCreatedEvent.php
+++ b/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryKeywordCreatedEvent.php
@@ -71,16 +71,21 @@ class CategoryKeywordCreatedEvent extends DomainEvent
         return (string) $this->category->getId();
     }
 
-    public function getResourceLocale(): ?string
+    public function getResourceLocale(): string
     {
         return $this->keyword->getLocale();
     }
 
     public function getResourceTitle(): ?string
     {
-        $translation = $this->category->findTranslationByLocale($this->keyword->getLocale());
+        $translation = $this->category->findTranslationByLocale($this->getResourceTitleLocale());
 
         return $translation ? $translation->getTranslation() : null;
+    }
+
+    public function getResourceTitleLocale(): string
+    {
+        return $this->getResourceLocale();
     }
 
     public function getResourceSecurityContext(): ?string

--- a/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryKeywordModifiedEvent.php
+++ b/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryKeywordModifiedEvent.php
@@ -71,16 +71,21 @@ class CategoryKeywordModifiedEvent extends DomainEvent
         return (string) $this->category->getId();
     }
 
-    public function getResourceLocale(): ?string
+    public function getResourceLocale(): string
     {
         return $this->keyword->getLocale();
     }
 
     public function getResourceTitle(): ?string
     {
-        $translation = $this->category->findTranslationByLocale($this->keyword->getLocale());
+        $translation = $this->category->findTranslationByLocale($this->getResourceTitleLocale());
 
         return $translation ? $translation->getTranslation() : null;
+    }
+
+    public function getResourceTitleLocale(): string
+    {
+        return $this->getResourceLocale();
     }
 
     public function getResourceSecurityContext(): ?string

--- a/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryKeywordModifiedEvent.php
+++ b/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryKeywordModifiedEvent.php
@@ -15,6 +15,7 @@ use Sulu\Bundle\CategoryBundle\Admin\CategoryAdmin;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\CategoryBundle\Entity\KeywordInterface;
 use Sulu\Bundle\EventLogBundle\Domain\Event\DomainEvent;
+use Webmozart\Assert\Assert;
 
 class CategoryKeywordModifiedEvent extends DomainEvent
 {
@@ -78,14 +79,12 @@ class CategoryKeywordModifiedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $translation = $this->category->findTranslationByLocale($this->getResourceTitleLocale());
+        $resourceTitleLocale = $this->getResourceTitleLocale();
+        Assert::notNull($resourceTitleLocale);
+
+        $translation = $this->category->findTranslationByLocale($resourceTitleLocale);
 
         return $translation ? $translation->getTranslation() : null;
-    }
-
-    public function getResourceTitleLocale(): string
-    {
-        return $this->getResourceLocale();
     }
 
     public function getResourceSecurityContext(): ?string

--- a/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryKeywordModifiedEvent.php
+++ b/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryKeywordModifiedEvent.php
@@ -15,7 +15,6 @@ use Sulu\Bundle\CategoryBundle\Admin\CategoryAdmin;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\CategoryBundle\Entity\KeywordInterface;
 use Sulu\Bundle\EventLogBundle\Domain\Event\DomainEvent;
-use Webmozart\Assert\Assert;
 
 class CategoryKeywordModifiedEvent extends DomainEvent
 {
@@ -79,10 +78,7 @@ class CategoryKeywordModifiedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $resourceTitleLocale = $this->getResourceTitleLocale();
-        Assert::notNull($resourceTitleLocale);
-
-        $translation = $this->category->findTranslationByLocale($resourceTitleLocale);
+        $translation = $this->category->findTranslationByLocale($this->keyword->getLocale());
 
         return $translation ? $translation->getTranslation() : null;
     }

--- a/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryKeywordRemovedEvent.php
+++ b/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryKeywordRemovedEvent.php
@@ -79,16 +79,21 @@ class CategoryKeywordRemovedEvent extends DomainEvent
         return (string) $this->category->getId();
     }
 
-    public function getResourceLocale(): ?string
+    public function getResourceLocale(): string
     {
         return $this->locale;
     }
 
     public function getResourceTitle(): ?string
     {
-        $translation = $this->category->findTranslationByLocale($this->locale);
+        $translation = $this->category->findTranslationByLocale($this->getResourceTitleLocale());
 
         return $translation ? $translation->getTranslation() : null;
+    }
+
+    public function getResourceTitleLocale(): string
+    {
+        return $this->getResourceLocale();
     }
 
     public function getResourceSecurityContext(): ?string

--- a/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryKeywordRemovedEvent.php
+++ b/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryKeywordRemovedEvent.php
@@ -14,7 +14,6 @@ namespace Sulu\Bundle\CategoryBundle\Domain\Event;
 use Sulu\Bundle\CategoryBundle\Admin\CategoryAdmin;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\EventLogBundle\Domain\Event\DomainEvent;
-use Webmozart\Assert\Assert;
 
 class CategoryKeywordRemovedEvent extends DomainEvent
 {
@@ -87,10 +86,7 @@ class CategoryKeywordRemovedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $resourceTitleLocale = $this->getResourceTitleLocale();
-        Assert::notNull($resourceTitleLocale);
-
-        $translation = $this->category->findTranslationByLocale($resourceTitleLocale);
+        $translation = $this->category->findTranslationByLocale($this->locale);
 
         return $translation ? $translation->getTranslation() : null;
     }

--- a/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryKeywordRemovedEvent.php
+++ b/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryKeywordRemovedEvent.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\CategoryBundle\Domain\Event;
 use Sulu\Bundle\CategoryBundle\Admin\CategoryAdmin;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\EventLogBundle\Domain\Event\DomainEvent;
+use Webmozart\Assert\Assert;
 
 class CategoryKeywordRemovedEvent extends DomainEvent
 {
@@ -86,14 +87,12 @@ class CategoryKeywordRemovedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $translation = $this->category->findTranslationByLocale($this->getResourceTitleLocale());
+        $resourceTitleLocale = $this->getResourceTitleLocale();
+        Assert::notNull($resourceTitleLocale);
+
+        $translation = $this->category->findTranslationByLocale($resourceTitleLocale);
 
         return $translation ? $translation->getTranslation() : null;
-    }
-
-    public function getResourceTitleLocale(): string
-    {
-        return $this->getResourceLocale();
     }
 
     public function getResourceSecurityContext(): ?string

--- a/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryModifiedEvent.php
+++ b/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryModifiedEvent.php
@@ -14,7 +14,6 @@ namespace Sulu\Bundle\CategoryBundle\Domain\Event;
 use Sulu\Bundle\CategoryBundle\Admin\CategoryAdmin;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\EventLogBundle\Domain\Event\DomainEvent;
-use Webmozart\Assert\Assert;
 
 class CategoryModifiedEvent extends DomainEvent
 {
@@ -80,10 +79,7 @@ class CategoryModifiedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $resourceTitleLocale = $this->getResourceTitleLocale();
-        Assert::notNull($resourceTitleLocale);
-
-        $translation = $this->category->findTranslationByLocale($resourceTitleLocale);
+        $translation = $this->category->findTranslationByLocale($this->locale);
 
         return $translation ? $translation->getTranslation() : null;
     }

--- a/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryModifiedEvent.php
+++ b/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryModifiedEvent.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\CategoryBundle\Domain\Event;
 use Sulu\Bundle\CategoryBundle\Admin\CategoryAdmin;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\EventLogBundle\Domain\Event\DomainEvent;
+use Webmozart\Assert\Assert;
 
 class CategoryModifiedEvent extends DomainEvent
 {
@@ -79,14 +80,12 @@ class CategoryModifiedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $translation = $this->category->findTranslationByLocale($this->getResourceTitleLocale());
+        $resourceTitleLocale = $this->getResourceTitleLocale();
+        Assert::notNull($resourceTitleLocale);
+
+        $translation = $this->category->findTranslationByLocale($resourceTitleLocale);
 
         return $translation ? $translation->getTranslation() : null;
-    }
-
-    public function getResourceTitleLocale(): string
-    {
-        return $this->getResourceLocale();
     }
 
     public function getResourceSecurityContext(): ?string

--- a/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryModifiedEvent.php
+++ b/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryModifiedEvent.php
@@ -72,16 +72,21 @@ class CategoryModifiedEvent extends DomainEvent
         return (string) $this->category->getId();
     }
 
-    public function getResourceLocale(): ?string
+    public function getResourceLocale(): string
     {
         return $this->locale;
     }
 
     public function getResourceTitle(): ?string
     {
-        $translation = $this->category->findTranslationByLocale($this->locale);
+        $translation = $this->category->findTranslationByLocale($this->getResourceTitleLocale());
 
         return $translation ? $translation->getTranslation() : null;
+    }
+
+    public function getResourceTitleLocale(): string
+    {
+        return $this->getResourceLocale();
     }
 
     public function getResourceSecurityContext(): ?string

--- a/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryMovedEvent.php
+++ b/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryMovedEvent.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\CategoryBundle\Domain\Event;
 use Sulu\Bundle\CategoryBundle\Admin\CategoryAdmin;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\EventLogBundle\Domain\Event\DomainEvent;
+use Webmozart\Assert\Assert;
 
 class CategoryMovedEvent extends DomainEvent
 {
@@ -69,12 +70,15 @@ class CategoryMovedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $defaultTranslation = $this->category->findTranslationByLocale($this->getResourceTitleLocale());
+        $resourceTitleLocale = $this->getResourceTitleLocale();
+        Assert::notNull($resourceTitleLocale);
 
-        return $defaultTranslation ? $defaultTranslation->getTranslation() : null;
+        $translation = $this->category->findTranslationByLocale($resourceTitleLocale);
+
+        return $translation ? $translation->getTranslation() : null;
     }
 
-    public function getResourceTitleLocale(): string
+    public function getResourceTitleLocale(): ?string
     {
         return $this->category->getDefaultLocale();
     }

--- a/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryMovedEvent.php
+++ b/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryMovedEvent.php
@@ -69,9 +69,14 @@ class CategoryMovedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $defaultTranslation = $this->category->findTranslationByLocale($this->category->getDefaultLocale());
+        $defaultTranslation = $this->category->findTranslationByLocale($this->getResourceTitleLocale());
 
         return $defaultTranslation ? $defaultTranslation->getTranslation() : null;
+    }
+
+    public function getResourceTitleLocale(): string
+    {
+        return $this->category->getDefaultLocale();
     }
 
     public function getResourceSecurityContext(): ?string

--- a/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryMovedEvent.php
+++ b/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryMovedEvent.php
@@ -14,7 +14,6 @@ namespace Sulu\Bundle\CategoryBundle\Domain\Event;
 use Sulu\Bundle\CategoryBundle\Admin\CategoryAdmin;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\EventLogBundle\Domain\Event\DomainEvent;
-use Webmozart\Assert\Assert;
 
 class CategoryMovedEvent extends DomainEvent
 {
@@ -70,10 +69,7 @@ class CategoryMovedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $resourceTitleLocale = $this->getResourceTitleLocale();
-        Assert::notNull($resourceTitleLocale);
-
-        $translation = $this->category->findTranslationByLocale($resourceTitleLocale);
+        $translation = $this->category->findTranslationByLocale($this->category->getDefaultLocale());
 
         return $translation ? $translation->getTranslation() : null;
     }

--- a/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryRemovedEvent.php
+++ b/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryRemovedEvent.php
@@ -27,14 +27,21 @@ class CategoryRemovedEvent extends DomainEvent
      */
     private $categoryTitle;
 
+    /**
+     * @var string|null
+     */
+    private $categoryTitleLocale;
+
     public function __construct(
         int $categoryId,
-        ?string $categoryName
+        ?string $categoryTitle,
+        ?string $categoryTitleLocale
     ) {
         parent::__construct();
 
         $this->categoryId = $categoryId;
-        $this->categoryTitle = $categoryName;
+        $this->categoryTitle = $categoryTitle;
+        $this->categoryTitleLocale = $categoryTitleLocale;
     }
 
     public function getEventType(): string
@@ -55,6 +62,11 @@ class CategoryRemovedEvent extends DomainEvent
     public function getResourceTitle(): ?string
     {
         return $this->categoryTitle;
+    }
+
+    public function getResourceTitleLocale(): ?string
+    {
+        return $this->categoryTitleLocale;
     }
 
     public function getResourceSecurityContext(): ?string

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/Domain/Event/CustomUrlCreatedEventTest.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/Domain/Event/CustomUrlCreatedEventTest.php
@@ -79,6 +79,13 @@ class CustomUrlCreatedEventTest extends TestCase
         static::assertSame('custom-url-title', $event->getResourceTitle());
     }
 
+    public function testGetResourceTitleLocale(): void
+    {
+        $event = $this->createCustomUrlCreatedEvent();
+
+        static::assertNull($event->getResourceTitleLocale());
+    }
+
     public function testGetResourceSecurityContext(): void
     {
         $event = $this->createCustomUrlCreatedEvent('test-io');

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/Domain/Event/CustomUrlModifiedEventTest.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/Domain/Event/CustomUrlModifiedEventTest.php
@@ -79,6 +79,13 @@ class CustomUrlModifiedEventTest extends TestCase
         static::assertSame('custom-url-title', $event->getResourceTitle());
     }
 
+    public function testGetResourceTitleLocale(): void
+    {
+        $event = $this->createCustomUrlModifiedEvent();
+
+        static::assertNull($event->getResourceTitleLocale());
+    }
+
     public function testGetResourceSecurityContext(): void
     {
         $event = $this->createCustomUrlModifiedEvent('test-io');

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/Domain/Event/CustomUrlRemovedEventTest.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/Domain/Event/CustomUrlRemovedEventTest.php
@@ -58,6 +58,13 @@ class CustomUrlRemovedEventTest extends TestCase
         static::assertSame('custom-url-title-123', $event->getResourceTitle());
     }
 
+    public function testGetResourceTitleLocale(): void
+    {
+        $event = $this->createCustomUrlRemovedEvent();
+
+        static::assertNull($event->getResourceTitleLocale());
+    }
+
     public function testGetResourceSecurityContext(): void
     {
         $event = $this->createCustomUrlRemovedEvent(

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/Domain/Event/CustomUrlRouteRemovedEventTest.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/Domain/Event/CustomUrlRouteRemovedEventTest.php
@@ -79,6 +79,13 @@ class CustomUrlRouteRemovedEventTest extends TestCase
         static::assertSame('custom-url-title', $event->getResourceTitle());
     }
 
+    public function testGetResourceTitleLocale(): void
+    {
+        $event = $this->createCustomUrlRouteRemovedEvent();
+
+        static::assertNull($event->getResourceTitleLocale());
+    }
+
     public function testGetResourceSecurityContext(): void
     {
         $event = $this->createCustomUrlRouteRemovedEvent('test-io');

--- a/src/Sulu/Bundle/EventLogBundle/Domain/Event/DomainEvent.php
+++ b/src/Sulu/Bundle/EventLogBundle/Domain/Event/DomainEvent.php
@@ -118,7 +118,7 @@ abstract class DomainEvent
      */
     public function getResourceTitleLocale(): ?string
     {
-        return null;
+        return $this->getResourceLocale();
     }
 
     public function getResourceSecurityContext(): ?string

--- a/src/Sulu/Bundle/EventLogBundle/Domain/Event/DomainEvent.php
+++ b/src/Sulu/Bundle/EventLogBundle/Domain/Event/DomainEvent.php
@@ -93,6 +93,10 @@ abstract class DomainEvent
 
     abstract public function getResourceId(): string;
 
+    /**
+     * This method should return the locale of a resource, which is affected by the current event.
+     * If all locales of a resource are effected by the current event, this method should return null.
+     */
     public function getResourceLocale(): ?string
     {
         return null;
@@ -104,6 +108,15 @@ abstract class DomainEvent
     }
 
     public function getResourceTitle(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * This method should return the locale in which the resource title is stored.
+     * If the resource title is not localized (e.g. a tag name), this method should return null.
+     */
+    public function getResourceTitleLocale(): ?string
     {
         return null;
     }

--- a/src/Sulu/Bundle/EventLogBundle/Domain/Model/EventRecord.php
+++ b/src/Sulu/Bundle/EventLogBundle/Domain/Model/EventRecord.php
@@ -78,6 +78,11 @@ class EventRecord implements EventRecordInterface
     /**
      * @var string|null
      */
+    private $resourceTitleLocale;
+
+    /**
+     * @var string|null
+     */
     private $resourceSecurityContext;
 
     /**
@@ -213,6 +218,18 @@ class EventRecord implements EventRecordInterface
     public function setResourceTitle(?string $resourceTitle): EventRecordInterface
     {
         $this->resourceTitle = $resourceTitle;
+
+        return $this;
+    }
+
+    public function getResourceTitleLocale(): ?string
+    {
+        return $this->resourceTitleLocale;
+    }
+
+    public function setResourceTitleLocale(?string $resourceTitleLocale): EventRecordInterface
+    {
+        $this->resourceTitleLocale = $resourceTitleLocale;
 
         return $this;
     }

--- a/src/Sulu/Bundle/EventLogBundle/Domain/Model/EventRecordInterface.php
+++ b/src/Sulu/Bundle/EventLogBundle/Domain/Model/EventRecordInterface.php
@@ -71,6 +71,10 @@ interface EventRecordInterface
 
     public function setResourceTitle(?string $resourceTitle): EventRecordInterface;
 
+    public function getResourceTitleLocale(): ?string;
+
+    public function setResourceTitleLocale(?string $resourceTitleLocale): EventRecordInterface;
+
     public function getResourceSecurityContext(): ?string;
 
     public function setResourceSecurityContext(?string $resourceSecurityContext): EventRecordInterface;

--- a/src/Sulu/Bundle/EventLogBundle/Infrastructure/Doctrine/Repository/EventRecordRepository.php
+++ b/src/Sulu/Bundle/EventLogBundle/Infrastructure/Doctrine/Repository/EventRecordRepository.php
@@ -54,6 +54,7 @@ class EventRecordRepository implements EventRecordRepositoryInterface
         $eventRecord->setResourceLocale($domainEvent->getResourceLocale());
         $eventRecord->setResourceWebspaceKey($domainEvent->getResourceWebspaceKey());
         $eventRecord->setResourceTitle($domainEvent->getResourceTitle());
+        $eventRecord->setResourceTitleLocale($domainEvent->getResourceTitleLocale());
         $eventRecord->setResourceSecurityContext($domainEvent->getResourceSecurityContext());
         $eventRecord->setResourceSecurityType($domainEvent->getResourceSecurityType());
 

--- a/src/Sulu/Bundle/EventLogBundle/Resources/config/doctrine/EventRecord.orm.xml
+++ b/src/Sulu/Bundle/EventLogBundle/Resources/config/doctrine/EventRecord.orm.xml
@@ -22,6 +22,7 @@
         <field name="resourceLocale" column="resourceLocale" type="string" nullable="true" length="191"/>
         <field name="resourceWebspaceKey" column="resourceWebspaceKey" type="string" nullable="true" length="191"/>
         <field name="resourceTitle" column="resourceTitle" type="string" nullable="true" length="191"/>
+        <field name="resourceTitleLocale" column="resourceTitleLocale" type="string" nullable="true" length="191"/>
         <field name="resourceSecurityContext" column="resourceSecurityContext" type="string" nullable="true" length="191"/>
         <field name="resourceSecurityType" column="resourceSecurityType" type="string" nullable="true" length="191"/>
     </mapped-superclass>

--- a/src/Sulu/Bundle/EventLogBundle/Tests/Functional/Infrastructure/Doctrine/Repository/EventRecordRepositoryTest.php
+++ b/src/Sulu/Bundle/EventLogBundle/Tests/Functional/Infrastructure/Doctrine/Repository/EventRecordRepositoryTest.php
@@ -55,6 +55,7 @@ class EventRecordRepositoryTest extends SuluTestCase
         $this->domainEvent->getResourceLocale()->willReturn('en');
         $this->domainEvent->getResourceWebspaceKey()->willReturn('sulu-io');
         $this->domainEvent->getResourceTitle()->willReturn('Test Page 1234');
+        $this->domainEvent->getResourceTitleLocale()->willReturn('en');
         $this->domainEvent->getResourceSecurityContext()->willReturn('sulu.webspaces.sulu-io');
         $this->domainEvent->getResourceSecurityType()->willReturn(SecurityBehavior::class);
     }
@@ -80,6 +81,7 @@ class EventRecordRepositoryTest extends SuluTestCase
         static::assertSame('en', $eventRecord->getResourceLocale());
         static::assertSame('sulu-io', $eventRecord->getResourceWebspaceKey());
         static::assertSame('Test Page 1234', $eventRecord->getResourceTitle());
+        static::assertSame('en', $eventRecord->getResourceTitleLocale());
         static::assertSame('sulu.webspaces.sulu-io', $eventRecord->getResourceSecurityContext());
         static::assertSame(SecurityBehavior::class, $eventRecord->getResourceSecurityType());
     }

--- a/src/Sulu/Bundle/EventLogBundle/Tests/Unit/Domain/Event/DomainEventTest.php
+++ b/src/Sulu/Bundle/EventLogBundle/Tests/Unit/Domain/Event/DomainEventTest.php
@@ -103,6 +103,13 @@ class DomainEventTest extends TestCase
         static::assertNull($event->getResourceTitle());
     }
 
+    public function testResourceTitleLocale(): void
+    {
+        $event = $this->createTestDomainEvent();
+
+        static::assertNull($event->getResourceTitleLocale());
+    }
+
     public function testResourceSecurityContext(): void
     {
         $event = $this->createTestDomainEvent();

--- a/src/Sulu/Bundle/EventLogBundle/Tests/Unit/Domain/Model/EventRecordTest.php
+++ b/src/Sulu/Bundle/EventLogBundle/Tests/Unit/Domain/Model/EventRecordTest.php
@@ -117,6 +117,15 @@ class EventRecordTest extends TestCase
         static::assertSame('title-1234', $event->getResourceTitle());
     }
 
+    public function testResourceTitleLocale(): void
+    {
+        $event = $this->createEventRecord();
+
+        static::assertNull($event->getResourceTitleLocale());
+        static::assertSame($event, $event->setResourceTitleLocale('en'));
+        static::assertSame('en', $event->getResourceTitleLocale());
+    }
+
     public function testResourceSecurityContext(): void
     {
         $event = $this->createEventRecord();

--- a/src/Sulu/Bundle/TagBundle/Tests/Unit/Domain/Event/TagCreatedEventTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Unit/Domain/Event/TagCreatedEventTest.php
@@ -72,6 +72,13 @@ class TagCreatedEventTest extends TestCase
         static::assertSame('tag-name', $event->getResourceTitle());
     }
 
+    public function testGetResourceTitleLocale(): void
+    {
+        $event = $this->createTagCreatedEvent();
+
+        static::assertNull($event->getResourceTitleLocale());
+    }
+
     public function testGetResourceSecurityContext(): void
     {
         $event = $this->createTagCreatedEvent();

--- a/src/Sulu/Bundle/TagBundle/Tests/Unit/Domain/Event/TagMergedEventTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Unit/Domain/Event/TagMergedEventTest.php
@@ -72,6 +72,13 @@ class TagMergedEventTest extends TestCase
         static::assertSame('tag-name', $event->getResourceTitle());
     }
 
+    public function testGetResourceTitleLocale(): void
+    {
+        $event = $this->createTagMergedEvent();
+
+        static::assertNull($event->getResourceTitleLocale());
+    }
+
     public function testGetResourceSecurityContext(): void
     {
         $event = $this->createTagMergedEvent();

--- a/src/Sulu/Bundle/TagBundle/Tests/Unit/Domain/Event/TagModifiedEventTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Unit/Domain/Event/TagModifiedEventTest.php
@@ -72,6 +72,13 @@ class TagModifiedEventTest extends TestCase
         static::assertSame('tag-name', $event->getResourceTitle());
     }
 
+    public function testGetResourceTitleLocale(): void
+    {
+        $event = $this->createTagModifiedEvent();
+
+        static::assertNull($event->getResourceTitleLocale());
+    }
+
     public function testGetResourceSecurityContext(): void
     {
         $event = $this->createTagModifiedEvent();

--- a/src/Sulu/Bundle/TagBundle/Tests/Unit/Domain/Event/TagRemovedEventTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Unit/Domain/Event/TagRemovedEventTest.php
@@ -64,6 +64,13 @@ class TagRemovedEventTest extends TestCase
         static::assertSame('tag-name-456', $event->getResourceTitle());
     }
 
+    public function testGetResourceTitleLocale(): void
+    {
+        $event = $this->createTagRemovedEvent();
+
+        static::assertNull($event->getResourceTitleLocale());
+    }
+
     public function testGetResourceSecurityContext(): void
     {
         $event = $this->createTagRemovedEvent();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #5940
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Add `resourceTitleLocale` field to `DomainEvent` and `EventRecord`
