### PR TITLE
Remove false x-default alternate url

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Extension/seo.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Extension/seo.html.twig
@@ -1,6 +1,5 @@
 {#-
  # content array
- # defaultLocale string
  # seo array
  # shadowBaseLocale string
  # urls array

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Extension/seo.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Extension/seo.html.twig
@@ -62,9 +62,6 @@
     {#- when only one language do not show alternative -#}
     {%- if urls|length > 1 -%}
         {%- for locale, url in urls -%}
-            {%- if defaultLocale == locale -%}
-                <link rel="alternate" href="{{ sulu_content_path(url, null, locale) }}" hreflang="x-default"/>
-            {%- endif -%}
             <link rel="alternate" href="{{ sulu_content_path(url, null, locale) }}" hreflang="{{ locale|replace({'_': '-'}) }}"/>
         {%- endfor -%}
     {%- endif -%}

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Sitemap/sitemap.xml.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Sitemap/sitemap.xml.twig
@@ -7,35 +7,38 @@
         {% if domain in location %}
             <url>
                 {% block url %}
-                    <loc>{{ location }}</loc>
-                    {% if entry.lastmod %}
-                        <lastmod>{{ entry.lastmod|date('Y-m-d') }}</lastmod>
-                    {% endif %}
-                    {% if entry.changefreq %}
-                        <changefreq>{{ entry.changefreq }}</changefreq>
-                    {% endif %}
-                    {% if entry.priority %}
-                        <priority>{{ entry.priority }}</priority>
-                    {% endif %}
+                    {% block loc %}
+                        <loc>{{ location }}</loc>
+                    {% endblock %}
 
-                    {% set amount = 0 %}
-                    {% set defaultHref = null %}
-                    {% if entry.alternateLinks|length > 1 %}
-                        {% for alternateLink in entry.alternateLinks %}
-                            {% set href = alternateLink.href %}
-                            {% if href is not empty and domain in href %}
-                                <xhtml:link rel="alternate" hreflang="{{ alternateLink.locale|replace({'_': '-'}) }}" href="{{ href }}"/>
-                                {% set amount = amount + 1 %}
-                                {% if entry.defaultLocale == alternateLink.locale %}
-                                    {% set defaultHref = href %}
+                    {% block lastmod %}
+                        {% if entry.lastmod %}
+                            <lastmod>{{ entry.lastmod|date('Y-m-d') }}</lastmod>
+                        {% endif %}
+                    {% endblock %}
+
+                    {% block changefreq %}
+                        {% if entry.changefreq %}
+                            <changefreq>{{ entry.changefreq }}</changefreq>
+                        {% endif %}
+                    {% endblock %}
+
+                    {% block priority %}
+                        {% if entry.priority %}
+                            <priority>{{ entry.priority }}</priority>
+                        {% endif %}
+                    {% endblock %}
+
+                    {% block alternateLinks %}
+                        {% if entry.alternateLinks|length > 1 %}
+                            {% for alternateLink in entry.alternateLinks %}
+                                {% set href = alternateLink.href %}
+                                {% if href is not empty and domain in href %}
+                                    <xhtml:link rel="alternate" hreflang="{{ alternateLink.locale|replace({'_': '-'}) }}" href="{{ href }}"/>
                                 {% endif %}
-                            {% endif %}
-                        {% endfor %}
-                    {% endif %}
-
-                    {% if defaultHref and amount > 0 %}
-                        <xhtml:link rel="alternate" hreflang="x-default" href="{{ defaultHref }}"/>
-                    {% endif %}
+                            {% endfor %}
+                        {% endif %}
+                    {% endblock %}
                 {% endblock %}
             </url>
         {% endif %}

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/SitemapControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/SitemapControllerTest.php
@@ -65,14 +65,6 @@ class SitemapControllerTest extends WebsiteTestCase
             'http://test.lo/en',
             $crawler->filterXPath('//x:urlset/x:url[1]/xhtml:link[2]')->attr('href')
         );
-        $this->assertEquals(
-            'x-default',
-            $crawler->filterXPath('//x:urlset/x:url[1]/xhtml:link[3]')->attr('hreflang')
-        );
-        $this->assertEquals(
-            'http://test.lo/en',
-            $crawler->filterXPath('//x:urlset/x:url[1]/xhtml:link[3]')->attr('href')
-        );
 
         $this->assertEquals('http://test.lo/en', $crawler->filterXPath('//x:urlset/x:url[2]/x:loc')->text());
         $this->assertEquals(
@@ -90,14 +82,6 @@ class SitemapControllerTest extends WebsiteTestCase
         $this->assertEquals(
             'http://test.lo/en-us',
             $crawler->filterXPath('//x:urlset/x:url[2]/xhtml:link[2]')->attr('href')
-        );
-        $this->assertEquals(
-            'x-default',
-            $crawler->filterXPath('//x:urlset/x:url[2]/xhtml:link[3]')->attr('hreflang')
-        );
-        $this->assertEquals(
-            'http://test.lo/en',
-            $crawler->filterXPath('//x:urlset/x:url[2]/xhtml:link[3]')->attr('href')
         );
 
         $this->assertEquals('http://test.lo/en', $crawler->filterXPath('//x:urlset/x:url[2]/x:loc')->text());

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/MetaTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/MetaTwigExtensionTest.php
@@ -85,7 +85,6 @@ class MetaTwigExtensionTest extends TestCase
         $this->assertEquals(
             [
                 '<link rel="alternate" href="/de/test" hreflang="de" />',
-                '<link rel="alternate" href="/en/test-en" hreflang="x-default" />',
                 '<link rel="alternate" href="/en/test-en" hreflang="en" />',
                 '<link rel="alternate" href="/en/test-en-us" hreflang="en-us" />',
                 '<link rel="alternate" href="/fr/test-fr" hreflang="fr" />',
@@ -120,7 +119,6 @@ class MetaTwigExtensionTest extends TestCase
 
         $this->assertEquals(
             [
-                '<link rel="alternate" href="/de/test" hreflang="x-default" />',
                 '<link rel="alternate" href="/de/test" hreflang="de" />',
                 '<link rel="alternate" href="/en/test-en" hreflang="en" />',
                 '<link rel="alternate" href="/en/test-en-us" hreflang="en-us" />',
@@ -150,7 +148,6 @@ class MetaTwigExtensionTest extends TestCase
         $this->assertEquals(
             [
                 '<link rel="alternate" href="/de/test" hreflang="de" />',
-                '<link rel="alternate" href="/en/test-en" hreflang="x-default" />',
                 '<link rel="alternate" href="/en/test-en" hreflang="en" />',
                 '<link rel="alternate" href="/en/test-en-us" hreflang="en-us" />',
                 '<link rel="alternate" href="/fr/test-fr" hreflang="fr" />',

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/Seo/SeoTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/Seo/SeoTwigExtensionTest.php
@@ -176,7 +176,6 @@ class SeoTwigExtensionTest extends TestCase
                     '<meta name="description" content="SEO description"/>',
                     '<meta name="keywords" content="SEO keywords"/>',
                     '<meta name="robots" content="noIndex,noFollow"/>',
-                    '<link rel="alternate" href="/en/url-en" hreflang="x-default"/>',
                     '<link rel="alternate" href="/en/url-en" hreflang="en"/>',
                     '<link rel="alternate" href="/de/url-de" hreflang="de"/>',
                     '<link rel="canonical" href="/canonical-url"/>',
@@ -205,7 +204,6 @@ class SeoTwigExtensionTest extends TestCase
                 [
                     '<title>Content title</title>',
                     '<meta name="robots" content="index,follow"/>',
-                    '<link rel="alternate" href="/de/url-de" hreflang="x-default"/>',
                     '<link rel="alternate" href="/en/url-en" hreflang="en"/>',
                     '<link rel="alternate" href="/de/url-de" hreflang="de"/>',
                     '<link rel="canonical" href="/en/url-en"/>',
@@ -238,7 +236,6 @@ class SeoTwigExtensionTest extends TestCase
                 [
                     '<title>Content title</title>',
                     '<meta name="robots" content="index,follow"/>',
-                    '<link rel="alternate" href="/de/url-de" hreflang="x-default"/>',
                     '<link rel="alternate" href="/en/url-en" hreflang="en"/>',
                     '<link rel="alternate" href="/de/url-de" hreflang="de"/>',
                 ],
@@ -272,7 +269,6 @@ class SeoTwigExtensionTest extends TestCase
                 [
                     '<title>Content title</title>',
                     '<meta name="robots" content="index,follow"/>',
-                    '<link rel="alternate" href="/de/url-de" hreflang="x-default"/>',
                     '<link rel="alternate" href="/en/url-en" hreflang="en"/>',
                     '<link rel="alternate" href="/de/url-de" hreflang="de"/>',
                     '<link rel="alternate" href="/de-at/url-de-at" hreflang="de-at"/>',
@@ -295,7 +291,6 @@ class SeoTwigExtensionTest extends TestCase
                 'de',
                 [
                     '<link rel="alternate" href="/en/url-en" hreflang="en"/>',
-                    '<link rel="alternate" href="/de/url-de" hreflang="x-default"/>',
                     '<link rel="alternate" href="/de/url-de" hreflang="de"/>',
                 ],
             ],
@@ -311,7 +306,6 @@ class SeoTwigExtensionTest extends TestCase
                 'en',
                 null,
                 [
-                    '<link rel="alternate" href="/en/url-en" hreflang="x-default"/>',
                     '<link rel="alternate" href="/en/url-en" hreflang="en"/>',
                     '<link rel="alternate" href="/de/url-de" hreflang="de"/>',
                 ],
@@ -333,9 +327,7 @@ class SeoTwigExtensionTest extends TestCase
                     // no alternate link if translation is the only one
                 ],
                 [
-                    '<link rel="alternate" href="/de/url-de" hreflang="x-default"/>',
                     '<link rel="alternate" href="/de/url-de" hreflang="de"/>',
-                    '<link rel="alternate" href="/en" hreflang="x-default"/>',
                     '<link rel="alternate" href="/en" hreflang="en"/>',
                 ],
             ],
@@ -353,9 +345,7 @@ class SeoTwigExtensionTest extends TestCase
                     // no alternate link if translation is the only one
                 ],
                 [
-                    '<link rel="alternate" href="/de/url-de" hreflang="x-default"/>',
                     '<link rel="alternate" href="/de/url-de" hreflang="de"/>',
-                    '<link rel="alternate" href="/en" hreflang="x-default"/>',
                     '<link rel="alternate" href="/en" hreflang="en"/>',
                 ],
             ],
@@ -370,7 +360,6 @@ class SeoTwigExtensionTest extends TestCase
                 'en',
                 null,
                 [
-                    '<link rel="alternate" href="/en" hreflang="x-default"/>',
                     '<link rel="alternate" href="/en" hreflang="en"/>',
                     '<link rel="alternate" href="/de" hreflang="de"/>',
                 ],
@@ -402,7 +391,6 @@ class SeoTwigExtensionTest extends TestCase
                     '<meta name="description" content="SEO description"/>',
                     '<meta name="keywords" content="SEO keywords"/>',
                     '<meta name="robots" content="index,follow"/>',
-                    '<link rel="alternate" href="/en/url-en" hreflang="x-default"/>',
                     '<link rel="alternate" href="/en/url-en" hreflang="en"/>',
                     '<link rel="alternate" href="/de/url-de" hreflang="de"/>',
                     '<link rel="canonical" href="/test-url"/>',

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Meta/MetaTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Meta/MetaTwigExtension.php
@@ -75,9 +75,6 @@ class MetaTwigExtension extends AbstractExtension
             // url = '/' means that there is no translation for this page
             // the only exception is the homepage where the requested resource-locator is '/'
             if ('/' !== $url || '/' === $this->requestAnalyzer->getResourceLocator()) {
-                if ($locale === $defaultLocale) {
-                    $result[] = $this->getAlternate($url, $webspaceKey, $locale, true);
-                }
                 $result[] = $this->getAlternate($url, $webspaceKey, $locale);
             }
         }
@@ -137,18 +134,17 @@ class MetaTwigExtension extends AbstractExtension
      * @param string $url
      * @param string $webspaceKey
      * @param string $locale
-     * @param bool $default
      *
      * @return string
      */
-    private function getAlternate($url, $webspaceKey, $locale, $default = false)
+    private function getAlternate($url, $webspaceKey, $locale)
     {
         $url = $this->contentPath->getContentPath($url, $webspaceKey, $locale);
 
         return \sprintf(
             '<link rel="alternate" href="%s" hreflang="%s" />',
             $url,
-            !$default ? \str_replace('_', '-', $locale) : 'x-default'
+            \str_replace('_', '-', $locale)
         );
     }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Meta/MetaTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Meta/MetaTwigExtension.php
@@ -65,11 +65,6 @@ class MetaTwigExtension extends AbstractExtension
         $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
         $currentPortal = $this->requestAnalyzer->getPortal();
 
-        $defaultLocale = null;
-        if (null !== $currentPortal && null !== ($defaultLocale = $currentPortal->getXDefaultLocalization())) {
-            $defaultLocale = $defaultLocale->getLocale();
-        }
-
         $result = [];
         foreach ($urls as $locale => $url) {
             // url = '/' means that there is no translation for this page

--- a/src/Sulu/Component/Localization/Localization.php
+++ b/src/Sulu/Component/Localization/Localization.php
@@ -108,6 +108,8 @@ class Localization implements \JsonSerializable, ArrayableInterface
      *
      * @var bool
      * @Groups({"frontend", "Default"})
+     *
+     * @deprecated Use $default instead.
      */
     private $xDefault;
 
@@ -300,9 +302,13 @@ class Localization implements \JsonSerializable, ArrayableInterface
      * Sets if this localization is the x-default one.
      *
      * @param bool $xDefault
+     *
+     * @deprecated Use setDefault to set the default Localization.
      */
     public function setXDefault($xDefault)
     {
+        @\trigger_error(\sprintf('The "%s" method is deprecated on "%s" use "setDefault" instead.', __METHOD__, __CLASS__), \E_USER_DEPRECATED);
+
         $this->xDefault = $xDefault;
     }
 
@@ -320,9 +326,13 @@ class Localization implements \JsonSerializable, ArrayableInterface
      * Returns if this localization is the x-default one.
      *
      * @return bool True if this is the x-default localization, otherwise false
+     *
+     * @deprecated Use getDefault to get the default Localization.
      */
     public function isXDefault()
     {
+        @\trigger_error(\sprintf('The "%s" method is deprecated on "%s" use "isDefault" instead.', __METHOD__, __CLASS__), \E_USER_DEPRECATED);
+
         return $this->xDefault;
     }
 

--- a/src/Sulu/Component/Localization/Localization.php
+++ b/src/Sulu/Component/Localization/Localization.php
@@ -109,7 +109,7 @@ class Localization implements \JsonSerializable, ArrayableInterface
      * @var bool
      * @Groups({"frontend", "Default"})
      *
-     * @deprecated Use $default instead.
+     * @deprecated use $default instead
      */
     private $xDefault;
 
@@ -303,7 +303,7 @@ class Localization implements \JsonSerializable, ArrayableInterface
      *
      * @param bool $xDefault
      *
-     * @deprecated Use setDefault to set the default Localization.
+     * @deprecated use setDefault to set the default Localization
      */
     public function setXDefault($xDefault)
     {
@@ -327,7 +327,7 @@ class Localization implements \JsonSerializable, ArrayableInterface
      *
      * @return bool True if this is the x-default localization, otherwise false
      *
-     * @deprecated Use getDefault to get the default Localization.
+     * @deprecated use getDefault to get the default Localization
      */
     public function isXDefault()
     {

--- a/src/Sulu/Component/Webspace/Loader/Exception/InvalidPortalDefaultLocalizationException.php
+++ b/src/Sulu/Component/Webspace/Loader/Exception/InvalidPortalDefaultLocalizationException.php
@@ -23,13 +23,13 @@ class InvalidPortalDefaultLocalizationException extends WebspaceException
      */
     private $portal;
 
-    public function __construct(Webspace $webspace, Portal $portal)
+    public function __construct(Webspace $webspace, Portal $portal, \Throwable $previous = null)
     {
         $this->webspace = $webspace;
         $this->portal = $portal;
         $message = 'The portal "' . $portal->getKey() . '" in the webspace definition "' . $webspace->getKey() . '" ' .
             'has multiple default localizations';
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Loader/Exception/InvalidWebspaceDefaultLocalizationException.php
+++ b/src/Sulu/Component/Webspace/Loader/Exception/InvalidWebspaceDefaultLocalizationException.php
@@ -15,10 +15,10 @@ use Sulu\Component\Webspace\Webspace;
 
 class InvalidWebspaceDefaultLocalizationException extends WebspaceException
 {
-    public function __construct(Webspace $webspace)
+    public function __construct(Webspace $webspace, \Throwable $previous = null)
     {
         $this->webspace = $webspace;
         $message = 'The webspace definition for "' . $webspace->getKey() . '" has has multiple default localization';
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Sulu/Component/Webspace/Loader/Exception/PortalDefaultLocalizationNotFoundException.php
+++ b/src/Sulu/Component/Webspace/Loader/Exception/PortalDefaultLocalizationNotFoundException.php
@@ -23,13 +23,13 @@ class PortalDefaultLocalizationNotFoundException extends WebspaceException
      */
     private $portal;
 
-    public function __construct(Webspace $webspace, Portal $portal)
+    public function __construct(Webspace $webspace, Portal $portal, \Throwable $previous = null)
     {
         $this->webspace = $webspace;
         $this->portal = $portal;
         $message = 'The portal "' . $portal->getKey() . '" in the webspace definition "' . $webspace->getKey() . '" ' .
             'has not specified the required attributes (a default localization)';
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
@@ -598,7 +598,7 @@ class XmlFileLoader10 extends BaseXmlFileLoader
         try {
             $this->validateDefaultLocalization($this->webspace->getLocalizations());
         } catch (InvalidDefaultLocalizationException $ex) {
-            throw new InvalidWebspaceDefaultLocalizationException($this->webspace);
+            throw new InvalidWebspaceDefaultLocalizationException($this->webspace, $ex);
         }
     }
 
@@ -620,7 +620,7 @@ class XmlFileLoader10 extends BaseXmlFileLoader
                     }
                 }
             } catch (InvalidDefaultLocalizationException $ex) {
-                throw new InvalidPortalDefaultLocalizationException($this->webspace, $portal);
+                throw new InvalidPortalDefaultLocalizationException($this->webspace, $portal, $ex);
             }
         }
     }

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
@@ -258,6 +258,9 @@ class XmlFileLoader10 extends BaseXmlFileLoader
 
         $xDefaultNode = $localizationNode->attributes->getNamedItem('x-default');
         if ($xDefaultNode) {
+            // @deprecated
+            @\trigger_error('Set x-default="true" attribute on the `<localization>` tag in webspace is deprecated use default="true" instead.', \E_USER_DEPRECATED);
+
             $localization->setXDefault('true' == $xDefaultNode->nodeValue);
         } else {
             $localization->setXDefault(false);

--- a/src/Sulu/Component/Webspace/Portal.php
+++ b/src/Sulu/Component/Webspace/Portal.php
@@ -51,6 +51,8 @@ class Portal
     /**
      * The x-default localization for this portal.
      *
+     * @deprecated Use $defaultLocalization instead.
+     *
      * @var Localization
      */
     private $xDefaultLocalization;
@@ -170,17 +172,25 @@ class Portal
 
     /**
      * @param Localization $xDefaultLocalization
+     *
+     * @deprecated Use setDefaultLocalization instead.
      */
     public function setXDefaultLocalization($xDefaultLocalization)
     {
+        @\trigger_error(\sprintf('The "%s" method is deprecated on "%s" use "setDefaultLocalization" instead.', __METHOD__, __CLASS__), \E_USER_DEPRECATED);
+
         $this->xDefaultLocalization = $xDefaultLocalization;
     }
 
     /**
      * @return Localization
+     *
+     * @deprecated Use getDefaultLocalization instead.
      */
     public function getXDefaultLocalization()
     {
+        @\trigger_error(\sprintf('The "%s" method is deprecated on "%s" use "getDefaultLocalization" instead.', __METHOD__, __CLASS__), \E_USER_DEPRECATED);
+
         return $this->xDefaultLocalization;
     }
 

--- a/src/Sulu/Component/Webspace/Portal.php
+++ b/src/Sulu/Component/Webspace/Portal.php
@@ -51,7 +51,7 @@ class Portal
     /**
      * The x-default localization for this portal.
      *
-     * @deprecated Use $defaultLocalization instead.
+     * @deprecated use $defaultLocalization instead
      *
      * @var Localization
      */
@@ -173,7 +173,7 @@ class Portal
     /**
      * @param Localization $xDefaultLocalization
      *
-     * @deprecated Use setDefaultLocalization instead.
+     * @deprecated use setDefaultLocalization instead
      */
     public function setXDefaultLocalization($xDefaultLocalization)
     {
@@ -185,7 +185,7 @@ class Portal
     /**
      * @return Localization
      *
-     * @deprecated Use getDefaultLocalization instead.
+     * @deprecated use getDefaultLocalization instead
      */
     public function getXDefaultLocalization()
     {

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -11,7 +11,6 @@
             "content": content|default([]),
             "urls": urls|default([]),
             "shadowBaseLocale": shadowBaseLocale|default(),
-            "defaultLocale": app.request.locale
         } %}
     {% endblock %}
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | part of fixes #6027 <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove x-default alternate url.

#### Why?

The `x-default` is for `[international pages](https://developers.google.com/search/blog/2013/04/x-default-hreflang-for-international-pages)` which means a page which you could select the language, so basically only one x-default url should exist, see also [google xdefault docs](https://developers.google.com/search/docs/advanced/crawling/localized-versions#xdefault) and [yandex xdefault docs](https://yandex.com/support/webmaster/yandex-indexing/locale-pages.html#auto).

If a website has international landingpage they should now override the `sitemap.xml` file to add it as an alternate link to the current webspace. 