### PR TITLE
Allow to submit inputted number by pressing enter key in Pagination component

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/Pagination.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/Pagination.js
@@ -111,7 +111,17 @@ class Pagination extends React.Component<Props> {
         }
     };
 
-    @action handleInputBlur = () => {
+    handleInputBlur = () => {
+        this.submitInputValue();
+    };
+
+    handleInputKeyPress = (key: ?string) => {
+        if (key === 'Enter') {
+            this.submitInputValue();
+        }
+    };
+
+    @action submitInputValue = () => {
         const {currentPage, onPageChange, totalPages} = this.props;
         let page = this.currentInputValue;
 
@@ -159,6 +169,7 @@ class Pagination extends React.Component<Props> {
                             inputMode="numeric"
                             onBlur={this.handleInputBlur}
                             onChange={this.handleInputChange}
+                            onKeyPress={this.handleInputKeyPress}
                             skin="dark"
                             type="text"
                             value={currentInputValue}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/tests/Pagination.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/tests/Pagination.test.js
@@ -181,7 +181,7 @@ test('Change limit to current limit should not call callback', () => {
     expect(changeSpy).not.toBeCalled();
 });
 
-test('Change input value should call callback', () => {
+test('Change callback should be called on blur when input was changed', () => {
     const changeSpy = jest.fn();
     const pagination = mount(
         <Pagination
@@ -195,12 +195,41 @@ test('Change input value should call callback', () => {
         </Pagination>
     );
 
+    pagination.find('Input').prop('onBlur')();
+    expect(changeSpy).not.toBeCalled();
+
     pagination.find('Input').prop('onChange')(3);
+    expect(changeSpy).not.toBeCalled();
+
     pagination.find('Input').prop('onBlur')();
     expect(changeSpy).toBeCalledWith(3);
 });
 
-test('Change input value to something lower than 1 should call callback with 1', () => {
+test('Change callback should be called on enter when input was changed', () => {
+    const changeSpy = jest.fn();
+    const pagination = mount(
+        <Pagination
+            currentLimit={10}
+            currentPage={6}
+            onLimitChange={jest.fn()}
+            onPageChange={changeSpy}
+            totalPages={10}
+        >
+            <p>Test</p>
+        </Pagination>
+    );
+
+    pagination.find('Input').prop('onKeyPress')('Enter');
+    expect(changeSpy).not.toBeCalled();
+
+    pagination.find('Input').prop('onChange')(3);
+    expect(changeSpy).not.toBeCalled();
+
+    pagination.find('Input').prop('onKeyPress')('Enter');
+    expect(changeSpy).toBeCalledWith(3);
+});
+
+test('Change callback should be called with 1 if input value is lower than 1', () => {
     const changeSpy = jest.fn();
     const pagination = mount(
         <Pagination
@@ -219,28 +248,26 @@ test('Change input value to something lower than 1 should call callback with 1',
     expect(changeSpy).toBeCalledWith(1);
 });
 
-test('Change input value to something higher than total pages should call callback with the amount of total pages',
-    () => {
-        const changeSpy = jest.fn();
-        const pagination = shallow(
-            <Pagination
-                currentLimit={10}
-                currentPage={6}
-                onLimitChange={jest.fn()}
-                onPageChange={changeSpy}
-                totalPages={10}
-            >
-                <p>Test</p>
-            </Pagination>
-        );
+test('Change callback should be called with value of totalPages if input value is higher than total pages', () => {
+    const changeSpy = jest.fn();
+    const pagination = shallow(
+        <Pagination
+            currentLimit={10}
+            currentPage={6}
+            onLimitChange={jest.fn()}
+            onPageChange={changeSpy}
+            totalPages={10}
+        >
+            <p>Test</p>
+        </Pagination>
+    );
 
-        pagination.find('Input').prop('onChange')(12);
-        pagination.find('Input').prop('onBlur')();
-        expect(changeSpy).toBeCalledWith(10);
-    }
-);
+    pagination.find('Input').prop('onChange')(12);
+    pagination.find('Input').prop('onBlur')();
+    expect(changeSpy).toBeCalledWith(10);
+});
 
-test('Change input value to the current value should not call callback', () => {
+test('Change callback should not be called if input value is equal to currentPage', () => {
     const changeSpy = jest.fn();
     const pagination = mount(
         <Pagination


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #6148
| License | MIT

#### What's in this PR?

This PR adjusts the `Pagination` component to submit the value of the input field when pressing `Enter`. The implementation is similar to the implementation of the `Search` input of the `List`:
https://github.com/sulu/sulu/blob/0238c55bd6a4d965aa7ebd12b2ba7467f33db957/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/Search.js#L48-L52

#### Why?

At the moment, the value is only submitted when the input field is blurred. See https://github.com/sulu/sulu/issues/6148
