### PR TITLE
Add props for displaying Snackbar inside of Dialog

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/Dialog.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/Dialog.js
@@ -40,20 +40,18 @@ class Dialog extends React.Component<Props> {
 
     @observable open: boolean = false;
     @observable visible: boolean = false;
-    @observable snackbarType: SnackbarType;
 
     constructor(props: Props) {
         super(props);
 
-        const {open, snackbarType} = this.props;
+        const {open} = this.props;
 
         this.open = open;
         this.visible = open;
-        this.snackbarType = snackbarType;
     }
 
     @action componentDidUpdate(prevProps: Props) {
-        const {open, snackbarMessage, snackbarType} = this.props;
+        const {open} = this.props;
 
         if (prevProps.open === false && open === true) {
             this.visible = true;
@@ -63,10 +61,6 @@ class Dialog extends React.Component<Props> {
             afterElementsRendered(action(() => {
                 this.open = open;
             }));
-        }
-
-        if (snackbarMessage && this.snackbarType !== snackbarType) {
-            this.snackbarType = snackbarType;
         }
     }
 
@@ -91,6 +85,7 @@ class Dialog extends React.Component<Props> {
             onSnackbarCloseClick,
             size,
             snackbarMessage,
+            snackbarType,
             title,
         } = this.props;
 
@@ -133,7 +128,7 @@ class Dialog extends React.Component<Props> {
                                             message={snackbarMessage || ''}
                                             onClick={onSnackbarClick}
                                             onCloseClick={onSnackbarCloseClick}
-                                            type={this.snackbarType}
+                                            type={snackbarType}
                                             visible={!!snackbarMessage}
                                         />
                                     </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/Dialog.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/Dialog.js
@@ -7,6 +7,7 @@ import {Portal} from 'react-portal';
 import {afterElementsRendered} from '../../utils/DOM';
 import Backdrop from '../Backdrop';
 import Button from '../Button';
+import Snackbar, {type SnackbarType} from '../Snackbar';
 import dialogStyles from './dialog.scss';
 import type {Node} from 'react';
 
@@ -19,8 +20,12 @@ type Props = {|
     confirmText: string,
     onCancel?: () => void,
     onConfirm: () => void,
+    onSnackbarClick?: () => void,
+    onSnackbarCloseClick?: () => void,
     open: boolean,
     size?: 'small' | 'large',
+    snackbarMessage?: string,
+    snackbarType: SnackbarType,
     title: string,
 |};
 
@@ -30,22 +35,25 @@ class Dialog extends React.Component<Props> {
         align: 'center',
         confirmDisabled: false,
         confirmLoading: false,
+        snackbarType: 'error',
     };
 
     @observable open: boolean = false;
     @observable visible: boolean = false;
+    @observable snackbarType: SnackbarType;
 
     constructor(props: Props) {
         super(props);
 
-        const {open} = this.props;
+        const {open, snackbarType} = this.props;
 
         this.open = open;
         this.visible = open;
+        this.snackbarType = snackbarType;
     }
 
     @action componentDidUpdate(prevProps: Props) {
-        const {open} = this.props;
+        const {open, snackbarMessage, snackbarType} = this.props;
 
         if (prevProps.open === false && open === true) {
             this.visible = true;
@@ -55,6 +63,10 @@ class Dialog extends React.Component<Props> {
             afterElementsRendered(action(() => {
                 this.open = open;
             }));
+        }
+
+        if (snackbarMessage && this.snackbarType !== snackbarType) {
+            this.snackbarType = snackbarType;
         }
     }
 
@@ -75,7 +87,10 @@ class Dialog extends React.Component<Props> {
             confirmText,
             onCancel,
             onConfirm,
+            onSnackbarClick,
+            onSnackbarCloseClick,
             size,
+            snackbarMessage,
             title,
         } = this.props;
 
@@ -113,6 +128,16 @@ class Dialog extends React.Component<Props> {
                         >
                             <div className={dialogClass}>
                                 <section className={dialogStyles.content}>
+                                    <div className={dialogStyles.snackbar}>
+                                        <Snackbar
+                                            message={snackbarMessage || ''}
+                                            onClick={onSnackbarClick}
+                                            onCloseClick={onSnackbarCloseClick}
+                                            type={this.snackbarType}
+                                            visible={!!snackbarMessage}
+                                        />
+                                    </div>
+
                                     <header className={dialogStyles.header}>
                                         {title}
                                     </header>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/README.md
@@ -69,6 +69,12 @@ const onCancel = () => {
     setOpen(false);
 };
 
+const snackbarMessage = snackbarType === 'error'
+    ? 'An error occurred'
+    : snackbarType === 'warning'
+        ? 'Something strange happened'
+        : undefined;
+
 <div>
     <button onClick={() => setOpen(true)}>Open dialog</button>
     <Dialog
@@ -78,13 +84,7 @@ const onCancel = () => {
         cancelText="No"
         confirmText="Yes"
         snackbarType={snackbarType}
-        snackbarMessage={
-            snackbarType === 'error'
-                ? 'An error occurred'
-                : snackbarType === 'warning'
-                    ? 'Something strange happened'
-                    : undefined
-        }
+        snackbarMessage={snackbarMessage}
         open={open}>
 
         <button onClick={() => setSnackbarType((type) => type !== 'error' ? 'error' : undefined)}>Toggle error</button>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/README.md
@@ -52,3 +52,44 @@ const onConfirm = () => {
     </Dialog>
 </div>
 ```
+
+Errors and warnings can be displayed at the top of the dialog.
+
+```javascript
+const [open, setOpen] = React.useState(false);
+const [snackbarType, setSnackbarType] = React.useState(undefined);
+
+const onConfirm = () => {
+    /* do confirm things */
+    setOpen(false);
+};
+
+const onCancel = () => {
+    /* do cancel things */
+    setOpen(false);
+};
+
+<div>
+    <button onClick={() => setOpen(true)}>Open dialog</button>
+    <Dialog
+        title="Question?"
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+        cancelText="No"
+        confirmText="Yes"
+        snackbarType={snackbarType}
+        snackbarMessage={
+            snackbarType === 'error'
+                ? 'An error occurred'
+                : snackbarType === 'warning'
+                    ? 'Something strange happened'
+                    : undefined
+        }
+        open={open}>
+
+        <button onClick={() => setSnackbarType((type) => type !== 'error' ? 'error' : undefined)}>Toggle error</button>
+        &nbsp;
+        <button onClick={() => setSnackbarType((type) => type !== 'warning' ? 'warning' : undefined)}>Toggle warning</button>
+    </Dialog>
+</div>
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/dialog.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/dialog.scss
@@ -80,6 +80,13 @@ $transitionDuration: 300ms;
     }
 }
 
+.snackbar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+}
+
 .article {
     max-height: $dialogContentMaxHeight;
     color: $contentColor;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/Dialog.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/Dialog.test.js
@@ -3,6 +3,10 @@ import {mount, shallow} from 'enzyme';
 import React from 'react';
 import Dialog from '../Dialog';
 
+jest.mock('../../../utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
+
 test('The component should render in body when open', () => {
     const view = mount(
         <Dialog
@@ -170,4 +174,105 @@ test('The component should call the callback when the cancel button is clicked',
     expect(onCancel).not.toBeCalled();
     view.find('Button[skin="secondary"]').simulate('click');
     expect(onCancel).toBeCalled();
+});
+
+test('The component should render with a warning', () => {
+    const onConfirm = jest.fn();
+    const view = mount(
+        <Dialog
+            confirmText="Confirm"
+            onConfirm={onConfirm}
+            open={true}
+            snackbarMessage="Something really strange happened"
+            snackbarType="warning"
+            title="My dialog title"
+        >
+            <div>My dialog content</div>
+        </Dialog>
+    );
+
+    expect(view.find('.snackbar.warning')).toHaveLength(1);
+    expect(view.find('.snackbar.warning').text()).toBe('sulu_admin.warning - Something really strange happened');
+    expect(view.find('.snackbar.error')).toHaveLength(0);
+});
+
+test('The component should render with an error', () => {
+    const onConfirm = jest.fn();
+    const view = mount(
+        <Dialog
+            confirmText="Confirm"
+            onConfirm={onConfirm}
+            open={true}
+            snackbarMessage="Money transfer unsuccessful"
+            snackbarType="error"
+            title="My dialog title"
+        >
+            <div>My dialog content</div>
+        </Dialog>
+    );
+
+    expect(view.find('.snackbar.error')).toHaveLength(1);
+    expect(view.find('.snackbar.error').text()).toBe('sulu_admin.error - Money transfer unsuccessful');
+    expect(view.find('.snackbar.warning')).toHaveLength(0);
+});
+
+test('The component should render with an error if the type is unknown', () => {
+    const onConfirm = jest.fn();
+    const view = mount(
+        <Dialog
+            confirmText="Confirm"
+            onConfirm={onConfirm}
+            open={true}
+            snackbarMessage="Money transfer unsuccessful"
+            title="My dialog title"
+        >
+            <div>My dialog content</div>
+        </Dialog>
+    );
+
+    expect(view.find('.snackbar.error')).toHaveLength(1);
+    expect(view.find('.snackbar.error').text()).toBe('sulu_admin.error - Money transfer unsuccessful');
+    expect(view.find('.snackbar.warning')).toHaveLength(0);
+});
+
+test('The component should call the callback when the snackbar close button is clicked', () => {
+    const onSnackbarCloseClick = jest.fn();
+    const view = mount(
+        <Dialog
+            confirmText="Confirm"
+            onConfirm={jest.fn()}
+            onSnackbarCloseClick={onSnackbarCloseClick}
+            open={true}
+            snackbarMessage="Money transfer unsuccessful"
+            snackbarType="error"
+            title="My dialog title"
+        >
+            My dialog content
+        </Dialog>
+    );
+
+    expect(onSnackbarCloseClick).not.toBeCalled();
+    view.find('.snackbar.error .su-times').simulate('click');
+    expect(onSnackbarCloseClick).toBeCalled();
+});
+
+test('The component should call the callback when the snackbar is clicked', () => {
+    const onSnackbarClick = jest.fn();
+    const view = mount(
+        <Dialog
+            confirmText="Confirm"
+            onConfirm={jest.fn()}
+            onSnackbarClick={onSnackbarClick}
+            open={true}
+            snackbarMessage="Something really strange happened"
+            snackbarType="warning"
+            title="My dialog title"
+        >
+            My dialog content
+        </Dialog>
+    );
+
+    expect(onSnackbarClick).not.toBeCalled();
+    view.find('.snackbar.warning').simulate('click');
+    expect(onSnackbarClick).toBeCalled();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/__snapshots__/Dialog.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/__snapshots__/Dialog.test.js.snap
@@ -15,6 +15,27 @@ Array [
       <section
         class="content"
       >
+        <div
+          class="snackbar"
+        >
+          <div
+            class="snackbar error"
+            role="button"
+          >
+            <span
+              aria-label="su-exclamation-triangle"
+              class="su-exclamation-triangle icon"
+            />
+            <div
+              class="text"
+            >
+              <strong>
+                sulu_admin.error
+              </strong>
+               - 
+            </div>
+          </div>
+        </div>
         <header
           class="header"
         >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/Snackbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/Snackbar.js
@@ -22,6 +22,8 @@ const ICONS = {
     warning: 'su-bell',
 };
 
+const DEFAULT_SNACKBAR_TYPE: SnackbarType = 'error';
+
 @observer
 class Snackbar extends React.Component<Props> {
     static defaultProps = {
@@ -29,20 +31,34 @@ class Snackbar extends React.Component<Props> {
     };
 
     @observable message: ?string;
+    @observable type: SnackbarType = DEFAULT_SNACKBAR_TYPE;
 
     @action updateMessage = () => {
         this.message = this.props.message;
     };
 
+    @action updateType = () => {
+        this.type = this.props.type;
+    };
+
     componentDidMount() {
         this.updateMessage();
+        this.updateType();
     }
 
     componentDidUpdate(prevProps: Props) {
-        const {message, visible} = this.props;
+        const {message, type, visible} = this.props;
 
-        if (prevProps.message !== message && visible) {
+        if (!visible) {
+            return;
+        }
+
+        if (prevProps.visible !== visible || prevProps.message !== message) {
             this.updateMessage();
+        }
+
+        if (prevProps.visible !== visible || prevProps.type !== type) {
+            this.updateType();
         }
     }
 
@@ -51,15 +67,16 @@ class Snackbar extends React.Component<Props> {
 
         if (!visible) {
             this.message = undefined;
+            this.type = DEFAULT_SNACKBAR_TYPE;
         }
     };
 
     render() {
-        const {onCloseClick, onClick, type, visible} = this.props;
+        const {onCloseClick, onClick, visible} = this.props;
 
         const snackbarClass = classNames(
             snackbarStyles.snackbar,
-            snackbarStyles[type],
+            snackbarStyles[this.type],
             {
                 [snackbarStyles.clickable]: onClick,
                 [snackbarStyles.visible]: visible,
@@ -68,9 +85,9 @@ class Snackbar extends React.Component<Props> {
 
         return (
             <div className={snackbarClass} onClick={onClick} onTransitionEnd={this.handleTransitionEnd} role="button">
-                <Icon className={snackbarStyles.icon} name={ICONS[type]} />
+                <Icon className={snackbarStyles.icon} name={ICONS[this.type]} />
                 <div className={snackbarStyles.text}>
-                    <strong>{translate('sulu_admin.' + type)}</strong> - {this.message}
+                    <strong>{translate('sulu_admin.' + this.type)}</strong> - {this.message}
                 </div>
                 {onCloseClick &&
                     <Icon className={snackbarStyles.closeIcon} name="su-times" onClick={onCloseClick} />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/Snackbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/Snackbar.js
@@ -7,11 +7,13 @@ import {translate} from '../../utils/Translator';
 import Icon from '../Icon';
 import snackbarStyles from './snackbar.scss';
 
+export type SnackbarType = 'error' | 'warning';
+
 type Props = {|
     message: string,
     onClick?: () => void,
     onCloseClick?: () => void,
-    type: 'error' | 'warning',
+    type: SnackbarType,
     visible: boolean,
 |};
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/index.js
@@ -1,4 +1,8 @@
 // @flow
-import Snackbar from './Snackbar';
+import Snackbar, {type SnackbarType} from './Snackbar';
+
+export type {
+    SnackbarType,
+};
 
 export default Snackbar;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/__snapshots__/Application.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/__snapshots__/Application.test.js.snap
@@ -138,18 +138,18 @@ Array [
             />
           </div>
           <div
-            class="snackbar warning"
+            class="snackbar error"
             role="button"
           >
             <span
-              aria-label="su-bell"
-              class="su-bell icon"
+              aria-label="su-exclamation-triangle"
+              class="su-exclamation-triangle icon"
             />
             <div
               class="text"
             >
               <strong>
-                sulu_admin.warning
+                sulu_admin.error
               </strong>
                - 
             </div>
@@ -324,18 +324,18 @@ Array [
             />
           </div>
           <div
-            class="snackbar warning"
+            class="snackbar error"
             role="button"
           >
             <span
-              aria-label="su-bell"
-              class="su-bell icon"
+              aria-label="su-exclamation-triangle"
+              class="su-exclamation-triangle icon"
             />
             <div
               class="text"
             >
               <strong>
-                sulu_admin.warning
+                sulu_admin.error
               </strong>
                - 
             </div>
@@ -1023,18 +1023,18 @@ Array [
             />
           </div>
           <div
-            class="snackbar warning"
+            class="snackbar error"
             role="button"
           >
             <span
-              aria-label="su-bell"
-              class="su-bell icon"
+              aria-label="su-exclamation-triangle"
+              class="su-exclamation-triangle icon"
             />
             <div
               class="text"
             >
               <strong>
-                sulu_admin.warning
+                sulu_admin.error
               </strong>
                - 
             </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/GhostDialog.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/GhostDialog.test.js.snap
@@ -15,6 +15,27 @@ Array [
       <section
         class="content"
       >
+        <div
+          class="snackbar"
+        >
+          <div
+            class="snackbar error"
+            role="button"
+          >
+            <span
+              aria-label="su-exclamation-triangle"
+              class="su-exclamation-triangle icon"
+            />
+            <div
+              class="text"
+            >
+              <strong>
+                sulu_admin.error
+              </strong>
+               - 
+            </div>
+          </div>
+        </div>
         <header
           class="header"
         >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/MissingTypeDialog.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/MissingTypeDialog.test.js.snap
@@ -15,6 +15,27 @@ Array [
       <section
         class="content"
       >
+        <div
+          class="snackbar"
+        >
+          <div
+            class="snackbar error"
+            role="button"
+          >
+            <span
+              aria-label="su-exclamation-triangle"
+              class="su-exclamation-triangle icon"
+            />
+            <div
+              class="text"
+            >
+              <strong>
+                sulu_admin.error
+              </strong>
+               - 
+            </div>
+          </div>
+        </div>
         <header
           class="header"
         >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
@@ -100,18 +100,18 @@ Array [
     />
   </div>,
   <div
-    class="snackbar warning"
+    class="snackbar error"
     role="button"
   >
     <span
-      aria-label="su-bell"
-      class="su-bell icon"
+      aria-label="su-exclamation-triangle"
+      class="su-exclamation-triangle icon"
     />
     <div
       class="text"
     >
       <strong>
-        sulu_admin.warning
+        sulu_admin.error
       </strong>
        - 
     </div>
@@ -323,18 +323,18 @@ Array [
     />
   </div>,
   <div
-    class="snackbar warning"
+    class="snackbar error"
     role="button"
   >
     <span
-      aria-label="su-bell"
-      class="su-bell icon"
+      aria-label="su-exclamation-triangle"
+      class="su-exclamation-triangle icon"
     />
     <div
       class="text"
     >
       <strong>
-        sulu_admin.warning
+        sulu_admin.error
       </strong>
        - 
     </div>
@@ -387,18 +387,18 @@ Array [
     />
   </div>,
   <div
-    class="snackbar warning"
+    class="snackbar error"
     role="button"
   >
     <span
-      aria-label="su-bell"
-      class="su-bell icon"
+      aria-label="su-exclamation-triangle"
+      class="su-exclamation-triangle icon"
     />
     <div
       class="text"
     >
       <strong>
-        sulu_admin.warning
+        sulu_admin.error
       </strong>
        - 
     </div>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #6123
| License | MIT
| Documentation PR | -

#### What's in this PR?

This pull request adds the functionality for displaying error messages and warnings inside dialogs.
