### PR TITLE
Upgrade react-datetime to 3.0.0

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
@@ -80,6 +80,16 @@ class DatePicker extends React.Component<Props> {
         this.props.onChange(date);
 
         this.setShowError(!!this.value && !date);
+
+        // can be removed when is fixed the following is fixed:
+        // https://github.com/arqex/react-datetime/pull/741
+        if (
+            (!this.value && date) ||
+            (this.value && !date) ||
+            !moment(this.value).isSame(date, 'day')
+        ) {
+            this.setOpen(false);
+        }
     };
 
     handleDatepickerChange = (date: string | Moment) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
@@ -86,7 +86,7 @@ class DatePicker extends React.Component<Props> {
         if (
             (!this.value && date) ||
             (this.value && !date) ||
-            !moment(this.value).isSame(date, 'day')
+            !moment(this.value, this.getFormat()).isSame(moment(date, this.getFormat()), 'day')
         ) {
             this.setOpen(false);
         }
@@ -189,7 +189,6 @@ class DatePicker extends React.Component<Props> {
         const {className, disabled, options, placeholder, valid} = this.props;
 
         const fieldOptions = {
-            closeOnSelect: true,
             ...options,
             dateFormat: this.getDateFormat() || false,
             timeFormat: this.getTimeFormat() || false,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
@@ -209,8 +209,8 @@ class DatePicker extends React.Component<Props> {
                                 <ReactDatetime
                                     {...fieldOptions}
                                     inputProps={inputProps}
-                                    onBlur={this.handleCloseOverlay}
                                     onChange={this.handleDatepickerChange}
+                                    onClose={this.handleCloseOverlay}
                                     open={this.open}
                                     renderInput={this.renderInput}
                                     value={this.value}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/README.md
@@ -1,4 +1,4 @@
-The DatePicker component builds on the top of the [react-datetime](https://github.com/YouCanBookMe/react-datetime) library. 
+The DatePicker component builds on the top of the [react-datetime](https://github.com/arqex/react-datetime) library. 
 
 ```javascript
 const [value, setValue] = React.useState(null);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/tests/DatePicker.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/tests/DatePicker.test.js
@@ -17,7 +17,8 @@ test('DatePicker should render', () => {
     const datePicker = mount(<DatePicker className="date-picker" onChange={onChange} value={null} />);
 
     expect(datePicker.render()).toMatchSnapshot();
-    expect(datePicker.find('DateTime').render()).toMatchSnapshot();
+
+    expect(datePicker.find(ReactDatetime).render()).toMatchSnapshot();
 });
 
 test('DatePicker should show disabled Input when disabled', () => {
@@ -40,18 +41,18 @@ test('DatePicker should open overlay on icon-click', () => {
     const onChange = jest.fn();
     const datePicker = mount(<DatePicker onChange={onChange} value={null} />);
 
-    expect(datePicker.find('DateTime').props().open).toBeFalsy();
+    expect(datePicker.find(ReactDatetime).props().open).toBeFalsy();
     datePicker.find('Icon').simulate('click');
-    expect(datePicker.find('DateTime').props().open).toBeTruthy();
+    expect(datePicker.find(ReactDatetime).props().open).toBeTruthy();
 });
 
 test('DatePicker should not open overlay on icon-click when disabled', () => {
     const onChange = jest.fn();
     const datePicker = mount(<DatePicker disabled={true} onChange={onChange} value={null} />);
 
-    expect(datePicker.find('DateTime').props().open).toBeFalsy();
+    expect(datePicker.find(ReactDatetime).props().open).toBeFalsy();
     datePicker.find('Icon').simulate('click');
-    expect(datePicker.find('DateTime').props().open).toBeFalsy();
+    expect(datePicker.find(ReactDatetime).props().open).toBeFalsy();
 });
 
 test('DatePicker should render with placeholder', () => {
@@ -132,7 +133,7 @@ test('DatePicker should render date picker with time picker', () => {
     const datePicker = mount(<DatePicker onChange={onChange} options={options} value={null} />);
 
     expect(datePicker.render()).toMatchSnapshot();
-    expect(datePicker.find('DateTime').render()).toMatchSnapshot();
+    expect(datePicker.find(ReactDatetime).render()).toMatchSnapshot();
 });
 
 test('DatePicker should render error', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/tests/__snapshots__/DatePicker.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/tests/__snapshots__/DatePicker.test.js.snap
@@ -106,43 +106,57 @@ exports[`DatePicker should render 2`] = `
           <tr>
             <td
               class="rdtDay rdtOld"
+              data-month="2"
               data-value="26"
+              data-year="2017"
             >
               26
             </td>
             <td
               class="rdtDay rdtOld"
+              data-month="2"
               data-value="27"
+              data-year="2017"
             >
               27
             </td>
             <td
               class="rdtDay rdtOld"
+              data-month="2"
               data-value="28"
+              data-year="2017"
             >
               28
             </td>
             <td
               class="rdtDay rdtOld"
+              data-month="2"
               data-value="29"
+              data-year="2017"
             >
               29
             </td>
             <td
               class="rdtDay rdtOld"
+              data-month="2"
               data-value="30"
+              data-year="2017"
             >
               30
             </td>
             <td
               class="rdtDay rdtOld"
+              data-month="2"
               data-value="31"
+              data-year="2017"
             >
               31
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="1"
+              data-year="2017"
             >
               1
             </td>
@@ -150,43 +164,57 @@ exports[`DatePicker should render 2`] = `
           <tr>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="2"
+              data-year="2017"
             >
               2
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="3"
+              data-year="2017"
             >
               3
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="4"
+              data-year="2017"
             >
               4
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="5"
+              data-year="2017"
             >
               5
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="6"
+              data-year="2017"
             >
               6
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="7"
+              data-year="2017"
             >
               7
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="8"
+              data-year="2017"
             >
               8
             </td>
@@ -194,43 +222,57 @@ exports[`DatePicker should render 2`] = `
           <tr>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="9"
+              data-year="2017"
             >
               9
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="10"
+              data-year="2017"
             >
               10
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="11"
+              data-year="2017"
             >
               11
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="12"
+              data-year="2017"
             >
               12
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="13"
+              data-year="2017"
             >
               13
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="14"
+              data-year="2017"
             >
               14
             </td>
             <td
               class="rdtDay rdtToday"
+              data-month="3"
               data-value="15"
+              data-year="2017"
             >
               15
             </td>
@@ -238,43 +280,57 @@ exports[`DatePicker should render 2`] = `
           <tr>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="16"
+              data-year="2017"
             >
               16
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="17"
+              data-year="2017"
             >
               17
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="18"
+              data-year="2017"
             >
               18
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="19"
+              data-year="2017"
             >
               19
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="20"
+              data-year="2017"
             >
               20
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="21"
+              data-year="2017"
             >
               21
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="22"
+              data-year="2017"
             >
               22
             </td>
@@ -282,43 +338,57 @@ exports[`DatePicker should render 2`] = `
           <tr>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="23"
+              data-year="2017"
             >
               23
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="24"
+              data-year="2017"
             >
               24
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="25"
+              data-year="2017"
             >
               25
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="26"
+              data-year="2017"
             >
               26
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="27"
+              data-year="2017"
             >
               27
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="28"
+              data-year="2017"
             >
               28
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="29"
+              data-year="2017"
             >
               29
             </td>
@@ -326,43 +396,57 @@ exports[`DatePicker should render 2`] = `
           <tr>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="30"
+              data-year="2017"
             >
               30
             </td>
             <td
               class="rdtDay rdtNew"
+              data-month="4"
               data-value="1"
+              data-year="2017"
             >
               1
             </td>
             <td
               class="rdtDay rdtNew"
+              data-month="4"
               data-value="2"
+              data-year="2017"
             >
               2
             </td>
             <td
               class="rdtDay rdtNew"
+              data-month="4"
               data-value="3"
+              data-year="2017"
             >
               3
             </td>
             <td
               class="rdtDay rdtNew"
+              data-month="4"
               data-value="4"
+              data-year="2017"
             >
               4
             </td>
             <td
               class="rdtDay rdtNew"
+              data-month="4"
               data-value="5"
+              data-year="2017"
             >
               5
             </td>
             <td
               class="rdtDay rdtNew"
+              data-month="4"
               data-value="6"
+              data-year="2017"
             >
               6
             </td>
@@ -530,43 +614,57 @@ exports[`DatePicker should render date picker with time picker 2`] = `
           <tr>
             <td
               class="rdtDay rdtOld"
+              data-month="2"
               data-value="26"
+              data-year="2017"
             >
               26
             </td>
             <td
               class="rdtDay rdtOld"
+              data-month="2"
               data-value="27"
+              data-year="2017"
             >
               27
             </td>
             <td
               class="rdtDay rdtOld"
+              data-month="2"
               data-value="28"
+              data-year="2017"
             >
               28
             </td>
             <td
               class="rdtDay rdtOld"
+              data-month="2"
               data-value="29"
+              data-year="2017"
             >
               29
             </td>
             <td
               class="rdtDay rdtOld"
+              data-month="2"
               data-value="30"
+              data-year="2017"
             >
               30
             </td>
             <td
               class="rdtDay rdtOld"
+              data-month="2"
               data-value="31"
+              data-year="2017"
             >
               31
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="1"
+              data-year="2017"
             >
               1
             </td>
@@ -574,43 +672,57 @@ exports[`DatePicker should render date picker with time picker 2`] = `
           <tr>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="2"
+              data-year="2017"
             >
               2
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="3"
+              data-year="2017"
             >
               3
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="4"
+              data-year="2017"
             >
               4
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="5"
+              data-year="2017"
             >
               5
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="6"
+              data-year="2017"
             >
               6
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="7"
+              data-year="2017"
             >
               7
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="8"
+              data-year="2017"
             >
               8
             </td>
@@ -618,43 +730,57 @@ exports[`DatePicker should render date picker with time picker 2`] = `
           <tr>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="9"
+              data-year="2017"
             >
               9
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="10"
+              data-year="2017"
             >
               10
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="11"
+              data-year="2017"
             >
               11
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="12"
+              data-year="2017"
             >
               12
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="13"
+              data-year="2017"
             >
               13
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="14"
+              data-year="2017"
             >
               14
             </td>
             <td
               class="rdtDay rdtToday"
+              data-month="3"
               data-value="15"
+              data-year="2017"
             >
               15
             </td>
@@ -662,43 +788,57 @@ exports[`DatePicker should render date picker with time picker 2`] = `
           <tr>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="16"
+              data-year="2017"
             >
               16
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="17"
+              data-year="2017"
             >
               17
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="18"
+              data-year="2017"
             >
               18
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="19"
+              data-year="2017"
             >
               19
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="20"
+              data-year="2017"
             >
               20
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="21"
+              data-year="2017"
             >
               21
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="22"
+              data-year="2017"
             >
               22
             </td>
@@ -706,43 +846,57 @@ exports[`DatePicker should render date picker with time picker 2`] = `
           <tr>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="23"
+              data-year="2017"
             >
               23
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="24"
+              data-year="2017"
             >
               24
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="25"
+              data-year="2017"
             >
               25
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="26"
+              data-year="2017"
             >
               26
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="27"
+              data-year="2017"
             >
               27
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="28"
+              data-year="2017"
             >
               28
             </td>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="29"
+              data-year="2017"
             >
               29
             </td>
@@ -750,43 +904,57 @@ exports[`DatePicker should render date picker with time picker 2`] = `
           <tr>
             <td
               class="rdtDay"
+              data-month="3"
               data-value="30"
+              data-year="2017"
             >
               30
             </td>
             <td
               class="rdtDay rdtNew"
+              data-month="4"
               data-value="1"
+              data-year="2017"
             >
               1
             </td>
             <td
               class="rdtDay rdtNew"
+              data-month="4"
               data-value="2"
+              data-year="2017"
             >
               2
             </td>
             <td
               class="rdtDay rdtNew"
+              data-month="4"
               data-value="3"
+              data-year="2017"
             >
               3
             </td>
             <td
               class="rdtDay rdtNew"
+              data-month="4"
               data-value="4"
+              data-year="2017"
             >
               4
             </td>
             <td
               class="rdtDay rdtNew"
+              data-month="4"
               data-value="5"
+              data-year="2017"
             >
               5
             </td>
             <td
               class="rdtDay rdtNew"
+              data-month="4"
               data-value="6"
+              data-year="2017"
             >
               6
             </td>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
@@ -37,7 +37,7 @@
         "path-to-regexp": "^6.1.0",
         "react-circular-progressbar": "^2.0.3",
         "react-color": "^2.14.1",
-        "react-datetime": "^2.11.0",
+        "react-datetime": "^3.0.0",
         "react-dropzone": "^11.2.0",
         "react-portal": "^4.1.0",
         "react-sortable-hoc": "^2.0.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? |  yes
| Deprecations? | no 
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Upgrade react-datetime to 3.0.0. https://github.com/arqex/react-datetime/blob/master/migrateToV3.md.

There is a problem currently with the 3.0 version as it seems not to close the overlay when choosing the time: https://github.com/arqex/react-datetime/pull/741#issuecomment-825612866

#### Why?

New version provide bugfixes and new features.