### PR TITLE
Duplicate phpcr permissions in database

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,16 @@
 
 ## 2.3
 
+### Change entityId field in AccessControl entity to string
+
+To allow entities with uuid's instead of auto generated ids to have object permissions,
+the `entityId` field of the `AccessControl` entity had to be changed from `integer` to `string`.
+Therefore the following sql statement needs to be executed.
+
+```sql
+ALTER TABLE se_access_controls CHANGE entityId entityId VARCHAR(36) NOT NULL;
+```
+
 ### Added resourceSecurityObjectId field to EventRecord
 
 Because a new `resourceSecurityObjectId` field has been added to the `EventRecord` entity

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,18 @@
 
 ## 2.3
 
+### Sync object permissions stored in phpcr to doctrine
+
+To enable permission checking on database level for resources with object permissions stored in phpcr,
+you need to sync these permissions into doctrine. A command is available for that:
+
+```bash
+bin/adminconsole sulu:security:sync-phpcr-permissions
+```
+
+This command needs to be executed just once when upgrading sulu to 2.3,
+in the future the permissions are being synced automatically.
+
 ### Change entityId field in AccessControl entity to string
 
 To allow entities with uuid's instead of auto generated ids to have object permissions,

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "matomo/device-detector": "^3.7 || ^4.0.1",
         "nyholm/psr7": "^1.0",
         "ocramius/proxy-manager": "^2.1",
-        "oro/doctrine-extensions": "^1.0 || ^2.0",
+        "oro/doctrine-extensions": "^1.0.3 || ^2.0",
         "pagerfanta/pagerfanta": "^1.0.4 || ^2.0",
         "ramsey/uuid": "^3.1 || ^4.0",
         "swiftmailer/swiftmailer": "^6.1.3",

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "matomo/device-detector": "^3.7 || ^4.0.1",
         "nyholm/psr7": "^1.0",
         "ocramius/proxy-manager": "^2.1",
-        "oro/doctrine-extensions": "^1.0.3 || ^2.0",
+        "oro/doctrine-extensions": "^1.0.8 || ^2.0",
         "pagerfanta/pagerfanta": "^1.0.4 || ^2.0",
         "ramsey/uuid": "^3.1 || ^4.0",
         "swiftmailer/swiftmailer": "^6.1.3",

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\CoreBundle\DependencyInjection;
 
+use Oro\ORM\Query\AST\Functions\Cast;
 use Oro\ORM\Query\AST\Functions\String\GroupConcat;
 use Sulu\Bundle\ContactBundle\Entity\Account;
 use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
@@ -19,7 +20,6 @@ use Sulu\Bundle\MediaBundle\Entity\CollectionInterface;
 use Sulu\Component\Content\Types\Block\BlockVisitorInterface;
 use Sulu\Component\HttpKernel\SuluKernel;
 use Sulu\Component\Rest\Csv\ObjectNotSupportedException;
-use Sulu\Component\Rest\DQL\Cast;
 use Sulu\Component\Rest\Exception\InvalidHashException;
 use Sulu\Component\Rest\Exception\MissingParameterException;
 use Sulu\Component\Rest\ListBuilder\Filter\InvalidFilterTypeOptionsException;

--- a/src/Sulu/Bundle/MediaBundle/Entity/FileVersionMetaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/FileVersionMetaRepository.php
@@ -33,7 +33,7 @@ class FileVersionMetaRepository extends EntityRepository implements FileVersionM
                 'accessControl',
                 'WITH',
                 'accessControl.entityClass = :entityClass '
-                . 'AND accessControl.entityId = CAST(collection.id AS VARCHAR)'
+                . 'AND accessControl.entityId = CAST(collection.id AS CHAR(36))'
             )
             ->where('file.version = fileVersion.version')
             ->andWhere('accessControl.id is null');
@@ -61,7 +61,7 @@ class FileVersionMetaRepository extends EntityRepository implements FileVersionM
                 'accessControl',
                 'WITH',
                 'accessControl.entityClass = :entityClass '
-                . 'AND accessControl.entityId = CAST(collection.id AS VARCHAR)'
+                . 'AND accessControl.entityId = CAST(collection.id AS CHAR(36))'
             )
             ->where('file.version = fileVersion.version')
             ->andWhere('accessControl.id is null')

--- a/src/Sulu/Bundle/MediaBundle/Entity/FileVersionMetaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/FileVersionMetaRepository.php
@@ -33,7 +33,7 @@ class FileVersionMetaRepository extends EntityRepository implements FileVersionM
                 'accessControl',
                 'WITH',
                 'accessControl.entityClass = :entityClass '
-                . 'AND accessControl.entityId = CAST(collection.id AS CHAR(36))'
+                . 'AND accessControl.entityId = CAST(collection.id AS STRING)'
             )
             ->where('file.version = fileVersion.version')
             ->andWhere('accessControl.id is null');
@@ -61,7 +61,7 @@ class FileVersionMetaRepository extends EntityRepository implements FileVersionM
                 'accessControl',
                 'WITH',
                 'accessControl.entityClass = :entityClass '
-                . 'AND accessControl.entityId = CAST(collection.id AS CHAR(36))'
+                . 'AND accessControl.entityId = CAST(collection.id AS STRING)'
             )
             ->where('file.version = fileVersion.version')
             ->andWhere('accessControl.id is null')

--- a/src/Sulu/Bundle/MediaBundle/Entity/FileVersionMetaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/FileVersionMetaRepository.php
@@ -33,7 +33,7 @@ class FileVersionMetaRepository extends EntityRepository implements FileVersionM
                 'accessControl',
                 'WITH',
                 'accessControl.entityClass = :entityClass '
-                . 'AND accessControl.entityId = CAST(collection.id AS STRING)'
+                . 'AND CAST(accessControl.entityId AS STRING) = CAST(collection.id AS STRING)'
             )
             ->where('file.version = fileVersion.version')
             ->andWhere('accessControl.id is null');
@@ -61,7 +61,7 @@ class FileVersionMetaRepository extends EntityRepository implements FileVersionM
                 'accessControl',
                 'WITH',
                 'accessControl.entityClass = :entityClass '
-                . 'AND accessControl.entityId = CAST(collection.id AS STRING)'
+                . 'AND CAST(accessControl.entityId AS STRING) = CAST(collection.id AS STRING)'
             )
             ->where('file.version = fileVersion.version')
             ->andWhere('accessControl.id is null')

--- a/src/Sulu/Bundle/MediaBundle/Entity/FileVersionMetaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/FileVersionMetaRepository.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\MediaBundle\Entity;
 
 use Doctrine\ORM\EntityRepository;
-use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Sulu\Bundle\SecurityBundle\Entity\AccessControl;
 
@@ -20,11 +19,6 @@ class FileVersionMetaRepository extends EntityRepository implements FileVersionM
 {
     public function findLatestWithoutSecurity()
     {
-        $entityIdCondition = 'accessControl.entityId = collection.id';
-        if ('postgresql' === $this->getDatabasePlatformName()) {
-            $entityIdCondition = 'accessControl.entityId = CAST(collection.id AS VARCHAR)';
-        }
-
         $queryBuilder = $this->createQueryBuilder('fileVersionMeta')
             ->addSelect('fileVersion')
             ->addSelect('file')
@@ -39,7 +33,7 @@ class FileVersionMetaRepository extends EntityRepository implements FileVersionM
                 'accessControl',
                 'WITH',
                 'accessControl.entityClass = :entityClass '
-                . 'AND ' . $entityIdCondition
+                . 'AND accessControl.entityId = CAST(collection.id AS VARCHAR)'
             )
             ->where('file.version = fileVersion.version')
             ->andWhere('accessControl.id is null');
@@ -54,11 +48,6 @@ class FileVersionMetaRepository extends EntityRepository implements FileVersionM
      */
     public function getQueryBuilderWithoutSecurity(QueryBuilder $queryBuilder)
     {
-        $entityIdCondition = 'accessControl.entityId = collection.id';
-        if ('postgresql' === $this->getDatabasePlatformName()) {
-            $entityIdCondition = 'accessControl.entityId = CAST(collection.id AS VARCHAR)';
-        }
-
         $queryBuilder->addSelect('fileVersion')
             ->addSelect('file')
             ->addSelect('media')
@@ -72,7 +61,7 @@ class FileVersionMetaRepository extends EntityRepository implements FileVersionM
                 'accessControl',
                 'WITH',
                 'accessControl.entityClass = :entityClass '
-                . 'AND ' . $entityIdCondition
+                . 'AND accessControl.entityId = CAST(collection.id AS VARCHAR)'
             )
             ->where('file.version = fileVersion.version')
             ->andWhere('accessControl.id is null')
@@ -93,10 +82,5 @@ class FileVersionMetaRepository extends EntityRepository implements FileVersionM
         $queryBuilder->setParameter('collectionId', $collectionId);
 
         return $queryBuilder->getQuery()->getResult();
-    }
-
-    private function getDatabasePlatformName(): string
-    {
-        return $this->_em->getConnection()->getDatabasePlatform()->getName();
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
+++ b/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
@@ -48,7 +48,7 @@ class AccessControlQueryEnhancer
             $user,
             $permission,
             'accessControl.entityClass = :entityClass',
-            'accessControl.entityId = CAST(' . $entityAlias . '.id AS CHAR(36))'
+            'accessControl.entityId = CAST(' . $entityAlias . '.id AS STRING)'
         );
 
         $queryBuilder->setParameter('entityClass', $entityClass);
@@ -67,7 +67,7 @@ class AccessControlQueryEnhancer
             $user,
             $permission,
             'accessControl.entityClass = ' . $entityAlias . '.' . $entityClassField,
-            'accessControl.entityId = CAST(' . $entityAlias . '.' . $entityIdField . ' AS CHAR(36))'
+            'accessControl.entityId = CAST(' . $entityAlias . '.' . $entityIdField . ' AS STRING)'
         );
     }
 

--- a/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
+++ b/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
@@ -48,7 +48,7 @@ class AccessControlQueryEnhancer
             $user,
             $permission,
             'accessControl.entityClass = :entityClass',
-            'accessControl.entityId = ' . $entityAlias . '.id'
+            'accessControl.entityId = CAST(' . $entityAlias . '.id AS VARCHAR)'
         );
 
         $queryBuilder->setParameter('entityClass', $entityClass);
@@ -67,7 +67,7 @@ class AccessControlQueryEnhancer
             $user,
             $permission,
             'accessControl.entityClass = ' . $entityAlias . '.' . $entityClassField,
-            'accessControl.entityId = ' . $entityAlias . '.' . $entityIdField
+            'accessControl.entityId = CAST(' . $entityAlias . '.' . $entityIdField . ' AS VARCHAR)'
         );
     }
 

--- a/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
+++ b/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
@@ -48,7 +48,7 @@ class AccessControlQueryEnhancer
             $user,
             $permission,
             'accessControl.entityClass = :entityClass',
-            'accessControl.entityId = CAST(' . $entityAlias . '.id AS VARCHAR)'
+            'accessControl.entityId = CAST(' . $entityAlias . '.id AS CHAR(36))'
         );
 
         $queryBuilder->setParameter('entityClass', $entityClass);
@@ -67,7 +67,7 @@ class AccessControlQueryEnhancer
             $user,
             $permission,
             'accessControl.entityClass = ' . $entityAlias . '.' . $entityClassField,
-            'accessControl.entityId = CAST(' . $entityAlias . '.' . $entityIdField . ' AS VARCHAR)'
+            'accessControl.entityId = CAST(' . $entityAlias . '.' . $entityIdField . ' AS CHAR(36))'
         );
     }
 

--- a/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
+++ b/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
@@ -48,7 +48,7 @@ class AccessControlQueryEnhancer
             $user,
             $permission,
             'accessControl.entityClass = :entityClass',
-            'accessControl.entityId = CAST(' . $entityAlias . '.id AS STRING)'
+            'CAST(accessControl.entityId AS STRING) = CAST(' . $entityAlias . '.id AS STRING)'
         );
 
         $queryBuilder->setParameter('entityClass', $entityClass);
@@ -67,7 +67,7 @@ class AccessControlQueryEnhancer
             $user,
             $permission,
             'accessControl.entityClass = ' . $entityAlias . '.' . $entityClassField,
-            'accessControl.entityId = CAST(' . $entityAlias . '.' . $entityIdField . ' AS STRING)'
+            'CAST(accessControl.entityId AS STRING) = CAST(' . $entityAlias . '.' . $entityIdField . ' AS STRING)'
         );
     }
 

--- a/src/Sulu/Bundle/SecurityBundle/Command/SyncPhpcrPermissionsCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/SyncPhpcrPermissionsCommand.php
@@ -57,7 +57,7 @@ class SyncPhpcrPermissionsCommand extends Command
 
     public function configure(): void
     {
-        $this->setDescription('Sync object permissions from phpcr into database');
+        $this->setDescription('Sync existing object permissions from phpcr into database to make them usable in database queries');
         $this->setHelp(
             'The <info>%command.name%</info> command syncs the object permissions of phpcr documents into the database.'
         );

--- a/src/Sulu/Bundle/SecurityBundle/Command/SyncPhpcrPermissionsCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/SyncPhpcrPermissionsCommand.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
+use Sulu\Component\Content\Document\Subscriber\SecuritySubscriber;
+use Sulu\Component\DocumentManager\Behavior\Mapping\UuidBehavior;
+use Sulu\Component\DocumentManager\Collection\QueryResultCollection;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Sulu\Component\Security\Authentication\RoleInterface;
+use Sulu\Component\Security\Authorization\AccessControl\DoctrineAccessControlProvider;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class SyncPhpcrPermissionsCommand extends Command
+{
+    protected static $defaultName = 'sulu:security:sync-phpcr-permissions';
+
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
+     * @var DocumentManagerInterface
+     */
+    private $documentManager;
+
+    /**
+     * @var DoctrineAccessControlProvider
+     */
+    private $doctrineAccessControlProvider;
+
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        DocumentManagerInterface $documentManager,
+        DoctrineAccessControlProvider $doctrineAccessControlProvider
+    ) {
+        $this->entityManager = $entityManager;
+        $this->documentManager = $documentManager;
+        $this->doctrineAccessControlProvider = $doctrineAccessControlProvider;
+
+        parent::__construct();
+    }
+
+    public function configure(): void
+    {
+        $this->setDescription('Sync object permissions from phpcr into database');
+        $this->setHelp(
+            'The <info>%command.name%</info> command syncs the object permissions of phpcr documents into the database.'
+        );
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $roleIds = $this->getRoleIds();
+
+        if (0 === \count($roleIds)) {
+            $io->success('Nothing to do');
+
+            return 0;
+        }
+
+        $documents = $this->findDocuments($roleIds);
+        $amountDocuments = $documents->count();
+
+        if (0 === $amountDocuments) {
+            $io->success('Nothing to do');
+
+            return 0;
+        }
+
+        $io->progressStart($amountDocuments);
+
+        $count = 0;
+        foreach ($documents as $document) {
+            $io->progressAdvance();
+
+            if (!$document instanceof SecurityBehavior || !$document instanceof UuidBehavior) {
+                continue;
+            }
+
+            $this->doctrineAccessControlProvider->setPermissions(
+                SecurityBehavior::class,
+                $document->getUuid(),
+                $document->getPermissions()
+            );
+
+            ++$count;
+        }
+
+        $io->progressFinish();
+
+        $io->success(\sprintf('Successfully synced %d documents', $count));
+
+        return 0;
+    }
+
+    /**
+     * @return int[]
+     */
+    private function getRoleIds(): array
+    {
+        $result = $this->entityManager->createQueryBuilder()
+            ->select('role.id')
+            ->from(RoleInterface::class, 'role')
+            ->getQuery()
+            ->getArrayResult();
+
+        return \array_column($result, 'id');
+    }
+
+    /**
+     * Find documents with permissions for at least one of the role ids.
+     *
+     * @param int[] $roleIds
+     *
+     * @return QueryResultCollection<object>
+     */
+    protected function findDocuments(array $roleIds): QueryResultCollection
+    {
+        $roleIdsConstraint = \implode(' OR ', \array_map(function($roleId) {
+            return \sprintf('[%s%s] IS NOT NULL', SecuritySubscriber::SECURITY_PROPERTY_PREFIX, $roleId);
+        }, $roleIds));
+
+        $sql2 = \sprintf(
+            'SELECT * FROM [nt:unstructured] AS a WHERE (%s)',
+            $roleIdsConstraint
+        );
+
+        return $this->documentManager->createQuery($sql2)->execute();
+    }
+}

--- a/src/Sulu/Bundle/SecurityBundle/Entity/AccessControl.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/AccessControl.php
@@ -38,7 +38,7 @@ class AccessControl implements AccessControlInterface
     /**
      * The id of the model this access control rule applies to.
      *
-     * @var int
+     * @var string
      */
     private $entityId;
 
@@ -76,12 +76,16 @@ class AccessControl implements AccessControlInterface
 
     public function getEntityId()
     {
+        if (\is_numeric($this->entityId)) {
+            return (int) $this->entityId;
+        }
+
         return $this->entityId;
     }
 
     public function setEntityId($entityId)
     {
-        $this->entityId = $entityId;
+        $this->entityId = (string) $entityId;
     }
 
     public function getEntityClass()

--- a/src/Sulu/Bundle/SecurityBundle/EventListener/PhpcrSecuritySubscriber.php
+++ b/src/Sulu/Bundle/SecurityBundle/EventListener/PhpcrSecuritySubscriber.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\EventListener;
+
+use Sulu\Component\Security\Authorization\AccessControl\DoctrineAccessControlProvider;
+use Sulu\Component\Security\Authorization\AccessControl\PhpcrAccessControlProvider;
+use Sulu\Component\Security\Event\PermissionUpdateEvent;
+use Sulu\Component\Security\Event\SecurityEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class PhpcrSecuritySubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var PhpcrAccessControlProvider
+     */
+    private $phpcrAccessControlProvider;
+
+    /**
+     * @var DoctrineAccessControlProvider
+     */
+    private $doctrineAccessControlProvider;
+
+    public function __construct(
+        PhpcrAccessControlProvider $phpcrAccessControlProvider,
+        DoctrineAccessControlProvider $doctrineAccessControlProvider
+    ) {
+        $this->phpcrAccessControlProvider = $phpcrAccessControlProvider;
+        $this->doctrineAccessControlProvider = $doctrineAccessControlProvider;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            SecurityEvents::PERMISSION_UPDATE => 'handlePermissionUpdate',
+        ];
+    }
+
+    public function handlePermissionUpdate(PermissionUpdateEvent $event): void
+    {
+        $type = $event->getType();
+        $identifier = $event->getIdentifier();
+        $permissions = $event->getPermissions();
+
+        if (!$this->phpcrAccessControlProvider->supports($type)) {
+            return;
+        }
+
+        $this->doctrineAccessControlProvider->setPermissions($type, $identifier, $permissions);
+    }
+}

--- a/src/Sulu/Bundle/SecurityBundle/EventListener/PhpcrSecuritySubscriber.php
+++ b/src/Sulu/Bundle/SecurityBundle/EventListener/PhpcrSecuritySubscriber.php
@@ -57,6 +57,7 @@ class PhpcrSecuritySubscriber implements EventSubscriberInterface
             return;
         }
 
+        // sync permissions stored in phpcr to doctrine to make them usable in doctrine queries and the list builder
         $this->doctrineAccessControlProvider->setPermissions($type, $identifier, $permissions);
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/command.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/command.xml
@@ -34,5 +34,14 @@
             <tag name="console.command" />
             <tag name="sulu.context" context="admin"/>
         </service>
+
+        <service id="sulu_security.command.sync_phpcr_permissions"
+                 class="Sulu\Bundle\SecurityBundle\Command\SyncPhpcrPermissionsCommand">
+            <argument type="service" id="doctrine.orm.default_entity_manager"/>
+            <argument type="service" id="sulu_document_manager.document_manager"/>
+            <argument type="service" id="sulu_security.doctrine_access_control_provider"/>
+            <tag name="console.command"/>
+            <tag name="sulu.context" context="admin"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/AccessControl.orm.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/AccessControl.orm.xml
@@ -13,7 +13,7 @@
         </id>
 
         <field name="permissions" type="smallint" column="permissions"/>
-        <field name="entityId" type="integer" column="entityId"/>
+        <field name="entityId" type="string" column="entityId" length="36"/>
         <field name="entityClass" type="string" column="entityClass" length="191"/>
 
         <many-to-one field="role" target-entity="Sulu\Component\Security\Authentication\RoleInterface">

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -332,5 +332,12 @@
             <argument type="service" id="sulu_security.access_control_manager" />
             <tag name="doctrine.event_subscriber"/>
         </service>
+
+        <service id="sulu_security.phpcr_security_subscriber" class="Sulu\Bundle\SecurityBundle\EventListener\PhpcrSecuritySubscriber">
+            <argument type="service" id="sulu_security.phpcr_access_control_provider" />
+            <argument type="service" id="sulu_security.doctrine_access_control_provider" />
+
+            <tag name="kernel.event_subscriber"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Component/Rest/DQL/Cast.php
+++ b/src/Sulu/Component/Rest/DQL/Cast.php
@@ -14,6 +14,10 @@ namespace Sulu\Component\Rest\DQL;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\Lexer;
 
+/**
+ * @deprecated
+ * @see \Oro\ORM\Query\AST\Functions\Cast
+ */
 class Cast extends FunctionNode
 {
     public $firstDateExpression = null;

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -1188,7 +1188,7 @@ class DoctrineListBuilderTest extends TestCase
             AccessControl::class,
             'accessControl',
             'WITH',
-            'accessControl.entityClass = :entityClass AND accessControl.entityId = CAST(SuluCoreBundle_Example.id AS CHAR(36)) AND accessControl.role IN (SELECT id)'
+            'accessControl.entityClass = :entityClass AND accessControl.entityId = CAST(SuluCoreBundle_Example.id AS STRING) AND accessControl.role IN (SELECT id)'
         )->shouldBeCalled();
         $this->queryBuilder->leftJoin('accessControl.role', 'role')->shouldBeCalled();
         $this->queryBuilder->andWhere(
@@ -1233,7 +1233,7 @@ class DoctrineListBuilderTest extends TestCase
             AccessControl::class,
             'accessControl',
             'WITH',
-            'accessControl.entityClass = :entityClass AND accessControl.entityId = CAST(stdClass.id AS CHAR(36)) AND accessControl.role IN (SELECT id)'
+            'accessControl.entityClass = :entityClass AND accessControl.entityId = CAST(stdClass.id AS STRING) AND accessControl.role IN (SELECT id)'
         )->shouldBeCalled();
         $this->queryBuilder->leftJoin('accessControl.role', 'role')->shouldBeCalled();
         $this->queryBuilder->andWhere(
@@ -1285,7 +1285,7 @@ class DoctrineListBuilderTest extends TestCase
             AccessControl::class,
             'accessControl',
             'WITH',
-            'accessControl.entityClass = :entityClass AND accessControl.entityId = CAST(stdClass.id AS CHAR(36)) AND accessControl.role IN (SELECT id)'
+            'accessControl.entityClass = :entityClass AND accessControl.entityId = CAST(stdClass.id AS STRING) AND accessControl.role IN (SELECT id)'
         )->shouldBeCalled();
         $this->queryBuilder->leftJoin('accessControl.role', 'role')->shouldBeCalled();
         $this->queryBuilder->andWhere(

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -1188,7 +1188,7 @@ class DoctrineListBuilderTest extends TestCase
             AccessControl::class,
             'accessControl',
             'WITH',
-            'accessControl.entityClass = :entityClass AND accessControl.entityId = CAST(SuluCoreBundle_Example.id AS STRING) AND accessControl.role IN (SELECT id)'
+            'accessControl.entityClass = :entityClass AND CAST(accessControl.entityId AS STRING) = CAST(SuluCoreBundle_Example.id AS STRING) AND accessControl.role IN (SELECT id)'
         )->shouldBeCalled();
         $this->queryBuilder->leftJoin('accessControl.role', 'role')->shouldBeCalled();
         $this->queryBuilder->andWhere(
@@ -1233,7 +1233,7 @@ class DoctrineListBuilderTest extends TestCase
             AccessControl::class,
             'accessControl',
             'WITH',
-            'accessControl.entityClass = :entityClass AND accessControl.entityId = CAST(stdClass.id AS STRING) AND accessControl.role IN (SELECT id)'
+            'accessControl.entityClass = :entityClass AND CAST(accessControl.entityId AS STRING) = CAST(stdClass.id AS STRING) AND accessControl.role IN (SELECT id)'
         )->shouldBeCalled();
         $this->queryBuilder->leftJoin('accessControl.role', 'role')->shouldBeCalled();
         $this->queryBuilder->andWhere(
@@ -1285,7 +1285,7 @@ class DoctrineListBuilderTest extends TestCase
             AccessControl::class,
             'accessControl',
             'WITH',
-            'accessControl.entityClass = :entityClass AND accessControl.entityId = CAST(stdClass.id AS STRING) AND accessControl.role IN (SELECT id)'
+            'accessControl.entityClass = :entityClass AND CAST(accessControl.entityId AS STRING) = CAST(stdClass.id AS STRING) AND accessControl.role IN (SELECT id)'
         )->shouldBeCalled();
         $this->queryBuilder->leftJoin('accessControl.role', 'role')->shouldBeCalled();
         $this->queryBuilder->andWhere(

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -1188,7 +1188,7 @@ class DoctrineListBuilderTest extends TestCase
             AccessControl::class,
             'accessControl',
             'WITH',
-            'accessControl.entityClass = :entityClass AND accessControl.entityId = CAST(SuluCoreBundle_Example.id AS VARCHAR) AND accessControl.role IN (SELECT id)'
+            'accessControl.entityClass = :entityClass AND accessControl.entityId = CAST(SuluCoreBundle_Example.id AS CHAR(36)) AND accessControl.role IN (SELECT id)'
         )->shouldBeCalled();
         $this->queryBuilder->leftJoin('accessControl.role', 'role')->shouldBeCalled();
         $this->queryBuilder->andWhere(
@@ -1233,7 +1233,7 @@ class DoctrineListBuilderTest extends TestCase
             AccessControl::class,
             'accessControl',
             'WITH',
-            'accessControl.entityClass = :entityClass AND accessControl.entityId = CAST(stdClass.id AS VARCHAR) AND accessControl.role IN (SELECT id)'
+            'accessControl.entityClass = :entityClass AND accessControl.entityId = CAST(stdClass.id AS CHAR(36)) AND accessControl.role IN (SELECT id)'
         )->shouldBeCalled();
         $this->queryBuilder->leftJoin('accessControl.role', 'role')->shouldBeCalled();
         $this->queryBuilder->andWhere(
@@ -1285,7 +1285,7 @@ class DoctrineListBuilderTest extends TestCase
             AccessControl::class,
             'accessControl',
             'WITH',
-            'accessControl.entityClass = :entityClass AND accessControl.entityId = CAST(stdClass.id AS VARCHAR) AND accessControl.role IN (SELECT id)'
+            'accessControl.entityClass = :entityClass AND accessControl.entityId = CAST(stdClass.id AS CHAR(36)) AND accessControl.role IN (SELECT id)'
         )->shouldBeCalled();
         $this->queryBuilder->leftJoin('accessControl.role', 'role')->shouldBeCalled();
         $this->queryBuilder->andWhere(

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Component\Rest\Tests\Unit\ListBuilder\Doctrine;
 
-use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Query\Expr\Select;
@@ -113,14 +111,6 @@ class DoctrineListBuilderTest extends TestCase
         $this->systemRoleQueryBuilder = $this->prophesize(QueryBuilder::class);
         $this->queryBuilder = $this->prophesize(QueryBuilder::class);
         $this->query = $this->prophesize(AbstractQuery::class);
-
-        /** @var Connection|ObjectProphecy $connection */
-        $connection = $this->prophesize(Connection::class);
-        /** @var AbstractPlatform|ObjectProphecy $databasePlatform */
-        $databasePlatform = $this->prophesize(AbstractPlatform::class);
-        $databasePlatform->getName()->willReturn('mysql');
-        $connection->getDatabasePlatform()->willReturn($databasePlatform->reveal());
-        $this->entityManager->getConnection()->willReturn($connection->reveal());
 
         $this->entityManager->createQueryBuilder()->willReturn($this->queryBuilder->reveal());
 
@@ -1198,7 +1188,7 @@ class DoctrineListBuilderTest extends TestCase
             AccessControl::class,
             'accessControl',
             'WITH',
-            'accessControl.entityClass = :entityClass AND accessControl.entityId = SuluCoreBundle_Example.id AND accessControl.role IN (SELECT id)'
+            'accessControl.entityClass = :entityClass AND accessControl.entityId = CAST(SuluCoreBundle_Example.id AS VARCHAR) AND accessControl.role IN (SELECT id)'
         )->shouldBeCalled();
         $this->queryBuilder->leftJoin('accessControl.role', 'role')->shouldBeCalled();
         $this->queryBuilder->andWhere(
@@ -1243,7 +1233,7 @@ class DoctrineListBuilderTest extends TestCase
             AccessControl::class,
             'accessControl',
             'WITH',
-            'accessControl.entityClass = :entityClass AND accessControl.entityId = stdClass.id AND accessControl.role IN (SELECT id)'
+            'accessControl.entityClass = :entityClass AND accessControl.entityId = CAST(stdClass.id AS VARCHAR) AND accessControl.role IN (SELECT id)'
         )->shouldBeCalled();
         $this->queryBuilder->leftJoin('accessControl.role', 'role')->shouldBeCalled();
         $this->queryBuilder->andWhere(
@@ -1295,7 +1285,7 @@ class DoctrineListBuilderTest extends TestCase
             AccessControl::class,
             'accessControl',
             'WITH',
-            'accessControl.entityClass = :entityClass AND accessControl.entityId = stdClass.id AND accessControl.role IN (SELECT id)'
+            'accessControl.entityClass = :entityClass AND accessControl.entityId = CAST(stdClass.id AS VARCHAR) AND accessControl.role IN (SELECT id)'
         )->shouldBeCalled();
         $this->queryBuilder->leftJoin('accessControl.role', 'role')->shouldBeCalled();
         $this->queryBuilder->andWhere(

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -11,6 +11,8 @@
 
 namespace Sulu\Component\Rest\Tests\Unit\ListBuilder\Doctrine;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Query\Expr\Select;
@@ -111,6 +113,14 @@ class DoctrineListBuilderTest extends TestCase
         $this->systemRoleQueryBuilder = $this->prophesize(QueryBuilder::class);
         $this->queryBuilder = $this->prophesize(QueryBuilder::class);
         $this->query = $this->prophesize(AbstractQuery::class);
+
+        /** @var Connection|ObjectProphecy $connection */
+        $connection = $this->prophesize(Connection::class);
+        /** @var AbstractPlatform|ObjectProphecy $databasePlatform */
+        $databasePlatform = $this->prophesize(AbstractPlatform::class);
+        $databasePlatform->getName()->willReturn('mysql');
+        $connection->getDatabasePlatform()->willReturn($databasePlatform->reveal());
+        $this->entityManager->getConnection()->willReturn($connection->reveal());
 
         $this->entityManager->createQueryBuilder()->willReturn($this->queryBuilder->reveal());
 

--- a/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlInterface.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlInterface.php
@@ -44,12 +44,12 @@ interface AccessControlInterface
     public function setPermissions($permissions);
 
     /**
-     * @return int
+     * @return string|int
      */
     public function getEntityId();
 
     /**
-     * @param int $entityId
+     * @param string|int $entityId
      */
     public function setEntityId($entityId);
 

--- a/src/Sulu/Component/Security/Authorization/AccessControl/SecuredEntityRepositoryTrait.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/SecuredEntityRepositoryTrait.php
@@ -53,7 +53,7 @@ trait SecuredEntityRepositoryTrait
             'accessControl',
             'WITH',
             'accessControl.entityClass = :entityClass '
-            . 'AND accessControl.entityId = CAST(' . $entityAlias . '.id AS VARCHAR)'
+            . 'AND accessControl.entityId = CAST(' . $entityAlias . '.id AS CHAR(36))'
         );
         $queryBuilder->leftJoin('accessControl.role', 'role');
         $queryBuilder->andWhere(

--- a/src/Sulu/Component/Security/Authorization/AccessControl/SecuredEntityRepositoryTrait.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/SecuredEntityRepositoryTrait.php
@@ -53,7 +53,7 @@ trait SecuredEntityRepositoryTrait
             'accessControl',
             'WITH',
             'accessControl.entityClass = :entityClass '
-            . 'AND accessControl.entityId = CAST(' . $entityAlias . '.id AS CHAR(36))'
+            . 'AND accessControl.entityId = CAST(' . $entityAlias . '.id AS STRING)'
         );
         $queryBuilder->leftJoin('accessControl.role', 'role');
         $queryBuilder->andWhere(

--- a/src/Sulu/Component/Security/Authorization/AccessControl/SecuredEntityRepositoryTrait.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/SecuredEntityRepositoryTrait.php
@@ -48,17 +48,12 @@ trait SecuredEntityRepositoryTrait
             \E_USER_DEPRECATED
         );
 
-        $entityIdCondition = 'accessControl.entityId = ' . $entityAlias . '.id';
-        if ('postgresql' === $this->getDatabasePlatformName($queryBuilder)) {
-            $entityIdCondition = 'accessControl.entityId = CAST(' . $entityAlias . '.id AS VARCHAR)';
-        }
-
         $queryBuilder->leftJoin(
             AccessControl::class,
             'accessControl',
             'WITH',
             'accessControl.entityClass = :entityClass '
-            . 'AND ' . $entityIdCondition
+            . 'AND accessControl.entityId = CAST(' . $entityAlias . '.id AS VARCHAR)'
         );
         $queryBuilder->leftJoin('accessControl.role', 'role');
         $queryBuilder->andWhere(
@@ -74,10 +69,5 @@ trait SecuredEntityRepositoryTrait
         $queryBuilder->setParameter('roleIds', $roleIds);
         $queryBuilder->setParameter('entityClass', $entityClass);
         $queryBuilder->setParameter('permission', $permission);
-    }
-
-    private function getDatabasePlatformName(QueryBuilder $queryBuilder): string
-    {
-        return $queryBuilder->getEntityManager()->getConnection()->getDatabasePlatform()->getName();
     }
 }

--- a/src/Sulu/Component/Security/Authorization/AccessControl/SecuredEntityRepositoryTrait.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/SecuredEntityRepositoryTrait.php
@@ -53,7 +53,7 @@ trait SecuredEntityRepositoryTrait
             'accessControl',
             'WITH',
             'accessControl.entityClass = :entityClass '
-            . 'AND accessControl.entityId = CAST(' . $entityAlias . '.id AS STRING)'
+            . 'AND CAST(accessControl.entityId AS STRING) = CAST(' . $entityAlias . '.id AS STRING)'
         );
         $queryBuilder->leftJoin('accessControl.role', 'role');
         $queryBuilder->andWhere(

--- a/src/Sulu/Component/Security/Authorization/AccessControl/SecuredEntityRepositoryTrait.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/SecuredEntityRepositoryTrait.php
@@ -48,11 +48,17 @@ trait SecuredEntityRepositoryTrait
             \E_USER_DEPRECATED
         );
 
+        $entityIdCondition = 'accessControl.entityId = ' . $entityAlias . '.id';
+        if ('postgresql' === $this->getDatabasePlatformName($queryBuilder)) {
+            $entityIdCondition = 'accessControl.entityId = CAST(' . $entityAlias . '.id AS VARCHAR)';
+        }
+
         $queryBuilder->leftJoin(
             AccessControl::class,
             'accessControl',
             'WITH',
-            'accessControl.entityClass = :entityClass AND accessControl.entityId = ' . $entityAlias . '.id'
+            'accessControl.entityClass = :entityClass '
+            . 'AND ' . $entityIdCondition
         );
         $queryBuilder->leftJoin('accessControl.role', 'role');
         $queryBuilder->andWhere(
@@ -68,5 +74,10 @@ trait SecuredEntityRepositoryTrait
         $queryBuilder->setParameter('roleIds', $roleIds);
         $queryBuilder->setParameter('entityClass', $entityClass);
         $queryBuilder->setParameter('permission', $permission);
+    }
+
+    private function getDatabasePlatformName(QueryBuilder $queryBuilder): string
+    {
+        return $queryBuilder->getEntityManager()->getConnection()->getDatabasePlatform()->getName();
     }
 }

--- a/src/Sulu/Component/Security/Event/PermissionUpdateEvent.php
+++ b/src/Sulu/Component/Security/Event/PermissionUpdateEvent.php
@@ -29,20 +29,20 @@ class PermissionUpdateEvent extends Event
     private $identifier;
 
     /**
-     * @var string
+     * @var mixed[]
      */
-    private $securityIdentity;
+    private $permissions;
 
     /**
      * @param string $type
      * @param string $identifier
-     * @param string $securityIdentity
+     * @param mixed[] $permissions
      */
-    public function __construct($type, $identifier, $securityIdentity)
+    public function __construct($type, $identifier, $permissions)
     {
         $this->type = $type;
         $this->identifier = $identifier;
-        $this->securityIdentity = $securityIdentity;
+        $this->permissions = $permissions;
     }
 
     /**
@@ -66,12 +66,23 @@ class PermissionUpdateEvent extends Event
     }
 
     /**
+     * @deprecated
+     * @see PermissionUpdateEvent::getPermissions()
+     *
      * Returns the security identifier for which the permissions have been updated.
      *
-     * @return string
+     * @return mixed[]
      */
     public function getSecurityIdentity()
     {
-        return $this->securityIdentity;
+        return $this->permissions;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getPermissions()
+    {
+        return $this->permissions;
     }
 }

--- a/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/DoctrineAccessControlProviderTest.php
+++ b/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/DoctrineAccessControlProviderTest.php
@@ -76,13 +76,13 @@ class DoctrineAccessControlProviderTest extends TestCase
 
         $accessControl1 = new AccessControl();
         $accessControl1->setEntityClass('AcmeBundle\Example');
-        $accessControl1->setEntityId(1);
+        $accessControl1->setEntityId('1');
         $accessControl1->setPermissions(64);
         $accessControl1->setRole($role1->reveal());
 
         $accessControl2 = new AccessControl();
         $accessControl2->setEntityClass('AcmeBundle\Example');
-        $accessControl2->setEntityId(1);
+        $accessControl2->setEntityId('1');
         $accessControl2->setPermissions(96);
         $accessControl2->setRole($role2->reveal());
 
@@ -117,13 +117,13 @@ class DoctrineAccessControlProviderTest extends TestCase
 
         $accessControl1 = new AccessControl();
         $accessControl1->setEntityClass('AcmeBundle\Example');
-        $accessControl1->setEntityId(1);
+        $accessControl1->setEntityId('1');
         $accessControl1->setPermissions(64);
         $accessControl1->setRole($role1->reveal());
 
         $accessControl2 = new AccessControl();
         $accessControl2->setEntityClass('AcmeBundle\Example');
-        $accessControl2->setEntityId(1);
+        $accessControl2->setEntityId('1');
         $accessControl2->setPermissions(96);
         $accessControl2->setRole($role2->reveal());
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

This pull request automatically duplicates object permissions of phpcr documents into the `AccessControl` entity.

#### Why?

To be able to filter on permissions for pages using the `DoctrineListBuilder`
