### PR TITLE
Fix sorting of activities

### DIFF
--- a/src/Sulu/Bundle/ActivityBundle/UserInterface/Controller/ActivityController.php
+++ b/src/Sulu/Bundle/ActivityBundle/UserInterface/Controller/ActivityController.php
@@ -132,6 +132,7 @@ class ActivityController extends AbstractRestController implements ClassResource
         $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
         $listBuilder->setSelectFields($fieldDescriptors);
         $listBuilder->sort($fieldDescriptors['timestamp'], ListBuilderInterface::SORTORDER_DESC);
+        $listBuilder->sort($fieldDescriptors['id'], ListBuilderInterface::SORTORDER_DESC);
 
         $translationLocale = $user->getLocale();
 
@@ -424,6 +425,7 @@ class ActivityController extends AbstractRestController implements ClassResource
         ];
 
         return [
+            'id' => $this->createFieldDescriptor('id'),
             'type' => $this->createFieldDescriptor('type'),
             'context' => $this->createFieldDescriptor('context'),
             'timestamp' => $this->createFieldDescriptor('timestamp'),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix sorting of activities

#### Why?

When editing a page and separately clicking `Save as draft` and `Publish`, three domain events are emitted:

1. a `PageModifiedEvent` representing the `Save as draft` click
2. a `PageModifiedEvent` and a `PagePublishedEvent` representing the `Publish` click

but the api controller returns the events in a wrong order:

1. the `PageModifiedEvent` of the `Save as draft` click
2. the `PagePublishedEvent` of the `Publish` click
3. the `PageModifiedEvent` of the `Publish` click
