### PR TITLE
Add copyLocale method to DocumentManager

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,11 @@
 
 ## 2.3
 
+### Extend DocumentManagerInterface
+
+The `DocumentManagerInterface` has been extended with a new method `copyLocale`. If you have overridden this service
+in your project, you have to implement that method as well.
+
 ### Added resourceTitleLocale field to EventRecord
 
 Because a new `resourceTitleLocale` field has been added to the `EventRecord` entity,

--- a/src/Sulu/Bundle/PageBundle/Controller/PageController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/PageController.php
@@ -234,6 +234,7 @@ class PageController extends AbstractRestController implements ClassResourceInte
                 case 'copy-locale':
                     $srcLocale = $this->getRequestParameter($request, 'src', false, $locale);
                     $destLocales = $this->getRequestParameter($request, 'dest', true);
+                    $destLocales = \explode(',', $destLocales);
 
                     $document = $this->documentManager->find($id, $srcLocale);
 

--- a/src/Sulu/Bundle/PageBundle/Controller/PageController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/PageController.php
@@ -238,7 +238,10 @@ class PageController extends AbstractRestController implements ClassResourceInte
 
                     $document = $this->documentManager->find($id, $srcLocale);
 
-                    $this->documentManager->copyLocale($document, $srcLocale, $destLocales);
+                    foreach ($destLocales as $destLocale) {
+                        $this->documentManager->copyLocale($document, $srcLocale, $destLocale);
+                    }
+
                     $this->documentManager->flush();
 
                     $data = $document;

--- a/src/Sulu/Bundle/PageBundle/Controller/PageController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/PageController.php
@@ -233,16 +233,17 @@ class PageController extends AbstractRestController implements ClassResourceInte
                     break;
                 case 'copy-locale':
                     $srcLocale = $this->getRequestParameter($request, 'src', false, $locale);
-                    $destLocale = $this->getRequestParameter($request, 'dest', true);
-                    $webspace = $this->getWebspace($request);
+                    $destLocales = $this->getRequestParameter($request, 'dest', true);
 
-                    // call repository method
-                    $data = $this->nodeRepository->copyLocale($id, $userId, $webspace, $srcLocale, \explode(',', $destLocale));
+                    $document = $this->documentManager->find($id, $srcLocale);
 
-                    if ($srcLocale !== $locale) {
-                        $data = $this->nodeRepository->getNode($id, $webspace, $locale);
+                    $this->documentManager->copyLocale($document, $srcLocale, $destLocales);
+                    $this->documentManager->flush();
+
+                    $data = $document;
+                    if ($locale !== $srcLocale) {
+                        $data = $this->documentManager->find($id, $locale);
                     }
-
                     break;
                 case 'unpublish':
                     $document = $this->documentManager->find($id, $locale);

--- a/src/Sulu/Bundle/PageBundle/Repository/NodeRepository.php
+++ b/src/Sulu/Bundle/PageBundle/Repository/NodeRepository.php
@@ -709,6 +709,12 @@ class NodeRepository implements NodeRepositoryInterface
 
     public function copyLocale($uuid, $userId, $webspaceKey, $srcLocale, $destLocales)
     {
+        @\trigger_error(
+            'The NodeRepository::copyLocale method is deprecated and will be removed in the future.'
+            . ' Use DocumentManagerInterface::copyLocale instead.',
+            \E_USER_DEPRECATED
+        );
+
         try {
             // call mapper function
             $structure = $this->getMapper()->copyLanguage($uuid, $userId, $webspaceKey, $srcLocale, $destLocales);

--- a/src/Sulu/Bundle/PageBundle/Repository/NodeRepositoryInterface.php
+++ b/src/Sulu/Bundle/PageBundle/Repository/NodeRepositoryInterface.php
@@ -189,6 +189,9 @@ interface NodeRepositoryInterface
     public function orderAt($uuid, $position, $webspaceKey, $languageCode, $userId);
 
     /**
+     * @deprecated
+     * @see DocumentManagerInterface::copyLocale()
+     *
      * @param string $uuid
      * @param int $userId
      * @param string $webspaceKey

--- a/src/Sulu/Bundle/PageBundle/Resources/config/document.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/document.xml
@@ -139,6 +139,14 @@
             <tag name="sulu_document_manager.event_subscriber"/>
         </service>
 
+        <service id="sulu_document_manager.document.subscriber.copy_locale"
+                 class="Sulu\Component\Content\Document\Subscriber\CopyLocaleSubscriber">
+            <argument type="service" id="sulu_document_manager.document_manager"/>
+            <argument type="service" id="sulu_document_manager.document_inspector"/>
+            <argument type="service" id="sulu.content.resource_locator.strategy_pool"/>
+            <tag name="sulu_document_manager.event_subscriber"/>
+        </service>
+
         <!-- Compat -->
         <service id="sulu_document_manager.document.subscriber.compat.content_mapper"
                  class="Sulu\Component\Content\Document\Subscriber\Compat\ContentMapperSubscriber">

--- a/src/Sulu/Component/Content/Document/Subscriber/CopyLocaleSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/CopyLocaleSubscriber.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Component\Content\Document\Subscriber;
 
-use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Component\Content\Document\Behavior\ExtensionBehavior;
 use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
 use Sulu\Component\Content\Document\Behavior\StructureBehavior;
@@ -23,6 +22,7 @@ use Sulu\Component\DocumentManager\Behavior\Mapping\ParentBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\TitleBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\UuidBehavior;
 use Sulu\Component\DocumentManager\DocumentAccessor;
+use Sulu\Component\DocumentManager\DocumentInspector;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Event\CopyLocaleEvent;
 use Sulu\Component\DocumentManager\Events;
@@ -78,7 +78,7 @@ class CopyLocaleSubscriber implements EventSubscriberInterface
 
         $webspaceKey = null;
         $resourceLocatorStrategy = null;
-        if ($document instanceof ResourceSegmentBehavior && $document instanceof WebspaceBehavior) {
+        if ($document instanceof WebspaceBehavior) {
             $webspaceKey = $document->getWebspaceName();
             $resourceLocatorStrategy = $this->resourceLocatorStrategyPool->getStrategyByWebspaceKey($webspaceKey);
         }

--- a/src/Sulu/Component/Content/Document/Subscriber/CopyLocaleSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/CopyLocaleSubscriber.php
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Document\Subscriber;
+
+use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
+use Sulu\Component\Content\Document\Behavior\ExtensionBehavior;
+use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
+use Sulu\Component\Content\Document\Behavior\StructureBehavior;
+use Sulu\Component\Content\Document\Behavior\WebspaceBehavior;
+use Sulu\Component\Content\Document\Behavior\WorkflowStageBehavior;
+use Sulu\Component\Content\Types\ResourceLocator\Strategy\ResourceLocatorStrategyPoolInterface;
+use Sulu\Component\DocumentManager\Behavior\Mapping\LocaleBehavior;
+use Sulu\Component\DocumentManager\Behavior\Mapping\ParentBehavior;
+use Sulu\Component\DocumentManager\Behavior\Mapping\TitleBehavior;
+use Sulu\Component\DocumentManager\Behavior\Mapping\UuidBehavior;
+use Sulu\Component\DocumentManager\DocumentAccessor;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Sulu\Component\DocumentManager\Event\CopyLocaleEvent;
+use Sulu\Component\DocumentManager\Events;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class CopyLocaleSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var DocumentManagerInterface
+     */
+    private $documentManager;
+
+    /**
+     * @var DocumentInspector
+     */
+    private $documentInspector;
+
+    /**
+     * @var ResourceLocatorStrategyPoolInterface
+     */
+    private $resourceLocatorStrategyPool;
+
+    public function __construct(
+        DocumentManagerInterface $documentManager,
+        DocumentInspector $documentInspector,
+        ResourceLocatorStrategyPoolInterface $resourceLocatorStrategyPool
+    ) {
+        $this->resourceLocatorStrategyPool = $resourceLocatorStrategyPool;
+        $this->documentInspector = $documentInspector;
+        $this->documentManager = $documentManager;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            Events::COPY_LOCALE => 'handleCopyLocale',
+        ];
+    }
+
+    public function handleCopyLocale(CopyLocaleEvent $event): void
+    {
+        $document = $event->getDocument();
+
+        if (!$document instanceof UuidBehavior) {
+            return;
+        }
+
+        $destLocales = $event->getDestLocales();
+        $uuid = $document->getUuid();
+
+        $webspaceKey = null;
+        $resourceLocatorStrategy = null;
+        if ($document instanceof ResourceSegmentBehavior && $document instanceof WebspaceBehavior) {
+            $webspaceKey = $document->getWebspaceName();
+            $resourceLocatorStrategy = $this->resourceLocatorStrategyPool->getStrategyByWebspaceKey($webspaceKey);
+        }
+
+        $parentUuid = null;
+        if ($document instanceof ParentBehavior) {
+            $parentDocument = $this->documentInspector->getParent($document);
+
+            if (null !== $parentDocument) {
+                $parentUuid = $this->documentInspector->getUuid($parentDocument);
+            }
+        }
+
+        foreach ($destLocales as $destLocale) {
+            $destDocument = $this->documentManager->find(
+                $uuid,
+                $destLocale
+            );
+
+            if ($destDocument instanceof LocaleBehavior) {
+                $destDocument->setLocale($destLocale);
+            }
+
+            if ($destDocument instanceof TitleBehavior && $document instanceof TitleBehavior) {
+                $destDocument->setTitle($document->getTitle());
+            }
+
+            if ($destDocument instanceof StructureBehavior && $document instanceof StructureBehavior) {
+                $destDocument->setStructureType($document->getStructureType());
+                $destDocument->getStructure()->bind($document->getStructure()->toArray());
+            }
+
+            if ($destDocument instanceof WorkflowStageBehavior) {
+                $documentAccessor = new DocumentAccessor($destDocument);
+                $documentAccessor->set(WorkflowStageSubscriber::PUBLISHED_FIELD, null);
+            }
+
+            if ($destDocument instanceof ExtensionBehavior && $document instanceof ExtensionBehavior) {
+                $destDocument->setExtensionsData($document->getExtensionsData());
+            }
+
+            // TODO: This can be removed if RoutingAuto replaces the ResourceLocator code.
+            if ($destDocument instanceof ResourceSegmentBehavior
+                && $destDocument instanceof TitleBehavior
+                && null !== $resourceLocatorStrategy
+                && null !== $parentUuid
+                && null !== $webspaceKey) {
+                $resourceLocator = $resourceLocatorStrategy->generate(
+                    $destDocument->getTitle(),
+                    $parentUuid,
+                    $webspaceKey,
+                    $destLocale
+                );
+
+                $destDocument->setResourceSegment($resourceLocator);
+            }
+
+            $this->documentManager->persist($destDocument, $destLocale);
+        }
+    }
+}

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -477,6 +477,12 @@ class ContentMapper implements ContentMapperInterface
         $destLocales,
         $structureType = LegacyStructure::TYPE_PAGE
     ) {
+        @\trigger_error(
+            'The ContentMapperInterface::copyLanguage method is deprecated and will be removed in the future.'
+            . ' Use DocumentManagerInterface::copyLocale instead.',
+            \E_USER_DEPRECATED
+        );
+
         if (!\is_array($destLocales)) {
             $destLocales = [$destLocales];
         }

--- a/src/Sulu/Component/Content/Mapper/ContentMapperInterface.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapperInterface.php
@@ -16,6 +16,7 @@ use PHPCR\Query\QueryInterface;
 use PHPCR\Query\QueryResultInterface;
 use Sulu\Component\Content\BreadcrumbItemInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\Localization\Localization;
 
 /**
@@ -158,6 +159,9 @@ interface ContentMapperInterface
 
     /**
      * Copies the content from one node from one localization to the other.
+     *
+     * @deprecated
+     * @see DocumentManagerInterface::copyLocale()
      *
      * @param string $uuid
      * @param string $userId

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/CopyLocaleSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/CopyLocaleSubscriberTest.php
@@ -61,7 +61,7 @@ class CopyLocaleSubscriberTest extends SubscriberTestCase
         /** @var CopyLocaleEvent|ObjectProphecy $event */
         $event = $this->prophesize(CopyLocaleEvent::class);
         $event->getLocale()->willReturn('en');
-        $event->getDestLocales()->willReturn(['de']);
+        $event->getDestLocale()->willReturn('de');
 
         $structureData = [
             'foo' => 'bar',

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/CopyLocaleSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/CopyLocaleSubscriberTest.php
@@ -52,7 +52,7 @@ class CopyLocaleSubscriberTest extends SubscriberTestCase
         $this->subscriber = new CopyLocaleSubscriber(
             $this->documentManager->reveal(),
             $this->documentInspector->reveal(),
-            $this->resourceLocatorStrategyPool->reveal(),
+            $this->resourceLocatorStrategyPool->reveal()
         );
     }
 

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/CopyLocaleSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/CopyLocaleSubscriberTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Tests\Unit\Document\Subscriber;
+
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
+use Sulu\Bundle\PageBundle\Document\PageDocument;
+use Sulu\Component\Content\Document\Structure\StructureInterface;
+use Sulu\Component\Content\Document\Subscriber\CopyLocaleSubscriber;
+use Sulu\Component\Content\Types\ResourceLocator\Strategy\ResourceLocatorStrategyInterface;
+use Sulu\Component\Content\Types\ResourceLocator\Strategy\ResourceLocatorStrategyPoolInterface;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Sulu\Component\DocumentManager\Event\CopyLocaleEvent;
+
+class CopyLocaleSubscriberTest extends SubscriberTestCase
+{
+    /**
+     * @var DocumentManagerInterface|ObjectProphecy
+     */
+    private $documentManager;
+
+    /**
+     * @var DocumentInspector|ObjectProphecy
+     */
+    private $documentInspector;
+
+    /**
+     * @var ResourceLocatorStrategyPoolInterface|ObjectProphecy
+     */
+    private $resourceLocatorStrategyPool;
+
+    /**
+     * @var CopyLocaleSubscriber
+     */
+    private $subscriber;
+
+    public function setUp(): void
+    {
+        $this->documentManager = $this->prophesize(DocumentManagerInterface::class);
+        $this->documentInspector = $this->prophesize(DocumentInspector::class);
+        $this->resourceLocatorStrategyPool = $this->prophesize(ResourceLocatorStrategyPoolInterface::class);
+
+        $this->subscriber = new CopyLocaleSubscriber(
+            $this->documentManager->reveal(),
+            $this->documentInspector->reveal(),
+            $this->resourceLocatorStrategyPool->reveal(),
+        );
+    }
+
+    public function testHandleCopyLocale(): void
+    {
+        /** @var CopyLocaleEvent|ObjectProphecy $event */
+        $event = $this->prophesize(CopyLocaleEvent::class);
+        $event->getLocale()->willReturn('en');
+        $event->getDestLocales()->willReturn(['de']);
+
+        $structureData = [
+            'foo' => 'bar',
+        ];
+
+        $extensionData = [
+            'bar' => 'baz',
+        ];
+
+        /** @var StructureInterface|ObjectProphecy $structure */
+        $structure = $this->prophesize(StructureInterface::class);
+        $structure->toArray()->willReturn($structureData);
+
+        /** @var PageDocument|ObjectProphecy $document */
+        $document = $this->prophesize(PageDocument::class);
+        $document->getUuid()->willReturn('page-uuid');
+        $document->getWebspaceName()->willReturn('sulu_io');
+        $document->getTitle()->willReturn('A page');
+        $document->getStructureType()->willReturn('default');
+        $document->getStructure()->willReturn($structure->reveal());
+        $document->getExtensionsData()->willReturn($extensionData);
+
+        $event->getDocument()->willReturn($document->reveal());
+
+        /** @var PageDocument|ObjectProphecy $parentDocument */
+        $parentDocument = $this->prophesize(PageDocument::class);
+        $this->documentInspector->getParent($document->reveal())->willReturn($parentDocument->reveal());
+        $this->documentInspector->getUuid($parentDocument->reveal())->willReturn('parent-page-uuid');
+
+        /** @var ResourceLocatorStrategyInterface|ObjectProphecy $resourceLocatorStrategy */
+        $resourceLocatorStrategy = $this->prophesize(ResourceLocatorStrategyInterface::class);
+        $this->resourceLocatorStrategyPool->getStrategyByWebspaceKey('sulu_io')->willReturn($resourceLocatorStrategy->reveal());
+
+        /** @var PageDocument|ObjectProphecy $destDocument */
+        $destDocument = $this->prophesize(PageDocument::class);
+        $this->documentManager->find('page-uuid', 'de')->willReturn($destDocument->reveal());
+
+        /** @var StructureInterface|ObjectProphecy $destStructure */
+        $destStructure = $this->prophesize(StructureInterface::class);
+
+        $destDocument->setLocale('de')->shouldBeCalled();
+        $destDocument->setTitle('A page')->shouldBeCalled();
+        $destDocument->getTitle()->willReturn('A page');
+        $destDocument->setStructureType('default')->shouldBeCalled();
+        $destDocument->getStructure()->willReturn($destStructure->reveal());
+        $destStructure->bind($structureData)->shouldBeCalled();
+        $destDocument->setExtensionsData($extensionData)->shouldBeCalled();
+
+        $resourceLocatorStrategy->generate(
+            'A page',
+            'parent-page-uuid',
+            'sulu_io',
+            'de'
+        )->willReturn('/a-page');
+        $destDocument->setResourceSegment('/a-page')->shouldBeCalled();
+
+        $this->documentManager->persist($destDocument->reveal(), 'de')->shouldBeCalled();
+
+        $this->subscriber->handleCopyLocale($event->reveal());
+    }
+}

--- a/src/Sulu/Component/DocumentManager/DocumentManager.php
+++ b/src/Sulu/Component/DocumentManager/DocumentManager.php
@@ -83,6 +83,12 @@ class DocumentManager implements DocumentManagerInterface
         return $event->getCopiedPath();
     }
 
+    public function copyLocale($document, $srcLocale, $destLocales)
+    {
+        $event = new Event\CopyLocaleEvent($document, $srcLocale, $destLocales);
+        $this->eventDispatcher->dispatch($event, Events::COPY_LOCALE);
+    }
+
     public function reorder($document, $destId)
     {
         $event = new Event\ReorderEvent($document, $destId);

--- a/src/Sulu/Component/DocumentManager/DocumentManager.php
+++ b/src/Sulu/Component/DocumentManager/DocumentManager.php
@@ -83,9 +83,9 @@ class DocumentManager implements DocumentManagerInterface
         return $event->getCopiedPath();
     }
 
-    public function copyLocale($document, $srcLocale, $destLocales)
+    public function copyLocale($document, $srcLocale, $destLocale)
     {
-        $event = new Event\CopyLocaleEvent($document, $srcLocale, $destLocales);
+        $event = new Event\CopyLocaleEvent($document, $srcLocale, $destLocale);
         $this->eventDispatcher->dispatch($event, Events::COPY_LOCALE);
     }
 

--- a/src/Sulu/Component/DocumentManager/DocumentManagerInterface.php
+++ b/src/Sulu/Component/DocumentManager/DocumentManagerInterface.php
@@ -81,6 +81,17 @@ interface DocumentManagerInterface
     public function copy($document, $destPath);
 
     /**
+     * Copy a specific locale of a document.
+     *
+     * @param object $document
+     * @param string $srcLocale
+     * @param string|string[] $destLocales
+     *
+     * @return void
+     */
+    public function copyLocale($document, $srcLocale, $destLocales);
+
+    /**
      * Re-Order node before or after a specific node.
      *
      * @param object $document

--- a/src/Sulu/Component/DocumentManager/DocumentManagerInterface.php
+++ b/src/Sulu/Component/DocumentManager/DocumentManagerInterface.php
@@ -85,11 +85,11 @@ interface DocumentManagerInterface
      *
      * @param object $document
      * @param string $srcLocale
-     * @param string|string[] $destLocales
+     * @param string $destLocale
      *
      * @return void
      */
-    public function copyLocale($document, $srcLocale, $destLocales);
+    public function copyLocale($document, $srcLocale, $destLocale);
 
     /**
      * Re-Order node before or after a specific node.

--- a/src/Sulu/Component/DocumentManager/Event/CopyLocaleEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/CopyLocaleEvent.php
@@ -14,32 +14,28 @@ namespace Sulu\Component\DocumentManager\Event;
 class CopyLocaleEvent extends AbstractMappingEvent
 {
     /**
-     * @var string[]
+     * @var string
      */
-    private $destLocales;
+    private $destLocale;
 
     /**
      * @param object $document
      * @param string $locale
-     * @param string|string[] $destLocales
+     * @param string $destLocale
      */
-    public function __construct($document, $locale, $destLocales)
+    public function __construct($document, $locale, $destLocale)
     {
         $this->document = $document;
         $this->locale = $locale;
 
-        if (!\is_array($destLocales)) {
-            $destLocales = [$destLocales];
-        }
-
-        $this->destLocales = $destLocales;
+        $this->destLocale = $destLocale;
     }
 
     /**
-     * @return string[]
+     * @return string
      */
-    public function getDestLocales()
+    public function getDestLocale()
     {
-        return $this->destLocales;
+        return $this->destLocale;
     }
 }

--- a/src/Sulu/Component/DocumentManager/Event/CopyLocaleEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/CopyLocaleEvent.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+class CopyLocaleEvent extends AbstractMappingEvent
+{
+    /**
+     * @var string[]
+     */
+    private $destLocales;
+
+    /**
+     * @param object $document
+     * @param string $locale
+     * @param string|string[] $destLocales
+     */
+    public function __construct($document, $locale, $destLocales)
+    {
+        $this->document = $document;
+        $this->locale = $locale;
+
+        if (!\is_array($destLocales)) {
+            $destLocales = [$destLocales];
+        }
+
+        $this->destLocales = $destLocales;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getDestLocales()
+    {
+        return $this->destLocales;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Events.php
+++ b/src/Sulu/Component/DocumentManager/Events.php
@@ -37,6 +37,11 @@ class Events
     const REMOVE_LOCALE = 'sulu_document_manager.remove_locale';
 
     /**
+     * Fired when a document localization is copied via the document manager.
+     */
+    const COPY_LOCALE = 'sulu_document_manager.copy_locale';
+
+    /**
      * Fired when a document should be refreshed.
      */
     const REFRESH = 'sulu_document_manager.refresh';


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | yes
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Add `copyLocale` method to `DocumentManagerInterface`

#### Why?

To allow listening to a new `CopyLocaleEvent` (this is needed for the domain events)