### PR TITLE
Add auditable fields to user entity

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,19 @@
 
 ## 2.3
 
+### Auditable Fields to User
+
+The `User` entity was extended with `creator`, `changer`, `created` and `changed` fields.
+For this the following database migration is needed:
+
+```sql
+ALTER TABLE se_users ADD created DATETIME NOT NULL, ADD changed DATETIME NOT NULL, ADD idUsersCreator INT DEFAULT NULL, ADD idUsersChanger INT DEFAULT NULL;
+ALTER TABLE se_users ADD CONSTRAINT FK_B10AC28EDBF11E1D FOREIGN KEY (idUsersCreator) REFERENCES se_users (id) ON DELETE SET NULL;
+ALTER TABLE se_users ADD CONSTRAINT FK_B10AC28E30D07CD5 FOREIGN KEY (idUsersChanger) REFERENCES se_users (id) ON DELETE SET NULL;
+CREATE INDEX IDX_B10AC28EDBF11E1D ON se_users (idUsersCreator);
+CREATE INDEX IDX_B10AC28E30D07CD5 ON se_users (idUsersChanger);
+```
+
 ### Deprecated table adapters `table_light` and `tree_table_slim`
 
 The two adapters `table_light` and `tree_table_slim` are deprecated and will be removed in `3.0`.

--- a/src/Sulu/Bundle/SecurityBundle/Entity/User.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/User.php
@@ -21,6 +21,8 @@ use JMS\Serializer\Annotation\VirtualProperty;
 use Serializable;
 use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
 use Sulu\Bundle\CoreBundle\Entity\ApiEntity;
+use Sulu\Component\Persistence\Model\AuditableInterface;
+use Sulu\Component\Persistence\Model\AuditableTrait;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Symfony\Component\Security\Core\User\EquatableInterface;
 use Symfony\Component\Security\Core\User\UserInterface as SymfonyUserInterface;
@@ -30,8 +32,10 @@ use Symfony\Component\Security\Core\User\UserInterface as SymfonyUserInterface;
  *
  * @ExclusionPolicy("all")
  */
-class User extends ApiEntity implements UserInterface, Serializable, EquatableInterface
+class User extends ApiEntity implements UserInterface, Serializable, EquatableInterface, AuditableInterface
 {
+    use AuditableTrait;
+
     /**
      * @var int
      * @Expose


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? |  yes
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add auditable fields to user entity.

#### Why?

So in the database it is recorded who and when a user was created and changed.
