### PR TITLE
Avoid fetching of node in markup listener to improve performance

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,16 @@
 # Upgrade
 
+## 2.2.11
+
+### Migrate role permissions properties
+
+For performance reasons we need to migrate the permission fields into a single field in PHPCR.
+Run the phpcr migration command which will handle migration:
+
+```bash
+bin/console phpcr:migrations:migrate
+```
+
 ## 2.2.6
 
 ### Changed ContentRepository to return title of source instead of link destination for internal link pages

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,10 +2,14 @@
 
 ## 2.2.11
 
-### Migrate role permissions properties
+### Migrate permissions properties for pages
 
-For performance reasons we need to migrate the permission fields into a single field in PHPCR.
-Run the phpcr migration command which will handle migration:
+The role-specific PHPCR properties used for storing page permissions decrease performance when
+used in combination with website security. To mitigate the problem and improve performance, all permissions 
+are now stored in a single property. 
+
+If you use page-specific permissions in your project, you need to migrate the existing data by running the 
+phpcr migration command:
 
 ```bash
 bin/console phpcr:migrations:migrate

--- a/src/Sulu/Bundle/PageBundle/Markup/Link/PageLinkProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Markup/Link/PageLinkProvider.php
@@ -169,17 +169,17 @@ class PageLinkProvider implements LinkProviderInterface
     /**
      * Returns current user or null if no user is loggedin.
      *
-     * @return UserInterface|void
+     * @return UserInterface|null
      */
     private function getCurrentUser()
     {
         if (!$this->tokenStorage) {
-            return;
+            return null;
         }
 
         $token = $this->tokenStorage->getToken();
         if (!$token) {
-            return;
+            return null;
         }
 
         $user = $token->getUser();
@@ -187,6 +187,6 @@ class PageLinkProvider implements LinkProviderInterface
             return $user;
         }
 
-        return;
+        return null;
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version202105311447.php
+++ b/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version202105311447.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PageBundle;
+
+use Jackalope\Node;
+use Jackalope\Query\Row;
+use PHPCR\Migrations\VersionInterface;
+use PHPCR\SessionInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+class Version202105311447 implements VersionInterface, ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    /**
+     * @return void
+     */
+    public function up(SessionInterface $session)
+    {
+        $liveSession = $this->container->get('sulu_document_manager.live_session');
+        $this->upgrade($liveSession);
+        $this->upgrade($session);
+
+        $liveSession->save();
+        $session->save();
+    }
+
+    /**
+     * @return void
+     */
+    public function down(SessionInterface $session)
+    {
+        $liveSession = $this->container->get('sulu_document_manager.live_session');
+
+        $this->downgrade($liveSession);
+        $this->downgrade($session);
+
+        $liveSession->save();
+        $session->save();
+    }
+
+    /**
+     * @return void
+     */
+    private function upgrade(SessionInterface $session)
+    {
+        $queryManager = $session->getWorkspace()->getQueryManager();
+
+        $query = 'SELECT * FROM [nt:unstructured] WHERE ([jcr:mixinTypes] = "sulu:page") OR [jcr:mixinTypes] = "sulu:home"';
+        $rows = $queryManager->createQuery($query, 'JCR-SQL2')->execute();
+
+        /** @var Row<mixed> $row */
+        foreach ($rows as $row) {
+            /** @var Node<mixed> $node */
+            $node = $row->getNode();
+
+            $permissions = [];
+            foreach ($node->getProperties('sec:role-*') as $property) {
+                $roleId = (int) \str_replace('sec:role-', '', $property->getName());
+
+                $rolePermissions = $property->getValue();
+                if (!$rolePermissions) {
+                    $rolePermissions = [];
+                }
+
+                $permissions[$roleId] = $rolePermissions;
+            }
+
+            $node->setProperty('sec:permissions', \json_encode($permissions));
+        }
+    }
+
+    /**
+     * @return void
+     */
+    private function downgrade(SessionInterface $session)
+    {
+        $queryManager = $session->getWorkspace()->getQueryManager();
+
+        $query = 'SELECT * FROM [nt:unstructured] WHERE ([jcr:mixinTypes] = "sulu:page") OR [jcr:mixinTypes] = "sulu:home"';
+        $rows = $queryManager->createQuery($query, 'JCR-SQL2')->execute();
+
+        /** @var Row<mixed> $row */
+        foreach ($rows as $row) {
+            /** @var Node<mixed> $node */
+            $node = $row->getNode();
+
+            if (!$node->hasProperty('sec:permissions')) {
+                continue;
+            }
+
+            $node->getProperty('sec:permissions')->remove();
+        }
+    }
+}

--- a/src/Sulu/Bundle/SecurityBundle/System/SystemStore.php
+++ b/src/Sulu/Bundle/SecurityBundle/System/SystemStore.php
@@ -22,12 +22,12 @@ class SystemStore implements SystemStoreInterface
     private $roleRepository;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $system;
 
     /**
-     * @var ?RoleInterface
+     * @var RoleInterface|null
      */
     private $anonymousRole;
 
@@ -41,7 +41,7 @@ class SystemStore implements SystemStoreInterface
         return $this->system;
     }
 
-    public function setSystem(string $system): void
+    public function setSystem(?string $system): void
     {
         $this->system = $system;
         $this->anonymousRole = null;

--- a/src/Sulu/Component/Content/Document/Subscriber/SecuritySubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/SecuritySubscriber.php
@@ -32,7 +32,7 @@ class SecuritySubscriber implements EventSubscriberInterface
      */
     const SECURITY_PROPERTY_PREFIX = 'sec:role-';
 
-    const SECURITY_PERMISSION_PROPERTY = 'sec:permission';
+    const SECURITY_PERMISSION_PROPERTY = 'sec:permissions';
 
     /**
      * @var array

--- a/src/Sulu/Component/Content/Document/Subscriber/SecuritySubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/SecuritySubscriber.php
@@ -157,13 +157,12 @@ class SecuritySubscriber implements EventSubscriberInterface
         $allowedPermissions = [];
         foreach ($permissions as $roleId => $permission) {
             $allowedRolePermissions = $this->getAllowedPermissions($permission);
-            // TODO use PropertyEncoder, once it is refactored
+            $allowedPermissions[$roleId] = $allowedRolePermissions;
+            // store role permissions in separated properties for backwards compatibility
             $node->setProperty(static::SECURITY_PROPERTY_PREFIX . $roleId, $allowedRolePermissions);
             if ($liveNode) {
                 $liveNode->setProperty(static::SECURITY_PROPERTY_PREFIX . $roleId, $allowedRolePermissions);
             }
-
-            $allowedPermissions[$roleId] = $allowedRolePermissions;
         }
 
         $jsonAllowedPermissions = \json_encode($allowedPermissions);

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/SecuritySubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/SecuritySubscriberTest.php
@@ -90,8 +90,8 @@ class SecuritySubscriberTest extends SubscriberTestCase
         $liveNode->setProperty('sec:role-1', ['view', 'add', 'edit'])->shouldBeCalled();
         $liveProperty->remove()->shouldNotBeCalled();
 
-        $this->node->setProperty('sec:permission', '{"1":["view","add","edit"]}')->shouldBeCalled();
-        $liveNode->setProperty('sec:permission', '{"1":["view","add","edit"]}')->shouldBeCalled();
+        $this->node->setProperty('sec:permissions', '{"1":["view","add","edit"]}')->shouldBeCalled();
+        $liveNode->setProperty('sec:permissions', '{"1":["view","add","edit"]}')->shouldBeCalled();
 
         $this->subscriber->handlePersist($this->persistEvent->reveal());
     }
@@ -117,7 +117,7 @@ class SecuritySubscriberTest extends SubscriberTestCase
         $this->node->setProperty('sec:role-1', ['view', 'add', 'edit'])->shouldBeCalled();
         $property->remove()->shouldNotBeCalled();
 
-        $this->node->setProperty('sec:permission', '{"1":["view","add","edit"]}')->shouldBeCalled();
+        $this->node->setProperty('sec:permissions', '{"1":["view","add","edit"]}')->shouldBeCalled();
 
         $this->subscriber->handlePersist($this->persistEvent->reveal());
     }
@@ -150,8 +150,8 @@ class SecuritySubscriberTest extends SubscriberTestCase
         $liveNode->setProperty('sec:role-1', ['view', 'add', 'edit'])->shouldBeCalled();
         $liveProperty->remove()->shouldBeCalled();
 
-        $this->node->setProperty('sec:permission', '{"1":["view","add","edit"]}')->shouldBeCalled();
-        $liveNode->setProperty('sec:permission', '{"1":["view","add","edit"]}')->shouldBeCalled();
+        $this->node->setProperty('sec:permissions', '{"1":["view","add","edit"]}')->shouldBeCalled();
+        $liveNode->setProperty('sec:permissions', '{"1":["view","add","edit"]}')->shouldBeCalled();
 
         $this->subscriber->handlePersist($this->persistEvent->reveal());
     }
@@ -179,8 +179,8 @@ class SecuritySubscriberTest extends SubscriberTestCase
         $property->remove()->shouldBeCalled();
         $liveProperty->remove()->shouldBeCalled();
 
-        $this->node->setProperty('sec:permission', '[]')->shouldBeCalled();
-        $liveNode->setProperty('sec:permission', '[]')->shouldBeCalled();
+        $this->node->setProperty('sec:permissions', '[]')->shouldBeCalled();
+        $liveNode->setProperty('sec:permissions', '[]')->shouldBeCalled();
 
         $this->subscriber->handlePersist($this->persistEvent->reveal());
     }
@@ -278,11 +278,11 @@ class SecuritySubscriberTest extends SubscriberTestCase
         $document = $this->prophesize(SecurityBehavior::class);
         $node = $this->prophesize(NodeInterface::class);
 
-        $node->hasProperty('sec:permission')
+        $node->hasProperty('sec:permissions')
             ->willReturn(true)
             ->shouldBeCalled();
 
-        $node->getPropertyValue('sec:permission')
+        $node->getPropertyValue('sec:permissions')
             ->willReturn('{
                 "1": ["view", "add", "edit"],
                 "2": ["view", "edit"]

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/SecuritySubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/SecuritySubscriberTest.php
@@ -15,6 +15,7 @@ use PHPCR\NodeInterface;
 use PHPCR\PropertyInterface;
 use PHPCR\SessionInterface;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
 use Sulu\Component\Content\Document\Subscriber\SecuritySubscriber;
 use Sulu\Component\Content\Document\Subscriber\StructureSubscriber;
@@ -25,7 +26,7 @@ use Sulu\Component\Security\Authorization\AccessControl\AccessControlManagerInte
 class SecuritySubscriberTest extends SubscriberTestCase
 {
     /**
-     * @var ObjectProphecy
+     * @var ObjectProphecy|NodeInterface
      */
     private $liveSession;
 
@@ -35,12 +36,12 @@ class SecuritySubscriberTest extends SubscriberTestCase
     private $subscriber;
 
     /**
-     * @var PropertyEncoder
+     * @var ObjectProphecy|PropertyEncoder
      */
     private $propertyEncoder;
 
     /**
-     * @var AccessControlManagerInterface
+     * @var ObjectProphecy|AccessControlManagerInterface
      */
     private $accessControlManager;
 
@@ -89,6 +90,9 @@ class SecuritySubscriberTest extends SubscriberTestCase
         $liveNode->setProperty('sec:role-1', ['view', 'add', 'edit'])->shouldBeCalled();
         $liveProperty->remove()->shouldNotBeCalled();
 
+        $this->node->setProperty('sec:permission', '{"1":["view","add","edit"]}')->shouldBeCalled();
+        $liveNode->setProperty('sec:permission', '{"1":["view","add","edit"]}')->shouldBeCalled();
+
         $this->subscriber->handlePersist($this->persistEvent->reveal());
     }
 
@@ -112,6 +116,8 @@ class SecuritySubscriberTest extends SubscriberTestCase
 
         $this->node->setProperty('sec:role-1', ['view', 'add', 'edit'])->shouldBeCalled();
         $property->remove()->shouldNotBeCalled();
+
+        $this->node->setProperty('sec:permission', '{"1":["view","add","edit"]}')->shouldBeCalled();
 
         $this->subscriber->handlePersist($this->persistEvent->reveal());
     }
@@ -144,6 +150,9 @@ class SecuritySubscriberTest extends SubscriberTestCase
         $liveNode->setProperty('sec:role-1', ['view', 'add', 'edit'])->shouldBeCalled();
         $liveProperty->remove()->shouldBeCalled();
 
+        $this->node->setProperty('sec:permission', '{"1":["view","add","edit"]}')->shouldBeCalled();
+        $liveNode->setProperty('sec:permission', '{"1":["view","add","edit"]}')->shouldBeCalled();
+
         $this->subscriber->handlePersist($this->persistEvent->reveal());
     }
 
@@ -169,6 +178,9 @@ class SecuritySubscriberTest extends SubscriberTestCase
 
         $property->remove()->shouldBeCalled();
         $liveProperty->remove()->shouldBeCalled();
+
+        $this->node->setProperty('sec:permission', '[]')->shouldBeCalled();
+        $liveNode->setProperty('sec:permission', '[]')->shouldBeCalled();
 
         $this->subscriber->handlePersist($this->persistEvent->reveal());
     }
@@ -266,17 +278,16 @@ class SecuritySubscriberTest extends SubscriberTestCase
         $document = $this->prophesize(SecurityBehavior::class);
         $node = $this->prophesize(NodeInterface::class);
 
-        /** @var PropertyInterface $roleProperty1 */
-        $roleProperty1 = $this->prophesize(PropertyInterface::class);
-        $roleProperty1->getName()->willReturn('sec:role-1');
-        $roleProperty1->getValue()->willReturn(['view', 'add', 'edit']);
+        $node->hasProperty('sec:permission')
+            ->willReturn(true)
+            ->shouldBeCalled();
 
-        /** @var PropertyInterface $roleProperty2 */
-        $roleProperty2 = $this->prophesize(PropertyInterface::class);
-        $roleProperty2->getName()->willReturn('sec:role-2');
-        $roleProperty2->getValue()->willReturn(['view', 'edit']);
-
-        $node->getProperties('sec:*')->willReturn([$roleProperty1->reveal(), $roleProperty2->reveal()]);
+        $node->getPropertyValue('sec:permission')
+            ->willReturn('{
+                "1": ["view", "add", "edit"],
+                "2": ["view", "edit"]
+            }')
+            ->shouldBeCalled();
 
         $this->hydrateEvent->getDocument()->willReturn($document);
         $this->hydrateEvent->getNode()->willReturn($node);

--- a/src/Sulu/Component/Content/Tests/Unit/Repository/ContentRepositoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Repository/ContentRepositoryTest.php
@@ -199,7 +199,7 @@ class ContentRepositoryTest extends TestCase
         $row->getValue('deTemplate')->willReturn('default');
         $row->getValue('deDeState')->willReturn(WorkflowStage::PUBLISHED);
         $row->getValue('de_atDe_atState')->willReturn(WorkflowStage::TEST);
-        $row->getValue('sec:permission')->willReturn('[]');
+        $row->getValue('sec:permissions')->willReturn('[]');
 
         $this->sessionManager->getContentPath('sulu_io')->willReturn('/cmf/sulu_io/contents');
 

--- a/src/Sulu/Component/Content/Tests/Unit/Repository/ContentRepositoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Repository/ContentRepositoryTest.php
@@ -12,7 +12,6 @@
 namespace Sulu\Component\Content\Tests\Unit\Repository;
 
 use Jackalope\Query\Row;
-use PHPCR\NodeInterface;
 use PHPCR\Query\QOM\ChildNodeInterface;
 use PHPCR\Query\QOM\ColumnInterface;
 use PHPCR\Query\QOM\ComparisonInterface;
@@ -28,6 +27,7 @@ use PHPCR\SessionInterface;
 use PHPCR\WorkspaceInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\SecurityBundle\System\SystemStoreInterface;
 use Sulu\Component\Content\Compat\LocalizationFinderInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
@@ -47,42 +47,42 @@ use Sulu\Component\Webspace\Webspace;
 class ContentRepositoryTest extends TestCase
 {
     /**
-     * @var SessionInterface
+     * @var ObjectProphecy|SessionInterface
      */
     private $session;
 
     /**
-     * @var SessionManagerInterface
+     * @var ObjectProphecy|SessionManagerInterface
      */
     private $sessionManager;
 
     /**
-     * @var DocumentManagerInterface
+     * @var ObjectProphecy|DocumentManagerInterface
      */
     private $documentManager;
 
     /**
-     * @var PropertyEncoder
+     * @var ObjectProphecy|PropertyEncoder
      */
     private $propertyEncoder;
 
     /**
-     * @var WebspaceManagerInterface
+     * @var ObjectProphecy|WebspaceManagerInterface
      */
     private $webspaceManager;
 
     /**
-     * @var LocalizationFinderInterface
+     * @var ObjectProphecy|LocalizationFinderInterface
      */
     private $localizationFinder;
 
     /**
-     * @var StructureManagerInterface
+     * @var ObjectProphecy|StructureManagerInterface
      */
     private $structureManager;
 
     /**
-     * @var SuluNodeHelper
+     * @var ObjectProphecy|SuluNodeHelper
      */
     private $nodeHelper;
 
@@ -92,12 +92,12 @@ class ContentRepositoryTest extends TestCase
     private $contentRepository;
 
     /**
-     * @var SystemStoreInterface
+     * @var ObjectProphecy|SystemStoreInterface
      */
     private $systemStore;
 
     /**
-     * @var QueryInterface
+     * @var ObjectProphecy|QueryInterface
      */
     private $query;
 
@@ -180,9 +180,8 @@ class ContentRepositoryTest extends TestCase
         $row->getPath()->willReturn('/cmf/sulu_io/contents');
         $this->nodeHelper->extractWebspaceFromPath('/cmf/sulu_io/contents')->willReturn('sulu_io');
 
-        $node = $this->prophesize(NodeInterface::class);
-        $node->getProperties('sec:role-*')->willReturn([]);
-        $row->getNode()->willReturn($node->reveal());
+        // avoid calling getNode to avoid triggering hydration process and node query
+        $row->getNode()->shouldNotBeCalled();
 
         $row->getValues()->willReturn(
             [
@@ -200,6 +199,7 @@ class ContentRepositoryTest extends TestCase
         $row->getValue('deTemplate')->willReturn('default');
         $row->getValue('deDeState')->willReturn(WorkflowStage::PUBLISHED);
         $row->getValue('de_atDe_atState')->willReturn(WorkflowStage::TEST);
+        $row->getValue('sec:permission')->willReturn('[]');
 
         $this->sessionManager->getContentPath('sulu_io')->willReturn('/cmf/sulu_io/contents');
 

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -76,6 +76,11 @@ class WebspaceManager implements WebspaceManagerInterface
      */
     private $structureMetadataFactory;
 
+    /**
+     * @var mixed[]
+     */
+    private $portalUrlCache = [];
+
     public function __construct(
         LoaderInterface $loader,
         ReplacerInterface $urlReplacer,
@@ -247,6 +252,16 @@ class WebspaceManager implements WebspaceManagerInterface
             $webspaceKey = $currentWebspace ? $currentWebspace->getKey() : $webspaceKey;
         }
 
+        if (isset($this->portalUrlCache[$webspaceKey][$domain][$environment][$languageCode])) {
+            $portalUrl = $this->portalUrlCache[$webspaceKey][$domain][$environment][$languageCode];
+
+            if (!$portalUrl) {
+                return null;
+            }
+
+            return $this->createResourceLocatorUrl($portalUrl, $resourceLocator, $scheme);
+        }
+
         $sameDomainUrl = null;
         $fullMatchedUrl = null;
         $partialMatchedUrl = null;
@@ -304,16 +319,22 @@ class WebspaceManager implements WebspaceManagerInterface
         }
 
         if ($sameDomainUrl) {
-            $url = $sameDomainUrl;
+            $portalUrl = $sameDomainUrl;
         } elseif ($fullMatchedUrl) {
-            $url = $fullMatchedUrl;
+            $portalUrl = $fullMatchedUrl;
         } elseif ($partialMatchedUrl) {
-            $url = $partialMatchedUrl;
+            $portalUrl = $partialMatchedUrl;
         } else {
+            $portalUrl = null;
+        }
+
+        $this->portalUrlCache[$webspaceKey][$domain][$environment][$languageCode] = $portalUrl;
+
+        if (!$portalUrl) {
             return null;
         }
 
-        return $this->createResourceLocatorUrl($url, $resourceLocator, $scheme);
+        return $this->createResourceLocatorUrl($portalUrl, $resourceLocator, $scheme);
     }
 
     public function getPortals(): array

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -266,8 +266,8 @@ class WebspaceManager implements WebspaceManagerInterface
                 || $portalInformation->getLocalization()->getLocale() === $languageCode
             );
             $sameWebspace = null === $webspaceKey || $portalInformation->getWebspace()->getKey() === $webspaceKey;
-            $url = $this->createResourceLocatorUrl($portalInformation->getUrl(), $resourceLocator, $scheme);
             if ($sameLocalization && $sameWebspace) {
+                $url = $this->createResourceLocatorUrl($portalInformation->getUrl(), $resourceLocator, $scheme);
                 if (RequestAnalyzerInterface::MATCH_TYPE_FULL === $portalInformation->getType()) {
                     if ($this->isFromDomain($url, $domain)) {
                         if ($portalInformation->isMain()) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #5935 <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Avoid fetching of node in markup listener.

#### Why?

Currently all nodes are lazy loaded inside the security check which has the effect that a lot of queries unneeded queries on the database is done and unneeded hydration is also done, which ends in a lot bigger response time as expected.

#### TODO

 - [x] Save Permission in one collected field
 - [x] Handle SetPermission on Document Hydrate
 - [x] Handle Saving of Permission
 - [x] Output object permission only when one role has permission set
 - [x] Target 2.2 Branch!
 - [x] Update TestCases
 - [x] Create Migration
 
 Before:
 
```bash
| sec:role-2                  | STRING (0)   |                                                                             |
| sec:role-3                  | STRING (0)   |                                                                             |
| sec:role-4                  | STRING (4)   | [0] view                                                                    |
```

Additional new Field:

```bash
| sec:permissions              | STRING (28)  | {"2":[],"3":[],"4":["view"]}                                                |
 ```
 
 
 #### Profiles
 
Unoptimized: https://blackfire.io/profiles/fc104978-ad6f-4f12-a73b-70dfe3df72a6/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=Sulu%5CComponent%5CContent%5CRepository%5CContentRepository%3A%3AresolveResultPermissions&callname=main()

![Bildschirmfoto 2021-06-01 um 10 03 19](https://user-images.githubusercontent.com/1698337/120288609-b15b6b80-c2c0-11eb-8e21-8ac68e7d40dd.png)


Optimized Permissions: https://blackfire.io/profiles/6ae6b900-f331-4dbe-8291-af0930232bc3/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=Sulu%5CComponent%5CWebspace%5CManager%5CWebspaceManager%3A%3AfindUrlByResourceLocator&callname=main()

Optimized Permissions WebspaceManager d7a679c86aff575b598532d84d63705cbadd1a67: https://blackfire.io/profiles/7754f2dc-ab51-4c51-beb4-01ad83d06f1d/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=Sulu%5CComponent%5CWebspace%5CManager%5CWebspaceManager%3A%3AfindUrlByResourceLocator&callname=main()

Optimized Permissions WebspaceManager Type b284d3952adb769cf587fadf1a09508f67793657: https://blackfire.io/profiles/20d266c7-e2e3-470c-ac08-f6e317dfaa8c/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=Sulu%5CComponent%5CWebspace%5CManager%5CWebspaceManager%3A%3AfindUrlByResourceLocator&callname=main()

Optimized Permissions WebspaceManager Type Always 1befd77ef019012feb9e45165670c4101afb2dbd: https://blackfire.io/profiles/d1b7718c-50d6-4593-b6dc-c18b32e094ee/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=Sulu%5CComponent%5CWebspace%5CManager%5CWebspaceManager%3A%3AfindUrlByResourceLocator&callname=main()

Optimized Permissions WebspaceManager Type Once cdc62a5a9622fa972a1225b37cba6c2fd2daefca: https://blackfire.io/profiles/519c4d61-dd4e-4fbe-a2b9-b160d9441f20/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=&callname=main()

<img width="626" alt="Bildschirmfoto 2021-06-01 um 01 36 17" src="https://user-images.githubusercontent.com/1698337/120288641-bc160080-c2c0-11eb-9764-d538853d98c6.png">
