### PR TITLE
Change Admin Reset Email to text/html

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
@@ -435,7 +435,7 @@ class ResettingController
             ->setSubject($this->getSubject())
             ->setFrom($from)
             ->setTo($to)
-            ->setBody($this->getMessage($user, $token));
+            ->setBody($this->getMessage($user, $token), 'text/html');
 
         $mailer->send($message);
         $user->setPasswordResetTokenEmailsSent($user->getPasswordResetTokenEmailsSent() + 1);

--- a/src/Sulu/Bundle/SecurityBundle/Resources/views/mail_templates/reset_password.html.twig
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/views/mail_templates/reset_password.html.twig
@@ -1,2 +1,3 @@
 {{ 'sulu_security.reset_mail_message'|trans({}, translation_domain) }}
+<br/>
 {{ reset_url }}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | yes
| License | MIT

#### What's in this PR?

Allows you to customize the password reset email with an HTML email

