### PR TITLE
UserManager dependency ContactManagerInterface in order to ContactMan…

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
+++ b/src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
@@ -15,7 +15,7 @@ use Doctrine\ORM\NoResultException;
 use Doctrine\Persistence\ObjectManager;
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
 use Sulu\Bundle\AdminBundle\UserManager\UserManagerInterface;
-use Sulu\Bundle\ContactBundle\Contact\ContactManager;
+use Sulu\Bundle\ContactBundle\Contact\ContactManagerInterface;
 use Sulu\Bundle\ContactBundle\Entity\Contact;
 use Sulu\Bundle\SecurityBundle\Domain\Event\UserCreatedEvent;
 use Sulu\Bundle\SecurityBundle\Domain\Event\UserEnabledEvent;
@@ -62,7 +62,7 @@ class UserManager implements UserManagerInterface
     private $groupRepository;
 
     /**
-     * @var ContactManager
+     * @var ContactManagerInterface
      */
     protected $contactManager;
 
@@ -86,7 +86,7 @@ class UserManager implements UserManagerInterface
         EncoderFactory $encoderFactory = null,
         RoleRepositoryInterface $roleRepository,
         GroupRepository $groupRepository,
-        ContactManager $contactManager,
+        ContactManagerInterface $contactManager,
         SaltGenerator $saltGenerator,
         UserRepositoryInterface $userRepository,
         DomainEventCollectorInterface $domainEventCollector


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Changing UserManager ContactManager dependency

#### Why?

<!-- Which problem does the PR fix? (add some context and maybe link to an issue here) -->
If we make a new ClassManager in our project, the UserManager class must have a ContactManagerInterface dependency in order to ContactManager.

