### PR TITLE
Include id in activity list response to prevent error when rendering rows

### DIFF
--- a/src/Sulu/Bundle/ActivityBundle/UserInterface/Controller/ActivityController.php
+++ b/src/Sulu/Bundle/ActivityBundle/UserInterface/Controller/ActivityController.php
@@ -173,7 +173,7 @@ class ActivityController extends AbstractRestController implements ClassResource
                         ]
                     ),
                     function(string $key) use ($configurationFieldDescriptors) {
-                        return \array_key_exists($key, $configurationFieldDescriptors);
+                        return $key === 'id' || \array_key_exists($key, $configurationFieldDescriptors);
                     },
                     \ARRAY_FILTER_USE_KEY
                 );

--- a/src/Sulu/Bundle/ActivityBundle/UserInterface/Controller/ActivityController.php
+++ b/src/Sulu/Bundle/ActivityBundle/UserInterface/Controller/ActivityController.php
@@ -173,7 +173,7 @@ class ActivityController extends AbstractRestController implements ClassResource
                         ]
                     ),
                     function(string $key) use ($configurationFieldDescriptors) {
-                        return $key === 'id' || \array_key_exists($key, $configurationFieldDescriptors);
+                        return 'id' === $key || \array_key_exists($key, $configurationFieldDescriptors);
                     },
                     \ARRAY_FILTER_USE_KEY
                 );


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

This PR includes the `id` of the activity in the list response of the `ActivityController"`.

#### Why?

Our list view uses the id as key for rendering the rows of the list. If not id is returned from the server, the following error is logged to the browser console:

![Screenshot 2021-05-20 at 15 02 25](https://user-images.githubusercontent.com/13310795/118983152-69614e00-b97c-11eb-97c9-8f6b7b69f59b.png)

