### PR TITLE
Activate PreviewBundle also for website context

### DIFF
--- a/config/bundles.php
+++ b/config/bundles.php
@@ -50,7 +50,7 @@ return [
     Sulu\Bundle\TestBundle\SuluTestBundle::class => ['dev' => true, 'test' => true],
     Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true],
     Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
-    Sulu\Bundle\PreviewBundle\SuluPreviewBundle::class => ['all' => true, 'admin' => true],
+    Sulu\Bundle\PreviewBundle\SuluPreviewBundle::class => ['all' => true],
     FOS\JsRoutingBundle\FOSJsRoutingBundle::class => ['all' => true, 'admin' => true],
     Symfony\Cmf\Bundle\RoutingBundle\CmfRoutingBundle::class => ['all' => true, 'website' => true],
 ];

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/services.xml
@@ -59,6 +59,8 @@
             <argument type="service" id="sulu_preview.preview"/>
             <argument type="service" id="security.token_storage"/>
             <argument type="service" id="profiler" on-invalid="null"/>
+
+            <tag name="sulu.context" context="admin"/>
         </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
+++ b/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
@@ -75,6 +75,7 @@ class SuluTestKernel extends SuluKernel
             new \Sulu\Bundle\CustomUrlBundle\SuluCustomUrlBundle(),
             new \Sulu\Bundle\RouteBundle\SuluRouteBundle(),
             new \Sulu\Bundle\MarkupBundle\SuluMarkupBundle(),
+            new \Sulu\Bundle\PreviewBundle\SuluPreviewBundle(),
             new \Sulu\Bundle\AudienceTargetingBundle\SuluAudienceTargetingBundle(),
         ];
 
@@ -104,7 +105,6 @@ class SuluTestKernel extends SuluKernel
 
         if (self::CONTEXT_ADMIN === $this->getContext()) {
             $bundles[] = new \Symfony\Bundle\SecurityBundle\SecurityBundle();
-            $bundles[] = new \Sulu\Bundle\PreviewBundle\SuluPreviewBundle();
             $bundles[] = new \FOS\JsRoutingBundle\FOSJsRoutingBundle();
         }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  
| Fixed tickets | fixes #
| Related issues/PRs | https://github.com/sulu/skeleton/pull/116
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Activate PreviewBundle also for website context.

#### Why?

This should be a step forward to a single kernel setup.