### PR TITLE
Add resourceSecurityObjectId to domain events

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,15 @@
 
 ## 2.3
 
+### Added resourceSecurityObjectId field to EventRecord
+
+Because a new `resourceSecurityObjectId` field has been added to the `EventRecord` entity,
+you need to update your database schema:
+
+```sql
+ALTER TABLE el_event_records ADD resourceSecurityObjectId VARCHAR(191) DEFAULT NULL;
+```
+
 ### JS Dependencies updated
 
 We always try to keep sulu compatible with newest dependencies in this release

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,11 +4,12 @@
 
 ### Added resourceSecurityObjectId field to EventRecord
 
-Because a new `resourceSecurityObjectId` field has been added to the `EventRecord` entity,
+Because a new `resourceSecurityObjectId` field has been added to the `EventRecord` entity
+and the existing `resourceSecurityType` field has been renamed to `resourceSecurityObjectType`,
 you need to update your database schema:
 
 ```sql
-ALTER TABLE el_event_records ADD resourceSecurityObjectId VARCHAR(191) DEFAULT NULL;
+ALTER TABLE el_event_records ADD resourceSecurityObjectId VARCHAR(191) DEFAULT NULL, CHANGE resourceSecurityType resourceSecurityObjectType VARCHAR(191) DEFAULT NULL;
 ```
 
 ### JS Dependencies updated

--- a/src/Sulu/Bundle/EventLogBundle/Domain/Event/DomainEvent.php
+++ b/src/Sulu/Bundle/EventLogBundle/Domain/Event/DomainEvent.php
@@ -130,4 +130,9 @@ abstract class DomainEvent
     {
         return null;
     }
+
+    public function getResourceSecurityObjectId(): ?string
+    {
+        return $this->getResourceId();
+    }
 }

--- a/src/Sulu/Bundle/EventLogBundle/Domain/Event/DomainEvent.php
+++ b/src/Sulu/Bundle/EventLogBundle/Domain/Event/DomainEvent.php
@@ -126,7 +126,7 @@ abstract class DomainEvent
         return null;
     }
 
-    public function getResourceSecurityType(): ?string
+    public function getResourceSecurityObjectType(): ?string
     {
         return null;
     }

--- a/src/Sulu/Bundle/EventLogBundle/Domain/Model/EventRecord.php
+++ b/src/Sulu/Bundle/EventLogBundle/Domain/Model/EventRecord.php
@@ -88,7 +88,7 @@ class EventRecord implements EventRecordInterface
     /**
      * @var string|null
      */
-    private $resourceSecurityType;
+    private $resourceSecurityObjectType;
 
     /**
      * @var string|null
@@ -251,14 +251,14 @@ class EventRecord implements EventRecordInterface
         return $this;
     }
 
-    public function getResourceSecurityType(): ?string
+    public function getResourceSecurityObjectType(): ?string
     {
-        return $this->resourceSecurityType;
+        return $this->resourceSecurityObjectType;
     }
 
-    public function setResourceSecurityType(?string $resourceSecurityType): EventRecordInterface
+    public function setResourceSecurityObjectType(?string $resourceSecurityObjectType): EventRecordInterface
     {
-        $this->resourceSecurityType = $resourceSecurityType;
+        $this->resourceSecurityObjectType = $resourceSecurityObjectType;
 
         return $this;
     }

--- a/src/Sulu/Bundle/EventLogBundle/Domain/Model/EventRecord.php
+++ b/src/Sulu/Bundle/EventLogBundle/Domain/Model/EventRecord.php
@@ -90,6 +90,11 @@ class EventRecord implements EventRecordInterface
      */
     private $resourceSecurityType;
 
+    /**
+     * @var string|null
+     */
+    private $resourceSecurityObjectId;
+
     public function getEventType(): string
     {
         return $this->eventType;
@@ -254,6 +259,18 @@ class EventRecord implements EventRecordInterface
     public function setResourceSecurityType(?string $resourceSecurityType): EventRecordInterface
     {
         $this->resourceSecurityType = $resourceSecurityType;
+
+        return $this;
+    }
+
+    public function getResourceSecurityObjectId(): ?string
+    {
+        return $this->resourceSecurityObjectId;
+    }
+
+    public function setResourceSecurityObjectId(?string $resourceSecurityObjectId): EventRecordInterface
+    {
+        $this->resourceSecurityObjectId = $resourceSecurityObjectId;
 
         return $this;
     }

--- a/src/Sulu/Bundle/EventLogBundle/Domain/Model/EventRecordInterface.php
+++ b/src/Sulu/Bundle/EventLogBundle/Domain/Model/EventRecordInterface.php
@@ -82,4 +82,8 @@ interface EventRecordInterface
     public function getResourceSecurityType(): ?string;
 
     public function setResourceSecurityType(?string $resourceSecurityType): EventRecordInterface;
+
+    public function getResourceSecurityObjectId(): ?string;
+
+    public function setResourceSecurityObjectId(?string $resourceSecurityObjectId): EventRecordInterface;
 }

--- a/src/Sulu/Bundle/EventLogBundle/Domain/Model/EventRecordInterface.php
+++ b/src/Sulu/Bundle/EventLogBundle/Domain/Model/EventRecordInterface.php
@@ -79,9 +79,9 @@ interface EventRecordInterface
 
     public function setResourceSecurityContext(?string $resourceSecurityContext): EventRecordInterface;
 
-    public function getResourceSecurityType(): ?string;
+    public function getResourceSecurityObjectType(): ?string;
 
-    public function setResourceSecurityType(?string $resourceSecurityType): EventRecordInterface;
+    public function setResourceSecurityObjectType(?string $resourceSecurityObjectType): EventRecordInterface;
 
     public function getResourceSecurityObjectId(): ?string;
 

--- a/src/Sulu/Bundle/EventLogBundle/Infrastructure/Doctrine/Repository/EventRecordRepository.php
+++ b/src/Sulu/Bundle/EventLogBundle/Infrastructure/Doctrine/Repository/EventRecordRepository.php
@@ -56,7 +56,7 @@ class EventRecordRepository implements EventRecordRepositoryInterface
         $eventRecord->setResourceTitle($domainEvent->getResourceTitle());
         $eventRecord->setResourceTitleLocale($domainEvent->getResourceTitleLocale());
         $eventRecord->setResourceSecurityContext($domainEvent->getResourceSecurityContext());
-        $eventRecord->setResourceSecurityType($domainEvent->getResourceSecurityType());
+        $eventRecord->setResourceSecurityObjectType($domainEvent->getResourceSecurityObjectType());
         $eventRecord->setResourceSecurityObjectId($domainEvent->getResourceSecurityObjectId());
 
         return $eventRecord;

--- a/src/Sulu/Bundle/EventLogBundle/Infrastructure/Doctrine/Repository/EventRecordRepository.php
+++ b/src/Sulu/Bundle/EventLogBundle/Infrastructure/Doctrine/Repository/EventRecordRepository.php
@@ -57,6 +57,7 @@ class EventRecordRepository implements EventRecordRepositoryInterface
         $eventRecord->setResourceTitleLocale($domainEvent->getResourceTitleLocale());
         $eventRecord->setResourceSecurityContext($domainEvent->getResourceSecurityContext());
         $eventRecord->setResourceSecurityType($domainEvent->getResourceSecurityType());
+        $eventRecord->setResourceSecurityObjectId($domainEvent->getResourceSecurityObjectId());
 
         return $eventRecord;
     }

--- a/src/Sulu/Bundle/EventLogBundle/Resources/config/doctrine/EventRecord.orm.xml
+++ b/src/Sulu/Bundle/EventLogBundle/Resources/config/doctrine/EventRecord.orm.xml
@@ -25,5 +25,6 @@
         <field name="resourceTitleLocale" column="resourceTitleLocale" type="string" nullable="true" length="191"/>
         <field name="resourceSecurityContext" column="resourceSecurityContext" type="string" nullable="true" length="191"/>
         <field name="resourceSecurityType" column="resourceSecurityType" type="string" nullable="true" length="191"/>
+        <field name="resourceSecurityObjectId" column="resourceSecurityObjectId" type="string" nullable="true" length="191"/>
     </mapped-superclass>
 </doctrine-mapping>

--- a/src/Sulu/Bundle/EventLogBundle/Resources/config/doctrine/EventRecord.orm.xml
+++ b/src/Sulu/Bundle/EventLogBundle/Resources/config/doctrine/EventRecord.orm.xml
@@ -24,7 +24,7 @@
         <field name="resourceTitle" column="resourceTitle" type="string" nullable="true" length="191"/>
         <field name="resourceTitleLocale" column="resourceTitleLocale" type="string" nullable="true" length="191"/>
         <field name="resourceSecurityContext" column="resourceSecurityContext" type="string" nullable="true" length="191"/>
-        <field name="resourceSecurityType" column="resourceSecurityType" type="string" nullable="true" length="191"/>
+        <field name="resourceSecurityObjectType" column="resourceSecurityObjectType" type="string" nullable="true" length="191"/>
         <field name="resourceSecurityObjectId" column="resourceSecurityObjectId" type="string" nullable="true" length="191"/>
     </mapped-superclass>
 </doctrine-mapping>

--- a/src/Sulu/Bundle/EventLogBundle/Tests/Functional/Infrastructure/Doctrine/Repository/EventRecordRepositoryTest.php
+++ b/src/Sulu/Bundle/EventLogBundle/Tests/Functional/Infrastructure/Doctrine/Repository/EventRecordRepositoryTest.php
@@ -57,7 +57,7 @@ class EventRecordRepositoryTest extends SuluTestCase
         $this->domainEvent->getResourceTitle()->willReturn('Test Page 1234');
         $this->domainEvent->getResourceTitleLocale()->willReturn('en');
         $this->domainEvent->getResourceSecurityContext()->willReturn('sulu.webspaces.sulu-io');
-        $this->domainEvent->getResourceSecurityType()->willReturn(SecurityBehavior::class);
+        $this->domainEvent->getResourceSecurityObjectType()->willReturn(SecurityBehavior::class);
         $this->domainEvent->getResourceSecurityObjectId()->willReturn('1234-1234-1234-1234');
     }
 
@@ -84,7 +84,7 @@ class EventRecordRepositoryTest extends SuluTestCase
         static::assertSame('Test Page 1234', $eventRecord->getResourceTitle());
         static::assertSame('en', $eventRecord->getResourceTitleLocale());
         static::assertSame('sulu.webspaces.sulu-io', $eventRecord->getResourceSecurityContext());
-        static::assertSame(SecurityBehavior::class, $eventRecord->getResourceSecurityType());
+        static::assertSame(SecurityBehavior::class, $eventRecord->getResourceSecurityObjectType());
         static::assertSame('1234-1234-1234-1234', $eventRecord->getResourceSecurityObjectId());
     }
 

--- a/src/Sulu/Bundle/EventLogBundle/Tests/Functional/Infrastructure/Doctrine/Repository/EventRecordRepositoryTest.php
+++ b/src/Sulu/Bundle/EventLogBundle/Tests/Functional/Infrastructure/Doctrine/Repository/EventRecordRepositoryTest.php
@@ -58,6 +58,7 @@ class EventRecordRepositoryTest extends SuluTestCase
         $this->domainEvent->getResourceTitleLocale()->willReturn('en');
         $this->domainEvent->getResourceSecurityContext()->willReturn('sulu.webspaces.sulu-io');
         $this->domainEvent->getResourceSecurityType()->willReturn(SecurityBehavior::class);
+        $this->domainEvent->getResourceSecurityObjectId()->willReturn('1234-1234-1234-1234');
     }
 
     public function testCreateForDomainEvent(): void
@@ -84,6 +85,7 @@ class EventRecordRepositoryTest extends SuluTestCase
         static::assertSame('en', $eventRecord->getResourceTitleLocale());
         static::assertSame('sulu.webspaces.sulu-io', $eventRecord->getResourceSecurityContext());
         static::assertSame(SecurityBehavior::class, $eventRecord->getResourceSecurityType());
+        static::assertSame('1234-1234-1234-1234', $eventRecord->getResourceSecurityObjectId());
     }
 
     public function testAddAndCommit(): void

--- a/src/Sulu/Bundle/EventLogBundle/Tests/Unit/Domain/Event/DomainEventTest.php
+++ b/src/Sulu/Bundle/EventLogBundle/Tests/Unit/Domain/Event/DomainEventTest.php
@@ -124,6 +124,13 @@ class DomainEventTest extends TestCase
         static::assertNull($event->getResourceSecurityType());
     }
 
+    public function testResourceSecurityObjectId(): void
+    {
+        $event = $this->createTestDomainEvent();
+
+        static::assertSame('test', $event->getResourceSecurityObjectId());
+    }
+
     private function createTestDomainEvent(): TestDomainEvent
     {
         return new TestDomainEvent();

--- a/src/Sulu/Bundle/EventLogBundle/Tests/Unit/Domain/Event/DomainEventTest.php
+++ b/src/Sulu/Bundle/EventLogBundle/Tests/Unit/Domain/Event/DomainEventTest.php
@@ -117,11 +117,11 @@ class DomainEventTest extends TestCase
         static::assertNull($event->getResourceSecurityContext());
     }
 
-    public function testResourceSecurityType(): void
+    public function testResourceSecurityObjectType(): void
     {
         $event = $this->createTestDomainEvent();
 
-        static::assertNull($event->getResourceSecurityType());
+        static::assertNull($event->getResourceSecurityObjectType());
     }
 
     public function testResourceSecurityObjectId(): void

--- a/src/Sulu/Bundle/EventLogBundle/Tests/Unit/Domain/Model/EventRecordTest.php
+++ b/src/Sulu/Bundle/EventLogBundle/Tests/Unit/Domain/Model/EventRecordTest.php
@@ -135,13 +135,13 @@ class EventRecordTest extends TestCase
         static::assertSame('sulu.webspaces.sulu-io', $event->getResourceSecurityContext());
     }
 
-    public function testResourceSecurityType(): void
+    public function testResourceSecurityObjectType(): void
     {
         $event = $this->createEventRecord();
 
-        static::assertNull($event->getResourceSecurityType());
-        static::assertSame($event, $event->setResourceSecurityType(SecurityBehavior::class));
-        static::assertSame(SecurityBehavior::class, $event->getResourceSecurityType());
+        static::assertNull($event->getResourceSecurityObjectType());
+        static::assertSame($event, $event->setResourceSecurityObjectType(SecurityBehavior::class));
+        static::assertSame(SecurityBehavior::class, $event->getResourceSecurityObjectType());
     }
 
     public function testResourceSecurityObjectId(): void

--- a/src/Sulu/Bundle/EventLogBundle/Tests/Unit/Domain/Model/EventRecordTest.php
+++ b/src/Sulu/Bundle/EventLogBundle/Tests/Unit/Domain/Model/EventRecordTest.php
@@ -144,6 +144,15 @@ class EventRecordTest extends TestCase
         static::assertSame(SecurityBehavior::class, $event->getResourceSecurityType());
     }
 
+    public function testResourceSecurityObjectId(): void
+    {
+        $event = $this->createEventRecord();
+
+        static::assertNull($event->getResourceSecurityObjectId());
+        static::assertSame($event, $event->setResourceSecurityObjectId('1'));
+        static::assertSame('1', $event->getResourceSecurityObjectId());
+    }
+
     private function createEventRecord(): EventRecord
     {
         return new EventRecord();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Add a `getResourceSecurityObjectId()` method to the `DomainEvent`

#### Why?

There is no object security on media itself, but on collections. Therefore it's required to store the `collectionId` somehow on the `EventRecord`, because that one is used to build the `SecurityCondition`