### PR TITLE
Cancel previous ci runs on push

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -7,6 +7,7 @@ on:
             - '[0-9]+.x'
             - '[0-9]+.[0-9]+'
 
+# This stops all previous ci runs of a pull request, if a new commit has been pushed
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref }}
     cancel-in-progress: true

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -7,6 +7,10 @@ on:
             - '[0-9]+.x'
             - '[0-9]+.[0-9]+'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref }}
+    cancel-in-progress: true
+
 jobs:
     js-css:
         name: "Node ${{ matrix.node-version }}"

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -9,7 +9,7 @@ on:
 
 # This stops all previous ci runs of a pull request, if a new commit has been pushed
 concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref }}
+    group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -7,7 +7,7 @@ on:
             - '[0-9]+.x'
             - '[0-9]+.[0-9]+'
 
-# This stops all previous ci runs of a pull request, if a new commit has been pushed
+# automatically cancel previously started workflows when pushing a new commit to a branch
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Cancel previous ci runs on push

#### Why?

To hopefully improve the php7.2-postgres and the php7.4-windows build times