### PR TITLE
Introduce ChangeContext to prevent marking form as dirty when setting default value

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
@@ -9,14 +9,14 @@ import FieldComponent from '../../components/Form/Field';
 import fieldRegistry from './registries/fieldRegistry';
 import fieldStyles from './field.scss';
 import FormInspector from './FormInspector';
-import type {FieldChangeContext, Error, ErrorCollection, SchemaEntry} from './types';
+import type {ChangeContext, Error, ErrorCollection, SchemaEntry} from './types';
 
 type Props = {|
     dataPath: string,
     error?: Error | ErrorCollection,
     formInspector: FormInspector,
     name: string,
-    onChange: (name: string, value: *, context: FieldChangeContext) => void,
+    onChange: (name: string, value: *, context?: ChangeContext) => void,
     onFinish: (dataPath: string, schemaPath: string) => void,
     onSuccess: ?() => void,
     router: ?Router,
@@ -32,14 +32,14 @@ class Field extends React.Component<Props> {
         showAllErrors: false,
     };
 
-    handleChange = (value: *, context?: FieldChangeContext) => {
+    handleChange = (value: *, context?: ChangeContext) => {
         const {name, onChange, schema} = this.props;
 
         if (schema.disabled) {
             return;
         }
 
-        onChange(name, value, context || {});
+        onChange(name, value, context);
     };
 
     handleFinish = (subDataPath: ?string, subSchemaPath: ?string) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
@@ -9,14 +9,14 @@ import FieldComponent from '../../components/Form/Field';
 import fieldRegistry from './registries/fieldRegistry';
 import fieldStyles from './field.scss';
 import FormInspector from './FormInspector';
-import type {Error, ErrorCollection, SchemaEntry} from './types';
+import type {FieldChangeContext, Error, ErrorCollection, SchemaEntry} from './types';
 
 type Props = {|
     dataPath: string,
     error?: Error | ErrorCollection,
     formInspector: FormInspector,
     name: string,
-    onChange: (string, *) => void,
+    onChange: (name: string, value: *, context: FieldChangeContext) => void,
     onFinish: (dataPath: string, schemaPath: string) => void,
     onSuccess: ?() => void,
     router: ?Router,
@@ -32,14 +32,14 @@ class Field extends React.Component<Props> {
         showAllErrors: false,
     };
 
-    handleChange = (value: *) => {
+    handleChange = (value: *, context?: FieldChangeContext) => {
         const {name, onChange, schema} = this.props;
 
         if (schema.disabled) {
             return;
         }
 
-        onChange(name, value);
+        onChange(name, value, context || {});
     };
 
     handleFinish = (subDataPath: ?string, subSchemaPath: ?string) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
@@ -10,7 +10,7 @@ import Renderer from './Renderer';
 import FormInspector from './FormInspector';
 import GhostDialog from './GhostDialog';
 import MissingTypeDialog from './MissingTypeDialog';
-import type {FormStoreInterface} from './types';
+import type {FieldChangeContext, FormStoreInterface} from './types';
 
 type Props = {|
     onError?: (errors: Object) => void,
@@ -55,13 +55,6 @@ class Form extends React.Component<Props> {
         this.displayGhostDialogDisposer();
     }
 
-    @action setRendererRef = () => {
-        const {store} = this.props;
-        // This avoids starting with an already dirty form
-        // That can happen if a field type calls the onChange handler to set a default value in their its constructor
-        store.dirty = false;
-    };
-
     @computed get formInspector(): FormInspector {
         return new FormInspector(this.props.store);
     }
@@ -96,8 +89,12 @@ class Form extends React.Component<Props> {
         }
     };
 
-    handleChange = (name: string, value: mixed) => {
-        this.props.store.change(name, value);
+    handleChange = (name: string, value: mixed, context: FieldChangeContext) => {
+        if (context.isDefaultValue) {
+            this.props.store.set(name, value);
+        } else {
+            this.props.store.change(name, value);
+        }
     };
 
     @action showGhostDialog() {
@@ -189,7 +186,6 @@ class Form extends React.Component<Props> {
                         onChange={this.handleChange}
                         onFieldFinish={this.handleFieldFinish}
                         onSuccess={onSuccess}
-                        ref={this.setRendererRef}
                         router={router}
                         schema={store.schema}
                         schemaPath=""

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
@@ -119,7 +119,7 @@ class Form extends React.Component<Props> {
     @action handleMissingTypeDialogConfirm = (type: string) => {
         const {store} = this.props;
 
-        store.setType(type);
+        store.changeType(type);
     };
 
     @action handleMissingTypeDialogCancel = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
@@ -10,7 +10,7 @@ import Renderer from './Renderer';
 import FormInspector from './FormInspector';
 import GhostDialog from './GhostDialog';
 import MissingTypeDialog from './MissingTypeDialog';
-import type {FieldChangeContext, FormStoreInterface} from './types';
+import type {ChangeContext, FormStoreInterface} from './types';
 
 type Props = {|
     onError?: (errors: Object) => void,
@@ -89,12 +89,8 @@ class Form extends React.Component<Props> {
         }
     };
 
-    handleChange = (name: string, value: mixed, context: FieldChangeContext) => {
-        if (context.isDefaultValue) {
-            this.props.store.set(name, value);
-        } else {
-            this.props.store.change(name, value);
-        }
+    handleChange = (name: string, value: mixed, context?: ChangeContext) => {
+        this.props.store.change(name, value, context);
     };
 
     @action showGhostDialog() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
@@ -8,14 +8,14 @@ import Router from '../../services/Router';
 import Field from './Field';
 import FormInspector from './FormInspector';
 import type {Element} from 'react';
-import type {ErrorCollection, Schema, SchemaEntry} from './types';
+import type {ErrorCollection, Schema, SchemaEntry, FieldChangeContext} from './types';
 
 type Props = {|
     data: Object,
     dataPath: string,
     errors?: ErrorCollection,
     formInspector: FormInspector,
-    onChange: (string, *) => void,
+    onChange: (name: string, value: *, context: FieldChangeContext) => void,
     onFieldFinish: ?(dataPath: string, schemaPath: string) => void,
     onSuccess: ?() => void,
     router: ?Router,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
@@ -8,14 +8,14 @@ import Router from '../../services/Router';
 import Field from './Field';
 import FormInspector from './FormInspector';
 import type {Element} from 'react';
-import type {ErrorCollection, Schema, SchemaEntry, FieldChangeContext} from './types';
+import type {ErrorCollection, Schema, SchemaEntry, ChangeContext} from './types';
 
 type Props = {|
     data: Object,
     dataPath: string,
     errors?: ErrorCollection,
     formInspector: FormInspector,
-    onChange: (name: string, value: *, context: FieldChangeContext) => void,
+    onChange: (name: string, value: *, context?: ChangeContext) => void,
     onFieldFinish: ?(dataPath: string, schemaPath: string) => void,
     onSuccess: ?() => void,
     router: ?Router,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Checkbox.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Checkbox.js
@@ -45,7 +45,7 @@ class Checkbox extends React.Component<FieldTypeProps<boolean>> {
         }
 
         if (value === undefined) {
-            onChange(defaultValue);
+            onChange(defaultValue, {isDefaultValue: true});
         }
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Select.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Select.js
@@ -35,7 +35,7 @@ export default class Select extends React.Component<Props> {
         });
 
         if (value === undefined) {
-            onChange(defaultValues);
+            onChange(defaultValues, {isDefaultValue: true});
         }
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
@@ -25,7 +25,7 @@ export default class SingleSelect extends React.Component<FieldTypeProps<string 
         }
 
         if (value === undefined) {
-            onChange(defaultValue);
+            onChange(defaultValue, {isDefaultValue: true});
         }
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
@@ -112,7 +112,7 @@ class SmartContent extends React.Component<Props> {
         const {datasourceResourceKey} = smartContentConfigStore.getConfig(this.provider);
 
         if (value === undefined) {
-            onChange(this.value);
+            onChange(this.value, {isDefaultValue: true});
         }
 
         this.smartContentStore = new SmartContentStore(

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Url.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Url.js
@@ -42,7 +42,7 @@ export default class Url extends React.Component<FieldTypeProps<?string>> {
             throw new Error('The "specific_part" default must be a string if set!');
         }
 
-        onChange(defaultSchemeOption.value + defaultSpecificPartOption.value);
+        onChange(defaultSchemeOption.value + defaultSpecificPartOption.value, {isDefaultValue: true});
     }
 
     handleBlur = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
@@ -204,7 +204,19 @@ export default class AbstractFormStore
         this.updateFieldPathEvaluations();
     }
 
+    changeMultiple() {
+        this.updateFieldPathEvaluations();
+    }
+
+    /**
+     * @deprecated
+     */
     setMultiple() {
+        log.warn(
+            'The "setMultiple" method is deprecated and will be removed. ' +
+            'Use the "changeMultiple" method instead.'
+        );
+
         this.updateFieldPathEvaluations();
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
@@ -204,7 +204,8 @@ export default class AbstractFormStore
         this.updateFieldPathEvaluations();
     }
 
-    changeMultiple() {
+    // eslint-disable-next-line no-unused-vars
+    changeMultiple(values: {[dataPath: string]: mixed}) {
         this.updateFieldPathEvaluations();
     }
 
@@ -287,8 +288,8 @@ export default class AbstractFormStore
         this.evaluatedSchema = evaluatedSchema;
     }
 
-    getValueByPath = (path: string): mixed => {
-        return jsonpointer.has(this.data, path) ? jsonpointer.get(this.data, path) : undefined;
+    getValueByPath = (dataPath: string): mixed => {
+        return jsonpointer.has(this.data, dataPath) ? jsonpointer.get(this.data, dataPath) : undefined;
     };
 
     getValuesByTag(tagName: string): Array<mixed> {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/MemoryFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/MemoryFormStore.js
@@ -39,21 +39,21 @@ export default class MemoryFormStore extends AbstractFormStore implements FormSt
         this.updateFieldPathEvaluationsDisposer = autorun(this.updateFieldPathEvaluations);
     }
 
-    @action change(path: string, value: mixed, context?: ChangeContext) {
-        jsonpointer.set(this.data, '/' + path, value);
+    @action change(dataPath: string, value: mixed, context?: ChangeContext) {
+        jsonpointer.set(this.data, '/' + dataPath, value);
 
         if (!context?.isDefaultValue && !context?.isServerValue) {
             this.dirty = true;
         }
     }
 
-    @action changeMultiple(data: Object, context?: ChangeContext) {
-        Object.keys(data).forEach((path) => {
-            this.change(path, data[path], context);
+    @action changeMultiple(values: {[dataPath: string]: mixed}, context?: ChangeContext) {
+        Object.keys(values).forEach((path) => {
+            this.change(path, values[path], context);
         });
         set(this.data, this.data);
 
-        super.changeMultiple();
+        super.changeMultiple(values);
     }
 
     get hasInvalidType() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/MemoryFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/MemoryFormStore.js
@@ -1,5 +1,5 @@
 // @flow
-import {action, autorun, observable} from 'mobx';
+import {action, autorun, observable, set} from 'mobx';
 import Ajv from 'ajv';
 import jsonpointer from 'json-pointer';
 import AbstractFormStore from './AbstractFormStore';
@@ -38,7 +38,7 @@ export default class MemoryFormStore extends AbstractFormStore implements FormSt
     }
 
     @action change(path: string, value: mixed) {
-        jsonpointer.set(this.data, '/' + path, value);
+        this.set(path, value);
         this.dirty = true;
     }
 
@@ -46,8 +46,15 @@ export default class MemoryFormStore extends AbstractFormStore implements FormSt
         return false;
     }
 
+    @action set(path: string, value: mixed) {
+        jsonpointer.set(this.data, '/' + path, value);
+    }
+
     @action setMultiple(data: Object) {
-        this.data = {...this.data, ...data};
+        Object.keys(data).forEach((path) => {
+            this.set(path, data[path]);
+        });
+        set(this.data, this.data);
 
         super.setMultiple();
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/MemoryFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/MemoryFormStore.js
@@ -42,7 +42,7 @@ export default class MemoryFormStore extends AbstractFormStore implements FormSt
     @action change(path: string, value: mixed, context?: ChangeContext) {
         jsonpointer.set(this.data, '/' + path, value);
 
-        if (!context?.isDefaultValue) {
+        if (!context?.isDefaultValue && !context?.isServerValue) {
             this.dirty = true;
         }
     }
@@ -74,7 +74,7 @@ export default class MemoryFormStore extends AbstractFormStore implements FormSt
         super.setMultiple();
     }
 
-    setType() {
+    changeType() {
         throw new Error('The MemoryFormStore cannot handle types');
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/MemoryFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/MemoryFormStore.js
@@ -40,7 +40,9 @@ export default class MemoryFormStore extends AbstractFormStore implements FormSt
     }
 
     @action change(dataPath: string, value: mixed, context?: ChangeContext) {
-        jsonpointer.set(this.data, '/' + dataPath, value);
+        const sanitizedDataPath = !dataPath.startsWith('/') ? '/' + dataPath : dataPath;
+
+        jsonpointer.set( this.data, sanitizedDataPath, value );
 
         if (!context?.isDefaultValue && !context?.isServerValue) {
             this.dirty = true;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
@@ -68,7 +68,10 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
             when(
                 () => !this.resourceStore.loading,
                 (): void => {
-                    this.setType(this.resourceStore.data[TYPE] || defaultType || Object.keys(this.types)[0]);
+                    this.changeType(
+                        this.resourceStore.data[TYPE] || defaultType || Object.keys(this.types)[0],
+                        {isDefaultValue: true}
+                    );
                 }
             );
         }
@@ -145,7 +148,7 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
         return this.resourceStore.copyFromLocale(sourceLocale, this.options)
             .then((response) => {
                 if (this.hasTypes) {
-                    this.setType(response[TYPE]);
+                    this.changeType(response[TYPE], {isServerValue: true});
                 }
             });
     }
@@ -177,7 +180,7 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
     }
 
     change(name: string, value: mixed, context?: ChangeContext) {
-        if (context?.isDefaultValue) {
+        if (context?.isDefaultValue || context?.isServerValue) {
             // set method of resource store will not mark the store as dirty
             this.resourceStore.set(name, value);
         } else {
@@ -186,7 +189,7 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
     }
 
     changeMultiple(data: Object, context?: ChangeContext) {
-        if (context?.isDefaultValue) {
+        if (context?.isDefaultValue || context?.isServerValue) {
             // setMultiple method of resource store will not mark the store as dirty
             this.resourceStore.setMultiple(data);
         } else {
@@ -230,16 +233,24 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
         this.schemaLoading = schemaLoading;
     }
 
+    /**
+     * @deprecated
+     */
     @action setType(type: string) {
+        log.warn(
+            'The "setType" method is deprecated and will be removed. ' +
+            'Use the "changeType" method instead.'
+        );
+
         this.validateTypes();
         this.type = type;
         this.set(TYPE, type);
     }
 
-    @action changeType(type: string) {
+    @action changeType(type: string, context?: ChangeContext) {
         this.validateTypes();
         this.type = type;
-        this.change(TYPE, type);
+        this.change(TYPE, type, context);
     }
 
     validateTypes() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
@@ -179,22 +179,24 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
         super.setMultiple();
     }
 
-    change(name: string, value: mixed, context?: ChangeContext) {
+    change(dataPath: string, value: mixed, context?: ChangeContext) {
         if (context?.isDefaultValue || context?.isServerValue) {
             // set method of resource store will not mark the store as dirty
-            this.resourceStore.set(name, value);
+            this.resourceStore.set(dataPath, value);
         } else {
-            this.resourceStore.change(name, value);
+            this.resourceStore.change(dataPath, value);
         }
     }
 
-    changeMultiple(data: Object, context?: ChangeContext) {
+    changeMultiple(values: {[dataPath: string]: mixed}, context?: ChangeContext) {
         if (context?.isDefaultValue || context?.isServerValue) {
             // setMultiple method of resource store will not mark the store as dirty
-            this.resourceStore.setMultiple(data);
+            this.resourceStore.setMultiple(values);
         } else {
-            this.resourceStore.change(data);
+            this.resourceStore.changeMultiple(values);
         }
+
+        super.changeMultiple(values);
     }
 
     @computed get locale(): ?IObservableValue<string> {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/SchemaFormStoreDecorator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/SchemaFormStoreDecorator.js
@@ -1,7 +1,8 @@
 // @flow
 import {action, computed, observable} from 'mobx';
+import log from 'loglevel';
 import metadataStore from './metadataStore';
-import type {FormStoreInterface, RawSchema, Schema, SchemaEntry} from '../types';
+import type {ChangeContext, FormStoreInterface, RawSchema, Schema, SchemaEntry} from '../types';
 
 export default class SchemaFormStoreDecorator implements FormStoreInterface {
     @observable innerFormStore: ?FormStoreInterface;
@@ -20,9 +21,15 @@ export default class SchemaFormStoreDecorator implements FormStoreInterface {
         }));
     }
 
-    change(name: string, value: mixed) {
+    change(name: string, value: mixed, context?: ChangeContext) {
         if (this.innerFormStore) {
-            this.innerFormStore.change(name, value);
+            this.innerFormStore.change(name, value, context);
+        }
+    }
+
+    changeMultiple(data: Object, context?: ChangeContext) {
+        if (this.innerFormStore) {
+            this.innerFormStore.changeMultiple(data, context);
         }
     }
 
@@ -34,14 +41,20 @@ export default class SchemaFormStoreDecorator implements FormStoreInterface {
         return {};
     }
 
-    set(name: string, value: mixed) {
-        if (this.innerFormStore) {
-            this.innerFormStore.set(name, value);
-        }
-    }
-
+    /**
+     * @deprecated
+     */
     setMultiple(data: Object) {
-        if (this.innerFormStore) {
+        log.warn(
+            'The "setMultiple" method is deprecated and will be removed. ' +
+            'Use the "changeMultiple" method instead.'
+        );
+
+        // the setMultiple method was removed from the FormStoreInterface
+        // we still want to call it to keep backwards compatibility if it is defined
+        // $FlowFixMe
+        if (this.innerFormStore && typeof this.innerFormStore.setMultiple === 'function') {
+            // $FlowFixMe
             this.innerFormStore.setMultiple(data);
         }
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/SchemaFormStoreDecorator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/SchemaFormStoreDecorator.js
@@ -27,6 +27,12 @@ export default class SchemaFormStoreDecorator implements FormStoreInterface {
         }
     }
 
+    changeType(type: string, context?: ChangeContext) {
+        if (this.innerFormStore) {
+            this.innerFormStore.changeType(type, context);
+        }
+    }
+
     changeMultiple(data: Object, context?: ChangeContext) {
         if (this.innerFormStore) {
             this.innerFormStore.changeMultiple(data, context);
@@ -205,8 +211,20 @@ export default class SchemaFormStoreDecorator implements FormStoreInterface {
         return {};
     }
 
+    /**
+     * @deprecated
+     */
     setType(type: string): void {
-        if (this.innerFormStore) {
+        log.warn(
+            'The "setType" method is deprecated and will be removed. ' +
+            'Use the "changeType" method instead.'
+        );
+
+        // the setType method was removed from the FormStoreInterface
+        // we still want to call it to keep backwards compatibility if it is defined
+        // $FlowFixMe
+        if (this.innerFormStore && typeof this.innerFormStore.setType === 'function') {
+            // $FlowFixMe
             return this.innerFormStore.setType(type);
         }
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/SchemaFormStoreDecorator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/SchemaFormStoreDecorator.js
@@ -34,6 +34,12 @@ export default class SchemaFormStoreDecorator implements FormStoreInterface {
         return {};
     }
 
+    set(name: string, value: mixed) {
+        if (this.innerFormStore) {
+            this.innerFormStore.set(name, value);
+        }
+    }
+
     setMultiple(data: Object) {
         if (this.innerFormStore) {
             this.innerFormStore.setMultiple(data);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/SchemaFormStoreDecorator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/SchemaFormStoreDecorator.js
@@ -21,9 +21,9 @@ export default class SchemaFormStoreDecorator implements FormStoreInterface {
         }));
     }
 
-    change(name: string, value: mixed, context?: ChangeContext) {
+    change(dataPath: string, value: mixed, context?: ChangeContext) {
         if (this.innerFormStore) {
-            this.innerFormStore.change(name, value, context);
+            this.innerFormStore.change(dataPath, value, context);
         }
     }
 
@@ -33,9 +33,9 @@ export default class SchemaFormStoreDecorator implements FormStoreInterface {
         }
     }
 
-    changeMultiple(data: Object, context?: ChangeContext) {
+    changeMultiple(values: {[dataPath: string]: mixed}, context?: ChangeContext) {
         if (this.innerFormStore) {
-            this.innerFormStore.changeMultiple(data, context);
+            this.innerFormStore.changeMultiple(values, context);
         }
     }
 
@@ -123,9 +123,9 @@ export default class SchemaFormStoreDecorator implements FormStoreInterface {
         return undefined;
     }
 
-    getValueByPath(path: string): mixed {
+    getValueByPath(dataPath: string): mixed {
         if (this.innerFormStore) {
-            return this.innerFormStore.getValueByPath(path);
+            return this.innerFormStore.getValueByPath(dataPath);
         }
 
         return false;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
@@ -391,9 +391,9 @@ test('Call onChange callback when value of Field changes', () => {
         />
     );
 
-    field.find('Text').simulate('change', 'test value');
+    field.find('Text').props().onChange('test value', {isDefaultValue: true});
 
-    expect(changeSpy).toBeCalledWith('test', 'test value');
+    expect(changeSpy).toBeCalledWith('test', 'test value', {isDefaultValue: true});
 });
 
 test('Do not call onChange callback when value of disabled Field changes', () => {
@@ -418,7 +418,7 @@ test('Do not call onChange callback when value of disabled Field changes', () =>
         />
     );
 
-    field.find('Text').simulate('change', 'test value');
+    field.find('Text').props().onChange('test value');
 
     expect(changeSpy).not.toBeCalled();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Form.test.js
@@ -48,7 +48,7 @@ jest.mock('../stores/ResourceFormStore', () => jest.fn(function(resourceStore) {
     this.getValueByPath = jest.fn();
     this.getSchemaEntryByPath = jest.fn().mockReturnValue({types: {default: {form: {}}}});
     this.types = {};
-    this.setType = jest.fn();
+    this.changeType = jest.fn();
 }));
 
 jest.mock('../../../stores/ResourceStore', () => jest.fn(function(resourceKey, id, observableOptions = {}) {
@@ -350,17 +350,8 @@ test('Should change data on store when changed', () => {
     const store = new ResourceFormStore(new ResourceStore('snippet', '1'), 'snippet');
     const form = shallow(<Form onSubmit={submitSpy} store={store} />);
 
-    form.find('Renderer').simulate('change', 'field', 'value');
-    expect(store.change).toBeCalledWith('field', 'value');
-});
-
-test('Reset dirty flag after form was rendered to avoid initial dirty state if defaults were set by fields', () => {
-    const submitSpy = jest.fn();
-    const store = new ResourceFormStore(new ResourceStore('snippet', '1'), 'snippet');
-    store.dirty = true;
-    mount(<Form onSubmit={submitSpy} store={store} />);
-
-    expect(store.dirty).toEqual(false);
+    form.find('Renderer').props().onChange('field', 'value', {isDefaultValue: true});
+    expect(store.change).toBeCalledWith('field', 'value', {isDefaultValue: true});
 });
 
 test('Should change data on store without sections', () => {
@@ -395,9 +386,9 @@ test('Should change data on store without sections', () => {
     };
 
     const form = mount(<Form onSubmit={submitSpy} store={store} />);
-    form.find('Input').at(0).instance().handleChange({currentTarget: {value: 'value!'}});
+    form.find('Input').at(0).props().onChange('value!');
 
-    expect(store.change).toBeCalledWith('item11', 'value!');
+    expect(store.change).toBeCalledWith('item11', 'value!', undefined);
 });
 
 test('Should show a GhostDialog if the current locale is not translated', () => {
@@ -508,7 +499,7 @@ test('Should set the type of the formStore to selected value in MissingTypeDialo
     form.find('MissingTypeDialog Button[skin="primary"]').simulate('click');
 
     expect(onMissingTypeCancelSpy).not.toBeCalledWith();
-    expect(formStore.setType).toBeCalledWith('default');
+    expect(formStore.changeType).toBeCalledWith('default');
 });
 
 test('Should call the onMissingTypeCancel callback if MissingTypeDialog is cancelled', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Checkbox.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Checkbox.test.js
@@ -131,7 +131,7 @@ test('Set default value if no value is passed', () => {
         />
     );
 
-    expect(changeSpy).toBeCalledWith(false);
+    expect(changeSpy).toBeCalledWith(false, {'isDefaultValue': true});
 });
 
 test('Do not set default value if a value is passed', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Select.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Select.test.js
@@ -277,7 +277,7 @@ test('Set default value if no value is passed', () => {
         />
     );
 
-    expect(changeSpy).toBeCalledWith(['mr']);
+    expect(changeSpy).toBeCalledWith(['mr'], {'isDefaultValue': true});
 });
 
 test('Set default value to a number of 0 should work', () => {
@@ -311,7 +311,7 @@ test('Set default value to a number of 0 should work', () => {
         />
     );
 
-    expect(changeSpy).toBeCalledWith([0]);
+    expect(changeSpy).toBeCalledWith([0], {'isDefaultValue': true});
 });
 
 test('Throw error if no value option is passed', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelect.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelect.test.js
@@ -301,7 +301,7 @@ test('Set default value if no value is passed', () => {
         />
     );
 
-    expect(changeSpy).toBeCalledWith('mr');
+    expect(changeSpy).toBeCalledWith('mr', {'isDefaultValue': true});
 });
 
 test('Allow to pass one value for undefined', () => {
@@ -371,7 +371,7 @@ test('Set default value to a number of 0 should work', () => {
         />
     );
 
-    expect(changeSpy).toBeCalledWith(0);
+    expect(changeSpy).toBeCalledWith(0, {'isDefaultValue': true});
 });
 
 test('Throw error if no values option is passed', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Url.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Url.test.js
@@ -140,7 +140,7 @@ test('Pass correct default props to Url component', () => {
     expect(url.find(UrlComponent).prop('protocols')).toEqual(
         ['http://', 'https://', 'ftp://', 'ftps://', 'mailto:', 'tel:']
     );
-    expect(changeSpy).toBeCalledWith('http://github.com');
+    expect(changeSpy).toBeCalledWith('http://github.com', {'isDefaultValue': true});
 });
 
 test('Throw error if only specific_part default is set', () => {
@@ -234,7 +234,7 @@ test('Build URL from defaults to pass as value to URL component', () => {
         />
     );
 
-    expect(changeSpy).toBeCalledWith('https://sulu.io');
+    expect(changeSpy).toBeCalledWith('https://sulu.io', {'isDefaultValue': true});
 });
 
 test('Should not pass any arguments to onFinish callback', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
@@ -5,6 +5,11 @@ import ResourceStore from '../../../../stores/ResourceStore';
 import metadataStore from '../../stores/metadataStore';
 import conditionDataProviderRegistry from '../../registries/conditionDataProviderRegistry';
 
+jest.mock('loglevel', () => ({
+    warn: jest.fn(),
+    info: jest.fn(),
+}));
+
 beforeEach(() => {
     conditionDataProviderRegistry.clear();
 });
@@ -19,6 +24,9 @@ jest.mock('../../../../stores/ResourceStore', () => function(resourceKey, id, op
         Object.assign(this.data, data);
     });
     this.change = jest.fn();
+    this.changeMultiple = jest.fn(function(data) {
+        Object.assign(this.data, data);
+    });
     this.copyFromLocale = jest.fn();
     this.data = mockObservable({});
     this.loading = false;
@@ -1125,6 +1133,54 @@ test('SetMultiple should be passed to resourceStore', () => {
     resourceFormStore.setMultiple(data);
 
     expect(resourceFormStore.resourceStore.setMultiple).toBeCalledWith(data);
+    resourceFormStore.destroy();
+});
+
+test('Should call change method of ResourceStore', () => {
+    const resourceFormStore = new ResourceFormStore(new ResourceStore('snippets', '3'), 'snippets');
+    resourceFormStore.change('title', 'Title');
+
+    expect(resourceFormStore.resourceStore.change).toBeCalledWith('title', 'Title');
+    resourceFormStore.destroy();
+});
+
+test('Should call set method of ResourceStore for server data', () => {
+    const resourceFormStore = new ResourceFormStore(new ResourceStore('snippets', '3'), 'snippets');
+    resourceFormStore.change('title', 'Title', {isDefaultValue: true});
+
+    expect(resourceFormStore.resourceStore.set).toBeCalledWith('title', 'Title');
+    resourceFormStore.destroy();
+});
+
+test('Should call set method of ResourceStore for default data', () => {
+    const resourceFormStore = new ResourceFormStore(new ResourceStore('snippets', '3'), 'snippets');
+    resourceFormStore.change('title', 'Title', {isDefaultValue: true});
+
+    expect(resourceFormStore.resourceStore.set).toBeCalledWith('title', 'Title');
+    resourceFormStore.destroy();
+});
+
+test('Should call changeMultiple method of ResourceStore', () => {
+    const resourceFormStore = new ResourceFormStore(new ResourceStore('snippets', '3'), 'snippets');
+    resourceFormStore.changeMultiple({title: 'test1', description: 'test2'});
+
+    expect(resourceFormStore.resourceStore.changeMultiple).toBeCalledWith({title: 'test1', description: 'test2'});
+    resourceFormStore.destroy();
+});
+
+test('Should call setMultiple method of ResourceStore for server data', () => {
+    const resourceFormStore = new ResourceFormStore(new ResourceStore('snippets', '3'), 'snippets');
+    resourceFormStore.changeMultiple({title: 'test1', description: 'test2'}, {isDefaultValue: true});
+
+    expect(resourceFormStore.resourceStore.setMultiple).toBeCalledWith({title: 'test1', description: 'test2'});
+    resourceFormStore.destroy();
+});
+
+test('Should call setMultiple method of ResourceStore for default data', () => {
+    const resourceFormStore = new ResourceFormStore(new ResourceStore('snippets', '3'), 'snippets');
+    resourceFormStore.changeMultiple({title: 'test1', description: 'test2'}, {isDefaultValue: true});
+
+    expect(resourceFormStore.resourceStore.setMultiple).toBeCalledWith({title: 'test1', description: 'test2'});
     resourceFormStore.destroy();
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -121,11 +121,16 @@ export interface FormStoreInterface {
     +options: SchemaOptions,
     +resourceKey: ?string,
     +schema: Object,
+    +set: (name: string, value: mixed) => void,
     +setMultiple: (data: Object) => void,
     +setType: (type: string) => void,
     +types: {[key: string]: SchemaType},
     +validate: () => boolean,
 }
+
+export type FieldChangeContext = {
+    isDefaultValue?: boolean,
+};
 
 export type FieldTypeProps<T> = {|
     dataPath: string,
@@ -137,7 +142,7 @@ export type FieldTypeProps<T> = {|
     label: ?string,
     maxOccurs: ?number,
     minOccurs: ?number,
-    onChange: (value: T) => void,
+    onChange: (value: T, context?: FieldChangeContext) => void,
     onFinish: (subDataPath: ?string, subSchemaPath: ?string) => void,
     onSuccess: ?() => void,
     router: ?Router,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -105,6 +105,7 @@ export type ConditionDataProvider = (
 
 export interface FormStoreInterface {
     +change: (name: string, value: mixed, context?: ChangeContext) => void, // TODO: rename parameter + check for starting slash
+    +changeType: (type: string, context?: ChangeContext) => void,
     +changeMultiple: (data: Object, context?: ChangeContext) => void, //  TODO: refine type of data
     // Only exists in one implementation, therefore optional. Maybe we can remove that definition one day...
     +copyFromLocale?: (string) => Promise<*>,
@@ -127,7 +128,6 @@ export interface FormStoreInterface {
     +options: SchemaOptions,
     +resourceKey: ?string,
     +schema: Object,
-    +setType: (type: string) => void,
     +types: {[key: string]: SchemaType},
     +validate: () => boolean,
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -104,9 +104,9 @@ export type ConditionDataProvider = (
 ) => {[string]: any};
 
 export interface FormStoreInterface {
-    +change: (name: string, value: mixed, context?: ChangeContext) => void, // TODO: rename parameter + check for starting slash
+    +change: (dataPath: string, value: mixed, context?: ChangeContext) => void,
+    +changeMultiple: (values: {[dataPath: string]: mixed}, context?: ChangeContext) => void,
     +changeType: (type: string, context?: ChangeContext) => void,
-    +changeMultiple: (data: Object, context?: ChangeContext) => void, //  TODO: refine type of data
     // Only exists in one implementation, therefore optional. Maybe we can remove that definition one day...
     +copyFromLocale?: (string) => Promise<*>,
     +data: {[string]: any},
@@ -117,7 +117,7 @@ export interface FormStoreInterface {
     +forbidden: boolean,
     +getPathsByTag: (tagName: string) => Array<string>,
     +getSchemaEntryByPath: (schemaPath: string) => ?SchemaEntry,
-    +getValueByPath: (path: string) => mixed,
+    +getValueByPath: (dataPath: string) => mixed,
     +getValuesByTag: (tagName: string) => Array<mixed>,
     +hasInvalidType: boolean,
     +id: ?string | number,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -92,6 +92,11 @@ export type FinishFieldHandler = (dataPath: string, schemaPath: string) => void;
 
 export type SaveHandler = (action: ?string | {[string]: any}) => void;
 
+export type ChangeContext = {
+    isDefaultValue?: boolean,
+    isServerValue?: boolean,
+};
+
 export type ConditionDataProvider = (
     data: {[string]: any},
     options: {[string]: any},
@@ -99,7 +104,8 @@ export type ConditionDataProvider = (
 ) => {[string]: any};
 
 export interface FormStoreInterface {
-    +change: (name: string, value: mixed) => void,
+    +change: (name: string, value: mixed, context?: ChangeContext) => void, // TODO: rename parameter + check for starting slash
+    +changeMultiple: (data: Object, context?: ChangeContext) => void, //  TODO: refine type of data
     // Only exists in one implementation, therefore optional. Maybe we can remove that definition one day...
     +copyFromLocale?: (string) => Promise<*>,
     +data: {[string]: any},
@@ -121,16 +127,10 @@ export interface FormStoreInterface {
     +options: SchemaOptions,
     +resourceKey: ?string,
     +schema: Object,
-    +set: (name: string, value: mixed) => void,
-    +setMultiple: (data: Object) => void,
     +setType: (type: string) => void,
     +types: {[key: string]: SchemaType},
     +validate: () => boolean,
 }
-
-export type FieldChangeContext = {
-    isDefaultValue?: boolean,
-};
 
 export type FieldTypeProps<T> = {|
     dataPath: string,
@@ -142,7 +142,7 @@ export type FieldTypeProps<T> = {|
     label: ?string,
     maxOccurs: ?number,
     minOccurs: ?number,
-    onChange: (value: T, context?: FieldChangeContext) => void,
+    onChange: (value: T, context?: ChangeContext) => void,
     onFinish: (subDataPath: ?string, subSchemaPath: ?string) => void,
     onSuccess: ?() => void,
     router: ?Router,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
@@ -253,11 +253,13 @@ export default class ResourceStore {
     }
 
     @action set(path: string, value: mixed) {
-        if (path === 'id' && (typeof value === 'string' || typeof value === 'number')) {
+        const strippedPath = path.startsWith('/') ? path.substring(1) : path;
+
+        if (strippedPath === 'id' && (typeof value === 'string' || typeof value === 'number')) {
             this.id = value;
         }
 
-        jsonpointer.set(this.data, '/' + path, value);
+        jsonpointer.set(this.data, '/' + strippedPath, value);
     }
 
     @action setMultiple(data: Object) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
@@ -94,6 +94,17 @@ test('Should set nested values', () => {
     expect(resourceStore.dirty).toBe(true);
 });
 
+test('Should set values when using path with leading slash', () => {
+    ResourceRequester.get.mockReturnValue(Promise.resolve({}));
+
+    const resourceStore = new ResourceStore('snippets', '1');
+    expect(resourceStore.dirty).toBe(false);
+    resourceStore.change('/test1/test2', 'value');
+
+    expect(resourceStore.data.test1.test2).toBe('value');
+    expect(resourceStore.dirty).toBe(true);
+});
+
 test('Should load the data with the ResourceRequester', () => {
     const promise = Promise.resolve({value: 'Value'});
     ResourceRequester.get.mockReturnValue(promise);
@@ -604,6 +615,13 @@ test('Should set the internal id if id is set using set', () => {
     const resourceStore = new ResourceStore('media');
     expect(resourceStore.id).toBe(undefined);
     resourceStore.set('id', 4);
+    expect(resourceStore.id).toBe(4);
+});
+
+test('Should set the internal id if id is set with leading slash', () => {
+    const resourceStore = new ResourceStore('media');
+    expect(resourceStore.id).toBe(undefined);
+    resourceStore.set('/id', 4);
     expect(resourceStore.id).toBe(4);
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteDraftToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteDraftToolbarAction.test.js
@@ -51,7 +51,7 @@ jest.mock('../../../../containers/Form/stores/ResourceFormStore', () => (
         }
 
         delete = jest.fn();
-        setMultiple = jest.fn();
+        changeMultiple = jest.fn();
     })
 );
 
@@ -241,7 +241,7 @@ test('Delete draft when dialog is confirmed', () => {
         element = mount(deleteDraftToolbarAction.getNode());
         expect(deleteDraftToolbarAction.form.showSuccessSnackbar).toBeCalledWith();
         expect(element.prop('confirmLoading')).toEqual(false);
-        expect(deleteDraftToolbarAction.resourceFormStore.setMultiple).toBeCalledWith(data);
+        expect(deleteDraftToolbarAction.resourceFormStore.changeMultiple).toBeCalledWith(data, {isServerValue: true});
         expect(deleteDraftToolbarAction.resourceFormStore.dirty).toEqual(false);
     });
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SetUnpublishedToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SetUnpublishedToolbarAction.test.js
@@ -51,7 +51,7 @@ jest.mock('../../../../containers/Form/stores/ResourceFormStore', () => (
         }
 
         delete = jest.fn();
-        setMultiple = jest.fn();
+        changeMultiple = jest.fn();
     })
 );
 
@@ -254,7 +254,10 @@ test('Unpublish page when dialog is confirmed', () => {
         element = mount(setUnpublishedToolbarAction.getNode());
         expect(setUnpublishedToolbarAction.form.showSuccessSnackbar).toBeCalledWith();
         expect(element.prop('confirmLoading')).toEqual(false);
-        expect(setUnpublishedToolbarAction.resourceFormStore.setMultiple).toBeCalledWith(data);
+        expect(setUnpublishedToolbarAction.resourceFormStore.changeMultiple).toBeCalledWith(
+            data,
+            {isServerValue: true}
+        );
         expect(setUnpublishedToolbarAction.resourceFormStore.dirty).toEqual(false);
     });
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TogglerToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TogglerToolbarAction.test.js
@@ -20,7 +20,7 @@ jest.mock('../../../../containers/Form', () => ({
         resourceStore;
         resourceKey;
 
-        set = jest.fn();
+        change = jest.fn();
 
         constructor(resourceStore) {
             this.resourceStore = resourceStore;
@@ -160,7 +160,7 @@ test.each([
         );
 
         return promise.then(() => {
-            expect(toolbarAction.resourceFormStore.set).toBeCalledWith(property, true);
+            expect(toolbarAction.resourceFormStore.change).toBeCalledWith(property, true, {isServerValue: true});
             expect(toolbarAction.form.showSuccessSnackbar).toBeCalled();
         });
     }
@@ -195,7 +195,7 @@ test.each([
         );
 
         return promise.then(() => {
-            expect(toolbarAction.resourceFormStore.set).toBeCalledWith(property, false);
+            expect(toolbarAction.resourceFormStore.change).toBeCalledWith(property, false, {isServerValue: true});
             expect(toolbarAction.form.showSuccessSnackbar).toBeCalled();
         });
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteDraftToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteDraftToolbarAction.js
@@ -125,7 +125,7 @@ export default class DeleteDraftToolbarAction extends AbstractFormToolbarAction 
             this.deletingDraft = false;
             this.showDeleteDraftDialog = false;
             this.form.showSuccessSnackbar();
-            this.resourceFormStore.setMultiple(response);
+            this.resourceFormStore.changeMultiple(response, {isServerValue: true});
             this.resourceFormStore.dirty = false;
         }));
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SetUnpublishedToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SetUnpublishedToolbarAction.js
@@ -125,7 +125,7 @@ export default class SetUnpublishedToolbarAction extends AbstractFormToolbarActi
             this.unpublishing = false;
             this.showUnpublishDialog = false;
             this.form.showSuccessSnackbar();
-            this.resourceFormStore.setMultiple(response);
+            this.resourceFormStore.changeMultiple(response, {isServerValue: true});
             this.resourceFormStore.dirty = false;
         }));
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/TogglerToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/TogglerToolbarAction.js
@@ -91,7 +91,7 @@ export default class TogglerToolbarAction extends AbstractFormToolbarAction {
                 id,
             }
         ).then(action((response) => {
-            this.resourceFormStore.set(this.property, response[this.property]);
+            this.resourceFormStore.change(this.property, response[this.property], {isServerValue: true});
             this.loading = false;
             this.form.showSuccessSnackbar();
         })).catch(action((error) => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
@@ -39,7 +39,7 @@ class MediaSelection extends React.Component<FieldTypeProps<Value>> {
         }
 
         if (this.value === undefined) {
-            onChange({ids: [], displayOption: defaultDisplayOption});
+            onChange({ids: [], displayOption: defaultDisplayOption}, {isDefaultValue: true});
         }
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaSelection.js
@@ -38,7 +38,7 @@ class SingleMediaSelection extends React.Component<FieldTypeProps<Value>> {
         }
 
         if (this.value === undefined) {
-            onChange({id: undefined, displayOption: defaultDisplayOption});
+            onChange({id: undefined, displayOption: defaultDisplayOption}, {isDefaultValue: true});
         }
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/MediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/MediaSelection.test.js
@@ -125,7 +125,7 @@ test('Set default display option if no value is passed', () => {
         />
     );
 
-    expect(changeSpy).toBeCalledWith({displayOption: 'left', ids: []});
+    expect(changeSpy).toBeCalledWith({displayOption: 'left', ids: []}, {'isDefaultValue': true});
 });
 
 test('Set types on MultiMediaSelection', () => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/SingleMediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/SingleMediaSelection.test.js
@@ -137,7 +137,7 @@ test('Set default display option if no value is passed', () => {
         />
     );
 
-    expect(changeSpy).toBeCalledWith({displayOption: 'left', id: undefined});
+    expect(changeSpy).toBeCalledWith({displayOption: 'left', id: undefined}, {'isDefaultValue': true});
 });
 
 test('Do not set default display option if value is passed', () => {

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/tests/toolbarActions/EnableUserToolbarAction.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/tests/toolbarActions/EnableUserToolbarAction.test.js
@@ -18,7 +18,7 @@ jest.mock('sulu-admin-bundle/containers/Form', () => ({
     ResourceFormStore: class {
         resourceStore;
 
-        set = jest.fn();
+        change = jest.fn();
 
         constructor(resourceStore) {
             this.resourceStore = resourceStore;
@@ -181,7 +181,7 @@ test('Set new enabled value to ResourceFormStore and show success-snackbar on su
     toolbarItemConfig.onClick();
 
     return enableUserPromise.then(() => {
-        expect(toolbarAction.resourceFormStore.set).toBeCalledWith('enabled', true);
+        expect(toolbarAction.resourceFormStore.change).toBeCalledWith('enabled', true, {isServerValue: true});
         expect(toolbarAction.form.showSuccessSnackbar).toBeCalled();
     });
 });

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/toolbarActions/EnableUserToolbarAction.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/toolbarActions/EnableUserToolbarAction.js
@@ -39,7 +39,7 @@ export default class EnableUserToolbarAction extends AbstractFormToolbarAction {
                 id,
             }
         ).then(action((response) => {
-            this.resourceFormStore.set('enabled', response.enabled);
+            this.resourceFormStore.change('enabled', response.enabled, {isServerValue: true});
             this.loading = false;
             this.form.showSuccessSnackbar();
         })).catch(action((error) => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #5927
| License | MIT

#### What's in this PR?

This PR adds an additional `FieldChangeContext` argument to the `onChange` callback that is passed to all field-types of the `Form` component. The argument allows to pass additional information about the change to the `Form` component.

The newly added argument is utilized to set a default value from a field-type to the store of the form without marking the form as dirty. 

#### Why?

At the moment, to allow for setting default values, the form is marked as not-dirty after  the initial rendering. Because of this, the form is marked as not-dirty too after switching the template of a form (see https://github.com/sulu/sulu/issues/5927)
