### PR TITLE
Add @babel/plugin-proposal-nullish-coalescing-operator to transpile code of react-leaflet package

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -2,7 +2,8 @@
     "presets": ["@babel/preset-env", "@babel/preset-react"],
     "plugins": [
         ["@babel/plugin-proposal-decorators", {"legacy": true}],
-        "@babel/plugin-transform-flow-strip-types"
+        "@babel/plugin-transform-flow-strip-types",
+        "@babel/plugin-proposal-nullish-coalescing-operator"
     ],
     "assumptions": {
         "setPublicClassFields": true

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "devDependencies": {
         "@babel/core": "^7.5.5",
         "@babel/plugin-proposal-decorators": "^7.4.4",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.2",
         "@babel/plugin-transform-flow-strip-types": "^7.4.4",
         "@babel/preset-env": "^7.5.5",
         "@babel/preset-react": "^7.0.0",
@@ -120,7 +121,7 @@
             ]
         },
         "transformIgnorePatterns": [
-            "node_modules/(?!(@ckeditor|ckeditor5|lodash-es)/)"
+            "node_modules/(?!(@ckeditor|ckeditor5|lodash-es|@react-leaflet|react-leaflet)/)"
         ],
         "testPathIgnorePatterns": [
             "vendor/friendsofsymfony"

--- a/src/Sulu/Bundle/LocationBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/LocationBundle/Resources/js/package.json
@@ -6,9 +6,7 @@
     "dependencies": {
         "classnames": "^2.2.5",
         "leaflet": "^1.5.1",
-        "react-leaflet": ">=3.1.0 <3.2.0 || ^3.2.1",
-        "@react-leaflet/core": ">=1.0.0 <1.1.0 || ^1.1.1"
-
+        "react-leaflet": "^3.2.0"
     },
     "devDependencies": {
         "enzyme": "^3.3.0",

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -146,7 +146,8 @@ module.exports = { // eslint-disable-line
             rules: [
                 {
                     test: /\.js$/,
-                    exclude: /node_modules\/(?!(sulu-(.*)-bundle|@ckeditor|lodash-es)\/)/,
+                    // eslint-disable-next-line max-len
+                    exclude: /node_modules\/(?!(sulu-(.*)-bundle|@ckeditor|ckeditor5|lodash-es|@react-leaflet|react-leaflet)\/)/,
                     use: {
                         loader: 'babel-loader',
                         options: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -78,7 +78,8 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
             rules: [
                 {
                     test: /\.js$/,
-                    exclude: /node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5|lodash-es)[/\\])/,
+                    // eslint-disable-next-line max-len
+                    exclude: /node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5|lodash-es|@react-leaflet|react-leaflet)[/\\])/,
                     use: {
                         loader: 'babel-loader',
                         options: {


### PR DESCRIPTION
#### What's in this PR?

This PR adds the `@babel/plugin-proposal-nullish-coalescing-operator` plugin to our babel configuration to transpile the code of the `react-leaflet` package. Without this change, the build errors with the following message when installing the newest version of the `react-leaflet` package:

```
ERROR in /sulu-skeleton/vendor/sulu/sulu/node_modules/react-leaflet/esm/Pane.js 25:37
Module parse failed: Unexpected token (25:37)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|   }
| 
>   const parentPaneName = props.pane ?? context.pane;
|   const parentPane = parentPaneName ? context.map.getPane(parentPaneName) : undefined;
|   const element = context.map.createPane(name, parentPane);
 @ /sulu-skeleton/vendor/sulu/sulu/node_modules/react-leaflet/esm/index.js 13:0-30 13:0-30
 @ /sulu-skeleton/vendor/sulu/sulu/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/Location.js
 @ /sulu-skeleton/vendor/sulu/sulu/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/index.js
 @ /sulu-skeleton/vendor/sulu/sulu/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Form/fields/Location.js
 @ /sulu-skeleton/vendor/sulu/sulu/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Form/index.js
 @ /sulu-skeleton/vendor/sulu/sulu/src/Sulu/Bundle/LocationBundle/Resources/js/index.js
 @ ./index.js
```

#### Why?

The reason for this problem is quite interesting; [`react-leaflet`](https://github.com/PaulLeCam/react-leaflet/releases/tag/v3.2.0) uses the [nullish coalescing operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator) in the code of the newly released version 3.2.0. This operator is supported by most modern browsers, but unfortunately `webpack@4` does not support the operator (https://github.com/webpack/webpack/issues/10227, https://github.com/acornjs/acorn/pull/890). Because of this, webpack crashes while processing the code of the `react-leaflet` package.

T solve the problem, the changes in this PR configure babel to transpile the nullish coalescing operator before the files are processed with webpack.