### PR TITLE
Add default sort order for categories

### DIFF
--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -340,6 +340,8 @@ class CategoryController extends AbstractRestController implements ClassResource
         $listBuilder->sort($fieldDescriptors['depth']);
         $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
 
+        // add default sort order
+        $listBuilder->sort($fieldDescriptors['name']);
         $listBuilder->addSelectField($fieldDescriptors['depth']);
         $listBuilder->addSelectField($fieldDescriptors['parent']);
         $listBuilder->addSelectField($fieldDescriptors['locale']);

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
@@ -803,6 +803,35 @@ class CategoryControllerTest extends SuluTestCase
         $this->assertEquals('Erste Kategorie', $categories[1]->name);
     }
 
+    public function testCGetFlatWithDefaultSorting(): void
+    {
+        $category1 = $this->createCategory('B', 'en');
+        $this->createCategoryTranslation($category1, 'de', 'B');
+        $category2 = $this->createCategory('A', 'en');
+        $this->createCategoryTranslation($category2, 'de', 'A');
+        $category3 = $this->createCategory('C', 'en');
+        $this->createCategoryTranslation($category3, 'de', 'C');
+
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->client->jsonRequest(
+            'GET',
+            '/api/categories?locale=de&flat=true'
+        );
+
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+
+        $response = \json_decode($this->client->getResponse()->getContent());
+        $categories = $response->_embedded->categories;
+
+        $this->assertCount(3, $categories);
+
+        $this->assertEquals('A', $categories[0]->name);
+        $this->assertEquals('B', $categories[1]->name);
+        $this->assertEquals('C', $categories[2]->name);
+    }
+
     public function testCGetLocaleFallback()
     {
         $category1 = $this->createCategory('first-category-key', 'en');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

Adds a default sort order to the category `listBuilder`.

#### Why?

Without this default sort order, the result order may differ between identical requests.
