### PR TITLE
Print warning logs to browser console in production build of administration interface

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -118,7 +118,7 @@ if (!window.ResizeObserver) {
 }
 
 window.log = log;
-log.setDefaultLevel(process.env.NODE_ENV === 'production' ? log.levels.ERROR : log.levels.TRACE);
+log.setDefaultLevel(process.env.NODE_ENV === 'production' ? log.levels.WARN : log.levels.TRACE);
 
 Requester.handleResponseHooks.push(logoutOnUnauthorizedResponse);
 


### PR DESCRIPTION
We use warnings for providing information that is relevant for the developer in various places. At the moment, these warnings are only visible if the project uses a development build of the administration interface (generated by `npm run watch`). 

https://github.com/sulu/sulu/blob/6b0623d5a80c557ec4b0a944784a00abe003fe38/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/IconFieldTransformer.js#L41-L43

https://github.com/sulu/sulu/blob/6b0623d5a80c557ec4b0a944784a00abe003fe38/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteDraftToolbarAction.js#L34-L37

https://github.com/sulu/sulu/blob/6b0623d5a80c557ec4b0a944784a00abe003fe38/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js#L208-L216

I think most developers use a production build and therefore we should include this warnings in the production build too.