### PR TITLE
Fix duplicating object permissions of phpcr into doctrine

### DIFF
--- a/src/Sulu/Component/Security/Authorization/AccessControl/DoctrineAccessControlProvider.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/DoctrineAccessControlProvider.php
@@ -15,6 +15,7 @@ use Doctrine\Persistence\ObjectManager;
 use ReflectionClass;
 use ReflectionException;
 use Sulu\Bundle\SecurityBundle\Entity\AccessControl;
+use Sulu\Component\Security\Authentication\RoleInterface;
 use Sulu\Component\Security\Authentication\RoleRepositoryInterface;
 use Sulu\Component\Security\Authorization\MaskConverterInterface;
 
@@ -78,7 +79,12 @@ class DoctrineAccessControlProvider implements AccessControlProviderInterface
                     $this->maskConverter->convertPermissionsToNumber($rolePermissions)
                 );
             } else {
+                /** @var RoleInterface|null $role */
                 $role = $this->roleRepository->findRoleById($roleId);
+
+                if (!$role) {
+                    continue;
+                }
 
                 $accessControl = new AccessControl();
                 $accessControl->setPermissions($this->maskConverter->convertPermissionsToNumber($rolePermissions));


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #6095
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix duplicating object permissions of phpcr into doctrine