### PR TITLE
Fix admin bundle without security checker enabled

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/AddAdminPass.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/AddAdminPass.php
@@ -24,6 +24,10 @@ class AddAdminPass implements CompilerPassInterface
 
     public function process(ContainerBuilder $container)
     {
+        if (!$container->hasDefinition(self::ADMIN_POOL_DEFINITION_ID)) {
+            return;
+        }
+
         $pool = $container->getDefinition(self::ADMIN_POOL_DEFINITION_ID);
 
         $adminServiceDefinitions = [];

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -33,7 +33,10 @@
 
             <tag name="sulu.context" context="admin"/>
         </service>
-        <service id="sulu_admin.admin_pool" class="%sulu_admin.admin_pool.class%" public="true"/>
+
+        <service id="sulu_admin.admin_pool" class="%sulu_admin.admin_pool.class%" public="true">
+            <tag name="sulu.context" context="admin"/>
+        </service>
 
         <service
             id="sulu_admin.metadata_provider_registry"
@@ -142,12 +145,16 @@
 
         <service id="sulu_admin.view_registry" class="Sulu\Bundle\AdminBundle\Admin\View\ViewRegistry">
             <argument type="service" id="sulu_admin.admin_pool"/>
+
+            <tag name="sulu.context" context="admin"/>
         </service>
 
         <service id="sulu_admin.navigation_registry" class="Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationRegistry">
             <argument type="service" id="translator"/>
             <argument type="service" id="sulu_admin.admin_pool"/>
             <argument type="service" id="sulu_admin.view_registry"/>
+
+            <tag name="sulu.context" context="admin"/>
         </service>
 
         <service

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/DependencyInjection/Compiler/AddAdminPassTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/DependencyInjection/Compiler/AddAdminPassTest.php
@@ -27,29 +27,48 @@ class AddAdminPassTest extends TestCase
         $poolDefinition = $this->prophesize(Definition::class);
 
         $container = $this->prophesize(ContainerBuilder::class);
-        $container->getDefinition(AddAdminPass::ADMIN_POOL_DEFINITION_ID)->willReturn($poolDefinition->reveal());
+        $container->hasDefinition(AddAdminPass::ADMIN_POOL_DEFINITION_ID)
+            ->willReturn(true)
+            ->shouldBeCalled();
+        $container->getDefinition(AddAdminPass::ADMIN_POOL_DEFINITION_ID)
+            ->willReturn($poolDefinition->reveal())
+            ->shouldBeCalled();
 
         $adminDefinition1 = $this->prophesize(Definition::class);
-        $adminDefinition1->getClass()->willReturn(TestAdmin1::class);
+        $adminDefinition1->getClass()
+            ->willReturn(TestAdmin1::class)
+            ->shouldBeCalled();
 
         $adminDefinition2 = $this->prophesize(Definition::class);
-        $adminDefinition2->getClass()->willReturn('%class2%');
+        $adminDefinition2->getClass()
+            ->willReturn('%class2%')
+            ->shouldBeCalled();
 
         $container->findTaggedServiceIds(AddAdminPass::ADMIN_TAG)->willReturn(
             [
                 'test_admin1' => [],
                 'test_admin2' => [],
             ]
-        );
+        )->shouldBeCalled();
 
-        $container->getDefinition('test_admin1')->willReturn($adminDefinition1->reveal());
-        $container->getDefinition('test_admin2')->willReturn($adminDefinition2->reveal());
+        $container->getDefinition('test_admin1')
+            ->willReturn($adminDefinition1->reveal())
+            ->shouldBeCalled();
+        $container->getDefinition('test_admin2')
+            ->willReturn($adminDefinition2->reveal())
+            ->shouldBeCalled();
 
         $parameterBag = $this->prophesize(ParameterBag::class);
-        $container->getParameterBag()->willReturn($parameterBag->reveal());
+        $container->getParameterBag()
+            ->willReturn($parameterBag->reveal())
+            ->shouldBeCalled();
 
-        $parameterBag->resolveValue(TestAdmin1::class)->willReturn(TestAdmin1::class);
-        $parameterBag->resolveValue('%class2%')->willReturn(TestAdmin2::class);
+        $parameterBag->resolveValue(TestAdmin1::class)
+            ->willReturn(TestAdmin1::class)
+            ->shouldBeCalled();
+        $parameterBag->resolveValue('%class2%')
+            ->willReturn(TestAdmin2::class)
+            ->shouldBeCalled();
 
         $admins = [];
 
@@ -77,21 +96,32 @@ class AddAdminPassTest extends TestCase
         $poolDefinition = $this->prophesize(Definition::class);
 
         $container = $this->prophesize(ContainerBuilder::class);
-        $container->getDefinition(AddAdminPass::ADMIN_POOL_DEFINITION_ID)->willReturn($poolDefinition->reveal());
+        $container->hasDefinition(AddAdminPass::ADMIN_POOL_DEFINITION_ID)
+            ->willReturn(true)
+            ->shouldBeCalled();
+        $container->getDefinition(AddAdminPass::ADMIN_POOL_DEFINITION_ID)
+            ->willReturn($poolDefinition->reveal())
+            ->shouldBeCalled();
 
         $adminDefinition1 = $this->prophesize(Definition::class);
-        $adminDefinition1->getClass()->willReturn(TestAdmin1::class);
+        $adminDefinition1->getClass()
+            ->willReturn(TestAdmin1::class)
+            ->shouldBeCalled();
 
         $container->findTaggedServiceIds(AddAdminPass::ADMIN_TAG)->willReturn(
             [
                 'test_admin1' => [],
             ]
-        );
+        )->shouldBeCalled();
 
-        $container->getDefinition('test_admin1')->willReturn($adminDefinition1->reveal());
+        $container->getDefinition('test_admin1')
+            ->willReturn($adminDefinition1->reveal())
+            ->shouldBeCalled();
 
         $parameterBag = $this->prophesize(ParameterBag::class);
-        $container->getParameterBag()->willReturn($parameterBag->reveal());
+        $container->getParameterBag()
+            ->willReturn($parameterBag->reveal())
+            ->shouldBeCalled();
 
         $parameterBag->resolveValue(TestAdmin1::class)->willReturn(TestAdmin1::class);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The admin pool service can currently only exist in the admin context as this is currently the only context which has by default the `security` checker enabled. In the future the security checker should also be available in the website context by default but at current state we need to disable the admin context.

#### Why?

Fix admin bundle without security checker enabled

#### Example Usage

1. Enable Website Security
2. Don't enable [sulu security checker](https://github.com/sulu/skeleton/blob/e3e24ffc23a50fc1ab03d9b78d98e22929dc6fdc/config/packages/security_admin.yaml#L43)

