### PR TITLE
Fix PortalRouteLoader for none bundle paths

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -187,6 +187,7 @@
         <!-- portal loader -->
         <service id="sulu_website.routing.portal_loader" class="%sulu_website.routing.portal_loader.class%">
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
+            <argument type="service" id="file_locator"/>
 
             <tag name="routing.loader"/>
         </service>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/routing_website.yml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/routing_website.yml
@@ -13,5 +13,5 @@ sulu_media:
     resource: "@SuluMediaBundle/Resources/config/routing_website.yml"
 
 _portal_loader_test:
-    resource: "@SuluWebsiteBundle/Tests/Application/config/routing_portal_loader_test.yml"
+    resource: "routing_portal_loader_test.yml"
     type: portal

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/PortalLoaderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/PortalLoaderTest.php
@@ -16,6 +16,7 @@ use Sulu\Bundle\WebsiteBundle\Routing\PortalLoader;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\PortalInformation;
+use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
 use Symfony\Component\Routing\Route;
@@ -50,13 +51,14 @@ class PortalLoaderTest extends TestCase
 
     public function setUp(): void
     {
-        parent::setUp();
-
         $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
         $this->loaderResolver = $this->prophesize(LoaderResolverInterface::class);
         $this->loader = $this->prophesize(LoaderInterface::class);
 
-        $this->portalLoader = new PortalLoader($this->webspaceManager->reveal());
+        $this->portalLoader = new PortalLoader(
+            $this->webspaceManager->reveal(),
+            new FileLocator()
+        );
         $this->portalLoader->setResolver($this->loaderResolver->reveal());
 
         $de = new Localization();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #5858
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix PortalRouteLoader for none bundle paths.

#### Why?

Currently a bundle was needed to create portal routes.