### PR TITLE
Fix segment switcher url only from same host

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/SegmentControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/SegmentControllerTest.php
@@ -12,6 +12,8 @@
 namespace Sulu\Bundle\WebsiteBundle\Tests\Functional\Controller;
 
 use Sulu\Bundle\TestBundle\Testing\WebsiteTestCase;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class SegmentControllerTest extends WebsiteTestCase
 {
@@ -25,36 +27,64 @@ class SegmentControllerTest extends WebsiteTestCase
         $this->client = $this->createWebsiteClient();
     }
 
-    public function testSwitch()
+    public function testSwitch(): void
     {
         $this->assertNull($this->client->getCookieJar()->get('_ss'));
 
         $this->client->request('GET', 'http://sulu.lo/_sulu_segment_switch?segment=s&url=http://sulu.lo/test');
         $response = $this->client->getResponse();
 
-        $this->assertEquals('s', $this->client->getCookieJar()->get('_ss')->getValue());
+        $this->assertHttpStatusCode(302, $response);
+        $cookie = $this->client->getCookieJar()->get('_ss');
+        $this->assertNotNull($cookie);
+        $this->assertEquals('s', $cookie->getValue());
+        $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertEquals('http://sulu.lo/test', $response->getTargetUrl());
     }
 
-    public function testSwitchNonExisting()
+    public function testSwitchNonExisting(): void
     {
         $this->assertNull($this->client->getCookieJar()->get('_ss'));
 
         $this->client->request('GET', 'http://sulu.lo/_sulu_segment_switch?segment=n&url=http://sulu.lo/test');
         $response = $this->client->getResponse();
 
+        $this->assertHttpStatusCode(302, $response);
         $this->assertNull($this->client->getCookieJar()->get('_ss'));
+        $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertEquals('http://sulu.lo/test', $response->getTargetUrl());
     }
 
-    public function testSwitchDefault()
+    public function testSwitchDefault(): void
     {
         $this->assertNull($this->client->getCookieJar()->get('_ss'));
 
         $this->client->request('GET', 'http://sulu.lo/_sulu_segment_switch?segment=w&url=http://sulu.lo/test');
         $response = $this->client->getResponse();
 
+        $this->assertHttpStatusCode(302, $response);
         $this->assertNull($this->client->getCookieJar()->get('_ss'));
+        $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertEquals('http://sulu.lo/test', $response->getTargetUrl());
+    }
+
+    public function testSwitchFalseExternalUrl(): void
+    {
+        $this->assertNull($this->client->getCookieJar()->get('_ss'));
+
+        $this->client->request('GET', 'http://sulu.lo/_sulu_segment_switch?segment=s&url=http://github.com/sulu/sulu');
+        $response = $this->client->getResponse();
+
+        $this->assertHttpStatusCode(400, $response);
+    }
+
+    public function testSwitchFalseNoUrl(): void
+    {
+        $this->assertNull($this->client->getCookieJar()->get('_ss'));
+
+        $this->client->request('GET', 'http://sulu.lo/_sulu_segment_switch?segment=s&url=');
+        $response = $this->client->getResponse();
+
+        $this->assertHttpStatusCode(400, $response);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #6070 <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix segment switcher url only form same host.

#### Why?

Currently the segment controller accept all urls as target, which allows redirect to external url which should not happen.