### PR TITLE
Add ext-exif to suggest section of the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -175,6 +175,7 @@
     "suggest": {
         "ext-fileinfo": "* - Needed to recognize file types of uploaded files",
         "ext-zip": "* - Needed by the download commands for the admin build and its translations",
+        "ext-exif": "* - Needed to automatically rotate uploaded images based on their EXIF information",
         "rokka/imagine-vips": "^0.9.2 - Rendering formats by using the libvips",
         "handcraftedinthealps/zendsearch": "To use the PHP based Zend Search library (based on Lucene)",
         "league/flysystem": "^1.0 - Needed for remote media-storages",


### PR DESCRIPTION
The `exif` extension is needed to automatically rotate uploaded images based on their EXIF information. See https://github.com/sulu/sulu/issues/6159