### PR TITLE
Add column width to list config

### DIFF
--- a/src/Sulu/Bundle/ActivityBundle/Resources/config/lists/activities.xml
+++ b/src/Sulu/Bundle/ActivityBundle/Resources/config/lists/activities.xml
@@ -3,7 +3,7 @@
     <key>activities</key>
 
     <properties>
-        <property name="timestamp" visibility="always" searchability="never" sortable="false">
+        <property name="timestamp" visibility="always" searchability="never" sortable="false" width="shrink">
             <field-name>timestamp</field-name>
             <entity-name>%sulu.model.activity.class%</entity-name>
 
@@ -15,7 +15,7 @@
             </transformer>
         </property>
 
-        <property name="type" visibility="always" searchability="never" sortable="false">
+        <property name="type" visibility="always" searchability="never" sortable="false" width="shrink">
             <field-name>type</field-name>
             <entity-name>%sulu.model.activity.class%</entity-name>
 

--- a/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/FieldMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/FieldMetadata.php
@@ -53,6 +53,11 @@ class FieldMetadata
      */
     protected $filterTypeParameters;
 
+    /**
+     * @var string
+     */
+    protected $width;
+
     public function __construct(string $name)
     {
         $this->name = $name;
@@ -131,5 +136,15 @@ class FieldMetadata
     public function getFilterTypeParameters(): ?array
     {
         return $this->filterTypeParameters;
+    }
+
+    public function setWidth(string $width): void
+    {
+        $this->width = $width;
+    }
+
+    public function getWidth(): string
+    {
+        return $this->width;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/XmlListMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/XmlListMetadataLoader.php
@@ -54,6 +54,7 @@ class XmlListMetadataLoader implements ListMetadataLoaderInterface
             $field->setTransformerTypeParameters($fieldDescriptor->getMetadata()->getTransformerTypeParameters());
             $field->setFilterType($fieldDescriptor->getMetadata()->getFilterType());
             $field->setFilterTypeParameters($fieldDescriptor->getMetadata()->getFilterTypeParameters());
+            $field->setWidth($fieldDescriptor->getWidth());
 
             $list->addField($field);
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Cell.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Cell.js
@@ -3,21 +3,21 @@ import type {Node} from 'react';
 import React from 'react';
 import classNames from 'classnames';
 import tableStyles from './table.scss';
+import type {Width} from './types';
 
 type Props = {
     children?: Node,
     className?: string,
     colSpan?: number,
     depth?: number,
-    /** If set to true, the cell will not stretch and stay at minimal width */
-    small: boolean,
+    width?: Width,
 };
 
 const DEPTH_PADDING = 25;
 
 export default class Cell extends React.PureComponent<Props> {
     static defaultProps = {
-        small: false,
+        width: 'auto',
     };
 
     render() {
@@ -26,13 +26,13 @@ export default class Cell extends React.PureComponent<Props> {
             children,
             className,
             depth,
-            small,
+            width,
         } = this.props;
         const cellClass = classNames(
             className,
             tableStyles.cell,
             {
-                [tableStyles.small]: small,
+                [tableStyles[width]]: width !== 'auto',
             }
         );
         const style = {};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/HeaderCell.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/HeaderCell.js
@@ -4,7 +4,7 @@ import React from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
 import tableStyles from './table.scss';
-import type {SortOrder} from './types';
+import type {SortOrder, Width} from './types';
 
 const ASCENDING_ICON = 'su-angle-up';
 const DESCENDING_ICON = 'su-angle-down';
@@ -17,9 +17,14 @@ type Props = {|
     onClick?: (sortColumn: string, sortOrder: SortOrder) => void, // TODO extract order to own type file
     /** If set, an indicator will show up */
     sortOrder?: ?SortOrder,
+    width?: Width,
 |};
 
 export default class HeaderCell extends React.PureComponent<Props> {
+    static defaultProps = {
+        width: 'auto',
+    };
+
     getSortOrderIcon = () => {
         const {sortOrder} = this.props;
 
@@ -45,12 +50,16 @@ export default class HeaderCell extends React.PureComponent<Props> {
             onClick,
             children,
             className,
+            width,
         } = this.props;
         const headerCellClass = classNames(
             className,
             tableStyles.headerCell,
             {
                 [tableStyles.clickable]: !!onClick,
+            },
+            {
+                [tableStyles[width]]: width !== 'auto',
             }
         );
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Row.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Row.js
@@ -76,7 +76,7 @@ export default class Row extends React.PureComponent<Props> {
 
             if (select) {
                 prependedCells.push(
-                    <Cell key="choice" small={true}>
+                    <Cell key="choice" width="shrink">
                         {select}
                     </Cell>
                 );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/table.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/table.scss
@@ -165,7 +165,7 @@ $borderRadius: 3px;
     color: $cellTextColor;
     background-color: $cellBackgroundColor;
 
-    &.small {
+    &.shrink {
         width: 1px;
     }
 }
@@ -277,10 +277,5 @@ $borderRadius: 3px;
         border-bottom-left-radius: 0;
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;
-    }
-
-    .cell,
-    .header-cell {
-        width: min-content;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/table.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/table.scss
@@ -88,6 +88,10 @@ $borderRadius: 3px;
     overflow: hidden;
     max-width: 250px;
     text-align: left;
+
+    &.shrink {
+        width: 1px;
+    }
 }
 
 .cell-content {
@@ -151,6 +155,10 @@ $borderRadius: 3px;
 .button-cell,
 .header-button-cell {
     width: 56px;
+
+    &.shrink {
+        width: 1px;
+    }
 }
 
 .cell,
@@ -164,10 +172,6 @@ $borderRadius: 3px;
     border-color: $cellBorderColor;
     color: $cellTextColor;
     background-color: $cellBackgroundColor;
-
-    &.shrink {
-        width: 1px;
-    }
 }
 
 .button-cell {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/Table.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/Table.test.js
@@ -62,6 +62,30 @@ test('Render the Table component with a skin', () => {
     )).toMatchSnapshot();
 });
 
+test('Render the Table component with shrunken cells', () => {
+    expect(render(
+        <Table>
+            <Header>
+                <HeaderCell>Column Title</HeaderCell>
+                <HeaderCell>Column Title</HeaderCell>
+                <HeaderCell>Column Title</HeaderCell>
+            </Header>
+            <Body>
+                <Row>
+                    <Cell width="shrink">Column Text</Cell>
+                    <Cell width="shrink">Column Text</Cell>
+                    <Cell width="shrink">Column Text</Cell>
+                </Row>
+                <Row>
+                    <Cell>Column Text</Cell>
+                    <Cell>Column Text</Cell>
+                    <Cell>Column Text</Cell>
+                </Row>
+            </Body>
+        </Table>
+    )).toMatchSnapshot();
+});
+
 test('Render the Table component in tree structure', () => {
     expect(render(
         <Table>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/__snapshots__/Table.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/__snapshots__/Table.test.js.snap
@@ -1086,3 +1086,105 @@ exports[`Render the Table component with a skin 1`] = `
   </table>
 </div>
 `;
+
+exports[`Render the Table component with shrunken cells 1`] = `
+<div
+  class="tableContainer dark"
+>
+  <table
+    class="table"
+  >
+    <thead
+      class="header"
+    >
+      <tr>
+        <th
+          class="headerCell"
+        >
+          <span>
+            Column Title
+          </span>
+        </th>
+        <th
+          class="headerCell"
+        >
+          <span>
+            Column Title
+          </span>
+        </th>
+        <th
+          class="headerCell"
+        >
+          <span>
+            Column Title
+          </span>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        class="row"
+      >
+        <td
+          class="cell shrink"
+        >
+          <div
+            class="cellContent"
+          >
+            Column Text
+          </div>
+        </td>
+        <td
+          class="cell shrink"
+        >
+          <div
+            class="cellContent"
+          >
+            Column Text
+          </div>
+        </td>
+        <td
+          class="cell shrink"
+        >
+          <div
+            class="cellContent"
+          >
+            Column Text
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            Column Text
+          </div>
+        </td>
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            Column Text
+          </div>
+        </td>
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            Column Text
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/types.js
@@ -10,3 +10,5 @@ export type ButtonConfig = {|
 |};
 
 export type Skin = 'dark' | 'light' | 'flat';
+
+export type Width = 'auto' | 'shrink';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/AbstractTableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/AbstractTableAdapter.js
@@ -91,6 +91,7 @@ export default class AbstractTableAdapter extends AbstractAdapter {
                     name={schemaKey}
                     onClick={columnSchema.sortable ? onSort : undefined}
                     sortOrder={sortColumn === schemaKey ? sortOrder : undefined}
+                    width={this.schema[schemaKey].width}
                 >
                     {label}
                 </Table.HeaderCell>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/AbstractTableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/AbstractTableAdapter.js
@@ -69,7 +69,7 @@ export default class AbstractTableAdapter extends AbstractAdapter {
             }
 
             return (
-                <Table.Cell key={item.id + schemaKey}>
+                <Table.Cell key={item.id + schemaKey} width={this.schema[schemaKey].width}>
                     {indicators}
                     {value}
                 </Table.Cell>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/DateTimeFieldTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/DateTimeFieldTransformer.js
@@ -64,9 +64,9 @@ export default class DateTimeFieldTransformer implements FieldTransformer {
         };
 
         return momentObject.calendar({
-            sameDay: '[' + translate('sulu_admin.sameDay') + '] HH:mm:ss',
-            lastDay: '[' + translate('sulu_admin.lastDay') + '] HH:mm:ss',
-            nextDay: '[' + translate('sulu_admin.nextDay') + '] HH:mm:ss',
+            sameDay: '[' + translate('sulu_admin.sameDay') + '] HH:mm',
+            lastDay: '[' + translate('sulu_admin.lastDay') + '] HH:mm',
+            nextDay: '[' + translate('sulu_admin.nextDay') + '] HH:mm',
             nextWeek: defaultFct(),
             lastWeek: defaultFct(),
             sameElse: defaultFct(),

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
@@ -225,20 +225,20 @@ test('Render data with skin', () => {
 test('Render data with shrunken cell', () => {
     const data = [
         {
-            id: 1,
-            status: 'planned',
+            title: '1',
+            description: 'planned',
         },
         {
-            id: 2,
-            status: 'running',
+            title: '2',
+            description: 'running',
         },
         {
-            id: 3,
-            status: 'succeeded',
+            title: '3',
+            description: 'succeeded',
         },
         {
-            id: 4,
-            status: 'failed',
+            title: '4',
+            description: 'failed',
         },
     ];
 
@@ -249,7 +249,7 @@ test('Render data with shrunken cell', () => {
             transformerTypeParameters: {},
             type: 'string',
             sortable: true,
-            visibility: 'no',
+            visibility: 'yes',
             label: 'Title',
             width: 'shrink',
         },
@@ -261,7 +261,7 @@ test('Render data with shrunken cell', () => {
             sortable: true,
             visibility: 'yes',
             label: 'Description',
-            width: 'shrink',
+            width: 'auto',
         },
     };
     const tableAdapter = render(

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
@@ -222,6 +222,61 @@ test('Render data with skin', () => {
     expect(tableAdapter).toMatchSnapshot();
 });
 
+test('Render data with shrunken cell', () => {
+    const data = [
+        {
+            id: 1,
+            status: 'planned',
+        },
+        {
+            id: 2,
+            status: 'running',
+        },
+        {
+            id: 3,
+            status: 'succeeded',
+        },
+        {
+            id: 4,
+            status: 'failed',
+        },
+    ];
+
+    const schema = {
+        title: {
+            filterType: null,
+            filterTypeParameters: null,
+            transformerTypeParameters: {},
+            type: 'string',
+            sortable: true,
+            visibility: 'no',
+            label: 'Title',
+            width: 'shrink',
+        },
+        description: {
+            filterType: null,
+            filterTypeParameters: null,
+            transformerTypeParameters: {},
+            type: 'string',
+            sortable: true,
+            visibility: 'yes',
+            label: 'Description',
+            width: 'shrink',
+        },
+    };
+    const tableAdapter = render(
+        <TableAdapter
+            {...listAdapterDefaultProps}
+            data={data}
+            page={2}
+            pageCount={5}
+            schema={schema}
+        />
+    );
+
+    expect(tableAdapter).toMatchSnapshot();
+});
+
 test('Render data without header', () => {
     const data = [];
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TableAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TableAdapter.test.js.snap
@@ -1251,7 +1251,7 @@ exports[`Render data with schema and selections 1`] = `
           class="row"
         >
           <td
-            class="cell small"
+            class="cell shrink"
           >
             <div
               class="cellContent"
@@ -1292,7 +1292,7 @@ exports[`Render data with schema and selections 1`] = `
           class="row"
         >
           <td
-            class="cell small"
+            class="cell shrink"
           >
             <div
               class="cellContent"
@@ -1327,7 +1327,7 @@ exports[`Render data with schema and selections 1`] = `
           class="row"
         >
           <td
-            class="cell small"
+            class="cell shrink"
           >
             <div
               class="cellContent"
@@ -1719,6 +1719,174 @@ exports[`Render data with schema not containing all fields 1`] = `
       <button
         class="button icon button"
         disabled=""
+        type="button"
+      >
+        <span
+          aria-label="su-angle-left"
+          class="su-angle-left buttonIcon"
+        />
+      </button>
+      <button
+        class="button icon button"
+        type="button"
+      >
+        <span
+          aria-label="su-angle-right"
+          class="su-angle-right buttonIcon"
+        />
+      </button>
+    </div>
+  </nav>
+</section>
+`;
+
+exports[`Render data with shrunken cell 1`] = `
+<section>
+  <div
+    class="tableContainer dark"
+  >
+    <table
+      class="table"
+    >
+      <thead
+        class="header"
+      >
+        <tr>
+          <th
+            class="headerCell clickable"
+          >
+            <button>
+              Description
+            </button>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          class="row"
+        >
+          <td
+            class="cell shrink"
+          >
+            <div
+              class="cellContent"
+            />
+          </td>
+        </tr>
+        <tr
+          class="row"
+        >
+          <td
+            class="cell shrink"
+          >
+            <div
+              class="cellContent"
+            />
+          </td>
+        </tr>
+        <tr
+          class="row"
+        >
+          <td
+            class="cell shrink"
+          >
+            <div
+              class="cellContent"
+            />
+          </td>
+        </tr>
+        <tr
+          class="row"
+        >
+          <td
+            class="cell shrink"
+          >
+            <div
+              class="cellContent"
+            />
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <nav
+    class="pagination"
+  >
+    <span
+      class="display"
+    >
+      :
+    </span>
+    <span>
+      <div
+        class="select"
+        role="none"
+      >
+        <button
+          class="displayValue dark"
+          type="button"
+        >
+          <div
+            aria-label="10"
+            class="croppedText"
+            title="10"
+          >
+            <div
+              aria-hidden="true"
+              class="front"
+            >
+              1
+            </div>
+            <div
+              aria-hidden="true"
+              class="back"
+            >
+              <span>
+                0
+              </span>
+            </div>
+            <div
+              class="whole"
+            >
+              10
+            </div>
+          </div>
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down toggle"
+          />
+        </button>
+      </div>
+    </span>
+    <div
+      class="loader"
+    />
+    <span>
+      Page:
+    </span>
+    <span
+      class="inputContainer"
+    >
+      <label
+        class="input dark center"
+      >
+        <input
+          inputmode="numeric"
+          type="text"
+          value="1"
+        />
+      </label>
+    </span>
+    <span
+      class="display"
+    >
+      of 5
+    </span>
+    <div
+      class="buttonGroup"
+    >
+      <button
+        class="button icon button"
         type="button"
       >
         <span

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TableAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TableAdapter.test.js.snap
@@ -1753,6 +1753,13 @@ exports[`Render data with shrunken cell 1`] = `
       >
         <tr>
           <th
+            class="headerCell clickable shrink"
+          >
+            <button>
+              Title
+            </button>
+          </th>
+          <th
             class="headerCell clickable"
           >
             <button>
@@ -1770,7 +1777,18 @@ exports[`Render data with shrunken cell 1`] = `
           >
             <div
               class="cellContent"
-            />
+            >
+              1
+            </div>
+          </td>
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              planned
+            </div>
           </td>
         </tr>
         <tr
@@ -1781,7 +1799,18 @@ exports[`Render data with shrunken cell 1`] = `
           >
             <div
               class="cellContent"
-            />
+            >
+              2
+            </div>
+          </td>
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              running
+            </div>
           </td>
         </tr>
         <tr
@@ -1792,7 +1821,18 @@ exports[`Render data with shrunken cell 1`] = `
           >
             <div
               class="cellContent"
-            />
+            >
+              3
+            </div>
+          </td>
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              succeeded
+            </div>
           </td>
         </tr>
         <tr
@@ -1803,7 +1843,18 @@ exports[`Render data with shrunken cell 1`] = `
           >
             <div
               class="cellContent"
-            />
+            >
+              4
+            </div>
+          </td>
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              failed
+            </div>
           </td>
         </tr>
       </tbody>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/types.js
@@ -2,6 +2,7 @@
 import type {Node} from 'react';
 import type {IObservableValue} from 'mobx/lib/mobx';
 import {RequestPromise} from '../../services/Requester';
+import type {Width} from '../../components/Table/types';
 
 export type DataItem = {
     id: string | number,
@@ -19,6 +20,7 @@ export type SchemaEntry = {
     transformerTypeParameters: {[string]: mixed},
     type: string,
     visibility: 'always' | 'yes' | 'no' | 'never',
+    width?: Width,
 };
 
 export type Schema = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
@@ -362,7 +362,7 @@ exports[`Should render the list with a title 1`] = `
                 class="row"
               >
                 <td
-                  class="cell small"
+                  class="cell shrink"
                 >
                   <div
                     class="cellContent"
@@ -397,7 +397,7 @@ exports[`Should render the list with a title 1`] = `
                 class="row"
               >
                 <td
-                  class="cell small"
+                  class="cell shrink"
                 >
                   <div
                     class="cellContent"
@@ -660,7 +660,7 @@ exports[`Should render the list with nodes of given ListItemActions 1`] = `
                   </div>
                 </td>
                 <td
-                  class="cell small"
+                  class="cell shrink"
                 >
                   <div
                     class="cellContent"
@@ -709,7 +709,7 @@ exports[`Should render the list with nodes of given ListItemActions 1`] = `
                   </div>
                 </td>
                 <td
-                  class="cell small"
+                  class="cell shrink"
                 >
                   <div
                     class="cellContent"
@@ -951,7 +951,7 @@ exports[`Should render the list with nodes of given ToolbarActions 1`] = `
                 class="row"
               >
                 <td
-                  class="cell small"
+                  class="cell shrink"
                 >
                   <div
                     class="cellContent"
@@ -986,7 +986,7 @@ exports[`Should render the list with nodes of given ToolbarActions 1`] = `
                 class="row"
               >
                 <td
-                  class="cell small"
+                  class="cell shrink"
                 >
                   <div
                     class="cellContent"
@@ -1227,7 +1227,7 @@ exports[`Should render the list with the correct resourceKey 1`] = `
                 class="row"
               >
                 <td
-                  class="cell small"
+                  class="cell shrink"
                 >
                   <div
                     class="cellContent"
@@ -1262,7 +1262,7 @@ exports[`Should render the list with the correct resourceKey 1`] = `
                 class="row"
               >
                 <td
-                  class="cell small"
+                  class="cell shrink"
                 >
                   <div
                     class="cellContent"

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/ListMetadata/XmlListMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/ListMetadata/XmlListMetadataLoaderTest.php
@@ -58,7 +58,8 @@ class XmlListMetadataLoaderTest extends TestCase
             FieldDescriptorInterface::VISIBILITY_YES,
             FieldDescriptorInterface::SEARCHABILITY_NEVER,
             'string',
-            true
+            true,
+            FieldDescriptorInterface::WIDTH_SHRINK
         );
 
         $firstNameMetadata = new SinglePropertyMetadata('firstName');
@@ -115,6 +116,7 @@ class XmlListMetadataLoaderTest extends TestCase
         $this->assertEquals('string', $contactListFields['firstName']->getFilterType());
         $this->assertEquals(null, $contactListFields['firstName']->getFilterTypeParameters());
         $this->assertEquals([], $contactListFields['firstName']->getTransformerTypeParameters());
+        $this->assertEquals(FieldDescriptorInterface::WIDTH_SHRINK, $contactListFields['firstName']->getWidth());
 
         $this->assertEquals('lastName', $contactListFields['lastName']->getName());
         $this->assertEquals('Last name', $contactListFields['lastName']->getLabel());

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/__snapshots__/TargetGroupRules.test.js.snap
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/__snapshots__/TargetGroupRules.test.js.snap
@@ -110,7 +110,7 @@ Array [
             </div>
           </td>
           <td
-            class="cell small"
+            class="cell shrink"
           >
             <div
               class="cellContent"
@@ -177,7 +177,7 @@ Array [
             </div>
           </td>
           <td
-            class="cell small"
+            class="cell shrink"
           >
             <div
               class="cellContent"
@@ -244,7 +244,7 @@ Array [
             </div>
           </td>
           <td
-            class="cell small"
+            class="cell shrink"
           >
             <div
               class="cellContent"

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineCaseFieldDescriptor.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineCaseFieldDescriptor.php
@@ -39,7 +39,8 @@ class DoctrineCaseFieldDescriptor extends AbstractDoctrineFieldDescriptor
         string $visibility = FieldDescriptorInterface::VISIBILITY_YES,
         string $searchability = FieldDescriptorInterface::SEARCHABILITY_NEVER,
         string $type = '',
-        bool $sortable = true
+        bool $sortable = true,
+        string $width = FieldDescriptorInterface::WIDTH_AUTO
     ) {
         parent::__construct(
             $name,
@@ -47,7 +48,8 @@ class DoctrineCaseFieldDescriptor extends AbstractDoctrineFieldDescriptor
             $visibility,
             $searchability,
             $type,
-            $sortable
+            $sortable,
+            $width
         );
 
         $this->case1 = $case1;

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineConcatenationFieldDescriptor.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineConcatenationFieldDescriptor.php
@@ -38,7 +38,8 @@ class DoctrineConcatenationFieldDescriptor extends AbstractDoctrineFieldDescript
         string $visibility = FieldDescriptorInterface::VISIBILITY_YES,
         string $searchability = FieldDescriptorInterface::SEARCHABILITY_NEVER,
         string $type = '',
-        bool $sortable = true
+        bool $sortable = true,
+        string $width = FieldDescriptorInterface::WIDTH_AUTO
     ) {
         parent::__construct(
             $name,
@@ -46,7 +47,8 @@ class DoctrineConcatenationFieldDescriptor extends AbstractDoctrineFieldDescript
             $visibility,
             $searchability,
             $type,
-            $sortable
+            $sortable,
+            $width
         );
         $this->fieldDescriptors = $fieldDescriptors;
         $this->glue = $glue;

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineCountFieldDescriptor.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineCountFieldDescriptor.php
@@ -35,7 +35,8 @@ class DoctrineCountFieldDescriptor extends DoctrineFieldDescriptor
         string $searchability = FieldDescriptorInterface::SEARCHABILITY_NEVER,
         string $type = '',
         bool $sortable = true,
-        bool $distinct = false
+        bool $distinct = false,
+        string $width = FieldDescriptorInterface::WIDTH_AUTO
     ) {
         parent::__construct(
             $fieldName,
@@ -46,7 +47,8 @@ class DoctrineCountFieldDescriptor extends DoctrineFieldDescriptor
             $visibility,
             $searchability,
             $type,
-            $sortable
+            $sortable,
+            $width
         );
 
         $this->distinct = $distinct;

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineFieldDescriptor.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineFieldDescriptor.php
@@ -54,7 +54,8 @@ class DoctrineFieldDescriptor extends AbstractDoctrineFieldDescriptor
         string $visibility = FieldDescriptorInterface::VISIBILITY_YES,
         string $searchability = FieldDescriptorInterface::SEARCHABILITY_NEVER,
         string $type = '',
-        bool $sortable = true
+        bool $sortable = true,
+        string $width = FieldDescriptorInterface::WIDTH_AUTO
     ) {
         parent::__construct(
             $name,
@@ -62,7 +63,8 @@ class DoctrineFieldDescriptor extends AbstractDoctrineFieldDescriptor
             $visibility,
             $searchability,
             $type,
-            $sortable
+            $sortable,
+            $width
         );
 
         $this->fieldName = $fieldName;

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineGroupConcatFieldDescriptor.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineGroupConcatFieldDescriptor.php
@@ -47,7 +47,8 @@ class DoctrineGroupConcatFieldDescriptor extends AbstractDoctrineFieldDescriptor
         string $searchability = FieldDescriptorInterface::SEARCHABILITY_NEVER,
         string $type = '',
         bool $sortable = true,
-        bool $distinct = false
+        bool $distinct = false,
+        string $width = FieldDescriptorInterface::WIDTH_AUTO
     ) {
         parent::__construct(
             $name,
@@ -55,7 +56,8 @@ class DoctrineGroupConcatFieldDescriptor extends AbstractDoctrineFieldDescriptor
             $visibility,
             $searchability,
             $type,
-            $sortable
+            $sortable,
+            $width
         );
 
         $this->fieldDescriptor = $fieldDescriptor;

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineIdentityFieldDescriptor.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineIdentityFieldDescriptor.php
@@ -54,7 +54,8 @@ class DoctrineIdentityFieldDescriptor extends AbstractDoctrineFieldDescriptor
         string $visibility = FieldDescriptorInterface::VISIBILITY_YES,
         string $searchability = FieldDescriptorInterface::SEARCHABILITY_NEVER,
         string $type = '',
-        bool $sortable = true
+        bool $sortable = true,
+        string $width = FieldDescriptorInterface::WIDTH_AUTO
     ) {
         parent::__construct(
             $name,
@@ -62,7 +63,8 @@ class DoctrineIdentityFieldDescriptor extends AbstractDoctrineFieldDescriptor
             $visibility,
             $searchability,
             $type,
-            $sortable
+            $sortable,
+            $width
         );
 
         $this->fieldName = $fieldName;

--- a/src/Sulu/Component/Rest/ListBuilder/FieldDescriptor.php
+++ b/src/Sulu/Component/Rest/ListBuilder/FieldDescriptor.php
@@ -62,6 +62,13 @@ class FieldDescriptor implements FieldDescriptorInterface
     private $sortable;
 
     /**
+     * @var string
+     *
+     * @Expose
+     */
+    private $width;
+
+    /**
      * The type of the field (only used for special fields like dates).
      *
      * @var string
@@ -81,7 +88,8 @@ class FieldDescriptor implements FieldDescriptorInterface
         string $visibility = FieldDescriptorInterface::VISIBILITY_YES,
         string $searchability = FieldDescriptorInterface::SEARCHABILITY_NEVER,
         string $type = '',
-        bool $sortable = true
+        bool $sortable = true,
+        string $width = FieldDescriptorInterface::WIDTH_AUTO
     ) {
         $this->name = $name;
         $this->visibility = $visibility;
@@ -89,6 +97,7 @@ class FieldDescriptor implements FieldDescriptorInterface
         $this->sortable = $sortable;
         $this->type = $type;
         $this->translation = null == $translation ? $name : $translation;
+        $this->width = $width;
     }
 
     public function getName()
@@ -141,6 +150,11 @@ class FieldDescriptor implements FieldDescriptorInterface
     public function getSortable()
     {
         return $this->sortable;
+    }
+
+    public function getWidth(): string
+    {
+        return $this->width;
     }
 
     public function getMetadata()

--- a/src/Sulu/Component/Rest/ListBuilder/FieldDescriptorInterface.php
+++ b/src/Sulu/Component/Rest/ListBuilder/FieldDescriptorInterface.php
@@ -32,6 +32,10 @@ interface FieldDescriptorInterface
 
     const SEARCHABILITY_NO = 'no';
 
+    const WIDTH_AUTO = 'auto';
+
+    const WIDTH_SHRINK = 'shrink';
+
     /**
      * Returns the name of the field.
      *
@@ -79,6 +83,8 @@ interface FieldDescriptorInterface
      * @return string
      */
     public function getSearchability();
+
+    public function getWidth(): string;
 
     /**
      * @return AbstractPropertyMetadata

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/AbstractPropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/AbstractPropertyMetadata.php
@@ -63,6 +63,11 @@ abstract class AbstractPropertyMetadata
      */
     private $filterTypeParameters;
 
+    /**
+     * @var string
+     */
+    private $width;
+
     public function __construct($name)
     {
         $this->name = $name;
@@ -204,5 +209,15 @@ abstract class AbstractPropertyMetadata
     public function setFilterTypeParameters($parameters)
     {
         $this->filterTypeParameters = $parameters;
+    }
+
+    public function setWidth(string $width): void
+    {
+        $this->width = $width;
+    }
+
+    public function getWidth(): string
+    {
+        return $this->width;
     }
 }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/FieldDescriptorFactory.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/FieldDescriptorFactory.php
@@ -181,7 +181,8 @@ class FieldDescriptorFactory implements FieldDescriptorFactoryInterface, CacheWa
                 $propertyMetadata->getVisibility(),
                 $propertyMetadata->getSearchability(),
                 $propertyMetadata->getType(),
-                $propertyMetadata->isSortable()
+                $propertyMetadata->isSortable(),
+                $propertyMetadata->getWidth()
             );
         }
 
@@ -192,7 +193,8 @@ class FieldDescriptorFactory implements FieldDescriptorFactoryInterface, CacheWa
             $propertyMetadata->getVisibility(),
             $propertyMetadata->getSearchability(),
             $propertyMetadata->getType(),
-            $propertyMetadata->isSortable()
+            $propertyMetadata->isSortable(),
+            $propertyMetadata->getWidth()
         );
     }
 
@@ -221,7 +223,8 @@ class FieldDescriptorFactory implements FieldDescriptorFactoryInterface, CacheWa
             $propertyMetadata->getSearchability(),
             $propertyMetadata->getType(),
             $propertyMetadata->isSortable(),
-            $this->resolveOptions($propertyMetadata->getDistinct(), $options)
+            $this->resolveOptions($propertyMetadata->getDistinct(), $options),
+            $propertyMetadata->getWidth()
         );
     }
 
@@ -242,7 +245,8 @@ class FieldDescriptorFactory implements FieldDescriptorFactoryInterface, CacheWa
             $propertyMetadata->getVisibility(),
             $propertyMetadata->getSearchability(),
             $propertyMetadata->getType(),
-            $propertyMetadata->isSortable()
+            $propertyMetadata->isSortable(),
+            $propertyMetadata->getWidth()
         );
     }
 
@@ -259,7 +263,8 @@ class FieldDescriptorFactory implements FieldDescriptorFactoryInterface, CacheWa
             $propertyMetadata->getSearchability(),
             $propertyMetadata->getType(),
             $propertyMetadata->isSortable(),
-            $this->resolveOptions($propertyMetadata->getDistinct(), $options)
+            $this->resolveOptions($propertyMetadata->getDistinct(), $options),
+            $propertyMetadata->getWidth()
         );
     }
 
@@ -278,7 +283,8 @@ class FieldDescriptorFactory implements FieldDescriptorFactoryInterface, CacheWa
             $propertyMetadata->getVisibility(),
             $propertyMetadata->getSearchability(),
             $propertyMetadata->getType(),
-            $propertyMetadata->isSortable()
+            $propertyMetadata->isSortable(),
+            $propertyMetadata->getWidth()
         );
     }
 
@@ -305,7 +311,8 @@ class FieldDescriptorFactory implements FieldDescriptorFactoryInterface, CacheWa
             $propertyMetadata->getVisibility(),
             $propertyMetadata->getSearchability(),
             $propertyMetadata->getType(),
-            $propertyMetadata->isSortable()
+            $propertyMetadata->isSortable(),
+            $propertyMetadata->getWidth()
         );
     }
 
@@ -317,7 +324,8 @@ class FieldDescriptorFactory implements FieldDescriptorFactoryInterface, CacheWa
             $generalMetadata->getVisibility(),
             $generalMetadata->getSearchability(),
             $generalMetadata->getType(),
-            $generalMetadata->isSortable()
+            $generalMetadata->isSortable(),
+            $generalMetadata->getWidth()
         );
     }
 

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/ListXmlLoader.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/ListXmlLoader.php
@@ -123,6 +123,15 @@ class ListXmlLoader
             XmlUtil::getBooleanValueFromXPath('@sortable', $xpath, $propertyNode, true)
         );
 
+        $propertyMetadata->setWidth(
+            XmlUtil::getValueFromXPath(
+                '@width',
+                $xpath,
+                $propertyNode,
+                FieldDescriptorInterface::WIDTH_AUTO
+            )
+        );
+
         if (null !== $type = XmlUtil::getValueFromXPath('x:transformer/@type', $xpath, $propertyNode)) {
             $propertyMetadata->setType($type);
         } elseif (null !== $type = XmlUtil::getValueFromXPath('@type', $xpath, $propertyNode)) {

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/Resources/schema/list-2.0.xsd
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/Resources/schema/list-2.0.xsd
@@ -186,6 +186,16 @@
         <xs:attribute type="xs:string" name="name" use="required"/>
         <xs:attribute type="xs:string" name="type" default="string"/>
         <xs:attribute type="xs:boolean" name="sortable" default="true"/>
+
+        <xs:attribute name="width" default="auto">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="auto" />
+                    <xs:enumeration value="shrink" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+
         <xs:attribute name="visibility" default="no">
             <xs:simpleType>
                 <xs:restriction base="xs:string">

--- a/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/FieldDescriptorFactoryTest.php
+++ b/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/FieldDescriptorFactoryTest.php
@@ -104,8 +104,6 @@ class FieldDescriptorFactoryTest extends TestCase
                 'disabled' => true,
                 'sortable' => false,
                 'class' => 'test-class',
-                'minWidth' => '50px',
-                'width' => '100px',
             ],
             'city' => ['name' => 'city', 'translation' => 'contact.address.city', 'default' => true],
             'extension' => ['name' => 'extension', 'translation' => 'extension.extension', 'default' => true],
@@ -122,7 +120,7 @@ class FieldDescriptorFactoryTest extends TestCase
 
         $expected = [
             'id' => ['name' => 'id', 'translation' => 'public.id', 'disabled' => true, 'type' => 'integer'],
-            'firstName' => ['name' => 'firstName', 'translation' => 'contact.contacts.firstName', 'default' => true],
+            'firstName' => ['name' => 'firstName', 'translation' => 'contact.contacts.firstName', 'default' => true, 'width' => 'shrink'],
             'lastName' => ['name' => 'lastName', 'translation' => 'contact.contacts.lastName', 'default' => true],
         ];
 
@@ -141,6 +139,7 @@ class FieldDescriptorFactoryTest extends TestCase
                 'translation' => 'Tags',
                 'instance' => DoctrineGroupConcatFieldDescriptor::class,
                 'disabled' => true,
+                'width' => 'shrink',
             ],
         ];
 
@@ -159,6 +158,7 @@ class FieldDescriptorFactoryTest extends TestCase
                 'translation' => 'Tag',
                 'instance' => DoctrineCaseFieldDescriptor::class,
                 'disabled' => true,
+                'width' => 'shrink',
             ],
         ];
 
@@ -182,6 +182,7 @@ class FieldDescriptorFactoryTest extends TestCase
                 'translation' => 'Tags',
                 'instance' => DoctrineIdentityFieldDescriptor::class,
                 'disabled' => true,
+                'width' => 'shrink',
             ],
         ];
 
@@ -231,6 +232,7 @@ class FieldDescriptorFactoryTest extends TestCase
                 'translation' => 'Tags',
                 'instance' => DoctrineCountFieldDescriptor::class,
                 'disabled' => true,
+                'width' => 'shrink',
             ],
         ];
 
@@ -275,6 +277,7 @@ class FieldDescriptorFactoryTest extends TestCase
                 'default' => false,
                 'type' => 'string',
                 'sortable' => true,
+                'width' => 'auto',
             ],
             $expected
         );
@@ -286,6 +289,7 @@ class FieldDescriptorFactoryTest extends TestCase
         $this->assertEquals($expected['default'], $fieldDescriptor->getDefault());
         $this->assertEquals($expected['type'], $fieldDescriptor->getType());
         $this->assertEquals($expected['sortable'], $fieldDescriptor->getSortable());
+        $this->assertEquals($expected['width'], $fieldDescriptor->getWidth());
 
         if (\array_key_exists('joins', $expected)) {
             foreach ($expected['joins'] as $name => $joinExpected) {

--- a/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/Resources/case.xml
+++ b/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/Resources/case.xml
@@ -1,7 +1,7 @@
 <list xmlns="http://schemas.sulu.io/list-builder/list">
     <key>case</key>
     <properties>
-        <case-property name="tag">
+        <case-property name="tag" width="shrink">
             <field>
                 <field-name>name</field-name>
                 <entity-name>SuluTagBundle:Tag</entity-name>

--- a/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/Resources/count.xml
+++ b/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/Resources/count.xml
@@ -1,7 +1,7 @@
 <list xmlns="http://schemas.sulu.io/list-builder/list">
     <key>count</key>
     <properties>
-        <count-property name="tags">
+        <count-property name="tags" width="shrink">
             <field-name>tags</field-name>
             <entity-name>%sulu.model.contact.class%</entity-name>
         </count-property>

--- a/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/Resources/group-concat.xml
+++ b/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/Resources/group-concat.xml
@@ -2,7 +2,7 @@
     <key>group-concat</key>
 
     <properties>
-        <group-concat-property name="tags" glue=",">
+        <group-concat-property name="tags" glue="," width="shrink">
             <field-name>name</field-name>
             <entity-name>SuluTagBundle:Tag</entity-name>
 

--- a/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/Resources/identity.xml
+++ b/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/Resources/identity.xml
@@ -2,7 +2,7 @@
     <key>identity</key>
 
     <properties>
-        <identity-property name="tags">
+        <identity-property name="tags" width="shrink">
             <field-name>tags</field-name>
             <entity-name>%sulu.model.contact.class%</entity-name>
         </identity-property>

--- a/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/Resources/minimal.xml
+++ b/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/Resources/minimal.xml
@@ -7,7 +7,7 @@
             <entity-name>%sulu.model.contact.class%</entity-name>
         </property>
 
-        <property name="firstName" translation="contact.contacts.firstName" visibility="always">
+        <property name="firstName" translation="contact.contacts.firstName" visibility="always" width="shrink">
             <field-name>firstName</field-name>
             <entity-name>%sulu.model.contact.class%</entity-name>
         </property>

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
@@ -163,6 +163,7 @@ class ListXmlLoaderTest extends TestCase
                 'visibility' => FieldDescriptorInterface::VISIBILITY_ALWAYS,
                 'searchability' => FieldDescriptorInterface::SEARCHABILITY_YES,
                 'entityName' => 'SuluContactBundle:Contact',
+                'width' => FieldDescriptorInterface::WIDTH_SHRINK,
             ],
             $propertiesMetadata[1]
         );
@@ -394,6 +395,7 @@ class ListXmlLoaderTest extends TestCase
                         'test2' => 'test',
                     ],
                 ],
+                'width' => FieldDescriptorInterface::WIDTH_SHRINK,
             ],
             $propertiesMetadata[0]
         );
@@ -466,6 +468,7 @@ class ListXmlLoaderTest extends TestCase
                 'transformer-type-params' => null,
                 'entityName' => null,
                 'joins' => [],
+                'width' => FieldDescriptorInterface::WIDTH_AUTO,
             ],
             $expected
         );
@@ -477,6 +480,7 @@ class ListXmlLoaderTest extends TestCase
         $this->assertEquals($expected['transformer-type-params'], $metadata->getTransformerTypeParameters());
         $this->assertEquals($expected['visibility'], $metadata->getVisibility());
         $this->assertEquals($expected['searchability'], $metadata->getSearchability());
+        $this->assertEquals($expected['width'], $metadata->getWidth());
 
         $this->assertEquals($expected['type'], $metadata->getType());
         $this->assertEquals($expected['sortable'], $metadata->isSortable());

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/Resources/identity.xml
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/Resources/identity.xml
@@ -2,7 +2,7 @@
     <key>identity</key>
 
     <properties>
-        <identity-property name="tags">
+        <identity-property name="tags" width="shrink">
             <field-name>tags</field-name>
             <entity-name>%sulu.model.contact.class%</entity-name>
 

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/Resources/minimal.xml
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/Resources/minimal.xml
@@ -8,7 +8,7 @@
             <transformer type="integer"/>
         </property>
 
-        <property name="firstName" translation="contact.contacts.firstName" searchability="yes" visibility="always">
+        <property name="firstName" translation="contact.contacts.firstName" searchability="yes" visibility="always" width="shrink">
             <field-name>firstName</field-name>
             <entity-name>%sulu.model.contact.class%</entity-name>
         </property>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| License | MIT

#### What's in this PR?

Adds the possibility to `shrink` specific columns in the table adapters.

#### Example Usage

```xml
        <property name="timestamp" visibility="always" searchability="never" sortable="false" width="shrink">
                  ....
        </property>
```
