### PR TITLE
Add additional parameter to pass data of current item to FieldTransformer

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/AbstractTableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/AbstractTableAdapter.js
@@ -37,7 +37,11 @@ export default class AbstractTableAdapter extends AbstractAdapter {
 
         return schemaKeys.map((schemaKey, index) => {
             const transformer = listFieldTransformerRegistry.get(this.schema[schemaKey].type);
-            const value = transformer.transform(item[schemaKey], this.schema[schemaKey].transformerTypeParameters);
+            const value = transformer.transform(
+                item[schemaKey],
+                this.schema[schemaKey].transformerTypeParameters,
+                item
+            );
 
             const indicators = [];
             if (index === 0) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/types.js
@@ -111,7 +111,7 @@ export type TreeItem = {
 };
 
 export interface FieldTransformer {
-    transform(value: *, parameters: {[string]: mixed}): Node,
+    transform(value: *, parameters: {[string]: mixed}, item: Object): Node,
 }
 
 export type ResolveCopyArgument = {copied: boolean, parent?: ?Object};


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #6127
| Related issues/PRs | #5918
| License | MIT

#### What's in this PR?

This PR adds an additional `item` parameter to the `FieldTransformer` interface. The new parameter is used to pass the data of the current item.

#### Why?

The data of the current item is needed to implement more complex fields like togglers. At the moment, implementing such a field via a workaround (see https://github.com/sulu/sulu/issues/5918#issuecomment-816696754).
