### PR TITLE
Changing the initializeListBuilder function from private to protected

### DIFF
--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -334,7 +334,7 @@ class CategoryController extends AbstractRestController implements ClassResource
         );
     }
 
-    private function initializeListBuilder($locale)
+    protected function initializeListBuilder($locale)
     {
         $fieldDescriptors = $this->fieldDescriptorFactory->getFieldDescriptors(CategoryInterface::RESOURCE_KEY);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no 
Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | #6136
| License | MIT
| Documentation PR |  not nesesary

#### What's in this PR?

It changes the method from private to protected, in order to allow it to be overridden. Right now it is not possible to call the parent:: initializeListBuilder($locale) from inside an overridden function.

#### Why?

It is manly to allow an alphabetical sort for categories, which is not there by standard: https://stackoverflow.com/questions/68185635/sulu-2-2-ist-there-a-way-that-categories-in-the-category-selection-content-type

#### Example Usage
It's a pretty unusual usecase I guess, so it is good, if it stays outside. Alternatively `$listBuilder->sort($fieldDescriptors['name']);` could be added by standard.

#### To Do

Nothing to do.