### PR TITLE
Reduce seo meta description length from 320 to 160 characters

### DIFF
--- a/src/Sulu/Bundle/PageBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/PageBundle/DependencyInjection/Configuration.php
@@ -30,7 +30,7 @@ class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('max_title_length')->defaultValue(70)->end()
-                        ->scalarNode('max_description_length')->defaultValue(320)->end()
+                        ->scalarNode('max_description_length')->defaultValue(160)->end()
                         ->scalarNode('max_keywords')->defaultValue(5)->end()
                         ->scalarNode('keywords_separator')->defaultValue(',')->end()
                         ->scalarNode('url_prefix')->defaultValue('www.yoursite.com/{locale}')->end()

--- a/src/Sulu/Bundle/PageBundle/Resources/config/forms/page_seo.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/forms/page_seo.xml
@@ -26,7 +26,7 @@
                 <info_text>sulu_page.meta_description_info_text</info_text>
             </meta>
             <params>
-                <param name="max_characters" value="320" />
+                <param name="max_characters" value="160" />
             </params>
         </property>
         <property name="ext/seo/keywords" type="text_line">

--- a/src/Sulu/Bundle/PageBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/PageBundle/Resources/translations/admin.de.json
@@ -38,7 +38,7 @@
     "sulu_page.meta_title": "Titel (Meta title)",
     "sulu_page.meta_title_info_text": "SEO Guidelines empfehlen einen Meta-Titel mit einer Länge von maximal 55 Zeichen.",
     "sulu_page.meta_description": "Beschreibung (Meta description)",
-    "sulu_page.meta_description_info_text": "SEO Guidelines empfehlen eine Meta-Beschreibung mit einer Länge von maximal 320 Zeichen.",
+    "sulu_page.meta_description_info_text": "SEO Guidelines empfehlen eine Meta-Beschreibung mit einer Länge von maximal 160 Zeichen.",
     "sulu_page.meta_keywords": "Keywords (Meta keywords)",
     "sulu_page.meta_keywords_info_text": "Keywords werden durch Kommas getrennt und sollten den den Inhalt der Seite beschreiben. SEO Guidelines empfehlen die Zuweisung von maximal 5 Keywords pro Seite.",
     "sulu_page.canonical_url": "Canonical URL  (Canonical tag)",

--- a/src/Sulu/Bundle/PageBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/PageBundle/Resources/translations/admin.en.json
@@ -38,7 +38,7 @@
     "sulu_page.meta_title": "Title (Meta title)",
     "sulu_page.meta_title_info_text": "SEO guidelines recommend to use a meta title that is no longer than 55 characters.",
     "sulu_page.meta_description": "Description (Meta description)",
-    "sulu_page.meta_description_info_text": "SEO guidelines recommend to use a meta description that is no longer than 320 characters.",
+    "sulu_page.meta_description_info_text": "SEO guidelines recommend to use a meta description that is no longer than 160 characters.",
     "sulu_page.meta_keywords": "Keywords (Meta keywords)",
     "sulu_page.meta_keywords_info_text": "Keywords are sperated by commas and should match the content of the page. SEO guidelines recommend to use no more than 5 keywords per page.",
     "sulu_page.canonical_url": "Canonical URL  (Canonical tag)",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets |  none
| Related issues/PRs |  none
| License | MIT

#### What's in this PR?

This PR changes the recommended length of the meta description shown in the SEO tab in the admin from 320 to 160 characters.

#### Why?

The 320 characters limit does not represent current recommendations. Google shortened its used length to about 160 characters. [Source](https://www.evergreenmedia.at/glossar/meta-description/#:~:text=eine%20Meta%20Description%3F-,Die%20ideale%20L%C3%A4nge%20f%C3%BCr%20eine%20Meta,zwischen%20140%20und%20155%20Zeichen).
