### PR TITLE
Add configuration to disable collaboration

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -153,6 +153,11 @@ class AdminController
      */
     private $collaborationInterval;
 
+    /**
+     * @var bool
+     */
+    private $collaborationEnabled;
+
     public function __construct(
         UrlGeneratorInterface $urlGenerator,
         TokenStorageInterface $tokenStorage,
@@ -176,7 +181,8 @@ class AdminController
         array $locales,
         array $translations,
         string $fallbackLocale,
-        string $collaborationInterval
+        string $collaborationInterval,
+        bool $collaborationEnabled = null
     ) {
         $this->urlGenerator = $urlGenerator;
         $this->tokenStorage = $tokenStorage;
@@ -201,6 +207,12 @@ class AdminController
         $this->translations = $translations;
         $this->fallbackLocale = $fallbackLocale;
         $this->collaborationInterval = $collaborationInterval;
+
+        if (null === $collaborationEnabled) {
+            @trigger_error('Instantiating the AdminController without the $collaborationEnabled argument is deprecated!', \E_USER_DEPRECATED);
+        }
+
+        $this->collaborationEnabled = $collaborationEnabled ?? true;
     }
 
     public function indexAction()
@@ -254,6 +266,7 @@ class AdminController
                 }, $this->dataProviderPool->getAll()),
                 'user' => $user,
                 'contact' => $contact,
+                'collaborationEnabled' => $this->collaborationEnabled,
                 'collaborationInterval' => $this->collaborationInterval * 1000,
             ],
         ];

--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -209,7 +209,7 @@ class AdminController
         $this->collaborationInterval = $collaborationInterval;
 
         if (null === $collaborationEnabled) {
-            @trigger_error('Instantiating the AdminController without the $collaborationEnabled argument is deprecated!', \E_USER_DEPRECATED);
+            @\trigger_error('Instantiating the AdminController without the $collaborationEnabled argument is deprecated!', \E_USER_DEPRECATED);
         }
 
         $this->collaborationEnabled = $collaborationEnabled ?? true;

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Configuration.php
@@ -21,6 +21,16 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * @var bool
+     */
+    private $debug;
+
+    public function __construct(bool $debug)
+    {
+        $this->debug = $debug;
+    }
+
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('sulu_admin');
@@ -48,6 +58,9 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('collaboration')
                     ->addDefaultsIfNotSet()
                     ->children()
+                        ->booleanNode('enabled')
+                            ->defaultValue(!$this->debug)
+                        ->end()
                         ->scalarNode('interval')
                             ->defaultValue(20)
                             ->info('The seconds between the keep alive messages for the collaboration feature')

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
@@ -131,15 +131,16 @@ class SuluAdminExtension extends Extension implements PrependExtensionInterface
         );
     }
 
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
-        $configuration = new Configuration();
+        $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter($this->getAlias() . '.name', $config['name']);
         $container->setParameter($this->getAlias() . '.email', $config['email']);
         $container->setParameter($this->getAlias() . '.user_data_service', $config['user_data_service']);
         $container->setParameter($this->getAlias() . '.resources', $config['resources']);
+        $container->setParameter($this->getAlias() . '.collaboration_enabled', $config['collaboration']['enabled']);
         $container->setParameter($this->getAlias() . '.collaboration_interval', $config['collaboration']['interval']);
         $container->setParameter($this->getAlias() . '.collaboration_threshold', $config['collaboration']['threshold']);
 
@@ -168,5 +169,10 @@ class SuluAdminExtension extends Extension implements PrependExtensionInterface
                 $fieldTypeOptionRegistry->addMethodCall('add', [$fieldTypeName, $baseFieldType, $fieldTypeConfig]);
             }
         }
+    }
+
+    public function getConfiguration(array $config, ContainerBuilder $container)
+    {
+        return new Configuration($container->getParameter('kernel.debug'));
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
@@ -171,7 +171,10 @@ class SuluAdminExtension extends Extension implements PrependExtensionInterface
         }
     }
 
-    public function getConfiguration(array $config, ContainerBuilder $container)
+    /**
+     * @param mixed[] $config
+     */
+    public function getConfiguration(array $config, ContainerBuilder $container): Configuration
     {
         return new Configuration($container->getParameter('kernel.debug'));
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -30,6 +30,7 @@
             <argument>%sulu_core.translations%</argument>
             <argument>%sulu_core.fallback_locale%</argument>
             <argument>%sulu_admin.collaboration_interval%</argument>
+            <argument>%sulu_admin.collaboration_enabled%</argument>
 
             <tag name="sulu.context" context="admin"/>
         </service>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -306,6 +306,7 @@ function processConfig(config: Object) {
     navigationRegistry.set(config.navigation);
     resourceRouteRegistry.setEndpoints(config.resources);
     smartContentConfigStore.setConfig(config.smartContent);
+    CollaborationStore.enabled = config.collaborationEnabled;
     CollaborationStore.interval = config.collaborationInterval;
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/CollaborationStore/CollaborationStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/CollaborationStore/CollaborationStore.js
@@ -4,6 +4,7 @@ import ResourceRequester from '../../services/ResourceRequester';
 import type {Collaboration} from './types';
 
 export default class CollaborationStore {
+    static enabled: boolean = true;
     static interval: number;
 
     resourceKey: string;
@@ -20,7 +21,7 @@ export default class CollaborationStore {
     }
 
     sendRequest() {
-        if (this.destroyed) {
+        if (!CollaborationStore.enabled || this.destroyed) {
             return;
         }
 
@@ -33,6 +34,10 @@ export default class CollaborationStore {
     }
 
     destroy() {
+        if (!CollaborationStore.enabled || this.destroyed) {
+            return;
+        }
+
         this.destroyed = true;
         ResourceRequester.delete('collaborations', {id: this.id, resourceKey: this.resourceKey});
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/CollaborationStore/tests/CollaborationStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/CollaborationStore/tests/CollaborationStore.test.js
@@ -10,6 +10,7 @@ jest.mock('../../../services/ResourceRequester', () => ({
 }));
 
 beforeEach(() => {
+    CollaborationStore.enabled = true;
     CollaborationStore.interval = 10000;
 });
 
@@ -69,4 +70,12 @@ test('Load collaborators repeatedly and stop when destroyed', () => {
             expect(ResourceRequester.delete).toHaveBeenLastCalledWith('collaborations', {id: 1, resourceKey: 'pages'});
         });
     });
+});
+
+test('Do not send collaboration request if disabled', () => {
+    CollaborationStore.enabled = false;
+
+    const collaborationStore = new CollaborationStore('pages', 1);
+
+    expect(ResourceRequester.put).not.toHaveBeenCalled();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/CollaborationStore/tests/CollaborationStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/CollaborationStore/tests/CollaborationStore.test.js
@@ -76,6 +76,8 @@ test('Do not send collaboration request if disabled', () => {
     CollaborationStore.enabled = false;
 
     const collaborationStore = new CollaborationStore('pages', 1);
+    collaborationStore.destroy();
 
     expect(ResourceRequester.put).not.toHaveBeenCalled();
+    expect(ResourceRequester.delete).not.toHaveBeenCalled();
 });

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
@@ -222,7 +222,8 @@ class AdminControllerTest extends TestCase
             $this->locales,
             $this->translations,
             $this->fallbackLocale,
-            10
+            10,
+            true
         );
     }
 
@@ -290,6 +291,7 @@ class AdminControllerTest extends TestCase
                         && 'navigation_item1' === $data['sulu_admin']['navigation'][0]['title']
                         && 'navigation_item2' === $data['sulu_admin']['navigation'][1]['title']
                         && $data['sulu_admin']['resources'] === $this->resources
+                        && true === $data['sulu_admin']['collaborationEnabled']
                         && 10000 === $data['sulu_admin']['collaborationInterval']
                         && $data['admin1'] === $admin1Config
                         && $data['admin2'] === $admin2Config;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Add configuration to disable collaboration.
By default, collaboration will be disabled in the `dev` environment and enabled in the others

#### Why?

Because it's often annoying that collaboration is enabled in dev mode.

#### Example Usage

```yaml
# config/packages/sulu_admin.yaml

sulu_admin:
    collaboration:
        enabled: false
```