### PR TITLE
Fixed single media selection import and checkbox empty import

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Content/Types/SingleMediaSelection.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/SingleMediaSelection.php
@@ -108,7 +108,7 @@ class SingleMediaSelection extends SimpleContentType implements PreResolvableCon
         }
 
         if (!empty($propertyValue)) {
-            return \json_encode($propertyValue);
+            return \json_encode($propertyValue) ?: '';
         }
 
         return '';

--- a/src/Sulu/Bundle/MediaBundle/Content/Types/SingleMediaSelection.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/SingleMediaSelection.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\MediaBundle\Content\Types;
 
+use PHPCR\NodeInterface;
 use Sulu\Bundle\MediaBundle\Admin\MediaAdmin;
 use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Bundle\MediaBundle\Entity\Collection;
@@ -98,6 +99,32 @@ class SingleMediaSelection extends SimpleContentType implements PreResolvableCon
     public function getViewData(PropertyInterface $property)
     {
         return $property->getValue();
+    }
+
+    public function exportData($propertyValue)
+    {
+        if (!\is_array($propertyValue)) {
+            return '';
+        }
+
+        if (!empty($propertyValue)) {
+            return \json_encode($propertyValue);
+        }
+
+        return '';
+    }
+
+    public function importData(
+        NodeInterface $node,
+        PropertyInterface $property,
+        $value,
+        $userId,
+        $webspaceKey,
+        $languageCode,
+        $segmentKey = null
+    ) {
+        $property->setValue(\json_decode($value, true));
+        $this->write($node, $property, $userId, $webspaceKey, $languageCode, $segmentKey);
     }
 
     public function preResolve(PropertyInterface $property)

--- a/src/Sulu/Bundle/PageBundle/Content/Types/Checkbox.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/Checkbox.php
@@ -60,7 +60,7 @@ class Checkbox extends SimpleContentType
     ) {
         $preparedValue = true;
 
-        if ('0' === $value) {
+        if ('0' === $value || '' === $value) {
             $preparedValue = false;
         }
 

--- a/src/Sulu/Bundle/PageBundle/Content/Types/Checkbox.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/Checkbox.php
@@ -60,7 +60,7 @@ class Checkbox extends SimpleContentType
     ) {
         $preparedValue = true;
 
-        if ('0' === $value || '' === $value) {
+        if ('0' === $value) {
             $preparedValue = false;
         }
 

--- a/src/Sulu/Component/Content/ContentTypeExportInterface.php
+++ b/src/Sulu/Component/Content/ContentTypeExportInterface.php
@@ -20,15 +20,20 @@ use Sulu\Component\Content\Compat\PropertyInterface;
 interface ContentTypeExportInterface
 {
     /**
+     * @param mixed $propertyValue
+     *
      * @return string
      */
     public function exportData($propertyValue);
 
     /**
+     * @param mixed $value
      * @param int $userId
      * @param string $webspaceKey
      * @param string $languageCode
      * @param string $segmentKey
+     *
+     * @return void
      */
     public function importData(
         NodeInterface $node,

--- a/src/Sulu/Component/Content/Types/BlockContentType.php
+++ b/src/Sulu/Component/Content/Types/BlockContentType.php
@@ -318,7 +318,7 @@ class BlockContentType extends ComplexContentType implements ContentTypeExportIn
         $blockPropertyWrapper->setValue($value);
 
         if ($isImport && $contentType instanceof ContentTypeExportInterface) {
-            return $contentType->importData(
+            $contentType->importData(
                 new SuluNode($node),
                 $blockPropertyWrapper,
                 $value,
@@ -327,6 +327,8 @@ class BlockContentType extends ComplexContentType implements ContentTypeExportIn
                 $languageCode,
                 $segmentKey
             );
+
+            return;
         }
 
         $contentType->write(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

When importing a xliff file into sulu the single_media_selection value will escape the string and lead to an error in the /admin interface.

Also when importing a checkbox with an empty target the set value was "true" and not "false".

#### Why?

Wrong logic in the import.
