### PR TITLE
Update babel.config.json to resolve warning

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -2,8 +2,9 @@
     "presets": ["@babel/preset-env", "@babel/preset-react"],
     "plugins": [
         ["@babel/plugin-proposal-decorators", {"legacy": true}],
-        "@babel/plugin-proposal-object-rest-spread",
-        "@babel/plugin-transform-flow-strip-types",
-        ["@babel/plugin-proposal-class-properties", {"loose": true}]
-    ]
+        "@babel/plugin-transform-flow-strip-types"
+    ],
+    "assumptions": {
+        "setPublicClassFields": true
+    }
 }

--- a/package.json
+++ b/package.json
@@ -32,9 +32,7 @@
     },
     "devDependencies": {
         "@babel/core": "^7.5.5",
-        "@babel/plugin-proposal-class-properties": "^7.5.5",
         "@babel/plugin-proposal-decorators": "^7.4.4",
-        "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
         "@babel/plugin-transform-flow-strip-types": "^7.4.4",
         "@babel/preset-env": "^7.5.5",
         "@babel/preset-react": "^7.0.0",


### PR DESCRIPTION
When building the administration interface application, the following warning is logged multiple times at the moment:
```
Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-methods since the "loose" mode option was set to "true" for @babel/plugin-proposal-class-properties.
The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
	["@babel/plugin-proposal-private-methods", { "loose": true }]
to the "plugins" section of your Babel config.
```
For example, see https://github.com/sulu/sulu/runs/2501494184