### PR TITLE
Change Admin Reset Email to text/html

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
@@ -445,7 +445,7 @@ class ResettingController
             ->setSubject($this->getSubject())
             ->setFrom($from)
             ->setTo($to)
-            ->setBody($this->getMessage($user, $token));
+            ->setBody($this->getMessage($user, $token), 'text/html');
 
         $mailer->send($message);
         $user->setPasswordResetTokenEmailsSent($user->getPasswordResetTokenEmailsSent() + 1);


### PR DESCRIPTION


| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| License | MIT

#### What's in this PR?

Allows you to customize the password reset email with an HTML email

