### PR TITLE
Prevent undefined array key error in PreviewRenderer if locale is not set

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -115,8 +115,8 @@ class PreviewRenderer implements PreviewRendererInterface
         $partial = false,
         $options = []
     ) {
-        $webspaceKey = $options['webspaceKey'];
-        $locale = $options['locale'];
+        $webspaceKey = $options['webspaceKey'] ?? null;
+        $locale = $options['locale'] ?? null;
 
         if (!$this->routeDefaultsProvider->supports(\get_class($object))) {
             throw new RouteDefaultsProviderNotFoundException($object, $id, $webspaceKey, $locale);


### PR DESCRIPTION
The locale was passed as explicit parameter that could be null in `2.2`:
https://github.com/sulu/sulu/blob/eac666bd7c9beb0e72e3fd8de8bfde7553100449/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php#L116

We fallback to `null` in the `Preview` class in multiple places:
https://github.com/sulu/sulu/blob/5e4f11ac8d160c4a1242b8454265925c72a9cf30/src/Sulu/Bundle/PreviewBundle/Preview/Preview.php#L95