### PR TITLE
Remove abstract from SuluTestCase

### DIFF
--- a/src/Sulu/Bundle/TestBundle/Testing/SuluTestCase.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/SuluTestCase.php
@@ -13,7 +13,7 @@ namespace Sulu\Bundle\TestBundle\Testing;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
-abstract class SuluTestCase extends WebTestCase
+class SuluTestCase extends WebTestCase
 {
     use ContainerTrait;
     use KernelTrait;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove abstract from SuluTestCase.

#### Why?

If a test runner like `PestPHP` is used you maybe want directly use the SuluTestCase and don't want to create an additional TestCase class. https://pestphp.com/docs/underlying-test-case. E.g.:

```php
uses(SuluTestCase::class);

it('test something', function () {
    $this->purgeDatabase();
    $this->initPhpcr();
    
    // ...
});
```
