### PR TITLE
Add default icon parameter to IconFieldTransformer

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/IconFieldTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/IconFieldTransformer.js
@@ -17,13 +17,14 @@ export default class IconFieldTransformer implements FieldTransformer {
 
         const {
             mapping,
-            default_mapping,
+            default: defaultIcon,
             skin = 'default',
         }: {
-            default_mapping: Object | string,
+            default: Object | string,
             mapping: mixed[],
             skin: Skin,
         } = parameters;
+
         if (!mapping) {
             return value;
         }
@@ -36,7 +37,7 @@ export default class IconFieldTransformer implements FieldTransformer {
 
         let iconConfig = mapping[value];
         if (!iconConfig) {
-            if (!default_mapping) {
+            if (!defaultIcon) {
                 log.warn(
                     `There was no icon specified in the "mapping" transformer parameter for the value "${value}".`
                 );
@@ -44,16 +45,16 @@ export default class IconFieldTransformer implements FieldTransformer {
                 return value;
             }
 
-            if (typeof default_mapping !== 'string' && typeof default_mapping !== 'object') {
+            if (typeof defaultIcon !== 'string' && typeof defaultIcon !== 'object') {
                 log.warn(
-                    'Transformer parameter "default_mapping" needs to be of type string or collection, ' +
-                    `${typeof default_mapping} given.`
+                    'Transformer parameter "default" needs to be of type string or collection, ' +
+                    `${typeof defaultIcon} given.`
                 );
 
                 return value;
             }
 
-            iconConfig = default_mapping;
+            iconConfig = defaultIcon;
         }
 
         if (skin && typeof skin !== 'string') {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/IconFieldTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/IconFieldTransformer.js
@@ -17,8 +17,10 @@ export default class IconFieldTransformer implements FieldTransformer {
 
         const {
             mapping,
+            default_mapping,
             skin = 'default',
         }: {
+            default_mapping: Object | string,
             mapping: mixed[],
             skin: Skin,
         } = parameters;
@@ -32,11 +34,26 @@ export default class IconFieldTransformer implements FieldTransformer {
             return null;
         }
 
-        const iconConfig = mapping[value];
+        let iconConfig = mapping[value];
         if (!iconConfig) {
-            log.warn(`There was no icon specified in the "mapping" transformer parameter for the value "${value}".`);
+            if (!default_mapping) {
+                log.warn(
+                    `There was no icon specified in the "mapping" transformer parameter for the value "${value}".`
+                );
 
-            return value;
+                return value;
+            }
+
+            if (typeof default_mapping !== 'string' && typeof default_mapping !== 'object') {
+                log.warn(
+                    'Transformer parameter "default_mapping" needs to be of type string or collection, ' +
+                    `${typeof default_mapping} given.`
+                );
+
+                return value;
+            }
+
+            iconConfig = default_mapping;
         }
 
         if (skin && typeof skin !== 'string') {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldTransformers/IconFieldTransformer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldTransformers/IconFieldTransformer.test.js
@@ -41,7 +41,7 @@ test('Test icon wrong type', () => {
     );
 });
 
-test('Test default_icon wrong type', () => {
+test('Test parameters/default wrong type', () => {
     expect(iconFieldTransformer.transform('default_failed', {
         mapping: {failed: 'su-fail'},
         default_mapping: 1}
@@ -92,7 +92,7 @@ test('Test icon object', () => {
     );
 });
 
-test('Test default_icon string', () => {
+test('Test parameters/default string', () => {
     expect(iconFieldTransformer.transform('default_failed', {
         default_mapping: 'su-default-ban',
         mapping: {failed: 'su-ban'},
@@ -104,7 +104,7 @@ test('Test default_icon string', () => {
     );
 });
 
-test('Test default_icon object', () => {
+test('Test parameters/default object', () => {
     expect(iconFieldTransformer.transform('default_failed', {
         default_mapping: {
             icon: 'su-default-ban',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldTransformers/IconFieldTransformer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldTransformers/IconFieldTransformer.test.js
@@ -44,10 +44,10 @@ test('Test icon wrong type', () => {
 test('Test parameters/default wrong type', () => {
     expect(iconFieldTransformer.transform('default_failed', {
         mapping: {failed: 'su-fail'},
-        default_mapping: 1}
+        default: 1}
     )).toBe('default_failed');
     expect(log.warn).toBeCalledWith(
-        'Transformer parameter "default_mapping" needs to be of type string or collection, number given.'
+        'Transformer parameter "default" needs to be of type string or collection, number given.'
     );
 });
 
@@ -94,7 +94,7 @@ test('Test icon object', () => {
 
 test('Test parameters/default string', () => {
     expect(iconFieldTransformer.transform('default_failed', {
-        default_mapping: 'su-default-ban',
+        default: 'su-default-ban',
         mapping: {failed: 'su-ban'},
     })).toEqual(
         <Icon
@@ -106,7 +106,7 @@ test('Test parameters/default string', () => {
 
 test('Test parameters/default object', () => {
     expect(iconFieldTransformer.transform('default_failed', {
-        default_mapping: {
+        default: {
             icon: 'su-default-ban',
             color: 'red',
         },

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldTransformers/IconFieldTransformer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldTransformers/IconFieldTransformer.test.js
@@ -41,6 +41,16 @@ test('Test icon wrong type', () => {
     );
 });
 
+test('Test default_icon wrong type', () => {
+    expect(iconFieldTransformer.transform('default_failed', {
+        mapping: {failed: 'su-fail'},
+        default_mapping: 1}
+    )).toBe('default_failed');
+    expect(log.warn).toBeCalledWith(
+        'Transformer parameter "default_mapping" needs to be of type string or collection, number given.'
+    );
+});
+
 test('Test icon is object without icon', () => {
     expect(iconFieldTransformer.transform('failed', {mapping: {failed: {}}})).toBe(null);
     expect(log.error).toBeCalledWith('Transformer parameter "mapping/failed/icon" needs to be of type string.');
@@ -78,6 +88,38 @@ test('Test icon object', () => {
             className={classNames(iconFieldTransformerStyles.listIcon, iconFieldTransformerStyles.default)}
             name="su-ban"
             style={{}}
+        />
+    );
+});
+
+test('Test default_icon string', () => {
+    expect(iconFieldTransformer.transform('default_failed', {
+        default_mapping: 'su-default-ban',
+        mapping: {failed: 'su-ban'},
+    })).toEqual(
+        <Icon
+            className={classNames(iconFieldTransformerStyles.listIcon, iconFieldTransformerStyles.default)}
+            name="su-default-ban"
+        />
+    );
+});
+
+test('Test default_icon object', () => {
+    expect(iconFieldTransformer.transform('default_failed', {
+        default_mapping: {
+            icon: 'su-default-ban',
+            color: 'red',
+        },
+        mapping: {
+            failed: {
+                icon: 'su-ban',
+            },
+        },
+    })).toEqual(
+        <Icon
+            className={classNames(iconFieldTransformerStyles.listIcon, iconFieldTransformerStyles.default)}
+            name="su-default-ban"
+            style={{color: 'red'}}
         />
     );
 });


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Extends the `IconFieldTransformer` with a `default_mapping` parameter. This parameter can be used to render a default icon for values which are not explicitly specified in the `mapping` collection.

#### Example Usage

`default` as a object:

```xml
         <transformer type="icon">
                <params>
                    <param name="default" type="collection">
                        <param name="icon" value="su-plus"/>
                        <param name="color" value="#FF0000"/>
                    </param>

                    <param name="mapping" type="collection">
                        <param name="modified" value="su-pen"/>
                        <param name="removed" value="su-trash-alt"/>
                    </param>
                </params>
            </transformer>
```

`default` as a string:

```xml
         <transformer type="icon">
                <params>
                    <param name="default" value="su-plus"/>

                    <param name="mapping" type="collection">
                        <param name="modified" value="su-pen"/>
                        <param name="removed" value="su-trash-alt"/>
                    </param>
                </params>
            </transformer>
```
