### PR TITLE
Display error message when upload fails in SingleMediaUpload component

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/SingleMediaDropzone.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/SingleMediaDropzone.js
@@ -13,6 +13,7 @@ const UPLOAD_ICON = 'su-upload';
 type Props = {|
     disabled: boolean,
     emptyIcon: string,
+    errorText?: ?string,
     image: ?string,
     mimeType: ?string,
     onDrop: (data: File) => void,
@@ -96,6 +97,7 @@ class SingleMediaDropzone extends React.Component<Props> {
         const {
             disabled,
             emptyIcon,
+            errorText,
             image,
             mimeType,
             progress,
@@ -114,64 +116,73 @@ class SingleMediaDropzone extends React.Component<Props> {
         );
 
         return (
-            <Dropzone
-                disabled={disabled}
-                multiple={false}
-                noClick={uploading}
-                onDragEnter={this.handleDragEnter}
-                onDragLeave={this.handleDragLeave}
-                onDrop={this.handleDrop}
-            >
-                {({getInputProps, getRootProps}) => (
-                    <Observer>
-                        {() => (
-                            <div {...getRootProps({className: mediaContainerClass})}>
-                                {image && !this.imageError &&
-                                    <Fragment>
-                                        <img className={singleMediaDropzoneStyles.thumbnail} key={image} src={image} />
-                                        {this.imageLoading && <Loader />}
-                                    </Fragment>
-                                }
-                                {(!image || this.imageError) && mimeType &&
-                                    <div className={singleMediaDropzoneStyles.mimeTypeIndicator}>
-                                        <MimeTypeIndicator iconSize={100} mimeType={mimeType} />
-                                    </div>
-                                }
-                                {!image && !mimeType &&
-                                    <div className={singleMediaDropzoneStyles.emptyIndicator}>
-                                        <Icon name={emptyIcon} />
-                                    </div>
-                                }
+            <>
+                <Dropzone
+                    disabled={disabled}
+                    multiple={false}
+                    noClick={uploading}
+                    onDragEnter={this.handleDragEnter}
+                    onDragLeave={this.handleDragLeave}
+                    onDrop={this.handleDrop}
+                >
+                    {({getInputProps, getRootProps}) => (
+                        <Observer>
+                            {() => (
+                                <div {...getRootProps({className: mediaContainerClass})}>
+                                    {image && !this.imageError &&
+                                        <Fragment>
+                                            <img
+                                                className={singleMediaDropzoneStyles.thumbnail}
+                                                key={image}
+                                                src={image}
+                                            />
+                                            {this.imageLoading && <Loader />}
+                                        </Fragment>
+                                    }
+                                    {(!image || this.imageError) && mimeType &&
+                                        <div className={singleMediaDropzoneStyles.mimeTypeIndicator}>
+                                            <MimeTypeIndicator iconSize={100} mimeType={mimeType} />
+                                        </div>
+                                    }
+                                    {!image && !mimeType &&
+                                        <div className={singleMediaDropzoneStyles.emptyIndicator}>
+                                            <Icon name={emptyIcon} />
+                                        </div>
+                                    }
 
-                                {!uploading
-                                    ? <div className={singleMediaDropzoneStyles.uploadIndicatorContainer}>
-                                        <div className={singleMediaDropzoneStyles.uploadIndicator}>
-                                            <div>
-                                                <Icon
-                                                    className={singleMediaDropzoneStyles.uploadIcon}
-                                                    name={UPLOAD_ICON}
-                                                />
-                                                {uploadText &&
-                                                    <div className={singleMediaDropzoneStyles.uploadInfoText}>
-                                                        {uploadText}
-                                                    </div>
-                                                }
+                                    {!uploading
+                                        ? <div className={singleMediaDropzoneStyles.uploadIndicatorContainer}>
+                                            <div className={singleMediaDropzoneStyles.uploadIndicator}>
+                                                <div>
+                                                    <Icon
+                                                        className={singleMediaDropzoneStyles.uploadIcon}
+                                                        name={UPLOAD_ICON}
+                                                    />
+                                                    {uploadText &&
+                                                        <div className={singleMediaDropzoneStyles.uploadInfoText}>
+                                                            {uploadText}
+                                                        </div>
+                                                    }
+                                                </div>
                                             </div>
                                         </div>
-                                    </div>
-                                    : <div className={singleMediaDropzoneStyles.progressbar}>
-                                        <CircularProgressbar
-                                            percentage={progress}
-                                            size={200}
-                                        />
-                                    </div>
-                                }
-                                <input {...getInputProps()} />
-                            </div>
-                        )}
-                    </Observer>
+                                        : <div className={singleMediaDropzoneStyles.progressbar}>
+                                            <CircularProgressbar
+                                                percentage={progress}
+                                                size={200}
+                                            />
+                                        </div>
+                                    }
+                                    <input {...getInputProps()} />
+                                </div>
+                            )}
+                        </Observer>
+                    )}
+                </Dropzone>
+                {errorText && (
+                    <div className={singleMediaDropzoneStyles.errorText}>{errorText}</div>
                 )}
-            </Dropzone>
+            </>
         );
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/singleMediaDropzone.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/singleMediaDropzone.scss
@@ -118,7 +118,7 @@ $mediaContainerBreakpoint: 520px;
     }
 }
 
-.errorText {
+.error-text {
     margin-top: 10px;
     color: $errorTextColor;
     text-align: center;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/singleMediaDropzone.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/singleMediaDropzone.scss
@@ -6,6 +6,7 @@ $uploadIndicatorBackgroundColor: rgba($alabaster, .8);
 $imageBorderColor: $silver;
 $emptyBackgroundColor: $white;
 $emptyColor: $alto;
+$errorTextColor: $persianRed;
 
 /* $dropzoneSize + 2 * $viewPaddingHorizontal because calc doesn't work for media-queries */
 $mediaContainerBreakpoint: 520px;
@@ -115,4 +116,10 @@ $mediaContainerBreakpoint: 520px;
     &.media-container {
         border-radius: 50%;
     }
+}
+
+.errorText {
+    margin-top: 10px;
+    color: $errorTextColor;
+    text-align: center;
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/tests/SingleMediaDropzone.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/tests/SingleMediaDropzone.test.js
@@ -22,6 +22,17 @@ test('Render a SingleMediaDropzone with the passed empty icon', () => {
     expect(render(<SingleMediaDropzone emptyIcon="su-user" image={undefined} onDrop={jest.fn()} />)).toMatchSnapshot();
 });
 
+test('Render a SingleMediaDropzone with an error text', () => {
+    expect(render(
+        <SingleMediaDropzone
+            emptyIcon="su-user"
+            errorText="some-custom-error-message"
+            image={undefined}
+            onDrop={jest.fn()}
+        />
+    )).toMatchSnapshot();
+});
+
 test('Render a SingleMediaDropzone with a loader if image has not been loaded yet', () => {
     const singleMediaDropzone = mount(<SingleMediaDropzone emptyIcon="su-user" image="test.jpg" onDrop={jest.fn()} />);
     expect(singleMediaDropzone.render()).toMatchSnapshot();

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/tests/__snapshots__/SingleMediaDropzone.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/tests/__snapshots__/SingleMediaDropzone.test.js.snap
@@ -208,6 +208,49 @@ exports[`Render a SingleMediaDropzone with a loader if image has not been loaded
 </div>
 `;
 
+exports[`Render a SingleMediaDropzone with an error text 1`] = `
+Array [
+  <div
+    class="mediaContainer default"
+    tabindex="0"
+  >
+    <div
+      class="emptyIndicator"
+    >
+      <span
+        aria-label="su-user"
+        class="su-user"
+      />
+    </div>
+    <div
+      class="uploadIndicatorContainer"
+    >
+      <div
+        class="uploadIndicator"
+      >
+        <div>
+          <span
+            aria-label="su-upload"
+            class="su-upload uploadIcon"
+          />
+        </div>
+      </div>
+    </div>
+    <input
+      autocomplete="off"
+      style="display:none"
+      tabindex="-1"
+      type="file"
+    />
+  </div>,
+  <div
+    class="errorText"
+  >
+    some-custom-error-message
+  </div>,
+]
+`;
+
 exports[`Render a SingleMediaDropzone with the default empty icon 1`] = `
 <div
   class="mediaContainer default"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/SingleMediaUpload.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/SingleMediaUpload.js
@@ -1,6 +1,6 @@
 // @flow
 import React, {Fragment} from 'react';
-import {action, observable} from 'mobx';
+import {action, computed, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import {Button, Dialog} from 'sulu-admin-bundle/components';
 import {translate} from 'sulu-admin-bundle/utils';
@@ -33,6 +33,16 @@ class SingleMediaUpload extends React.Component<Props> {
 
     @observable showDeleteDialog: boolean = false;
     @observable deleting: boolean = false;
+
+    @computed get errorMessage(): ?string {
+        const error = this.props.mediaUploadStore.error;
+
+        if (!error) {
+            return undefined;
+        }
+
+        return error.detail || error.title || translate('sulu_media.upload_server_error');
+    }
 
     constructor(props: Props) {
         super(props);
@@ -115,6 +125,7 @@ class SingleMediaUpload extends React.Component<Props> {
                 <SingleMediaDropzone
                     disabled={disabled}
                     emptyIcon={emptyIcon}
+                    errorText={this.errorMessage}
                     image={mediaUploadStore.getThumbnail(imageSize)}
                     mimeType={mimeType}
                     onDrop={this.handleMediaDrop}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/tests/SingleMediaUpload.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/tests/SingleMediaUpload.test.js
@@ -46,6 +46,27 @@ test('Render a SingleMediaUpload in disabled state', () => {
     )).toMatchSnapshot();
 });
 
+test('Render a SingleMediaUpload with an error message from the MediaUploadStore', () => {
+    const mediaUploadStore = new MediaUploadStore(
+        {id: 1, locale: 'en', mimeType: 'image/jpeg', title: 'test', thumbnails: {}, url: ''},
+        observable.box('en')
+    );
+
+    mediaUploadStore.error = {
+        'code': 5003,
+        'detail': 'The uploaded file exceeds the configured maximum filesize.',
+    };
+
+    expect(render(
+        <SingleMediaUpload
+            collectionId={5}
+            disabled={true}
+            mediaUploadStore={mediaUploadStore}
+            uploadText="Upload media"
+        />
+    )).toMatchSnapshot();
+});
+
 test('Render a SingleMediaUpload with an empty icon if no image is passed', () => {
     const mediaUploadStore = new MediaUploadStore(
         undefined,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/tests/__snapshots__/SingleMediaUpload.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/tests/__snapshots__/SingleMediaUpload.test.js.snap
@@ -219,6 +219,49 @@ exports[`Render a SingleMediaUpload with an empty icon if no image is passed 1`]
 </div>
 `;
 
+exports[`Render a SingleMediaUpload with an error message from the MediaUploadStore 1`] = `
+Array [
+  <div
+    class="mediaContainer default disabled"
+  >
+    <img
+      class="thumbnail"
+      src="sulu-400x400"
+    />
+    <div
+      class="uploadIndicatorContainer"
+    >
+      <div
+        class="uploadIndicator"
+      >
+        <div>
+          <span
+            aria-label="su-upload"
+            class="su-upload uploadIcon"
+          />
+          <div
+            class="uploadInfoText"
+          >
+            Upload media
+          </div>
+        </div>
+      </div>
+    </div>
+    <input
+      autocomplete="off"
+      style="display:none"
+      tabindex="-1"
+      type="file"
+    />
+  </div>,
+  <div
+    class="errorText"
+  >
+    The uploaded file exceeds the configured maximum filesize.
+  </div>,
+]
+`;
+
 exports[`Render a SingleMediaUpload with the round skin 1`] = `
 Array [
   <div


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Related issues/PRs | replaces #4368
| License | MIT

#### What's in this PR?

This PR adjusts the `SingleMediaUpload` component to display an error message if an error happens while uploading a media. The `SingleMediaUpload` component is used in the media form and in the contact/account form. The error handling is implemented similar to the error handling in the [`MediaOverview` view](https://github.com/sulu/sulu/blob/b4a37a639e9859970eaa132bdbf7f7d494d7f58a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js#L147-L153). 

![Screenshot 2021-05-07 at 15 16 42](https://user-images.githubusercontent.com/13310795/117455196-3dd77000-af47-11eb-8930-f5791b2d5fcc.png)

#### Why?

Because the user does not see any helpful feedback if an error happens at the moment.
