### PR TITLE
guzzle.xml - required package + version on deprecated

### DIFF
--- a/src/Sulu/Bundle/LocationBundle/Resources/config/guzzle.xml
+++ b/src/Sulu/Bundle/LocationBundle/Resources/config/guzzle.xml
@@ -8,7 +8,7 @@
     <services>
         <!-- Guzzle client -->
         <service id="sulu_location.geolocator.guzzle.client" class="%sulu_location.guzzle.client.class%">
-            <deprecated />
+            <deprecated package="sulu/sulu" version="2.2" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| License | MIT

#### What's in this PR?

Since symfony/dependency-injection 5.1: Not setting the attribute "version" of the node "deprecated" in "/var/www/project/vendor/sulu/sulu/src/Sulu/Bundle/LocationBundle/DependencyInjection/../Resources/config/guzzle.xml" is deprecated.

#### Why?

Since symfony/dependency-injection 5.1: Not setting the attribute "package" of the node "deprecated" in "/var/www/project/vendor/sulu/sulu/src/Sulu/Bundle/LocationBundle/DependencyInjection/../Resources/config/guzzle.xml" is deprecated.