### PR TITLE
Add entity_class and route_schema param to route field type

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
@@ -126,6 +126,14 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
             },
             formInspector,
             onChange,
+            schemaOptions: {
+                entity_class: {
+                    value: entityClass,
+                } = {},
+                route_schema: {
+                    value: routeSchema,
+                } = {},
+            } = {},
         } = this.props;
 
         const requestOptions = {...formInspector.options};
@@ -147,6 +155,8 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
                 resourceKey: formInspector.resourceKey,
                 locale: formInspector.locale ? formInspector.locale.get() : userStore.contentLocale,
                 id: formInspector.id,
+                entityClass,
+                routeSchema,
                 ...requestOptions,
             }
         ).then(action((response) => {
@@ -196,6 +206,11 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
             dataPath,
             disabled,
             formInspector,
+            schemaOptions: {
+                entity_class: {
+                    value: entityClass,
+                } = {},
+            } = {},
             value,
         } = this.props;
 
@@ -230,6 +245,7 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
                             locale: formInspector.locale ? formInspector.locale.get() : userStore.contentLocale,
                             resourceKey: formInspector.resourceKey,
                             webspace: formInspector.options.webspace,
+                            entityClass,
                             ...options,
                         }}
                         resourceKey={historyResourceKey}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
@@ -137,6 +137,9 @@ test('Pass correct options to ResourceLocatorHistory if entity already existed',
                 options: {history: true},
             }}
             formInspector={formInspector}
+            schemaOptions={{
+                entity_class: {name: 'entity_class', value: 'entity-class-value'},
+            }}
         />
     );
 
@@ -144,7 +147,7 @@ test('Pass correct options to ResourceLocatorHistory if entity already existed',
         resourceLocator.update();
         expect(resourceLocator.find('ResourceLocatorHistory')).toHaveLength(1);
         expect(resourceLocator.find('ResourceLocatorHistory').prop('options'))
-            .toEqual({history: true, webspace: 'sulu', resourceKey: 'test'});
+            .toEqual({entityClass: 'entity-class-value', history: true, webspace: 'sulu', resourceKey: 'test'});
         expect(resourceLocator.find('ResourceLocatorHistory').prop('resourceKey')).toEqual('page_resourcelocators');
         expect(resourceLocator.find('ResourceLocatorHistory').prop('id')).toEqual(1);
     });
@@ -332,7 +335,7 @@ test('Should automatically request new URL when part field is finished on add fo
     });
 });
 
-test('Should request URL with FormInspector options and resourceStorePropertiesToRequest field-type-option', () => {
+test('Should request URL with parameters from FormInspector options, fieldTypeOptions and schemaOptions', () => {
     const resourceStore = new ResourceStore('test', undefined, {locale: observable.box('en')});
     const formInspector = new FormInspector(
         new ResourceFormStore(
@@ -364,6 +367,10 @@ test('Should request URL with FormInspector options and resourceStorePropertiesT
             }}
             formInspector={formInspector}
             onChange={changeSpy}
+            schemaOptions={{
+                entity_class: {name: 'entity_class', value: 'entity-class-value'},
+                route_schema: {name: 'entity_class', value: '/events/{implode("-", object)}'},
+            }}
             schemaPath="/url"
         />
     );
@@ -391,6 +398,8 @@ test('Should request URL with FormInspector options and resourceStorePropertiesT
             locale: 'en',
             parts: {title: 'title-value', subtitle: 'subtitle-value'},
             resourceKey: 'test',
+            entityClass: 'entity-class-value',
+            routeSchema: '/events/{implode("-", object)}',
             webspace: 'example',
             requestParamKey: 'property-value',
         }

--- a/src/Sulu/Bundle/RouteBundle/Tests/Application/translations/messages.de.json
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Application/translations/messages.de.json
@@ -1,0 +1,3 @@
+{
+    "app.event": "Veranstaltung"
+}

--- a/src/Sulu/Bundle/RouteBundle/Tests/Application/translations/messages.en.json
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Application/translations/messages.en.json
@@ -1,0 +1,3 @@
+{
+    "app.event": "Event"
+}

--- a/src/Sulu/Bundle/RouteBundle/Tests/Functional/Controller/RouteControllerTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Functional/Controller/RouteControllerTest.php
@@ -87,6 +87,47 @@ class RouteControllerTest extends SuluTestCase
         $this->assertEquals('/2019/custom-part/test', $result['resourcelocator']);
     }
 
+    public function testGenerateWithTranslationInSchema(): void
+    {
+        // test english translation
+        $this->client->jsonRequest(
+            'POST',
+            '/api/routes?action=generate',
+            [
+                'locale' => 'en',
+                'resourceKey' => 'event-resource-key',
+                'entityClass' => 'event-class',
+                'routeSchema' => '/{translator.trans("app.event")}/{object["title"]}',
+                'parts' => [
+                    'title' => 'Tomorrowland',
+                ],
+            ]
+        );
+
+        $result = \json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+        $this->assertEquals('/event/tomorrowland', $result['resourcelocator']);
+
+        // test german translation
+        $this->client->jsonRequest(
+            'POST',
+            '/api/routes?action=generate',
+            [
+                'locale' => 'de',
+                'resourceKey' => 'event-resource-key',
+                'entityClass' => 'event-class',
+                'routeSchema' => '/{translator.trans("app.event")}/{object["title"]}',
+                'parts' => [
+                    'title' => 'Tomorrowland',
+                ],
+            ]
+        );
+
+        $result = \json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+        $this->assertEquals('/veranstaltung/tomorrowland', $result['resourcelocator']);
+    }
+
     public function testGenerateWithConflict(): void
     {
         $this->createRoute('/prefix/2019/test');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Related issues/PRs | https://github.com/sulu/sulu/issues/5676, https://github.com/sulu/SuluArticleBundle/issues/514
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/644

#### What's in this PR?

This PR adds a `entity_class` param and a `route_schema` param to the `route` field type. This makes it easier to implement routes for custom entities.

#### Why?

When implementing routes for a custom entity, it is necessary to configure a `RouteBundle` mapping for the entity. If you want to use live generation (https://github.com/sulu/SuluArticleBundle/issues/514) for the URL, this mapping looks like this:

```yaml
sulu_route:
    mappings:
        App\Entity\Event:
            generator: schema
            options:
                route_schema: /events/{implode("-", object)}
            resource_key: events
```

Unfortunately, this mapping is a bit misleading because mappings for live generation are not compatible with the `bin/console sulu:route:update` command (https://github.com/sulu/sulu/issues/5676). 

With this PR, instead of configuring a misleading mapping, the data required for generating an URL is set directly to the `route` property in the form configuration:

```xml
<property name="routePath" type="route" mandatory="true">
    <meta>
        <title>sulu_admin.url</title>
    </meta>

    <params>
        <param name="entity_class" value="App\Entity\Event"/>
        <param name="route_schema" value="/events/new-part/{implode('-', object)}"/>
    </params>
</property>
```