### PR TITLE
Add custom binary operators for AND and OR to jexl

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -4,7 +4,6 @@ import log from 'loglevel';
 import React from 'react';
 import {render} from 'react-dom';
 import {configure} from 'mobx';
-import jexl from 'jexl';
 import ResizeObserver from 'resize-observer-polyfill';
 import Requester from './services/Requester';
 import Router, {routeRegistry} from './services/Router';
@@ -110,6 +109,7 @@ import {navigationRegistry} from './containers/Navigation';
 import {smartContentConfigStore} from './containers/SmartContent';
 import PreviewForm from './views/PreviewForm';
 import FormOverlayList from './views/FormOverlayList';
+import {initializeJexl} from './utils/jexl';
 
 configure({enforceActions: 'observed'});
 
@@ -122,9 +122,7 @@ log.setDefaultLevel(process.env.NODE_ENV === 'production' ? log.levels.ERROR : l
 
 Requester.handleResponseHooks.push(logoutOnUnauthorizedResponse);
 
-jexl.addTransform('length', (value: Array<*>) => value.length);
-jexl.addTransform('includes', (value: Array<*>, search) => value.includes(search));
-jexl.addTransform('values', (value: Array<*>) => Object.values(value));
+initializeJexl();
 
 const FIELD_TYPE_BLOCK = 'block';
 const FIELD_TYPE_CHANGELOG_LINE = 'changelog_line';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/jexl/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/jexl/index.js
@@ -1,0 +1,4 @@
+// @flow
+import initializeJexl from './initializeJexl';
+
+export {initializeJexl};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/jexl/initializeJexl.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/jexl/initializeJexl.js
@@ -1,0 +1,37 @@
+// @flow
+import jexl from 'jexl';
+
+// See https://github.com/TomFrost/Jexl/blob/471f167b3ae77924b8eb409ad68d47f75ac930fb/lib/grammar.js#L91
+const andBinaryOpFunc = (left: any, right: any): any => {
+    return left.eval().then((leftVal: any) => {
+        if (!leftVal) {
+            return leftVal;
+        }
+
+        return right.eval();
+    });
+};
+
+// See https://github.com/TomFrost/Jexl/blob/471f167b3ae77924b8eb409ad68d47f75ac930fb/lib/grammar.js#L101
+const orBinaryOpFunc = (left: any, right: any): any => {
+    return left.eval().then((leftVal: any): any => {
+        if (leftVal) {
+            return leftVal;
+        }
+
+        return right.eval();
+    });
+};
+
+const initializeJexl = () => {
+    jexl.addBinaryOp('AND', 10, andBinaryOpFunc, true);
+    jexl.addBinaryOp('and', 10, andBinaryOpFunc, true);
+    jexl.addBinaryOp('OR', 10, orBinaryOpFunc, true);
+    jexl.addBinaryOp('or', 10, orBinaryOpFunc, true);
+
+    jexl.addTransform('length', (value: Array<*>) => value.length);
+    jexl.addTransform('includes', (value: Array<*>, search) => value.includes(search));
+    jexl.addTransform('values', (value: Array<*>) => Object.values(value));
+};
+
+export default initializeJexl;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/jexl/tests/jexl.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/jexl/tests/jexl.test.js
@@ -1,0 +1,72 @@
+// @flow
+import jexl from 'jexl';
+import initializeJexl from '../initializeJexl';
+
+initializeJexl();
+
+test('Test jexl AND binary operator', () => {
+    const context = {
+        val1: 1,
+        val2: 'foo',
+    };
+
+    expect(jexl.evalSync('1 == val1 AND "foo" == val2', context)).toBe(true);
+    expect(jexl.evalSync('1 == val1 AND "bar" == val2', context)).toBe(false);
+    expect(jexl.evalSync('2 == val1 AND "foo" == val2', context)).toBe(false);
+    expect(jexl.evalSync('2 == val1 AND "bar" == val2', context)).toBe(false);
+
+    expect(jexl.evalSync('1 == val1 and "foo" == val2', context)).toBe(true);
+    expect(jexl.evalSync('1 == val1 and "bar" == val2', context)).toBe(false);
+    expect(jexl.evalSync('2 == val1 and "foo" == val2', context)).toBe(false);
+    expect(jexl.evalSync('2 == val1 and "bar" == val2', context)).toBe(false);
+});
+
+test('Test jexl OR binary operator', () => {
+    const context = {
+        val1: 1,
+        val2: 'foo',
+    };
+
+    expect(jexl.evalSync('1 == val1 OR "foo" == val2', context)).toBe(true);
+    expect(jexl.evalSync('1 == val1 OR "bar" == val2', context)).toBe(true);
+    expect(jexl.evalSync('2 == val1 OR "foo" == val2', context)).toBe(true);
+    expect(jexl.evalSync('2 == val1 OR "bar" == val2', context)).toBe(false);
+
+    expect(jexl.evalSync('1 == val1 or "foo" == val2', context)).toBe(true);
+    expect(jexl.evalSync('1 == val1 or "bar" == val2', context)).toBe(true);
+    expect(jexl.evalSync('2 == val1 or "foo" == val2', context)).toBe(true);
+    expect(jexl.evalSync('2 == val1 or "bar" == val2', context)).toBe(false);
+});
+
+test('Test jexl length transform', () => {
+    const context = {
+        stringVal: 'foo',
+        arrayVal: ['bar', 'baz'],
+    };
+
+    expect(jexl.evalSync('stringVal|length', context)).toBe(3);
+    expect(jexl.evalSync('arrayVal|length', context)).toBe(2);
+});
+
+test('Test jexl includes transform', () => {
+    const context = {
+        val: ['foo', 'bar', 'baz'],
+    };
+
+    expect(jexl.evalSync('val|includes("bar")', context)).toBe(true);
+    expect(jexl.evalSync('val|includes("abc")', context)).toBe(false);
+});
+
+test('Test jexl values transform', () => {
+    const context = {
+        objectVal: {
+            foo: 'abc',
+            bar: 1,
+            baz: true,
+        },
+        arrayVal: ['abc', 1, true],
+    };
+
+    expect(jexl.evalSync('objectVal|values', context)).toEqual(['abc', 1, true]);
+    expect(jexl.evalSync('arrayVal|values', context)).toEqual(['abc', 1, true]);
+});

--- a/src/Sulu/Bundle/PageBundle/Resources/config/forms/page_settings.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/forms/page_settings.xml
@@ -52,7 +52,7 @@
             name="navContexts"
             type="page_settings_navigation_select"
             colspan="6"
-            visibleCondition="shadowOn == false &amp;&amp; path != ''"
+            visibleCondition="shadowOn == false AND path != ''"
         >
             <meta>
                 <title>sulu_page.show_page_in</title>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#657

#### What's in this PR?

Add custom binary operators for AND and OR to jexl

#### Why?

Otherwise, the visible condition needs to be written like `1 == val1 &amp;&amp; "foo" == val2`, because `&` is not allowed in xml

#### Example Usage

```
1 == val1 AND "foo" == val2
1 == val1 and "foo" == val2
1 == val1 OR "foo" == val2
1 == val1 or "foo" == val2
```

#### To Do

- [x] Create a documentation PR
