### PR TITLE
Fix json schema of teaser_selection

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Teaser/TeaserContentType.php
+++ b/src/Sulu/Bundle/PageBundle/Teaser/TeaserContentType.php
@@ -201,7 +201,10 @@ class TeaserContentType extends SimpleContentType implements PreResolvableConten
 
         $itemsMetadata = new ArrayMetadata(
             new ObjectMetadata([
-                new PropertyMetadata('id', true, new StringMetadata()),
+                new PropertyMetadata('id', true, new AnyOfsMetadata([
+                    new StringMetadata(),
+                    new NumberMetadata(),
+                ])),
                 new PropertyMetadata('type', true, new StringMetadata()),
                 new PropertyMetadata('title', false, new StringMetadata()),
                 new PropertyMetadata('description', false, new StringMetadata()),

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Teaser/TeaserContentTypeTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Teaser/TeaserContentTypeTest.php
@@ -200,7 +200,14 @@ class TeaserContentTypeTest extends TestCase
             'type' => 'object',
             'properties' => [
                 'id' => [
-                    'type' => 'string',
+                    'anyOf' => [
+                        [
+                            'type' => 'string',
+                        ],
+                        [
+                            'type' => 'number',
+                        ],
+                    ],
                 ],
                 'type' => [
                     'type' => 'string',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix json schema of teaser_selection

#### Why?

If there were teasers selected, which had a number as `id`, the schema didn't validate and therefore couldn't be saved in the admin ui.
