### PR TITLE
Fix ckeditor bug with inserting tables

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/application.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/application.scss
@@ -27,9 +27,9 @@
     display: flex;
     width: 100vw;
     min-height: 500px;
-    overflow: hidden;
     will-change: width;
     transition: width $navigationMoveAnimationDuration;
+    contain: layout;
 
     &.with-pinned-navigation {
         width: calc(100vw - $navigationWidth);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
@@ -51,6 +51,8 @@ $textEditorUnpublishedLinkColor: $gold;
         --ck-color-button-on-background: $textEditorDarkBackgroundColor;
         --ck-color-button-on-hover-background: var(--ck-color-button-on-background);
         --ck-color-button-on-active-background: var(--ck-color-button-on-background);
+        --ck-color-split-button-hover-background: transparent;
+        --ck-color-split-button-hover-border: transparent;
 
         /* panel */
         --ck-color-panel-background: $textEditorPanelBackground;
@@ -133,6 +135,19 @@ $textEditorUnpublishedLinkColor: $gold;
                 > .ck.ck-toolbar {
                     border-bottom-right-radius: 0 !important;
                 }
+            }
+        }
+
+        /* Make the last 5 toolbar items open their dropdown panels on the left side instead of on the right side */
+        .ck.ck-toolbar__items > .ck:nth-last-child(-n + 5) .ck-dropdown__panel_se {
+            border-top-right-radius: 0 !important;
+            border-top-left-radius: $textEditorBorderRadius !important;
+            left: unset !important;
+            right: 0 !important;
+
+            > .ck.ck-toolbar {
+                border-top-right-radius: 0 !important;
+                border-top-left-radius: $textEditorBorderRadius !important;
             }
         }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix ckeditor bug with inserting tables

Make `insert-table` overlay open on left side instead of right side

![image](https://user-images.githubusercontent.com/5758674/118982152-70d42780-b97b-11eb-8efb-7ddc33fa07b6.png)

instead of

![image](https://user-images.githubusercontent.com/5758674/118982071-58640d00-b97b-11eb-9945-505766b61de0.png)

