### PR TITLE
Avoid false alternate link to homepage

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Sitemap/PagesSitemapProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Sitemap/PagesSitemapProvider.php
@@ -135,6 +135,10 @@ class PagesSitemapProvider extends AbstractSitemapProvider
         );
 
         foreach ($contentPage->getUrls() as $urlLocale => $href) {
+            if (null === $href) {
+                continue;
+            }
+
             $url = $this->webspaceManager->findUrlByResourceLocator(
                 $href,
                 $this->environment,

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/SitemapController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/SitemapController.php
@@ -58,13 +58,19 @@ class SitemapController
      */
     private $cacheLifeTime;
 
+    /**
+     * @var bool
+     */
+    private $debug;
+
     public function __construct(
         XmlSitemapRendererInterface $xmlSitemapRenderer,
         SitemapProviderPoolInterface $sitemapProviderPool,
         XmlSitemapDumperInterface $xmlSitemapDumper,
         Filesystem $filesystem,
         UrlGeneratorInterface $router,
-        int $cacheLifeTime
+        int $cacheLifeTime,
+        bool $debug = false
     ) {
         $this->xmlSitemapRenderer = $xmlSitemapRenderer;
         $this->sitemapProviderPool = $sitemapProviderPool;
@@ -72,6 +78,7 @@ class SitemapController
         $this->filesystem = $filesystem;
         $this->router = $router;
         $this->cacheLifeTime = $cacheLifeTime;
+        $this->debug = $debug;
     }
 
     /**
@@ -223,6 +230,10 @@ class SitemapController
             SuluHttpCache::HEADER_REVERSE_PROXY_TTL,
             $response->getAge() + $this->cacheLifeTime
         );
+
+        if ($this->debug) {
+            return $response;
+        }
 
         return $response->setMaxAge(240)
             ->setSharedMaxAge(960);

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -54,6 +54,7 @@
             <argument type="service" id="filesystem"/>
             <argument type="service" id="router"/>
             <argument>%sulu_website.sitemap.cache.lifetime%</argument>
+            <argument>%kernel.debug%</argument>
 
             <tag name="sulu.context" context="website" />
         </service>

--- a/src/Sulu/Component/Content/Repository/Content.php
+++ b/src/Sulu/Component/Content/Repository/Content.php
@@ -109,7 +109,7 @@ class Content implements \ArrayAccess
     private $url;
 
     /**
-     * @var string[]
+     * @var array<string, string|null>
      */
     private $urls;
 
@@ -341,7 +341,7 @@ class Content implements \ArrayAccess
     }
 
     /**
-     * @return string[]
+     * @return array<string, string|null>
      */
     public function getUrls()
     {
@@ -349,7 +349,7 @@ class Content implements \ArrayAccess
     }
 
     /**
-     * @param string[] $urls
+     * @param array<string, string|null> $urls
      */
     public function setUrls(array $urls)
     {

--- a/src/Sulu/Component/Content/Repository/ContentRepository.php
+++ b/src/Sulu/Component/Content/Repository/ContentRepository.php
@@ -653,11 +653,13 @@ class ContentRepository implements ContentRepositoryInterface
 
         if ($mapping->resolveUrl()) {
             $url = $this->resolveUrl($row, $locale);
+            /** @var array<string, string|null> $urls */
             $urls = [];
             \array_walk(
                 $locales,
-                function($item) use (&$urls, $row) {
-                    $urls[$item] = $this->resolveUrl($row, $item);
+                /** @var array<string, string|null> $urls */
+                function($locale) use (&$urls, $row) {
+                    $urls[$locale] = $this->resolveUrl($row, $locale);
                 }
             );
 
@@ -774,22 +776,22 @@ class ContentRepository implements ContentRepositoryInterface
      *
      * @param string $locale
      *
-     * @return string
+     * @return string|null
      */
     private function resolveUrl(Row $row, $locale)
     {
         if (WorkflowStage::PUBLISHED !== $this->resolveProperty($row, $locale . 'State', $locale)) {
-            return;
+            return null;
         }
 
         $template = $this->resolveProperty($row, 'template', $locale);
         if (empty($template)) {
-            return;
+            return null;
         }
 
         $structure = $this->structureManager->getStructure($template);
         if (!$structure || !$structure->hasTag('sulu.rlp')) {
-            return;
+            return null;
         }
 
         $propertyName = $structure->getPropertyByTagName('sulu.rlp')->getName();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes part of #6027
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove fallback to the homepage as alternate links.

#### Why?

Avoid false alternate link to homepage in the sitemap. We can currently not change this on the template itself, this will be fixed in a seperate PR on the 2.2 branch where this is possible over the localization PR. 
