### PR TITLE
Use case-insensitive comparison when comparing old and new email in UserManager

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ProfileControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ProfileControllerTest.php
@@ -11,6 +11,8 @@
 
 namespace Sulu\Bundle\SecurityBundle\Tests\Functional\Controller;
 
+use Sulu\Bundle\ContactBundle\Entity\Contact;
+use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
@@ -87,6 +89,22 @@ class ProfileControllerTest extends SuluTestCase
 
     public function testPutEmailNotUnique()
     {
+        $existingContact = new Contact();
+        $existingContact->setFirstName('Max');
+        $existingContact->setLastName('Muster');
+
+        $existingUser = new User();
+        $existingUser->setUsername('existing-username');
+        $existingUser->setEmail('existing@email.com');
+        $existingUser->setPassword('securepassword');
+        $existingUser->setSalt('salt');
+        $existingUser->setLocale('de');
+        $existingUser->setContact($existingContact);
+
+        static::getEntityManager()->persist($existingContact);
+        static::getEntityManager()->persist($existingUser);
+        static::getEntityManager()->flush();
+
         $this->client->jsonRequest(
             'PUT',
             '/api/profile',
@@ -94,7 +112,7 @@ class ProfileControllerTest extends SuluTestCase
                 'firstName' => 'Hans',
                 'lastName' => 'Mustermann',
                 'username' => 'hansi',
-                'email' => '',
+                'email' => 'existing@email.com',
                 'password' => 'testpassword',
                 'locale' => 'de',
             ]
@@ -103,18 +121,34 @@ class ProfileControllerTest extends SuluTestCase
         $response = \json_decode($this->client->getResponse()->getContent());
         $this->assertHttpStatusCode(409, $this->client->getResponse());
         $this->assertEquals(1004, $response->code);
-        $this->assertEquals('The email address "" is already assigned to another contact.', $response->detail);
+        $this->assertEquals('The email address "existing@email.com" is already assigned to another contact.', $response->detail);
     }
 
     public function testPutUsernameNotUnique()
     {
+        $existingContact = new Contact();
+        $existingContact->setFirstName('Max');
+        $existingContact->setLastName('Muster');
+
+        $existingUser = new User();
+        $existingUser->setUsername('existing-username');
+        $existingUser->setEmail('existing@email.com');
+        $existingUser->setPassword('securepassword');
+        $existingUser->setSalt('salt');
+        $existingUser->setLocale('de');
+        $existingUser->setContact($existingContact);
+
+        static::getEntityManager()->persist($existingContact);
+        static::getEntityManager()->persist($existingUser);
+        static::getEntityManager()->flush();
+
         $this->client->jsonRequest(
             'PUT',
             '/api/profile',
             [
                 'firstName' => 'Hans',
                 'lastName' => 'Mustermann',
-                'username' => '',
+                'username' => 'existing-username',
                 'email' => 'hans.mustermann@muster.at',
                 'password' => 'testpassword',
                 'locale' => 'de',

--- a/src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
+++ b/src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
@@ -178,7 +178,7 @@ class UserManager implements UserManagerInterface
 
             // check if username is already in database and the current user is not the user with this username
             if (!$patch || null !== $username) {
-                if (strcasecmp($username, $user->getUsername()) !== 0 && !$this->isUsernameUnique($username)) {
+                if ($username && 0 !== \strcasecmp($username, $user->getUsername()) && !$this->isUsernameUnique($username)) {
                     throw new UsernameNotUniqueException($username);
                 }
                 $user->setUsername($username);
@@ -680,14 +680,10 @@ class UserManager implements UserManagerInterface
                 $user->setEmail($email);
             }
         } else {
-            if (null !== $email) {
-                if (strcasecmp($email, $user->getEmail()) !== 0 && !$this->isEmailUnique($email)) {
-                    throw new EmailNotUniqueException($email);
-                }
-                $user->setEmail($email);
-            } else {
-                $user->setEmail(null);
+            if ($email && 0 !== \strcasecmp($email, $user->getEmail()) && !$this->isEmailUnique($email)) {
+                throw new EmailNotUniqueException($email);
             }
+            $user->setEmail($email);
         }
     }
 

--- a/src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
+++ b/src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
@@ -178,9 +178,7 @@ class UserManager implements UserManagerInterface
 
             // check if username is already in database and the current user is not the user with this username
             if (!$patch || null !== $username) {
-                if ($user->getUsername() != $username &&
-                    !$this->isUsernameUnique($username)
-                ) {
+                if (strcasecmp($username, $user->getUsername()) !== 0 && !$this->isUsernameUnique($username)) {
                     throw new UsernameNotUniqueException($username);
                 }
                 $user->setUsername($username);
@@ -683,9 +681,7 @@ class UserManager implements UserManagerInterface
             }
         } else {
             if (null !== $email) {
-                if ($email !== $user->getEmail() &&
-                    !$this->isEmailUnique($email)
-                ) {
+                if (strcasecmp($email, $user->getEmail()) !== 0 && !$this->isEmailUnique($email)) {
                     throw new EmailNotUniqueException($email);
                 }
                 $user->setEmail($email);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #5596
| License | MIT

#### What's in this PR?

This PR adjusts the `UserManager` service to use a case-insensitive comparison for comparing the old and the new email address when changing the email address of a user.

#### Why?

See #5596