### PR TITLE
Render name of user with bold font in activity list

### DIFF
--- a/src/Sulu/Bundle/ActivityBundle/Resources/config/lists/activities.xml
+++ b/src/Sulu/Bundle/ActivityBundle/Resources/config/lists/activities.xml
@@ -68,6 +68,6 @@
         <!-- Visibility of this property is set to 'yes' in the ActivitiesListMetadataVisitor based on the given metadata-options -->
         <property name="resource" visibility="never" searchability="never" sortable="false" width="shrink"/>
 
-        <property name="text" visibility="always" searchability="never" sortable="false" />
+        <property name="text" visibility="always" searchability="never" sortable="false" type="html"/>
     </properties>
 </list>

--- a/src/Sulu/Bundle/ActivityBundle/Tests/Functional/UserInterface/Controller/ActivityControllerTest.php
+++ b/src/Sulu/Bundle/ActivityBundle/Tests/Functional/UserInterface/Controller/ActivityControllerTest.php
@@ -158,7 +158,7 @@ class ActivityControllerTest extends SuluTestCase
         $content = \json_decode((string) $this->client->getResponse()->getContent());
 
         self::assertSame(
-            'Max Mustermann has created the page "Test Page 1234"',
+            '<b>Max Mustermann</b> has created the page "Test Page 1234"',
             $content->_embedded->activities[0]->text
         );
 

--- a/src/Sulu/Bundle/ActivityBundle/UserInterface/Controller/ActivityController.php
+++ b/src/Sulu/Bundle/ActivityBundle/UserInterface/Controller/ActivityController.php
@@ -376,16 +376,15 @@ class ActivityController extends AbstractRestController implements ClassResource
     {
         $translationParameters = $this->getTranslationParameters($activity, $translationLocale);
 
-        $user = $activity['userFullName'] ?? $this->translator->trans('sulu_activity.someone', [], 'admin', $translationLocale);
+        $translationParameters['{userFullName}'] = isset($activity['userFullName'])
+            ? \sprintf('<b>%s</b>', $activity['userFullName'])
+            : $this->translator->trans('sulu_activity.someone', [], 'admin', $translationLocale);
 
-        $resourceTitle = $this->getLocalizedValue(
+        $translationParameters['{resourceTitle}'] = $this->getLocalizedValue(
             $activity['resourceTitle'],
             $activity['resourceTitleLocale'] ?? null,
             $translationLocale
         );
-
-        $translationParameters['{userFullName}'] = $user;
-        $translationParameters['{resourceTitle}'] = $resourceTitle;
 
         return $this->translator->trans(
             \sprintf(

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/HtmlFieldTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/HtmlFieldTransformer.js
@@ -1,0 +1,21 @@
+// @flow
+import React from 'react';
+import sanitizeHtml from 'sanitize-html';
+import type {Node} from 'react';
+import type {FieldTransformer} from '../types';
+
+export default class HtmlFieldTransformer implements FieldTransformer {
+    transform(value: *): Node {
+        if (!value) {
+            return null;
+        }
+
+        const sanitizedHtml = sanitizeHtml(value, {
+            allowedTags: ['b', 'em', 'i', 's', 'small', 'strong', 'sub', 'sup', 'time', 'u'],
+            allowedAttributes: {},
+            disallowedTagsMode: 'recursiveEscape',
+        });
+
+        return <div dangerouslySetInnerHTML={{__html: sanitizedHtml}} />;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/index.js
@@ -22,6 +22,7 @@ import NumberFieldFilterType from './fieldFilterTypes/NumberFieldFilterType';
 import NumberFieldTransformer from './fieldTransformers/NumberFieldTransformer';
 import SelectionFieldFilterType from './fieldFilterTypes/SelectionFieldFilterType';
 import TimeFieldTransformer from './fieldTransformers/TimeFieldTransformer';
+import HtmlFieldTransformer from './fieldTransformers/HtmlFieldTransformer';
 import ColumnListAdapter from './adapters/ColumnListAdapter';
 import TreeTableAdapter from './adapters/TreeTableAdapter';
 import TableAdapter from './adapters/TableAdapter';
@@ -70,6 +71,7 @@ export {
     BoolFieldTransformer,
     ColorFieldTransformer,
     IconFieldTransformer,
+    HtmlFieldTransformer,
 };
 export type {
     ListAdapterProps,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldTransformers/HtmlFieldTransformer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldTransformers/HtmlFieldTransformer.test.js
@@ -1,0 +1,38 @@
+// @flow
+import {mount} from 'enzyme';
+import HtmlFieldTransformer from '../../fieldTransformers/HtmlFieldTransformer';
+
+const htmlTransformer = new HtmlFieldTransformer();
+
+test('Test undefined', () => {
+    expect(htmlTransformer.transform(undefined)).toBe(null);
+});
+
+test('Test string', () => {
+    const result = mount(htmlTransformer.transform('test string'));
+
+    expect(result.html()).toEqual('<div>test string</div>');
+});
+
+test('Test number', () => {
+    const result = mount(htmlTransformer.transform(5));
+
+    expect(result.html()).toEqual('<div>5</div>');
+});
+
+test('Test html string with allowed tags', () => {
+    const result = mount(htmlTransformer.transform('I am a <b>bold</b> and <i>italic</i>'));
+
+    expect(result.html()).toEqual('<div>I am a <b>bold</b> and <i>italic</i></div>');
+});
+
+test('Test html string with disallowed tags', () => {
+    const result = mount(htmlTransformer.transform(
+        'Unwanted and dangerous <table>tags</table> are <u>sanitized</u> <script>console.log("muhahaha")</script>'
+    ));
+
+    expect(result.html()).toEqual(
+        // eslint-disable-next-line max-len
+        '<div>Unwanted and dangerous &lt;table&gt;tags&lt;/table&gt; are <u>sanitized</u> &lt;script&gt;console.log("muhahaha")&lt;/script&gt;</div>'
+    );
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -38,6 +38,7 @@ import {
     BooleanFieldFilterType,
     BoolFieldTransformer,
     ColorFieldTransformer,
+    HtmlFieldTransformer,
     IconFieldTransformer,
     BytesFieldTransformer,
     ColumnListAdapter,
@@ -216,6 +217,7 @@ function registerListFieldTransformers() {
     listFieldTransformerRegistry.add('bool', new BoolFieldTransformer());
     listFieldTransformerRegistry.add('color', new ColorFieldTransformer());
     listFieldTransformerRegistry.add('icon', new IconFieldTransformer());
+    listFieldTransformerRegistry.add('html', new HtmlFieldTransformer());
 
     // TODO: Remove this type when not needed anymore
     listFieldTransformerRegistry.add('title', new StringFieldTransformer());

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
@@ -41,6 +41,7 @@
         "react-portal": "^4.1.0",
         "react-sortable-hoc": "^2.0.0",
         "resize-observer-polyfill": "^1.5.0",
+        "sanitize-html": "^2.3.3",
         "textversionjs": "^1.1.3",
         "url-search-params-polyfill": "^8.0.0"
     },


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

This pull requests registers a `html` field transformer that allows to render simple HTML markups. At the moment, the transformer escapes all tags beside of `<b>`, `<em>`, `<i>`, `<s>`, `<small>`, `<strong>`, `<sub>`, `<sup>`, `<time>` and `<u>` for security reasons. The new field transformer is used to render the name of the user with a bold font in the activity list.

#### Why?

Because the name of the user is important information inside of the activities list. Rendering it with a bold font makes it easier to spot it.