### PR TITLE
Add more space between avatar and logo to properties

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Resources/config/forms/account_details.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/forms/account_details.xml
@@ -8,7 +8,7 @@
     <properties>
         <section name="logo" colspan="4">
             <properties>
-                <property name="logo" type="single_media_upload">
+                <property name="logo" type="single_media_upload" colspan="11" spaceAfter="1">
                     <params>
                         <param name="upload_text">
                             <meta>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/forms/contact_details.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/forms/contact_details.xml
@@ -8,7 +8,7 @@
     <properties>
         <section name="avatar" colspan="4">
             <properties>
-                <property name="avatar" type="single_media_upload">
+                <property name="avatar" type="single_media_upload" colspan="11" spaceAfter="1">
                     <params>
                         <param name="upload_text">
                             <meta>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add more space between avatar / logo and properties

#### Why

That it have have more space.
