### PR TITLE
Activate FOSJSRoutingBundle also for website context

### DIFF
--- a/config/bundles.php
+++ b/config/bundles.php
@@ -51,6 +51,6 @@ return [
     Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true],
     Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
     Sulu\Bundle\PreviewBundle\SuluPreviewBundle::class => ['all' => true, 'admin' => true],
-    FOS\JsRoutingBundle\FOSJsRoutingBundle::class => ['all' => true, 'admin' => true],
+    FOS\JsRoutingBundle\FOSJsRoutingBundle::class => ['all' => true],
     Symfony\Cmf\Bundle\RoutingBundle\CmfRoutingBundle::class => ['all' => true, 'website' => true],
 ];

--- a/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
+++ b/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
@@ -50,6 +50,7 @@ class SuluTestKernel extends SuluKernel
             new \Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
             new \FOS\RestBundle\FOSRestBundle(),
             new \HandcraftedInTheAlps\RestRoutingBundle\RestRoutingBundle(),
+            new \FOS\JsRoutingBundle\FOSJsRoutingBundle(),
 
             // Massive
             new \Massive\Bundle\SearchBundle\MassiveSearchBundle(),
@@ -105,7 +106,6 @@ class SuluTestKernel extends SuluKernel
         if (self::CONTEXT_ADMIN === $this->getContext()) {
             $bundles[] = new \Symfony\Bundle\SecurityBundle\SecurityBundle();
             $bundles[] = new \Sulu\Bundle\PreviewBundle\SuluPreviewBundle();
-            $bundles[] = new \FOS\JsRoutingBundle\FOSJsRoutingBundle();
         }
 
         // @phpstan-ignore-next-line


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Activate FOSJSRoutingBundle also for website context.

#### Why?

Make it easier in the future to migrate to a single kernel setup.