### PR TITLE
Disable pagination when using ColumnListAdapter

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
@@ -152,7 +152,9 @@ class List extends React.Component<Props> {
         }
 
         if (store !== prevProps.store) {
-            store.updateLoadingStrategy(new this.currentAdapter.LoadingStrategy({paginated}));
+            store.updateLoadingStrategy(new this.currentAdapter.LoadingStrategy({
+                paginated: this.currentAdapter.paginatable && paginated,
+            }));
             store.updateStructureStrategy(new this.currentAdapter.StructureStrategy());
         }
     }
@@ -181,7 +183,7 @@ class List extends React.Component<Props> {
         if (!(this.props.store.loadingStrategy instanceof this.currentAdapter.LoadingStrategy)) {
             this.props.store.updateLoadingStrategy(
                 new this.currentAdapter.LoadingStrategy({
-                    paginated: this.props.paginated,
+                    paginated: this.currentAdapter.paginatable && this.props.paginated,
                 })
             );
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/AbstractAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/AbstractAdapter.js
@@ -12,4 +12,6 @@ export default class AbstractAdapter extends React.Component<ListAdapterProps> {
     static hasColumnOptions: boolean = false;
 
     static searchable: boolean = true;
+
+    static paginatable: boolean = true;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
@@ -22,6 +22,8 @@ class ColumnListAdapter extends AbstractAdapter {
 
     static searchable = false;
 
+    static paginatable = false;
+
     static defaultProps = {
         data: [],
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
@@ -14,6 +14,7 @@ import AbstractAdapter from '../adapters/AbstractAdapter';
 import TableAdapter from '../adapters/TableAdapter';
 import FolderAdapter from '../adapters/FolderAdapter';
 import StringFieldTransformer from '../fieldTransformers/StringFieldTransformer';
+import ColumnListAdapter from '../adapters/ColumnListAdapter';
 
 let mockStructureStrategyData;
 let mockStructureStrategyVisibleItems;
@@ -796,7 +797,7 @@ test('ListStore should be initialized correctly on init and update', () => {
     expect(listStore.updateStructureStrategy).toBeCalledWith(expect.any(TableAdapter.StructureStrategy));
 });
 
-test('LoadingStrategyOptions should be passed correctly to the LoadingStrategy', () => {
+test('Correct LoadingStrategyOptions should be passed to the LoadingStrategy if paginated prop is set', () => {
     const listStore = new ListStore('test', 'test', 'list_test', {page: observable.box(1)});
 
     TableAdapter.LoadingStrategy = (jest.fn(): any);
@@ -811,6 +812,21 @@ test('LoadingStrategyOptions should be passed correctly to the LoadingStrategy',
     });
     mount(<List adapters={['table', 'folder']} paginated={true} store={listStore} />);
     expect(TableAdapter.LoadingStrategy).toBeCalledWith({paginated: true});
+});
+
+test('Correct LoadingStrategyOptions should not be passed to the LoadingStrategy if adapter is not paginatable', () => {
+    const listStore = new ListStore('test', 'test', 'list_test', {page: observable.box(1)});
+
+    ColumnListAdapter.LoadingStrategy = (jest.fn(): any);
+
+    listAdapterRegistry.get.mockImplementation((adapter) => {
+        switch (adapter) {
+            case 'column_list':
+                return ColumnListAdapter;
+        }
+    });
+    mount(<List adapters={['column_list']} paginated={true} store={listStore} />);
+    expect(ColumnListAdapter.LoadingStrategy).toBeCalledWith({paginated: false});
 });
 
 test('ListStore should be updated with current active element', () => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #5975
| License | MIT

#### What's in this PR?

This PR adds an additional `paginatable` variable to the `AbstractAdapter` that allows the adapter define if it supports pagination. The `AbstractAdapter` already contains a similar `searchable` variable.

#### Why?

Some list adapter such as the `ColumnListAdapter` do not support pagination. Enabling pagination in this adapters will lead to missing items in the list (see #5975).
