### PR TITLE
Display overlay to select collection when dragging media into root collection

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -103,7 +103,7 @@ class MediaCollection extends React.Component<Props> {
 
         if (addable && !hideUploadAction) {
             listActions.push({
-                disabled: collectionStore.loading || !collectionStore.id,
+                disabled: collectionStore.loading,
                 icon: 'su-upload',
                 label: translate('sulu_media.upload_file'),
                 onClick: onUploadOverlayOpen,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -112,7 +112,8 @@ class MediaCollection extends React.Component<Props> {
 
         return (
             <MultiMediaDropzone
-                collectionId={!collectionStore.loading && addable ? collectionStore.id : undefined}
+                collectionId={collectionStore.id}
+                disabled={collectionStore.loading || !addable}
                 locale={locale}
                 onClose={onUploadOverlayClose}
                 onOpen={onUploadOverlayOpen}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
@@ -831,7 +831,6 @@ exports[`Render the MediaCollection for all media 1`] = `
       >
         <button
           class="button icon hasText"
-          disabled=""
           type="button"
         >
           <span

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/tests/__snapshots__/MultiMediaDropzone.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/tests/__snapshots__/MultiMediaDropzone.test.js.snap
@@ -1,17 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Render a MultiMediaDropzone 1`] = `
-<div
-  class="dropzone"
-  tabindex="0"
->
-  <div />
-  <input
-    autocomplete="off"
-    multiple=""
-    style="display:none"
-    tabindex="-1"
-    type="file"
-  />
-</div>
+Array [
+  <div
+    class="dropzone"
+    tabindex="0"
+  >
+    <div />
+    <input
+      autocomplete="off"
+      multiple=""
+      style="display:none"
+      tabindex="-1"
+      type="file"
+    />
+  </div>,
+  <div>
+    single-list-overlay-mock
+  </div>,
+]
 `;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -273,7 +273,7 @@ export default withToolbar(MediaOverview, function() {
 
     if (!collectionLocked && addPermission) {
         items.push({
-            disabled: !this.collectionId.get() || collectionLoading,
+            disabled: collectionLoading,
             icon: 'su-upload',
             label: translate('sulu_media.upload_file'),
             onClick: action(() => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -374,35 +374,6 @@ test('Delete overlay should be shown when delete button is clicked', () => {
         .toEqual(true);
 });
 
-test('Upload button should be disabled if no collection is selected', () => {
-    const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
-    const MediaOverview = require('../MediaOverview').default;
-    const toolbarFunction = findWithHighOrderFunction(withToolbar, MediaOverview);
-
-    const router = {
-        restore: jest.fn(),
-        bind: jest.fn(),
-        route: {
-            options: {
-                locales: ['de'],
-                permissions: {
-                    add: true,
-                    delete: true,
-                    edit: true,
-                },
-            },
-        },
-    };
-    const mediaOverview = mount(<MediaOverview router={router} />).at(0).instance();
-    mediaOverview.locale.set('de');
-
-    expect(toolbarFunction.call(mediaOverview).items[0].label).toEqual('sulu_media.upload_file');
-    expect(toolbarFunction.call(mediaOverview).items[0].disabled).toEqual(true);
-
-    mediaOverview.collectionId.set(4);
-    expect(toolbarFunction.call(mediaOverview).items[0].disabled).toEqual(false);
-});
-
 test('Upload button should be disabled if collection is loading', () => {
     const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
     const MediaOverview = require('../MediaOverview').default;

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
@@ -24,6 +24,7 @@
     "sulu_media.remove_collection_warning": "Diese Operation löscht einen Ordner und kann nicht rückgängig gemacht werden. Wollen Sie wirklich fortfahren?",
     "sulu_media.move_collection": "Ordner verschieben",
     "sulu_media.edit_collection": "Ordner bearbeiten",
+    "sulu_media.select_collection_for_upload": "Ordner zum Hochladen auswählen",
     "sulu_media.download_media": "Medium downloaden",
     "sulu_media.download_counter": "Anzahl Downloads",
     "sulu_media.delete_media": "Medium löschen",

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
@@ -24,6 +24,7 @@
     "sulu_media.remove_collection_warning": "This operation deletes a collection and cannot be undone. Do you really wish to proceed?",
     "sulu_media.move_collection": "Move collection",
     "sulu_media.edit_collection": "Edit collection",
+    "sulu_media.select_collection_for_upload": "Select collection for upload",
     "sulu_media.download_media": "Download media",
     "sulu_media.download_counter": "Download count",
     "sulu_media.delete_media": "Delete media",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Fixed tickets | fixes #5038
| Related issues/PRs | builds upon #6050
| License | MIT

#### What's in this PR?

This PR enables the `Upload file` button of the media list implemented in #6050 if no collection is selected. If a file is submitted for upload when no collection is selected, an overlay is displayed that allows the user to select the collection for the upload.

#### Why?

Because it is not intuitive for users that they need to navigate into a collection in order to be able to upload a file. See #5038
