### PR TITLE
Add fallback for form metadata for none exist user locale

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
@@ -28,12 +28,29 @@ class FormMetadataProvider implements MetadataProviderInterface
      */
     private $formMetadataLoaders;
 
+    /**
+     * @var string
+     */
+    private $defaultLocale;
+
+    /**
+     * @param string[]|null $locales
+     */
     public function __construct(
         ExpressionLanguage $expressionLanguage,
-        iterable $formMetadataLoaders
+        iterable $formMetadataLoaders,
+        ?array $locales = []
     ) {
         $this->expressionLanguage = $expressionLanguage;
         $this->formMetadataLoaders = $formMetadataLoaders;
+
+        if (!$locales) {
+            @\trigger_error('The usage of the "FormMetadataProvider" without "$locales" is deprecated. Please add "$locales" instead.', \E_USER_DEPRECATED);
+
+            $locales = ['en'];
+        }
+
+        $this->defaultLocale = $locales[0];
     }
 
     public function getMetadata(string $key, string $locale, array $metadataOptions = []): MetadataInterface
@@ -43,6 +60,14 @@ class FormMetadataProvider implements MetadataProviderInterface
             $form = $metadataLoader->getMetadata($key, $locale, $metadataOptions);
             if ($form) {
                 break;
+            }
+        }
+        if (!$form) {
+            foreach ($this->formMetadataLoaders as $metadataLoader) {
+                $form = $metadataLoader->getMetadata($key, $this->defaultLocale, $metadataOptions);
+                if ($form) {
+                    break;
+                }
             }
         }
         if (!$form) {

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
@@ -31,26 +31,23 @@ class FormMetadataProvider implements MetadataProviderInterface
     /**
      * @var string
      */
-    private $defaultLocale;
+    private $fallbackLocale;
 
-    /**
-     * @param string[]|null $locales
-     */
     public function __construct(
         ExpressionLanguage $expressionLanguage,
         iterable $formMetadataLoaders,
-        ?array $locales = []
+        ?string $fallbackLocale = null
     ) {
         $this->expressionLanguage = $expressionLanguage;
         $this->formMetadataLoaders = $formMetadataLoaders;
 
-        if (!$locales) {
-            @\trigger_error('The usage of the "FormMetadataProvider" without "$locales" is deprecated. Please add "$locales" instead.', \E_USER_DEPRECATED);
+        if (!$fallbackLocale) {
+            @\trigger_error('The usage of the "FormMetadataProvider" without "$fallbackLocale" is deprecated. Please add "$fallbackLocale" instead.', \E_USER_DEPRECATED);
 
-            $locales = ['en'];
+            $fallbackLocale = 'en';
         }
 
-        $this->defaultLocale = $locales[0];
+        $this->fallbackLocale = $fallbackLocale;
     }
 
     public function getMetadata(string $key, string $locale, array $metadataOptions = []): MetadataInterface
@@ -64,7 +61,7 @@ class FormMetadataProvider implements MetadataProviderInterface
         }
         if (!$form) {
             foreach ($this->formMetadataLoaders as $metadataLoader) {
-                $form = $metadataLoader->getMetadata($key, $this->defaultLocale, $metadataOptions);
+                $form = $metadataLoader->getMetadata($key, $this->fallbackLocale, $metadataOptions);
                 if ($form) {
                     break;
                 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -47,6 +47,7 @@
         >
             <argument type="service" id="sulu_core.expression_language" />
             <argument type="tagged" tag="sulu_admin.form_metadata_loader"/>
+            <argument>%sulu_core.fallback_locale%</argument>
             <tag name="sulu_admin.metadata_provider" type="form" />
         </service>
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -56,6 +56,37 @@ class AdminControllerTest extends SuluTestCase
         $this->assertEquals('de_at', $response->sulu_admin->localizations[3]->localization);
     }
 
+    public function testGetConfigWithFallbackNonExistUserLocale()
+    {
+        $this->initPhpcr();
+
+        $this->getTestUser()->setLocale('not-exist');
+
+        $collectionType = new LoadCollectionTypes();
+        $collectionType->load($this->getEntityManager());
+
+        $this->client->jsonRequest('GET', '/admin/config');
+
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+
+        $response = \json_decode($this->client->getResponse()->getContent());
+
+        $this->assertObjectHasAttribute('sulu_admin', $response);
+        $this->assertObjectHasAttribute('navigation', $response->sulu_admin);
+        $this->assertObjectHasAttribute('resources', $response->sulu_admin);
+        $this->assertObjectHasAttribute('routes', $response->sulu_admin);
+        $this->assertObjectHasAttribute('fieldTypeOptions', $response->sulu_admin);
+        $this->assertIsArray($response->sulu_admin->navigation);
+        $this->assertIsArray($response->sulu_admin->routes);
+        $this->assertIsObject($response->sulu_admin->resources);
+        $this->assertObjectHasAttribute('sulu_preview', $response);
+
+        $this->assertEquals('en', $response->sulu_admin->localizations[0]->localization);
+        $this->assertEquals('en_us', $response->sulu_admin->localizations[1]->localization);
+        $this->assertEquals('de', $response->sulu_admin->localizations[2]->localization);
+        $this->assertEquals('de_at', $response->sulu_admin->localizations[3]->localization);
+    }
+
     public function testTemplateConfig(): void
     {
         $this->initPhpcr();

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -28,7 +28,7 @@ class AdminControllerTest extends SuluTestCase
         $this->purgeDatabase();
     }
 
-    public function testGetConfig()
+    public function testGetConfig(): void
     {
         $this->initPhpcr();
         $collectionType = new LoadCollectionTypes();
@@ -38,7 +38,7 @@ class AdminControllerTest extends SuluTestCase
 
         $this->assertHttpStatusCode(200, $this->client->getResponse());
 
-        $response = \json_decode($this->client->getResponse()->getContent());
+        $response = \json_decode($this->client->getResponse()->getContent() ?: '');
 
         $this->assertObjectHasAttribute('sulu_admin', $response);
         $this->assertObjectHasAttribute('navigation', $response->sulu_admin);
@@ -56,7 +56,7 @@ class AdminControllerTest extends SuluTestCase
         $this->assertEquals('de_at', $response->sulu_admin->localizations[3]->localization);
     }
 
-    public function testGetConfigWithFallbackNonExistUserLocale()
+    public function testGetConfigWithFallbackNonExistUserLocale(): void
     {
         $this->initPhpcr();
 
@@ -69,7 +69,7 @@ class AdminControllerTest extends SuluTestCase
 
         $this->assertHttpStatusCode(200, $this->client->getResponse());
 
-        $response = \json_decode($this->client->getResponse()->getContent());
+        $response = \json_decode($this->client->getResponse()->getContent() ?: '');
 
         $this->assertObjectHasAttribute('sulu_admin', $response);
         $this->assertObjectHasAttribute('navigation', $response->sulu_admin);
@@ -133,7 +133,7 @@ class AdminControllerTest extends SuluTestCase
         ], $config);
     }
 
-    public function testGetNotExistingMetdata()
+    public function testGetNotExistingMetdata(): void
     {
         $this->client->jsonRequest('GET', '/admin/metadata/test1/test');
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
@@ -29,13 +29,13 @@ class FormMetadataProviderTest extends KernelTestCase
         $this->formMetadataProvider = $this->getContainer()->get('sulu_admin_test.form_metadata_provider');
     }
 
-    public function testMetadataNotFound()
+    public function testMetadataNotFound(): void
     {
         $this->expectException(MetadataNotFoundException::class);
         $this->formMetadataProvider->getMetadata('form_without_metadata', 'en');
     }
 
-    public function testGetMetadataFromFormMetadataXmlLoader()
+    public function testGetMetadataFromFormMetadataXmlLoader(): void
     {
         $form = $this->formMetadataProvider->getMetadata('form_with_schema', 'en');
         $this->assertInstanceOf(FormMetadata::class, $form);
@@ -44,7 +44,16 @@ class FormMetadataProviderTest extends KernelTestCase
         $this->assertCount(2, \array_keys($schema));
     }
 
-    public function testGetMetadataWithExpression()
+    public function testGetMetadataFromFormMetadataXmlLoaderFallbackLocale(): void
+    {
+        $form = $this->formMetadataProvider->getMetadata('form_with_schema', 'not-exist');
+        $this->assertInstanceOf(FormMetadata::class, $form);
+        $this->assertCount(3, $form->getItems());
+        $schema = $form->getSchema()->toJsonSchema();
+        $this->assertCount(2, \array_keys($schema));
+    }
+
+    public function testGetMetadataWithExpression(): void
     {
         $form = $this->formMetadataProvider->getMetadata(
             'form_with_webspace_expression_param',
@@ -56,7 +65,7 @@ class FormMetadataProviderTest extends KernelTestCase
         $this->assertEquals('sulu_io', $form->getItems()['name']->getOptions()['id']->getValue());
     }
 
-    public function testGetMetadataWithLocaleInExpression()
+    public function testGetMetadataWithLocaleInExpression(): void
     {
         $form = $this->formMetadataProvider->getMetadata(
             'form_with_locale_expression_param',
@@ -67,14 +76,14 @@ class FormMetadataProviderTest extends KernelTestCase
         $this->assertEquals('en', $form->getItems()['name']->getOptions()['id']->getValue());
     }
 
-    public function testGetMetadataFromStructureLoader()
+    public function testGetMetadataFromStructureLoader(): void
     {
         $typedForm = $this->formMetadataProvider->getMetadata('page', 'en');
         $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
         $this->assertCount(2, $typedForm->getForms());
     }
 
-    public function testGetMetadataTagFiltered()
+    public function testGetMetadataTagFiltered(): void
     {
         $typedForm = $this->formMetadataProvider->getMetadata(
             'page',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add fallback for form metadata for none exist user locale

#### Why?

See https://github.com/sulu/sulu/issues/6106.