### PR TITLE
Rename CategoryKeywordCreatedEvent to CategoryKeywordAddedEvent

### DIFF
--- a/src/Sulu/Bundle/CategoryBundle/Category/KeywordManager.php
+++ b/src/Sulu/Bundle/CategoryBundle/Category/KeywordManager.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\CategoryBundle\Category;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryKeywordCreatedEvent;
+use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryKeywordAddedEvent;
 use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryKeywordModifiedEvent;
 use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryKeywordRemovedEvent;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
@@ -89,7 +89,7 @@ class KeywordManager implements KeywordManagerInterface
         foreach ($keyword->getCategoryTranslations() as $categoryTranslation) {
             $event = $keyword->getId()
                 ? new CategoryKeywordModifiedEvent($categoryTranslation->getCategory(), $keyword)
-                : new CategoryKeywordCreatedEvent($categoryTranslation->getCategory(), $keyword);
+                : new CategoryKeywordAddedEvent($categoryTranslation->getCategory(), $keyword);
 
             $this->domainEventCollector->collect($event);
         }

--- a/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryKeywordAddedEvent.php
+++ b/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryKeywordAddedEvent.php
@@ -16,7 +16,7 @@ use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\CategoryBundle\Entity\KeywordInterface;
 use Sulu\Bundle\EventLogBundle\Domain\Event\DomainEvent;
 
-class CategoryKeywordCreatedEvent extends DomainEvent
+class CategoryKeywordAddedEvent extends DomainEvent
 {
     /**
      * @var CategoryInterface
@@ -50,7 +50,7 @@ class CategoryKeywordCreatedEvent extends DomainEvent
 
     public function getEventType(): string
     {
-        return 'keyword_created';
+        return 'keyword_added';
     }
 
     public function getEventContext(): array

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Category/KeywordManagerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Category/KeywordManagerTest.php
@@ -15,7 +15,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sulu\Bundle\CategoryBundle\Category\KeywordManager;
-use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryKeywordCreatedEvent;
+use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryKeywordAddedEvent;
 use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryKeywordModifiedEvent;
 use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryKeywordRemovedEvent;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
@@ -87,7 +87,7 @@ class KeywordManagerTest extends TestCase
             $keyword->addCategoryTranslation($categoryTranslation->reveal())->shouldBeCalledTimes($has ? 0 : 1);
             $keyword->getCategoryTranslations()->willReturn([$categoryTranslation->reveal()]);
 
-            $domainEventCollector->collect(Argument::type(CategoryKeywordCreatedEvent::class))->shouldBeCalled();
+            $domainEventCollector->collect(Argument::type(CategoryKeywordAddedEvent::class))->shouldBeCalled();
         }
 
         $manager = new KeywordManager(
@@ -138,7 +138,7 @@ class KeywordManagerTest extends TestCase
         $category->findTranslationByLocale($locale)->willReturn(false);
         $category->setChanged(Argument::any())->willReturn(null);
 
-        $domainEventCollector->collect(Argument::type(CategoryKeywordCreatedEvent::class))->shouldBeCalled();
+        $domainEventCollector->collect(Argument::type(CategoryKeywordAddedEvent::class))->shouldBeCalled();
 
         $manager = new KeywordManager(
             $repository->reveal(),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Related issues/PRs | #5939
| License | MIT

#### Why?

I think we should use `added` instead of `created` if the event is about the relationship to a sub-entity (eg. translation, media-version, category-keyword). this would be consistent to other events such as:

- `PageTranslationAddedEvent`
- `PageVersionAddedEvent`
