### PR TITLE
Fix audience targeting loop with user context based caching

### DIFF
--- a/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/AudienceTargetingCacheListener.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/AudienceTargetingCacheListener.php
@@ -44,7 +44,8 @@ class AudienceTargetingCacheListener implements EventSubscriberInterface
     {
         $request = $cacheEvent->getRequest();
 
-        // requests like "/_sulu_target_group" or "/_fos_user_context_hash" should be ignored
+        // the friendsofsymfony/http-cache-bundle package uses the "internalRequest" attribute to mark internal requests
+        // return early in this case to prevent loops on requests "/_sulu_target_group" or "/_fos_user_context_hash"
         if ($request->attributes->get('internalRequest', false)) {
             return;
         }

--- a/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/AudienceTargetingCacheListener.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/AudienceTargetingCacheListener.php
@@ -44,6 +44,7 @@ class AudienceTargetingCacheListener implements EventSubscriberInterface
     {
         $request = $cacheEvent->getRequest();
 
+        // requests like "/_sulu_target_group" or "/_fos_user_context_hash" should be ignored
         if ($request->attributes->get('internalRequest', false)) {
             return;
         }

--- a/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/AudienceTargetingCacheListener.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/AudienceTargetingCacheListener.php
@@ -42,12 +42,14 @@ class AudienceTargetingCacheListener implements EventSubscriberInterface
 
     public function preHandle(CacheEvent $cacheEvent)
     {
-        if (self::TARGET_GROUP_URL === $cacheEvent->getRequest()->getRequestUri()) {
+        $request = $cacheEvent->getRequest();
+
+        if ($request->attributes->get('internalRequest', false)) {
             return;
         }
 
         $this->hadValidTargetGroupCookie = $this->setTargetGroupHeader(
-            $cacheEvent->getRequest(),
+            $request,
             $cacheEvent->getKernel()
         );
     }
@@ -113,6 +115,8 @@ class AudienceTargetingCacheListener implements EventSubscriberInterface
             [],
             $request->server->all()
         );
+
+        $request->attributes->set('internalRequest', true);
 
         if ($currentTargetGroup) {
             $targetGroupRequest->headers->set(static::TARGET_GROUP_HEADER, $currentTargetGroup);

--- a/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/AudienceTargetingCacheListener.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/AudienceTargetingCacheListener.php
@@ -56,12 +56,13 @@ class AudienceTargetingCacheListener implements EventSubscriberInterface
 
     public function postHandle(CacheEvent $cacheEvent)
     {
-        if (self::TARGET_GROUP_URL === $cacheEvent->getRequest()->getRequestUri()) {
+        $request = $cacheEvent->getRequest();
+
+        if ($request->attributes->get('internalRequest', false)) {
             return;
         }
 
         $response = $cacheEvent->getResponse();
-        $request = $cacheEvent->getRequest();
 
         if (!$this->hadValidTargetGroupCookie) {
             $this->setTargetGroupCookie($response, $request);
@@ -116,7 +117,7 @@ class AudienceTargetingCacheListener implements EventSubscriberInterface
             $request->server->all()
         );
 
-        $request->attributes->set('internalRequest', true);
+        $targetGroupRequest->attributes->set('internalRequest', true);
 
         if ($currentTargetGroup) {
             $targetGroupRequest->headers->set(static::TARGET_GROUP_HEADER, $currentTargetGroup);

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/AudienceTargetingCacheListenerTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/AudienceTargetingCacheListenerTest.php
@@ -26,7 +26,7 @@ class AudienceTargetingCacheListenerTest extends TestCase
 {
     use ReadObjectAttributeTrait;
 
-    public function testHandle()
+    public function testHandle(): void
     {
         $request = $this->getRequest();
         $response = $this->getResponse();
@@ -71,7 +71,20 @@ class AudienceTargetingCacheListenerTest extends TestCase
         );
     }
 
-    public function testHandleWithCorrectCookies()
+    public function testHandleInternalRequest(): void
+    {
+        $request = $this->getRequest();
+        $request->attributes->set('internalRequest', true);
+        $response = $this->getResponse();
+        $httpCache = $this->prophesize(SuluHttpCache::class);
+        $httpCache->handle(Argument::any())
+            ->shouldNotBeCalled();
+
+        $audienceTargetingCacheListener = new AudienceTargetingCacheListener();
+        $audienceTargetingCacheListener->preHandle($this->getCacheEvent($httpCache->reveal(), $request, $response));
+    }
+
+    public function testHandleWithCorrectCookies(): void
     {
         $request = $this->getRequest(true);
         $response = $this->getResponse();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix audience targeting loop with user context based caching.

#### Why?

Avoid infinite loop between audience targeting and user context based caching.

#### Example Usage

Kernel.php on prod:

```php
            // Activate the following for user based caching see also:
            // https://foshttpcachebundle.readthedocs.io/en/latest/features/user-context.html
            $this->httpCache->addSubscriber(
                new \FOS\HttpCache\SymfonyCache\UserContextListener([
                    'session_name_prefix' => 'SULUSESSID',
                ])
            );

            $this->httpCache->addSubscriber(new AudienceTargetingCacheListener());
```

