### PR TITLE
Upgrade react-sortable-hoc to 2.0.0 and query-string to 7.0.0 version

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
@@ -40,7 +40,7 @@
         "react-datetime": "^2.11.0",
         "react-dropzone": "^11.2.0",
         "react-portal": "^4.1.0",
-        "react-sortable-hoc": "^1.11.0",
+        "react-sortable-hoc": "^2.0.0",
         "resize-observer-polyfill": "^1.5.0",
         "textversionjs": "^1.1.3",
         "url-search-params-polyfill": "^8.0.0"

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/package.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "classnames": "^2.2.5",
         "debounce": "^1.0.2",
-        "query-string": "^6.0.0"
+        "query-string": "^7.0.0"
     },
     "devDependencies": {
         "enzyme": "^3.3.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | yes (dependency update)
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Upgrade react-sortable-hoc to 2.0.0 version and query-string to 7.0.0 version.

#### Why?

New Version provide bugfixes and new features.
