### PR TITLE
Use light skin for lists inside of tabs

### DIFF
--- a/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
+++ b/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
@@ -153,6 +153,11 @@ class CategoryAdmin extends Admin
                     ->setResourceKey('category_keywords')
                     ->setListKey('category_keywords')
                     ->addListAdapters(['table'])
+                    ->addAdapterOptions([
+                        'table' => [
+                            'skin' => 'light',
+                        ],
+                    ])
                     ->addRouterAttributesToListRequest(['id' => 'categoryId'])
                     ->setFormKey('category_keywords')
                     ->addRouterAttributesToFormRequest(['id' => 'categoryId'])

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -176,6 +176,11 @@ class ContactAdmin extends Admin
                     ->setUserSettingsKey('contact_media')
                     ->setTabTitle('sulu_contact.documents')
                     ->addListAdapters(['table'])
+                    ->addAdapterOptions([
+                        'table' => [
+                            'skin' => 'light',
+                        ],
+                    ])
                     ->addToolbarActions($contactDocumentsToolbarActions)
                     ->addItemActions($contactDocumentsItemActions)
                     ->addRouterAttributesToListRequest(['id' => 'contactId'])
@@ -270,6 +275,11 @@ class ContactAdmin extends Admin
                     ->setListKey('account_contacts')
                     ->setTabTitle('sulu_contact.people')
                     ->addListAdapters(['table'])
+                    ->addAdapterOptions([
+                        'table' => [
+                            'skin' => 'light',
+                        ],
+                    ])
                     ->setEditView(static::CONTACT_EDIT_FORM_VIEW)
                     ->addRouterAttributesToListRequest(['id'])
                     ->addToolbarActions([
@@ -288,6 +298,11 @@ class ContactAdmin extends Admin
                     ->setUserSettingsKey('contact_media')
                     ->setTabTitle('sulu_contact.documents')
                     ->addListAdapters(['table'])
+                    ->addAdapterOptions([
+                        'table' => [
+                            'skin' => 'light',
+                        ],
+                    ])
                     ->addRouterAttributesToListRequest(['id' => 'contactId'])
                     ->addToolbarActions($accountDocumentsToolbarActions)
                     ->addItemActions($accountDocumentsItemActions)

--- a/src/Sulu/Bundle/CustomUrlBundle/Admin/CustomUrlAdmin.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Admin/CustomUrlAdmin.php
@@ -80,7 +80,11 @@ class CustomUrlAdmin extends Admin
                     ->setResourceKey(CustomUrlDocument::RESOURCE_KEY)
                     ->setListKey('custom_urls')
                     ->addListAdapters(['table'])
-                    ->addAdapterOptions(['table' => ['skin' => 'light']])
+                    ->addAdapterOptions([
+                        'table' => [
+                            'skin' => 'light',
+                        ],
+                    ])
                     ->addRouterAttributesToListRequest(['webspace'])
                     ->addRouterAttributesToFormRequest(['webspace'])
                     ->disableSearching()

--- a/src/Sulu/Bundle/WebsiteBundle/Admin/WebsiteAdmin.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Admin/WebsiteAdmin.php
@@ -79,7 +79,11 @@ class WebsiteAdmin extends Admin
                     ->setResourceKey(AnalyticsInterface::RESOURCE_KEY)
                     ->setListKey(AnalyticsInterface::LIST_KEY)
                     ->addListAdapters(['table'])
-                    ->addAdapterOptions(['table' => ['skin' => 'light']])
+                    ->addAdapterOptions([
+                        'table' => [
+                            'skin' => 'light',
+                        ],
+                    ])
                     ->addRouterAttributesToListRequest(['webspace'])
                     ->addRouterAttributesToFormRequest(['webspace'])
                     ->disableSearching()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

This PR adjusts all lists inside of tab views to use the `light` skin.

##### Before

![Screenshot 2021-05-26 at 16 37 59](https://user-images.githubusercontent.com/13310795/119679584-c52a4c00-be40-11eb-9c54-ea957356a52d.png)

##### After

![Screenshot 2021-05-26 at 16 38 35](https://user-images.githubusercontent.com/13310795/119679676-d6735880-be40-11eb-84dd-7f5d0c434f29.png)
