### PR TITLE
Fix overflowing inside grid elements

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/grid.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/grid.scss
@@ -5,7 +5,7 @@
 
 .grid {
     margin-bottom: -$sectionMarginBottom;
-    overflow-y: hidden;
+    contain: layout;
 }
 
 .grid-section {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #6051 and fixes #5938
| Related issues/PRs | # 
| License | MIT
| Documentation PR | sulu/sulu-docs# 

#### What's in this PR?

Fix overflowing inside grid elements.

#### Why?

The `overflow-y: hidden` does not allow that elements can go out of it. This was introduced for some overlays.