### PR TITLE
Fix alternate page urls meta tags

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/ParameterResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/ParameterResolver.php
@@ -108,9 +108,11 @@ class ParameterResolver implements ParameterResolverInterface
         foreach ($allLocalizations as $localization) {
             $locale = $localization->getLocale();
 
+            $alternate = true;
             if (\array_key_exists($locale, $pageUrls)) {
                 $url = $this->webspaceManager->findUrlByResourceLocator($pageUrls[$locale], null, $locale);
             } else {
+                $alternate = false;
                 $url = $this->webspaceManager->findUrlByResourceLocator('/', null, $locale);
             }
 
@@ -118,6 +120,7 @@ class ParameterResolver implements ParameterResolverInterface
                 'locale' => $locale,
                 'url' => $url,
                 'country' => $localization->getCountry(),
+                'alternate' => $alternate,
             ];
         }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
@@ -97,6 +97,7 @@ class TemplateAttributeResolver implements TemplateAttributeResolverInterface
                 $localizations[$locale] = [
                     'locale' => $locale,
                     'url' => $url,
+                    'alternate' => true,
                 ];
             }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Extension/seo.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Extension/seo.html.twig
@@ -74,7 +74,9 @@
     {#- when only one language do not show alternative -#}
     {%- if localizations|length > 1 -%}
         {%- for localization in localizations -%}
-            <link rel="alternate" href="{{ localization.url }}" hreflang="{{ localization.locale|replace({'_': '-'}) }}"/>
+            {%- if localization.alternate is not defined or localization.alternate -%}
+                <link rel="alternate" href="{{ localization.url }}" hreflang="{{ localization.locale|replace({'_': '-'}) }}"/>
+            {%- endif -%}
         {%- endfor -%}
     {%- endif -%}
 {%- endblock -%}

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Resolver/ParameterResolverTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Resolver/ParameterResolverTest.php
@@ -170,11 +170,13 @@ class ParameterResolverTest extends TestCase
                     'locale' => 'en',
                     'url' => '/en/test',
                     'country' => null,
+                    'alternate' => true,
                 ],
                 'de' => [
                     'locale' => 'de',
                     'url' => '/de/test',
                     'country' => null,
+                    'alternate' => true,
                 ],
             ],
             'segmentKey' => 'w',
@@ -257,11 +259,13 @@ class ParameterResolverTest extends TestCase
                     'locale' => 'en',
                     'url' => '/en/test',
                     'country' => null,
+                    'alternate' => true,
                 ],
                 'de' => [
                     'locale' => 'de',
                     'url' => '/de/test',
                     'country' => null,
+                    'alternate' => true,
                 ],
             ],
             'webspaceKey' => 'sulu',
@@ -333,11 +337,94 @@ class ParameterResolverTest extends TestCase
                     'locale' => 'en_gb',
                     'url' => '/en/test',
                     'country' => 'gb',
+                    'alternate' => true,
                 ],
                 'de_at' => [
                     'locale' => 'de_at',
                     'url' => '/de/test',
                     'country' => 'at',
+                    'alternate' => true,
+                ],
+            ],
+            'webspaceKey' => 'sulu',
+            'segments' => [],
+        ], $resolvedData);
+    }
+
+    public function testResolveLocalizationsAlternate(): void
+    {
+        $parameterResolver = new ParameterResolver(
+            $this->structureResolver->reveal(),
+            $this->requestAnalyzerResolver->reveal(),
+            $this->webspaceManager->reveal(),
+            $this->requestStack->reveal(),
+            '_sulu_segment_switch',
+            ['urls' => false]
+        );
+
+        $localization1 = $this->prophesize(Localization::class);
+        $localization1->getLocale()->willReturn('en_gb');
+        $localization1->getCountry()->willReturn('gb');
+        $localization2 = $this->prophesize(Localization::class);
+        $localization2->getLocale()->willReturn('de_at');
+        $localization2->getCountry()->willReturn('at');
+
+        $this->structureResolver->resolve($this->structure->reveal(), true)
+            ->shouldBeCalledTimes(1)
+            ->willReturn([
+                'content' => [],
+                'view' => [],
+                'urls' => [
+                    'en_gb' => '/test',
+                ],
+                'extension' => [
+                    'seo' => [],
+                    'excerpt' => [],
+                ],
+            ]);
+        $this->requestAnalyzerResolver->resolve($this->requestAnalyzer)
+            ->shouldBeCalledTimes(1)
+            ->willReturn(['webspaceKey' => 'sulu']);
+        $this->webspaceManager->findUrlByResourceLocator('/test', null, 'en_gb')
+            ->shouldBeCalled()
+            ->willReturn('/en/test');
+        $this->webspaceManager->findUrlByResourceLocator('/', null, 'de_at')
+            ->shouldBeCalled()
+            ->willReturn('/de');
+        $this->requestAnalyzer->getPortal()->willReturn($this->portal->reveal())->shouldBeCalledTimes(1);
+        $this->portal->getLocalizations()
+            ->willReturn([$localization1->reveal(), $localization2->reveal()])->shouldBeCalledTimes(1);
+
+        $this->webspace->getSegments()->willReturn([]);
+
+        $resolvedData = $parameterResolver->resolve(
+            [
+                'testKey' => 'testValue',
+            ],
+            $this->requestAnalyzer->reveal(),
+            $this->structure->reveal()
+        );
+
+        $this->assertEquals([
+            'testKey' => 'testValue',
+            'content' => [],
+            'view' => [],
+            'extension' => [
+                'seo' => [],
+                'excerpt' => [],
+            ],
+            'localizations' => [
+                'en_gb' => [
+                    'locale' => 'en_gb',
+                    'url' => '/en/test',
+                    'country' => 'gb',
+                    'alternate' => true,
+                ],
+                'de_at' => [
+                    'locale' => 'de_at',
+                    'url' => '/de',
+                    'country' => 'at',
+                    'alternate' => false,
                 ],
             ],
             'webspaceKey' => 'sulu',

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Resolver/TemplateAttributeResolverTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Resolver/TemplateAttributeResolverTest.php
@@ -166,10 +166,12 @@ class TemplateAttributeResolverTest extends TestCase
                 'en' => [
                     'locale' => 'en',
                     'url' => 'http://sulu.io/en/test',
+                    'alternate' => true,
                 ],
                 'de' => [
                     'locale' => 'de',
                     'url' => 'http://sulu.io/de/test',
+                    'alternate' => true,
                 ],
             ],
             'request' => [
@@ -217,10 +219,12 @@ class TemplateAttributeResolverTest extends TestCase
                 'en' => [
                     'locale' => 'en',
                     'url' => 'http://sulu.io/en/test',
+                    'alternate' => true,
                 ],
                 'de' => [
                     'locale' => 'de',
                     'url' => 'http://sulu.io/de/test',
+                    'alternate' => true,
                 ],
             ],
             'request' => [
@@ -263,10 +267,12 @@ class TemplateAttributeResolverTest extends TestCase
                 'en' => [
                     'locale' => 'en',
                     'url' => 'http://sulu.io/en/test',
+                    'alternate' => true,
                 ],
                 'de' => [
                     'locale' => 'de',
                     'url' => 'http://sulu.io/de/test',
+                    'alternate' => true,
                 ],
             ],
             'request' => [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes part of #6027 
| Related issues/PRs | #6072
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix alternate page urls meta tags.

#### Why?

A alternate meta tag should not link to the homepage when the page does not exist in the current language.
