### PR TITLE
Do not reset cursor while editing value of DatePicker input

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
@@ -132,6 +132,7 @@ class DatePicker extends React.Component<Props> {
     getInputChange = (props: Object) => {
         return (value: ?string, event: SyntheticEvent<HTMLInputElement>) => {
             this.inputChanged = true;
+            this.setValue(value);
             props.onChange(event);
         };
     };


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

This PR prevents that the cursor is set to the end of the input when editing the value of a `DatePicker` via its input. The problem was probably introduced when we updated the version of the `react-datetime` package in https://github.com/sulu/sulu/pull/5956.

#### Why?

It is really annoying to change the value of a `DatePicker` via its input at the moment.

