### PR TITLE
Add props for displaying Snackbar inside of Overlay

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
@@ -9,6 +9,7 @@ import Icon from '../Icon';
 import Button from '../Button';
 import {afterElementsRendered} from '../../utils/DOM';
 import Backdrop from '../Backdrop';
+import Snackbar, {type SnackbarType} from '../Snackbar';
 import Actions from './Actions';
 import overlayStyles from './overlay.scss';
 import type {Action, Size} from './types';
@@ -22,8 +23,12 @@ type Props = {
     confirmText: string,
     onClose: () => void,
     onConfirm: () => void,
+    onSnackbarClick?: () => void,
+    onSnackbarCloseClick?: () => void,
     open: boolean,
     size?: Size,
+    snackbarMessage?: string,
+    snackbarType: SnackbarType,
     title: string,
 };
 
@@ -36,15 +41,17 @@ class Overlay extends React.Component<Props> {
         actions: [],
         confirmDisabled: false,
         confirmLoading: false,
+        snackbarType: 'error',
     };
 
     @observable open: boolean = false;
     @observable visible: boolean = false;
+    @observable snackbarType: SnackbarType;
 
     constructor(props: Props) {
         super(props);
 
-        const {open} = this.props;
+        const {open, snackbarType} = this.props;
 
         if (open) {
             Mousetrap.bind(CLOSE_OVERLAY_KEY, this.close);
@@ -52,6 +59,7 @@ class Overlay extends React.Component<Props> {
 
         this.open = open;
         this.visible = open;
+        this.snackbarType = snackbarType;
     }
 
     componentWillUnmount() {
@@ -61,7 +69,7 @@ class Overlay extends React.Component<Props> {
     }
 
     @action componentDidUpdate(prevProps: Props) {
-        const {open} = this.props;
+        const {open, snackbarMessage, snackbarType} = this.props;
 
         if (prevProps.open !== open) {
             if (open) {
@@ -77,6 +85,10 @@ class Overlay extends React.Component<Props> {
 
         if (prevProps.open === false && open === true) {
             this.visible = true;
+        }
+
+        if (snackbarMessage && this.snackbarType !== snackbarType) {
+            this.snackbarType = snackbarType;
         }
     }
 
@@ -103,8 +115,11 @@ class Overlay extends React.Component<Props> {
             confirmLoading,
             confirmText,
             onConfirm,
-            title,
+            onSnackbarClick,
+            onSnackbarCloseClick,
             size,
+            snackbarMessage,
+            title,
         } = this.props;
 
         const {open, visible} = this;
@@ -154,6 +169,15 @@ class Overlay extends React.Component<Props> {
                                             {confirmText}
                                         </Button>
                                     </footer>
+                                    <div className={overlayStyles.snackbar}>
+                                        <Snackbar
+                                            message={snackbarMessage || ''}
+                                            onClick={onSnackbarClick}
+                                            onCloseClick={onSnackbarCloseClick}
+                                            type={this.snackbarType}
+                                            visible={!!snackbarMessage}
+                                        />
+                                    </div>
                                 </section>
                             </div>
                         </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
@@ -46,12 +46,11 @@ class Overlay extends React.Component<Props> {
 
     @observable open: boolean = false;
     @observable visible: boolean = false;
-    @observable snackbarType: SnackbarType;
 
     constructor(props: Props) {
         super(props);
 
-        const {open, snackbarType} = this.props;
+        const {open} = this.props;
 
         if (open) {
             Mousetrap.bind(CLOSE_OVERLAY_KEY, this.close);
@@ -59,7 +58,6 @@ class Overlay extends React.Component<Props> {
 
         this.open = open;
         this.visible = open;
-        this.snackbarType = snackbarType;
     }
 
     componentWillUnmount() {
@@ -69,7 +67,7 @@ class Overlay extends React.Component<Props> {
     }
 
     @action componentDidUpdate(prevProps: Props) {
-        const {open, snackbarMessage, snackbarType} = this.props;
+        const {open} = this.props;
 
         if (prevProps.open !== open) {
             if (open) {
@@ -85,10 +83,6 @@ class Overlay extends React.Component<Props> {
 
         if (prevProps.open === false && open === true) {
             this.visible = true;
-        }
-
-        if (snackbarMessage && this.snackbarType !== snackbarType) {
-            this.snackbarType = snackbarType;
         }
     }
 
@@ -119,6 +113,7 @@ class Overlay extends React.Component<Props> {
             onSnackbarCloseClick,
             size,
             snackbarMessage,
+            snackbarType,
             title,
         } = this.props;
 
@@ -174,7 +169,7 @@ class Overlay extends React.Component<Props> {
                                             message={snackbarMessage || ''}
                                             onClick={onSnackbarClick}
                                             onCloseClick={onSnackbarCloseClick}
-                                            type={this.snackbarType}
+                                            type={snackbarType}
                                             visible={!!snackbarMessage}
                                         />
                                     </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/README.md
@@ -38,6 +38,12 @@ const onConfirm = () => {
     setOpen(false);
 };
 
+const snackbarMessage = snackbarType === 'error'
+    ? 'An error occurred'
+    : snackbarType === 'warning'
+        ? 'Something strange happened'
+        : undefined;
+
 <div>
     <button onClick={() => setOpen(true)}>Open overlay</button>
     <Overlay
@@ -48,13 +54,7 @@ const onConfirm = () => {
         onConfirm={onConfirm}
         open={open}
         snackbarType={snackbarType}
-        snackbarMessage={
-            snackbarType === 'error'
-                ? 'An error occurred'
-                : snackbarType === 'warning'
-                    ? 'Something strange happened'
-                    : undefined
-        }>
+        snackbarMessage={snackbarMessage}>
         <div style={{padding: '50px', display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
             <button onClick={() => setSnackbarType((type) => type !== 'error' ? 'error' : undefined)}>Toggle error</button>
             &nbsp;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/README.md
@@ -27,3 +27,39 @@ const onConfirm = () => {
     </Overlay>
 </div>
 ```
+
+Errors and warnings can be displayed at the top of the overlay.
+
+```javascript
+const [open, setOpen] = React.useState(false);
+const [snackbarType, setSnackbarType] = React.useState(undefined);
+const onConfirm = () => {
+    /* do confirm things */
+    setOpen(false);
+};
+
+<div>
+    <button onClick={() => setOpen(true)}>Open overlay</button>
+    <Overlay
+        title="Njan Njan Njan"
+        onClose={() => setOpen(false)}
+        confirmText="Apply"
+        size="large"
+        onConfirm={onConfirm}
+        open={open}
+        snackbarType={snackbarType}
+        snackbarMessage={
+            snackbarType === 'error'
+                ? 'An error occurred'
+                : snackbarType === 'warning'
+                    ? 'Something strange happened'
+                    : undefined
+        }>
+        <div style={{padding: '50px', display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
+            <button onClick={() => setSnackbarType((type) => type !== 'error' ? 'error' : undefined)}>Toggle error</button>
+            &nbsp;
+            <button onClick={() => setSnackbarType((type) => type !== 'warning' ? 'warning' : undefined)}>Toggle warning</button>
+        </div>
+    </Overlay>
+</div>
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/overlay.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/overlay.scss
@@ -109,3 +109,10 @@ $transitionDuration: 300ms;
         cursor: pointer;
     }
 }
+
+.snackbar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/Overlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/Overlay.test.js
@@ -166,3 +166,116 @@ test('The component should call the callback when the confirm button is clicked'
     view.find('Button').simulate('click');
     expect(onConfirm).toBeCalled();
 });
+
+test('The component should render with a warning', () => {
+    const onClose = jest.fn();
+    const onConfirm = jest.fn();
+    const view = mount(
+        <Overlay
+            confirmText="Alright mate!"
+            onClose={onClose}
+            onConfirm={onConfirm}
+            open={true}
+            snackbarMessage="Something really strange happened"
+            snackbarType="warning"
+            title="My title"
+        >
+            <p>My overlay content</p>
+        </Overlay>
+    );
+
+    expect(view.find('.snackbar.warning')).toHaveLength(1);
+    expect(view.find('.snackbar.warning').text()).toBe('sulu_admin.warning - Something really strange happened');
+    expect(view.find('.snackbar.error')).toHaveLength(0);
+});
+
+test('The component should render with an error', () => {
+    const onClose = jest.fn();
+    const onConfirm = jest.fn();
+    const view = mount(
+        <Overlay
+            confirmText="Alright mate!"
+            onClose={onClose}
+            onConfirm={onConfirm}
+            open={true}
+            snackbarMessage="Money transfer unsuccessful"
+            snackbarType="error"
+            title="My title"
+        >
+            <p>My overlay content</p>
+        </Overlay>
+    );
+
+    expect(view.find('.snackbar.error')).toHaveLength(1);
+    expect(view.find('.snackbar.error').text()).toBe('sulu_admin.error - Money transfer unsuccessful');
+    expect(view.find('.snackbar.warning')).toHaveLength(0);
+});
+
+test('The component should render with an error if type is unknown', () => {
+    const onClose = jest.fn();
+    const onConfirm = jest.fn();
+    const view = mount(
+        <Overlay
+            confirmText="Alright mate!"
+            onClose={onClose}
+            onConfirm={onConfirm}
+            open={true}
+            snackbarMessage="Money transfer unsuccessful"
+            title="My title"
+        >
+            <p>My overlay content</p>
+        </Overlay>
+    );
+
+    expect(view.find('.snackbar.error')).toHaveLength(1);
+    expect(view.find('.snackbar.error').text()).toBe('sulu_admin.error - Money transfer unsuccessful');
+    expect(view.find('.snackbar.warning')).toHaveLength(0);
+});
+
+test('The component should call the callback when the snackbar close button is clicked', () => {
+    const onSnackbarCloseClick = jest.fn();
+    const onClose = jest.fn();
+    const onConfirm = jest.fn();
+    const view = mount(
+        <Overlay
+            confirmText="Alright mate!"
+            onClose={onClose}
+            onConfirm={onConfirm}
+            onSnackbarCloseClick={onSnackbarCloseClick}
+            open={true}
+            snackbarMessage="Money transfer unsuccessful"
+            snackbarType="error"
+            title="My title"
+        >
+            <p>My overlay content</p>
+        </Overlay>
+    );
+
+    expect(onSnackbarCloseClick).not.toBeCalled();
+    view.find('.snackbar.error .su-times').simulate('click');
+    expect(onSnackbarCloseClick).toBeCalled();
+});
+
+test('The component should call the callback when the snackbar is clicked', () => {
+    const onSnackbarClick = jest.fn();
+    const onClose = jest.fn();
+    const onConfirm = jest.fn();
+    const view = mount(
+        <Overlay
+            confirmText="Alright mate!"
+            onClose={onClose}
+            onConfirm={onConfirm}
+            onSnackbarClick={onSnackbarClick}
+            open={true}
+            snackbarMessage="Something really strange happened"
+            snackbarType="warning"
+            title="My title"
+        >
+            <p>My overlay content</p>
+        </Overlay>
+    );
+
+    expect(onSnackbarClick).not.toBeCalled();
+    view.find('.snackbar.warning').simulate('click');
+    expect(onSnackbarClick).toBeCalled();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/__snapshots__/Overlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/__snapshots__/Overlay.test.js.snap
@@ -73,6 +73,27 @@ Array [
             </span>
           </button>
         </footer>
+        <div
+          class="snackbar"
+        >
+          <div
+            class="snackbar error"
+            role="button"
+          >
+            <span
+              aria-label="su-exclamation-triangle"
+              class="su-exclamation-triangle icon"
+            />
+            <div
+              class="text"
+            >
+              <strong>
+                sulu_admin.error
+              </strong>
+               - 
+            </div>
+          </div>
+        </div>
       </section>
     </div>
   </div>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/FormOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/FormOverlay.js
@@ -4,7 +4,6 @@ import {action, computed, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import Overlay from '../../components/Overlay';
 import {translate} from '../../utils';
-import Snackbar from '../../components/Snackbar';
 import Form from '../Form';
 import formOverlayStyles from './formOverlay.scss';
 import type {FormStoreInterface} from '../Form/types';
@@ -117,16 +116,13 @@ class FormOverlay extends React.Component<Props> {
                 confirmText={confirmText}
                 onClose={onClose}
                 onConfirm={this.handleOverlayConfirm}
+                onSnackbarCloseClick={this.handleErrorSnackbarClose}
                 open={open}
                 size={size}
+                snackbarMessage={this.formErrors[this.formErrors.length - 1]}
+                snackbarType="error"
                 title={title}
             >
-                <Snackbar
-                    message={this.formErrors[this.formErrors.length - 1]}
-                    onCloseClick={this.handleErrorSnackbarClose}
-                    type="error"
-                    visible={!!this.formErrors.length}
-                />
                 <div className={formOverlayStyles.form}>
                     <Form
                         onError={this.handleFormError}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/tests/FormOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/tests/FormOverlay.test.js
@@ -277,7 +277,7 @@ test('Should display Snackbar with generic message if an error happens while sav
     const formStore = new ResourceFormStore(new ResourceStore('test'), 'test');
     const confirmSpy = jest.fn();
 
-    const formOverlay = shallow(<FormOverlay
+    const formOverlay = mount(<FormOverlay
         confirmDisabled={false}
         confirmLoading={false}
         confirmText="confirm-text"
@@ -311,7 +311,7 @@ test('Should display Snackbar with message from server if an error happens while
     const formStore = new ResourceFormStore(new ResourceStore('test'), 'test');
     const confirmSpy = jest.fn();
 
-    const formOverlay = shallow(<FormOverlay
+    const formOverlay = mount(<FormOverlay
         confirmDisabled={false}
         confirmLoading={false}
         confirmText="confirm-text"
@@ -345,7 +345,7 @@ test('Should display Snackbar if a form is not valid', () => {
     const formStore = new ResourceFormStore(new ResourceStore('test'), 'test');
     const confirmSpy = jest.fn();
 
-    const formOverlay = shallow(<FormOverlay
+    const formOverlay = mount(<FormOverlay
         confirmDisabled={false}
         confirmLoading={false}
         confirmText="confirm-text"
@@ -368,7 +368,7 @@ test('Should hide Snackbar when closeClick callback of Snackbar is fired', () =>
     const formStore = new ResourceFormStore(new ResourceStore('test'), 'test');
     const confirmSpy = jest.fn();
 
-    const formOverlay = shallow(<FormOverlay
+    const formOverlay = mount(<FormOverlay
         confirmDisabled={false}
         confirmLoading={false}
         confirmText="confirm-text"
@@ -393,7 +393,7 @@ test('Should clear old errors if Overlay is opened a second time', () => {
     const formStore = new ResourceFormStore(new ResourceStore('test'), 'test');
     const confirmSpy = jest.fn();
 
-    const formOverlay = shallow(<FormOverlay
+    const formOverlay = mount(<FormOverlay
         confirmDisabled={false}
         confirmLoading={false}
         confirmText="confirm-text"
@@ -411,6 +411,7 @@ test('Should clear old errors if Overlay is opened a second time', () => {
 
     formOverlay.setProps({open: false});
     formOverlay.setProps({open: true});
+    formOverlay.update();
 
     expect(formOverlay.find(Snackbar).props().visible).toBeFalsy();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/tests/__snapshots__/FormOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/tests/__snapshots__/FormOverlay.test.js.snap
@@ -32,29 +32,6 @@ Array [
           class="article"
         >
           <div
-            class="snackbar error"
-            role="button"
-          >
-            <span
-              aria-label="su-exclamation-triangle"
-              class="su-exclamation-triangle icon"
-            />
-            <div
-              class="text"
-            >
-              <strong>
-                sulu_admin.error
-              </strong>
-               - 
-            </div>
-            <span
-              aria-label="su-times"
-              class="su-times clickable closeIcon"
-              role="button"
-              tabindex="0"
-            />
-          </div>
-          <div
             class="form"
           >
             <div>
@@ -77,6 +54,33 @@ Array [
             </span>
           </button>
         </footer>
+        <div
+          class="snackbar"
+        >
+          <div
+            class="snackbar error"
+            role="button"
+          >
+            <span
+              aria-label="su-exclamation-triangle"
+              class="su-exclamation-triangle icon"
+            />
+            <div
+              class="text"
+            >
+              <strong>
+                sulu_admin.error
+              </strong>
+               - 
+            </div>
+            <span
+              aria-label="su-times"
+              class="su-times clickable closeIcon"
+              role="button"
+              tabindex="0"
+            />
+          </div>
+        </div>
       </section>
     </div>
   </div>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/__snapshots__/MultiSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/__snapshots__/MultiSelection.test.js.snap
@@ -395,6 +395,27 @@ Array [
             </span>
           </button>
         </footer>
+        <div
+          class="snackbar"
+        >
+          <div
+            class="snackbar error"
+            role="button"
+          >
+            <span
+              aria-label="su-exclamation-triangle"
+              class="su-exclamation-triangle icon"
+            />
+            <div
+              class="text"
+            >
+              <strong>
+                sulu_admin.error
+              </strong>
+               - 
+            </div>
+          </div>
+        </div>
       </section>
     </div>
   </div>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ProfileFormOverlay/tests/__snapshots__/ProfileFormOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ProfileFormOverlay/tests/__snapshots__/ProfileFormOverlay.test.js.snap
@@ -32,29 +32,6 @@ Array [
           class="article"
         >
           <div
-            class="snackbar error"
-            role="button"
-          >
-            <span
-              aria-label="su-exclamation-triangle"
-              class="su-exclamation-triangle icon"
-            />
-            <div
-              class="text"
-            >
-              <strong>
-                sulu_admin.error
-              </strong>
-               - 
-            </div>
-            <span
-              aria-label="su-times"
-              class="su-times clickable closeIcon"
-              role="button"
-              tabindex="0"
-            />
-          </div>
-          <div
             class="form"
           >
             <div>
@@ -77,6 +54,33 @@ Array [
             </span>
           </button>
         </footer>
+        <div
+          class="snackbar"
+        >
+          <div
+            class="snackbar error"
+            role="button"
+          >
+            <span
+              aria-label="su-exclamation-triangle"
+              class="su-exclamation-triangle icon"
+            />
+            <div
+              class="text"
+            >
+              <strong>
+                sulu_admin.error
+              </strong>
+               - 
+            </div>
+            <span
+              aria-label="su-times"
+              class="su-times clickable closeIcon"
+              role="button"
+              tabindex="0"
+            />
+          </div>
+        </div>
       </section>
     </div>
   </div>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/tests/__snapshots__/ResourceLocatorHistory.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/tests/__snapshots__/ResourceLocatorHistory.test.js.snap
@@ -162,6 +162,27 @@ Array [
             </span>
           </button>
         </footer>
+        <div
+          class="snackbar"
+        >
+          <div
+            class="snackbar error"
+            role="button"
+          >
+            <span
+              aria-label="su-exclamation-triangle"
+              class="su-exclamation-triangle icon"
+            />
+            <div
+              class="text"
+            >
+              <strong>
+                sulu_admin.error
+              </strong>
+               - 
+            </div>
+          </div>
+        </div>
       </section>
     </div>
   </div>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/__snapshots__/FilterOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/__snapshots__/FilterOverlay.test.js.snap
@@ -423,6 +423,27 @@ Array [
             </span>
           </button>
         </footer>
+        <div
+          class="snackbar"
+        >
+          <div
+            class="snackbar error"
+            role="button"
+          >
+            <span
+              aria-label="su-exclamation-triangle"
+              class="su-exclamation-triangle icon"
+            />
+            <div
+              class="text"
+            >
+              <strong>
+                sulu_admin.error
+              </strong>
+               - 
+            </div>
+          </div>
+        </div>
       </section>
     </div>
   </div>,
@@ -492,6 +513,27 @@ Array [
             </span>
           </button>
         </footer>
+        <div
+          class="snackbar"
+        >
+          <div
+            class="snackbar error"
+            role="button"
+          >
+            <span
+              aria-label="su-exclamation-triangle"
+              class="su-exclamation-triangle icon"
+            />
+            <div
+              class="text"
+            >
+              <strong>
+                sulu_admin.error
+              </strong>
+               - 
+            </div>
+          </div>
+        </div>
       </section>
     </div>
   </div>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/__snapshots__/FormOverlayList.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/__snapshots__/FormOverlayList.test.js.snap
@@ -41,29 +41,6 @@ Array [
           class="article"
         >
           <div
-            class="snackbar error"
-            role="button"
-          >
-            <span
-              aria-label="su-exclamation-triangle"
-              class="su-exclamation-triangle icon"
-            />
-            <div
-              class="text"
-            >
-              <strong>
-                sulu_admin.error
-              </strong>
-               - 
-            </div>
-            <span
-              aria-label="su-times"
-              class="su-times clickable closeIcon"
-              role="button"
-              tabindex="0"
-            />
-          </div>
-          <div
             class="form"
           >
             <div>
@@ -86,6 +63,33 @@ Array [
             </span>
           </button>
         </footer>
+        <div
+          class="snackbar"
+        >
+          <div
+            class="snackbar error"
+            role="button"
+          >
+            <span
+              aria-label="su-exclamation-triangle"
+              class="su-exclamation-triangle icon"
+            />
+            <div
+              class="text"
+            >
+              <strong>
+                sulu_admin.error
+              </strong>
+               - 
+            </div>
+            <span
+              aria-label="su-times"
+              class="su-times clickable closeIcon"
+              role="button"
+              tabindex="0"
+            />
+          </div>
+        </div>
       </section>
     </div>
   </div>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
@@ -254,6 +254,25 @@ Array [
             </span>
           </button>
         </footer>
+        <div
+          class="snackbar"
+        >
+          <div
+            class="snackbar error"
+            role="button"
+          >
+            <span
+              aria-label="su-exclamation-triangle"
+              class="su-exclamation-triangle icon"
+            />
+            <div
+              class="text"
+            >
+              <strong />
+               - 
+            </div>
+          </div>
+        </div>
       </section>
     </div>
   </div>,

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/__snapshots__/RuleOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/__snapshots__/RuleOverlay.test.js.snap
@@ -168,6 +168,27 @@ Array [
             </span>
           </button>
         </footer>
+        <div
+          class="snackbar"
+        >
+          <div
+            class="snackbar error"
+            role="button"
+          >
+            <span
+              aria-label="su-exclamation-triangle"
+              class="su-exclamation-triangle icon"
+            />
+            <div
+              class="text"
+            >
+              <strong>
+                sulu_admin.error
+              </strong>
+               - 
+            </div>
+          </div>
+        </div>
       </section>
     </div>
   </div>,

--- a/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/__snapshots__/LocationOverlay.test.js.snap
+++ b/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/__snapshots__/LocationOverlay.test.js.snap
@@ -446,6 +446,27 @@ Array [
             </span>
           </button>
         </footer>
+        <div
+          class="snackbar"
+        >
+          <div
+            class="snackbar error"
+            role="button"
+          >
+            <span
+              aria-label="su-exclamation-triangle"
+              class="su-exclamation-triangle icon"
+            />
+            <div
+              class="text"
+            >
+              <strong>
+                sulu_admin.error
+              </strong>
+               - 
+            </div>
+          </div>
+        </div>
       </section>
     </div>
   </div>,
@@ -919,6 +940,27 @@ Array [
             </span>
           </button>
         </footer>
+        <div
+          class="snackbar"
+        >
+          <div
+            class="snackbar error"
+            role="button"
+          >
+            <span
+              aria-label="su-exclamation-triangle"
+              class="su-exclamation-triangle icon"
+            />
+            <div
+              class="text"
+            >
+              <strong>
+                sulu_admin.error
+              </strong>
+               - 
+            </div>
+          </div>
+        </div>
       </section>
     </div>
   </div>,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
@@ -646,6 +646,27 @@ Array [
             </span>
           </button>
         </footer>
+        <div
+          class="snackbar"
+        >
+          <div
+            class="snackbar error"
+            role="button"
+          >
+            <span
+              aria-label="su-exclamation-triangle"
+              class="su-exclamation-triangle icon"
+            />
+            <div
+              class="text"
+            >
+              <strong>
+                sulu_admin.error
+              </strong>
+               - 
+            </div>
+          </div>
+        </div>
       </section>
     </div>
   </div>,
@@ -1297,6 +1318,27 @@ Array [
             </span>
           </button>
         </footer>
+        <div
+          class="snackbar"
+        >
+          <div
+            class="snackbar error"
+            role="button"
+          >
+            <span
+              aria-label="su-exclamation-triangle"
+              class="su-exclamation-triangle icon"
+            />
+            <div
+              class="text"
+            >
+              <strong>
+                sulu_admin.error
+              </strong>
+               - 
+            </div>
+          </div>
+        </div>
       </section>
     </div>
   </div>,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #6128, #6155 
| License | MIT
| Documentation PR | -

#### What's in this PR?

This pull request adds the functionality for displaying error messages and warnings inside overlays.

**!!! This pull request depends on #6155 !!!**