### PR TITLE
Replace deprecated data_path_to_auto_complete with resource_store_properties_to_request

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Resources/config/forms/account_details.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/forms/account_details.xml
@@ -62,8 +62,8 @@
 
                     <params>
                         <param name="type" value="auto_complete" />
-                        <param name="data_path_to_auto_complete" type="collection">
-                            <param name="id" value="accountId" />
+                        <param name="resource_store_properties_to_request" type="collection">
+                            <param name="accountId" value="id" />
                         </param>
                     </params>
                 </property>


### PR DESCRIPTION
I would be nice to have an example for the `resource_store_properties_to_request` param in the code of the `sulu/sulu` package.