### PR TITLE
Fix eslint import/order style

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/ArrowMenu.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/ArrowMenu.js
@@ -1,6 +1,5 @@
 // @flow
 import React, {Fragment} from 'react';
-import type {ChildrenArray, Element, ElementRef} from 'react';
 import {action, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import classNames from 'classnames';
@@ -10,6 +9,7 @@ import Section from './Section';
 import Item from './Item';
 import Action from './Action';
 import arrowMenuStyles from './arrowMenu.scss';
+import type {ChildrenArray, Element, ElementRef} from 'react';
 
 type Props = {
     anchorElement: Element<*>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/Section.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/Section.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
-import type {Node} from 'react';
 import sectionStyles from './section.scss';
+import type {Node} from 'react';
 
 type Props = {
     children?: Node,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/SingleItemSection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/SingleItemSection.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react';
-import type {ChildrenArray, Element} from 'react';
 import Item from './Item';
 import Section from './Section';
+import type {ChildrenArray, Element} from 'react';
 
 type Props = {
     children: ChildrenArray<Element<typeof Item> | false>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/AutoCompletePopover.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/AutoCompletePopover.js
@@ -1,12 +1,12 @@
 // @flow
 import React from 'react';
-import type {ElementRef} from 'react';
 import Mousetrap from 'mousetrap';
 import {computed, observable} from 'mobx';
 import Menu from '../Menu';
 import Popover from '../Popover';
 import Suggestion from './Suggestion';
 import autoCompletePopoverStyles from './autoCompletePopover.scss';
+import type {ElementRef} from 'react';
 
 type Props = {
     anchorElement: ElementRef<*>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/Suggestion.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/Suggestion.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react';
-import type {Node} from 'react';
 import Icon from '../Icon';
 import suggestionStyles from './suggestion.scss';
+import type {Node} from 'react';
 
 type Props = {|
     children: string | (highlight: (text: string) => Node) => Node,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/Block.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/Block.js
@@ -1,10 +1,10 @@
 // @flow
 import React, {Fragment} from 'react';
-import type {Node} from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
 import SingleSelect from '../SingleSelect';
 import blockStyles from './block.scss';
+import type {Node} from 'react';
 
 type Props = {
     activeType?: string,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlock.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlock.js
@@ -1,9 +1,9 @@
 // @flow
 import React from 'react';
-import type {ComponentType} from 'react';
 import {SortableElement} from 'react-sortable-hoc';
 import Block from '../Block';
 import SortableHandle from './SortableHandle';
+import type {ComponentType} from 'react';
 import type {RenderBlockContentCallback} from './types';
 
 type Props = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Breadcrumb/Breadcrumb.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Breadcrumb/Breadcrumb.js
@@ -1,9 +1,9 @@
 // @flow
 import React from 'react';
-import type {ChildrenArray, Element} from 'react';
 import Icon from '../Icon';
 import Item from './Item';
 import breadcrumbStyles from './breadcrumb.scss';
+import type {ChildrenArray, Element} from 'react';
 
 const ICON_ANGLE_RIGHT = 'su-angle-right';
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/Button.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/Button.js
@@ -1,10 +1,10 @@
 // @flow
 import React from 'react';
-import type {ElementRef, Node} from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
 import Loader from '../Loader';
 import buttonStyles from './button.scss';
+import type {ElementRef, Node} from 'react';
 import type {ButtonSkin} from './types';
 
 const LOADER_SIZE = 25;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ButtonGroup/ButtonGroup.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ButtonGroup/ButtonGroup.js
@@ -1,10 +1,10 @@
 // @flow
 import React from 'react';
 import classNames from 'classnames';
-import type {ChildrenArray, Element} from 'react';
 import Button from '../Button';
 import DropdownButton from '../DropdownButton';
 import buttonGroupStyles from './buttonGroup.scss';
+import type {ChildrenArray, Element} from 'react';
 
 type Props = {
     children: ChildrenArray<Element<typeof Button | typeof DropdownButton> | false>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Card/Card.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Card/Card.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react';
-import type {Node} from 'react';
 import Icon from '../Icon';
 import cardStyles from './card.scss';
+import type {Node} from 'react';
 
 type Props<T> = {|
     children: Node,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CardCollection/CardCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CardCollection/CardCollection.js
@@ -1,10 +1,10 @@
 // @flow
 import React, {Fragment} from 'react';
-import type {ChildrenArray, Element} from 'react';
 import {translate} from '../../utils/Translator';
 import Button from '../Button';
 import Card from '../Card';
 import cardCollectionStyles from './cardCollection.scss';
+import type {ChildrenArray, Element} from 'react';
 
 type Props = {|
     children?: ChildrenArray<Element<typeof Card>> | false,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/Checkbox.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/Checkbox.js
@@ -2,8 +2,8 @@
 import React from 'react';
 import classNames from 'classnames';
 import Switch from '../Switch';
-import type {SwitchProps} from '../Switch';
 import checkboxStyles from './checkbox.scss';
+import type {SwitchProps} from '../Switch';
 
 type Props<T> = {|
     ...SwitchProps<T>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/CheckboxGroup.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/CheckboxGroup.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
-import type {ChildrenArray, Element} from 'react';
 import Checkbox from './Checkbox';
+import type {ChildrenArray, Element} from 'react';
 
 type Props<T> = {|
     children: ChildrenArray<Element<typeof Checkbox>>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Chip/Chip.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Chip/Chip.js
@@ -1,9 +1,9 @@
 // @flow
 import React from 'react';
-import type {Node} from 'react';
 import classNames from 'classnames';
 import Icon from '../../components/Icon';
 import chipStyles from './chip.scss';
+import type {Node} from 'react';
 
 type Props<T> = {|
     children: Node,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColorPicker/ColorPicker.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColorPicker/ColorPicker.js
@@ -1,12 +1,12 @@
 // @flow
 import React, {Fragment} from 'react';
-import type {ElementRef} from 'react';
 import {SketchPicker} from 'react-color';
 import {observer} from 'mobx-react';
 import {action, computed, observable} from 'mobx';
 import Input from '../Input';
 import Popover from '../Popover';
 import colorPickerStyles from './colorPicker.scss';
+import type {ElementRef} from 'react';
 import './colorPickerGlobal.scss';
 
 type Props = {|

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Column.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Column.js
@@ -1,10 +1,10 @@
 // @flow
-import type {ChildrenArray, Element} from 'react';
 import React from 'react';
 import classNames from 'classnames';
 import Loader from '../Loader';
 import Item from './Item';
 import columnStyles from './column.scss';
+import type {ChildrenArray, Element} from 'react';
 
 type Props = {|
     children?: ChildrenArray<Element<typeof Item>>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ColumnList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ColumnList.js
@@ -2,13 +2,13 @@
 import {observer} from 'mobx-react';
 import {action, observable} from 'mobx';
 import React from 'react';
-import type {ChildrenArray, Element, ElementRef} from 'react';
 import classNames from 'classnames';
 import Column from './Column';
 import Item from './Item';
 import Toolbar from './Toolbar';
-import type {ToolbarItemConfig} from './types';
 import columnListStyles from './columnList.scss';
+import type {ToolbarItemConfig} from './types';
+import type {ChildrenArray, Element, ElementRef} from 'react';
 
 type Props = {|
     children: ChildrenArray<Element<typeof Column>>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Item.js
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react';
-import type {Element, Node} from 'react';
 import {action, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import classNames from 'classnames';
@@ -8,8 +7,9 @@ import Input from '../Input';
 import CroppedText from '../CroppedText';
 import Icon from '../Icon';
 import ItemButton from './ItemButton';
-import type {ItemButtonConfig} from './types';
 import itemStyles from './item.scss';
+import type {ItemButtonConfig} from './types';
+import type {Element, Node} from 'react';
 
 type Props = {|
     active: boolean,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Toolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Toolbar.js
@@ -1,12 +1,12 @@
 // @flow
 import React from 'react';
-import type {ElementRef} from 'react';
 import {action, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import ToolbarDropdown from './ToolbarDropdown';
 import ToolbarButton from './ToolbarButton';
-import type {ToolbarItemConfig} from './types';
 import toolbarStyles from './toolbar.scss';
+import type {ToolbarItemConfig} from './types';
+import type {ElementRef} from 'react';
 
 type Props = {|
     toolbarItems: Array<ToolbarItemConfig>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ToolbarButton.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ToolbarButton.js
@@ -2,8 +2,8 @@
 import React from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
-import type {ToolbarButton as ToolbarButtonProps} from './types';
 import toolbarStyles from './toolbar.scss';
+import type {ToolbarButton as ToolbarButtonProps} from './types';
 
 export default class ToolbarButton extends React.Component<ToolbarButtonProps> {
     static defaultProps = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ToolbarDropdown.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ToolbarDropdown.js
@@ -5,9 +5,9 @@ import {observable, action} from 'mobx';
 import {observer} from 'mobx-react';
 import Icon from '../Icon';
 import ArrowMenu from '../ArrowMenu';
-import type {ToolbarDropdown as ToolbarDropdownProps} from './types';
 import toolbarStyles from './toolbar.scss';
 import toolbarDropdownStyles from './toolbarDropdown.scss';
+import type {ToolbarDropdown as ToolbarDropdownProps} from './types';
 
 @observer
 class ToolbarDropdown extends React.Component<ToolbarDropdownProps> {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ToolbarDropdownList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ToolbarDropdownList.js
@@ -1,10 +1,10 @@
 // @flow
 import React from 'react';
-import type {Element} from 'react';
 import classNames from 'classnames';
 import ToolbarDropdownListOption from './ToolbarDropdownListOption';
-import type {ToolbarDropdownOptionConfig} from './types';
 import toolbarDropdownStyles from './toolbarDropdown.scss';
+import type {ToolbarDropdownOptionConfig} from './types';
+import type {Element} from 'react';
 
 type Props = {|
     onClick: () => void,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
@@ -1,15 +1,15 @@
 // @flow
 import React from 'react';
 import ReactDOM from 'react-dom';
-import type {ElementRef} from 'react';
 import ReactDatetime from 'react-datetime';
 import {observer} from 'mobx-react';
 import {action, observable} from 'mobx';
 import 'react-datetime/css/react-datetime.css';
-import type Moment from 'moment';
 import moment from 'moment';
 import Input from '../Input';
 import Popover from '../Popover';
+import type Moment from 'moment';
+import type {ElementRef} from 'react';
 import './datePicker.scss';
 
 type Props = {|

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/Dialog.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/Dialog.js
@@ -3,12 +3,12 @@ import classNames from 'classnames';
 import {action, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import React, {Fragment} from 'react';
-import type {Node} from 'react';
 import {Portal} from 'react-portal';
 import {afterElementsRendered} from '../../utils/DOM';
 import Backdrop from '../Backdrop';
 import Button from '../Button';
 import dialogStyles from './dialog.scss';
+import type {Node} from 'react';
 
 type Props = {|
     cancelText?: string,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DropdownButton/DropdownButton.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DropdownButton/DropdownButton.js
@@ -1,10 +1,10 @@
 // @flow
 import React from 'react';
-import type {ChildrenArray, Element} from 'react';
 import {observer} from 'mobx-react';
 import {action, observable} from 'mobx';
 import ArrowMenu from '../ArrowMenu';
 import Button from '../Button';
+import type {ChildrenArray, Element} from 'react';
 
 type Props = {|
     children: ChildrenArray<Element<typeof ArrowMenu.Action> | false>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/FileUploadButton/FileUploadButton.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/FileUploadButton/FileUploadButton.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react';
-import type {Node} from 'react';
 import Dropzone from 'react-dropzone';
 import Button from '../Button';
+import type {Node} from 'react';
 import type {ButtonSkin} from '../Button';
 
 type Props = {|

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/FolderList/FolderList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/FolderList/FolderList.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react';
-import type {ChildrenArray, Element} from 'react';
 import Folder from './Folder';
 import folderListStyles from './folderList.scss';
+import type {ChildrenArray, Element} from 'react';
 
 type Props = {
     children: ChildrenArray<Element<typeof Folder>>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/Field.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/Field.js
@@ -1,15 +1,15 @@
 // @flow
 import React from 'react';
-import type {Node} from 'react';
 import {observer} from 'mobx-react';
 import {action, computed, observable} from 'mobx';
 import classNames from 'classnames';
 import ArrowMenu from '../ArrowMenu';
 import Grid from '../Grid';
-import type {ColSpan} from '../Grid';
 import Icon from '../Icon';
 import fieldStyles from './field.scss';
 import gridStyles from './grid.scss';
+import type {ColSpan} from '../Grid';
+import type {Node} from 'react';
 import type {FormFieldTypes} from './types';
 
 type Props<T: string | number> = {|

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/Form.js
@@ -1,10 +1,10 @@
 // @flow
 import React from 'react';
-import type {Node} from 'react';
 import Grid from '../Grid';
 import Field from './Field';
 import Section from './Section';
 import gridStyles from './grid.scss';
+import type {Node} from 'react';
 
 type Props = {|
     children: Node,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/Section.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/Section.js
@@ -1,11 +1,11 @@
 // @flow
 import React from 'react';
-import type {ChildrenArray, Element} from 'react';
 import Divider from '../Divider';
 import Grid from '../Grid';
-import type {ColSpan} from '../Grid';
 import Field from './Field';
 import gridStyles from './grid.scss';
+import type {ColSpan} from '../Grid';
+import type {ChildrenArray, Element} from 'react';
 
 type Props = {|
     children: ?ChildrenArray<?Element<typeof Field | typeof Section>>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/BaseItem.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/BaseItem.js
@@ -1,9 +1,9 @@
 // @flow
 import React from 'react';
-import type {Node} from 'react';
 import classNames from 'classnames';
-import type {BaseItemProps} from './types';
 import baseItemStyles from './baseItem.scss';
+import type {Node} from 'react';
+import type {BaseItemProps} from './types';
 
 type Props = {|
     ...BaseItemProps,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/Grid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/Grid.js
@@ -1,10 +1,10 @@
 // @flow
 import React from 'react';
-import type {Node} from 'react';
 import classNames from 'classnames';
 import Item from './Item';
 import Section from './Section';
 import gridStyles from './grid.scss';
+import type {Node} from 'react';
 
 type Props = {
     children: Node,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/Item.js
@@ -1,10 +1,10 @@
 // @flow
 import React from 'react';
-import type {Node} from 'react';
 import classNames from 'classnames';
-import type {BaseItemProps} from './types';
 import BaseItem from './BaseItem';
 import itemStyles from './item.scss';
+import type {BaseItemProps} from './types';
+import type {Node} from 'react';
 
 type Props = {|
     ...BaseItemProps,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/Section.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/Section.js
@@ -1,11 +1,11 @@
 // @flow
 import React from 'react';
-import type {ChildrenArray, Element} from 'react';
 import classNames from 'classnames';
-import type {BaseItemProps} from './types';
 import BaseItem from './BaseItem';
 import Item from './Item';
 import sectionStyles from './section.scss';
+import type {BaseItemProps} from './types';
+import type {ChildrenArray, Element} from 'react';
 
 type Props = {|
     ...BaseItemProps,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/ImageRectangleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/ImageRectangleSelection.js
@@ -4,9 +4,9 @@ import log from 'loglevel';
 import {observer} from 'mobx-react';
 import React from 'react';
 import RectangleSelection from '../RectangleSelection';
-import type {SelectionData} from '../RectangleSelection';
 import withContainerSize from '../withContainerSize';
 import imageRectangleSelectionStyles from './imageRectangleSelection.scss';
+import type {SelectionData} from '../RectangleSelection';
 
 type Props = {|
     containerHeight: number,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/InfiniteScroller/InfiniteScroller.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/InfiniteScroller/InfiniteScroller.js
@@ -1,10 +1,10 @@
 // @flow
 import React, {type Node} from 'react';
 import debounce from 'debounce';
-import type {ElementRef} from 'react';
 import {translate} from '../../utils/Translator';
 import Loader from '../Loader';
 import infiniteScrollerStyles from './infiniteScroller.scss';
+import type {ElementRef} from 'react';
 
 type Props = {
     children: Node,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
@@ -1,12 +1,12 @@
 // @flow
 import React, {Fragment} from 'react';
-import type {ElementRef} from 'react';
 import classNames from 'classnames';
 import CharacterCounter from '../CharacterCounter';
 import Icon from '../Icon';
 import Loader from '../Loader';
 import SegmentCounter from '../SegmentCounter';
 import inputStyles from './input.scss';
+import type {ElementRef} from 'react';
 import type {InputProps} from './types';
 
 const LOADER_SIZE = 20;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Masonry/Masonry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Masonry/Masonry.js
@@ -1,9 +1,9 @@
 // @flow
-import type {ChildrenArray, Node, ElementRef} from 'react';
 import React from 'react';
 import imagesLoaded from 'imagesloaded';
 import MasonryLayout from 'masonry-layout';
 import masonryStyles from './masonry.scss';
+import type {ChildrenArray, Node, ElementRef} from 'react';
 
 const MASONRY_OPTIONS = {
     gutter: 30,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Matrix.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Matrix.js
@@ -1,11 +1,11 @@
 // @flow
-import type {ChildrenArray, Element} from 'react';
 import React from 'react';
 import classNames from 'classnames';
 import Row from './Row';
 import Item from './Item';
-import type {MatrixValues} from './types';
 import matrixStyles from './matrix.scss';
+import type {MatrixValues} from './types';
+import type {ChildrenArray, Element} from 'react';
 
 type Props = {|
     children: ChildrenArray<Element<typeof Row>>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Row.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Row.js
@@ -2,10 +2,10 @@
 import React from 'react';
 import {observer} from 'mobx-react';
 import {computed} from 'mobx';
-import type {ChildrenArray, Element} from 'react';
 import {translate} from '../../utils/index';
 import Item from './Item';
 import rowStyles from './row.scss';
+import type {ChildrenArray, Element} from 'react';
 import type {MatrixRowValue} from './types';
 
 type Props = {|

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Menu/Menu.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Menu/Menu.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react';
-import type {ChildrenArray, Element, ElementRef} from 'react';
 import Divider from './Divider';
 import menuStyles from './menu.scss';
+import type {ChildrenArray, Element, ElementRef} from 'react';
 
 type Props = {
     children?: ChildrenArray<Element<*> | false>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/MultiAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/MultiAutoComplete.js
@@ -1,6 +1,5 @@
 // @flow
 import React, {Fragment} from 'react';
-import type {ElementRef} from 'react';
 import {action, computed, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import debounce from 'debounce';
@@ -11,6 +10,7 @@ import Loader from '../Loader';
 import AutoCompletePopover from '../AutoCompletePopover';
 import Chip from '../Chip';
 import multiAutoCompleteStyles from './multiAutoComplete.scss';
+import type {ElementRef} from 'react';
 
 type Props = {|
     allowAdd: boolean,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/Header.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/Header.js
@@ -2,9 +2,9 @@
 import React from 'react';
 import classNames from 'classnames';
 import Loader from '../Loader';
-import type {Button as ButtonConfig} from './types';
 import Button from './Button';
 import headerStyles from './header.scss';
+import type {Button as ButtonConfig} from './types';
 
 const LOADER_SIZE = 24;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/Item.js
@@ -1,10 +1,10 @@
 // @flow
 import React from 'react';
-import type {Node} from 'react';
 import {SortableHandle} from 'react-sortable-hoc';
 import classNames from 'classnames';
 import Icon from '../Icon';
 import itemStyles from './item.scss';
+import type {Node} from 'react';
 
 const DRAG_ICON = 'su-more';
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/MultiItemSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/MultiItemSelection.js
@@ -1,12 +1,12 @@
 // @flow
 import React from 'react';
-import type {ChildrenArray, Element} from 'react';
 import {SortableContainer, SortableElement} from 'react-sortable-hoc';
 import classNames from 'classnames';
-import type {Button} from './types';
 import Header from './Header';
 import Item from './Item';
 import multiItemSelectionStyles from './multiItemSelection.scss';
+import type {Button} from './types';
+import type {ChildrenArray, Element} from 'react';
 
 type Props<T, U, V, W> = {|
     children?: ChildrenArray<Element<typeof Item>>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/MultiSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/MultiSelect.js
@@ -1,9 +1,9 @@
 // @flow
 import React from 'react';
-import type {Element} from 'react';
-import type {SelectProps} from '../Select';
 import Select from '../Select';
 import {translate} from '../../utils/Translator';
+import type {Element} from 'react';
+import type {SelectProps} from '../Select';
 
 type Props<T: string | number> = {|
     ...SelectProps<T>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Item.js
@@ -1,9 +1,9 @@
 // @flow
 import React from 'react';
 import classNames from 'classnames';
-import type {ChildrenArray, Element} from 'react';
 import Icon from '../Icon';
 import itemStyles from './item.scss';
+import type {ChildrenArray, Element} from 'react';
 
 type Props = {
     active?: boolean,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Navigation.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Navigation.js
@@ -1,12 +1,12 @@
 // @flow
 import React from 'react';
-import type {ChildrenArray, Element} from 'react';
 import {observer} from 'mobx-react';
 import {action, observable} from 'mobx';
 import classNames from 'classnames';
 import Icon from '../Icon';
 import Item from './Item';
 import navigationStyles from './navigation.scss';
+import type {ChildrenArray, Element} from 'react';
 
 type Props = {|
     appVersion: ?string,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Number/Number.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Number/Number.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
-import type {ElementRef} from 'react';
 import Input from '../Input';
+import type {ElementRef} from 'react';
 import type {InputProps} from '../Input';
 
 type Props = {|

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Actions.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Actions.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react';
 import Button from '../Button';
-import type {Action} from './types';
 import actionsStyles from './actions.scss';
+import type {Action} from './types';
 
 type Props = {
     actions: Array<Action>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
@@ -3,16 +3,16 @@ import classNames from 'classnames';
 import Mousetrap from 'mousetrap';
 import {action, observable} from 'mobx';
 import {observer} from 'mobx-react';
-import type {Node} from 'react';
 import React, {Fragment} from 'react';
 import {Portal} from 'react-portal';
 import Icon from '../Icon';
 import Button from '../Button';
 import {afterElementsRendered} from '../../utils/DOM';
 import Backdrop from '../Backdrop';
-import type {Action, Size} from './types';
 import Actions from './Actions';
 import overlayStyles from './overlay.scss';
+import type {Action, Size} from './types';
+import type {Node} from 'react';
 
 type Props = {
     actions: Array<Action>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
@@ -3,12 +3,12 @@ import React, {Fragment} from 'react';
 import {Portal} from 'react-portal';
 import {observer} from 'mobx-react';
 import {action, computed, observable} from 'mobx';
-import type {ElementRef, Node} from 'react';
 import {afterElementsRendered} from '../../utils/DOM';
 import Backdrop from '../Backdrop';
-import type {PopoverDimensions} from './types';
 import PopoverPositioner from './PopoverPositioner';
 import popoverStyles from './popover.scss';
+import type {PopoverDimensions} from './types';
+import type {ElementRef, Node} from 'react';
 
 type Props = {
     /** This element will be used to position the popover */

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/Radio.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/Radio.js
@@ -2,8 +2,8 @@
 import React from 'react';
 import classNames from 'classnames';
 import Switch from '../Switch';
-import type {SwitchProps} from '../Switch';
 import radioStyles from './radio.scss';
+import type {SwitchProps} from '../Switch';
 
 type Props<T> = {|
     ...SwitchProps<T>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/RadioGroup.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/RadioGroup.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
-import type {ChildrenArray, Element} from 'react';
 import Radio from './Radio';
+import type {ChildrenArray, Element} from 'react';
 
 type Props = {|
     children: ChildrenArray<Element<typeof Radio>>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/ModifiableRectangle.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/ModifiableRectangle.js
@@ -3,8 +3,8 @@ import {action, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import React, {Fragment} from 'react';
 import {translate} from '../../utils/Translator';
-import type {RectangleChange} from './types';
 import modifiableRectangleStyles from './modifiableRectangle.scss';
+import type {RectangleChange} from './types';
 
 type Props = {
     backdropSize: number,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/RectangleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/RectangleSelection.js
@@ -1,16 +1,16 @@
 // @flow
-import type {Node} from 'react';
 import {observer} from 'mobx-react';
 import {computed} from 'mobx';
 import React from 'react';
 import withContainerSize from '../withContainerSize';
-import type {Normalizer, RectangleChange, SelectionData} from './types';
 import ModifiableRectangle from './ModifiableRectangle';
 import PositionNormalizer from './normalizers/PositionNormalizer';
 import RatioNormalizer from './normalizers/RatioNormalizer';
 import RoundingNormalizer from './normalizers/RoundingNormalizer';
 import SizeNormalizer from './normalizers/SizeNormalizer';
 import rectangleSelectionStyles from './rectangleSelection.scss';
+import type {Normalizer, RectangleChange, SelectionData} from './types';
+import type {Node} from 'react';
 
 type Props = {
     children?: Node,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
@@ -2,9 +2,9 @@
 import React from 'react';
 import {action, computed, observable} from 'mobx';
 import {observer} from 'mobx-react';
-import type {IObservableValue} from 'mobx';
 import Input from '../Input';
 import resourceLocatorStyles from './resourceLocator.scss';
+import type {IObservableValue} from 'mobx';
 
 type Props = {|
     disabled: boolean,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Action.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Action.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
-import type {ElementRef} from 'react';
 import actionStyles from './action.scss';
+import type {ElementRef} from 'react';
 
 type Props<T> = {|
     afterAction?: () => void,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/DisplayValue.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/DisplayValue.js
@@ -1,10 +1,10 @@
 // @flow
 import React from 'react';
-import type {ElementRef, Node} from 'react';
 import classNames from 'classnames';
 import CroppedText from '../CroppedText';
 import Icon from '../Icon';
 import displayValueStyles from './displayValue.scss';
+import type {ElementRef, Node} from 'react';
 import type {Skin} from './types';
 
 type Props = {|

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Option.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Option.js
@@ -1,11 +1,11 @@
 // @flow
 import React from 'react';
-import type {ElementRef} from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
 import Checkbox from '../Checkbox';
-import type {OptionSelectedVisualization} from './types';
 import optionStyles from './option.scss';
+import type {OptionSelectedVisualization} from './types';
+import type {ElementRef} from 'react';
 
 type Props<T> = {|
     anchorWidth: number,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Select.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Select.js
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react';
-import type {Element, ElementRef} from 'react';
 import {action, observable, computed} from 'mobx';
 import {observer} from 'mobx-react';
 import debounce from 'debounce';
@@ -9,9 +8,10 @@ import Popover from '../Popover';
 import Menu from '../Menu';
 import Action from './Action';
 import Option from './Option';
-import type {OptionSelectedVisualization, SelectChildren, SelectProps} from './types';
 import DisplayValue from './DisplayValue';
 import selectStyles from './select.scss';
+import type {OptionSelectedVisualization, SelectChildren, SelectProps} from './types';
+import type {Element, ElementRef} from 'react';
 
 const HORIZONTAL_OFFSET = -20;
 const VERTICAL_OFFSET = 2;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/types.js
@@ -1,8 +1,8 @@
 // @flow
-import type {ChildrenArray, Element} from 'react';
 import Select from './Select';
 import Action from './Action';
 import Option from './Option';
+import type {ChildrenArray, Element} from 'react';
 
 export type SelectProps<T> = {|
     children: SelectChildren<T>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/SingleAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/SingleAutoComplete.js
@@ -1,12 +1,12 @@
 // @flow
 import React from 'react';
-import type {ElementRef} from 'react';
 import {observer} from 'mobx-react';
 import {action, computed, observable} from 'mobx';
 import debounce from 'debounce';
 import Input from '../Input';
 import AutoCompletePopover from '../AutoCompletePopover';
 import singleAutoCompleteStyles from './singleAutoComplete.scss';
+import type {ElementRef} from 'react';
 
 const LENS_ICON = 'su-search';
 const DEBOUNCE_TIME = 300;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/SingleItemSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/SingleItemSelection.js
@@ -1,11 +1,11 @@
 // @flow
 import React from 'react';
 import classNames from 'classnames';
-import type {Node} from 'react';
 import Icon from '../Icon';
 import Loader from '../Loader/Loader';
 import singleItemSelectionStyles from './singleItemSelection.scss';
 import Button from './Button';
+import type {Node} from 'react';
 import type {Button as ButtonConfig} from './types';
 
 type Props<T, U> = {|

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleSelect/SingleSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleSelect/SingleSelect.js
@@ -1,9 +1,9 @@
 // @flow
 import React from 'react';
-import type {Element} from 'react';
-import type {SelectProps} from '../Select';
 import Select from '../Select';
 import {translate} from '../../utils/Translator';
+import type {Element} from 'react';
+import type {SelectProps} from '../Select';
 
 type Props<T> = {|
     ...SelectProps<T>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Switch/Switch.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Switch/Switch.js
@@ -2,8 +2,8 @@
 import React from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
-import type {SwitchProps} from './types';
 import switchStyles from './switch.scss';
+import type {SwitchProps} from './types';
 
 type Props<T> = {|
     ...SwitchProps<T>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Body.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Body.js
@@ -1,8 +1,8 @@
 // @flow
-import type {ChildrenArray, Element} from 'react';
 import React from 'react';
-import type {ButtonConfig, SelectMode} from './types';
 import Row from './Row';
+import type {ChildrenArray, Element} from 'react';
+import type {ButtonConfig, SelectMode} from './types';
 
 type Props<T: number | string> = {
     /** @ignore */

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Cell.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Cell.js
@@ -1,8 +1,8 @@
 // @flow
-import type {Node} from 'react';
 import React from 'react';
 import classNames from 'classnames';
 import tableStyles from './table.scss';
+import type {Node} from 'react';
 
 type Props = {
     children?: Node,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Header.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Header.js
@@ -1,11 +1,11 @@
 // @flow
-import type {ChildrenArray, Element} from 'react';
 import React, {Fragment} from 'react';
 import Checkbox from '../Checkbox';
 import Icon from '../Icon';
 import HeaderCell from './HeaderCell';
-import type {ButtonConfig, SelectMode, Skin} from './types';
 import tableStyles from './table.scss';
+import type {ButtonConfig, SelectMode, Skin} from './types';
+import type {ChildrenArray, Element} from 'react';
 
 type Props = {
     allSelected: boolean,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/HeaderCell.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/HeaderCell.js
@@ -1,9 +1,9 @@
 // @flow
-import type {Node} from 'react';
 import React from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
 import tableStyles from './table.scss';
+import type {Node} from 'react';
 import type {SortOrder} from './types';
 
 const ASCENDING_ICON = 'su-angle-up';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Row.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Row.js
@@ -1,15 +1,15 @@
 // @flow
 import React, {Fragment} from 'react';
-import type {ChildrenArray, Element} from 'react';
 import classNames from 'classnames';
 import Checkbox from '../Checkbox';
 import {Radio} from '../Radio';
 import Icon from '../Icon/Icon';
 import Loader from '../Loader/Loader';
-import type {ButtonConfig, SelectMode} from './types';
 import ButtonCell from './ButtonCell';
 import Cell from './Cell';
 import tableStyles from './table.scss';
+import type {ButtonConfig, SelectMode} from './types';
+import type {ChildrenArray, Element} from 'react';
 
 type Props = {
     /** @ignore */

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Table.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Table.js
@@ -1,7 +1,6 @@
 // @flow
 import {observer} from 'mobx-react';
 import React from 'react';
-import type {ChildrenArray, Element} from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
 import Header from './Header';
@@ -9,8 +8,9 @@ import Body from './Body';
 import Row from './Row';
 import Cell from './Cell';
 import HeaderCell from './HeaderCell';
-import type {ButtonConfig, SelectMode, Skin} from './types';
 import tableStyles from './table.scss';
+import type {ButtonConfig, SelectMode, Skin} from './types';
+import type {ChildrenArray, Element} from 'react';
 
 const PLACEHOLDER_ICON = 'su-battery-low';
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tabs/Tab.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tabs/Tab.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react';
-import type {Element} from 'react';
 import classNames from 'classnames';
 import tabStyles from './tab.scss';
+import type {Element} from 'react';
 
 type Props = {
     badges: Element<*>[],

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tabs/Tabs.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tabs/Tabs.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react';
-import type {ChildrenArray, Element} from 'react';
 import Tab from './Tab';
 import tabsStyles from './tabs.scss';
+import type {ChildrenArray, Element} from 'react';
 
 type Props = {
     children: ChildrenArray<Element<typeof Tab> | false>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toggler/Toggler.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toggler/Toggler.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react';
 import Switch from '../Switch';
-import type {SwitchProps} from '../Switch';
 import togglerStyles from './toggler.scss';
+import type {SwitchProps} from '../Switch';
 
 type Props<T> = {|
     ...SwitchProps<T>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Button.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Button.js
@@ -1,11 +1,11 @@
 // @flow
 import classNames from 'classnames';
 import React from 'react';
-import type {ElementRef} from 'react';
 import Icon from '../Icon';
 import Loader from '../Loader';
-import type {Button as ButtonProps} from './types';
 import buttonStyles from './button.scss';
+import type {Button as ButtonProps} from './types';
+import type {ElementRef} from 'react';
 
 const LOADER_SIZE = 20;
 const ICON_ANGLE_DOWN = 'su-angle-down';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Controls.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Controls.js
@@ -1,9 +1,9 @@
 // @flow
-import type {ChildrenArray} from 'react';
 import React from 'react';
 import classNames from 'classnames';
-import type {Group, Item, Skin} from './types';
 import controlsStyles from './controls.scss';
+import type {Group, Item, Skin} from './types';
+import type {ChildrenArray} from 'react';
 
 type Props = {|
     children: ChildrenArray<Item | Group | false>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Dropdown.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Dropdown.js
@@ -1,14 +1,14 @@
 // @flow
 import React from 'react';
-import type {ElementRef} from 'react';
 import {action, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import classNames from 'classnames';
 import Popover from '../Popover';
-import type {DropdownOption, Dropdown as DropdownProps} from './types';
 import Button from './Button';
 import OptionList from './OptionList';
 import dropdownStyles from './dropdown.scss';
+import type {DropdownOption, Dropdown as DropdownProps} from './types';
+import type {ElementRef} from 'react';
 
 @observer
 class Dropdown extends React.Component<DropdownProps> {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Icons.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Icons.js
@@ -1,9 +1,9 @@
 // @flow
 import React from 'react';
-import type {ChildrenArray, Node} from 'react';
 import classNames from 'classnames';
-import type {Skin} from './types';
 import iconsStyles from './icons.scss';
+import type {ChildrenArray, Node} from 'react';
+import type {Skin} from './types';
 
 type Props = {
     children: ChildrenArray<Node>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Items.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Items.js
@@ -1,12 +1,12 @@
 // @flow
-import type {ChildrenArray, ElementRef} from 'react';
 import React from 'react';
 import {observer} from 'mobx-react';
 import {action, observable, computed} from 'mobx';
 import classNames from 'classnames';
 import debounce from 'debounce';
-import type {Item, Skin} from './types';
 import itemsStyles from './items.scss';
+import type {Item, Skin} from './types';
+import type {ChildrenArray, ElementRef} from 'react';
 
 type Props = {|
     children: ChildrenArray<false | Item>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Option.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Option.js
@@ -2,8 +2,8 @@
 import classNames from 'classnames';
 import React from 'react';
 import Icon from '../Icon';
-import type {Skin} from './types';
 import optionStyles from './option.scss';
+import type {Skin} from './types';
 
 const ICON_CHECKMARK = 'su-check';
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/OptionList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/OptionList.js
@@ -2,8 +2,8 @@
 import classNames from 'classnames';
 import React from 'react';
 import Option from './Option';
-import type {Skin} from './types';
 import optionListStyles from './optionList.scss';
+import type {Skin} from './types';
 
 type Props = {
     onClose?: () => void,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Select.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Select.js
@@ -1,14 +1,14 @@
 // @flow
 import React from 'react';
-import type {ElementRef} from 'react';
 import {action, computed, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import classNames from 'classnames';
 import Popover from '../Popover';
-import type {SelectOption, Select as SelectProps} from './types';
 import Button from './Button';
 import OptionList from './OptionList';
 import selectStyles from './select.scss';
+import type {SelectOption, Select as SelectProps} from './types';
+import type {ElementRef} from 'react';
 
 @observer
 class Select<T: ?string | number> extends React.Component<SelectProps<T>> {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Toolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Toolbar.js
@@ -1,5 +1,4 @@
 // @flow
-import type {ChildrenArray, Element} from 'react';
 import React from 'react';
 import classNames from 'classnames';
 import Button from './Button';
@@ -9,8 +8,9 @@ import Items from './Items';
 import Icons from './Icons';
 import Toggler from './Toggler';
 import Select from './Select';
-import type {Skin} from './types';
 import toolbarStyles from './toolbar.scss';
+import type {Skin} from './types';
+import type {ChildrenArray, Element} from 'react';
 
 type Props = {
     children: ChildrenArray<false | Element<typeof Controls>>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/types.js
@@ -1,11 +1,11 @@
 // @flow
-import type {Element, Node, ElementRef} from 'react';
 import ItemsComponent from './Items';
 import IconsComponent from './Icons';
 import ButtonComponent from './Button';
 import DropdownComponent from './Dropdown';
 import SelectComponent from './Select';
 import TogglerComponent from './Toggler';
+import type {Element, Node, ElementRef} from 'react';
 
 export type Item =
     Element<typeof ButtonComponent>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/withContainerSize/withContainerSize.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/withContainerSize/withContainerSize.js
@@ -1,11 +1,11 @@
 // @flow
 import {action, observable} from 'mobx';
-import type {ComponentType, ElementRef} from 'react';
 import React from 'react';
 import {observer} from 'mobx-react';
 import {buildHocDisplayName} from '../../utils/react';
 import {afterElementsRendered} from '../../utils/DOM';
 import styles from './withContainerSize.scss';
+import type {ComponentType, ElementRef} from 'react';
 import type {WithContainerSizeElement} from './types';
 
 export default function withContainerSize(Component: ComponentType<*>, containerClass: string = styles.container) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/CKEditor5.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/CKEditor5.js
@@ -1,7 +1,5 @@
 // @flow
 import React from 'react';
-import type {ElementRef} from 'react';
-import type {IObservableValue} from 'mobx';
 import log from 'loglevel';
 import AlignmentPlugin from '@ckeditor/ckeditor5-alignment/src/alignment';
 import BoldPlugin from '@ckeditor/ckeditor5-basic-styles/src/bold';
@@ -23,6 +21,8 @@ import ExternalLinkPlugin from './plugins/ExternalLinkPlugin';
 import InternalLinkPlugin from './plugins/InternalLinkPlugin';
 import configRegistry from './registries/configRegistry';
 import pluginRegistry from './registries/pluginRegistry';
+import type {IObservableValue} from 'mobx';
+import type {ElementRef} from 'react';
 import './ckeditor5.scss';
 
 type Props = {|

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -5,10 +5,10 @@ import React, {Fragment} from 'react';
 import {action, observable, toJS} from 'mobx';
 import {observer} from 'mobx-react';
 import BlockCollection from '../../components/BlockCollection';
-import type {BlockEntry} from '../../components/BlockCollection/types';
-import type {BlockError, FieldTypeProps} from '../Form/types';
 import blockPreviewTransformerRegistry from './registries/blockPreviewTransformerRegistry';
 import FieldRenderer from './FieldRenderer';
+import type {BlockEntry} from '../../components/BlockCollection/types';
+import type {BlockError, FieldTypeProps} from '../Form/types';
 
 const MISSING_BLOCK_ERROR_MESSAGE = 'The "block" field type needs at least one type to be configured!';
 const BLOCK_PREVIEW_TAG = 'sulu.block_preview';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldRenderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldRenderer.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react';
 import Router from '../../services/Router';
-import type {ErrorCollection} from '../Form/types';
 import {FormInspector, Renderer} from '../Form';
+import type {ErrorCollection} from '../Form/types';
 import type {Schema} from '../Form';
 
 type Props = {|

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/DateTimeBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/DateTimeBlockPreviewTransformer.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react';
-import type {Node} from 'react';
 import moment from 'moment';
 import log from 'loglevel';
+import type {Node} from 'react';
 import type {BlockPreviewTransformer} from '../types';
 
 const format = 'YYYY-MM-DD';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/SelectBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/SelectBlockPreviewTransformer.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
-import type {Node} from 'react';
 import {isObservableArray} from 'mobx';
+import type {Node} from 'react';
 import type {BlockPreviewTransformer} from '../types';
 import type {SchemaEntry} from '../../Form/types';
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/SmartContentBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/SmartContentBlockPreviewTransformer.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react';
+import {translate} from '../../../utils/Translator';
 import type {Node} from 'react';
 import type {BlockPreviewTransformer} from '../types';
-import {translate} from '../../../utils/Translator';
 
 export default class SmartContentBlockPreviewTransformer implements BlockPreviewTransformer {
     transform(value: *): Node {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/StripHtmlBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/StripHtmlBlockPreviewTransformer.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
-import type {Node} from 'react';
 import textVersion from 'textversionjs';
+import type {Node} from 'react';
 import type {BlockPreviewTransformer} from '../types';
 
 const MAX_LENGTH = 50;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/TimeBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/TimeBlockPreviewTransformer.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react';
-import type {Node} from 'react';
 import moment from 'moment';
 import log from 'loglevel';
+import type {Node} from 'react';
 import type {BlockPreviewTransformer} from '../types';
 
 const format = 'HH:mm:ss';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
@@ -7,9 +7,9 @@ import Loader from '../../components/Loader';
 import PermissionHint from '../../components/PermissionHint';
 import Router from '../../services/Router';
 import Renderer from './Renderer';
-import type {FormStoreInterface} from './types';
 import FormInspector from './FormInspector';
 import GhostDialog from './GhostDialog';
+import type {FormStoreInterface} from './types';
 
 type Props = {|
     onError?: (errors: Object) => void,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react';
-import type {Element} from 'react';
 import {action} from 'mobx';
 import {observer} from 'mobx-react';
 import jsonpointer from 'json-pointer';
@@ -8,6 +7,7 @@ import Form from '../../components/Form';
 import Router from '../../services/Router';
 import Field from './Field';
 import FormInspector from './FormInspector';
+import type {Element} from 'react';
 import type {ErrorCollection, Schema, SchemaEntry} from './types';
 
 type Props = {|

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/CardCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/CardCollection.js
@@ -1,14 +1,14 @@
 // @flow
 import React, {Fragment} from 'react';
-import type {ElementRef} from 'react';
 import {action, observable, toJS} from 'mobx';
 import {observer} from 'mobx-react';
 import CardCollectionComponent from '../../../components/CardCollection';
 import Overlay from '../../../components/Overlay';
 import Form, {MemoryFormStore} from '../../../containers/Form';
 import {translate} from '../../../utils/Translator';
-import type {FieldTypeProps} from '../../../types';
 import cardCollectionStyles from './cardCollection.scss';
+import type {FieldTypeProps} from '../../../types';
+import type {ElementRef} from 'react';
 
 @observer
 class CardCollection extends React.Component<FieldTypeProps<Array<Object>>> {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
@@ -5,9 +5,9 @@ import {observer} from 'mobx-react';
 import ResourceLocatorComponent from '../../../components/ResourceLocator';
 import ResourceLocatorHistory from '../../../containers/ResourceLocatorHistory';
 import Requester from '../../../services/Requester';
-import type {FieldTypeProps} from '../../../types';
 import userStore from '../../../stores/userStore';
 import resourceLocatorStyles from './resourceLocator.scss';
+import type {FieldTypeProps} from '../../../types';
 
 const PART_TAG = 'sulu.rlp.part';
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -1,7 +1,6 @@
 // @flow
 import React from 'react';
 import {computed, observable, intercept, toJS, reaction, isArrayLike} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import equals from 'fast-deep-equal';
 import {observer} from 'mobx-react';
 import jsonpointer from 'json-pointer';
@@ -14,9 +13,10 @@ import MultiAutoComplete from '../../../containers/MultiAutoComplete';
 import {translate} from '../../../utils/Translator';
 import MultiSelectionComponent from '../../MultiSelection';
 import userStore from '../../../stores/userStore';
+import selectionStyles from './selection.scss';
 import type {FieldTypeProps} from '../../../types';
 import type {SchemaOption} from '../types';
-import selectionStyles from './selection.scss';
+import type {IObservableValue} from 'mobx';
 
 type Value = Array<string | number>;
 type Props = FieldTypeProps<Value>;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
@@ -1,15 +1,15 @@
 // @flow
 import React from 'react';
 import {computed, observable} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import jsonpointer from 'json-pointer';
 import log from 'loglevel';
-import type {FieldTypeProps} from '../../../types';
 import ResourceSingleSelect from '../../../containers/ResourceSingleSelect';
 import SingleAutoComplete from '../../../containers/SingleAutoComplete';
 import SingleSelectionContainer from '../../../containers/SingleSelection';
 import userStore from '../../../stores/userStore';
 import {translate} from '../../../utils/Translator';
+import type {FieldTypeProps} from '../../../types';
+import type {IObservableValue} from 'mobx';
 
 type Value = Object | string | number;
 type Props = FieldTypeProps<Value>;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
@@ -3,10 +3,10 @@ import React from 'react';
 import {computed, toJS, reaction, when} from 'mobx';
 import equals from 'fast-deep-equal';
 import jsonpointer from 'json-pointer';
-import type {FieldTypeProps} from '../../../types';
 import SmartContentComponent, {smartContentConfigStore, SmartContentStore} from '../../SmartContent';
-import type {FilterCriteria, Presentation} from '../../SmartContent/types';
 import smartContentStorePool from './smartContentStorePool';
+import type {FieldTypeProps} from '../../../types';
+import type {FilterCriteria, Presentation} from '../../SmartContent/types';
 
 type Props = FieldTypeProps<?FilterCriteria>;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/TextEditor.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/TextEditor.js
@@ -2,8 +2,8 @@
 import React from 'react';
 import {observable} from 'mobx';
 import TextEditorContainer from '../../../containers/TextEditor';
-import type {FieldTypeProps} from '../../../types';
 import userStore from '../../../stores/userStore';
+import type {FieldTypeProps} from '../../../types';
 
 export default class TextEditor extends React.Component<FieldTypeProps<?string>> {
     render() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Url.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Url.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
-import type {FieldTypeProps} from '../../../types';
 import UrlComponent from '../../../components/Url';
+import type {FieldTypeProps} from '../../../types';
 
 export default class Url extends React.Component<FieldTypeProps<?string>> {
     constructor(props: FieldTypeProps<?string>) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
@@ -1,9 +1,9 @@
 // @flow
 import {action, computed, observable, set, toJS, untracked, when} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import jexl from 'jexl';
 import jsonpointer from 'json-pointer';
 import log from 'loglevel';
+import type {IObservableValue} from 'mobx';
 import type {RawSchema, RawSchemaEntry, Schema, SchemaEntry} from '../types';
 
 const SECTION_TYPE = 'section';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/MemoryFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/MemoryFormStore.js
@@ -1,10 +1,10 @@
 // @flow
 import {action, autorun, observable} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import Ajv from 'ajv';
 import jsonpointer from 'json-pointer';
-import type {FormStoreInterface, RawSchema} from '../types';
 import AbstractFormStore from './AbstractFormStore';
+import type {FormStoreInterface, RawSchema} from '../types';
+import type {IObservableValue} from 'mobx';
 
 const ajv = new Ajv({allErrors: true, jsonPointers: true});
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
@@ -1,12 +1,12 @@
 // @flow
 import {action, autorun, computed, observable, when} from 'mobx';
-import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
 import Ajv from 'ajv';
 import jsonpointer from 'json-pointer';
 import ResourceStore from '../../../stores/ResourceStore';
-import type {FormStoreInterface, RawSchema, SchemaEntry, SchemaType, SchemaTypes} from '../types';
 import AbstractFormStore from './AbstractFormStore';
 import metadataStore from './metadataStore';
+import type {FormStoreInterface, RawSchema, SchemaEntry, SchemaType, SchemaTypes} from '../types';
+import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
 
 // TODO do not hardcode "template", use some kind of metadata instead
 const TYPE = 'template';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -1,8 +1,8 @@
 // @flow
-import type {IObservableValue} from 'mobx';
 import Router from '../../services/Router';
-import type {ColSpan} from '../../components/Grid';
 import FormInspector from './FormInspector';
+import type {IObservableValue} from 'mobx';
+import type {ColSpan} from '../../components/Grid';
 
 export type SchemaType = {
     key: string,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/FormOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/FormOverlay.js
@@ -1,16 +1,16 @@
 // @flow
 import React from 'react';
 import {action, computed, observable} from 'mobx';
-import type {ElementRef} from 'react';
 import {observer} from 'mobx-react';
 import Overlay from '../../components/Overlay';
 import {translate} from '../../utils';
 import Snackbar from '../../components/Snackbar';
 import Form from '../Form';
+import formOverlayStyles from './formOverlay.scss';
 import type {FormStoreInterface} from '../Form/types';
 import type {ResourceFormStore} from '../Form';
 import type {Size} from '../../components/Overlay/types';
-import formOverlayStyles from './formOverlay.scss';
+import type {ElementRef} from 'react';
 
 type Props = {|
     confirmDisabled: boolean,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/ColumnOptionsOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/ColumnOptionsOverlay.js
@@ -6,9 +6,9 @@ import classNames from 'classnames';
 import {arrayMove, SortableContainer, SortableElement} from 'react-sortable-hoc';
 import Overlay from '../../components/Overlay';
 import {translate} from '../../utils';
-import type {Schema, SchemaEntry} from './types';
 import ColumnOptionComponent from './ColumnOption';
 import columnOptionsStyles from './columnOptions.scss';
+import type {Schema, SchemaEntry} from './types';
 
 type Props = {|
     onClose: () => void,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/FieldFilter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/FieldFilter.js
@@ -5,8 +5,8 @@ import {observer} from 'mobx-react';
 import ArrowMenu from '../../components/ArrowMenu';
 import Button from '../../components/Button';
 import FieldFilterItem from './FieldFilterItem';
-import type {Schema} from './types';
 import fieldFilterStyles from './fieldFilter.scss';
+import type {Schema} from './types';
 
 type Props = {|
     fields: Schema,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/FieldFilterItem.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/FieldFilterItem.js
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react';
-import type {Node} from 'react';
 import {action, autorun, computed, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import Mousetrap from 'mousetrap';
@@ -12,6 +11,7 @@ import {translate} from '../../utils/Translator';
 import AbstractFieldFilterType from './fieldFilterTypes/AbstractFieldFilterType';
 import listFieldFilterTypeRegistry from './registries/listFieldFilterTypeRegistry';
 import fieldFilterItemStyles from './fieldFilterItem.scss';
+import type {Node} from 'react';
 
 type Props = {|
     column: string,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
@@ -1,9 +1,7 @@
 // @flow
 import {observer} from 'mobx-react';
 import {action, computed, intercept, observable} from 'mobx';
-import type {IValueWillChange} from 'mobx';
 import React, {Fragment} from 'react';
-import type {Node} from 'react';
 import equal from 'fast-deep-equal';
 import classNames from 'classnames';
 import jexl from 'jexl';
@@ -15,6 +13,14 @@ import PermissionHint from '../../components/PermissionHint';
 import userStore from '../../stores/userStore';
 import SingleListOverlay from '../SingleListOverlay';
 import {translate} from '../../utils/Translator';
+import ListStore from './stores/ListStore';
+import listAdapterRegistry from './registries/listAdapterRegistry';
+import AbstractAdapter from './adapters/AbstractAdapter';
+import AdapterSwitch from './AdapterSwitch';
+import Search from './Search';
+import listStyles from './list.scss';
+import ColumnOptionsOverlay from './ColumnOptionsOverlay';
+import FieldFilter from './FieldFilter';
 import type {
     ItemActionsProvider,
     ResolveCopyArgument,
@@ -24,14 +30,8 @@ import type {
     Schema,
     SortOrder,
 } from './types';
-import ListStore from './stores/ListStore';
-import listAdapterRegistry from './registries/listAdapterRegistry';
-import AbstractAdapter from './adapters/AbstractAdapter';
-import AdapterSwitch from './AdapterSwitch';
-import Search from './Search';
-import listStyles from './list.scss';
-import ColumnOptionsOverlay from './ColumnOptionsOverlay';
-import FieldFilter from './FieldFilter';
+import type {Node} from 'react';
+import type {IValueWillChange} from 'mobx';
 
 type Props = {|
     adapterOptions?: {[adapterKey: string]: {[key: string]: mixed}},

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/AbstractTableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/AbstractTableAdapter.js
@@ -5,9 +5,9 @@ import GhostIndicator from '../../../components/GhostIndicator';
 import PublishIndicator from '../../../components/PublishIndicator';
 import Table from '../../../components/Table';
 import listFieldTransformerRegistry from '../registries/listFieldTransformerRegistry';
-import type {Schema} from '../types';
 import AbstractAdapter from './AbstractAdapter';
 import abstractTableAdapterStyles from './abstractTableAdapter.scss';
+import type {Schema} from '../types';
 
 export default class AbstractTableAdapter extends AbstractAdapter {
     static hasColumnOptions: boolean = true;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TableAdapter.js
@@ -1,12 +1,12 @@
 // @flow
 import {observer} from 'mobx-react';
 import React from 'react';
-import type {Element} from 'react';
 import Pagination from '../../../components/Pagination';
 import Table from '../../../components/Table';
 import FlatStructureStrategy from '../structureStrategies/FlatStructureStrategy';
 import DefaultLoadingStrategy from '../loadingStrategies/DefaultLoadingStrategy';
 import AbstractTableAdapter from './AbstractTableAdapter';
+import type {Element} from 'react';
 
 @observer
 class TableAdapter extends AbstractTableAdapter {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/AbstractFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/AbstractFieldFilterType.js
@@ -1,6 +1,6 @@
 // @flow
-import type {Node} from 'react';
 import {action, observable} from 'mobx';
+import type {Node} from 'react';
 
 export default class AbstractFieldFilterType<T> {
     onChange: (value: T) => void;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/DateFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/DateFieldFilterType.js
@@ -1,10 +1,10 @@
 // @flow
 import React, {Fragment} from 'react';
-import type {ElementRef} from 'react';
 import DatePicker from '../../../components/DatePicker';
 import {translate} from '../../../utils/Translator';
 import AbstractFieldFilterType from './AbstractFieldFilterType';
 import dateFieldFilterTypeStyles from './dateFieldFilterType.scss';
+import type {ElementRef} from 'react';
 
 function formatDate(date: ?Date) {
     if (!date) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/NumberFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/NumberFieldFilterType.js
@@ -1,11 +1,11 @@
 // @flow
 import React from 'react';
-import type {ElementRef} from 'react';
 import {computed} from 'mobx';
 import Input from '../../../components/Input';
 import SingleSelect from '../../../components/SingleSelect';
 import AbstractFieldFilterType from './AbstractFieldFilterType';
 import numberFieldFilterTypeStyles from './numberFieldFilterType.scss';
+import type {ElementRef} from 'react';
 
 const operatorMapping = {
     lt: '<',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/SelectionFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/SelectionFieldFilterType.js
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react';
-import type {ElementRef} from 'react';
 import {action, autorun, computed, observable, toJS, untracked, when} from 'mobx';
 import equals from 'fast-deep-equal';
 import MultiSelectionStore from '../../../stores/MultiSelectionStore';
@@ -8,6 +7,7 @@ import MultiAutoComplete from '../../MultiAutoComplete';
 import ResourceCheckboxGroup from '../../ResourceCheckboxGroup';
 import AbstractFieldFilterType from './AbstractFieldFilterType';
 import selectionFieldFilterTypeStyles from './selectionFieldFilterType.scss';
+import type {ElementRef} from 'react';
 
 const TYPE_AUTO_COMPLETE = 'auto_complete';
 const TYPE_SELECT = 'select';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/TextFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/TextFieldFilterType.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react';
-import type {ElementRef} from 'react';
 import Input from '../../../components/Input';
 import AbstractFieldFilterType from './AbstractFieldFilterType';
+import type {ElementRef} from 'react';
 
 class TextFieldFilterType extends AbstractFieldFilterType<?{eq: string}> {
     handleChange = (value: ?string) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/BoolFieldTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/BoolFieldTransformer.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react';
+import Checkbox from '../../../components/Checkbox';
 import type {Node} from 'react';
 import type {FieldTransformer} from '../types';
-import Checkbox from '../../../components/Checkbox';
 
 export default class BoolFieldTransformer implements FieldTransformer {
     transform(value: *): Node {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/NumberFieldTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/NumberFieldTransformer.js
@@ -1,6 +1,6 @@
 // @flow
-import type {Node} from 'react';
 import log from 'loglevel';
+import type {Node} from 'react';
 import type {FieldTransformer} from '../types';
 
 export default class NumberFieldTransformer implements FieldTransformer {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/loadingStrategies/DefaultLoadingStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/loadingStrategies/DefaultLoadingStrategy.js
@@ -1,8 +1,8 @@
 // @flow
 import {action} from 'mobx';
 import ResourceRequester from '../../../services/ResourceRequester';
-import type {LoadingStrategyOptions, LoadOptions} from '../types';
 import AbstractLoadingStrategy from './AbstractLoadingStrategy';
+import type {LoadingStrategyOptions, LoadOptions} from '../types';
 
 export default class DefaultLoadingStrategy extends AbstractLoadingStrategy {
     options: LoadingStrategyOptions;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/loadingStrategies/FullLoadingStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/loadingStrategies/FullLoadingStrategy.js
@@ -2,8 +2,8 @@
 import {action} from 'mobx';
 import log from 'loglevel';
 import ResourceRequester from '../../../services/ResourceRequester';
-import type {LoadOptions} from '../types';
 import AbstractLoadingStrategy from './AbstractLoadingStrategy';
+import type {LoadOptions} from '../types';
 
 export default class FullLoadingStrategy extends AbstractLoadingStrategy {
     // @deprecated

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/loadingStrategies/InfiniteLoadingStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/loadingStrategies/InfiniteLoadingStrategy.js
@@ -1,8 +1,8 @@
 // @flow
 import {action} from 'mobx';
 import ResourceRequester from '../../../services/ResourceRequester';
-import type {LoadOptions} from '../types';
 import AbstractLoadingStrategy from './AbstractLoadingStrategy';
+import type {LoadOptions} from '../types';
 
 export default class InfiniteLoadingStrategy extends AbstractLoadingStrategy {
     load(resourceKey: string, options: LoadOptions, parentId: ?string | number) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/loadingStrategies/PaginatedLoadingStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/loadingStrategies/PaginatedLoadingStrategy.js
@@ -2,8 +2,8 @@
 import {action} from 'mobx';
 import log from 'loglevel';
 import ResourceRequester from '../../../services/ResourceRequester';
-import type {LoadOptions} from '../types';
 import AbstractLoadingStrategy from './AbstractLoadingStrategy';
+import type {LoadOptions} from '../types';
 
 export default class PaginatedLoadingStrategy extends AbstractLoadingStrategy {
     // @deprecated

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
@@ -1,9 +1,10 @@
 // @flow
 import {action, autorun, computed, intercept, observable, untracked} from 'mobx';
-import type {IObservableValue, IValueWillChange} from 'mobx';
 import equals from 'fast-deep-equal';
 import log from 'loglevel';
 import ResourceRequester, {RequestPromise} from '../../../services/ResourceRequester';
+import userStore from '../../../stores/userStore';
+import metadataStore from './metadataStore';
 import type {
     LoadingStrategyInterface,
     ObservableOptions,
@@ -11,8 +12,7 @@ import type {
     SortOrder,
     StructureStrategyInterface,
 } from '../types';
-import userStore from '../../../stores/userStore';
-import metadataStore from './metadataStore';
+import type {IObservableValue, IValueWillChange} from 'mobx';
 
 const USER_SETTING_PREFIX = 'sulu_admin.list_store';
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/types.js
@@ -1,7 +1,7 @@
 // @flow
+import {RequestPromise} from '../../services/Requester';
 import type {Node} from 'react';
 import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
-import {RequestPromise} from '../../services/Requester';
 
 export type DataItem = {
     id: string | number,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/ForgotPasswordForm.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/ForgotPasswordForm.js
@@ -1,6 +1,5 @@
 // @flow
 import React, {Fragment} from 'react';
-import type {ElementRef} from 'react';
 import {action, computed, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import {translate} from '../../utils/index';
@@ -8,6 +7,7 @@ import Button from '../../components/Button/index';
 import Input from '../../components/Input/index';
 import Header from './Header';
 import formStyles from './form.scss';
+import type {ElementRef} from 'react';
 
 type Props = {|
     loading: boolean,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/Header.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/Header.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react';
-import type {Node} from 'react';
 import classNames from 'classnames';
 import headerStyles from './header.scss';
+import type {Node} from 'react';
 
 type Props = {
     children: Node,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/LoginForm.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/LoginForm.js
@@ -1,6 +1,5 @@
 // @flow
 import React, {Fragment} from 'react';
-import type {ElementRef} from 'react';
 import {action, computed, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import classNames from 'classnames';
@@ -9,6 +8,7 @@ import Button from '../../components/Button/index';
 import Input from '../../components/Input/index';
 import formStyles from './form.scss';
 import Header from './Header';
+import type {ElementRef} from 'react';
 
 type Props = {|
     error: boolean,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/ResetPasswordForm.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/ResetPasswordForm.js
@@ -1,6 +1,5 @@
 // @flow
 import React, {Fragment} from 'react';
-import type {ElementRef} from 'react';
 import {action, computed, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import classNames from 'classnames';
@@ -9,6 +8,7 @@ import Button from '../../components/Button/index';
 import Input from '../../components/Input/index';
 import formStyles from './form.scss';
 import Header from './Header';
+import type {ElementRef} from 'react';
 
 type Props = {|
     loading: boolean,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/MultiAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/MultiAutoComplete.js
@@ -1,10 +1,10 @@
 // @flow
 import React from 'react';
-import type {ElementRef} from 'react';
 import {observer} from 'mobx-react';
 import MultiAutoCompleteComponent from '../../components/MultiAutoComplete';
 import SearchStore from '../../stores/SearchStore';
 import MultiSelectionStore from '../../stores/MultiSelectionStore';
+import type {ElementRef} from 'react';
 
 type Props = {|
     allowAdd: boolean,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/MultiListOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/MultiListOverlay.js
@@ -1,10 +1,10 @@
 // @flow
 import React from 'react';
 import {comparer, computed, observable, reaction} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import ListStore from '../../containers/List/stores/ListStore';
 import ListOverlay from '../ListOverlay';
+import type {IObservableValue} from 'mobx';
 import type {OverlayType} from '../ListOverlay';
 
 const USER_SETTINGS_KEY = 'multi_list_overlay';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
@@ -1,7 +1,6 @@
 // @flow
 import React, {Fragment} from 'react';
 import {action, comparer, observable, reaction, toJS} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import equals from 'fast-deep-equal';
 import jexl from 'jexl';
@@ -12,6 +11,7 @@ import PublishIndicator from '../../components/PublishIndicator';
 import MultiSelectionStore from '../../stores/MultiSelectionStore';
 import MultiListOverlay from '../MultiListOverlay';
 import multiSelectionStyles from './multiSelection.scss';
+import type {IObservableValue} from 'mobx';
 
 type Props = {|
     adapter: string,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceMultiSelect/ResourceMultiSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceMultiSelect/ResourceMultiSelect.js
@@ -1,5 +1,4 @@
 // @flow
-import type {Element} from 'react';
 import React from 'react';
 import {observable, action} from 'mobx';
 import {observer} from 'mobx-react';
@@ -7,6 +6,7 @@ import equals from 'fast-deep-equal';
 import MultiSelectComponent from '../../components/MultiSelect';
 import ResourceListStore from '../../stores/ResourceListStore';
 import Loader from '../../components/Loader';
+import type {Element} from 'react';
 
 type Props<T: string | number> = {|
     allSelectedText?: string,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceSingleSelect/EditLine.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceSingleSelect/EditLine.js
@@ -1,9 +1,9 @@
 // @flow
 import React from 'react';
-import type {ElementRef} from 'react';
 import Button from '../../components/Button';
 import Input from '../../components/Input';
 import editLineStyles from './editLine.scss';
+import type {ElementRef} from 'react';
 
 type Props<T> = {|
     id: T,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceSingleSelect/EditOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceSingleSelect/EditOverlay.js
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react';
-import type {ElementRef} from 'react';
 import {action, autorun, observable, toJS} from 'mobx';
 import {observer} from 'mobx-react';
 import Button from '../../components/Button';
@@ -9,6 +8,7 @@ import ResourceListStore from '../../stores/ResourceListStore';
 import {translate} from '../../utils/Translator';
 import EditLine from './EditLine';
 import editOverlayStyles from './editOverlay.scss';
+import type {ElementRef} from 'react';
 
 type Props = {|
     displayProperty: string,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceSingleSelect/ResourceSingleSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceSingleSelect/ResourceSingleSelect.js
@@ -1,6 +1,5 @@
 // @flow
 import React, {Fragment} from 'react';
-import type {Element} from 'react';
 import {action, computed, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import ResourceListStore from '../../stores/ResourceListStore';
@@ -8,6 +7,7 @@ import Loader from '../../components/Loader';
 import SingleSelect from '../../components/SingleSelect';
 import {translate} from '../../utils/Translator';
 import EditOverlay from './EditOverlay';
+import type {Element} from 'react';
 
 type Props<T> = {|
     disabled: boolean,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Sidebar/withSidebar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Sidebar/withSidebar.js
@@ -1,12 +1,12 @@
 // @flow
 import {autorun} from 'mobx';
-import type {Component} from 'react';
 import log from 'loglevel';
 import {getViewKeyFromRoute} from '../../services/Router';
 import {buildHocDisplayName} from '../../utils/react';
+import sidebarStore from './stores/sidebarStore';
 import type {ViewProps} from '../index';
 import type {SidebarConfig} from './types';
-import sidebarStore from './stores/sidebarStore';
+import type {Component} from 'react';
 
 const UPDATE_ROUTE_HOOK_PRIORITY = 1024;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/SingleListOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/SingleListOverlay.js
@@ -1,10 +1,10 @@
 // @flow
 import React from 'react';
 import {autorun, comparer, computed, observable} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import ListStore from '../../containers/List/stores/ListStore';
 import ListOverlay from '../ListOverlay';
+import type {IObservableValue} from 'mobx';
 import type {OverlayType} from '../ListOverlay';
 
 const USER_SETTINGS_KEY = 'single_list_overlay';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
@@ -1,7 +1,6 @@
 // @flow
 import React, {Fragment} from 'react';
 import {action, reaction, observable, toJS} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import jexl from 'jexl';
 import SingleItemSelection from '../../components/SingleItemSelection';
@@ -9,6 +8,7 @@ import PublishIndicator from '../../components/PublishIndicator';
 import SingleSelectionStore from '../../stores/SingleSelectionStore';
 import SingleListOverlay from '../SingleListOverlay';
 import singleSelectionStyles from './singleSelection.scss';
+import type {IObservableValue} from 'mobx';
 
 type Props = {|
     adapter: string,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/FilterOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/FilterOverlay.js
@@ -14,8 +14,8 @@ import MultiSelectionStore from '../../stores/MultiSelectionStore';
 import {translate} from '../../utils/Translator';
 import MultiSelect from '../../components/MultiSelect';
 import SmartContentStore from './stores/SmartContentStore';
-import type {Conjunction, FilterCriteria, Sorting, SortOrder, Type} from './types';
 import filterOverlayStyles from './filterOverlay.scss';
+import type {Conjunction, FilterCriteria, Sorting, SortOrder, Type} from './types';
 
 type Props = {|
     categoryRootKey: ?string,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/stores/SmartContentStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/stores/SmartContentStore.js
@@ -1,11 +1,11 @@
 // @flow
 import {action, autorun, computed, observable, toJS} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import equals from 'fast-deep-equal';
 import Requester from '../../../services/Requester';
 import Config from '../../../services/Config';
 import ResourceRequester from '../../../services/ResourceRequester';
 import {buildQueryString} from '../../../utils/Request';
+import type {IObservableValue} from 'mobx';
 import type {Conjunction, FilterCriteria, SortOrder} from '../types';
 
 export default class SmartContentStore {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/stores/ToolbarStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/stores/ToolbarStore.js
@@ -1,7 +1,7 @@
 // @flow
-import type {Node} from 'react';
 import {action, autorun, computed, observable} from 'mobx';
 import log from 'loglevel';
+import type {Node} from 'react';
 import type {Button, Select, ToolbarConfig, ToolbarItemConfig} from '../types';
 
 const SHOW_SUCCESS_DURATION = 1500;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/stores/toolbarStorePool.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/stores/toolbarStorePool.js
@@ -1,6 +1,6 @@
 // @flow
-import type {ToolbarConfig} from '../types';
 import ToolbarStore from './ToolbarStore';
+import type {ToolbarConfig} from '../types';
 
 export const DEFAULT_STORE_KEY = 'default';
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/withToolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/withToolbar.js
@@ -1,12 +1,12 @@
 // @flow
 import {autorun} from 'mobx';
-import type {Component} from 'react';
 import log from 'loglevel';
 import {getViewKeyFromRoute} from '../../services/Router';
 import {buildHocDisplayName} from '../../utils/react';
+import toolbarStorePool, {DEFAULT_STORE_KEY} from './stores/toolbarStorePool';
 import type {ViewProps} from '../index';
 import type {ToolbarConfig} from './types';
-import toolbarStorePool, {DEFAULT_STORE_KEY} from './stores/toolbarStorePool';
+import type {Component} from 'react';
 
 const UPDATE_ROUTE_HOOK_PRIORITY = 1024;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/ViewRenderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/ViewRenderer.js
@@ -1,9 +1,9 @@
 // @flow
 import React from 'react';
-import type {Element} from 'react';
 import {observer} from 'mobx-react';
 import Router, {getViewKeyFromRoute, Route} from '../../services/Router';
 import viewRegistry from './registries/viewRegistry';
+import type {Element} from 'react';
 import type {View} from './types';
 
 type Props = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/types.js
@@ -1,6 +1,6 @@
 // @flow
-import type {Component, Element} from 'react';
 import Router, {Route} from '../../services/Router';
+import type {Component, Element} from 'react';
 import type {AttributeMap} from '../../services/Router';
 
 export type ViewProps = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/updateRouterAttributesFromView.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/updateRouterAttributesFromView.js
@@ -1,6 +1,6 @@
 // @flow
-import type {UpdateAttributesHook} from '../../services/Router/types';
 import viewRegistry from './registries/viewRegistry';
+import type {UpdateAttributesHook} from '../../services/Router/types';
 
 const updateRouterAttributesFromView: UpdateAttributesHook = function(route, attributes: Object) {
     const parentAttributes = route.parent ? updateRouterAttributesFromView(route.parent, attributes) : {};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/index.js
@@ -16,14 +16,11 @@ import List, {
     DefaultLoadingStrategy,
     PaginatedLoadingStrategy,
 } from './List';
-import type {ListAdapterProps, LoadingStrategyInterface, StructureStrategyInterface} from './List';
 import {blockPreviewTransformerRegistry} from './FieldBlocks';
 import {viewRegistry} from './ViewRenderer';
 import Sidebar, {sidebarStore, sidebarRegistry} from './Sidebar';
-import type {ViewProps} from './ViewRenderer';
 import {withToolbar} from './Toolbar';
 import Form, {CardCollection, fieldRegistry, FormInspector, ResourceFormStore, ResourceLocator} from './Form';
-import type {SchemaOption} from './Form/types';
 import ResourceLocatorHistory from './ResourceLocatorHistory';
 import ResourceMultiSelect from './ResourceMultiSelect';
 import ResourceSingleSelect from './ResourceSingleSelect';
@@ -34,6 +31,9 @@ import SingleAutoComplete from './SingleAutoComplete';
 import SingleListOverlay from './SingleListOverlay';
 import SingleSelection from './SingleSelection';
 import TextEditor, {textEditorRegistry} from './TextEditor';
+import type {SchemaOption} from './Form/types';
+import type {ViewProps} from './ViewRenderer';
+import type {ListAdapterProps, LoadingStrategyInterface, StructureStrategyInterface} from './List';
 
 export type {
     ListAdapterProps,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/registries/resourceRouteRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/registries/resourceRouteRegistry.js
@@ -1,8 +1,8 @@
 // @flow
 import {isObservableArray, toJS} from 'mobx';
 import symfonyRouting from 'fos-jsrouting/router';
-import type {EndpointConfiguration} from '../types';
 import {transformDateForUrl} from '../../../utils/Date';
+import type {EndpointConfiguration} from '../types';
 
 function transformParameter(parameter) {
     return Array.isArray(parameter) || isObservableArray(parameter)

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -1,13 +1,13 @@
 // @flow
 import {action, autorun, computed, observable, toJS} from 'mobx';
-import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
 import equal from 'fast-deep-equal';
 import log from 'loglevel';
 import {compile} from 'path-to-regexp';
 import {transformDateForUrl} from '../../utils/Date';
-import type {AttributeMap, UpdateAttributesHook, UpdateRouteHook, UpdateRouteMethod} from './types';
 import routeRegistry from './registries/routeRegistry';
 import Route from './Route';
+import type {AttributeMap, UpdateAttributesHook, UpdateRouteHook, UpdateRouteMethod} from './types';
+import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
 
 const OBJECT_DELIMITER = '.';
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/getViewKeyFromRoute.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/getViewKeyFromRoute.js
@@ -1,6 +1,6 @@
 // @flow
-import type {AttributeMap} from './types';
 import Route from './Route';
+import type {AttributeMap} from './types';
 
 export default function getViewKeyFromRoute(route: ?Route, attributes: ?AttributeMap) {
     if (!route) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/registries/routeRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/registries/routeRegistry.js
@@ -1,6 +1,6 @@
 // @flow
-import type {RouteConfig, RouteMap} from '../types';
 import Route from '../Route';
+import type {RouteConfig, RouteMap} from '../types';
 
 class RouteRegistry {
     routes: RouteMap;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MultiSelectionStore/MultiSelectionStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MultiSelectionStore/MultiSelectionStore.js
@@ -1,8 +1,8 @@
 // @flow
 import {action, computed, observable} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import {arrayMove} from '../../utils';
 import {ResourceRequester} from '../../services';
+import type {IObservableValue} from 'mobx';
 
 export default class MultiSelectionStore<T = string | number, U: {id: T} = Object> {
     @observable items: Array<U> = [];

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
@@ -1,9 +1,9 @@
 // @flow
 import {action, autorun, observable, toJS, set, when} from 'mobx';
-import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
 import log from 'loglevel';
 import jsonpointer from 'json-pointer';
 import ResourceRequester from '../../services/ResourceRequester';
+import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
 import type {ObservableOptions} from './types';
 
 export default class ResourceStore {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/SingleSelectionStore/SingleSelectionStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/SingleSelectionStore/SingleSelectionStore.js
@@ -1,7 +1,7 @@
 // @flow
 import {action, observable} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import {ResourceRequester} from '../../services';
+import type {IObservableValue} from 'mobx';
 
 export default class SingleSelectionStore<T, U: {id: T} = Object> {
     @observable item: ?U;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/index.js
@@ -1,11 +1,11 @@
 // @flow
 import localizationStore from './localizationStore';
-import type {Localization} from './localizationStore/types';
 import MultiSelectionStore from './MultiSelectionStore';
 import ResourceListStore from './ResourceListStore';
 import ResourceStore from './ResourceStore';
 import SingleSelectionStore from './SingleSelectionStore';
 import userStore from './userStore';
+import type {Localization} from './localizationStore/types';
 
 export {
     MultiSelectionStore,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/logoutOnUnauthorizedResponse.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/logoutOnUnauthorizedResponse.js
@@ -1,6 +1,6 @@
 // @flow
-import type {HandleResponseHook} from '../../services/Requester/types';
 import userStore from './userStore';
+import type {HandleResponseHook} from '../../services/Requester/types';
 
 const logoutOnUnauthorizedResponse: HandleResponseHook = function(response: Response) {
     if (response.status === 401) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/updateRouterAttributesFromUserStoreContentLocale.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/updateRouterAttributesFromUserStoreContentLocale.js
@@ -1,8 +1,8 @@
 // @flow
 import {toJS} from 'mobx';
-import type {AttributeMap, UpdateAttributesHook} from '../../services/Router/types';
 import {Route} from '../../services/Router';
 import userStore from './userStore';
+import type {AttributeMap, UpdateAttributesHook} from '../../services/Router/types';
 
 const updateRouterAttributesFromUserStoreContentLocale: UpdateAttributesHook = function(
     route: Route,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/updateUserStoreContentLocaleFromRouterAttributes.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/updateUserStoreContentLocaleFromRouterAttributes.js
@@ -1,6 +1,6 @@
 // @flow
-import type {UpdateRouteHook} from '../../services/Router/types';
 import userStore from './userStore';
+import type {UpdateRouteHook} from '../../services/Router/types';
 
 const updateUserStoreContentLocaleFromRouterAttributes: UpdateRouteHook = function(newRoute, newAttributes) {
     if (!newRoute || !newAttributes) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -1,7 +1,5 @@
 // @flow
-import type {ElementRef} from 'react';
 import React from 'react';
-import type {IObservableValue} from 'mobx';
 import {action, computed, toJS, isObservableArray, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import equals from 'fast-deep-equal';
@@ -9,8 +7,6 @@ import Dialog from '../../components/Dialog';
 import PublishIndicator from '../../components/PublishIndicator';
 import {default as FormContainer, ResourceFormStore} from '../../containers/Form';
 import {withToolbar} from '../../containers/Toolbar';
-import type {ViewProps} from '../../containers/ViewRenderer';
-import type {AttributeMap, UpdateRouteMethod} from '../../services/Router/types';
 import ResourceStore from '../../stores/ResourceStore';
 import CollaborationStore from '../../stores/CollaborationStore';
 import {translate} from '../../utils/Translator';
@@ -18,6 +14,10 @@ import {Route} from '../../services/Router';
 import formToolbarActionRegistry from './registries/formToolbarActionRegistry';
 import AbstractFormToolbarAction from './toolbarActions/AbstractFormToolbarAction';
 import formStyles from './form.scss';
+import type {AttributeMap, UpdateRouteMethod} from '../../services/Router/types';
+import type {ViewProps} from '../../containers/ViewRenderer';
+import type {IObservableValue} from 'mobx';
+import type {ElementRef} from 'react';
 
 type Props = {
     ...ViewProps,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/AbstractFormToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/AbstractFormToolbarAction.js
@@ -1,9 +1,9 @@
 // @flow
-import type {Node} from 'react';
 import {ResourceFormStore} from '../../../containers/Form';
-import type {ToolbarItemConfig} from '../../../containers/Toolbar/types';
 import Router from '../../../services/Router';
 import Form from '../Form';
+import type {ToolbarItemConfig} from '../../../containers/Toolbar/types';
+import type {Node} from 'react';
 
 export default class AbstractFormToolbarAction {
     resourceFormStore: ResourceFormStore;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DropdownToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DropdownToolbarAction.js
@@ -1,11 +1,11 @@
 // @flow
 import React, {Fragment} from 'react';
 import {ResourceFormStore} from '../../../containers/Form';
-import type {DropdownOption} from '../../../components/Toolbar/types';
 import Router from '../../../services/Router';
 import formToolbarActionRegistry from '../registries/formToolbarActionRegistry';
 import Form from '../Form';
 import AbstractFormToolbarAction from './AbstractFormToolbarAction';
+import type {DropdownOption} from '../../../components/Toolbar/types';
 
 export default class DropdownToolbarAction extends AbstractFormToolbarAction {
     toolbarActions: Array<AbstractFormToolbarAction> = [];

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/TypeToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/TypeToolbarAction.js
@@ -1,7 +1,7 @@
 // @flow
 import jexl from 'jexl';
-import type {ToolbarItemConfig} from '../../../containers/Toolbar/types';
 import AbstractFormToolbarAction from './AbstractFormToolbarAction';
+import type {ToolbarItemConfig} from '../../../containers/Toolbar/types';
 
 export default class TypeToolbarAction extends AbstractFormToolbarAction {
     getToolbarItemConfig(): ?ToolbarItemConfig<string> {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
@@ -2,14 +2,14 @@
 import React, {Fragment} from 'react';
 import {observer} from 'mobx-react';
 import {action, observable, toJS} from 'mobx';
-import type {ElementRef} from 'react';
-import type {IObservableValue} from 'mobx';
-import type {ViewProps} from '../../containers/ViewRenderer';
 import {translate} from '../../utils/Translator';
 import FormOverlay from '../../containers/FormOverlay';
 import ResourceStore from '../../stores/ResourceStore';
 import List from '../List';
 import ResourceFormStore from '../../containers/Form/stores/ResourceFormStore';
+import type {ViewProps} from '../../containers/ViewRenderer';
+import type {IObservableValue} from 'mobx';
+import type {ElementRef} from 'react';
 
 type Props = ViewProps & {
     resourceStore?: ResourceStore,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -1,22 +1,22 @@
 // @flow
-import type {IObservableValue} from 'mobx';
 import {action, computed, observable, toJS} from 'mobx';
 import {observer} from 'mobx-react';
-import type {ElementRef} from 'react';
 import React, {Fragment} from 'react';
 import equals from 'fast-deep-equal';
 import {default as ListContainer, ListStore} from '../../containers/List';
 import {withToolbar} from '../../containers/Toolbar';
-import type {ViewProps} from '../../containers/ViewRenderer';
 import {translate} from '../../utils/Translator';
 import ResourceStore from '../../stores/ResourceStore';
-import type {ItemActionConfig} from '../../containers/List/types';
 import {Route} from '../../services/Router';
 import listToolbarActionRegistry from './registries/listToolbarActionRegistry';
 import listItemActionRegistry from './registries/listItemActionRegistry';
 import AbstractListToolbarAction from './toolbarActions/AbstractListToolbarAction';
 import AbstractListItemAction from './itemActions/AbstractListItemAction';
 import listStyles from './list.scss';
+import type {ItemActionConfig} from '../../containers/List/types';
+import type {ViewProps} from '../../containers/ViewRenderer';
+import type {ElementRef} from 'react';
+import type {IObservableValue} from 'mobx';
 
 const DEFAULT_USER_SETTINGS_KEY = 'list';
 const DEFAULT_LIMIT = 10;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/itemActions/AbstractListItemAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/itemActions/AbstractListItemAction.js
@@ -1,10 +1,10 @@
 // @flow
-import type {Node} from 'react';
-import type {ItemActionConfig} from '../../../containers/List/types';
 import ResourceStore from '../../../stores/ResourceStore';
 import Router from '../../../services/Router';
 import List from '../../../views/List/List';
 import ListStore from '../../../containers/List/stores/ListStore';
+import type {ItemActionConfig} from '../../../containers/List/types';
+import type {Node} from 'react';
 
 export default class AbstractListItemAction {
     listStore: ListStore;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/AbstractListToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/AbstractListToolbarAction.js
@@ -1,10 +1,10 @@
 // @flow
-import type {Node} from 'react';
-import type {ToolbarItemConfig} from '../../../containers/Toolbar/types';
 import ResourceStore from '../../../stores/ResourceStore';
 import Router from '../../../services/Router';
 import List from '../../../views/List/List';
 import ListStore from '../../../containers/List/stores/ListStore';
+import type {ToolbarItemConfig} from '../../../containers/Toolbar/types';
+import type {Node} from 'react';
 
 export default class AbstractListToolbarAction {
     listStore: ListStore;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
@@ -5,11 +5,11 @@ import {observer} from 'mobx-react';
 import jexl from 'jexl';
 import Loader from '../../components/Loader';
 import Tabs from '../../views/Tabs';
-import type {ViewProps} from '../../containers/ViewRenderer';
 import ResourceStore from '../../stores/ResourceStore';
 import {Route} from '../../services/Router';
-import type {AttributeMap} from '../../services/Router';
 import resourceTabsStyles from './resourceTabs.scss';
+import type {AttributeMap} from '../../services/Router';
+import type {ViewProps} from '../../containers/ViewRenderer';
 
 type Props = {
     ...ViewProps,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/Tabs.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/Tabs.js
@@ -1,14 +1,14 @@
 // @flow
 import React, {Fragment} from 'react';
-import type {Element, Node} from 'react';
 import {autorun, computed} from 'mobx';
 import {observer} from 'mobx-react';
 import TabsComponent from '../../components/Tabs';
-import type {ViewProps} from '../../containers/ViewRenderer';
 import {translate} from '../../utils/Translator';
 import {Route} from '../../services/Router';
 import Badge, {type BadgeOptions} from '../../containers/Badge';
 import tabsStyles from './tabs.scss';
+import type {ViewProps} from '../../containers/ViewRenderer';
+import type {Element, Node} from 'react';
 
 type Props<T> = {
     ...ViewProps,

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/Form/fields/TargetGroupRules.js
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/Form/fields/TargetGroupRules.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
-import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import TargetGroupRulesComponent from '../../../containers/TargetGroupRules';
+import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import type {Rule} from '../../../containers/TargetGroupRules/types';
 
 class TargetGroupRules extends React.Component<FieldTypeProps<Array<Rule>>> {

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/ruleTypes/KeyValue.js
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/ruleTypes/KeyValue.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react';
 import {Input} from 'sulu-admin-bundle/components';
-import type {RuleTypeProps} from '../types';
 import keyValueStyles from './keyValue.scss';
+import type {RuleTypeProps} from '../types';
 
 export default class KeyValue extends React.Component<RuleTypeProps> {
     handleParameterChange = (parameter: ?string) => {

--- a/src/Sulu/Bundle/CategoryBundle/Resources/js/containers/List/fieldTransformers/CategoryKeywordsMultipleUsageTransformer.js
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/js/containers/List/fieldTransformers/CategoryKeywordsMultipleUsageTransformer.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
-import type {Node} from 'react';
 import {Checkbox} from 'sulu-admin-bundle/components';
+import type {Node} from 'react';
 import type {FieldTransformer} from 'sulu-admin-bundle/types';
 
 export default class CategoryKeywordsMultipleUsageTransformer implements FieldTransformer {

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/components/ContactDetails/Email.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/components/ContactDetails/Email.js
@@ -2,8 +2,8 @@
 import React from 'react';
 import {Email as EmailComponent} from 'sulu-admin-bundle/components';
 import {translate} from 'sulu-admin-bundle/utils';
-import type {FormFieldTypes} from 'sulu-admin-bundle/types';
 import Field from './Field';
+import type {FormFieldTypes} from 'sulu-admin-bundle/types';
 
 type Props = {|
     email: ?string,

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/components/ContactDetails/Fax.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/components/ContactDetails/Fax.js
@@ -2,8 +2,8 @@
 import React from 'react';
 import {Phone as PhoneComponent} from 'sulu-admin-bundle/components';
 import {translate} from 'sulu-admin-bundle/utils';
-import type {FormFieldTypes} from 'sulu-admin-bundle/types';
 import Field from './Field';
+import type {FormFieldTypes} from 'sulu-admin-bundle/types';
 
 type Props = {|
     fax: ?string,

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/components/ContactDetails/Field.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/components/ContactDetails/Field.js
@@ -1,9 +1,9 @@
 // @flow
 import React from 'react';
-import type {Node} from 'react';
 import {Form, Icon} from 'sulu-admin-bundle/components';
-import type {FormFieldTypes} from 'sulu-admin-bundle/types';
 import fieldStyles from './field.scss';
+import type {Node} from 'react';
+import type {FormFieldTypes} from 'sulu-admin-bundle/types';
 
 type Props = {|
     children: Node,

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/components/ContactDetails/Phone.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/components/ContactDetails/Phone.js
@@ -2,8 +2,8 @@
 import React from 'react';
 import {Phone as PhoneComponent} from 'sulu-admin-bundle/components';
 import {translate} from 'sulu-admin-bundle/utils';
-import type {FormFieldTypes} from 'sulu-admin-bundle/types';
 import Field from './Field';
+import type {FormFieldTypes} from 'sulu-admin-bundle/types';
 
 type Props = {|
     index: number,

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/components/ContactDetails/SocialMedia.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/components/ContactDetails/SocialMedia.js
@@ -2,8 +2,8 @@
 import React from 'react';
 import {Input} from 'sulu-admin-bundle/components';
 import {translate} from 'sulu-admin-bundle/utils';
-import type {FormFieldTypes} from 'sulu-admin-bundle/types';
 import Field from './Field';
+import type {FormFieldTypes} from 'sulu-admin-bundle/types';
 
 type Props = {|
     index: number,

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/components/ContactDetails/Website.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/components/ContactDetails/Website.js
@@ -2,8 +2,8 @@
 import React from 'react';
 import {Url} from 'sulu-admin-bundle/components';
 import {translate} from 'sulu-admin-bundle/utils';
-import type {FormFieldTypes} from 'sulu-admin-bundle/types';
 import Field from './Field';
+import type {FormFieldTypes} from 'sulu-admin-bundle/types';
 
 type Props = {|
     index: number,

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/containers/Form/fields/Bic.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/containers/Form/fields/Bic.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
-import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import BicComponent from '../../../components/Bic';
+import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 
 export default class Bic extends React.Component<FieldTypeProps<?string>> {
     render() {

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/containers/Form/fields/ContactAccountSelection.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/containers/Form/fields/ContactAccountSelection.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
-import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import ContactAccountSelectionComponent from '../../ContactAccountSelection';
+import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 
 class ContactAccountSelection extends React.Component<FieldTypeProps<Array<string>>> {
     handleChange = (value: Array<Object>) => {

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/containers/Form/fields/ContactDetails.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/containers/Form/fields/ContactDetails.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
-import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import ContactDetailsComponent from '../../../components/ContactDetails';
+import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import type {ContactDetailsValue} from '../../../components/ContactDetails/types';
 
 export default class ContactDetails extends React.Component<FieldTypeProps<ContactDetailsValue>> {

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/containers/Form/fields/Iban.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/containers/Form/fields/Iban.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
-import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import IbanComponent from '../../../components/Iban';
+import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 
 export default class Iban extends React.Component<FieldTypeProps<?string>> {
     render() {

--- a/src/Sulu/Bundle/CustomUrlBundle/Resources/js/containers/Form/fields/CustomUrl.js
+++ b/src/Sulu/Bundle/CustomUrlBundle/Resources/js/containers/Form/fields/CustomUrl.js
@@ -2,9 +2,9 @@
 import React from 'react';
 import {observer} from 'mobx-react';
 import {ResourceLocatorHistory} from 'sulu-admin-bundle/containers';
-import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import CustomUrlComponent from '../../../components/CustomUrl';
 import customUrlStyles from './customUrl.scss';
+import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 
 @observer
 class CustomUrl extends React.Component<FieldTypeProps<Array<?string>>> {

--- a/src/Sulu/Bundle/CustomUrlBundle/Resources/js/containers/Form/fields/CustomUrlsDomainSelect.js
+++ b/src/Sulu/Bundle/CustomUrlBundle/Resources/js/containers/Form/fields/CustomUrlsDomainSelect.js
@@ -3,8 +3,8 @@ import React from 'react';
 import {computed} from 'mobx';
 import {observer} from 'mobx-react';
 import {SingleSelect} from 'sulu-admin-bundle/components';
-import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import {webspaceStore} from 'sulu-page-bundle/stores';
+import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 
 @observer
 class CustomUrlsDomainSelect extends React.Component<FieldTypeProps<string>> {

--- a/src/Sulu/Bundle/CustomUrlBundle/Resources/js/containers/Form/fields/CustomUrlsLocaleSelect.js
+++ b/src/Sulu/Bundle/CustomUrlBundle/Resources/js/containers/Form/fields/CustomUrlsLocaleSelect.js
@@ -3,8 +3,8 @@ import React from 'react';
 import {computed} from 'mobx';
 import {observer} from 'mobx-react';
 import {SingleSelect} from 'sulu-admin-bundle/components';
-import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import {webspaceStore} from 'sulu-page-bundle/stores';
+import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 
 @observer
 class CustomUrlsLocaleSelect extends React.Component<FieldTypeProps<string>> {

--- a/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Form/fields/Location.js
+++ b/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Form/fields/Location.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react';
+import LocationComponent from '../../../containers/Location';
 import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import type {Location as LocationValue} from '../../../types';
-import LocationComponent from '../../../containers/Location';
 
 export default class Location extends React.Component<FieldTypeProps<?LocationValue>> {
     handleChange = (value: ?LocationValue) => {

--- a/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/Location.js
+++ b/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/Location.js
@@ -6,9 +6,9 @@ import {CroppedText, Icon} from 'sulu-admin-bundle/components';
 import {translate} from 'sulu-admin-bundle/utils';
 import {Map, Marker, TileLayer, Tooltip} from 'react-leaflet';
 import classNames from 'classnames';
-import type {Location as LocationValue} from '../../types';
 import locationStyles from './location.scss';
 import LocationOverlay from './LocationOverlay';
+import type {Location as LocationValue} from '../../types';
 
 type Props = {|
     disabled: boolean,

--- a/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/LocationOverlay.js
+++ b/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/LocationOverlay.js
@@ -6,8 +6,8 @@ import {Form, Input, Number, Overlay} from 'sulu-admin-bundle/components';
 import {translate} from 'sulu-admin-bundle/utils';
 import {Map, Marker, TileLayer} from 'react-leaflet';
 import {SingleAutoComplete} from 'sulu-admin-bundle/containers';
-import type {Location as LocationValue} from '../../types';
 import locationOverlayStyles from './locationOverlay.scss';
+import type {Location as LocationValue} from '../../types';
 
 type Props = {
     onClose: () => void,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/ImageFocusPoint/ImageFocusPoint.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/ImageFocusPoint/ImageFocusPoint.js
@@ -1,12 +1,12 @@
 // @flow
 import React from 'react';
-import type {ElementRef} from 'react';
 import {action, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import {Loader} from 'sulu-admin-bundle/components';
-import type {Point} from './types';
 import ImageFocusPointCell from './ImageFocusPointCell';
 import imageFocusPointStyles from './imageFocusPoint.scss';
+import type {Point} from './types';
+import type {ElementRef} from 'react';
 
 const FOCUS_POINT_MATRIX_SIZE = 3;
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/ImageFocusPoint/ImageFocusPointCell.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/ImageFocusPoint/ImageFocusPointCell.js
@@ -2,8 +2,8 @@
 import React from 'react';
 import classNames from 'classnames';
 import {Icon} from 'sulu-admin-bundle/components';
-import type {ArrowDirection, Point} from './types';
 import imageFocusPointCellStyles from './imageFocusPointCell.scss';
+import type {ArrowDirection, Point} from './types';
 
 const ICON_UP = 'su-angle-up';
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/DownloadList.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/DownloadList.js
@@ -1,9 +1,9 @@
 // @flow
 import React from 'react';
-import type {ElementRef} from 'react';
 import {Menu, Popover} from 'sulu-admin-bundle/components';
-import type {DownloadItemsList} from './types';
 import DownloadListItem from './DownloadListItem';
+import type {ElementRef} from 'react';
+import type {DownloadItemsList} from './types';
 
 type Props = {
     buttonRef: ?ElementRef<'button'>,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
@@ -1,6 +1,5 @@
 // @flow
 import React, {Fragment} from 'react';
-import type {ElementRef} from 'react';
 import classNames from 'classnames';
 import {observer} from 'mobx-react';
 import {action, observable} from 'mobx';
@@ -8,6 +7,7 @@ import {Checkbox, CroppedText, GhostIndicator, Icon, Loader} from 'sulu-admin-bu
 import MimeTypeIndicator from '../MimeTypeIndicator';
 import DownloadList from './DownloadList';
 import mediaCardStyles from './mediaCard.scss';
+import type {ElementRef} from 'react';
 
 const DOWNLOAD_ICON = 'su-download';
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/types.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/types.js
@@ -1,7 +1,7 @@
 // @flow
-import type {Element} from 'react';
 import {Menu} from 'sulu-admin-bundle/components';
 import DownloadListItem from './DownloadListItem';
+import type {Element} from 'react';
 
 type DownloadItem = Element<typeof DownloadListItem>;
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/CKEditor5/plugins/InternalLinkPlugin/overlays/MediaInternalLinkTypeOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/CKEditor5/plugins/InternalLinkPlugin/overlays/MediaInternalLinkTypeOverlay.js
@@ -4,8 +4,8 @@ import {observable} from 'mobx';
 import {Dialog, Input, Form} from 'sulu-admin-bundle/components';
 import {userStore} from 'sulu-admin-bundle/stores';
 import {translate} from 'sulu-admin-bundle/utils';
-import type {InternalLinkTypeOverlayProps} from 'sulu-admin-bundle/types';
 import SingleMediaSelection from '../../../../SingleMediaSelection';
+import type {InternalLinkTypeOverlayProps} from 'sulu-admin-bundle/types';
 import type {Value} from '../../../../SingleMediaSelection/types';
 import type {Media} from '../../../../../types';
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/MediaSelectionBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/MediaSelectionBlockPreviewTransformer.js
@@ -1,9 +1,9 @@
 // @flow
 import React from 'react';
-import type {Node} from 'react';
 import {isObservableArray} from 'mobx';
-import type {BlockPreviewTransformer} from 'sulu-admin-bundle/types';
 import mediaSelectionBlockPreviewTransformerStyles from './mediaSelectionBlockPreviewTransformer.scss';
+import type {Node} from 'react';
+import type {BlockPreviewTransformer} from 'sulu-admin-bundle/types';
 
 const MAX_LENGTH = 8;
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/SingleMediaSelectionBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/SingleMediaSelectionBlockPreviewTransformer.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react';
+import singleMediaSelectionBlockPreviewTransformerStyles from './singleMediaSelectionBlockPreviewTransformer.scss';
 import type {Node} from 'react';
 import type {BlockPreviewTransformer} from 'sulu-admin-bundle/types';
-import singleMediaSelectionBlockPreviewTransformerStyles from './singleMediaSelectionBlockPreviewTransformer.scss';
 
 export default class SingleMediaSelectionBlockPreviewTransformer implements BlockPreviewTransformer {
     imageFormatUrl: string;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
@@ -2,7 +2,6 @@
 import React from 'react';
 import {observer} from 'mobx-react';
 import log from 'loglevel';
-import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import userStore from 'sulu-admin-bundle/stores/userStore';
 import {computed, isArrayLike, observable} from 'mobx';
 import {
@@ -11,6 +10,7 @@ import {
     validateDisplayOption,
 } from '../../../utils/MediaSelectionHelper';
 import MultiMediaSelection from '../../MultiMediaSelection';
+import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import type {Media} from '../../../types';
 import type {Value} from '../../MultiMediaSelection';
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaVersionUpload.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaVersionUpload.js
@@ -1,9 +1,9 @@
 // @flow
 import React from 'react';
 import {ResourceStore} from 'sulu-admin-bundle/stores';
-import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import {ResourceFormStore} from 'sulu-admin-bundle/containers';
 import MediaVersionUploadComponent from '../../MediaVersionUpload';
+import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 
 class MediaVersionUpload extends React.Component<FieldTypeProps<void>> {
     resourceStore: ResourceStore;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaSelection.js
@@ -1,7 +1,6 @@
 // @flow
 import React from 'react';
 import {observer} from 'mobx-react';
-import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import userStore from 'sulu-admin-bundle/stores/userStore';
 import {computed, observable} from 'mobx';
 import {
@@ -10,6 +9,7 @@ import {
     validateDisplayOption,
 } from '../../../utils/MediaSelectionHelper';
 import SingleMediaSelectionComponent from '../../SingleMediaSelection';
+import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import type {Media} from '../../../types';
 import type {Value} from '../../SingleMediaSelection';
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaUpload.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaUpload.js
@@ -1,10 +1,10 @@
 // @flow
 import React from 'react';
-import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import userStore from 'sulu-admin-bundle/stores/userStore';
 import {observable} from 'mobx';
 import MediaUploadStore from '../../../stores/MediaUploadStore';
 import SingleMediaUploadComponent from '../../SingleMediaUpload';
+import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import type {Media} from '../../../types';
 
 export default class SingleMediaUpload extends React.Component<FieldTypeProps<Media>> {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/adapters/MediaCardAdapter.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/adapters/MediaCardAdapter.js
@@ -2,9 +2,9 @@
 import {observer} from 'mobx-react';
 import React from 'react';
 import {Masonry, InfiniteScroller} from 'sulu-admin-bundle/components';
-import type {ListAdapterProps} from 'sulu-admin-bundle/containers';
 import {translate} from 'sulu-admin-bundle/utils';
 import MediaCard from '../../../components/MediaCard';
+import type {ListAdapterProps} from 'sulu-admin-bundle/containers';
 
 const THUMBNAIL_SIZE = 'sulu-240x';
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionFormOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionFormOverlay.js
@@ -6,8 +6,8 @@ import {ResourceStore} from 'sulu-admin-bundle/stores';
 import {Form, ResourceFormStore} from 'sulu-admin-bundle/containers';
 import {translate} from 'sulu-admin-bundle/utils';
 import {Dialog, Overlay} from 'sulu-admin-bundle/components';
-import type {OverlayType, OperationType} from './types';
 import collectionFormOverlayStyles from './collectionFormOverlay.scss';
+import type {OverlayType, OperationType} from './types';
 
 type Props = {
     onClose: () => void,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
@@ -1,7 +1,6 @@
 //@flow
 import React from 'react';
 import {action, computed, observable} from 'mobx';
-import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
 import {observer} from 'mobx-react';
 import {List, ListStore, SingleListOverlay} from 'sulu-admin-bundle/containers';
 import {ResourceStore} from 'sulu-admin-bundle/stores';
@@ -10,8 +9,9 @@ import {Button, ButtonGroup, Dialog, DropdownButton} from 'sulu-admin-bundle/com
 import CollectionFormOverlay from './CollectionFormOverlay';
 import CollectionBreadcrumb from './CollectionBreadcrumb';
 import PermissionFormOverlay from './PermissionFormOverlay';
-import type {OperationType, OverlayType} from './types';
 import collectionSectionStyles from './collectionSection.scss';
+import type {OperationType, OverlayType} from './types';
+import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
 
 const COLLECTIONS_RESOURCE_KEY = 'collections';
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -1,16 +1,16 @@
 // @flow
 import React from 'react';
-import type {ElementRef} from 'react';
 import {action, when} from 'mobx';
-import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
 import {observer} from 'mobx-react';
 import {Divider} from 'sulu-admin-bundle/components';
 import {List, ListStore} from 'sulu-admin-bundle/containers';
 import CollectionStore from '../../stores/CollectionStore';
 import MultiMediaDropzone from '../MultiMediaDropzone';
-import type {OverlayType} from './types';
 import CollectionSection from './CollectionSection';
 import MediaSection from './MediaSection';
+import type {OverlayType} from './types';
+import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
+import type {ElementRef} from 'react';
 
 type Props = {|
     collectionListStore: ListStore,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaSection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaSection.js
@@ -1,7 +1,7 @@
 //@flow
 import React from 'react';
-import type {ElementRef} from 'react';
 import {List, ListStore} from 'sulu-admin-bundle/containers';
+import type {ElementRef} from 'react';
 
 type Props = {|
     adapters: Array<string>,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/MediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/MediaSelectionOverlay.js
@@ -1,7 +1,6 @@
 // @flow
 import React from 'react';
 import {action, autorun, observable} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import {ListStore} from 'sulu-admin-bundle/containers';
 import {Overlay} from 'sulu-admin-bundle/components';
@@ -9,6 +8,7 @@ import {translate} from 'sulu-admin-bundle/utils';
 import MediaCollection from '../MediaCollection';
 import CollectionStore from '../../stores/CollectionStore';
 import mediaSelectionOverlayStyles from './mediaSelectionOverlay.scss';
+import type {IObservableValue} from 'mobx';
 
 const MEDIA_RESOURCE_KEY = 'media';
 const COLLECTIONS_RESOURCE_KEY = 'collections';

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaVersionUpload/CropOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaVersionUpload/CropOverlay.js
@@ -3,12 +3,12 @@ import React, {Fragment} from 'react';
 import {action, computed, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import {ImageRectangleSelection, Loader, Overlay, SingleSelect} from 'sulu-admin-bundle/components';
-import type {SelectionData} from 'sulu-admin-bundle/types';
 import {translate} from 'sulu-admin-bundle/utils';
 import MediaFormatStore from '../../stores/MediaFormatStore';
-import type {MediaFormat} from '../../stores/MediaFormatStore';
 import formatStore from '../../stores/formatStore';
 import cropOverlayStyles from './cropOverlay.scss';
+import type {MediaFormat} from '../../stores/MediaFormatStore';
+import type {SelectionData} from 'sulu-admin-bundle/types';
 
 type Props = {|
     id: string | number,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaVersionUpload/FocusPointOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaVersionUpload/FocusPointOverlay.js
@@ -6,8 +6,8 @@ import {Overlay} from 'sulu-admin-bundle/components';
 import {ResourceStore} from 'sulu-admin-bundle/stores';
 import {translate} from 'sulu-admin-bundle/utils';
 import ImageFocusPoint from '../../components/ImageFocusPoint';
-import type {Point} from '../../components/ImageFocusPoint';
 import focusPointOverlayStyles from './focusPointOverlay.scss';
+import type {Point} from '../../components/ImageFocusPoint';
 
 type Props = {|
     onClose: () => void,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/DropzoneOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/DropzoneOverlay.js
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react';
-import type {ChildrenArray, Element} from 'react';
 import {observer} from 'mobx-react';
 import Mousetrap from 'mousetrap';
 import {Portal} from 'react-portal';
@@ -8,6 +7,7 @@ import {translate} from 'sulu-admin-bundle/utils';
 import {Icon} from 'sulu-admin-bundle/components';
 import MediaItem from './MediaItem';
 import dropzoneOverlayStyles from './dropzoneOverlay.scss';
+import type {ChildrenArray, Element} from 'react';
 
 type Props = {
     children?: ChildrenArray<Element<typeof MediaItem>>,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
@@ -1,14 +1,14 @@
 // @flow
 import React from 'react';
-import type {ElementRef, Node} from 'react';
 import {observer, Observer} from 'mobx-react';
 import {action, observable} from 'mobx';
-import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
 import Dropzone from 'react-dropzone';
 import MediaUploadStore from '../../stores/MediaUploadStore';
 import MediaItem from './MediaItem';
 import DropzoneOverlay from './DropzoneOverlay';
 import dropzoneStyles from './dropzone.scss';
+import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
+import type {ElementRef, Node} from 'react';
 
 type Props = {
     children: Node,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/MultiMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/MultiMediaSelection.js
@@ -6,12 +6,12 @@ import equals from 'fast-deep-equal';
 import {CroppedText, MultiItemSelection} from 'sulu-admin-bundle/components';
 import {translate} from 'sulu-admin-bundle/utils';
 import {MultiSelectionStore} from 'sulu-admin-bundle/stores';
-import type {IObservableValue} from 'mobx';
 import {getIconForDisplayOption, getTranslationForDisplayOption} from '../../utils/MediaSelectionHelper';
 import MultiMediaSelectionOverlay from '../MultiMediaSelectionOverlay';
 import MimeTypeIndicator from '../../components/MimeTypeIndicator';
-import type {DisplayOption, Media} from '../../types';
 import multiMediaSelectionStyle from './multiMediaSelection.scss';
+import type {DisplayOption, Media} from '../../types';
+import type {IObservableValue} from 'mobx';
 import type {Value} from './types';
 
 type Props = {|

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelectionOverlay/MultiMediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelectionOverlay/MultiMediaSelectionOverlay.js
@@ -1,10 +1,10 @@
 // @flow
 import React from 'react';
 import {comparer, computed, observable} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import {ListStore} from 'sulu-admin-bundle/containers';
 import MediaSelectionOverlay from '../MediaSelectionOverlay';
+import type {IObservableValue} from 'mobx';
 
 type Props = {|
     confirmLoading: boolean,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/SingleMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/SingleMediaSelection.js
@@ -1,7 +1,6 @@
 // @flow
 import React, {Fragment} from 'react';
 import {observer} from 'mobx-react';
-import type {IObservableValue} from 'mobx';
 import {action, observable, reaction, toJS} from 'mobx';
 import SingleItemSelection from 'sulu-admin-bundle/components/SingleItemSelection';
 import {translate} from 'sulu-admin-bundle/utils/Translator';
@@ -9,9 +8,10 @@ import SingleSelectionStore from 'sulu-admin-bundle/stores/SingleSelectionStore'
 import {getIconForDisplayOption, getTranslationForDisplayOption} from '../../utils/MediaSelectionHelper';
 import SingleMediaSelectionOverlay from '../SingleMediaSelectionOverlay';
 import MimeTypeIndicator from '../../components/MimeTypeIndicator';
+import singleMediaSelectionStyle from './singleMediaSelection.scss';
 import type {DisplayOption, Media} from '../../types';
 import type {Value} from './types';
-import singleMediaSelectionStyle from './singleMediaSelection.scss';
+import type {IObservableValue} from 'mobx';
 
 type Props = {|
     disabled: boolean,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelectionOverlay/SingleMediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelectionOverlay/SingleMediaSelectionOverlay.js
@@ -1,10 +1,10 @@
 // @flow
 import React from 'react';
 import {autorun, comparer, computed, observable} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import {ListStore} from 'sulu-admin-bundle/containers';
 import MediaSelectionOverlay from '../MediaSelectionOverlay';
+import type {IObservableValue} from 'mobx';
 
 type Props = {|
     excludedIds: Array<number>,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/CollectionStore/CollectionStore.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/CollectionStore/CollectionStore.js
@@ -1,7 +1,7 @@
 // @flow
 import {computed} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import {ResourceStore} from 'sulu-admin-bundle/stores';
+import type {IObservableValue} from 'mobx';
 
 const COLLECTIONS_RESOURCE_KEY = 'collections';
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/MediaUploadStore.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/MediaUploadStore.js
@@ -1,7 +1,7 @@
 // @flow
 import {action, computed, observable} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import {ResourceRequester, resourceRouteRegistry} from 'sulu-admin-bundle/services';
+import type {IObservableValue} from 'mobx';
 import type {Media} from '../../types';
 
 const RESOURCE_KEY = 'media';

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/utils/MediaSelectionHelper/convertDisplayOptionsFromParams.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/utils/MediaSelectionHelper/convertDisplayOptionsFromParams.js
@@ -1,7 +1,7 @@
 //@flow
+import validateDisplayOption from './validateDisplayOption';
 import type {SchemaOption} from 'sulu-admin-bundle/containers';
 import type {DisplayOption} from '../../types';
-import validateDisplayOption from './validateDisplayOption';
 
 export default function convertDisplayOptionsFromParams(displayOptions: ?Array<SchemaOption>): Array<DisplayOption> {
     if (!displayOptions) {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/MediaFormats.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/MediaFormats.js
@@ -5,11 +5,11 @@ import {observer} from 'mobx-react';
 import copyToClipboard from 'copy-to-clipboard';
 import {Loader, Table} from 'sulu-admin-bundle/components';
 import {withToolbar} from 'sulu-admin-bundle/containers';
-import type {ViewProps} from 'sulu-admin-bundle/containers';
 import {ResourceStore} from 'sulu-admin-bundle/stores';
 import {translate} from 'sulu-admin-bundle/utils';
 import formatStore from '../../stores/formatStore';
 import mediaFormatsStyles from './mediaFormats.scss';
+import type {ViewProps} from 'sulu-admin-bundle/containers';
 
 const COLLECTION_ROUTE = 'sulu_media.overview';
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaHistory/MediaHistory.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaHistory/MediaHistory.js
@@ -1,15 +1,15 @@
 // @flow
 import React, {Fragment} from 'react';
 import {action, computed, observable} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import {Dialog, Loader, Table} from 'sulu-admin-bundle/components';
 import {withToolbar} from 'sulu-admin-bundle/containers';
-import type {ViewProps} from 'sulu-admin-bundle/containers';
 import {ResourceStore} from 'sulu-admin-bundle/stores';
 import {ResourceRequester} from 'sulu-admin-bundle/services';
 import {translate} from 'sulu-admin-bundle/utils';
 import mediaHistoryStyles from './mediaHistory.scss';
+import type {ViewProps} from 'sulu-admin-bundle/containers';
+import type {IObservableValue} from 'mobx';
 
 const COLLECTION_ROUTE = 'sulu_media.overview';
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -1,14 +1,14 @@
 // @flow
 import React from 'react';
-import type {ElementRef} from 'react';
 import {action, autorun, observable} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import {List, ListStore, SingleListOverlay, withToolbar} from 'sulu-admin-bundle/containers';
-import type {ViewProps} from 'sulu-admin-bundle/containers';
 import {translate} from 'sulu-admin-bundle/utils';
 import MediaCollection from '../../containers/MediaCollection';
 import CollectionStore from '../../stores/CollectionStore';
+import type {ViewProps} from 'sulu-admin-bundle/containers';
+import type {IObservableValue} from 'mobx';
+import type {ElementRef} from 'react';
 
 const COLLECTION_ROUTE = 'sulu_media.overview';
 const MEDIA_ROUTE = 'sulu_media.form.details';

--- a/src/Sulu/Bundle/PageBundle/Resources/js/components/WebspaceSelect/WebspaceSelect.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/components/WebspaceSelect/WebspaceSelect.js
@@ -1,10 +1,10 @@
 // @flow
 import React from 'react';
-import type {ChildrenArray, Element} from 'react';
 import {action, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import {Icon, ArrowMenu} from 'sulu-admin-bundle/components';
 import webspaceSelectStyles from './webspaceSelect.scss';
+import type {ChildrenArray, Element} from 'react';
 
 type Props = {
     children: ChildrenArray<Element<typeof ArrowMenu.Item>>,

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/fields/PageSettingsNavigationSelect.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/fields/PageSettingsNavigationSelect.js
@@ -3,9 +3,9 @@ import React from 'react';
 import {computed} from 'mobx';
 import {observer} from 'mobx-react';
 import {MultiSelect} from 'sulu-admin-bundle/components';
-import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import {translate} from 'sulu-admin-bundle/utils';
 import webspaceStore from '../../../stores/webspaceStore';
+import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 
 @observer
 class PageSettingsNavigationSelect extends React.Component<FieldTypeProps<Array<string | number>>> {

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/fields/SearchResult.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/fields/SearchResult.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react';
 import {observer} from 'mobx-react';
-import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import SearchResultComponent from '../../../components/SearchResult';
+import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 
 @observer
 class SearchResult extends React.Component<FieldTypeProps<typeof undefined>> {

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/fields/SettingsVersions.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/fields/SettingsVersions.js
@@ -1,13 +1,13 @@
 // @flow
 import React, {Fragment} from 'react';
 import {action, computed, observable} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import {Dialog} from 'sulu-admin-bundle/components';
 import {List, ListStore} from 'sulu-admin-bundle/containers';
 import {ResourceRequester} from 'sulu-admin-bundle/services';
-import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import {translate} from 'sulu-admin-bundle/utils';
+import type {FieldTypeProps} from 'sulu-admin-bundle/types';
+import type {IObservableValue} from 'mobx';
 
 type Props = FieldTypeProps<void>;
 

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/fields/TeaserSelection.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/fields/TeaserSelection.js
@@ -1,12 +1,12 @@
 // @flow
 import React from 'react';
 import {computed, observable} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import jsonpointer from 'json-pointer';
-import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import {userStore} from 'sulu-admin-bundle/stores';
 import TeaserSelectionComponent, {teaserProviderRegistry} from '../../TeaserSelection';
+import type {FieldTypeProps} from 'sulu-admin-bundle/types';
+import type {IObservableValue} from 'mobx';
 import type {TeaserItem, TeaserSelectionValue} from '../../TeaserSelection/types';
 
 @observer

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/TeaserSelection/Item.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/TeaserSelection/Item.js
@@ -1,17 +1,17 @@
 // @flow
 import React, {Fragment} from 'react';
 import {action, observable} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import textVersion from 'textversionjs';
 import {MimeTypeIndicator} from 'sulu-media-bundle/components';
 import {SingleMediaSelectionOverlay} from 'sulu-media-bundle/containers';
-import type {Media} from 'sulu-media-bundle/types';
 import {Button, Icon, Input} from 'sulu-admin-bundle/components';
 import {TextEditor} from 'sulu-admin-bundle/containers';
 import {translate} from 'sulu-admin-bundle/utils';
 import teaserProviderRegistry from './registries/teaserProviderRegistry';
 import itemStyles from './item.scss';
+import type {Media} from 'sulu-media-bundle/types';
+import type {IObservableValue} from 'mobx';
 import type {TeaserItem} from './types';
 
 type Props = {|

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/TeaserSelection/TeaserSelection.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/TeaserSelection/TeaserSelection.js
@@ -1,7 +1,6 @@
 // @flow
 import React, {Fragment} from 'react';
 import {action, computed, observable} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import {MultiItemSelection} from 'sulu-admin-bundle/components';
 import {MultiListOverlay} from 'sulu-admin-bundle/containers';
@@ -9,6 +8,7 @@ import {arrayMove} from 'sulu-admin-bundle/utils';
 import TeaserStore from './stores/TeaserStore';
 import Item from './Item';
 import teaserProviderRegistry from './registries/teaserProviderRegistry';
+import type {IObservableValue} from 'mobx';
 import type {PresentationItem, TeaserItem, TeaserSelectionValue} from './types';
 
 type Props = {|

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/TeaserSelection/stores/TeaserStore.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/TeaserSelection/stores/TeaserStore.js
@@ -1,7 +1,7 @@
 // @flow
 import {action, autorun, observable} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import ResourceRequester from 'sulu-admin-bundle/services/ResourceRequester';
+import type {IObservableValue} from 'mobx';
 import type {TeaserItem} from '../types';
 
 export default class TeaserStore {

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/PageList.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/PageList.js
@@ -1,18 +1,18 @@
 // @flow
 import {action, intercept, observable} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import React from 'react';
 import {List, ListStore, withToolbar} from 'sulu-admin-bundle/containers';
 import userStore from 'sulu-admin-bundle/stores/userStore/userStore';
-import type {Localization} from 'sulu-admin-bundle/stores';
-import type {ViewProps} from 'sulu-admin-bundle/containers';
-import type {AttributeMap} from 'sulu-admin-bundle/services';
 import {translate} from 'sulu-admin-bundle/utils';
 import {CacheClearToolbarAction} from 'sulu-website-bundle/containers';
 import {Route} from 'sulu-admin-bundle/services';
-import type {Webspace} from '../../stores/webspaceStore/types';
 import pageListStyles from './pageList.scss';
+import type {Localization} from 'sulu-admin-bundle/stores';
+import type {ViewProps} from 'sulu-admin-bundle/containers';
+import type {AttributeMap} from 'sulu-admin-bundle/services';
+import type {Webspace} from '../../stores/webspaceStore/types';
+import type {IObservableValue} from 'mobx';
 
 const USER_SETTINGS_KEY = 'page_list';
 const PAGES_RESOURCE_KEY = 'pages';

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageTabs/PageTabs.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageTabs/PageTabs.js
@@ -1,9 +1,9 @@
 // @flow
 import React from 'react';
 import {observer} from 'mobx-react';
-import type {ViewProps} from 'sulu-admin-bundle/containers';
 import {ResourceTabs} from 'sulu-admin-bundle/views';
 import webspaceStore from '../../stores/webspaceStore';
+import type {ViewProps} from 'sulu-admin-bundle/containers';
 
 @observer
 class PageTabs extends React.Component<ViewProps> {

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/WebspaceTabs/WebspaceTabs.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/WebspaceTabs/WebspaceTabs.js
@@ -1,17 +1,17 @@
 // @flow
 import React from 'react';
 import {action, computed, intercept, observable} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
-import type {ViewProps} from 'sulu-admin-bundle/containers';
-import type {AttributeMap} from 'sulu-admin-bundle/services';
 import {userStore} from 'sulu-admin-bundle/stores';
 import {Tabs} from 'sulu-admin-bundle/views';
 import {Route} from 'sulu-admin-bundle/services';
 import WebspaceSelect from '../../components/WebspaceSelect';
 import webspaceStore from '../../stores/webspaceStore';
-import type {Webspace} from '../../stores/webspaceStore/types';
 import webspaceTabsStyles from './webspaceTabs.scss';
+import type {Webspace} from '../../stores/webspaceStore/types';
+import type {AttributeMap} from 'sulu-admin-bundle/services';
+import type {ViewProps} from 'sulu-admin-bundle/containers';
+import type {IObservableValue} from 'mobx';
 
 const USER_SETTING_PREFIX = 'sulu_page.webspace_tabs';
 const USER_SETTING_WEBSPACE = [USER_SETTING_PREFIX, 'webspace'].join('.');

--- a/src/Sulu/Bundle/RouteBundle/Resources/js/containers/Form/fields/PageTreeRoute.js
+++ b/src/Sulu/Bundle/RouteBundle/Resources/js/containers/Form/fields/PageTreeRoute.js
@@ -1,13 +1,13 @@
 // @flow
 import React, {Component, Fragment} from 'react';
-import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import {observer} from 'mobx-react';
 import {action, observable} from 'mobx';
-import type {IObservableValue} from 'mobx';
 import {userStore} from 'sulu-admin-bundle/stores';
 import {Grid} from 'sulu-admin-bundle/components';
 import {SingleSelection, ResourceLocator} from 'sulu-admin-bundle/containers';
 import {translate} from 'sulu-admin-bundle/utils';
+import type {IObservableValue} from 'mobx';
+import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import type {PageTreeRouteValue} from '../../types.js';
 
 type Props = FieldTypeProps<?PageTreeRouteValue>;

--- a/src/Sulu/Bundle/RouteBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/RouteBundle/Resources/js/index.js
@@ -2,8 +2,8 @@
 import {resourceRouteRegistry} from 'sulu-admin-bundle/services/ResourceRequester';
 import {fieldRegistry, ResourceLocator} from 'sulu-admin-bundle/containers';
 import initializer from 'sulu-admin-bundle/services/initializer';
-import type {FieldTypeProps} from '../../../AdminBundle/Resources/js/containers/Form/types';
 import PageTreeRoute from './containers/Form/fields/PageTreeRoute';
+import type {FieldTypeProps} from '../../../AdminBundle/Resources/js/containers/Form/types';
 
 initializer.addUpdateConfigHook('sulu_admin', (config: Object, initialized: boolean) => {
     if (initialized) {

--- a/src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/Search.js
+++ b/src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/Search.js
@@ -10,8 +10,8 @@ import searchStore from './stores/searchStore';
 import indexStore from './stores/indexStore';
 import SearchField from './SearchField';
 import SearchResult from './SearchResult';
-import type {Index} from './types';
 import searchStyles from './search.scss';
+import type {Index} from './types';
 
 type Props = {|
     router: Router,

--- a/src/Sulu/Bundle/SearchBundle/Resources/js/views/Search/Search.js
+++ b/src/Sulu/Bundle/SearchBundle/Resources/js/views/Search/Search.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react';
 import {withToolbar} from 'sulu-admin-bundle/containers';
-import type {ViewProps} from 'sulu-admin-bundle/containers';
 import SearchContainer from '../../containers/Search';
+import type {ViewProps} from 'sulu-admin-bundle/containers';
 
 class Search extends React.Component<ViewProps> {
     render() {

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/fields/Permissions.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/fields/Permissions.js
@@ -2,8 +2,8 @@
 import React from 'react';
 import {computed} from 'mobx';
 import {observer} from 'mobx-react';
-import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import PermissionsContainer from '../../Permissions';
+import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import type {ContextPermission} from '../../Permissions';
 
 type Props = FieldTypeProps<?Array<ContextPermission>>;

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/fields/RoleAssignments.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/fields/RoleAssignments.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
-import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import RoleAssignmentsContainer from '../../RoleAssignments';
+import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 
 type Props = FieldTypeProps<?Array<Object>>;
 

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/fields/RolePermissions.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/fields/RolePermissions.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
-import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import RolePermissionsContainer from '../../RolePermissions';
+import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import type {RolePermissions as RolePermissionsType} from '../../RolePermissions/types';
 
 class RolePermissions extends React.Component<FieldTypeProps<RolePermissionsType>> {

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/PermissionMatrix.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/PermissionMatrix.js
@@ -4,11 +4,11 @@ import {toJS} from 'mobx';
 import {observer} from 'mobx-react';
 import {Matrix} from 'sulu-admin-bundle/components';
 import {translate} from 'sulu-admin-bundle/utils';
+import {getActionIcon} from '../../utils/Permission';
+import permissionsStyle from './permissions.scss';
 import type {MatrixValues} from 'sulu-admin-bundle/components/Matrix/types';
 import type {Actions, SecurityContexts} from '../../stores/securityContextStore/types';
-import {getActionIcon} from '../../utils/Permission';
 import type {ContextPermission} from './types';
-import permissionsStyle from './permissions.scss';
 
 type Props = {|
     contextPermissions: Array<ContextPermission>,

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/Permissions.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/Permissions.js
@@ -5,10 +5,10 @@ import {observer} from 'mobx-react';
 import {Loader, MultiSelect} from 'sulu-admin-bundle/components';
 import {webspaceStore} from 'sulu-page-bundle/stores';
 import securityContextStore from '../../stores/securityContextStore';
-import type {SecurityContextGroups, SecurityContexts} from '../../stores/securityContextStore/types';
-import type {ContextPermission} from './types';
 import permissionsStyle from './permissions.scss';
 import PermissionMatrix from './PermissionMatrix';
+import type {SecurityContextGroups, SecurityContexts} from '../../stores/securityContextStore/types';
+import type {ContextPermission} from './types';
 
 type Props = {|
     disabled: boolean,

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/PermissionMatrix.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/PermissionMatrix.test.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react';
 import {mount, render} from 'enzyme';
-import type {MatrixValues} from 'sulu-admin-bundle/components/Matrix/types';
 import PermissionMatrix from '../PermissionMatrix';
+import type {MatrixValues} from 'sulu-admin-bundle/components/Matrix/types';
 import type {ContextPermission} from '../types';
 import type {SecurityContexts} from '../../../stores/securityContextStore/types';
 

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/Permissions.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/Permissions.test.js
@@ -4,10 +4,10 @@ import {mount} from 'enzyme';
 import {webspaceStore} from 'sulu-page-bundle/stores';
 import {defaultWebspace} from 'sulu-admin-bundle/utils/TestHelper';
 import Permissions from '../Permissions';
-import type {ContextPermission} from '../types';
-import type {SecurityContextGroups} from '../../../stores/securityContextStore/types';
 import securityContextStore from '../../../stores/securityContextStore/securityContextStore';
 import PermissionMatrix from '../PermissionMatrix';
+import type {ContextPermission} from '../types';
+import type {SecurityContextGroups} from '../../../stores/securityContextStore/types';
 
 jest.mock('sulu-page-bundle/stores/webspaceStore', () => ({
     allWebspaces: [],

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/RoleAssignment.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/RoleAssignment.js
@@ -2,9 +2,9 @@
 import React from 'react';
 import {observer} from 'mobx-react';
 import {MultiSelect} from 'sulu-admin-bundle/components';
-import type {Localization} from 'sulu-admin-bundle/stores';
 import classNames from 'classnames';
 import roleAssignmentStyle from './roleAssignment.scss';
+import type {Localization} from 'sulu-admin-bundle/stores';
 
 type Props = {|
     disabled: boolean,

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/RoleAssignment.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/RoleAssignment.test.js
@@ -1,9 +1,9 @@
 // @flow
 import React from 'react';
 import {render, shallow} from 'enzyme';
-import type {Localization} from 'sulu-admin-bundle/stores';
 import {MultiSelect} from 'sulu-admin-bundle/components';
 import RoleAssignment from '../RoleAssignment';
+import type {Localization} from 'sulu-admin-bundle/stores';
 
 jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: (key) => key,

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/SnippetAreas.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/SnippetAreas.js
@@ -4,11 +4,11 @@ import {action, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import {Button, Dialog, Loader, Table} from 'sulu-admin-bundle/components';
 import {SingleListOverlay, withToolbar} from 'sulu-admin-bundle/containers';
-import type {ViewProps} from 'sulu-admin-bundle/containers';
 import {translate} from 'sulu-admin-bundle/utils';
 import {CacheClearToolbarAction} from 'sulu-website-bundle/containers';
 import SnippetAreaStore from './stores/SnippetAreaStore';
 import snippetAreasStyles from './snippetAreas.scss';
+import type {ViewProps} from 'sulu-admin-bundle/containers';
 
 @observer
 class SnippetAreas extends React.Component<ViewProps> {

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/Form/fields/AnalyticsDomainSelect.js
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/Form/fields/AnalyticsDomainSelect.js
@@ -3,8 +3,8 @@ import React from 'react';
 import {computed} from 'mobx';
 import {observer} from 'mobx-react';
 import {MultiSelect} from 'sulu-admin-bundle/components';
-import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import {webspaceStore} from 'sulu-page-bundle/stores';
+import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 
 @observer
 class AnalyticsDomainSelect extends React.Component<FieldTypeProps<Array<string>>> {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix eslint import/order style.

#### Why?

New eslint-plugin-import release which did change the order of the import by import type. 