### PR TITLE
Reload items of current page after deleting selected items via ListStore

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/Pagination.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/Pagination.js
@@ -33,23 +33,20 @@ class Pagination extends React.Component<Props> {
     @action componentDidMount() {
         const {currentPage} = this.props;
 
-        if (!currentPage) {
-            return;
-        }
-
-        this.currentInputValue = this.props.currentPage;
+        this.currentInputValue = currentPage;
+        this.validateAndSubmitInputValue();
     }
 
     @action componentDidUpdate(prevProps: Props) {
-        const {currentPage} = this.props;
+        const {currentPage, totalPages} = this.props;
 
         if (prevProps.currentPage !== currentPage) {
-            if (!currentPage) {
-                this.currentInputValue = 1;
-                return;
-            }
-
             this.currentInputValue = currentPage;
+            this.validateAndSubmitInputValue();
+        }
+
+        if (prevProps.totalPages !== totalPages) {
+            this.validateAndSubmitInputValue();
         }
     }
 
@@ -112,16 +109,16 @@ class Pagination extends React.Component<Props> {
     };
 
     handleInputBlur = () => {
-        this.submitInputValue();
+        this.validateAndSubmitInputValue();
     };
 
     handleInputKeyPress = (key: ?string) => {
         if (key === 'Enter') {
-            this.submitInputValue();
+            this.validateAndSubmitInputValue();
         }
     };
 
-    @action submitInputValue = () => {
+    @action validateAndSubmitInputValue = () => {
         const {currentPage, onPageChange, totalPages} = this.props;
         let page = this.currentInputValue;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/tests/Pagination.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/tests/Pagination.test.js
@@ -73,6 +73,68 @@ test('Render disabled previous link current page is first page', () => {
     )).toMatchSnapshot();
 });
 
+test('Should call callback with updated page when initialized with an invalid page', () => {
+    const changeSpy = jest.fn();
+
+    mount(
+        <Pagination
+            currentLimit={10}
+            currentPage={15}
+            onLimitChange={jest.fn()}
+            onPageChange={changeSpy}
+            totalPages={10}
+        >
+            <p>Test</p>
+        </Pagination>
+    );
+
+    expect(changeSpy).toBeCalledWith(10);
+});
+
+test('Should call callback with updated page when changing page to invalid value', () => {
+    const changeSpy = jest.fn();
+
+    const pagination = mount(
+        <Pagination
+            currentLimit={10}
+            currentPage={5}
+            onLimitChange={jest.fn()}
+            onPageChange={changeSpy}
+            totalPages={10}
+        >
+            <p>Test</p>
+        </Pagination>
+    );
+
+    pagination.setProps({currentPage: 8});
+    expect(changeSpy).not.toBeCalled();
+
+    pagination.setProps({currentPage: 15});
+    expect(changeSpy).toBeCalledWith(10);
+});
+
+test('Should call callback with updated page when changing total number of pages to lower value', () => {
+    const changeSpy = jest.fn();
+
+    const pagination = mount(
+        <Pagination
+            currentLimit={10}
+            currentPage={5}
+            onLimitChange={jest.fn()}
+            onPageChange={changeSpy}
+            totalPages={10}
+        >
+            <p>Test</p>
+        </Pagination>
+    );
+
+    pagination.setProps({totalPages: 7});
+    expect(changeSpy).not.toBeCalled();
+
+    pagination.setProps({totalPages: 3});
+    expect(changeSpy).toBeCalledWith(3);
+});
+
 test('Click previous link should call callback', () => {
     const clickSpy = jest.fn();
     const pagination = mount(
@@ -127,7 +189,7 @@ test('Click previous link on first page should not call callback', () => {
     expect(clickSpy).not.toBeCalled();
 });
 
-test('Click next link on laster page should call callback', () => {
+test('Click next link on last page should not call callback', () => {
     const clickSpy = jest.fn();
     const pagination = mount(
         <Pagination

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
@@ -517,6 +517,7 @@ export default class ListStore {
             .then(action(() => {
                 this.selectionIds.forEach(this.remove);
                 this.clearSelection();
+                this.reload();
                 this.deletingSelection = false;
             }))
             .catch(action((error) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/UploadToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/UploadToolbarAction.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import log from 'loglevel';
 import {action, computed, observable} from 'mobx';
-import Dropzone, {DropzoneRef, FileRejection} from 'react-dropzone';
+import Dropzone from 'react-dropzone';
 import symfonyRouting from 'fos-jsrouting/router';
 import {translate, transformBytesToReadableString} from '../../../utils';
 import ResourceStore from '../../../stores/ResourceStore';
@@ -10,6 +10,7 @@ import Router from '../../../services/Router';
 import List from '../../../views/List/List';
 import ListStore from '../../../containers/List/stores/ListStore';
 import AbstractListToolbarAction from './AbstractListToolbarAction';
+import type {ElementRef} from 'react';
 
 const defaultOptions = {
     credentials: 'same-origin',
@@ -19,7 +20,7 @@ const defaultOptions = {
 };
 
 export default class UploadToolbarAction extends AbstractListToolbarAction {
-    @observable dropzoneRef: ?DropzoneRef;
+    @observable dropzoneRef: ?ElementRef<Dropzone>;
     @observable errors: string[] = [];
 
     constructor(
@@ -113,7 +114,7 @@ export default class UploadToolbarAction extends AbstractListToolbarAction {
         super(listStore, list, router, locales, resourceStore, options);
     }
 
-    @action setDropzoneRef = (ref: ?DropzoneRef) => {
+    @action setDropzoneRef = (ref: ?ElementRef<Dropzone>) => {
         this.dropzoneRef = ref;
     };
 
@@ -144,7 +145,7 @@ export default class UploadToolbarAction extends AbstractListToolbarAction {
         this.list.errors = [...this.list.errors, error];
     };
 
-    handleError = (fileRejections: FileRejection[]) => {
+    handleError = (fileRejections: any[]) => {
         for (const fileRejection of fileRejections) {
             for (const {code} of fileRejection.errors) {
                 let error;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #6140, fixes #6154
| License | MIT

#### What's in this PR?

This PR adjusts the `ListStore` to reload the items for the currently loaded page after deleting the selected items.

#### Why?

See #6140 and #6154
