### PR TITLE
Use symlinked location instead of real path when resolving dependencies

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,11 +66,10 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                     'vendor/friendsofsymfony/jsrouting-bundle/Resources/public/js'
                 ),
             },
-            symlinks: false,
-            modules: ['node_modules', nodeModulesPath],
+            symlinks: false, // @see https://github.com/sulu/sulu/pull/6117
         },
         resolveLoader: {
-            modules: ['node_modules', nodeModulesPath],
+            symlinks: false, // @see https://github.com/sulu/sulu/pull/6117
         },
         module: {
             rules: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,6 +66,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                     'vendor/friendsofsymfony/jsrouting-bundle/Resources/public/js'
                 ),
             },
+            symlinks: false,
             modules: ['node_modules', nodeModulesPath],
         },
         resolveLoader: {


### PR DESCRIPTION
#### What's in this PR?

This PR configures webpack to use the symlinked location instead of the real path when resolving dependencies of a file. 

#### Why?

The `sulu/skeleton` uses the `assets/admin` directory as root directory for the administration interface javascript application. This application imports the `sulu/sulu` code by requiring the bundles from the the `vendor` directory in its package.json.

When using the real path for resolving dependencies, the following setup causes webpack to resolve `xyz@v6` instead of `xyz@v7` during build because dependencies are resolved starting from `vendor/sulu/sulu/src/Sulu/Bundle/*/Resources/js/...`:
- Code inside of `vendor/sulu/sulu` requires package `xyz@v7`
- Unrelated javascript application in project root requires package `xyz@v6`

When using the symlinked location for resolving dependencies, this setup does not cause any problems because dependencies are resolved starting from `assets/admin/node_modules/sulu-admin-bundle/...` instead of `vendor/sulu/sulu/src/Sulu/Bundle/AdminBundle/Resources/js/...` and therefore the `assets/admin/node_modules` folder has higher priority than the `node_modules` folder in the project root.


#### Reproducable

- https://github.com/sulu/skeleton/compare/2.2.10...alexander-schranz:reproducable/main-directory-package?expand=1 
- https://github.com/alexander-schranz/skeleton/tree/reproducable/main-directory-package

```
yarn install
cd assets/admin
npm install
npm run build
```

Without disabling the `symlink` option, an error will pop up when **visiting the administration interface in the browser**.
