### PR TITLE
Fix route collection builder is deprecation message

### DIFF
--- a/src/Sulu/Component/HttpKernel/SuluKernel.php
+++ b/src/Sulu/Component/HttpKernel/SuluKernel.php
@@ -151,6 +151,9 @@ abstract class SuluKernel extends Kernel
         }
     }
 
+    /**
+     * * @param RouteCollectionBuilder|RoutingConfigurator $routes Is a RouteCollectionBuilder for Symfony <= 4.4
+     */
     protected function import($routes, $confDir, $pattern)
     {
         $configExtensions = $this->getConfigExtensions();

--- a/src/Sulu/Component/HttpKernel/SuluKernel.php
+++ b/src/Sulu/Component/HttpKernel/SuluKernel.php
@@ -124,6 +124,9 @@ abstract class SuluKernel extends Kernel
         return $class;
     }
 
+    /**
+     * * @param RouteCollectionBuilder|RoutingConfigurator $routes Is a RouteCollectionBuilder for Symfony <= 4.4
+     */
     protected function configureRoutes(RoutingConfigurator $routes)
     {
         $confDir = $this->getProjectDir() . '/config';
@@ -149,7 +152,7 @@ abstract class SuluKernel extends Kernel
     }
 
     /**
-     * @param RoutingConfigurator $routes
+     * @param RouteCollectionBuilder|RoutingConfigurator $routes Is a RouteCollectionBuilder for Symfony <= 4.4
      */
     protected function import($routes, $confDir, $pattern)
     {

--- a/src/Sulu/Component/HttpKernel/SuluKernel.php
+++ b/src/Sulu/Component/HttpKernel/SuluKernel.php
@@ -150,8 +150,6 @@ abstract class SuluKernel extends Kernel
 
     /**
      * @param RoutingConfigurator $routes
-     * @param $confDir
-     * @param $pattern
      */
     protected function import($routes, $confDir, $pattern)
     {

--- a/src/Sulu/Component/HttpKernel/SuluKernel.php
+++ b/src/Sulu/Component/HttpKernel/SuluKernel.php
@@ -151,9 +151,6 @@ abstract class SuluKernel extends Kernel
         }
     }
 
-    /**
-     * @param RouteCollectionBuilder|RoutingConfigurator $routes Is a RouteCollectionBuilder for Symfony <= 4.4
-     */
     protected function import($routes, $confDir, $pattern)
     {
         $configExtensions = $this->getConfigExtensions();

--- a/src/Sulu/Component/HttpKernel/SuluKernel.php
+++ b/src/Sulu/Component/HttpKernel/SuluKernel.php
@@ -18,7 +18,6 @@ use Symfony\Component\Config\Resource\GlobResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
-use Symfony\Component\Routing\RouteCollectionBuilder;
 
 /**
  * Base class for all Sulu kernels.
@@ -125,7 +124,7 @@ abstract class SuluKernel extends Kernel
         return $class;
     }
 
-    protected function configureRoutes(RouteCollectionBuilder $routes)
+    protected function configureRoutes(RoutingConfigurator $routes)
     {
         $confDir = $this->getProjectDir() . '/config';
 
@@ -150,7 +149,9 @@ abstract class SuluKernel extends Kernel
     }
 
     /**
-     * @param RouteCollectionBuilder|RoutingConfigurator $routes Is a RouteCollectionBuilder for Symfony <= 4.4
+     * @param RoutingConfigurator $routes
+     * @param $confDir
+     * @param $pattern
      */
     protected function import($routes, $confDir, $pattern)
     {

--- a/src/Sulu/Component/HttpKernel/SuluKernel.php
+++ b/src/Sulu/Component/HttpKernel/SuluKernel.php
@@ -125,7 +125,7 @@ abstract class SuluKernel extends Kernel
     }
 
     /**
-     * * @param RouteCollectionBuilder|RoutingConfigurator $routes Is a RouteCollectionBuilder for Symfony <= 4.4
+     * @param RouteCollectionBuilder|RoutingConfigurator $routes Is a RouteCollectionBuilder for Symfony <= 4.4
      */
     protected function configureRoutes(RoutingConfigurator $routes)
     {

--- a/src/Sulu/Component/HttpKernel/SuluKernel.php
+++ b/src/Sulu/Component/HttpKernel/SuluKernel.php
@@ -18,6 +18,7 @@ use Symfony\Component\Config\Resource\GlobResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+use Symfony\Component\Routing\RouteCollectionBuilder;
 
 /**
  * Base class for all Sulu kernels.
@@ -127,7 +128,7 @@ abstract class SuluKernel extends Kernel
     /**
      * @param RouteCollectionBuilder|RoutingConfigurator $routes Is a RouteCollectionBuilder for Symfony <= 4.4
      */
-    protected function configureRoutes(RoutingConfigurator $routes)
+    protected function configureRoutes($routes)
     {
         $confDir = $this->getProjectDir() . '/config';
 
@@ -152,7 +153,7 @@ abstract class SuluKernel extends Kernel
     }
 
     /**
-     * * @param RouteCollectionBuilder|RoutingConfigurator $routes Is a RouteCollectionBuilder for Symfony <= 4.4
+     * @param RouteCollectionBuilder|RoutingConfigurator $routes Is a RouteCollectionBuilder for Symfony <= 4.4
      */
     protected function import($routes, $confDir, $pattern)
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets |
| Related issues/PRs |
| License | MIT
| Documentation PR |

#### What's in this PR?

Since symfony/routing 5.1: The "Symfony\Component\Routing\RouteCollectionBuilder" class is deprecated, use "Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator" instead.

<!-- Explain the contents of the PR. -->

These versions is no longer maintained.
https://symfony.com/releases/4.0
https://symfony.com/releases/4.1
https://symfony.com/releases/4.2
https://symfony.com/releases/4.3