### PR TITLE
Run php lint task in own step

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -61,7 +61,7 @@ jobs:
                   npm run build
 
     php:
-        name: "PHP ${{ matrix.php-version }} (${{ matrix.database }}, ${{ matrix.phpcr-transport }}, ${{ matrix.dependency-versions }}, Lint ${{ matrix.lint }})"
+        name: "PHP ${{ matrix.php-version }} (${{ matrix.database }}, ${{ matrix.phpcr-transport }}, ${{ matrix.dependency-versions }}"
         runs-on: ubuntu-latest
 
         env:
@@ -81,7 +81,6 @@ jobs:
                       dependency-versions: 'lowest'
                       php-extensions: 'ctype, iconv, mysql, gd'
                       tools: 'composer:v1'
-                      lint: false
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: disabled
                           DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/sulu_test?serverVersion=12.5
@@ -94,7 +93,6 @@ jobs:
                       dependency-versions: 'highest'
                       php-extensions: 'ctype, iconv, mysql, imagick'
                       tools: 'composer:v2'
-                      lint: true
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: weak
                           DATABASE_URL: mysql://root:root@127.0.0.1:3306/sulu_test?serverVersion=5.7
@@ -162,10 +160,36 @@ jobs:
               run: time composer test
               env: ${{ matrix.env }}
 
+    php-lint:
+        name: "PHP Lint"
+        runs-on: ubuntu-latest
+
+        env:
+            APP_ENV: test
+            APP_SECRET: a448d1dfcaa563fce56c2fd9981f662b
+            MAILER_URL: null://localhost
+            SULU_ADMIN_EMAIL:
+
+        steps:
+            - name: Checkout project
+              uses: actions/checkout@v2
+
+            - name: Install and configure PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.0'
+                  extensions: 'ctype, iconv, mysql, imagick'
+                  tools: 'composer:v2'
+                  coverage: none
+
+            - name: Install composer dependencies
+              uses: ramsey/composer-install@v1
+              with:
+                  dependency-versions: highest
+
             - name: Lint code
               if: ${{ matrix.lint }}
               run: composer lint
-              env: ${{ matrix.env }}
 
     php-windows:
         name: "PHP ${{ matrix.php-version }} on Windows (mysql ${{ matrix.mysql-version }}, ${{ matrix.phpcr-transport }}, ${{ matrix.dependency-versions }})"

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -158,13 +158,13 @@ jobs:
               run: composer bootstrap-test-environment
               env: ${{ matrix.env }}
 
+            - name: Execute test cases
+              run: time composer test
+              env: ${{ matrix.env }}
+
             - name: Lint code
               if: ${{ matrix.lint }}
               run: composer lint
-              env: ${{ matrix.env }}
-
-            - name: Execute test cases
-              run: time composer test
               env: ${{ matrix.env }}
 
     php-windows:

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -61,7 +61,7 @@ jobs:
                   npm run build
 
     php:
-        name: "PHP ${{ matrix.php-version }} (${{ matrix.database }}, ${{ matrix.phpcr-transport }}, ${{ matrix.dependency-versions }}"
+        name: "PHP ${{ matrix.php-version }} (${{ matrix.database }}, ${{ matrix.phpcr-transport }}, ${{ matrix.dependency-versions }})"
         runs-on: ubuntu-latest
 
         env:

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -188,7 +188,6 @@ jobs:
                   dependency-versions: highest
 
             - name: Lint code
-              if: ${{ matrix.lint }}
               run: composer lint
 
     php-windows:

--- a/composer.json
+++ b/composer.json
@@ -204,13 +204,13 @@
             "@php bin/runtests --initialize --no-bundle-tests --no-component-tests"
         ],
         "lint": [
-            "@phpstan",
-            "@php-cs",
             "@lint-twig",
             "@lint-yaml",
             "@lint-container",
             "@lint-composer",
-            "@lint-doctrine"
+            "@lint-doctrine",
+            "@php-cs",
+            "@phpstan"
         ],
         "test": [
             "Composer\\Config::disableProcessTimeout",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Run test before linting tasks.

#### Why?

Its for PR more important that the test are green then phpstan or php-cs is green. This make in case of external contributions better to give feedback is something is failing in both in lint and test.