### PR TITLE
Replace Array.isArray with isArrayLike

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/SelectBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/SelectBlockPreviewTransformer.js
@@ -1,13 +1,13 @@
 // @flow
 import React from 'react';
-import {isObservableArray} from 'mobx';
+import {isArrayLike} from 'mobx';
 import type {Node} from 'react';
 import type {BlockPreviewTransformer} from '../types';
 import type {SchemaEntry} from '../../Form/types';
 
 export default class SelectBlockPreviewTransformer implements BlockPreviewTransformer {
     transform(value: *, schema: SchemaEntry): Node {
-        if (!Array.isArray(value) && !isObservableArray(value)) {
+        if (!isArrayLike(value)) {
             return null;
         }
 
@@ -16,10 +16,11 @@ export default class SelectBlockPreviewTransformer implements BlockPreviewTransf
         }
 
         const values = schema.options.values.value;
-        if (!Array.isArray(values)) {
+        if (!isArrayLike(values)) {
             throw new Error('The "SingleSelect" field type must have a "values" option defined being an array!');
         }
 
+        // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
         const selectedValues = values.filter((option) => value.includes(option.name));
 
         if (!selectedValues) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/SingleSelectBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/SingleSelectBlockPreviewTransformer.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import {isArrayLike} from 'mobx';
 import type {Node} from 'react';
 import type {BlockPreviewTransformer} from '../types';
 import type {SchemaEntry} from '../../Form/types';
@@ -11,10 +12,11 @@ export default class SingleSelectBlockPreviewTransformer implements BlockPreview
         }
 
         const values = schema.options.values.value;
-        if (!Array.isArray(values)) {
+        if (!isArrayLike(values)) {
             throw new Error('The "SingleSelect" field type must have a "values" option defined being an array!');
         }
 
+        // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
         const selectedValue = values.find((option) => option.name === value);
 
         if (!selectedValue) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {computed} from 'mobx';
+import {computed, isArrayLike} from 'mobx';
 import {observer} from 'mobx-react';
 import log from 'loglevel';
 import jexl from 'jexl';
@@ -92,7 +92,7 @@ class Field extends React.Component<Props> {
             return;
         }
 
-        if (Array.isArray(error)) {
+        if (isArrayLike(error)) {
             // this happens when the error is in a block field type
             // since the error is shown on the child elements of the block we do not have to mark the block separately
             return;
@@ -109,9 +109,11 @@ class Field extends React.Component<Props> {
             return error.keyword;
         }
 
+        // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
         for (const childKey in error) {
             // this happens when it is an error collection and not a single error
             // we will find the first child error with a keyword recursively
+            // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
             return this.findErrorKeyword(error[childKey]);
         }
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/conditionDataProviders/parentConditionDataProvider.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/conditionDataProviders/parentConditionDataProvider.js
@@ -1,5 +1,5 @@
 // @flow
-import {isObservableArray} from 'mobx';
+import {isArrayLike} from 'mobx';
 import jsonpointer from 'json-pointer';
 
 export default function(data: Object, dataPath: ?string): {[string]: any} {
@@ -15,7 +15,7 @@ export default function(data: Object, dataPath: ?string): {[string]: any} {
         parentDataPath = parentDataPath.substring(0, parentDataPath.lastIndexOf('/'));
         const evaluatedData = jsonpointer.get(data, parentDataPath);
 
-        if (Array.isArray(evaluatedData) || isObservableArray(evaluatedData)) {
+        if (isArrayLike(evaluatedData)) {
             continue;
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Select.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Select.js
@@ -1,8 +1,9 @@
 // @flow
 import React from 'react';
-import {computed} from 'mobx';
+import {computed, isArrayLike} from 'mobx';
 import MultiSelectComponent from '../../../components/MultiSelect';
 import type {FieldTypeProps} from '../../../types';
+import type {IObservableArray} from 'mobx/lib/mobx';
 
 type Props = FieldTypeProps<?Array<string | number>>;
 
@@ -22,10 +23,11 @@ export default class Select extends React.Component<Props> {
             return;
         }
 
-        if (!Array.isArray(defaultOptions)) {
+        if (!isArrayLike(defaultOptions)) {
             throw new Error('The "default_values" schema option must be an array!');
         }
 
+        // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
         const defaultValues = defaultOptions.map(({name: defaultValue}) => {
             if (typeof defaultValue !== 'number' && typeof defaultValue !== 'string') {
                 throw new Error('A single schema option of "default_values" must be a string or number');
@@ -39,13 +41,14 @@ export default class Select extends React.Component<Props> {
         }
     }
 
-    @computed get values() {
+    @computed get values(): Array<any> | IObservableArray<any> {
         const {values} = this.props.schemaOptions;
 
-        if (!values || !Array.isArray(values.value)) {
+        if (!values || !isArrayLike(values.value)) {
             throw new Error('The "values" option has to be set for the Select FieldType');
         }
 
+        // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
         return values.value;
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -16,7 +16,7 @@ import userStore from '../../../stores/userStore';
 import selectionStyles from './selection.scss';
 import type {FieldTypeProps} from '../../../types';
 import type {SchemaOption} from '../types';
-import type {IObservableValue} from 'mobx/lib/mobx';
+import type {IObservableArray, IObservableValue} from 'mobx/lib/mobx';
 
 type Value = Array<string | number>;
 type Props = FieldTypeProps<Value>;
@@ -51,10 +51,10 @@ class Selection extends React.Component<Props> {
             formInspector,
             schemaOptions: {
                 request_parameters: {
-                    value: requestParameters = [],
+                    value: unvalidatedRequestParameters = [],
                 } = {},
                 resource_store_properties_to_request: {
-                    value: resourceStorePropertiesToRequest = [],
+                    value: unvalidatedResourceStorePropertiesToRequest = [],
                 } = {},
             },
         } = this.props;
@@ -63,13 +63,17 @@ class Selection extends React.Component<Props> {
             throw new Error('The selection field needs a "resource_key" option to work properly');
         }
 
-        if (!Array.isArray(requestParameters)) {
+        if (!isArrayLike(unvalidatedRequestParameters)) {
             throw new Error('The "request_parameters" schemaOption must be an array!');
         }
+        // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
+        const requestParameters: Array<any> | IObservableArray<any> = unvalidatedRequestParameters;
 
-        if (!Array.isArray(resourceStorePropertiesToRequest)) {
+        if (!isArrayLike(unvalidatedResourceStorePropertiesToRequest)) {
             throw new Error('The "resource_store_properties_to_request" schemaOption must be an array!');
         }
+        // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
+        const resourceStorePropertiesToRequest: Array | IObservableArray = unvalidatedResourceStorePropertiesToRequest;
 
         this.requestOptions = this.buildRequestOptions(
             requestParameters,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {toJS} from 'mobx';
+import {isArrayLike, toJS} from 'mobx';
 import SingleSelectComponent from '../../../components/SingleSelect';
 import type {FieldTypeProps} from '../../../types';
 
@@ -40,12 +40,13 @@ export default class SingleSelect extends React.Component<FieldTypeProps<string 
         const {schemaOptions, disabled, value} = this.props;
         const values = toJS(schemaOptions.values);
 
-        if (!values || !Array.isArray(values.value)) {
+        if (!values || !isArrayLike(values.value)) {
             throw new Error('The "values" schema option of the SingleSelect field-type must be an array!');
         }
 
         return (
             <SingleSelectComponent disabled={!!disabled} onChange={this.handleChange} value={value}>
+                {/*$FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array*/}
                 {values.value.map(({name: value, title}, index) => {
                     if (typeof value !== 'string' && typeof value !== 'number' && value !== undefined) {
                         throw new Error(

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {computed, observable, reaction, toJS} from 'mobx';
+import {computed, isArrayLike, observable, reaction, toJS} from 'mobx';
 import log from 'loglevel';
 import jsonpointer from 'json-pointer';
 import equals from 'fast-deep-equal';
@@ -14,7 +14,7 @@ import FormInspector from '../FormInspector';
 import SingleSelectionStore from '../../../stores/SingleSelectionStore';
 import type {SchemaOption} from '../types';
 import type {FieldTypeProps} from '../../../types';
-import type {IObservableValue} from 'mobx/lib/mobx';
+import type {IObservableArray, IObservableValue} from 'mobx/lib/mobx';
 
 type Value = ?(string | number);
 type Props = FieldTypeProps<Value>;
@@ -44,10 +44,10 @@ class SingleSelection extends React.Component<Props>
             formInspector,
             schemaOptions: {
                 request_parameters: {
-                    value: requestParameters = [],
+                    value: unvalidatedRequestParameters = [],
                 } = {},
                 resource_store_properties_to_request: {
-                    value: resourceStorePropertiesToRequest = [],
+                    value: unvalidatedResourceStorePropertiesToRequest = [],
                 } = {},
             },
         } = this.props;
@@ -56,13 +56,17 @@ class SingleSelection extends React.Component<Props>
             throw new Error('The selection field needs a "resource_key" option to work properly');
         }
 
-        if (!Array.isArray(requestParameters)) {
+        if (!isArrayLike(unvalidatedRequestParameters)) {
             throw new Error('The "request_parameters" schemaOption must be an array!');
         }
+        // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
+        const requestParameters: Array<any> | IObservableArray<any> = unvalidatedRequestParameters;
 
-        if (!Array.isArray(resourceStorePropertiesToRequest)) {
+        if (!isArrayLike(unvalidatedResourceStorePropertiesToRequest)) {
             throw new Error('The "resource_store_properties_to_request" schemaOption must be an array!');
         }
+        // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
+        const resourceStorePropertiesToRequest: Array | IObservableArray = unvalidatedResourceStorePropertiesToRequest;
 
         this.requestOptions = this.buildRequestOptions(
             requestParameters,
@@ -304,7 +308,7 @@ class SingleSelection extends React.Component<Props>
             },
             schemaOptions: {
                 form_options_to_list_options: {
-                    value: formOptionsToListOptions = [],
+                    value: unvalidatedFormOptionsToListOptions = [],
                 } = {},
                 item_disabled_condition: {
                     value: itemDisabledCondition,
@@ -330,9 +334,11 @@ class SingleSelection extends React.Component<Props>
             throw new Error('The "allow_deselect_for_disabled_items" schema option must be a boolean if given!');
         }
 
-        if (!Array.isArray(formOptionsToListOptions)) {
+        if (!isArrayLike(unvalidatedFormOptionsToListOptions)) {
             throw new Error('The "form_options_to_list_options" option has to be an array if defined!');
         }
+        // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
+        const formOptionsToListOptions: Array<any> | IObservableArray<any> = unvalidatedFormOptionsToListOptions;
 
         if (typeDetailOptions && typeof typeDetailOptions !== 'object') {
             throw new Error('The "detail_options" option has to be an array if defined!');
@@ -433,7 +439,7 @@ class SingleSelection extends React.Component<Props>
             formInspector,
             schemaOptions: {
                 data_path_to_auto_complete: {
-                    value: dataPathToAutoComplete = [],
+                    value: unvalidatedDataPathToAutoComplete = [],
                 } = {},
             },
         } = this.props;
@@ -453,9 +459,11 @@ class SingleSelection extends React.Component<Props>
             },
         } = fieldTypeOptions;
 
-        if (!Array.isArray(dataPathToAutoComplete)) {
+        if (!isArrayLike(unvalidatedDataPathToAutoComplete)) {
             throw new Error('The "data_path_to_auto_complete" schemaOption must be an array!');
         }
+        // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
+        const dataPathToAutoComplete: Array<any> | IObservableArray<any> = unvalidatedDataPathToAutoComplete;
 
         if (dataPathToAutoComplete.length > 0 ){
             // @deprecated

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {computed, toJS, reaction, when} from 'mobx';
+import {computed, toJS, reaction, when, isArrayLike} from 'mobx';
 import equals from 'fast-deep-equal';
 import jsonpointer from 'json-pointer';
 import SmartContentComponent, {smartContentConfigStore, SmartContentStore} from '../../SmartContent';
@@ -27,12 +27,13 @@ class SmartContent extends React.Component<Props> {
             } = {},
         } = this.props;
 
-        if (!Array.isArray(schemaPresentations)) {
+        if (!isArrayLike(schemaPresentations)) {
             throw new Error(
                 'The "present_as" schemaOption must be an array, but received ' + typeof schemaPresentations + '!'
             );
         }
 
+        // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
         return schemaPresentations.map((presentation) => {
             const {name, title} = presentation;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Url.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Url.js
@@ -1,7 +1,9 @@
 // @flow
 import React from 'react';
+import {isArrayLike} from 'mobx';
 import UrlComponent from '../../../components/Url';
 import type {FieldTypeProps} from '../../../types';
+import type {IObservableArray} from 'mobx/lib/mobx';
 
 export default class Url extends React.Component<FieldTypeProps<?string>> {
     constructor(props: FieldTypeProps<?string>) {
@@ -11,15 +13,17 @@ export default class Url extends React.Component<FieldTypeProps<?string>> {
             onChange,
             schemaOptions: {
                 defaults: {
-                    value: defaults,
+                    value: unvalidatedDefaults,
                 } = {},
             } = {},
             value,
         } = this.props;
 
-        if (defaults !== undefined && !Array.isArray(defaults)) {
+        if (unvalidatedDefaults !== undefined && !isArrayLike(unvalidatedDefaults)) {
             throw new Error('The "defaults" schema option must be an array!');
         }
+        // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
+        const defaults: Array<any> | IObservableArray<any> = unvalidatedDefaults;
 
         const defaultSchemeOption = defaults && defaults.find((defaultOption) => defaultOption.name === 'scheme');
         const defaultSpecificPartOption = defaults && defaults.find(
@@ -60,7 +64,7 @@ export default class Url extends React.Component<FieldTypeProps<?string>> {
                     value: defaults = [],
                 } = {},
                 schemes: {
-                    value: schemes = undefined,
+                    value: unvalidatedSchemes = undefined,
                 } = {},
             } = {},
             value,
@@ -68,8 +72,14 @@ export default class Url extends React.Component<FieldTypeProps<?string>> {
 
         let protocols = undefined;
 
-        if (schemes) {
-            if (!Array.isArray(schemes) || schemes.length === 0) {
+        if (unvalidatedSchemes) {
+            if (!isArrayLike(unvalidatedSchemes)) {
+                throw new Error('The "schemes" schema option must be an array!');
+            }
+            // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
+            const schemes: Array<any> | IObservableArray<any> = unvalidatedSchemes;
+
+            if (schemes.length === 0) {
                 throw new Error('The "schemes" schema option must contain some values!');
             }
 
@@ -83,11 +93,12 @@ export default class Url extends React.Component<FieldTypeProps<?string>> {
             });
         }
 
-        if (!Array.isArray(defaults)) {
+        if (!isArrayLike(defaults)) {
             throw new Error('The "defaults" schema option must be an array!');
         }
 
         let defaultProtocol = protocols ? protocols[0] : undefined;
+        // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
         const defaultScheme = defaults.find((defaultOption) => defaultOption.name === 'scheme');
 
         if (defaultScheme && defaultScheme.value) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
@@ -1,5 +1,5 @@
 // @flow
-import {action, computed, isObservableArray, observable, set, toJS} from 'mobx';
+import {action, computed, isArrayLike, observable, set, toJS} from 'mobx';
 import jsonpointer from 'json-pointer';
 import log from 'loglevel';
 import type {IObservableValue} from 'mobx/lib/mobx';
@@ -54,7 +54,7 @@ function collectTagPathsWithPriority(
         if (types
             && Object.keys(types).length > 0
             && data[key]
-            && (Array.isArray(data[key]) || isObservableArray(data[key]))
+            && (isArrayLike(data[key]))
         ) {
             for (const childKey of data[key].keys()) {
                 const childData = data[key][childKey];

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/structureStrategies/ColumnStructureStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/structureStrategies/ColumnStructureStrategy.js
@@ -1,5 +1,5 @@
 // @flow
-import {action, computed, observable} from 'mobx';
+import {action, computed, isArrayLike, observable} from 'mobx';
 import {arrayMove} from '../../../utils';
 import type {ColumnItem, StructureStrategyInterface} from '../types';
 
@@ -129,8 +129,9 @@ export default class ColumnStructureStrategy implements StructureStrategyInterfa
         const resourceKey = Object.keys(item._embedded)[0];
         const childItems = item._embedded[resourceKey];
 
-        if (Array.isArray(childItems) && !this.rawData.has(item.id)) {
+        if (isArrayLike(childItems) && !this.rawData.has(item.id)) {
             this.rawData.set(item.id, []);
+            // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
             childItems.forEach((childItem) => {
                 this.addItem(childItem, item.id);
             });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/Navigation.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/Navigation.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 import {observer} from 'mobx-react';
-import {computed} from 'mobx';
+import {computed, isArrayLike} from 'mobx';
 import {default as NavigationComponent} from '../../components/Navigation';
 import Router from '../../services/Router';
 import userStore from '../../stores/userStore';
@@ -96,7 +96,8 @@ class Navigation extends React.Component<Props> {
                         title={item.label}
                         value={item.id}
                     >
-                        {Array.isArray(item.items) &&
+                        {isArrayLike(item.items) &&
+                            // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
                             item.items.filter((subItem: NavigationItem) => subItem.visible).map((subItem) => (
                                 <NavigationComponent.Item
                                     active={this.isItemActive(subItem)}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/TextEditor/adapters/CKEditor5.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/TextEditor/adapters/CKEditor5.js
@@ -1,7 +1,9 @@
 // @flow
 import React from 'react';
+import {isArrayLike} from 'mobx';
 import CKEditor5Component from '../../CKEditor5';
 import type {TextEditorProps} from '../types';
+import type {IObservableArray} from 'mobx/lib/mobx';
 
 export default class CKEditor5 extends React.Component<TextEditorProps> {
     render() {
@@ -14,11 +16,13 @@ export default class CKEditor5 extends React.Component<TextEditorProps> {
             value,
         } = this.props;
 
-        const formatOptionValues = options && options.formats ? options.formats.value : [];
+        const unvalidatedFormatOptionValues = options && options.formats ? options.formats.value : [];
 
-        if (!Array.isArray(formatOptionValues)) {
+        if (!isArrayLike(unvalidatedFormatOptionValues)) {
             throw new Error('The passed "formats" must be an array of strings');
         }
+        // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
+        const formatOptionValues: Array<any> | IObservableArray<any> = unvalidatedFormatOptionValues;
 
         const formats = formatOptionValues.length
             ? formatOptionValues.map((format) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/Requester.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/Requester.js
@@ -1,5 +1,5 @@
 // @flow
-import {isObservableArray} from 'mobx';
+import {isArrayLike} from 'mobx';
 import RequestPromise from './RequestPromise';
 import type {HandleResponseHook} from './types';
 
@@ -21,7 +21,7 @@ function transformResponseObject(data: Object) {
             return transformedData;
         }
 
-        if (Array.isArray(value)) {
+        if (isArrayLike(value)) {
             transformedData[key] = transformResponseArray(value);
 
             return transformedData;
@@ -59,7 +59,7 @@ function transformRequestObject(data: Object): Object {
             return transformedData;
         }
 
-        if (Array.isArray(value) || isObservableArray(value)) {
+        if (isArrayLike(value) || isArrayLike(value)) {
             transformedData[key] = transformRequestArray(value);
 
             return transformedData;
@@ -79,7 +79,7 @@ function transformRequestObject(data: Object): Object {
 
 function transformRequestArray(data) {
     return data.map((value) => {
-        if (Array.isArray(value) || isObservableArray(value)) {
+        if (isArrayLike(value)) {
             return transformRequestArray(value);
         }
 
@@ -92,7 +92,7 @@ function transformRequestArray(data) {
 }
 
 function transformRequestData(data: Object | Array<Object>) {
-    if (Array.isArray(data) || isObservableArray(data)) {
+    if (isArrayLike(data)) {
         return transformRequestArray(data);
     }
 
@@ -114,7 +114,7 @@ function handleResponse(response: Response, options: ?Object): Promise<Object | 
     }
 
     return response.json().then((data) => {
-        if (Array.isArray(data)) {
+        if (isArrayLike(data)) {
             return transformResponseArray(data);
         }
 
@@ -124,7 +124,7 @@ function handleResponse(response: Response, options: ?Object): Promise<Object | 
 
 function handleObjectResponse(response: Response, options: ?Object): Promise<Object> {
     return handleResponse(response, options).then((response) => {
-        if (Array.isArray(response)) {
+        if (isArrayLike(response)) {
             throw Error('Response was expected to be an object, but an array was given');
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/Requester.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/Requester.js
@@ -59,7 +59,7 @@ function transformRequestObject(data: Object): Object {
             return transformedData;
         }
 
-        if (isArrayLike(value) || isArrayLike(value)) {
+        if (isArrayLike(value)) {
             transformedData[key] = transformRequestArray(value);
 
             return transformedData;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/registries/resourceRouteRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/registries/resourceRouteRegistry.js
@@ -1,11 +1,11 @@
 // @flow
-import {isObservableArray, toJS} from 'mobx';
+import {isArrayLike, toJS} from 'mobx';
 import symfonyRouting from 'fos-jsrouting/router';
 import {transformDateForUrl} from '../../../utils/Date';
 import type {EndpointConfiguration} from '../types';
 
 function transformParameter(parameter) {
-    return Array.isArray(parameter) || isObservableArray(parameter)
+    return isArrayLike(parameter)
         ? parameter.map(transformParameter).join(',')
         : parameter instanceof Date
             ? transformDateForUrl(parameter)

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -1,5 +1,5 @@
 // @flow
-import {action, autorun, computed, observable, toJS} from 'mobx';
+import {action, autorun, computed, isArrayLike, observable, toJS} from 'mobx';
 import equal from 'fast-deep-equal';
 import log from 'loglevel';
 import {compile} from 'path-to-regexp';
@@ -70,7 +70,7 @@ function equalBindings(value1, value2) {
 }
 
 function addValueToSearchParameters(searchParameters: URLSearchParams, value: Object, path: string) {
-    if (Array.isArray(value)) {
+    if (isArrayLike(value)) {
         addArrayToSearchParameters(searchParameters, value, path);
     } else if (value instanceof Date) {
         addDateToSearchParameters(searchParameters, value, path);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {action, computed, toJS, isObservableArray, observable} from 'mobx';
+import {action, computed, toJS, observable, isArrayLike} from 'mobx';
 import {observer} from 'mobx-react';
 import equals from 'fast-deep-equal';
 import log from 'loglevel';
@@ -277,10 +277,7 @@ class Form extends React.Component<Props> {
             },
         } = router;
 
-        if (
-            !Array.isArray(rawToolbarActions)
-            && !isObservableArray(rawToolbarActions)
-        ) {
+        if (!isArrayLike(rawToolbarActions)) {
             throw new Error('The view "Form" needs some defined toolbarActions to work properly!');
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DropdownToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DropdownToolbarAction.js
@@ -1,5 +1,6 @@
 // @flow
 import React, {Fragment} from 'react';
+import {isArrayLike} from 'mobx';
 import {ResourceFormStore} from '../../../containers/Form';
 import Router from '../../../services/Router';
 import ResourceStore from '../../../stores/ResourceStore';
@@ -30,12 +31,13 @@ export default class DropdownToolbarAction extends AbstractFormToolbarAction {
 
         const {toolbarActions} = this.options;
 
-        if (!Array.isArray(toolbarActions)) {
+        if (!isArrayLike(toolbarActions)) {
             throw new Error('The passed "toolbarActions" option must be of type object or array');
         }
 
-        this.toolbarActions = toolbarActions
-            .map((action) => {
+        // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
+        this.toolbarActions = toolbarActions.map(
+            (action) => {
                 if (action === null || typeof action !== 'object') {
                     throw new Error('The passed entries in the "actions" option must be objects');
                 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/UploadToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/UploadToolbarAction.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 import log from 'loglevel';
-import {action, computed, observable} from 'mobx';
+import {action, computed, isArrayLike, observable} from 'mobx';
 import Dropzone, {DropzoneRef, FileRejection} from 'react-dropzone';
 import symfonyRouting from 'fos-jsrouting/router';
 import {translate, transformBytesToReadableString} from '../../../utils';
@@ -303,10 +303,11 @@ export default class UploadToolbarAction extends AbstractListToolbarAction {
             return undefined;
         }
 
-        if (!Array.isArray(accept)) {
+        if (!isArrayLike(accept)) {
             throw new Error('The "accept" option must be an array!');
         }
 
+        // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
         return accept;
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/MediaSelectionBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/MediaSelectionBlockPreviewTransformer.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {isObservableArray} from 'mobx';
+import {isArrayLike} from 'mobx';
 import mediaSelectionBlockPreviewTransformerStyles from './mediaSelectionBlockPreviewTransformer.scss';
 import type {Node} from 'react';
 import type {BlockPreviewTransformer} from 'sulu-admin-bundle/types';
@@ -17,7 +17,7 @@ export default class MediaSelectionBlockPreviewTransformer implements BlockPrevi
     transform(value: *): Node {
         const {ids} = value;
 
-        if ((!Array.isArray(ids) && !isObservableArray(ids)) || ids.length === 0) {
+        if ((!isArrayLike(ids)) || ids.length === 0) {
             return null;
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
@@ -57,7 +57,7 @@ class MediaSelection extends React.Component<FieldTypeProps<Value>> {
                 + 'This decreases performance and might lead to errors or other unexpected behaviour.'
             );
 
-            // $FlowFixMe: flow does recognize that isArrayLike(value) means that value is an array
+            // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
             return {ids: value.map((item) => item && typeof item === 'object' ? item.id : item)};
         }
 
@@ -103,10 +103,10 @@ class MediaSelection extends React.Component<FieldTypeProps<Value>> {
 
         const locale = formInspector.locale ? formInspector.locale : observable.box(userStore.contentLocale);
 
-        if (displayOptions !== undefined && displayOptions !== null && !Array.isArray(displayOptions)) {
+        if (displayOptions !== undefined && displayOptions !== null && !isArrayLike(displayOptions)) {
             throw new Error('The "displayOptions" option has to be an Array if set.');
         }
-
+        // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
         const displayOptionValues = convertDisplayOptionsFromParams(displayOptions);
 
         if (mediaTypes !== undefined && mediaTypes !== null && typeof mediaTypes !== 'string') {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaSelection.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import {observer} from 'mobx-react';
 import userStore from 'sulu-admin-bundle/stores/userStore';
-import {computed, observable} from 'mobx';
+import {computed, isArrayLike, observable} from 'mobx';
 import {
     convertDisplayOptionsFromParams,
     convertMediaTypesFromParams,
@@ -89,10 +89,11 @@ class SingleMediaSelection extends React.Component<FieldTypeProps<Value>> {
         } = schemaOptions;
         const locale = formInspector.locale ? formInspector.locale : observable.box(userStore.contentLocale);
 
-        if (displayOptions !== undefined && displayOptions !== null && !Array.isArray(displayOptions)) {
+        if (displayOptions !== undefined && displayOptions !== null && !isArrayLike(displayOptions)) {
             throw new Error('The "displayOptions" option has to be an Array if set.');
         }
 
+        // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
         const displayOptionValues = convertDisplayOptionsFromParams(displayOptions);
 
         if (mediaTypes !== undefined && mediaTypes !== null && typeof mediaTypes !== 'string') {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/MediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/MediaSelectionOverlay.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {action, autorun, observable} from 'mobx';
+import {action, autorun, isArrayLike, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import {ListStore} from 'sulu-admin-bundle/containers';
 import {Overlay} from 'sulu-admin-bundle/components';
@@ -71,7 +71,9 @@ class MediaSelectionOverlay extends React.Component<Props> {
             'thumbnails',
         ];
 
-        if (Array.isArray(types) && types.length > 0) {
+        // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
+        if (isArrayLike(types) && types.length > 0) {
+            // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
             options.types = types.join(',');
         }
 

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/fields/PageSettingsShadowLocaleSelect.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/fields/PageSettingsShadowLocaleSelect.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {toJS} from 'mobx';
+import {isArrayLike, toJS} from 'mobx';
 import {SingleSelect} from 'sulu-admin-bundle/components';
 import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 
@@ -17,7 +17,7 @@ export default class PageSettingsShadowLocaleSelect extends React.Component<Fiel
         const contentLocales = toJS(formInspector.getValueByPath('/contentLocales'));
         const locale = formInspector.locale;
 
-        if (!Array.isArray(contentLocales)) {
+        if (!isArrayLike(contentLocales)) {
             throw new Error('The "contentLocales" should be an array!');
         }
 

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/fields/TeaserSelection.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/fields/TeaserSelection.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {computed, observable} from 'mobx';
+import {computed, isArrayLike, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import jsonpointer from 'json-pointer';
 import {userStore} from 'sulu-admin-bundle/stores';
@@ -55,12 +55,13 @@ class TeaserSelection extends React.Component<FieldTypeProps<TeaserSelectionValu
             } = {},
         } = schemaOptions;
 
-        if (!Array.isArray(presentAs)) {
+        if (!isArrayLike(presentAs)) {
             throw new Error(
                 'The "present_as" schemaOption must be an array, but received ' + typeof presentAs + '!'
             );
         }
 
+        // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
         const presentations = presentAs.map((presentation) => {
             const {name, title} = presentation;
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

In PR https://github.com/sulu/sulu/pull/6077 the `Schema` has become `observable` to update the frontend data on a schema change. This had the side effect, that all arrays became `observableArrays` in the schema.

Until now the default `Array.isArray` method is used to check, if the object is really an array. Sadly this method doesn't recognise `ObservableArrays` and thus we had to change all `Array.isArray` calls to the mobx method `isArrayLike`.

As a result of this change, another side effect occurred. Flow is not able to recognise, that after the `isArrayLike` check, the variable is really an array. So we unfortunately have to add multiple `$FlowFixMe` comments. 