### PR TITLE
Add CategoryTranslationAddedEvent

### DIFF
--- a/src/Sulu/Bundle/CategoryBundle/Category/CategoryManager.php
+++ b/src/Sulu/Bundle/CategoryBundle/Category/CategoryManager.php
@@ -173,12 +173,8 @@ class CategoryManager implements CategoryManagerInterface
         if (!$isNewCategory) {
             $categoryEntity = $this->findById($this->getProperty($data, 'id'));
 
-            foreach ($categoryEntity->getTranslations() as $translation) {
-                if ($translation->getLocale() === $locale) {
-                    $isNewLocale = false;
-
-                    break;
-                }
+            if (false !== $categoryEntity->findTranslationByLocale($locale)) {
+                $isNewLocale = false;
             }
         } else {
             $categoryEntity = $this->categoryRepository->createNew();

--- a/src/Sulu/Bundle/CategoryBundle/Category/CategoryManager.php
+++ b/src/Sulu/Bundle/CategoryBundle/Category/CategoryManager.php
@@ -15,7 +15,7 @@ use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\CategoryBundle\Api\Category as CategoryWrapper;
 use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryCreatedEvent;
-use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryLocaleAddedEvent;
+use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryTranslationAddedEvent;
 use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryModifiedEvent;
 use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryMovedEvent;
 use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryRemovedEvent;
@@ -248,7 +248,7 @@ class CategoryManager implements CategoryManagerInterface
         if ($isNewCategory) {
             $this->domainEventCollector->collect(new CategoryCreatedEvent($categoryEntity, $locale, $data));
         } elseif ($isNewLocale) {
-            $this->domainEventCollector->collect(new CategoryLocaleAddedEvent($categoryEntity, $locale, $data));
+            $this->domainEventCollector->collect(new CategoryTranslationAddedEvent($categoryEntity, $locale, $data));
         } else {
             $this->domainEventCollector->collect(new CategoryModifiedEvent($categoryEntity, $locale, $data));
         }

--- a/src/Sulu/Bundle/CategoryBundle/Category/CategoryManager.php
+++ b/src/Sulu/Bundle/CategoryBundle/Category/CategoryManager.php
@@ -15,10 +15,10 @@ use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\CategoryBundle\Api\Category as CategoryWrapper;
 use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryCreatedEvent;
-use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryTranslationAddedEvent;
 use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryModifiedEvent;
 use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryMovedEvent;
 use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryRemovedEvent;
+use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryTranslationAddedEvent;
 use Sulu\Bundle\CategoryBundle\Entity\Category;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryMetaRepositoryInterface;
@@ -168,13 +168,13 @@ class CategoryManager implements CategoryManagerInterface
     public function save($data, $userId, $locale, $patch = false)
     {
         $isNewCategory = !$this->getProperty($data, 'id');
-        $isNewLocale = true;
+        $isNewTranslation = true;
 
         if (!$isNewCategory) {
             $categoryEntity = $this->findById($this->getProperty($data, 'id'));
 
             if (false !== $categoryEntity->findTranslationByLocale($locale)) {
-                $isNewLocale = false;
+                $isNewTranslation = false;
             }
         } else {
             $categoryEntity = $this->categoryRepository->createNew();
@@ -247,7 +247,7 @@ class CategoryManager implements CategoryManagerInterface
 
         if ($isNewCategory) {
             $this->domainEventCollector->collect(new CategoryCreatedEvent($categoryEntity, $locale, $data));
-        } elseif ($isNewLocale) {
+        } elseif ($isNewTranslation) {
             $this->domainEventCollector->collect(new CategoryTranslationAddedEvent($categoryEntity, $locale, $data));
         } else {
             $this->domainEventCollector->collect(new CategoryModifiedEvent($categoryEntity, $locale, $data));

--- a/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryLocaleAddedEvent.php
+++ b/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryLocaleAddedEvent.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CategoryBundle\Domain\Event;
+
+use Sulu\Bundle\CategoryBundle\Admin\CategoryAdmin;
+use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
+use Sulu\Bundle\EventLogBundle\Domain\Event\DomainEvent;
+
+class CategoryLocaleAddedEvent extends DomainEvent
+{
+    /**
+     * @var CategoryInterface
+     */
+    private $category;
+
+    /**
+     * @var string
+     */
+    private $locale;
+
+    /**
+     * @var mixed[]
+     */
+    private $payload;
+
+    /**
+     * @param mixed[] $payload
+     */
+    public function __construct(
+        CategoryInterface $category,
+        string $locale,
+        array $payload
+    ) {
+        parent::__construct();
+
+        $this->category = $category;
+        $this->locale = $locale;
+        $this->payload = $payload;
+    }
+
+    public function getCategory(): CategoryInterface
+    {
+        return $this->category;
+    }
+
+    public function getEventType(): string
+    {
+        return 'locale_added';
+    }
+
+    public function getEventPayload(): ?array
+    {
+        return $this->payload;
+    }
+
+    public function getResourceKey(): string
+    {
+        return CategoryInterface::RESOURCE_KEY;
+    }
+
+    public function getResourceId(): string
+    {
+        return (string) $this->category->getId();
+    }
+
+    public function getResourceLocale(): string
+    {
+        return $this->locale;
+    }
+
+    public function getResourceTitle(): ?string
+    {
+        $translation = $this->category->findTranslationByLocale($this->locale);
+
+        return $translation ? $translation->getTranslation() : null;
+    }
+
+    public function getResourceSecurityContext(): ?string
+    {
+        return CategoryAdmin::SECURITY_CONTEXT;
+    }
+}

--- a/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryTranslationAddedEvent.php
+++ b/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryTranslationAddedEvent.php
@@ -15,7 +15,7 @@ use Sulu\Bundle\CategoryBundle\Admin\CategoryAdmin;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\EventLogBundle\Domain\Event\DomainEvent;
 
-class CategoryLocaleAddedEvent extends DomainEvent
+class CategoryTranslationAddedEvent extends DomainEvent
 {
     /**
      * @var CategoryInterface
@@ -54,7 +54,7 @@ class CategoryLocaleAddedEvent extends DomainEvent
 
     public function getEventType(): string
     {
-        return 'locale_added';
+        return 'translation_added';
     }
 
     public function getEventPayload(): ?array


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | -
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

This pull request adds a `CategoryLocaleAddedEvent`, which is being thrown instead of the `CategoryModifiedEvent`, if the saved locale didn't exist before
