### PR TITLE
Create missing node when editing page without node in live workspace

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Document/Subscriber/PublishSubscriber.php
+++ b/src/Sulu/Bundle/PageBundle/Document/Subscriber/PublishSubscriber.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\PageBundle\Document\Subscriber;
 
 use PHPCR\NodeInterface;
+use PHPCR\PathNotFoundException;
 use PHPCR\PropertyInterface;
 use PHPCR\SessionInterface;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\PropertyEncoder;
@@ -98,7 +99,14 @@ class PublishSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $liveNode = $this->getLiveNode($event->getDocument());
+        try {
+            $liveNode = $this->getLiveNode($event->getDocument());
+        } catch (PathNotFoundException $e) {
+            $this->createNodesWithUuid($node);
+
+            return;
+        }
+
         $nodeName = $node->getName();
 
         if ($liveNode->getName() !== $nodeName) {

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
@@ -1050,6 +1050,34 @@ class PageControllerTest extends SuluTestCase
         $this->assertEquals('article test', $response->article);
     }
 
+    public function testPutWithMissingNodeInLiveWorkspace(): void
+    {
+        $data = [
+            [
+                'template' => 'simple',
+                'title' => 'test1',
+                'url' => '/test1',
+            ],
+        ];
+        $data = $this->setUpContent($data);
+
+        // simulate error during page creation be removing node from live workspace
+        $this->liveSession->getNodeByIdentifier($data[0]['id'])->remove();
+        $this->liveSession->save();
+
+        $data[0]['title'] = 'new title';
+
+        $this->client->jsonRequest(
+            'PUT',
+            '/api/pages/' . $data[0]['id'] . '?webspace=sulu_io&language=en',
+            $data[0]
+        );
+
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+        $response = \json_decode($this->client->getResponse()->getContent() ?: '');
+        $this->assertEquals('new title', $response->title);
+    }
+
     public function testPutShadow()
     {
         $data = [

--- a/src/Sulu/Component/Content/Document/Subscriber/SecuritySubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/SecuritySubscriber.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\Content\Document\Subscriber;
 
 use PHPCR\NodeInterface;
+use PHPCR\PathNotFoundException;
 use PHPCR\SessionInterface;
 use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\PathBehavior;
@@ -237,6 +238,10 @@ class SecuritySubscriber implements EventSubscriberInterface
             return null;
         }
 
-        return $this->liveSession->getNode($path);
+        try {
+            return $this->liveSession->getNode($path);
+        } catch (PathNotFoundException $e) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #5779
| License | MIT

#### What's in this PR?

This PR adjusts the code of the `PublishSubscriber` and `SecuritySubscriber` to allow for editing a page with a missing node in the live workspace.

#### Why?

If an error happens during the creation of the page, the system might end up in a state in which the page exists in the `draft` workspace but does not exist in the `live` workspace. At the moment, it is not possible to edit or delete such a page via the administration interface.

See #5779 for an in depth description of the issue.

#### Steps to Reproduce

1. Create a page
2. Remove the node of the page from the `live` workspace via `bin/websiteconsole doctrine:phpcr:shell`  or `bin/websiteconsole doctrine:phpcr:node:remove`
3. Try to modify the page in the administration interface

