### PR TITLE
Include form data when updating context of preview

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,10 @@
 # Upgrade
 
+### Preview updateContext method
+
+The method `Preview::updateContext` has been extended with the `data` argument. The argument is necessary
+to make sure that the rendered data are consistent with the template.
+
 ## 2.3.0-RC1
 
 ### Auditable Fields to User

--- a/src/Sulu/Bundle/PreviewBundle/Controller/PreviewController.php
+++ b/src/Sulu/Bundle/PreviewBundle/Controller/PreviewController.php
@@ -108,6 +108,8 @@ class PreviewController
         $provider = $this->getRequestParameter($request, 'provider', true);
         $token = $this->getRequestParameter($request, 'token', true);
         $context = $this->getRequestParameter($request, 'context', true);
+        /** @var mixed[] $data */
+        $data = $this->getRequestParameter($request, 'data', true);
 
         $options = $this->getOptionsFromRequest($request);
 
@@ -118,6 +120,7 @@ class PreviewController
         $content = $this->preview->updateContext(
             $token,
             $context,
+            $data,
             $options
         );
 

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
@@ -107,12 +107,17 @@ class Preview implements PreviewInterface
     public function updateContext(
         string $token,
         array $context,
+        array $data,
         array $options = []
     ): string {
         $locale = $options['locale'] ?? null;
         $cacheItem = $this->fetch($token);
 
         $provider = $this->getProvider($cacheItem->getProviderKey());
+        if (!empty($data)) {
+            $provider->setValues($cacheItem->getObject(), $locale, $data);
+        }
+
         if (0 === \count($context)) {
             return $this->renderer->render(
                 $cacheItem->getObject(),

--- a/src/Sulu/Bundle/PreviewBundle/Preview/PreviewInterface.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/PreviewInterface.php
@@ -51,11 +51,16 @@ interface PreviewInterface
     /**
      * Updates given context and restart preview with given data.
      *
+     * @param mixed[] $context
+     * @param mixed[] $data
+     * @param mixed[] $options
+     *
      * @return string Complete html response
      */
     public function updateContext(
         string $token,
         array $context,
+        array $data,
         array $options = []
     ): string;
 

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
@@ -139,7 +139,7 @@ class Preview extends React.Component<Props> {
         this.typeDisposer = reaction(
             () => toJS(formStore.type),
             (type) => {
-                previewStore.updateContext(type).then(this.setContent);
+                previewStore.updateContext(type, formStore.data).then(this.setContent);
             }
         );
     };

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/stores/PreviewStore.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/stores/PreviewStore.js
@@ -106,7 +106,7 @@ export default class PreviewStore {
         });
     }
 
-    updateContext(type: string): Promise<string> {
+    updateContext(type: string, data: Object): Promise<string> {
         const route = generateRoute('update-context', {
             webspaceKey: this.webspace,
             segmentKey: this.segment,
@@ -118,7 +118,7 @@ export default class PreviewStore {
             dateTime: this.dateTime && transformDateForUrl(this.dateTime),
         });
 
-        return Requester.post(route, {context: {template: type}}).then((response) => {
+        return Requester.post(route, {data, context: {template: type}}).then((response) => {
             return response.content;
         });
     }

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/Preview.test.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/Preview.test.js
@@ -477,7 +477,7 @@ test('React and update-context when type is changed', () => {
     formStore.type.set('homepage');
 
     return startPromise.then(() => {
-        expect(previewStore.updateContext).toBeCalledWith('homepage');
+        expect(previewStore.updateContext).toBeCalledWith('homepage', observable.map({title: 'Test'}));
     });
 });
 

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Controller/PreviewControllerTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Controller/PreviewControllerTest.php
@@ -237,6 +237,7 @@ class PreviewControllerTest extends TestCase
             ],
             [
                 'context' => ['template' => 'default'],
+                'data' => ['title' => 'test'],
             ]
         );
 
@@ -244,6 +245,7 @@ class PreviewControllerTest extends TestCase
         $this->preview->updateContext(
             'test-token',
             ['template' => 'default'],
+            ['title' => 'test'],
             ['targetGroupId' => 1, 'segmentKey' => 's', 'webspaceKey' => 'sulu_io', 'locale' => 'de']
         )->shouldBeCalled()->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
 
@@ -268,6 +270,7 @@ class PreviewControllerTest extends TestCase
             ],
             [
                 'context' => ['template' => 'default'],
+                'data' => ['title' => 'test'],
             ]
         );
 
@@ -275,6 +278,7 @@ class PreviewControllerTest extends TestCase
         $this->preview->updateContext(
             'test-token',
             ['template' => 'default'],
+            ['title' => 'test'],
             ['targetGroupId' => 1, 'segmentKey' => 'w', 'webspaceKey' => 'sulu_io', 'locale' => 'de']
         )->shouldBeCalled()->willReturn('<html><body><a href="/test">SULU is awesome</a></body></html>');
 

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/PreviewTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/PreviewTest.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\PreviewBundle\Tests\Unit\Preview;
 use Doctrine\Common\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\PreviewBundle\Preview\Exception\ProviderNotFoundException;
 use Sulu\Bundle\PreviewBundle\Preview\Exception\TokenNotFoundException;
 use Sulu\Bundle\PreviewBundle\Preview\Object\PreviewObjectProviderInterface;
@@ -65,7 +66,7 @@ class PreviewTest extends TestCase
     private $webspaceKey = 'sulu_io';
 
     /**
-     * @var \stdClass
+     * @var \stdClass|ObjectProphecy
      */
     private $object;
 

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/PreviewTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/PreviewTest.php
@@ -394,7 +394,7 @@ class PreviewTest extends TestCase
 
         $this->provider->deserialize($dataJson, $cacheData['objectClass'])->willReturn($this->object->reveal());
         $this->provider->setContext($this->object->reveal(), $this->locale, $context)->willReturn($newObject->reveal());
-        $this->provider->setValues(Argument::cetera())->shouldNotBeCalled();
+        $this->provider->setValues($this->object->reveal(), $this->locale, $data)->shouldBeCalled();
         $this->provider->serialize($newObject->reveal())->willReturn($expectedData['object'])->shouldBeCalled();
 
         $this->renderer->render(
@@ -428,6 +428,7 @@ class PreviewTest extends TestCase
         $result = $this->preview->updateContext(
             $token,
             $context,
+            $data,
             ['webspaceKey' => $this->webspaceKey, 'locale' => $this->locale]
         );
 
@@ -462,6 +463,7 @@ class PreviewTest extends TestCase
         $this->cache->contains($token)->willReturn(true);
         $this->cache->fetch($token)->willReturn(\json_encode($cacheData));
 
+        $this->provider->setValues($this->object->reveal(), $this->locale, $data)->shouldBeCalled();
         $this->provider->deserialize($dataJson, $cacheData['objectClass'])->willReturn($this->object->reveal());
         $this->provider->setContext($this->object->reveal(), $this->locale, $context)->willReturn($newObject->reveal());
 
@@ -475,6 +477,7 @@ class PreviewTest extends TestCase
         $this->preview->updateContext(
             $token,
             $context,
+            $data,
             ['webspaceKey' => $this->webspaceKey, 'locale' => $this->locale]
         );
     }
@@ -500,8 +503,8 @@ class PreviewTest extends TestCase
         $this->cache->fetch($token)->willReturn(\json_encode($cacheData));
 
         $this->provider->deserialize($dataJson, $cacheData['objectClass'])->willReturn($this->object->reveal());
+        $this->provider->setValues($this->object->reveal(), $this->locale, $data)->shouldBeCalled();
         $this->provider->setContext(Argument::cetera())->shouldNotBeCalled();
-        $this->provider->setValues(Argument::cetera())->shouldNotBeCalled();
         $this->provider->serialize(Argument::cetera())->shouldNotBeCalled();
 
         $this->renderer->render(
@@ -518,6 +521,7 @@ class PreviewTest extends TestCase
         $result = $this->preview->updateContext(
             $token,
             $context,
+            $data,
             ['webspaceKey' => $this->webspaceKey, 'locale' => $this->locale]
         );
 
@@ -559,7 +563,7 @@ class PreviewTest extends TestCase
 
         $this->provider->deserialize($dataJson, $cacheData['objectClass'])->willReturn($this->object->reveal());
         $this->provider->setContext($this->object->reveal(), $this->locale, $context)->willReturn($newObject->reveal());
-        $this->provider->setValues(Argument::cetera())->shouldNotBeCalled();
+        $this->provider->setValues($this->object->reveal(), $this->locale, $data)->shouldBeCalled();
         $this->provider->serialize($newObject->reveal())->willReturn($expectedData['object'])->shouldBeCalled();
 
         $this->renderer->render(
@@ -593,6 +597,7 @@ class PreviewTest extends TestCase
         $result = $this->preview->updateContext(
             $token,
             $context,
+            $data,
             ['targetGroupId' => 2, 'segmentKey' => null, 'webspaceKey' => $this->webspaceKey, 'locale' => $this->locale]
         );
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Related issues/PRs | preparation for https://github.com/sulu/sulu/issues/5983
| License | MIT

#### What's in this PR?

Extends the `updateContext` with the `data` property. 

#### Why?

When the template is changed, two requests are sent. The first request is `updateContext` which just updates the template and re-renders the complete page. The second request is `update`, this request updates the `data` and just re-renders the `content` area. 

To fix the issue https://github.com/sulu/sulu/issues/5983 we will implement a fallback to the `default` block type, if the origin `block-type` is not available in the new template. Then the `updateContext` request must also send the correct `data` otherwise the re-rendering fails, because the old `block-type` is not available in the new template but still in the `data` object.

With the changes from this PR the data is also sent with the `updateContext` request and so the re-rendering uses the correct data.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
