### PR TITLE
Remove obsolete .scrutinizer.yml file

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -146,7 +146,7 @@ jobs:
             - name: Run php-cs-fixer
               if: ${{ matrix.php-cs-fixer }}
               run: |
-                  composer global require friendsofphp/php-cs-fixer --prefer-dist --no-interaction
+                  composer global require friendsofphp/php-cs-fixer:^2.17 --prefer-dist --no-interaction
                   GLOBAL_BIN_DIR=$(composer global config bin-dir --absolute --quiet)
                   $GLOBAL_BIN_DIR/php-cs-fixer fix --dry-run --diff
 

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,5 +1,0 @@
-imports:
-    - php
-
-filter:
-    excluded_paths: [tests/*, src/Sulu/Bundle/*/Tests/*]


### PR DESCRIPTION
#### Why?

We moved to GitHub Actions and therefore do not use Scrutinizer CI anymore 🙂 