### PR TITLE
Adjust ResourceFormStore to read type directly from ResourceStore data

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
@@ -1187,20 +1187,17 @@ test('Should call setMultiple method of ResourceStore for default data', () => {
 test('Destroying the store should call all the disposers', () => {
     const resourceFormStore = new ResourceFormStore(new ResourceStore('snippets', '2'), 'snippets');
     resourceFormStore.schemaDisposer = jest.fn();
-    resourceFormStore.typeDisposer = jest.fn();
     resourceFormStore.updateFieldPathEvaluationsDisposer = jest.fn();
 
     resourceFormStore.destroy();
 
     expect(resourceFormStore.schemaDisposer).toBeCalled();
-    expect(resourceFormStore.typeDisposer).toBeCalled();
     expect(resourceFormStore.updateFieldPathEvaluationsDisposer).toBeCalled();
 });
 
 test('Destroying the store should not fail if no disposers are available', () => {
     const resourceFormStore = new ResourceFormStore(new ResourceStore('snippets', '2'), 'snippets');
     resourceFormStore.schemaDisposer = undefined;
-    resourceFormStore.typeDisposer = undefined;
 
     resourceFormStore.destroy();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TypeToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TypeToolbarAction.test.js
@@ -31,6 +31,10 @@ jest.mock('../../../../containers/Form', () => ({
             return this.resourceStore.dirty;
         }
 
+        get type() {
+            return this.data.template;
+        }
+
         changeType = jest.fn();
     },
 }));
@@ -58,7 +62,7 @@ function createTypeToolbarAction(options = {}) {
 test('Return item config with correct disabled, loading, options, icon, type and value ', () => {
     const typeToolbarAction = createTypeToolbarAction();
     typeToolbarAction.resourceFormStore.typesLoading = false;
-    typeToolbarAction.resourceFormStore.type = 'default';
+    typeToolbarAction.resourceFormStore.data.template = 'default';
     typeToolbarAction.resourceFormStore.types = {
         homepage: {
             key: 'homepage',
@@ -91,7 +95,7 @@ test('Return item config with correct disabled, loading, options, icon, type and
 test('Return item config with options sorted by title if sort_by is set to title', () => {
     const typeToolbarAction = createTypeToolbarAction({sort_by: 'title'});
     typeToolbarAction.resourceFormStore.typesLoading = false;
-    typeToolbarAction.resourceFormStore.type = 'default';
+    typeToolbarAction.resourceFormStore.data.template = 'default';
     typeToolbarAction.resourceFormStore.types = {
         homepage: {
             key: 'homepage',
@@ -120,7 +124,7 @@ test('Return item config with options sorted by title if sort_by is set to title
 test('Return item config with loading select', () => {
     const typeToolbarAction = createTypeToolbarAction();
     typeToolbarAction.resourceFormStore.typesLoading = true;
-    typeToolbarAction.resourceFormStore.type = 'homepage';
+    typeToolbarAction.resourceFormStore.data.template = 'homepage';
     typeToolbarAction.resourceFormStore.types = {};
 
     expect(typeToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
@@ -134,7 +138,7 @@ test('Change the type of the FormStore when FormStore is not dirty and another t
     const typeToolbarAction = createTypeToolbarAction();
     typeToolbarAction.resourceFormStore.resourceStore.dirty = false;
     typeToolbarAction.resourceFormStore.typesLoading = false;
-    typeToolbarAction.resourceFormStore.type = 'default';
+    typeToolbarAction.resourceFormStore.data.template = 'default';
     typeToolbarAction.resourceFormStore.types = {
         default: {
             key: 'default',
@@ -166,7 +170,7 @@ test('Display warning dialog when FormStore is dirty and another type is selecte
     const typeToolbarAction = createTypeToolbarAction();
     typeToolbarAction.resourceFormStore.resourceStore.dirty = true;
     typeToolbarAction.resourceFormStore.typesLoading = false;
-    typeToolbarAction.resourceFormStore.type = 'default';
+    typeToolbarAction.resourceFormStore.data.template = 'default';
     typeToolbarAction.resourceFormStore.types = {
         default: {
             key: 'default',
@@ -209,7 +213,7 @@ test('Change the type of the FormStore when warning dialog is confirmed', () => 
     const typeToolbarAction = createTypeToolbarAction();
     typeToolbarAction.resourceFormStore.resourceStore.dirty = true;
     typeToolbarAction.resourceFormStore.typesLoading = false;
-    typeToolbarAction.resourceFormStore.type = 'default';
+    typeToolbarAction.resourceFormStore.data.template = 'default';
     typeToolbarAction.resourceFormStore.types = {
         default: {
             key: 'default',
@@ -245,7 +249,7 @@ test('Do not change the type of the FormStore when warning dialog is canceled', 
     const typeToolbarAction = createTypeToolbarAction();
     typeToolbarAction.resourceFormStore.resourceStore.dirty = true;
     typeToolbarAction.resourceFormStore.typesLoading = false;
-    typeToolbarAction.resourceFormStore.type = 'default';
+    typeToolbarAction.resourceFormStore.data.template = 'default';
     typeToolbarAction.resourceFormStore.types = {
         default: {
             key: 'default',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #6145
| License | MIT

#### What's in this PR?

This PR adjusts the `ResourceFormStore` to read type directly from the `ResourceStore` data instead of storing it in separate property.

#### Why?

Storing the type in an additional property on the `ResourceFormStore` is error prone because the value can get out of sync with the `ResourceStore` data. At the moment, the property of the `ResourceFormStore` gets out of sync when switching the locale of a page to a locale that uses another template (see #6145).
