### PR TITLE
Use requester service to fetch metadata in metadataStore service

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/metadataStore/metadataStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/metadataStore/metadataStore.js
@@ -1,6 +1,7 @@
 // @flow
 import symfonyRouting from 'fos-jsrouting/router';
 import {buildQueryString} from '../../utils/Request';
+import {Requester} from '../../services';
 
 const defaultOptions = {
     credentials: 'same-origin',
@@ -27,7 +28,7 @@ class MetadataStore {
 
         if (!this.metadataPromises[type][keyWithOptions]) {
             const url = symfonyRouting.generate('sulu_admin.metadata', parameters);
-            const response = fetch(url, defaultOptions).then((response) => {
+            const response = Requester.fetch(url, defaultOptions).then((response) => {
                 if (!response.ok) {
                     this.metadataPromises[type][keyWithOptions] = undefined;
                     return Promise.reject(response);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/metadataStore/tests/metadataStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/metadataStore/tests/metadataStore.test.js
@@ -1,6 +1,11 @@
 // @flow
 import SymfonyRouting from 'fos-jsrouting/router';
 import metadataStore from '../metadataStore';
+import {Requester} from '../../../services';
+
+jest.mock('../../../services/Requester', () => ({
+    fetch: jest.fn(),
+}));
 
 test('Load metadata for given type and key', () => {
     const snippetMetadata = {
@@ -60,8 +65,7 @@ test('Load metadata for given type and key', () => {
         return '/metadata/' + value.type + '/' + value.key;
     });
 
-    window.fetch = jest.fn();
-    window.fetch.mockImplementation((key) => {
+    Requester.fetch.mockImplementation((key) => {
         switch (key) {
             case '/metadata/form/snippets':
                 return snippetResponsePromise;
@@ -98,12 +102,10 @@ test('Load configuration twice should return the same promise', () => {
             get: jest.fn(),
         },
     };
-
     response.json.mockReturnValue(Promise.resolve(tagMetadata));
-    const tagPromise = Promise.resolve(response);
 
-    window.fetch = jest.fn();
-    window.fetch.mockReturnValue(tagPromise);
+    const tagPromise = Promise.resolve(response);
+    Requester.fetch.mockReturnValue(tagPromise);
 
     const tagPromise1 = metadataStore.loadMetadata('form', 'tags');
     const tagPromise2 = metadataStore.loadMetadata('form', 'tags');
@@ -131,9 +133,7 @@ test('Load metadata should not cache metadata if no-store is set in response', (
     response.headers.get.mockReturnValue('no-store');
 
     const responsePromise = Promise.resolve(response);
-
-    window.fetch = jest.fn();
-    window.fetch.mockReturnValue(responsePromise);
+    Requester.fetch.mockReturnValue(responsePromise);
 
     const metadataPromise1 = metadataStore.loadMetadata('form', 'no_cache');
 
@@ -141,7 +141,7 @@ test('Load metadata should not cache metadata if no-store is set in response', (
         expect(metadata1).toBe(metadata);
 
         const metadataPromise2 = metadataStore.loadMetadata('form', 'no_cache');
-        expect(window.fetch).toBeCalledTimes(2);
+        expect(Requester.fetch).toBeCalledTimes(2);
 
         return metadataPromise2.then((metadata2) => {
             expect(metadata2).toBe(metadata);
@@ -164,9 +164,7 @@ test('Load metadata should cache metadata if no-store is not set in response', (
     response.json.mockReturnValue(Promise.resolve(metadata));
 
     const responsePromise = Promise.resolve(response);
-
-    window.fetch = jest.fn();
-    window.fetch.mockReturnValue(responsePromise);
+    Requester.fetch.mockReturnValue(responsePromise);
 
     const metadataPromise1 = metadataStore.loadMetadata('form', 'no_cache');
 
@@ -174,7 +172,7 @@ test('Load metadata should cache metadata if no-store is not set in response', (
         expect(metadata1).toBe(metadata);
 
         const metadataPromise2 = metadataStore.loadMetadata('form', 'no_cache');
-        expect(window.fetch).toBeCalledTimes(1);
+        expect(Requester.fetch).toBeCalledTimes(1);
 
         return metadataPromise2.then((metadata2) => {
             expect(metadata2).toBe(metadata);
@@ -188,8 +186,7 @@ test('Load metadata should reject with response when the response contains error
     };
 
     const promise = Promise.resolve(response);
-    window.fetch = jest.fn();
-    window.fetch.mockReturnValue(promise);
+    Requester.fetch.mockReturnValue(promise);
 
     expect(metadataStore.loadMetadata('form', 'reject')).rejects.toEqual(response);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/toolbarActions/UploadToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/toolbarActions/UploadToolbarAction.test.js
@@ -9,6 +9,7 @@ import Router from '../../../../services/Router';
 import ResourceStore from '../../../../stores/ResourceStore';
 import List from '../../../../views/List';
 import UploadToolbarAction from '../../toolbarActions/UploadToolbarAction';
+import {Requester} from '../../../../services';
 
 jest.mock('loglevel', () => ({
     warn: jest.fn(),
@@ -30,6 +31,10 @@ jest.mock('../../../../services/Router', () => jest.fn(function() {
     this.attributes = {
         locale: 'en',
     };
+}));
+
+jest.mock('../../../../services/Requester', () => ({
+    fetch: jest.fn(),
 }));
 
 function createUploadToolbarAction(options = {}) {
@@ -96,9 +101,7 @@ test('Should make xhr request on confirm', () => {
         statusText: '',
         ok: true,
     });
-
-    // eslint-disable-next-line no-undef
-    global.fetch = jest.fn(() => promise);
+    Requester.fetch.mockReturnValue(promise);
 
     SymfonyRouting.generate.mockImplementation((routeName, params) => {
         return routeName + '?' + Object.keys(params).map((key) => key + '=' + params[key]).join('&');
@@ -123,7 +126,7 @@ test('Should make xhr request on confirm', () => {
 
     uploadToolbarAction.handleConfirm([new File(['foo'], 'foo.jpg')]);
 
-    expect(fetch).toBeCalledWith('foo?locale=en&locale2=en&foo=bar&baz=foo', expect.objectContaining({
+    expect(Requester.fetch).toBeCalledWith('foo?locale=en&locale2=en&foo=bar&baz=foo', expect.objectContaining({
         method: 'POST',
         body: expect.any(FormData),
         credentials: 'same-origin',
@@ -236,9 +239,7 @@ test('Should display error if server error occurs', () => {
         ok: false,
         json: () => jsonPromise,
     });
-
-    // eslint-disable-next-line no-undef
-    global.fetch = jest.fn(() => fetchPromise);
+    Requester.fetch.mockReturnValue(fetchPromise);
 
     SymfonyRouting.generate.mockImplementation((routeName, params) => {
         return routeName + '?' + Object.keys(params).map((key) => key + '=' + params[key]).join('&');
@@ -255,7 +256,7 @@ test('Should display error if server error occurs', () => {
 
     uploadToolbarAction.handleConfirm([new File(['foo'], 'foo.jpg')]);
 
-    expect(fetch).toBeCalledWith('foo?', expect.objectContaining({
+    expect(Requester.fetch).toBeCalledWith('foo?', expect.objectContaining({
         method: 'POST',
         body: expect.any(FormData),
         credentials: 'same-origin',
@@ -289,9 +290,7 @@ test('Should display error message returned by server if server error occurs', (
         ok: false,
         json: () => jsonPromise,
     });
-
-    // eslint-disable-next-line no-undef
-    global.fetch = jest.fn(() => fetchPromise);
+    Requester.fetch.mockReturnValue(fetchPromise);
 
     SymfonyRouting.generate.mockImplementation((routeName, params) => {
         return routeName + '?' + Object.keys(params).map((key) => key + '=' + params[key]).join('&');
@@ -308,7 +307,7 @@ test('Should display error message returned by server if server error occurs', (
 
     uploadToolbarAction.handleConfirm([new File(['foo'], 'foo.jpg')]);
 
-    expect(fetch).toBeCalledWith('foo?', expect.objectContaining({
+    expect(Requester.fetch).toBeCalledWith('foo?', expect.objectContaining({
         method: 'POST',
         body: expect.any(FormData),
         credentials: 'same-origin',
@@ -342,9 +341,7 @@ test('Should display error message from deprecated errorCodeMapping option if se
         ok: false,
         json: () => jsonPromise,
     });
-
-    // eslint-disable-next-line no-undef
-    global.fetch = jest.fn(() => fetchPromise);
+    Requester.fetch.mockReturnValue(fetchPromise);
 
     SymfonyRouting.generate.mockImplementation((routeName, params) => {
         return routeName + '?' + Object.keys(params).map((key) => key + '=' + params[key]).join('&');
@@ -366,7 +363,7 @@ test('Should display error message from deprecated errorCodeMapping option if se
 
     expect(log.warn).toBeCalledWith(expect.stringContaining('The "errorCodeMapping" option is deprecated'));
 
-    expect(fetch).toBeCalledWith('foo?', expect.objectContaining({
+    expect(Requester.fetch).toBeCalledWith('foo?', expect.objectContaining({
         method: 'POST',
         body: expect.any(FormData),
         credentials: 'same-origin',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/UploadToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/UploadToolbarAction.js
@@ -9,6 +9,7 @@ import ResourceStore from '../../../stores/ResourceStore';
 import Router from '../../../services/Router';
 import List from '../../../views/List/List';
 import ListStore from '../../../containers/List/stores/ListStore';
+import {Requester} from '../../../services';
 import AbstractListToolbarAction from './AbstractListToolbarAction';
 
 const defaultOptions = {
@@ -198,7 +199,7 @@ export default class UploadToolbarAction extends AbstractListToolbarAction {
             formData.append(requestPropertyName + '[]', file);
         }
 
-        fetch(this.url, {...defaultOptions, method: 'POST', body: formData}).then((response) => {
+        Requester.fetch(this.url, {...defaultOptions, method: 'POST', body: formData}).then((response) => {
             if (!response.ok) {
                 const translatedErrorMessage = translate(
                     this.errorCodeMapping[response.status] || 'sulu_admin.unexpected_upload_error',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #5916
| License | MIT

#### What's in this PR?

This PR adjusts the `metadataStore` service and the `UploadToolbarAction` to use the `Requester` service instead of calling fetch directly. To do this, the PR adds a `Requester.fetch()` method that serves as a replacement for the global `fetch()` function.

#### Why?

The `Requester` service allows to register hooks that are called for each request. These hooks are not called if the global `fetch()` function is used. For example, the redirect to the login view is implemented as hook that listens for `401` responses. Without these change, the **user is not redirected to the login view when a metadata request fails** (see #5916).

#### How to test?

1. Navigate to the snippet list
2. Remove the `SULUSESSID` cookie
3. Click the "Add" button in the toolbar
4. RESULT: Login form should be displayed
