### PR TITLE
Add postinstall info command

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Command/InfoCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/InfoCommand.php
@@ -50,7 +50,7 @@ class InfoCommand extends Command
 <title>Welcome to the Sulu CMS 👋</title>
 <title>==========================</title>
 
-<subtitle>📘 Documentations</subtitle>
+<subtitle>📘 Documentation</subtitle>
 <subtitle>-----------------</subtitle>
 
  - Sulu Documentation: <href=https://docs.sulu.io/>https://docs.sulu.io/</>
@@ -63,7 +63,7 @@ class InfoCommand extends Command
  - Sulu Demo Project: <href=https://github.com/sulu/sulu-demo/>https://github.com/sulu/sulu-demo/</>
  - Sulu Workshop Project: <href=https://github.com/sulu/sulu-workshop/>https://github.com/sulu/sulu-workshop/</>
  - Sulu Source Code: <href=https://github.com/sulu/sulu/>https://github.com/sulu/sulu/</>
- - Sulu Official Bundles: <href=https://github.com/sulu?q=Bundle>https://github.com/sulu?q=Bundle</>
+ - Official Sulu Bundles: <href=https://github.com/sulu?q=Bundle>https://github.com/sulu?q=Bundle</>
 
 <subtitle>📺 News and Updates</subtitle>
 <subtitle>-------------------</subtitle>
@@ -84,12 +84,12 @@ class InfoCommand extends Command
 
 ---
 
-Continue now with the "Getting Started" documentation to setup your project:
+Continue with the "Getting Started" documentation to setup your project:
 
  - <href=https://docs.sulu.io/en/%s/book/getting-started.html>https://docs.sulu.io/en/%s/book/getting-started.html</> 🚀
 
 
-<star>If you like sulu let us now by give us a star ⭐ on github: <href=https://github.com/sulu/sulu>https://github.com/sulu/sulu</></star>
+<star>If you like Sulu, don't hesitate to spread some love and leave a star ⭐  on GitHub: <href=https://github.com/sulu/sulu>https://github.com/sulu/sulu</></star>
 EOT;
 
         $text = \sprintf(

--- a/src/Sulu/Bundle/AdminBundle/Command/InfoCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/InfoCommand.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class InfoCommand extends Command
+{
+    protected static $defaultName = 'sulu:admin:info';
+
+    /**
+     * @var string string
+     */
+    private $suluVersion;
+
+    public function __construct(string $suluVersion)
+    {
+        parent::__construct();
+        $this->suluVersion = $suluVersion;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $docsVersion = 'latest';
+        if (false !== \strpos($this->suluVersion, '.')) {
+            $separators = \explode('.', $this->suluVersion);
+            $parsedVersion = $separators[0] . '.' . $separators[1];
+            if (\is_numeric($parsedVersion)) {
+                $docsVersion = $parsedVersion;
+            }
+        }
+
+        $output->getFormatter()->setStyle('title', new OutputFormatterStyle('green'));
+        $output->getFormatter()->setStyle('subtitle', new OutputFormatterStyle('blue'));
+        $output->getFormatter()->setStyle('star', new OutputFormatterStyle('yellow'));
+
+        $text = <<<EOT
+<title>Welcome to the Sulu CMS 👋</title>
+<title>==========================</title>
+
+<subtitle>📘 Documentations</subtitle>
+<subtitle>-----------------</subtitle>
+
+ - Sulu Documentation: <href=https://docs.sulu.io/>https://docs.sulu.io/</>
+ - Symfony Documentation: <href=https://symfony.com/doc/current/index.html>href=https://symfony.com/doc/current/index.html</>
+ - Doctrine ORM Documentation: <href=https://www.doctrine-project.org/projects/doctrine-orm/en/2.9/index.html>https://www.doctrine-project.org/projects/doctrine-orm/en/2.9/index.html</>
+
+<subtitle>📦 Examples, Code and Bundles</subtitle>
+<subtitle>-----------------------------</subtitle>
+
+ - Sulu Demo Project: <href=https://github.com/sulu/sulu-demo/>https://github.com/sulu/sulu-demo/</>
+ - Sulu Workshop Project: <href=https://github.com/sulu/sulu-workshop/>https://github.com/sulu/sulu-workshop/</>
+ - Sulu Source Code: <href=https://github.com/sulu/sulu/>https://github.com/sulu/sulu/</>
+ - Sulu Official Bundles: <href=https://github.com/sulu?q=Bundle>https://github.com/sulu?q=Bundle</>
+
+<subtitle>📺 News and Updates</subtitle>
+<subtitle>-------------------</subtitle>
+
+ - Sulu Blog: <href=https://sulu.io/know-how/blog>https://sulu.io/know-how/blog</>
+ - Sulu Guides: <href=https://sulu.io/know-how/guides>https://sulu.io/know-how/guides</>
+ - Sulu Newsletter: <href=https://sulu.io/#newsletter>https://sulu.io/#newsletter</>
+
+<subtitle>🤝 Community</subtitle>
+<subtitle>------------</subtitle>
+
+ - Github Issues: <href=https://github.com/sulu/sulu/issues>https://github.com/sulu/sulu/issues</>
+ - Github Discussions: <href=https://github.com/sulu/sulu/discussions>https://github.com/sulu/sulu/discussions</>
+ - Stackoverflow: <href=https://stackoverflow.com/tags/sulu>https://stackoverflow.com/tags/sulu</>
+ - Sulu Slack Channel: <href=https://sulu.io/services-and-support#chat>https://sulu.io/services-and-support#chat</>
+ - Symfony Slack Channel: <href=https://symfony.com/community>https://symfony.com/community</>
+ - Doctrine Slack Channel: <href=https://www.doctrine-project.org/community/index.html>https://www.doctrine-project.org/community/index.html</>
+
+---
+
+Continue now with the "Getting Started" documentation to setup your project:
+
+ - <href=https://docs.sulu.io/en/%s/book/getting-started.html>https://docs.sulu.io/en/%s/book/getting-started.html</> 🚀
+
+
+<star>If you like sulu let us now by give us a star ⭐ on github: <href=https://github.com/sulu/sulu>https://github.com/sulu/sulu</></star>
+EOT;
+
+        $text = \sprintf(
+            \str_replace("\n", \PHP_EOL, $text),
+            $docsVersion,
+            $docsVersion
+        );
+
+        $output->writeln($text);
+
+        return 0;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Command/InfoCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/InfoCommand.php
@@ -54,7 +54,7 @@ class InfoCommand extends Command
 <subtitle>-----------------</subtitle>
 
  - Sulu Documentation: <href=https://docs.sulu.io/>https://docs.sulu.io/</>
- - Symfony Documentation: <href=https://symfony.com/doc/current/index.html>href=https://symfony.com/doc/current/index.html</>
+ - Symfony Documentation: <href=https://symfony.com/doc/current/index.html>https://symfony.com/doc/current/index.html</>
  - Doctrine ORM Documentation: <href=https://www.doctrine-project.org/projects/doctrine-orm/en/2.9/index.html>https://www.doctrine-project.org/projects/doctrine-orm/en/2.9/index.html</>
 
 <subtitle>📦 Examples, Code and Bundles</subtitle>
@@ -89,7 +89,7 @@ Continue with the "Getting Started" documentation to setup your project:
  - <href=https://docs.sulu.io/en/%s/book/getting-started.html>https://docs.sulu.io/en/%s/book/getting-started.html</> 🚀
 
 
-<star>If you like Sulu, don't hesitate to spread some love and leave a star ⭐  on GitHub: <href=https://github.com/sulu/sulu>https://github.com/sulu/sulu</></star>
+<star>If you like Sulu, don't hesitate to spread some love and leave a star ⭐ on GitHub: <href=https://github.com/sulu/sulu>https://github.com/sulu/sulu</></star>
 EOT;
 
         $text = \sprintf(

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -242,6 +242,11 @@
             <tag name="console.command"/>
         </service>
 
+        <service id="sulu_admin.info_command" class="Sulu\Bundle\AdminBundle\Command\InfoCommand">
+            <argument>%sulu.version%</argument>
+            <tag name="console.command"/>
+        </service>
+
         <service
             id="sulu_admin.download_language_command"
             class="Sulu\Bundle\AdminBundle\Command\DownloadLanguageCommand"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? |  yes
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add postinstall info command

#### Why?

Output some helpfully link after `composer create-project sulu/skeleton` ...

![Bildschirmfoto 2021-06-10 um 10 10 23](https://user-images.githubusercontent.com/1698337/121489180-1e16ea00-c9d4-11eb-818d-c14b6a3d3c35.png)

Maybe we short something, more lines as currently should it not be as it will else not fit on default laptop screens.