### PR TITLE
Add AccountManager to UPGRADE.md

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -129,6 +129,7 @@ call to pass the correct parameters:
 - `Sulu\Bundle\ContactBundle\Controller\ContactTitleController`
 - `Sulu\Bundle\ContactBundle\Controller\AccountMediaController`
 - `Sulu\Bundle\ContactBundle\Controller\AccountController`
+- `Sulu\Bundle\ContactBundle\Contact\AccountManager`
 - `Sulu\Bundle\SecurityBundle\Controller\ResettingController`
 - `Sulu\Bundle\SecurityBundle\Controller\RoleController`
 - `Sulu\Bundle\SecurityBundle\UserManager\UserManager`


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Adds the missing `AccountManager` service to the upgrade.md