### PR TITLE
Disable system collections in overlay when moving media between collections

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
@@ -256,6 +256,7 @@ class CollectionSection extends React.Component<Props> {
                     clearSelectionOnClose={true}
                     confirmLoading={resourceStore.moving}
                     disabledIds={resourceStore.id ? [resourceStore.id] : []}
+                    itemDisabledCondition="!!locked"
                     listKey={COLLECTIONS_RESOURCE_KEY}
                     locale={locale}
                     onClose={this.handleMoveCollectionClose}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -211,6 +211,7 @@ class MediaOverview extends React.Component<ViewProps> {
                     clearSelectionOnClose={true}
                     confirmLoading={this.mediaMoving}
                     disabledIds={this.collectionStore.id ? [this.collectionStore.id] : []}
+                    itemDisabledCondition="!!locked"
                     listKey={COLLECTIONS_RESOURCE_KEY}
                     locale={this.locale}
                     onClose={this.handleMoveMediaOverlayClose}
@@ -292,7 +293,7 @@ export default withToolbar(MediaOverview, function() {
         });
     }
 
-    if (editPermission) {
+    if (!collectionLocked && editPermission) {
         items.push({
             disabled: this.mediaListStore.selectionIds.length === 0,
             icon: 'su-arrows-alt',

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -561,7 +561,7 @@ test('Toolbar buttons should disappear when permissions are missing on current c
     expect(toolbarFunction.call(mediaOverview.instance()).items).toHaveLength(0);
 });
 
-test('Move overlay button should be disabled if nothing is selected', () => {
+test('Move button should be disabled if nothing is selected', () => {
     const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
     const MediaOverview = require('../MediaOverview').default;
     const toolbarFunction = findWithHighOrderFunction(withToolbar, MediaOverview);
@@ -592,6 +592,40 @@ test('Move overlay button should be disabled if nothing is selected', () => {
 
     mediaOverview.mediaListStore.selectionIds.push(8);
     expect(toolbarFunction.call(mediaOverview).items[2].disabled).toEqual(false);
+});
+
+test('Move button should disappear if collection is locked', () => {
+    const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
+    const MediaOverview = require('../MediaOverview').default;
+    const toolbarFunction = findWithHighOrderFunction(withToolbar, MediaOverview);
+
+    const router = {
+        restore: jest.fn(),
+        bind: jest.fn(),
+        route: {
+            options: {
+                locales: ['de'],
+                permissions: {
+                    add: true,
+                    delete: true,
+                    edit: true,
+                },
+            },
+        },
+        attributes: {
+            id: 4,
+        },
+    };
+    const mediaOverview = mount(<MediaOverview router={router} />).at(0).instance();
+    mediaOverview.collectionId.set(4);
+    mediaOverview.locale.set('de');
+
+    expect(toolbarFunction.call(mediaOverview).items).toHaveLength(3);
+    expect(toolbarFunction.call(mediaOverview).items[2].label).toEqual('sulu_admin.move_selected');
+
+    mediaOverview.collectionStore.resourceStore.data.locked = true;
+
+    expect(toolbarFunction.call(mediaOverview).items).toHaveLength(2);
 });
 
 test('Move overlay should disappear when overlay is closed', () => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

This PR prevents the user from moving media items or collections into system collections by disabling them in the overlay that is used for selecting the target collection. Additionally, the PR hides the `Move selected` toolbar action inside of system collections to prevent the user from moving media items that are stored in a system collection.

#### Why?

System collections are used to store images like contact avatars or preview images. It should not be possible to move unrelated media items into this collections.
