### PR TITLE
Add autocomplete attributes to LoginForm, ResetPasswordForm, ForgotPasswordForm

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/PasswordConfirmation.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/PasswordConfirmation.js
@@ -80,6 +80,7 @@ class PasswordConfirmation extends React.Component<Props> {
             <Grid className={passwordConfirmationStyles.grid}>
                 <Grid.Item colSpan={6}>
                     <Input
+                        autocomplete="new-password"
                         disabled={disabled}
                         icon={LOCK_ICON}
                         onChange={this.handleFirstChange}
@@ -90,6 +91,7 @@ class PasswordConfirmation extends React.Component<Props> {
                 </Grid.Item>
                 <Grid.Item className={passwordConfirmationStyles.item} colSpan={6}>
                     <Input
+                        autocomplete="new-password"
                         disabled={disabled}
                         icon={LOCK_ICON}
                         onChange={this.handleSecondChange}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/tests/__snapshots__/PasswordConfirmation.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/tests/__snapshots__/PasswordConfirmation.test.js.snap
@@ -19,6 +19,7 @@ exports[`Should render disabled input-components when disabled 1`] = `
         />
       </div>
       <input
+        autocomplete="new-password"
         type="password"
         value=""
       />
@@ -39,6 +40,7 @@ exports[`Should render disabled input-components when disabled 1`] = `
         />
       </div>
       <input
+        autocomplete="new-password"
         type="password"
         value=""
       />
@@ -66,6 +68,7 @@ exports[`Should render two password fields and add a debounced function 1`] = `
         />
       </div>
       <input
+        autocomplete="new-password"
         disabled=""
         type="password"
         value=""
@@ -87,6 +90,7 @@ exports[`Should render two password fields and add a debounced function 1`] = `
         />
       </div>
       <input
+        autocomplete="new-password"
         disabled=""
         type="password"
         value=""

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/__snapshots__/Application.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/__snapshots__/Application.test.js.snap
@@ -417,6 +417,7 @@ Array [
                   />
                 </div>
                 <input
+                  autocomplete="new-password"
                   type="password"
                   value=""
                 />
@@ -442,6 +443,7 @@ Array [
                   />
                 </div>
                 <input
+                  autocomplete="new-password"
                   type="password"
                   value=""
                 />
@@ -557,6 +559,7 @@ Array [
                   />
                 </div>
                 <input
+                  autocomplete="username"
                   type="text"
                   value=""
                 />
@@ -582,6 +585,7 @@ Array [
                   />
                 </div>
                 <input
+                  autocomplete="current-password"
                   type="password"
                   value=""
                 />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/ForgotPasswordForm.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/ForgotPasswordForm.js
@@ -72,6 +72,7 @@ class ForgotPasswordForm extends React.Component<Props> {
                                 {translate('sulu_admin.username_or_email')}
                             </div>
                             <Input
+                                autocomplete="username"
                                 icon="su-user"
                                 inputRef={this.setInputRef}
                                 onChange={this.handleUserChange}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/LoginForm.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/LoginForm.js
@@ -85,6 +85,7 @@ class LoginForm extends React.Component<Props> {
                                 {translate('sulu_admin.username_or_email')}
                             </div>
                             <Input
+                                autocomplete="username"
                                 icon="su-user"
                                 inputRef={this.setInputRef}
                                 onChange={this.handleUserChange}
@@ -97,6 +98,7 @@ class LoginForm extends React.Component<Props> {
                                 {translate('sulu_admin.password')}
                             </div>
                             <Input
+                                autocomplete="current-password"
                                 icon="su-lock"
                                 onChange={this.handlePasswordChange}
                                 type="password"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/ResetPasswordForm.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/ResetPasswordForm.js
@@ -91,6 +91,7 @@ class ForgotPasswordForm extends React.Component<Props> {
                                 {translate('sulu_admin.password')}
                             </div>
                             <Input
+                                autocomplete="new-password"
                                 icon="su-lock"
                                 inputRef={this.setInputRef}
                                 onChange={this.handlePassword1Change}
@@ -104,6 +105,7 @@ class ForgotPasswordForm extends React.Component<Props> {
                                 {translate('sulu_admin.repeat_password')}
                             </div>
                             <Input
+                                autocomplete="new-password"
                                 icon="su-lock"
                                 onChange={this.handlePassword2Change}
                                 type="password"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/__snapshots__/ForgotPasswordForm.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/__snapshots__/ForgotPasswordForm.test.js.snap
@@ -98,6 +98,7 @@ Array [
             />
           </div>
           <input
+            autocomplete="username"
             type="text"
             value=""
           />
@@ -164,6 +165,7 @@ Array [
             />
           </div>
           <input
+            autocomplete="username"
             type="text"
             value=""
           />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/__snapshots__/ForgotPasswordForm.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/__snapshots__/ForgotPasswordForm.test.js.snap
@@ -31,6 +31,7 @@ Array [
             />
           </div>
           <input
+            autocomplete="username"
             type="text"
             value=""
           />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/__snapshots__/Login.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/__snapshots__/Login.test.js.snap
@@ -47,6 +47,7 @@ exports[`Should render the Login component when initialized is true 1`] = `
                 />
               </div>
               <input
+                autocomplete="username"
                 type="text"
                 value=""
               />
@@ -72,6 +73,7 @@ exports[`Should render the Login component when initialized is true 1`] = `
                 />
               </div>
               <input
+                autocomplete="current-password"
                 type="password"
                 value=""
               />
@@ -170,6 +172,7 @@ exports[`Should render the Login with forgot password view 1`] = `
                 />
               </div>
               <input
+                autocomplete="username"
                 type="text"
                 value=""
               />
@@ -268,6 +271,7 @@ exports[`Should render the Login with forgot password with success 1`] = `
                 />
               </div>
               <input
+                autocomplete="username"
                 type="text"
                 value=""
               />
@@ -366,6 +370,7 @@ exports[`Should render the Login with reset password view 1`] = `
                 />
               </div>
               <input
+                autocomplete="new-password"
                 type="password"
                 value=""
               />
@@ -391,6 +396,7 @@ exports[`Should render the Login with reset password view 1`] = `
                 />
               </div>
               <input
+                autocomplete="new-password"
                 type="password"
                 value=""
               />
@@ -489,6 +495,7 @@ exports[`Should render the LoginForm component with error 1`] = `
                 />
               </div>
               <input
+                autocomplete="username"
                 type="text"
                 value=""
               />
@@ -514,6 +521,7 @@ exports[`Should render the LoginForm component with error 1`] = `
                 />
               </div>
               <input
+                autocomplete="current-password"
                 type="password"
                 value=""
               />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/__snapshots__/LoginForm.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/__snapshots__/LoginForm.test.js.snap
@@ -31,6 +31,7 @@ Array [
             />
           </div>
           <input
+            autocomplete="username"
             type="text"
             value=""
           />
@@ -56,6 +57,7 @@ Array [
             />
           </div>
           <input
+            autocomplete="current-password"
             type="password"
             value=""
           />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/__snapshots__/LoginForm.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/__snapshots__/LoginForm.test.js.snap
@@ -124,6 +124,7 @@ Array [
             />
           </div>
           <input
+            autocomplete="username"
             type="text"
             value=""
           />
@@ -149,6 +150,7 @@ Array [
             />
           </div>
           <input
+            autocomplete="current-password"
             type="password"
             value=""
           />
@@ -230,6 +232,7 @@ Array [
             />
           </div>
           <input
+            autocomplete="username"
             type="text"
             value=""
           />
@@ -255,6 +258,7 @@ Array [
             />
           </div>
           <input
+            autocomplete="current-password"
             type="password"
             value=""
           />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/__snapshots__/ResetPasswordForm.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/__snapshots__/ResetPasswordForm.test.js.snap
@@ -31,6 +31,7 @@ Array [
             />
           </div>
           <input
+            autocomplete="new-password"
             type="password"
             value=""
           />
@@ -56,6 +57,7 @@ Array [
             />
           </div>
           <input
+            autocomplete="new-password"
             type="password"
             value=""
           />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/__snapshots__/ResetPasswordForm.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/__snapshots__/ResetPasswordForm.test.js.snap
@@ -124,6 +124,7 @@ Array [
             />
           </div>
           <input
+            autocomplete="new-password"
             type="password"
             value=""
           />
@@ -149,6 +150,7 @@ Array [
             />
           </div>
           <input
+            autocomplete="new-password"
             type="password"
             value=""
           />


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets |
| Related issues/PRs |
| License | MIT
| Documentation PR |

#### What's in this PR?

Add autocomplete attributes to LoginForm, ResetPasswordForm, ForgotPasswordForm

#### Why?

This helps browsers / password managers fill the fields correctly.
