### PR TITLE
Fix phpstan baseline and fix import/order eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -112,7 +112,18 @@
             "error",
             "prefer-double"
         ],
-        "import/order": "error",
+        "import/order": [
+            "error", {
+                "groups": [
+                    "builtin",
+                    "external",
+                    "parent",
+                    "sibling",
+                    "index",
+                    "type"
+                ]
+            }
+        ],
         "import/no-dynamic-require": "error",
         "import/no-webpack-loader-syntax": "error",
         "import/export": "error",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix phpstan baseline. And manual configure the `import/order` rule.

#### Why?

New doctrine/orm release.