### PR TITLE
PreviewRenderer.php bugfix

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -115,7 +115,7 @@ class PreviewRenderer implements PreviewRendererInterface
         $partial = false,
         $options = []
     ) {
-        $webspaceKey = $options['webspaceKey'] ?? null;
+        $webspaceKey = $options['webspace'] ?? null;
         $locale = $options['locale'] ?? null;
 
         if (!$this->routeDefaultsProvider->supports(\get_class($object))) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #6100
| Related issues/PRs | #6100
| License | MIT

We do not have webspaceKey, but we have webspace
```
PreviewRenderer.php on line 120:
array:3 [▼
  "locale" => "lt"
  "targetGroup" => "-1"
  "webspace" => "kuro-kainos"
]
```