### PR TITLE
Fix Permission check in PageController for the Multi Webspace Column View Overlay

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -298,7 +298,7 @@ class PageAdmin extends Admin
         $webspaceContexts = [];
         foreach ($this->webspaceManager->getWebspaceCollection() as $webspace) {
             /* @var Webspace $webspace */
-            $webspaceContexts[self::SECURITY_CONTEXT_PREFIX . $webspace->getKey()] = [
+            $webspaceContexts[self::getPageSecurityContext($webspace->getKey())] = [
                 PermissionTypes::VIEW,
                 PermissionTypes::ADD,
                 PermissionTypes::EDIT,
@@ -379,7 +379,7 @@ class PageAdmin extends Admin
     {
         foreach ($this->webspaceManager->getWebspaceCollection()->getWebspaces() as $webspace) {
             $hasWebspacePermission = $this->securityChecker->hasPermission(
-                self::SECURITY_CONTEXT_PREFIX . $webspace->getKey(),
+                self::getPageSecurityContext($webspace->getKey()),
                 PermissionTypes::EDIT
             );
 
@@ -389,5 +389,15 @@ class PageAdmin extends Admin
         }
 
         return false;
+    }
+
+    /**
+     * Returns security context for pages in given webspace.
+     *
+     * @final
+     */
+    public static function getPageSecurityContext(string $webspaceKey): string
+    {
+        return \sprintf('%s%s', self::SECURITY_CONTEXT_PREFIX, $webspaceKey);
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Controller/PageController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/PageController.php
@@ -496,7 +496,8 @@ class PageController extends AbstractRestController implements ClassResourceInte
             }
 
             if ($webspaceNodes === static::WEBSPACE_NODES_ALL) {
-                $contents = $this->getWebspaceNodes($mapping, $contents, $locale, $user);
+                $contents = $this->
+                    ($mapping, $contents, $locale, $user);
             } elseif ($webspaceNodes === static::WEBSPACE_NODE_SINGLE) {
                 $contents = $this->getWebspaceNode($mapping, $contents, $webspaceKey, $locale, $user);
             }
@@ -624,7 +625,14 @@ class PageController extends AbstractRestController implements ClassResourceInte
             if (null === $webspace->getLocalization($locale)) {
                 continue;
             }
-
+            if (
+                false === $this->securityChecker->hasPermission(
+                    new SecurityCondition('sulu.webspaces.' . $webspace->getKey(), $locale, SecurityBehavior::class),
+                    'view'
+                )
+            ) {
+                continue;
+            }
             $paths[] = $this->sessionManager->getContentPath($webspace->getKey());
             $webspaces[$webspace->getKey()] = $webspace;
         }

--- a/src/Sulu/Bundle/PageBundle/Controller/PageController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/PageController.php
@@ -496,8 +496,7 @@ class PageController extends AbstractRestController implements ClassResourceInte
             }
 
             if ($webspaceNodes === static::WEBSPACE_NODES_ALL) {
-                $contents = $this->
-                    ($mapping, $contents, $locale, $user);
+                $contents = $this->getWebspaceNodes($mapping, $contents, $locale, $user);
             } elseif ($webspaceNodes === static::WEBSPACE_NODE_SINGLE) {
                 $contents = $this->getWebspaceNode($mapping, $contents, $webspaceKey, $locale, $user);
             }

--- a/src/Sulu/Bundle/PageBundle/Controller/PageController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/PageController.php
@@ -622,15 +622,10 @@ class PageController extends AbstractRestController implements ClassResourceInte
         $webspaces = [];
         /** @var Webspace $webspace */
         foreach ($this->webspaceManager->getWebspaceCollection() as $webspace) {
-            if (null === $webspace->getLocalization($locale)) {
-                continue;
-            }
-            if (
-                false === $this->securityChecker->hasPermission(
+            if (false === $this->securityChecker->hasPermission(
                     new SecurityCondition('sulu.webspaces.' . $webspace->getKey(), $locale, SecurityBehavior::class),
                     'view'
-                )
-            ) {
+                ) || null === $webspace->getLocalization($locale)) {
                 continue;
             }
             $paths[] = $this->sessionManager->getContentPath($webspace->getKey());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes
| Related issues/PRs |
| License | MIT
| Documentation PR | sulu/sulu-docs

#### What's in this PR?

Check if the user has the right to view a webspace so as not to return the webspace trees that he cannot view

#### Why?

When a user does not have the right to "view" on a webspace he can still view the complete tree structure of a webpsace
