### PR TITLE
Merge local data with remote data when switching template of page

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
@@ -104,7 +104,7 @@ export default class AbstractFormStore
     +metadataOptions: ?{[string]: any};
     +loading: boolean;
     +locale: ?IObservableValue<string>;
-    schema: Schema;
+    @observable schema: Schema;
     modifiedFields: Array<string> = [];
     @observable errors: Object = {};
     validator: ?(data: Object) => boolean;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
@@ -5,7 +5,7 @@ import log from 'loglevel';
 import type {IObservableValue} from 'mobx/lib/mobx';
 import type {Schema, SchemaEntry} from '../types';
 
-const SECTION_TYPE = 'section';
+export const SECTION_TYPE = 'section';
 
 function addSchemaProperties(data: Object, key: string, schema: Schema) {
     const type = schema[key].type;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
@@ -38,17 +38,6 @@ function mergeData(
             types: localTypes,
         } = localSchema[name] || {};
 
-        if (remoteType === SECTION_TYPE && remoteItems &&
-            localType === SECTION_TYPE && localItems) {
-            result = mergeData(
-                localItems,
-                remoteItems,
-                localData,
-                remoteData
-            );
-            continue;
-        }
-
         if (remoteType === SECTION_TYPE && remoteItems) {
             result = mergeData(
                 localSchema,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
@@ -183,9 +183,7 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
                         // $FlowFixMe
                         localTypes[localChildData.type]?.form || localTypes[localDefaultType].form;
 
-                    const remoteChildSchema =
-                        // $FlowFixMe
-                        remoteTypes[resultType].form;
+                    const remoteChildSchema = remoteTypes[resultType].form;
 
                     const resultChildData = this.mergeData(
                         localChildSchema,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
@@ -3,14 +3,13 @@ import {action, autorun, computed, get, isArrayLike, observable, toJS, when} fro
 import jsonpointer from 'json-pointer';
 import {createAjv} from '../../../utils/Ajv';
 import ResourceStore from '../../../stores/ResourceStore';
-import AbstractFormStore from './AbstractFormStore';
+import AbstractFormStore, {SECTION_TYPE} from './AbstractFormStore';
 import metadataStore from './metadataStore';
 import type {FormStoreInterface, Schema, SchemaEntry, SchemaType, SchemaTypes} from '../types';
 import type {IObservableValue} from 'mobx/lib/mobx';
 
 // TODO do not hardcode "template", use some kind of metadata instead
 const TYPE = 'template';
-const SECTION_TYPE = 'section';
 
 const ajv = createAjv();
 
@@ -105,7 +104,7 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
         if (oldSchema && toJS(this.type) === this.data['originTemplate']) {
             return this.resourceStore.requestData().then((data: Object) => {
                 const result = this.calculateDifference(oldSchema, newSchema, this.data, data);
-                this.setMultipleRecursive(result);
+                this.setMultiple(result);
                 this.validate();
             });
         }
@@ -173,7 +172,10 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
                             newChildData,
                             parentPath.concat([key, childKey])
                         );
+
+                        continue;
                     }
+                    result[key][childKey] = oldChildData;
                 }
 
                 continue;
@@ -300,10 +302,6 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
 
     setMultiple(data: Object) {
         this.resourceStore.setMultiple(data);
-    }
-
-    setMultipleRecursive(data: Object) {
-        this.resourceStore.setMultipleRecursive(data);
     }
 
     change(name: string, value: mixed) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
@@ -93,7 +93,7 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
 
         return this.resourceStore.requestData().then((data: Object) => {
             this.removeObsoleteData(this.schema, schema, this.data);
-            const result = this.calculateDifference(this.schema, schema, this.data, data);
+            const result = this.mergeData(this.schema, schema, this.data, data);
             this.setMultiple(result);
 
             this.schema = schema;
@@ -103,7 +103,7 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
         });
     };
 
-    calculateDifference(
+    mergeData(
         oldSchema: Schema,
         newSchema: Schema,
         oldData: Object,
@@ -121,7 +121,7 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
 
             if (newType === SECTION_TYPE && newItems &&
                 oldType === SECTION_TYPE && oldItems) {
-                result = this.calculateDifference(
+                result = this.mergeData(
                     oldItems,
                     newItems,
                     oldData,
@@ -156,7 +156,7 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
                         result[key] = [];
                     }
                     if (!(oldChildData.type in newTypes)) {
-                        result[key][childKey] = this.calculateDifference(
+                        result[key][childKey] = this.mergeData(
                             oldChildSchema,
                             newChildSchema,
                             oldChildData,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
@@ -193,10 +193,21 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
                         result[name] = [];
                     }
 
-                    if (Object.keys(resultChildData).length > 1) {
-                        if (resultChildData.type && !(resultChildData.type in remoteTypes)) {
-                            //set default type
-                            resultChildData.type = remoteDefaultType;
+                    if (Object.keys(resultChildData).length > 0) {
+                        if (!resultChildData?.type) {
+                            const {
+                                defaultType: remoteChildDefaultType,
+                                types: remoteChildTypes,
+                            } = remoteChildSchema;
+                            const localChildDataType = localChildData?.type;
+
+                            resultChildData.type = localChildDataType && remoteChildTypes &&
+                            localChildDataType in remoteChildTypes ?
+                                localChildData.type :
+                                remoteChildData?.type || remoteChildDefaultType;
+                        }
+                        if (resultChildData.settings) {
+                            resultChildData.settings = localChildData?.settings || remoteChildData.settings;
                         }
 
                         result[name][key] = resultChildData;
@@ -208,13 +219,6 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
 
             if (!localData[name] && remoteData[name]) {
                 result[name] = remoteData[name];
-                if (remoteData.type) {
-                    result.type = remoteData.type;
-                }
-
-                if (remoteData.settings) {
-                    result.settings = localData?.settings || remoteData.settings;
-                }
             }
 
             if (localData[name] && remoteSchema[name].type !== localSchema[name]?.type) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
@@ -14,7 +14,7 @@ jest.mock('../../../../stores/ResourceStore', () => function(resourceKey, id, op
     this.resourceKey = resourceKey;
     this.save = jest.fn().mockReturnValue(Promise.resolve());
     this.delete = jest.fn().mockReturnValue(Promise.resolve());
-    this.loadData = jest.fn().mockReturnValue(Promise.resolve());
+    this.requestData = jest.fn().mockReturnValue(Promise.resolve());
     this.set = jest.fn();
     this.setMultiple = jest.fn(function(data) {
         Object.assign(this.data, data);
@@ -711,7 +711,7 @@ test('Change schema back to originSchema should merge current and origin data', 
     };
 
     // $FlowFixMe
-    resourceStore.loadData.mockReturnValue(Promise.resolve(originData));
+    resourceStore.requestData.mockReturnValue(Promise.resolve(originData));
     metadataStore.getSchema.mockReturnValue(newSchemaPromise);
     metadataStore.getJsonSchema.mockReturnValue(jsonSchemaPromise);
     const resourceFormStore = new ResourceFormStore(resourceStore, 'pages');
@@ -819,7 +819,7 @@ test('Change schema back to originSchema should merge current and origin data pa
     };
 
     // $FlowFixMe
-    resourceStore.loadData.mockReturnValue(Promise.resolve(originData));
+    resourceStore.requestData.mockReturnValue(Promise.resolve(originData));
     metadataStore.getSchema.mockReturnValue(newSchemaPromise);
     metadataStore.getJsonSchema.mockReturnValue(jsonSchemaPromise);
     const resourceFormStore = new ResourceFormStore(resourceStore, 'pages');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
@@ -726,22 +726,10 @@ test('Change schema back to originSchema should merge current and origin data', 
             {
                 description: 'Origin Description',
                 blocks: [
-                    {
-                        title: 'block1_title',
-                        type: 'headline',
-                    },
-                    {
-                        title: 'block2_title',
-                        type: 'headline',
-                    },
-                    {
-                        description: 'block3_description',
-                        type: 'description',
-                    },
-                    {
-                        description: 'block4_description',
-                        type: 'description',
-                    },
+                    {title: 'block1_title', type: 'headline'},
+                    {title: 'block2_title', type: 'headline'},
+                    {description: 'block3_description', type: 'description'},
+                    {description: 'block4_description', type: 'description'},
                 ],
             }
         );
@@ -852,14 +840,8 @@ test('Change schema back to originSchema should merge current and origin data pa
                 blocks: [
                     undefined,
                     undefined,
-                    {
-                        description: 'block3_description_origin',
-                        type: 'description',
-                    },
-                    {
-                        description: 'block4_description_origin',
-                        type: 'description',
-                    },
+                    {description: 'block3_description_origin', type: 'description'},
+                    {description: 'block4_description_origin', type: 'description'},
                 ],
             }
         );
@@ -1082,8 +1064,14 @@ test('Change schema back to originSchema should merge current and origin data pa
                     {
                         type: 'block_in_block',
                         inlineBlock: [
-                            {title: 'block_in_block1_title', description: 'block_in_block1_description', type: 'headline'},
-                            {title: 'block_in_block2_title', description: 'block_in_block2_description', type: 'headline'},
+                            {
+                                title: 'block_in_block1_title',
+                                description: 'block_in_block1_description', type: 'headline',
+                            },
+                            {
+                                title: 'block_in_block2_title',
+                                description: 'block_in_block2_description', type: 'headline',
+                            },
                             {text: 'block_in_block3_text', type: 'textBlock'},
                             {text: 'block_in_block4_text', type: 'textBlock'},
                         ],

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
@@ -14,11 +14,13 @@ jest.mock('../../../../stores/ResourceStore', () => function(resourceKey, id, op
     this.resourceKey = resourceKey;
     this.save = jest.fn().mockReturnValue(Promise.resolve());
     this.delete = jest.fn().mockReturnValue(Promise.resolve());
+    this.loadData = jest.fn().mockReturnValue(Promise.resolve());
     this.set = jest.fn();
     this.setMultiple = jest.fn(function(data) {
         Object.assign(this.data, data);
     });
     this.change = jest.fn();
+    this.remove = jest.fn();
     this.copyFromLocale = jest.fn();
     this.data = mockObservable({});
     this.loading = false;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
@@ -573,10 +573,7 @@ test('Change schema should update data and use default-type for unknown block ty
         expect(toJS(resourceFormStore.type)).toEqual('default');
         expect(resourceFormStore.schema).toEqual(newSchema);
         expect(resourceStore.setMultiple).toHaveBeenCalledWith({
-            'blocks': [
-                {'description': undefined, 'type': 'description'},
-                {'description': undefined, 'type': 'description'},
-            ],
+            'blocks': [],
         });
         resourceFormStore.destroy();
         done();
@@ -771,8 +768,8 @@ test('Change schema should merge current and origin data partially in block', (d
         expect(resourceStore.setMultiple).toHaveBeenCalledWith( {
             description: 'Origin Description',
             blocks: [
-                {title: 'block1_title', type: 'headline'},
-                {title: 'block2_title', type: 'headline'},
+                undefined,
+                undefined,
                 {description: 'block3_description_origin', type: 'description'},
                 {description: 'block4_description_origin', type: 'description'},
             ],
@@ -995,7 +992,7 @@ test('Change schema should merge current and origin data partially block in bloc
         expect(resourceFormStore.schema).toEqual(newSchema);
         expect(resourceStore.setMultiple).toHaveBeenCalledWith( {
             blocks: [
-                {title: 'block1_title', description: 'block1_description', type: 'headline'},
+                undefined,
                 {title: 'block2_title_remote', description: 'block2_description_remote', type: 'headline'},
                 {text: 'block3_text_remote', type: 'textEditor'},
                 {text: 'block4_text_remote', type: 'textEditor'},

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
@@ -458,20 +458,18 @@ test('Change schema should update data and use remoteData for invalid blocks', (
         expect(toJS(resourceFormStore.type)).toEqual('default');
         expect(resourceFormStore.schema).toEqual(newSchema);
         expect(resourceStore.setMultiple).toHaveBeenCalledWith({
+            title: 'Title',
             blocks: [
                 {text: 'block1_text_remote', type: 'textEditor'},
                 {text: 'block2_text_remote', type: 'textEditor'},
+                {text: 'block3_text', type: 'textEditor'},
+                {text: 'block4_text', type: 'textEditor'},
                 {
                     type: 'block_in_block',
                     inlineBlock: [
                         {
-                            title: 'block_in_block1_title_remote',
                             description: 'block_in_block1_description',
-                            type: 'headline',
-                        },
-                        {
-                            title: 'block_in_block2_title_remote',
-                            description: 'block_in_block2_description',
+                            title: 'block_in_block1_title',
                             type: 'headline',
                         },
                         {text: 'block_in_block3_text', type: 'textBlock'},
@@ -573,7 +571,17 @@ test('Change schema should update data and use default-type for unknown block ty
         expect(toJS(resourceFormStore.type)).toEqual('default');
         expect(resourceFormStore.schema).toEqual(newSchema);
         expect(resourceStore.setMultiple).toHaveBeenCalledWith({
-            'blocks': [],
+            title: 'Title',
+            blocks: [
+                {
+                    description: undefined,
+                    type: 'description',
+                },
+                {
+                    description: undefined,
+                    type: 'description',
+                },
+            ],
         });
         resourceFormStore.destroy();
         done();
@@ -656,6 +664,7 @@ test('Change schema should merge locale and remote data', (done) => {
         expect(resourceFormStore.schema).toEqual(newSchema);
         expect(resourceStore.setMultiple).toHaveBeenNthCalledWith(1,
             {
+                title: 'Title',
                 description: 'Origin Description',
                 blocks: [
                     {title: 'block1_title', type: 'headline'},
@@ -747,8 +756,8 @@ test('Change schema should merge current and origin data partially in block', (d
         title: 'Title',
         description: 'Origin Description',
         blocks: [
-            {title: 'block1_title_origin', type: 'headline'},
-            {title: 'block2_title_origin', type: 'headline'},
+            {title: 'block1_title', type: 'headline'},
+            {title: 'block2_title', type: 'headline'},
             {description: 'block3_description_origin', type: 'description'},
             {description: 'block4_description_origin', type: 'description'},
         ],
@@ -766,10 +775,11 @@ test('Change schema should merge current and origin data partially in block', (d
         expect(toJS(resourceFormStore.type)).toEqual('default');
         expect(resourceFormStore.schema).toEqual(newSchema);
         expect(resourceStore.setMultiple).toHaveBeenCalledWith( {
+            title: 'Title',
             description: 'Origin Description',
             blocks: [
-                undefined,
-                undefined,
+                {title: 'block1_title', type: 'headline'},
+                {title: 'block2_title', type: 'headline'},
                 {description: 'block3_description_origin', type: 'description'},
                 {description: 'block4_description_origin', type: 'description'},
             ],
@@ -991,10 +1001,17 @@ test('Change schema should merge current and origin data partially block in bloc
         expect(toJS(resourceFormStore.type)).toEqual('default');
         expect(resourceFormStore.schema).toEqual(newSchema);
         expect(resourceStore.setMultiple).toHaveBeenCalledWith( {
+            description: undefined,
+            title: 'Title',
             blocks: [
-                undefined,
-                {title: 'block2_title_remote', description: 'block2_description_remote', type: 'headline'},
-                {text: 'block3_text_remote', type: 'textEditor'},
+                {title: 'block1_title', description: 'block1_description', type: 'headline'},
+                {text: 'block4_text', type: 'textEditor'},
+                {
+                    type: 'block_in_block',
+                    inlineBlock: [
+                        {text: 'block_in_block4_text', type: 'textBlock'},
+                    ],
+                },
                 {text: 'block4_text_remote', type: 'textEditor'},
                 {
                     type: 'block_in_block',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
@@ -19,7 +19,6 @@ jest.mock('../../../../stores/ResourceStore', () => function(resourceKey, id, op
     this.setMultiple = jest.fn(function(data) {
         Object.assign(this.data, data);
     });
-    this.setMultipleRecursive = jest.fn();
     this.change = jest.fn();
     this.remove = jest.fn();
     this.copyFromLocale = jest.fn();
@@ -722,7 +721,7 @@ test('Change schema back to originSchema should merge current and origin data', 
     setTimeout(() => {
         expect(toJS(resourceFormStore.type)).toEqual('default');
         expect(resourceFormStore.schema).toEqual(newSchema);
-        expect(resourceStore.setMultipleRecursive).toHaveBeenNthCalledWith(1,
+        expect(resourceStore.setMultiple).toHaveBeenNthCalledWith(1,
             {
                 description: 'Origin Description',
                 blocks: [
@@ -834,12 +833,12 @@ test('Change schema back to originSchema should merge current and origin data pa
     setTimeout(() => {
         expect(toJS(resourceFormStore.type)).toEqual('default');
         expect(resourceFormStore.schema).toEqual(newSchema);
-        expect(resourceStore.setMultipleRecursive).toHaveBeenNthCalledWith(1,
+        expect(resourceStore.setMultiple).toHaveBeenNthCalledWith(1,
             {
                 description: 'Origin Description',
                 blocks: [
-                    undefined,
-                    undefined,
+                    {title: 'block1_title', type: 'headline'},
+                    {title: 'block2_title', type: 'headline'},
                     {description: 'block3_description_origin', type: 'description'},
                     {description: 'block4_description_origin', type: 'description'},
                 ],
@@ -1054,23 +1053,30 @@ test('Change schema back to originSchema should merge current and origin data pa
     setTimeout(() => {
         expect(toJS(resourceFormStore.type)).toEqual('default');
         expect(resourceFormStore.schema).toEqual(newSchema);
-        expect(resourceStore.setMultipleRecursive).toHaveBeenNthCalledWith(1,
+        expect(resourceStore.setMultiple).toHaveBeenNthCalledWith(1,
             {
                 blocks: [
-                    undefined,
-                    undefined,
-                    undefined,
+                    {title: 'block1_title', description: 'block1_description', type: 'headline'},
+                    {text: 'block4_text', type: 'textEditor'},
+                    {
+                        type: 'block_in_block',
+                        inlineBlock: [
+                            {text: 'block_in_block4_text', type: 'textBlock'},
+                        ],
+                    },
                     {text: 'block4_text', type: 'textEditor'},
                     {
                         type: 'block_in_block',
                         inlineBlock: [
                             {
                                 title: 'block_in_block1_title',
-                                description: 'block_in_block1_description', type: 'headline',
+                                description: 'block_in_block1_description',
+                                type: 'headline',
                             },
                             {
                                 title: 'block_in_block2_title',
-                                description: 'block_in_block2_description', type: 'headline',
+                                description: 'block_in_block2_description',
+                                type: 'headline',
                             },
                             {text: 'block_in_block3_text', type: 'textBlock'},
                             {text: 'block_in_block4_text', type: 'textBlock'},

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
@@ -300,6 +300,13 @@ test('Change schema should update data and remove obsolete data', (done) => {
 
     const resourceStore = new ResourceStore('pages', '1');
 
+    const originData = {
+        title: 'Title',
+        description: 'Description',
+    };
+
+    // $FlowFixMe
+    resourceStore.requestData.mockReturnValue(Promise.resolve(originData));
     metadataStore.getSchema.mockReturnValue(newSchemaPromise);
     metadataStore.getJsonSchema.mockReturnValue(jsonSchemaPromise);
     const resourceFormStore = new ResourceFormStore(resourceStore, 'pages');
@@ -374,6 +381,12 @@ test('Change schema should update data and remove obsolete data with blocks', (d
         ],
     });
 
+    const originData = {
+        title: 'Title',
+    };
+
+    // $FlowFixMe
+    resourceStore.requestData.mockReturnValue(Promise.resolve(originData));
     metadataStore.getSchema.mockReturnValue(newSchemaPromise);
     metadataStore.getJsonSchema.mockReturnValue(jsonSchemaPromise);
     const resourceFormStore = new ResourceFormStore(resourceStore, 'pages');
@@ -535,6 +548,16 @@ test('Change schema should update data and remove obsolete data with blocks in b
         ],
     });
 
+    const originData = {
+        title: 'Title',
+        blocks: [
+            {text: 'block1_text', type: 'textEditor'},
+            {text: 'block2_text', type: 'textEditor'},
+        ],
+    };
+
+    // $FlowFixMe
+    resourceStore.requestData.mockReturnValue(Promise.resolve(originData));
     metadataStore.getSchema.mockReturnValue(newSchemaPromise);
     metadataStore.getJsonSchema.mockReturnValue(jsonSchemaPromise);
     const resourceFormStore = new ResourceFormStore(resourceStore, 'pages');
@@ -626,6 +649,16 @@ test('Change schema should update data and use default-type for unknown block ty
         ],
     });
 
+    const originData = {
+        title: 'Title',
+        blocks: [
+            {title: 'block1_description', type: 'description'},
+            {title: 'block2_description', type: 'description'},
+        ],
+    };
+
+    // $FlowFixMe
+    resourceStore.requestData.mockReturnValue(Promise.resolve(originData));
     metadataStore.getSchema.mockReturnValue(newSchemaPromise);
     metadataStore.getJsonSchema.mockReturnValue(jsonSchemaPromise);
     const resourceFormStore = new ResourceFormStore(resourceStore, 'pages');
@@ -642,7 +675,7 @@ test('Change schema should update data and use default-type for unknown block ty
     }, 0);
 });
 
-test('Change schema back to originSchema should merge current and origin data', (done) => {
+test('Change schema should merge current and origin data', (done) => {
     const newSchema = {
         title: {
             label: 'Title',
@@ -696,7 +729,6 @@ test('Change schema back to originSchema should merge current and origin data', 
             {title: 'block1_title', type: 'headline'},
             {title: 'block2_title', type: 'headline'},
         ],
-        originTemplate: 'default',
     });
 
     const originData = {
@@ -737,7 +769,7 @@ test('Change schema back to originSchema should merge current and origin data', 
     }, 0);
 });
 
-test('Change schema back to originSchema should merge current and origin data partially in block', (done) => {
+test('Change schema should merge current and origin data partially in block', (done) => {
     const oldSchema = {
         title: {
             label: 'Title',
@@ -808,7 +840,6 @@ test('Change schema back to originSchema should merge current and origin data pa
             {title: 'block1_title', type: 'headline'},
             {title: 'block2_title', type: 'headline'},
         ],
-        originTemplate: 'default',
     });
 
     const originData = {
@@ -849,7 +880,7 @@ test('Change schema back to originSchema should merge current and origin data pa
     }, 0);
 });
 
-test('Change schema back to originSchema should merge current and origin data partially block in blocks', (done) => {
+test('Change schema should merge current and origin data partially block in blocks', (done) => {
     const oldSchema = {
         title: {
             label: 'Title',
@@ -1009,7 +1040,6 @@ test('Change schema back to originSchema should merge current and origin data pa
 
     const resourceStore = new ResourceStore('pages', '1');
     resourceStore.data = observable({
-        originTemplate: 'default',
         title: 'Title',
         blocks: [
             {title: 'block1_title', description: 'block1_description', type: 'headline'},

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
@@ -277,6 +277,277 @@ test('Change type should update schema and data', (done) => {
     }, 0);
 });
 
+test('Change schema should update data and remove obsolete data', (done) => {
+    const oldSchema = {
+        title: {
+            label: 'Title',
+            type: 'text_line',
+        },
+        description: {
+            label: 'Description',
+            type: 'text_line',
+        },
+    };
+
+    const newSchema = {
+        title: {
+            label: 'Title',
+            type: 'text_line',
+        },
+    };
+    const newSchemaPromise = Promise.resolve(newSchema);
+    const jsonSchemaPromise = Promise.resolve({});
+
+    const resourceStore = new ResourceStore('pages', '1');
+
+    metadataStore.getSchema.mockReturnValue(newSchemaPromise);
+    metadataStore.getJsonSchema.mockReturnValue(jsonSchemaPromise);
+    const resourceFormStore = new ResourceFormStore(resourceStore, 'pages');
+    resourceFormStore.type = observable.box('default');
+    resourceFormStore.schema = oldSchema;
+
+    setTimeout(() => {
+        expect(toJS(resourceFormStore.type)).toEqual('default');
+        expect(resourceFormStore.schema).toEqual(newSchema);
+        expect(resourceStore.remove).toBeCalledWith('description');
+        resourceFormStore.destroy();
+        done();
+    }, 0);
+});
+
+test('Change schema should update data and remove obsolete data with blocks', (done) => {
+    const oldSchema = {
+        title: {
+            label: 'Title',
+            type: 'text_line',
+        },
+        description: {
+            label: 'Description',
+            type: 'text_line',
+        },
+        blocks: {
+            defaultType: 'headline',
+            type: 'block',
+            types: {
+                headline: {
+                    name: 'headline',
+                    title: 'Headline',
+                    form: {
+                        title: {
+                            label: 'Title',
+                            type: 'text_line',
+                        },
+                    },
+                },
+                description: {
+                    name: 'description',
+                    title: 'Description',
+                    form: {
+                        description: {
+                            label: 'Description',
+                            type: 'text_area',
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    const newSchema = {
+        title: {
+            label: 'Title',
+            type: 'text_line',
+        },
+    };
+    const newSchemaPromise = Promise.resolve(newSchema);
+    const jsonSchemaPromise = Promise.resolve({});
+
+    const resourceStore = new ResourceStore('pages', '1');
+
+    metadataStore.getSchema.mockReturnValue(newSchemaPromise);
+    metadataStore.getJsonSchema.mockReturnValue(jsonSchemaPromise);
+    const resourceFormStore = new ResourceFormStore(resourceStore, 'pages');
+    resourceFormStore.type = observable.box('default');
+    resourceFormStore.schema = oldSchema;
+
+    setTimeout(() => {
+        expect(toJS(resourceFormStore.type)).toEqual('default');
+        expect(resourceFormStore.schema).toEqual(newSchema);
+        expect(resourceStore.remove).toBeCalledWith('description');
+        expect(resourceStore.remove).toBeCalledWith('blocks');
+        resourceFormStore.destroy();
+        done();
+    }, 0);
+});
+
+test('Change schema should update data and remove obsolete data with blocks in blocks', (done) => {
+    const oldSchema = {
+        title: {
+            label: 'Title',
+            type: 'text_line',
+        },
+        description: {
+            label: 'Description',
+            type: 'text_line',
+        },
+        blocks: {
+            defaultType: 'headline',
+            type: 'block',
+            types: {
+                headline: {
+                    name: 'headline',
+                    title: 'Headline',
+                    form: {
+                        title: {
+                            label: 'Title',
+                            type: 'text_line',
+                        },
+                        description: {
+                            label: 'Description',
+                            type: 'text_area',
+                        },
+                    },
+                },
+                textEditor: {
+                    name: 'textEditor',
+                    title: 'Text Editor',
+                    form: {
+                        text: {
+                            label: 'Text',
+                            type: 'text_editor',
+                        },
+                    },
+                },
+                block_in_block: {
+                    name: 'block_in_block',
+                    title: 'Block in Block',
+                    form: {
+                        inlineBlock: {
+                            defaultType: 'headline',
+                            type: 'block',
+                            types: {
+                                headline: {
+                                    name: 'headline',
+                                    title: 'Headline',
+                                    form: {
+                                        title: {
+                                            label: 'Title',
+                                            type: 'text_line',
+                                        },
+                                        description: {
+                                            label: 'Description',
+                                            type: 'text_area',
+                                        },
+                                    },
+                                },
+                                textBlock: {
+                                    name: 'textBlock',
+                                    title: 'Text Block',
+                                    form: {
+                                        text: {
+                                            label: 'Text',
+                                            type: 'text_editor',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    const newSchema = {
+        title: {
+            label: 'Title',
+            type: 'text_line',
+        },
+        blocks: {
+            defaultType: 'textEditor',
+            type: 'block',
+            types: {
+                textEditor: {
+                    name: 'textEditor',
+                    title: 'Text Editor',
+                    form: {
+                        text: {
+                            label: 'Text',
+                            type: 'text_editor',
+                        },
+                    },
+                },
+                block_in_block: {
+                    name: 'block_in_block',
+                    title: 'Block in Block',
+                    form: {
+                        inlineBlock: {
+                            defaultType: 'textBlock',
+                            type: 'block',
+                            types: {
+                                textBlock: {
+                                    name: 'textBlock',
+                                    title: 'Text Block',
+                                    form: {
+                                        text: {
+                                            label: 'Text',
+                                            type: 'text_editor',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    };
+    const newSchemaPromise = Promise.resolve(newSchema);
+    const jsonSchemaPromise = Promise.resolve({});
+
+    const resourceStore = new ResourceStore('pages', '1');
+    resourceStore.data = observable({
+        title: 'Title',
+        blocks: [
+            {title: 'block1_title', description: 'block1_description', type: 'headline'},
+            {title: 'block2_title', description: 'block2_description', type: 'headline'},
+            {text: 'block3_text', type: 'textEditor'},
+            {text: 'block4_text', type: 'textEditor'},
+            {
+                type: 'block_in_block',
+                inlineBlock: [
+                    {title: 'block_in_block1_title', description: 'block_in_block1_description', type: 'headline'},
+                    {title: 'block_in_block2_title', description: 'block_in_block2_description', type: 'headline'},
+                    {text: 'block_in_block3_text', type: 'textBlock'},
+                    {text: 'block_in_block4_text', type: 'textBlock'},
+                ],
+            },
+        ],
+    });
+
+    metadataStore.getSchema.mockReturnValue(newSchemaPromise);
+    metadataStore.getJsonSchema.mockReturnValue(jsonSchemaPromise);
+    const resourceFormStore = new ResourceFormStore(resourceStore, 'pages');
+    resourceFormStore.type = observable.box('default');
+    resourceFormStore.schema = oldSchema;
+
+    setTimeout(() => {
+        expect(toJS(resourceFormStore.type)).toEqual('default');
+        expect(resourceFormStore.schema).toEqual(newSchema);
+        expect(resourceStore.remove).toHaveBeenNthCalledWith(1, 'description');
+        expect(resourceStore.remove).toHaveBeenNthCalledWith(2, 'blocks/0/title');
+        expect(resourceStore.remove).toHaveBeenNthCalledWith(3, 'blocks/0/description');
+        expect(resourceStore.remove).toHaveBeenNthCalledWith(4, 'blocks/1/title');
+        expect(resourceStore.remove).toHaveBeenNthCalledWith(5, 'blocks/1/description');
+        expect(resourceStore.remove).toHaveBeenNthCalledWith(6, 'blocks/4/inlineBlock/0/title');
+        expect(resourceStore.remove).toHaveBeenNthCalledWith(7, 'blocks/4/inlineBlock/0/description');
+        expect(resourceStore.remove).toHaveBeenNthCalledWith(8, 'blocks/4/inlineBlock/1/title');
+        expect(resourceStore.remove).toHaveBeenNthCalledWith(9, 'blocks/4/inlineBlock/1/description');
+        resourceFormStore.destroy();
+        done();
+    }, 0);
+});
+
 test('Change type should throw an error if no types are available', () => {
     const promise = Promise.resolve({});
     metadataStore.getSchema.mockReturnValue(promise);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
@@ -19,6 +19,7 @@ jest.mock('../../../../stores/ResourceStore', () => function(resourceKey, id, op
     this.setMultiple = jest.fn(function(data) {
         Object.assign(this.data, data);
     });
+    this.setMultipleRecursive = jest.fn();
     this.change = jest.fn();
     this.remove = jest.fn();
     this.copyFromLocale = jest.fn();
@@ -721,13 +722,29 @@ test('Change schema back to originSchema should merge current and origin data', 
     setTimeout(() => {
         expect(toJS(resourceFormStore.type)).toEqual('default');
         expect(resourceFormStore.schema).toEqual(newSchema);
-        expect(resourceStore.change).toHaveBeenNthCalledWith(1, 'description', 'Origin Description');
-        expect(resourceStore.change).toHaveBeenNthCalledWith(2, 'blocks', [
-            {title: 'block1_title', type: 'headline'},
-            {title: 'block2_title', type: 'headline'},
-            {description: 'block3_description', type: 'description'},
-            {description: 'block4_description', type: 'description'},
-        ]);
+        expect(resourceStore.setMultipleRecursive).toHaveBeenNthCalledWith(1,
+            {
+                description: 'Origin Description',
+                blocks: [
+                    {
+                        title: 'block1_title',
+                        type: 'headline',
+                    },
+                    {
+                        title: 'block2_title',
+                        type: 'headline',
+                    },
+                    {
+                        description: 'block3_description',
+                        type: 'description',
+                    },
+                    {
+                        description: 'block4_description',
+                        type: 'description',
+                    },
+                ],
+            }
+        );
         resourceFormStore.destroy();
         done();
     }, 0);
@@ -829,12 +846,251 @@ test('Change schema back to originSchema should merge current and origin data pa
     setTimeout(() => {
         expect(toJS(resourceFormStore.type)).toEqual('default');
         expect(resourceFormStore.schema).toEqual(newSchema);
-        expect(resourceStore.change).toHaveBeenNthCalledWith(1,
-            'description', 'Origin Description');
-        expect(resourceStore.change).toHaveBeenNthCalledWith(2,
-            'blocks/2', {description: 'block3_description_origin', type: 'description'});
-        expect(resourceStore.change).toHaveBeenNthCalledWith(3,
-            'blocks/3', {description: 'block4_description_origin', type: 'description'});
+        expect(resourceStore.setMultipleRecursive).toHaveBeenNthCalledWith(1,
+            {
+                description: 'Origin Description',
+                blocks: [
+                    undefined,
+                    undefined,
+                    {
+                        description: 'block3_description_origin',
+                        type: 'description',
+                    },
+                    {
+                        description: 'block4_description_origin',
+                        type: 'description',
+                    },
+                ],
+            }
+        );
+        resourceFormStore.destroy();
+        done();
+    }, 0);
+});
+
+test('Change schema back to originSchema should merge current and origin data partially block in blocks', (done) => {
+    const oldSchema = {
+        title: {
+            label: 'Title',
+            type: 'text_line',
+        },
+        description: {
+            label: 'Description',
+            type: 'text_line',
+        },
+        blocks: {
+            defaultType: 'headline',
+            type: 'block',
+            types: {
+                headline: {
+                    name: 'headline',
+                    title: 'Headline',
+                    form: {
+                        title: {
+                            label: 'Title',
+                            type: 'text_line',
+                        },
+                        description: {
+                            label: 'Description',
+                            type: 'text_area',
+                        },
+                    },
+                },
+                textEditor: {
+                    name: 'textEditor',
+                    title: 'Text Editor',
+                    form: {
+                        text: {
+                            label: 'Text',
+                            type: 'text_editor',
+                        },
+                    },
+                },
+                block_in_block: {
+                    name: 'block_in_block',
+                    title: 'Block in Block',
+                    form: {
+                        inlineBlock: {
+                            defaultType: 'headline',
+                            type: 'block',
+                            types: {
+                                headline: {
+                                    name: 'headline',
+                                    title: 'Headline',
+                                    form: {
+                                        title: {
+                                            label: 'Title',
+                                            type: 'text_line',
+                                        },
+                                        description: {
+                                            label: 'Description',
+                                            type: 'text_area',
+                                        },
+                                    },
+                                },
+                                textBlock: {
+                                    name: 'textBlock',
+                                    title: 'Text Block',
+                                    form: {
+                                        text: {
+                                            label: 'Text',
+                                            type: 'text_editor',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    const newSchema = {
+        title: {
+            label: 'Title',
+            type: 'text_line',
+        },
+        description: {
+            label: 'Description',
+            type: 'text_line',
+        },
+        blocks: {
+            defaultType: 'headline',
+            type: 'block',
+            types: {
+                headline: {
+                    name: 'headline',
+                    title: 'Headline',
+                    form: {
+                        title: {
+                            label: 'Title',
+                            type: 'text_line',
+                        },
+                        description: {
+                            label: 'Description',
+                            type: 'text_area',
+                        },
+                    },
+                },
+                textEditor: {
+                    name: 'textEditor',
+                    title: 'Text Editor',
+                    form: {
+                        text: {
+                            label: 'Text',
+                            type: 'text_editor',
+                        },
+                    },
+                },
+                block_in_block: {
+                    name: 'block_in_block',
+                    title: 'Block in Block',
+                    form: {
+                        inlineBlock: {
+                            defaultType: 'headline',
+                            type: 'block',
+                            types: {
+                                headline: {
+                                    name: 'headline',
+                                    title: 'Headline',
+                                    form: {
+                                        title: {
+                                            label: 'Title',
+                                            type: 'text_line',
+                                        },
+                                        description: {
+                                            label: 'Description',
+                                            type: 'text_area',
+                                        },
+                                    },
+                                },
+                                textBlock: {
+                                    name: 'textBlock',
+                                    title: 'Text Block',
+                                    form: {
+                                        text: {
+                                            label: 'Text',
+                                            type: 'text_editor',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    const newSchemaPromise = Promise.resolve(newSchema);
+    const jsonSchemaPromise = Promise.resolve({});
+
+    const resourceStore = new ResourceStore('pages', '1');
+    resourceStore.data = observable({
+        originTemplate: 'default',
+        title: 'Title',
+        blocks: [
+            {title: 'block1_title', description: 'block1_description', type: 'headline'},
+            {text: 'block4_text', type: 'textEditor'},
+            {
+                type: 'block_in_block',
+                inlineBlock: [
+                    {text: 'block_in_block4_text', type: 'textBlock'},
+                ],
+            },
+        ],
+    });
+
+    const originData = {
+        title: 'Title',
+        blocks: [
+            {title: 'block1_title', description: 'block1_description', type: 'headline'},
+            {title: 'block2_title', description: 'block2_description', type: 'headline'},
+            {text: 'block3_text', type: 'textEditor'},
+            {text: 'block4_text', type: 'textEditor'},
+            {
+                type: 'block_in_block',
+                inlineBlock: [
+                    {title: 'block_in_block1_title', description: 'block_in_block1_description', type: 'headline'},
+                    {title: 'block_in_block2_title', description: 'block_in_block2_description', type: 'headline'},
+                    {text: 'block_in_block3_text', type: 'textBlock'},
+                    {text: 'block_in_block4_text', type: 'textBlock'},
+                ],
+            },
+        ],
+    };
+
+    // $FlowFixMe
+    resourceStore.requestData.mockReturnValue(Promise.resolve(originData));
+    metadataStore.getSchema.mockReturnValue(newSchemaPromise);
+    metadataStore.getJsonSchema.mockReturnValue(jsonSchemaPromise);
+    const resourceFormStore = new ResourceFormStore(resourceStore, 'pages');
+    resourceFormStore.type = observable.box('default');
+    resourceFormStore.schema = oldSchema;
+
+    setTimeout(() => {
+        expect(toJS(resourceFormStore.type)).toEqual('default');
+        expect(resourceFormStore.schema).toEqual(newSchema);
+        expect(resourceStore.setMultipleRecursive).toHaveBeenNthCalledWith(1,
+            {
+                blocks: [
+                    undefined,
+                    undefined,
+                    undefined,
+                    {text: 'block4_text', type: 'textEditor'},
+                    {
+                        type: 'block_in_block',
+                        inlineBlock: [
+                            {title: 'block_in_block1_title', description: 'block_in_block1_description', type: 'headline'},
+                            {title: 'block_in_block2_title', description: 'block_in_block2_description', type: 'headline'},
+                            {text: 'block_in_block3_text', type: 'textBlock'},
+                            {text: 'block_in_block4_text', type: 'textBlock'},
+                        ],
+                    },
+                ],
+            }
+        );
         resourceFormStore.destroy();
         done();
     }, 0);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
@@ -1,5 +1,5 @@
 // @flow
-import {action, autorun, isArrayLike, observable, set, toJS, when} from 'mobx';
+import {action, autorun, observable, set, toJS, when} from 'mobx';
 import log from 'loglevel';
 import jsonpointer from 'json-pointer';
 import ResourceRequester from '../../services/ResourceRequester';
@@ -292,31 +292,6 @@ export default class ResourceStore {
             'ResourceStore changed "' + this.resourceKey + '" data with the ID "' + (this.id || 'undefined') + '"',
             this.data
         );
-    }
-
-    @action setMultipleRecursive(data: Object, parentPath: string = '') {
-        if (data.id) {
-            this.id = data.id;
-        }
-
-        Object.keys(data).forEach((path) => {
-            if (isArrayLike(data[path])) {
-                this.setMultipleRecursive(data[path], parentPath + path);
-
-                return;
-            }
-
-            const absolutePath = (parentPath ? parentPath + '/' : '') + path;
-            this.set(absolutePath, data[path]);
-        });
-        set(this.data, this.data);
-
-        if (parentPath === '') {
-            log.info(
-                'ResourceStore changed "' + this.resourceKey + '" data with the ID "' + (this.id || 'undefined') + '"',
-                this.data
-            );
-        }
     }
 
     @action change(path: string, value: mixed) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
@@ -67,7 +67,7 @@ export default class ResourceStore {
         this.setLoading(true);
         this.setForbidden(false);
 
-        this.requestData()
+        this.requestRemoteData()
             .then(action((response: Object) => {
                 if (this.idQueryParameter) {
                     this.handleIdQueryParameterResponse(response);
@@ -87,7 +87,7 @@ export default class ResourceStore {
             }));
     };
 
-    requestData = () => {
+    requestRemoteData = (options: Object = {}) => {
         const {
             id,
             observableOptions: {
@@ -95,7 +95,6 @@ export default class ResourceStore {
             },
         } = this;
 
-        const options = {};
         if (locale) {
             options.locale = locale.get();
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
@@ -67,7 +67,7 @@ export default class ResourceStore {
         this.setLoading(true);
         this.setForbidden(false);
 
-        this.loadData()
+        this.requestData()
             .then(action((response: Object) => {
                 if (this.idQueryParameter) {
                     this.handleIdQueryParameterResponse(response);
@@ -87,7 +87,7 @@ export default class ResourceStore {
             }));
     };
 
-    loadData = () => {
+    requestData = () => {
         const {
             id,
             observableOptions: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
@@ -264,11 +264,6 @@ export default class ResourceStore {
             }));
     }
 
-    @action remove(path: string) {
-        jsonpointer.remove(this.data, '/' + path);
-        this.dirty = true;
-    }
-
     @action set(path: string, value: mixed) {
         if (path === 'id' && (typeof value === 'string' || typeof value === 'number')) {
             this.id = value;

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
@@ -137,9 +137,9 @@ class Preview extends React.Component<Props> {
         );
 
         this.typeDisposer = reaction(
-            () => toJS(formStore.type),
-            (type) => {
-                previewStore.updateContext(type, formStore.data).then(this.setContent);
+            () => toJS(formStore.schema),
+            () => {
+                previewStore.updateContext(formStore.type, formStore.data).then(this.setContent);
             }
         );
     };

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
@@ -42,7 +42,7 @@ class Preview extends React.Component<Props> {
     @observable webspaceOptions: Array<Object> = [];
     @observable reloadCounter: number = 0;
 
-    typeDisposer: () => mixed;
+    schemaDisposer: () => mixed;
     dataDisposer: () => mixed;
 
     @computed get webspaceKey() {
@@ -136,7 +136,7 @@ class Preview extends React.Component<Props> {
             }
         );
 
-        this.typeDisposer = reaction(
+        this.schemaDisposer = reaction(
             () => toJS(formStore.schema),
             () => {
                 previewStore.updateContext(toJS(formStore.type), toJS(formStore.data)).then(this.setContent);
@@ -162,8 +162,8 @@ class Preview extends React.Component<Props> {
     };
 
     componentWillUnmount() {
-        if (this.typeDisposer) {
-            this.typeDisposer();
+        if (this.schemaDisposer) {
+            this.schemaDisposer();
         }
 
         if (this.dataDisposer) {

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
@@ -139,7 +139,7 @@ class Preview extends React.Component<Props> {
         this.typeDisposer = reaction(
             () => toJS(formStore.schema),
             () => {
-                previewStore.updateContext(formStore.type, formStore.data).then(this.setContent);
+                previewStore.updateContext(toJS(formStore.type), toJS(formStore.data)).then(this.setContent);
             }
         );
     };

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/Preview.test.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/Preview.test.js
@@ -449,7 +449,7 @@ test('Dont react or update preview when data is changed during preview-store is 
     });
 });
 
-test('React and update-context when type is changed', () => {
+test('React and update-context when schema is changed', () => {
     const resourceStore = new ResourceStore('pages', 1);
     const formStore = new ResourceFormStore(resourceStore, 'pages');
 
@@ -459,6 +459,7 @@ test('React and update-context when type is changed', () => {
     formStore.loading = false;
     // $FlowFixMe
     formStore.type = observable.box('default');
+    formStore.schema = observable.box({title: {label: 'Title'}});
 
     const router = new Router({});
     const preview = mount(<Preview formStore={formStore} router={router} />);
@@ -475,9 +476,11 @@ test('React and update-context when type is changed', () => {
 
     // $FlowFixMe
     formStore.type.set('homepage');
+    // $FlowFixMe
+    formStore.schema.set({title: {label: 'Title', colSpan: 12}});
 
     return startPromise.then(() => {
-        expect(previewStore.updateContext).toBeCalledWith('homepage', observable.map({title: 'Test'}));
+        expect(previewStore.updateContext).toBeCalledWith('homepage', {title: 'Test'});
     });
 });
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes https://github.com/sulu/sulu/issues/5983
| Related issues/PRs | builds upon https://github.com/sulu/sulu/pull/6076
| License | MIT

#### What's in this PR?

See https://github.com/sulu/sulu/issues/5983

* on template change, obsolete data will be removed from the `resourceStore`
* if data uses block-types which are not available in the new template, these blocks are set to the default block-type
* if the user switches back to the origin template, the data will be fetched from the backend and merged with the current data of the frontend

