### PR TITLE
Allow to set settings_form_key param for blocks inside of page templates

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
@@ -188,10 +188,12 @@ class StructureFormMetadataLoader implements FormMetadataLoaderInterface, CacheW
         foreach ($itemsMetadata as $itemMetadata) {
             if ($itemMetadata instanceof FieldMetadata) {
                 if ('block' === $itemMetadata->getType()) {
-                    $optionMetadata = new OptionMetadata();
-                    $optionMetadata->setName('settings_form_key');
-                    $optionMetadata->setValue('page_block_settings');
-                    $itemMetadata->addOption($optionMetadata);
+                    if (!array_key_exists('settings_form_key', $itemMetadata->getOptions())) {
+                        $optionMetadata = new OptionMetadata();
+                        $optionMetadata->setName('settings_form_key');
+                        $optionMetadata->setValue('page_block_settings');
+                        $itemMetadata->addOption($optionMetadata);
+                    }
                 }
 
                 foreach ($itemMetadata->getTypes() as $type) {

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/forms/form_with_blocks.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/forms/form_with_blocks.xml
@@ -12,7 +12,7 @@
                 <title lang="en">Content</title>
             </meta>
             <params>
-                <param name="settings_form_key" value="page_block_settings" />
+                <param name="settings_form_key" value="test_block_settings" />
             </params>
             <types>
                 <type name="editor">

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/overview.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/overview.xml
@@ -43,6 +43,29 @@
                 </type>
             </types>
         </block>
+
+        <block name="blocks_with_custom_settings_form_key" default-type="editor" minOccurs="0">
+            <params>
+                <param name="settings_form_key" value="custom_block_settings" />
+            </params>
+
+            <types>
+                <type name="editor">
+                    <meta>
+                        <title lang="en">Editor</title>
+                        <title lang="de">Editor</title>
+                    </meta>
+                    <properties>
+                        <property name="text_editor" type="text_editor">
+                            <meta>
+                                <title lang="en">Text Editor</title>
+                                <title lang="de">Texteditor</title>
+                            </meta>
+                        </property>
+                    </properties>
+                </type>
+            </types>
+        </block>
     </properties>
 </template>
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
@@ -47,7 +47,7 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
         $this->assertInstanceOf(FormMetadata::class, $overviewForm);
         $this->assertEquals('overview', $overviewForm->getName());
         $this->assertEquals('Overview', $overviewForm->getTitle());
-        $this->assertCount(7, $overviewForm->getItems());
+        $this->assertCount(8, $overviewForm->getItems());
         $this->assertCount(1, $overviewForm->getTags());
         $this->assertNotNull($overviewForm->getSchema());
         $this->assertInstanceOf(SchemaMetadata::class, $overviewForm->getSchema());
@@ -82,7 +82,7 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
         $this->assertInstanceOf(FormMetadata::class, $overviewForm);
         $this->assertEquals('overview', $overviewForm->getName());
         $this->assertEquals('Overview', $overviewForm->getTitle());
-        $this->assertCount(7, $overviewForm->getItems());
+        $this->assertCount(8, $overviewForm->getItems());
         $this->assertCount(1, $overviewForm->getTags());
         $this->assertNotNull($overviewForm->getSchema());
         $this->assertInstanceOf(SchemaMetadata::class, $overviewForm->getSchema());
@@ -107,6 +107,10 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
         $this->assertEquals(
             'page_block_settings',
             $overviewForm->getItems()['blocks']->getOptions()['settings_form_key']->getValue()
+        );
+        $this->assertEquals(
+            'custom_block_settings',
+            $overviewForm->getItems()['blocks_with_custom_settings_form_key']->getOptions()['settings_form_key']->getValue()
         );
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
@@ -143,7 +143,7 @@ class XmlFormMetadataLoaderTest extends KernelTestCase
         $options = $blocks->getOptions();
         $this->assertCount(1, $options);
         $this->assertEquals('settings_form_key', $options['settings_form_key']->getName());
-        $this->assertEquals('page_block_settings', $options['settings_form_key']->getValue());
+        $this->assertEquals('test_block_settings', $options['settings_form_key']->getValue());
 
         $types = $blocks->getTypes();
         $this->assertCount(2, $types);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #5727
| License | MIT

#### What's in this PR?

This PR adjusts the `StructureFormMetadataLoader` to allow for setting the `settings_form_key` param for blocks inside of page templates.

#### Why?

See #5727
