### PR TITLE
Update friendsofphp/php-cs-fixer package to version 3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,7 +14,7 @@ Gruntfile.js export-ignore
 phpunit.xml.dist export-ignore
 phpstan.neon export-ignore
 phpstan-baseline.neon export-ignore
-.php_cs.dist export-ignore
+.php-cs-fixer.dist.php export-ignore
 README.md export-ignore
 UPGRADE.md export-ignore
 /src/Sulu/Bundle/*/Tests export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,8 @@ composer.lock
 package-lock.json
 node_modules/
 yarn.lock
-.php_cs.cache
+
+.php-cs-fixer.cache
 .eslintcache
 .env.local
 

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -13,8 +13,8 @@ $finder = PhpCsFixer\Finder::create()
     ->exclude(['var/cache', 'tests/Resources/cache', 'node_modules'])
     ->in(__DIR__);
 
-return PhpCsFixer\Config::create()
-    ->setRiskyAllowed(true)
+$config = new PhpCsFixer\Config();
+$config->setRiskyAllowed(true)
     ->setRules([
         '@Symfony' => true,
         'array_syntax' => ['syntax' => 'short'],
@@ -24,7 +24,7 @@ return PhpCsFixer\Config::create()
         'header_comment' => ['header' => $header],
         'native_constant_invocation' => true,
         'native_function_casing' => true,
-        'native_function_invocation' => true,
+        'native_function_invocation' => ['include' => ['@internal']],
         'no_superfluous_phpdoc_tags' => ['allow_mixed' => true, 'remove_inheritdoc' => true],
         'ordered_imports' => true,
         'phpdoc_align' => ['align' => 'left'],
@@ -32,3 +32,5 @@ return PhpCsFixer\Config::create()
         'single_line_throw' => false,
     ])
     ->setFinder($finder);
+
+return $config;

--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,7 @@
         "twig/twig": "^1.41 || ^2.10 || ^3.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.17",
+        "friendsofphp/php-cs-fixer": "^3.0",
         "google/cloud-storage": "^1.0",
         "handcraftedinthealps/zendsearch": "^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.3",

--- a/src/Sulu/Bundle/AdminBundle/Admin/Admin.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Admin.php
@@ -21,8 +21,8 @@ use Sulu\Bundle\AdminBundle\Admin\View\ViewProviderInterface;
  */
 abstract class Admin implements ViewProviderInterface, NavigationProviderInterface
 {
-    const SULU_ADMIN_SECURITY_SYSTEM = 'Sulu';
-    const SETTINGS_NAVIGATION_ITEM = 'sulu_admin.settings';
+    public const SULU_ADMIN_SECURITY_SYSTEM = 'Sulu';
+    public const SETTINGS_NAVIGATION_ITEM = 'sulu_admin.settings';
 
     public static function getPriority(): int
     {

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilder.php
@@ -24,7 +24,7 @@ class FormOverlayListViewBuilder implements FormOverlayListViewBuilderInterface
     }
     use TabViewChildBuilderTrait;
 
-    const TYPE = 'sulu_admin.form_overlay_list';
+    public const TYPE = 'sulu_admin.form_overlay_list';
 
     public function __construct(string $name, string $path)
     {

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilder.php
@@ -17,7 +17,7 @@ class FormViewBuilder implements FormViewBuilderInterface
     use FormViewBuilderTrait;
     use TabViewChildBuilderTrait;
 
-    const TYPE = 'sulu_admin.form';
+    public const TYPE = 'sulu_admin.form';
 
     public function __construct(string $name, string $path)
     {

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilder.php
@@ -17,7 +17,7 @@ class ListViewBuilder implements ListViewBuilderInterface
     use ListViewBuilderTrait;
     use TabViewChildBuilderTrait;
 
-    const TYPE = 'sulu_admin.list';
+    public const TYPE = 'sulu_admin.list';
 
     public function __construct(string $name, string $path)
     {

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/PreviewFormViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/PreviewFormViewBuilder.php
@@ -17,7 +17,7 @@ class PreviewFormViewBuilder implements PreviewFormViewBuilderInterface
     use FormViewBuilderTrait;
     use TabViewChildBuilderTrait;
 
-    const TYPE = 'sulu_admin.preview_form';
+    public const TYPE = 'sulu_admin.preview_form';
 
     public function __construct(string $name, string $path)
     {

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ResourceTabViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ResourceTabViewBuilder.php
@@ -17,7 +17,7 @@ class ResourceTabViewBuilder implements ResourceTabViewBuilderInterface
     use FormViewBuilderTrait;
     use TabViewBuilderTrait;
 
-    const TYPE = 'sulu_admin.resource_tabs';
+    public const TYPE = 'sulu_admin.resource_tabs';
 
     public function __construct(string $name, string $path)
     {

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/TabViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/TabViewBuilder.php
@@ -16,7 +16,7 @@ class TabViewBuilder implements TabViewBuilderInterface
     use ViewBuilderTrait;
     use TabViewBuilderTrait;
 
-    const TYPE = 'sulu_admin.tabs';
+    public const TYPE = 'sulu_admin.tabs';
 
     public function __construct(string $name, string $path)
     {

--- a/src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php
@@ -21,9 +21,9 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class UpdateBuildCommand extends Command
 {
-    const EXIT_CODE_ABORTED_MANUAL_BUILD = 1;
-    const EXIT_CODE_COULD_NOT_INSTALL_NPM_PACKAGES = 2;
-    const EXIT_CODE_COULD_NOT_BUILD_ADMIN_ASSETS = 3;
+    public const EXIT_CODE_ABORTED_MANUAL_BUILD = 1;
+    public const EXIT_CODE_COULD_NOT_INSTALL_NPM_PACKAGES = 2;
+    public const EXIT_CODE_COULD_NOT_BUILD_ADMIN_ASSETS = 3;
 
     protected static $defaultName = 'sulu:admin:update-build';
 
@@ -52,13 +52,13 @@ class UpdateBuildCommand extends Command
      */
     private $remoteArchive;
 
-    const ASSETS_DIR = \DIRECTORY_SEPARATOR . 'assets' . \DIRECTORY_SEPARATOR . 'admin' . \DIRECTORY_SEPARATOR;
+    public const ASSETS_DIR = \DIRECTORY_SEPARATOR . 'assets' . \DIRECTORY_SEPARATOR . 'admin' . \DIRECTORY_SEPARATOR;
 
-    const BUILD_DIR = \DIRECTORY_SEPARATOR . 'public' . \DIRECTORY_SEPARATOR . 'build' . \DIRECTORY_SEPARATOR . 'admin';
+    public const BUILD_DIR = \DIRECTORY_SEPARATOR . 'public' . \DIRECTORY_SEPARATOR . 'build' . \DIRECTORY_SEPARATOR . 'admin';
 
-    const REPOSITORY_NAME = 'skeleton';
+    public const REPOSITORY_NAME = 'skeleton';
 
-    const VERSION_REGEX = '/^\d+\.\d+\.\d+(-(alpha|beta|RC)\d+)?$/';
+    public const VERSION_REGEX = '/^\d+\.\d+\.\d+(-(alpha|beta|RC)\d+)?$/';
 
     public function __construct(HttpClientInterface $httpClient, string $projectDir, string $suluVersion)
     {

--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -36,7 +36,7 @@ use Twig\Environment;
 
 class AdminController
 {
-    const TRANSLATION_DOMAIN = 'admin';
+    public const TRANSLATION_DOMAIN = 'admin';
 
     /**
      * @var UrlGeneratorInterface

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/AddAdminPass.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/AddAdminPass.php
@@ -19,8 +19,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class AddAdminPass implements CompilerPassInterface
 {
-    const ADMIN_POOL_DEFINITION_ID = 'sulu_admin.admin_pool';
-    const ADMIN_TAG = 'sulu.admin';
+    public const ADMIN_POOL_DEFINITION_ID = 'sulu_admin.admin_pool';
+    public const ADMIN_TAG = 'sulu.admin';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/AddMetadataProviderPass.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/AddMetadataProviderPass.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class AddMetadataProviderPass implements CompilerPassInterface
 {
-    const TAG = 'sulu_admin.metadata_provider';
+    public const TAG = 'sulu_admin.metadata_provider';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/AdminBundle/FormMetadata/FormXmlLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/FormMetadata/FormXmlLoader.php
@@ -24,9 +24,9 @@ use Sulu\Component\Content\Metadata\Parser\SchemaXmlParser;
  */
 class FormXmlLoader extends AbstractLoader
 {
-    const SCHEMA_PATH = '/schema/form-1.0.xsd';
+    public const SCHEMA_PATH = '/schema/form-1.0.xsd';
 
-    const SCHEMA_NAMESPACE_URI = 'http://schemas.sulu.io/template/template';
+    public const SCHEMA_NAMESPACE_URI = 'http://schemas.sulu.io/template/template';
 
     /**
      * @var PropertiesXmlParser

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/OptionMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/OptionMetadata.php
@@ -13,11 +13,11 @@ namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
 
 class OptionMetadata
 {
-    const TYPE_STRING = 'string';
+    public const TYPE_STRING = 'string';
 
-    const TYPE_COLLECTION = 'collection';
+    public const TYPE_COLLECTION = 'collection';
 
-    const TYPE_EXPRESSION = 'expression';
+    public const TYPE_EXPRESSION = 'expression';
 
     /**
      * @var null|string

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/StructureFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/StructureFormMetadataLoaderTest.php
@@ -27,7 +27,7 @@ use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 
 class StructureFormMetadataLoaderTest extends TestCase
 {
-    const CACHE_DIR = __DIR__ . '/../../../../../../../tests/Resources/cache';
+    public const CACHE_DIR = __DIR__ . '/../../../../../../../tests/Resources/cache';
 
     /**
      * @var ObjectProphecy&StructureMetadataFactoryInterface

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/XmlFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/XmlFormMetadataLoaderTest.php
@@ -25,7 +25,7 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\XmlFormMetadataLoader;
 
 class XmlFormMetadataLoaderTest extends TestCase
 {
-    const CACHE_DIR = __DIR__ . '/../../../../../../../tests/Resources/cache';
+    public const CACHE_DIR = __DIR__ . '/../../../../../../../tests/Resources/cache';
 
     /**
      * @var ObjectProphecy&FormXmlLoader

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Admin/AudienceTargetingAdmin.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Admin/AudienceTargetingAdmin.php
@@ -27,13 +27,13 @@ use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
  */
 class AudienceTargetingAdmin extends Admin
 {
-    const SECURITY_CONTEXT = 'sulu.settings.target-groups';
+    public const SECURITY_CONTEXT = 'sulu.settings.target-groups';
 
-    const LIST_VIEW = 'sulu_audience_targeting.list';
+    public const LIST_VIEW = 'sulu_audience_targeting.list';
 
-    const ADD_FORM_VIEW = 'sulu_audience_targeting.add_form';
+    public const ADD_FORM_VIEW = 'sulu_audience_targeting.add_form';
 
-    const EDIT_FORM_VIEW = 'sulu_audience_targeting.edit_form';
+    public const EDIT_FORM_VIEW = 'sulu_audience_targeting.edit_form';
 
     /**
      * @var ViewBuilderFactoryInterface

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroupRuleInterface.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroupRuleInterface.php
@@ -18,11 +18,11 @@ use Doctrine\Common\Collections\Collection;
  */
 interface TargetGroupRuleInterface
 {
-    const FREQUENCY_HIT = 1;
+    public const FREQUENCY_HIT = 1;
 
-    const FREQUENCY_SESSION = 2;
+    public const FREQUENCY_SESSION = 2;
 
-    const FREQUENCY_VISITOR = 3;
+    public const FREQUENCY_VISITOR = 3;
 
     /**
      * @return int

--- a/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/AudienceTargetingCacheListener.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/AudienceTargetingCacheListener.php
@@ -26,17 +26,17 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  */
 class AudienceTargetingCacheListener implements EventSubscriberInterface
 {
-    const TARGET_GROUP_URL = '/_sulu_target_group';
+    public const TARGET_GROUP_URL = '/_sulu_target_group';
 
-    const TARGET_GROUP_HEADER = 'X-Sulu-Target-Group';
+    public const TARGET_GROUP_HEADER = 'X-Sulu-Target-Group';
 
-    const TARGET_GROUP_COOKIE = '_svtg';
+    public const TARGET_GROUP_COOKIE = '_svtg';
 
-    const TARGET_GROUP_COOKIE_LIFETIME = 2147483647;
+    public const TARGET_GROUP_COOKIE_LIFETIME = 2147483647;
 
-    const VISITOR_SESSION_COOKIE = '_svs';
+    public const VISITOR_SESSION_COOKIE = '_svs';
 
-    const USER_CONTEXT_URL_HEADER = 'X-Forwarded-URL';
+    public const USER_CONTEXT_URL_HEADER = 'X-Forwarded-URL';
 
     protected $hadValidTargetGroupCookie = false;
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Rule/BrowserRule.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Rule/BrowserRule.php
@@ -18,7 +18,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class BrowserRule implements RuleInterface
 {
-    const BROWSER = 'browser';
+    public const BROWSER = 'browser';
 
     private static $browsers = ['Chrome', 'Firefox', 'Internet Explorer', 'Opera', 'Safari'];
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Rule/DeviceTypeRule.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Rule/DeviceTypeRule.php
@@ -20,13 +20,13 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class DeviceTypeRule implements RuleInterface
 {
-    const DEVICE_TYPE = 'device_type';
+    public const DEVICE_TYPE = 'device_type';
 
-    const SMARTPHONE = 'smartphone';
+    public const SMARTPHONE = 'smartphone';
 
-    const TABLET = 'tablet';
+    public const TABLET = 'tablet';
 
-    const DESKTOP = 'desktop';
+    public const DESKTOP = 'desktop';
 
     private static $deviceTypes = [self::SMARTPHONE, self::TABLET, self::DESKTOP];
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Rule/LocaleRule.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Rule/LocaleRule.php
@@ -20,7 +20,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class LocaleRule implements RuleInterface
 {
-    const LOCALE = 'locale';
+    public const LOCALE = 'locale';
 
     /**
      * @var RequestStack

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Rule/OperatingSystemRule.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Rule/OperatingSystemRule.php
@@ -18,7 +18,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class OperatingSystemRule implements RuleInterface
 {
-    const OPERATING_SYSTEM = 'os';
+    public const OPERATING_SYSTEM = 'os';
 
     private static $operatingSystems = ['Android', 'iOS', 'GNU/Linux', 'Mac', 'Windows'];
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Rule/ReferrerRule.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Rule/ReferrerRule.php
@@ -17,7 +17,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ReferrerRule implements RuleInterface
 {
-    const REFERRER = 'referrer';
+    public const REFERRER = 'referrer';
 
     /**
      * @var RequestStack

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Functional/Controller/TargetGroupControllerTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Functional/Controller/TargetGroupControllerTest.php
@@ -21,7 +21,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 class TargetGroupControllerTest extends SuluTestCase
 {
-    const BASE_URL = 'api/target-groups';
+    public const BASE_URL = 'api/target-groups';
 
     /**
      * @var KernelBrowser

--- a/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
+++ b/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
@@ -23,13 +23,13 @@ use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 
 class CategoryAdmin extends Admin
 {
-    const SECURITY_CONTEXT = 'sulu.settings.categories';
+    public const SECURITY_CONTEXT = 'sulu.settings.categories';
 
-    const LIST_VIEW = 'sulu_category.list';
+    public const LIST_VIEW = 'sulu_category.list';
 
-    const ADD_FORM_VIEW = 'sulu_category.add_form';
+    public const ADD_FORM_VIEW = 'sulu_category.add_form';
 
-    const EDIT_FORM_VIEW = 'sulu_category.edit_form';
+    public const EDIT_FORM_VIEW = 'sulu_category.edit_form';
 
     /**
      * @var ViewBuilderFactoryInterface

--- a/src/Sulu/Bundle/CategoryBundle/Category/KeywordManagerInterface.php
+++ b/src/Sulu/Bundle/CategoryBundle/Category/KeywordManagerInterface.php
@@ -19,11 +19,11 @@ use Sulu\Bundle\CategoryBundle\Entity\KeywordInterface;
  */
 interface KeywordManagerInterface
 {
-    const FORCE_OVERWRITE = 'overwrite';
+    public const FORCE_OVERWRITE = 'overwrite';
 
-    const FORCE_DETACH = 'detach';
+    public const FORCE_DETACH = 'detach';
 
-    const FORCE_MERGE = 'merge';
+    public const FORCE_MERGE = 'merge';
 
     /**
      * Add given keyword to the category.

--- a/src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
@@ -37,11 +37,11 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class KeywordController extends AbstractRestController implements ClassResourceInterface, SecuredControllerInterface
 {
-    const FORCE_OVERWRITE = 'overwrite';
+    public const FORCE_OVERWRITE = 'overwrite';
 
-    const FORCE_DETACH = 'detach';
+    public const FORCE_DETACH = 'detach';
 
-    const FORCE_MERGE = 'merge';
+    public const FORCE_MERGE = 'merge';
 
     /**
      * @var RestHelperInterface

--- a/src/Sulu/Bundle/CategoryBundle/Event/CategoryEvents.php
+++ b/src/Sulu/Bundle/CategoryBundle/Event/CategoryEvents.php
@@ -19,5 +19,5 @@ final class CategoryEvents
      *
      * @var string
      */
-    const CATEGORY_DELETE = 'sulu.category.delete';
+    public const CATEGORY_DELETE = 'sulu.category.delete';
 }

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -25,21 +25,21 @@ use Symfony\Component\Intl\Countries;
 
 class ContactAdmin extends Admin
 {
-    const CONTACT_SECURITY_CONTEXT = 'sulu.contact.people';
+    public const CONTACT_SECURITY_CONTEXT = 'sulu.contact.people';
 
-    const ACCOUNT_SECURITY_CONTEXT = 'sulu.contact.organizations';
+    public const ACCOUNT_SECURITY_CONTEXT = 'sulu.contact.organizations';
 
-    const CONTACT_LIST_VIEW = 'sulu_contact.contacts_list';
+    public const CONTACT_LIST_VIEW = 'sulu_contact.contacts_list';
 
-    const CONTACT_ADD_FORM_VIEW = 'sulu_contact.contact_add_form';
+    public const CONTACT_ADD_FORM_VIEW = 'sulu_contact.contact_add_form';
 
-    const CONTACT_EDIT_FORM_VIEW = 'sulu_contact.contact_edit_form';
+    public const CONTACT_EDIT_FORM_VIEW = 'sulu_contact.contact_edit_form';
 
-    const ACCOUNT_LIST_VIEW = 'sulu_contact.accounts_list';
+    public const ACCOUNT_LIST_VIEW = 'sulu_contact.accounts_list';
 
-    const ACCOUNT_ADD_FORM_VIEW = 'sulu_contact.account_add_form';
+    public const ACCOUNT_ADD_FORM_VIEW = 'sulu_contact.account_add_form';
 
-    const ACCOUNT_EDIT_FORM_VIEW = 'sulu_contact.account_edit_form';
+    public const ACCOUNT_EDIT_FORM_VIEW = 'sulu_contact.account_edit_form';
 
     /**
      * @var ViewBuilderFactoryInterface

--- a/src/Sulu/Bundle/ContactBundle/Api/Account.php
+++ b/src/Sulu/Bundle/ContactBundle/Api/Account.php
@@ -40,7 +40,7 @@ use Sulu\Component\Rest\ApiWrapper;
  */
 class Account extends ApiWrapper
 {
-    const TYPE = 'account';
+    public const TYPE = 'account';
 
     /**
      * @var Media

--- a/src/Sulu/Bundle/ContactBundle/Api/Contact.php
+++ b/src/Sulu/Bundle/ContactBundle/Api/Contact.php
@@ -41,7 +41,7 @@ use Sulu\Component\Security\Authentication\UserInterface;
  */
 class Contact extends ApiWrapper
 {
-    const TYPE = 'contact';
+    public const TYPE = 'contact';
 
     /**
      * @var Media

--- a/src/Sulu/Bundle/ContactBundle/Content/Types/ContactAccountSelection.php
+++ b/src/Sulu/Bundle/ContactBundle/Content/Types/ContactAccountSelection.php
@@ -31,9 +31,9 @@ use Sulu\Component\Serializer\ArraySerializerInterface;
  */
 class ContactAccountSelection extends ComplexContentType implements ContentTypeExportInterface, PreResolvableContentTypeInterface
 {
-    const PREFIX_CONTACT = 'c';
+    public const PREFIX_CONTACT = 'c';
 
-    const PREFIX_ACCOUNT = 'a';
+    public const PREFIX_ACCOUNT = 'a';
 
     /**
      * @var ContactManagerInterface

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/ListBuilderMetadataProviderCompilerPass.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/ListBuilderMetadataProviderCompilerPass.php
@@ -20,9 +20,9 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class ListBuilderMetadataProviderCompilerPass implements CompilerPassInterface
 {
-    const CHAIN_PROVIDER_ID = 'sulu_core.list_builder.metadata.provider.chain';
+    public const CHAIN_PROVIDER_ID = 'sulu_core.list_builder.metadata.provider.chain';
 
-    const PROVIDER_TAG_ID = 'sulu.list-builder.metadata.provider';
+    public const PROVIDER_TAG_ID = 'sulu.list-builder.metadata.provider';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RegisterContentTypesCompilerPass.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RegisterContentTypesCompilerPass.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class RegisterContentTypesCompilerPass implements CompilerPassInterface
 {
-    const CONTENT_TYPE_TAG = 'sulu.content.type';
+    public const CONTENT_TYPE_TAG = 'sulu.content.type';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RegisterLocalizationProvidersPass.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RegisterLocalizationProvidersPass.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class RegisterLocalizationProvidersPass implements CompilerPassInterface
 {
-    const LOCALIZATION_PROVIDER_TAG = 'sulu.localization_provider';
+    public const LOCALIZATION_PROVIDER_TAG = 'sulu.localization_provider';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RemoveForeignContextServicesPass.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RemoveForeignContextServicesPass.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class RemoveForeignContextServicesPass implements CompilerPassInterface
 {
-    const SULU_CONTEXT_TAG = 'sulu.context';
+    public const SULU_CONTEXT_TAG = 'sulu.context';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/SubscriberDebugCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/SubscriberDebugCommand.php
@@ -23,7 +23,7 @@ class SubscriberDebugCommand extends Command
 {
     protected static $defaultName = 'sulu:document:subscriber:debug';
 
-    const PREFIX = 'sulu_document_manager.';
+    public const PREFIX = 'sulu_document_manager.';
 
     /**
      * @var EventDispatcherInterface

--- a/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Compiler/DocumentFixturePass.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Compiler/DocumentFixturePass.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class DocumentFixturePass implements CompilerPassInterface
 {
-    const TAG_NAME = 'sulu.document_manager_fixture';
+    public const TAG_NAME = 'sulu.document_manager_fixture';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/DocumentManagerBundle/Document/Subscriber/SecuritySubscriber.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Document/Subscriber/SecuritySubscriber.php
@@ -23,7 +23,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  */
 class SecuritySubscriber implements EventSubscriberInterface
 {
-    const USER_OPTION = 'user';
+    public const USER_OPTION = 'user';
 
     /**
      * @var TokenStorageInterface

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Functional/BaseTestCase.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Functional/BaseTestCase.php
@@ -15,9 +15,9 @@ use Sulu\Bundle\TestBundle\Testing\KernelTestCase;
 
 abstract class BaseTestCase extends KernelTestCase
 {
-    const BASE_NAME = 'test';
+    public const BASE_NAME = 'test';
 
-    const BASE_PATH = '/test';
+    public const BASE_PATH = '/test';
 
     public function setUp(): void
     {

--- a/src/Sulu/Bundle/HttpCacheBundle/Cache/SuluHttpCache.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Cache/SuluHttpCache.php
@@ -34,7 +34,7 @@ class SuluHttpCache extends HttpCache implements CacheInvalidation
 {
     use EventDispatchingHttpCache;
 
-    const HEADER_REVERSE_PROXY_TTL = 'X-Reverse-Proxy-TTL';
+    public const HEADER_REVERSE_PROXY_TTL = 'X-Reverse-Proxy-TTL';
 
     /**
      * @param string $cacheDir

--- a/src/Sulu/Bundle/HttpCacheBundle/CacheLifetime/CacheLifetimeResolverInterface.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/CacheLifetime/CacheLifetimeResolverInterface.php
@@ -20,12 +20,12 @@ interface CacheLifetimeResolverInterface
     /**
      * Cache lifetime in seconds.
      */
-    const TYPE_SECONDS = 'seconds';
+    public const TYPE_SECONDS = 'seconds';
 
     /**
      * Cache lifetime as cron expression.
      */
-    const TYPE_EXPRESSION = 'expression';
+    public const TYPE_EXPRESSION = 'expression';
 
     /**
      * Get cache lifetime in seconds.

--- a/src/Sulu/Bundle/LocationBundle/Geolocator/Service/GoogleGeolocator.php
+++ b/src/Sulu/Bundle/LocationBundle/Geolocator/Service/GoogleGeolocator.php
@@ -26,7 +26,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 class GoogleGeolocator implements GeolocatorInterface
 {
-    const ENDPOINT = 'https://maps.googleapis.com/maps/api/geocode/json';
+    public const ENDPOINT = 'https://maps.googleapis.com/maps/api/geocode/json';
 
     /**
      * @var HttpClientInterface|ClientInterface

--- a/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/ParserCompilerPass.php
+++ b/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/ParserCompilerPass.php
@@ -20,11 +20,11 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class ParserCompilerPass implements CompilerPassInterface
 {
-    const SERVICE_ID = 'sulu_markup.response_listener';
+    public const SERVICE_ID = 'sulu_markup.response_listener';
 
-    const TAG_NAME = 'sulu_markup.parser';
+    public const TAG_NAME = 'sulu_markup.parser';
 
-    const TYPE_ATTRIBUTE = 'type';
+    public const TYPE_ATTRIBUTE = 'type';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/TagCompilerPass.php
+++ b/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/TagCompilerPass.php
@@ -20,15 +20,15 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class TagCompilerPass implements CompilerPassInterface
 {
-    const SERVICE_ID = 'sulu_markup.tag.registry';
+    public const SERVICE_ID = 'sulu_markup.tag.registry';
 
-    const TAG_NAME = 'sulu_markup.tag';
+    public const TAG_NAME = 'sulu_markup.tag';
 
-    const NAMESPACE_ATTRIBUTE = 'namespace';
+    public const NAMESPACE_ATTRIBUTE = 'namespace';
 
-    const TAG_ATTRIBUTE = 'tag';
+    public const TAG_ATTRIBUTE = 'tag';
 
-    const TYPE_ATTRIBUTE = 'type';
+    public const TYPE_ATTRIBUTE = 'type';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/MarkupBundle/Markup/HtmlTagExtractor.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/HtmlTagExtractor.php
@@ -16,11 +16,11 @@ namespace Sulu\Bundle\MarkupBundle\Markup;
  */
 class HtmlTagExtractor implements TagExtractorInterface
 {
-    const COUNT_REGEX = '/<%1$s-[a-z]+/';
+    public const COUNT_REGEX = '/<%1$s-[a-z]+/';
 
-    const ATTRIBUTE_REGEX = '/(?<name>\b[\w-]+\b)\s*=\s*"(?<value>[^"]*)"/';
+    public const ATTRIBUTE_REGEX = '/(?<name>\b[\w-]+\b)\s*=\s*"(?<value>[^"]*)"/';
 
-    const TAG_REGEX = '/(?<tag><%1$s-(?<name>[a-z]+)(?<attributes>(?:(?!>|\/>).)*)(?:\/>|>(?<content>(?:(?!<\/%1$s-\2>).)*)<\/%1$s-\2>))/s';
+    public const TAG_REGEX = '/(?<tag><%1$s-(?<name>[a-z]+)(?<attributes>(?:(?!>|\/>).)*)(?:\/>|>(?<content>(?:(?!<\/%1$s-\2>).)*)<\/%1$s-\2>))/s';
 
     /**
      * @var string

--- a/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
@@ -18,11 +18,11 @@ use Symfony\Component\HttpFoundation\UrlHelper;
 
 class LinkTag implements TagInterface
 {
-    const VALIDATE_UNPUBLISHED = 'unpublished';
+    public const VALIDATE_UNPUBLISHED = 'unpublished';
 
-    const VALIDATE_REMOVED = 'removed';
+    public const VALIDATE_REMOVED = 'removed';
 
-    const DEFAULT_PROVIDER = 'page';
+    public const DEFAULT_PROVIDER = 'page';
 
     /**
      * @var LinkProviderPoolInterface

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlMarkupParserTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlMarkupParserTest.php
@@ -22,9 +22,9 @@ use Sulu\Bundle\MarkupBundle\Tag\TagRegistryInterface;
 
 class HtmlMarkupParserTest extends TestCase
 {
-    const VALIDATE_UNPUBLISHED = 'unpublished';
+    public const VALIDATE_UNPUBLISHED = 'unpublished';
 
-    const VALIDATE_REMOVED = 'removed';
+    public const VALIDATE_REMOVED = 'removed';
 
     /**
      * @var TagInterface

--- a/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
+++ b/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
@@ -25,19 +25,19 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class MediaAdmin extends Admin
 {
-    const SECURITY_CONTEXT = 'sulu.media.collections';
+    public const SECURITY_CONTEXT = 'sulu.media.collections';
 
-    const SECURITY_CONTEXT_GROUP = 'Media';
+    public const SECURITY_CONTEXT_GROUP = 'Media';
 
-    const MEDIA_OVERVIEW_VIEW = 'sulu_media.overview';
+    public const MEDIA_OVERVIEW_VIEW = 'sulu_media.overview';
 
-    const EDIT_FORM_VIEW = 'sulu_media.form';
+    public const EDIT_FORM_VIEW = 'sulu_media.form';
 
-    const EDIT_FORM_DETAILS_VIEW = 'sulu_media.form.details';
+    public const EDIT_FORM_DETAILS_VIEW = 'sulu_media.form.details';
 
-    const EDIT_FORM_FORMATS_VIEW = 'sulu_media.form.formats';
+    public const EDIT_FORM_FORMATS_VIEW = 'sulu_media.form.formats';
 
-    const EDIT_FORM_HISTORY_VIEW = 'sulu_media.form.history';
+    public const EDIT_FORM_HISTORY_VIEW = 'sulu_media.form.history';
 
     /**
      * @var ViewBuilderFactoryInterface

--- a/src/Sulu/Bundle/MediaBundle/Api/Media.php
+++ b/src/Sulu/Bundle/MediaBundle/Api/Media.php
@@ -42,22 +42,22 @@ class Media extends ApiWrapper
     /**
      * @var string
      */
-    const MEDIA_TYPE_IMAGE = 'image';
+    public const MEDIA_TYPE_IMAGE = 'image';
 
     /**
      * @var string
      */
-    const MEDIA_TYPE_VIDEO = 'video';
+    public const MEDIA_TYPE_VIDEO = 'video';
 
     /**
      * @var string
      */
-    const MEDIA_TYPE_AUDIO = 'audio';
+    public const MEDIA_TYPE_AUDIO = 'audio';
 
     /**
      * @var string
      */
-    const MEDIA_TYPE_DOCUMENT = 'document';
+    public const MEDIA_TYPE_DOCUMENT = 'document';
 
     /**
      * @var string

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
@@ -20,11 +20,11 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    const STORAGE_GOOGLE_CLOUD = 'google_cloud';
+    public const STORAGE_GOOGLE_CLOUD = 'google_cloud';
 
-    const STORAGE_S3 = 's3';
+    public const STORAGE_S3 = 's3';
 
-    const STORAGE_AZURE_BLOB = 'azure_blob';
+    public const STORAGE_AZURE_BLOB = 'azure_blob';
 
     public function getConfigTreeBuilder()
     {

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/ImageTransformationCompilerPass.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/ImageTransformationCompilerPass.php
@@ -20,9 +20,9 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class ImageTransformationCompilerPass implements CompilerPassInterface
 {
-    const POOL_SERVICE_ID = 'sulu_media.image.transformation_pool';
+    public const POOL_SERVICE_ID = 'sulu_media.image.transformation_pool';
 
-    const TAG = 'sulu_media.image.transformation';
+    public const TAG = 'sulu_media.image.transformation';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/MediaBundle/Media/Exception/MediaException.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Exception/MediaException.php
@@ -23,175 +23,175 @@ class MediaException extends Exception
      *
      * @var int
      */
-    const EXCEPTION_CODE_UPLOAD_ERROR = 5001;
+    public const EXCEPTION_CODE_UPLOAD_ERROR = 5001;
 
     /**
      * The uploaded file was not found.
      *
      * @var int
      */
-    const EXCEPTION_CODE_UPLOADED_FILE_NOT_FOUND = 5002;
+    public const EXCEPTION_CODE_UPLOADED_FILE_NOT_FOUND = 5002;
 
     /**
      * The file is bigger as the max file size in the config.
      *
      * @var int
      */
-    const EXCEPTION_CODE_MAX_FILE_SIZE = 5003;
+    public const EXCEPTION_CODE_MAX_FILE_SIZE = 5003;
 
     /**
      * The file mime type is not supported.
      *
      * @var int
      */
-    const EXCEPTION_CODE_BLOCKED_FILE_TYPE = 5004;
+    public const EXCEPTION_CODE_BLOCKED_FILE_TYPE = 5004;
 
     /**
      * The collection was not found.
      *
      * @var int
      */
-    const EXCEPTION_CODE_COLLECTION_NOT_FOUND = 5005;
+    public const EXCEPTION_CODE_COLLECTION_NOT_FOUND = 5005;
 
     /**
      * The file version was not found.
      *
      * @var int
      */
-    const EXCEPTION_CODE_FILE_VERSION_NOT_FOUND = 5006;
+    public const EXCEPTION_CODE_FILE_VERSION_NOT_FOUND = 5006;
 
     /**
      * The file has not the correct media type as the followed file versions.
      *
      * @var int
      */
-    const EXCEPTION_CODE_INVALID_MEDIA_TYPE = 5007;
+    public const EXCEPTION_CODE_INVALID_MEDIA_TYPE = 5007;
 
     /**
      * Image id was not found in request.
      *
      * @var int
      */
-    const EXCEPTION_CODE_IMAGE_PROXY_MEDIA_ID_NOT_FOUND = 5008;
+    public const EXCEPTION_CODE_IMAGE_PROXY_MEDIA_ID_NOT_FOUND = 5008;
 
     /**
      * Media not loaded by proxy id.
      *
      * @var int
      */
-    const EXCEPTION_CODE_IMAGE_PROXY_MEDIA_NOT_FOUND = 5009;
+    public const EXCEPTION_CODE_IMAGE_PROXY_MEDIA_NOT_FOUND = 5009;
 
     /**
      * Original image not found.
      *
      * @var int
      */
-    const EXCEPTION_CODE_IMAGE_PROXY_ORIGINAL_NOT_FOUND = 5010;
+    public const EXCEPTION_CODE_IMAGE_PROXY_ORIGINAL_NOT_FOUND = 5010;
 
     /**
      * The image url was not found.
      *
      * @var int
      */
-    const EXCEPTION_CODE_IMAGE_PROXY_URL_NOT_FOUND = 5011;
+    public const EXCEPTION_CODE_IMAGE_PROXY_URL_NOT_FOUND = 5011;
 
     /**
      * The image url was not valid.
      *
      * @var int
      */
-    const EXCEPTION_CODE_IMAGE_PROXY_INVALID_URL = 5012;
+    public const EXCEPTION_CODE_IMAGE_PROXY_INVALID_URL = 5012;
 
     /**
      * the image format was not found.
      *
      * @var int
      */
-    const EXCEPTION_CODE_IMAGE_PROXY_INVALID_IMAGE_FORMAT = 5013;
+    public const EXCEPTION_CODE_IMAGE_PROXY_INVALID_IMAGE_FORMAT = 5013;
 
     /**
      * The configured format options are invalid.
      *
      * @var int
      */
-    const EXCEPTION_CODE_IMAGE_PROXY_INVALID_FORMAT_OPTIONS = 5014;
+    public const EXCEPTION_CODE_IMAGE_PROXY_INVALID_FORMAT_OPTIONS = 5014;
 
     /**
      * The media was not found.
      *
      * @var int
      */
-    const EXCEPTION_CODE_MEDIA_NOT_FOUND = 5015;
+    public const EXCEPTION_CODE_MEDIA_NOT_FOUND = 5015;
 
     /**
      * The collection type was not found.
      *
      * @var int
      */
-    const EXCEPTION_CODE_COLLECTION_TYPE_NOT_FOUND = 5016;
+    public const EXCEPTION_CODE_COLLECTION_TYPE_NOT_FOUND = 5016;
 
     /**
      * The media type was not found.
      *
      * @var int
      */
-    const EXCEPTION_CODE_MEDIA_TYPE_NOT_FOUND = 5017;
+    public const EXCEPTION_CODE_MEDIA_TYPE_NOT_FOUND = 5017;
 
     /**
      * No previews are generated for this extension.
      *
      * @var int
      */
-    const EXCEPTION_INVALID_MIMETYPE_FOR_PREVIEW = 5018;
+    public const EXCEPTION_INVALID_MIMETYPE_FOR_PREVIEW = 5018;
 
     /**
      * Ghostscript was not found at location.
      *
      * @var int
      */
-    const EXCEPTION_CODE_GHOST_SCRIPT_NOT_FOUND = 5019;
+    public const EXCEPTION_CODE_GHOST_SCRIPT_NOT_FOUND = 5019;
 
     /**
      * A file with this name exists.
      *
      * @var int
      */
-    const EXCEPTION_FILENAME_ALREADY_EXISTS = 5020;
+    public const EXCEPTION_FILENAME_ALREADY_EXISTS = 5020;
 
     /**
      * File is not found in media object.
      *
      * @var int
      */
-    const EXCEPTION_CODE_FILE_NOT_FOUND = 5021;
+    public const EXCEPTION_CODE_FILE_NOT_FOUND = 5021;
 
     /**
      * Format cache is not found.
      *
      * @var int
      */
-    const EXCEPTION_CACHE_NOT_FOUND = 5022;
+    public const EXCEPTION_CACHE_NOT_FOUND = 5022;
 
     /**
      * Systemfile is not found.
      *
      * @var int
      */
-    const EXCEPTION_CODE_ORIGINAL_FILE_NOT_FOUND = 5027;
+    public const EXCEPTION_CODE_ORIGINAL_FILE_NOT_FOUND = 5027;
 
     /**
      * Format is not found.
      *
      * @var int
      */
-    const EXCEPTION_FORMAT_NOT_FOUND = 5028;
+    public const EXCEPTION_FORMAT_NOT_FOUND = 5028;
 
     /**
      * Format options parameter is missing.
      *
      * @var int
      */
-    const EXCEPTION_FORMAT_OPTIONS_MISSING_PARAMETER = 5029;
+    public const EXCEPTION_FORMAT_OPTIONS_MISSING_PARAMETER = 5029;
 
     public function toArray()
     {

--- a/src/Sulu/Bundle/MediaBundle/Media/FileValidator/FileValidatorInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FileValidator/FileValidatorInterface.php
@@ -19,13 +19,13 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
  */
 interface FileValidatorInterface
 {
-    const VALIDATOR_FILE_SET = 'FILE_SET';
+    public const VALIDATOR_FILE_SET = 'FILE_SET';
 
-    const VALIDATOR_FILE_ERRORS = 'FILE_ERRORS';
+    public const VALIDATOR_FILE_ERRORS = 'FILE_ERRORS';
 
-    const VALIDATOR_BLOCK_FILE_TYPES = 'BLOCK_FILE_TYPES';
+    public const VALIDATOR_BLOCK_FILE_TYPES = 'BLOCK_FILE_TYPES';
 
-    const VALIDATOR_MAX_FILE_SIZE = 'MAX_FILE_SIZE';
+    public const VALIDATOR_MAX_FILE_SIZE = 'MAX_FILE_SIZE';
 
     /**
      * Validated a given file.

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/BaseXmlFormatLoader.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/BaseXmlFormatLoader.php
@@ -21,17 +21,17 @@ use Symfony\Component\Config\Util\XmlUtils;
  */
 abstract class BaseXmlFormatLoader extends FileLoader
 {
-    const XML_NAMESPACE_URI = 'http://schemas.sulu.io/media/formats';
+    public const XML_NAMESPACE_URI = 'http://schemas.sulu.io/media/formats';
 
-    const SCHEMA_URI = '';
+    public const SCHEMA_URI = '';
 
-    const SCHEME_PATH = '';
+    public const SCHEME_PATH = '';
 
-    const SCALE_MODE_DEFAULT = ImageInterface::THUMBNAIL_OUTBOUND;
+    public const SCALE_MODE_DEFAULT = ImageInterface::THUMBNAIL_OUTBOUND;
 
-    const SCALE_RETINA_DEFAULT = false;
+    public const SCALE_RETINA_DEFAULT = false;
 
-    const SCALE_FORCE_RATIO_DEFAULT = true;
+    public const SCALE_FORCE_RATIO_DEFAULT = true;
 
     /**
      * @var \DOMXPath

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader10.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader10.php
@@ -20,9 +20,9 @@ use Sulu\Bundle\MediaBundle\Media\FormatLoader\Exception\MissingScaleDimensionEx
  */
 class XmlFormatLoader10 extends BaseXmlFormatLoader
 {
-    const SCHEMA_URI = 'http://schemas.sulu.io/media/formats-1.0.xsd';
+    public const SCHEMA_URI = 'http://schemas.sulu.io/media/formats-1.0.xsd';
 
-    const SCHEME_PATH = '/schema/formats/formats-1.0.xsd';
+    public const SCHEME_PATH = '/schema/formats/formats-1.0.xsd';
 
     public function load($resource, $type = null)
     {

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader11.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader11.php
@@ -18,9 +18,9 @@ use Sulu\Bundle\MediaBundle\Media\FormatLoader\Exception\MissingScaleDimensionEx
  */
 class XmlFormatLoader11 extends BaseXmlFormatLoader
 {
-    const SCHEMA_URI = 'http://schemas.sulu.io/media/formats-1.1.xsd';
+    public const SCHEMA_URI = 'http://schemas.sulu.io/media/formats-1.1.xsd';
 
-    const SCHEME_PATH = '/schema/formats/formats-1.1.xsd';
+    public const SCHEME_PATH = '/schema/formats/formats-1.1.xsd';
 
     protected function getKeyFromFormatNode(\DOMNode $formatNode)
     {

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Focus/Focus.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Focus/Focus.php
@@ -23,32 +23,32 @@ class Focus implements FocusInterface
     /**
      * 0 is the x value if the focus point is set on the most left column.
      */
-    const FOCUS_LEFT = 0;
+    public const FOCUS_LEFT = 0;
 
     /**
      * 1 is the x value if the focus point is set on the center column.
      */
-    const FOCUS_CENTER = 1;
+    public const FOCUS_CENTER = 1;
 
     /**
      * 2 is the x value if the focus point is set on the most right column.
      */
-    const FOCUS_RIGHT = 2;
+    public const FOCUS_RIGHT = 2;
 
     /**
      * 0 is the y value if the focus point is set on the most top row.
      */
-    const FOCUS_TOP = 0;
+    public const FOCUS_TOP = 0;
 
     /**
      * 1 is the y value if the focus point is set on the middle row.
      */
-    const FOCUS_MIDDLE = 1;
+    public const FOCUS_MIDDLE = 1;
 
     /**
      * 2 is the y value if the focus point is set on the most bottom row.
      */
-    const FOCUS_BOTTOM = 2;
+    public const FOCUS_BOTTOM = 2;
 
     public function focus(ImageInterface $image, $x, $y, $width, $height)
     {

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -49,7 +49,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  */
 class MediaManager implements MediaManagerInterface
 {
-    const ENTITY_NAME_COLLECTION = 'SuluMediaBundle:Collection';
+    public const ENTITY_NAME_COLLECTION = 'SuluMediaBundle:Collection';
 
     /**
      * The repository for communication with the database.

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/StorageInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/StorageInterface.php
@@ -17,9 +17,9 @@ namespace Sulu\Bundle\MediaBundle\Media\Storage;
  */
 interface StorageInterface
 {
-    const TYPE_REMOTE = 'remote';
+    public const TYPE_REMOTE = 'remote';
 
-    const TYPE_LOCAL = 'local';
+    public const TYPE_LOCAL = 'local';
 
     /**
      * Save the document in a storage and give back the path to the document.

--- a/src/Sulu/Bundle/MediaBundle/Media/TypeManager/TypeManagerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/TypeManager/TypeManagerInterface.php
@@ -19,9 +19,9 @@ use Sulu\Bundle\MediaBundle\Entity\MediaType;
  */
 interface TypeManagerInterface
 {
-    const ENTITY_CLASS_MEDIATYPE = 'Sulu\Bundle\MediaBundle\Entity\MediaType';
+    public const ENTITY_CLASS_MEDIATYPE = 'Sulu\Bundle\MediaBundle\Entity\MediaType';
 
-    const ENTITY_NAME_MEDIATYPE = 'SuluMediaBundle:MediaType';
+    public const ENTITY_NAME_MEDIATYPE = 'SuluMediaBundle:MediaType';
 
     /**
      * Returns a Media Type by a given ID.

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -34,17 +34,17 @@ class PageAdmin extends Admin
      *
      * @var string
      */
-    const SECURITY_CONTEXT_PREFIX = 'sulu.webspaces.';
+    public const SECURITY_CONTEXT_PREFIX = 'sulu.webspaces.';
 
-    const SECURITY_CONTEXT_GROUP = 'Webspaces';
+    public const SECURITY_CONTEXT_GROUP = 'Webspaces';
 
-    const WEBSPACE_TABS_VIEW = 'sulu_page.webspaces';
+    public const WEBSPACE_TABS_VIEW = 'sulu_page.webspaces';
 
-    const PAGES_VIEW = 'sulu_page.pages_list';
+    public const PAGES_VIEW = 'sulu_page.pages_list';
 
-    const ADD_FORM_VIEW = 'sulu_page.page_add_form';
+    public const ADD_FORM_VIEW = 'sulu_page.page_add_form';
 
-    const EDIT_FORM_VIEW = 'sulu_page.page_edit_form';
+    public const EDIT_FORM_VIEW = 'sulu_page.page_edit_form';
 
     /**
      * @var ViewBuilderFactoryInterface

--- a/src/Sulu/Bundle/PageBundle/Content/Structure/ExcerptStructureExtension.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Structure/ExcerptStructureExtension.php
@@ -32,7 +32,7 @@ class ExcerptStructureExtension extends AbstractExtension implements ExportExten
     /**
      * name of structure extension.
      */
-    const EXCERPT_EXTENSION_NAME = 'excerpt';
+    public const EXCERPT_EXTENSION_NAME = 'excerpt';
 
     /**
      * will be filled with data in constructor

--- a/src/Sulu/Bundle/PageBundle/Content/Structure/SeoStructureExtension.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Structure/SeoStructureExtension.php
@@ -23,7 +23,7 @@ class SeoStructureExtension extends AbstractExtension implements ExportExtension
     /**
      * name of structure extension.
      */
-    const SEO_EXTENSION_NAME = 'seo';
+    public const SEO_EXTENSION_NAME = 'seo';
 
     protected $seoAttributes = [
         'hideInSitemap',

--- a/src/Sulu/Bundle/PageBundle/Content/Types/Date.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/Date.php
@@ -20,7 +20,7 @@ use Sulu\Component\Content\SimpleContentType;
  */
 class Date extends SimpleContentType
 {
-    const FORMAT = 'Y-m-d';
+    public const FORMAT = 'Y-m-d';
 
     public function __construct()
     {

--- a/src/Sulu/Bundle/PageBundle/Content/Types/DateTime.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/DateTime.php
@@ -20,7 +20,7 @@ use Sulu\Component\Content\SimpleContentType;
  */
 class DateTime extends SimpleContentType
 {
-    const FORMAT = 'Y-m-d\TH:i:s';
+    public const FORMAT = 'Y-m-d\TH:i:s';
 
     public function __construct()
     {

--- a/src/Sulu/Bundle/PageBundle/Content/Types/SegmentSelect.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/SegmentSelect.php
@@ -17,7 +17,7 @@ use Sulu\Component\Content\ComplexContentType;
 
 class SegmentSelect extends ComplexContentType
 {
-    const SEPARATOR = '-';
+    public const SEPARATOR = '-';
 
     public function write(NodeInterface $node, PropertyInterface $property, $userId, $webspaceKey, $languageCode, $segmentKey)
     {

--- a/src/Sulu/Bundle/PageBundle/Controller/PageController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/PageController.php
@@ -52,9 +52,9 @@ class PageController extends AbstractRestController implements ClassResourceInte
 {
     use RequestParametersTrait;
 
-    const WEBSPACE_NODE_SINGLE = 'single';
+    public const WEBSPACE_NODE_SINGLE = 'single';
 
-    const WEBSPACE_NODES_ALL = 'all';
+    public const WEBSPACE_NODES_ALL = 'all';
 
     protected static $relationName = 'pages';
 

--- a/src/Sulu/Bundle/PageBundle/DependencyInjection/Compiler/ContentExportCompilerPass.php
+++ b/src/Sulu/Bundle/PageBundle/DependencyInjection/Compiler/ContentExportCompilerPass.php
@@ -20,9 +20,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class ContentExportCompilerPass implements CompilerPassInterface
 {
-    const CONTENT_EXPORT_SERVICE_ID = 'sulu_page.export.manager';
+    public const CONTENT_EXPORT_SERVICE_ID = 'sulu_page.export.manager';
 
-    const STRUCTURE_EXTENSION_TAG = 'sulu.content.export';
+    public const STRUCTURE_EXTENSION_TAG = 'sulu.content.export';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/PageBundle/DependencyInjection/Compiler/SmartContentDataProviderCompilerPass.php
+++ b/src/Sulu/Bundle/PageBundle/DependencyInjection/Compiler/SmartContentDataProviderCompilerPass.php
@@ -20,9 +20,9 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class SmartContentDataProviderCompilerPass implements CompilerPassInterface
 {
-    const POOL_SERVICE_ID = 'sulu_page.smart_content.data_provider_pool';
+    public const POOL_SERVICE_ID = 'sulu_page.smart_content.data_provider_pool';
 
-    const STRUCTURE_EXTENSION_TAG = 'sulu.smart_content.data_provider';
+    public const STRUCTURE_EXTENSION_TAG = 'sulu.smart_content.data_provider';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/PageBundle/DependencyInjection/Compiler/StructureExtensionCompilerPass.php
+++ b/src/Sulu/Bundle/PageBundle/DependencyInjection/Compiler/StructureExtensionCompilerPass.php
@@ -20,9 +20,9 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class StructureExtensionCompilerPass implements CompilerPassInterface
 {
-    const STRUCTURE_MANAGER_ID = 'sulu_page.extension.manager';
+    public const STRUCTURE_MANAGER_ID = 'sulu_page.extension.manager';
 
-    const STRUCTURE_EXTENSION_TAG = 'sulu.structure.extension';
+    public const STRUCTURE_EXTENSION_TAG = 'sulu.structure.extension';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201507231648.php
+++ b/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201507231648.php
@@ -20,15 +20,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class Version201507231648 implements VersionInterface, ContainerAwareInterface
 {
-    const SHADOW_ON_PROPERTY = 'i18n:%s-shadow-on';
+    public const SHADOW_ON_PROPERTY = 'i18n:%s-shadow-on';
 
-    const SHADOW_BASE_PROPERTY = 'i18n:%s-shadow-base';
+    public const SHADOW_BASE_PROPERTY = 'i18n:%s-shadow-base';
 
-    const TAGS_PROPERTY = 'i18n:%s-excerpt-tags';
+    public const TAGS_PROPERTY = 'i18n:%s-excerpt-tags';
 
-    const CATEGORIES_PROPERTY = 'i18n:%s-excerpt-categories';
+    public const CATEGORIES_PROPERTY = 'i18n:%s-excerpt-categories';
 
-    const NAVIGATION_CONTEXT_PROPERTY = 'i18n:%s-navContexts';
+    public const NAVIGATION_CONTEXT_PROPERTY = 'i18n:%s-navContexts';
 
     /**
      * @var ContainerInterface

--- a/src/Sulu/Bundle/PageBundle/Rule/PageRule.php
+++ b/src/Sulu/Bundle/PageBundle/Rule/PageRule.php
@@ -22,7 +22,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class PageRule implements RuleInterface
 {
-    const PAGE = 'page';
+    public const PAGE = 'page';
 
     /**
      * @var RequestStack

--- a/src/Sulu/Bundle/PageBundle/Search/Metadata/StructureProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Search/Metadata/StructureProvider.php
@@ -42,13 +42,13 @@ use Sulu\Component\DocumentManager\Metadata\MetadataFactory;
  */
 class StructureProvider implements ProviderInterface
 {
-    const FIELD_STRUCTURE_TYPE = '_structure_type';
+    public const FIELD_STRUCTURE_TYPE = '_structure_type';
 
-    const FIELD_TEASER_DESCRIPTION = '_teaser_description';
+    public const FIELD_TEASER_DESCRIPTION = '_teaser_description';
 
-    const FIELD_TEASER_MEDIA = '_teaser_media';
+    public const FIELD_TEASER_MEDIA = '_teaser_media';
 
-    const FIELD_WEBSPACE_KEY = 'webspace_key';
+    public const FIELD_WEBSPACE_KEY = 'webspace_key';
 
     /**
      * @var Factory

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Events.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Events.php
@@ -19,7 +19,7 @@ final class Events
     /**
      * Will be raised right before preview rendering.
      */
-    const PRE_RENDER = 'sulu.preview.pre-render';
+    public const PRE_RENDER = 'sulu.preview.pre-render';
 
     /**
      * No object can be created for this class.

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Exception/PreviewRendererException.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Exception/PreviewRendererException.php
@@ -16,7 +16,7 @@ namespace Sulu\Bundle\PreviewBundle\Preview\Exception;
  */
 abstract class PreviewRendererException extends PreviewException
 {
-    const BASE_CODE = 9900;
+    public const BASE_CODE = 9900;
 
     /**
      * @var mixed

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
@@ -20,7 +20,7 @@ use Sulu\Bundle\PreviewBundle\Preview\Renderer\PreviewRendererInterface;
 
 class Preview implements PreviewInterface
 {
-    const CONTENT_REPLACER = '<!-- CONTENT-REPLACER -->';
+    public const CONTENT_REPLACER = '<!-- CONTENT-REPLACER -->';
 
     /**
      * @var PreviewObjectProviderRegistryInterface

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class PreviewKernel extends Kernel
 {
-    const CONTEXT_PREVIEW = 'preview';
+    public const CONTEXT_PREVIEW = 'preview';
 
     /**
      * @var string

--- a/src/Sulu/Bundle/RouteBundle/Content/Type/PageTreeRouteContentType.php
+++ b/src/Sulu/Bundle/RouteBundle/Content/Type/PageTreeRouteContentType.php
@@ -29,7 +29,7 @@ use Sulu\Component\DocumentManager\DocumentRegistry;
  */
 class PageTreeRouteContentType extends SimpleContentType
 {
-    const NAME = 'page_tree_route';
+    public const NAME = 'page_tree_route';
 
     /**
      * @var DocumentManagerInterface

--- a/src/Sulu/Bundle/RouteBundle/DependencyInjection/RouteGeneratorCompilerPass.php
+++ b/src/Sulu/Bundle/RouteBundle/DependencyInjection/RouteGeneratorCompilerPass.php
@@ -20,11 +20,11 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class RouteGeneratorCompilerPass implements CompilerPassInterface
 {
-    const TAG_NAME = 'sulu.route_generator';
+    public const TAG_NAME = 'sulu.route_generator';
 
-    const SERVICE_ID = 'sulu_route.chain_generator';
+    public const SERVICE_ID = 'sulu_route.chain_generator';
 
-    const PARAMETER_NAME = 'sulu_route.mappings';
+    public const PARAMETER_NAME = 'sulu_route.mappings';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/RouteBundle/Document/Subscriber/RoutableSubscriber.php
+++ b/src/Sulu/Bundle/RouteBundle/Document/Subscriber/RoutableSubscriber.php
@@ -37,9 +37,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class RoutableSubscriber implements EventSubscriberInterface
 {
-    const ROUTE_PROPERTY = 'routePath';
+    public const ROUTE_PROPERTY = 'routePath';
 
-    const TAG_NAME = 'sulu_route.route_path';
+    public const TAG_NAME = 'sulu_route.route_path';
 
     /**
      * @var ChainRouteGeneratorInterface

--- a/src/Sulu/Bundle/RouteBundle/PageTree/PageTreeRepository.php
+++ b/src/Sulu/Bundle/RouteBundle/PageTree/PageTreeRepository.php
@@ -27,9 +27,9 @@ use Sulu\Component\Route\Document\Behavior\RoutableBehavior;
  */
 class PageTreeRepository implements PageTreeUpdaterInterface, PageTreeMoverInterface
 {
-    const ROUTE_PROPERTY = 'routePath';
+    public const ROUTE_PROPERTY = 'routePath';
 
-    const TAG_NAME = 'sulu_route.route_path';
+    public const TAG_NAME = 'sulu_route.route_path';
 
     /**
      * @var DocumentManagerInterface

--- a/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
@@ -33,7 +33,7 @@ use Symfony\Component\Routing\RouteCollection;
  */
 class RouteProvider implements RouteProviderInterface
 {
-    const ROUTE_PREFIX = 'sulu_route_';
+    public const ROUTE_PREFIX = 'sulu_route_';
 
     /**
      * @var RouteRepositoryInterface

--- a/src/Sulu/Bundle/RouteBundle/Tests/Functional/Controller/RouteControllerTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Functional/Controller/RouteControllerTest.php
@@ -18,13 +18,13 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 class RouteControllerTest extends SuluTestCase
 {
-    const TEST_ENTITY = 'AppBundle\\Entity\\Test';
+    public const TEST_ENTITY = 'AppBundle\\Entity\\Test';
 
-    const TEST_RESOURCE_KEY = 'tests';
+    public const TEST_RESOURCE_KEY = 'tests';
 
-    const TEST_ID = 1;
+    public const TEST_ID = 1;
 
-    const TEST_LOCALE = 'de';
+    public const TEST_LOCALE = 'de';
 
     /**
      * @var EntityManagerInterface

--- a/src/Sulu/Bundle/SearchBundle/Admin/SearchAdmin.php
+++ b/src/Sulu/Bundle/SearchBundle/Admin/SearchAdmin.php
@@ -19,7 +19,7 @@ use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
 
 class SearchAdmin extends Admin
 {
-    const SEARCH_VIEW = 'sulu_search.search';
+    public const SEARCH_VIEW = 'sulu_search.search';
     /**
      * @var ViewBuilderFactoryInterface
      */

--- a/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
+++ b/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
@@ -27,20 +27,20 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class SecurityAdmin extends Admin
 {
-    const ROLE_SECURITY_CONTEXT = 'sulu.security.roles';
+    public const ROLE_SECURITY_CONTEXT = 'sulu.security.roles';
 
     /**
      * @deprecated The group functionality was deprecated in Sulu 2.1 and will be removed in Sulu 3.0
      */
-    const GROUP_SECURITY_CONTEXT = 'sulu.security.groups';
+    public const GROUP_SECURITY_CONTEXT = 'sulu.security.groups';
 
-    const USER_SECURITY_CONTEXT = 'sulu.security.users';
+    public const USER_SECURITY_CONTEXT = 'sulu.security.users';
 
-    const LIST_VIEW = 'sulu_security.roles_list';
+    public const LIST_VIEW = 'sulu_security.roles_list';
 
-    const ADD_FORM_VIEW = 'sulu_security.role_add_form';
+    public const ADD_FORM_VIEW = 'sulu_security.role_add_form';
 
-    const EDIT_FORM_VIEW = 'sulu_security.role_edit_form';
+    public const EDIT_FORM_VIEW = 'sulu_security.role_edit_form';
 
     /**
      * Should be called after ContactAdmin.

--- a/src/Sulu/Bundle/SecurityBundle/Controller/GroupController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/GroupController.php
@@ -67,7 +67,7 @@ class GroupController extends AbstractRestController implements ClassResourceInt
      */
     private $entityManager;
 
-    const ENTITY_NAME_ROLE = 'SuluSecurityBundle:Role';
+    public const ENTITY_NAME_ROLE = 'SuluSecurityBundle:Role';
 
     // TODO: move the field descriptors to a manager
     public function __construct(

--- a/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
@@ -40,7 +40,7 @@ class RoleController extends AbstractRestController implements ClassResourceInte
 {
     protected static $entityKey = 'roles';
 
-    const ENTITY_NAME_PERMISSION = 'SuluSecurityBundle:Permission';
+    public const ENTITY_NAME_PERMISSION = 'SuluSecurityBundle:Permission';
 
     protected $bundlePrefix = 'security.roles.';
 

--- a/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Compiler/AccessControlProviderPass.php
+++ b/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Compiler/AccessControlProviderPass.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class AccessControlProviderPass implements CompilerPassInterface
 {
-    const ACCESS_CONTROL_TAG = 'sulu.access_control';
+    public const ACCESS_CONTROL_TAG = 'sulu.access_control';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -28,13 +28,13 @@ use Sulu\Component\Webspace\Webspace;
  */
 class SnippetAdmin extends Admin
 {
-    const SECURITY_CONTEXT = 'sulu.global.snippets';
+    public const SECURITY_CONTEXT = 'sulu.global.snippets';
 
-    const LIST_VIEW = 'sulu_snippet.list';
+    public const LIST_VIEW = 'sulu_snippet.list';
 
-    const ADD_FORM_VIEW = 'sulu_snippet.add_form';
+    public const ADD_FORM_VIEW = 'sulu_snippet.add_form';
 
-    const EDIT_FORM_VIEW = 'sulu_snippet.edit_form';
+    public const EDIT_FORM_VIEW = 'sulu_snippet.edit_form';
 
     /**
      * @var ViewBuilderFactoryInterface

--- a/src/Sulu/Bundle/TagBundle/Admin/TagAdmin.php
+++ b/src/Sulu/Bundle/TagBundle/Admin/TagAdmin.php
@@ -22,13 +22,13 @@ use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 
 class TagAdmin extends Admin
 {
-    const SECURITY_CONTEXT = 'sulu.settings.tags';
+    public const SECURITY_CONTEXT = 'sulu.settings.tags';
 
-    const LIST_VIEW = 'sulu_tag.list';
+    public const LIST_VIEW = 'sulu_tag.list';
 
-    const ADD_FORM_VIEW = 'sulu_tag.add_form';
+    public const ADD_FORM_VIEW = 'sulu_tag.add_form';
 
-    const EDIT_FORM_VIEW = 'sulu_tag.edit_form';
+    public const EDIT_FORM_VIEW = 'sulu_tag.edit_form';
 
     /**
      * @var ViewBuilderFactoryInterface

--- a/src/Sulu/Bundle/TagBundle/Controller/Exception/ConstraintViolationException.php
+++ b/src/Sulu/Bundle/TagBundle/Controller/Exception/ConstraintViolationException.php
@@ -24,7 +24,7 @@ class ConstraintViolationException extends RestException
      *
      * @var int
      */
-    const EXCEPTION_CODE_NON_UNIQUE_NAME = 1101;
+    public const EXCEPTION_CODE_NON_UNIQUE_NAME = 1101;
 
     /**
      * The field of the tag which is not unique.

--- a/src/Sulu/Bundle/TagBundle/Event/TagEvents.php
+++ b/src/Sulu/Bundle/TagBundle/Event/TagEvents.php
@@ -19,11 +19,11 @@ final class TagEvents
      *
      * @var string
      */
-    const TAG_DELETE = 'sulu.tag.delete';
+    public const TAG_DELETE = 'sulu.tag.delete';
 
     /**
      * The tag.merge event is thrown when a Tag gets merged into another one.
      * The event listener receives a TagMergeEvent instance.
      */
-    const TAG_MERGE = 'sulu.tag.merge';
+    public const TAG_MERGE = 'sulu.tag.merge';
 }

--- a/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
@@ -26,7 +26,7 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
  */
 class TestUserProvider implements UserProviderInterface
 {
-    const TEST_USER_USERNAME = 'test';
+    public const TEST_USER_USERNAME = 'test';
 
     /**
      * @var UserInterface

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/AnalyticsController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/AnalyticsController.php
@@ -29,7 +29,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class AnalyticsController extends AbstractRestController implements ClassResourceInterface, SecuredControllerInterface
 {
-    const RESULT_KEY = 'analytics';
+    public const RESULT_KEY = 'analytics';
 
     /**
      * @var AnalyticsManagerInterface

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/RouterListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/RouterListener.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
  */
 class RouterListener implements EventSubscriberInterface
 {
-    const REQUEST_ANALYZER = '_requestAnalyzer';
+    public const REQUEST_ANALYZER = '_requestAnalyzer';
 
     /**
      * @var BaseRouterListener

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/SegmentCacheListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/SegmentCacheListener.php
@@ -17,9 +17,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class SegmentCacheListener implements EventSubscriberInterface
 {
-    const SEGMENT_COOKIE = '_ss';
+    public const SEGMENT_COOKIE = '_ss';
 
-    const SEGMENT_HEADER = 'X-Sulu-Segment';
+    public const SEGMENT_HEADER = 'X-Sulu-Segment';
 
     public static function getSubscribedEvents()
     {

--- a/src/Sulu/Bundle/WebsiteBundle/Events.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Events.php
@@ -19,5 +19,5 @@ final class Events
     /**
      * Will be raised after http caches have been cleared.
      */
-    const CACHE_CLEAR = 'sulu_website.cache_clear';
+    public const CACHE_CLEAR = 'sulu_website.cache_clear';
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapProviderInterface.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapProviderInterface.php
@@ -19,7 +19,7 @@ interface SitemapProviderInterface
     /**
      * Google limit for sitemap-url elements.
      */
-    const PAGE_SIZE = 50000;
+    public const PAGE_SIZE = 50000;
 
     /**
      * Returns sitemap-entries.

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapUrl.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapUrl.php
@@ -19,19 +19,19 @@ class SitemapUrl
     /**
      * Constants which indicates the change frequency (google will use them).
      */
-    const CHANGE_FREQUENCY_ALWAYS = 'always';
+    public const CHANGE_FREQUENCY_ALWAYS = 'always';
 
-    const CHANGE_FREQUENCY_HOURLY = 'hourly';
+    public const CHANGE_FREQUENCY_HOURLY = 'hourly';
 
-    const CHANGE_FREQUENCY_DAILY = 'daily';
+    public const CHANGE_FREQUENCY_DAILY = 'daily';
 
-    const CHANGE_FREQUENCY_WEEKLY = 'weekly';
+    public const CHANGE_FREQUENCY_WEEKLY = 'weekly';
 
-    const CHANGE_FREQUENCY_MONTHLY = 'monthly';
+    public const CHANGE_FREQUENCY_MONTHLY = 'monthly';
 
-    const CHANGE_FREQUENCY_YEARLY = 'yearly';
+    public const CHANGE_FREQUENCY_YEARLY = 'yearly';
 
-    const CHANGE_FREQUENCY_NEVER = 'never';
+    public const CHANGE_FREQUENCY_NEVER = 'never';
 
     /**
      * Relative URL.

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Navigation/NavigationMapperTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Navigation/NavigationMapperTest.php
@@ -654,7 +654,7 @@ class ExcerptStructureExtension extends AbstractExtension
     /**
      * name of structure extension.
      */
-    const EXCERPT_EXTENSION_NAME = 'excerpt';
+    public const EXCERPT_EXTENSION_NAME = 'excerpt';
 
     /**
      * will be filled with data in constructor

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapGeneratorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapGeneratorTest.php
@@ -380,7 +380,7 @@ class ExcerptStructureExtension extends AbstractExtension
     /**
      * name of structure extension.
      */
-    const EXCERPT_EXTENSION_NAME = 'excerpt';
+    public const EXCERPT_EXTENSION_NAME = 'excerpt';
 
     /**
      * will be filled with data in constructor

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Core/UtilTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Core/UtilTwigExtension.php
@@ -48,7 +48,7 @@ class UtilTwigExtension extends AbstractExtension
         );
 
         if (\function_exists('tld_extract')) {
-            return \tld_extract($url, $mode);
+            return tld_extract($url, $mode);
         }
 
         throw new \LogicException(

--- a/src/Sulu/Component/Content/Compat/Structure.php
+++ b/src/Sulu/Component/Content/Compat/Structure.php
@@ -28,27 +28,27 @@ abstract class Structure implements StructureInterface
     /**
      * indicates that the node is a content node.
      */
-    const NODE_TYPE_CONTENT = 1;
+    public const NODE_TYPE_CONTENT = 1;
 
     /**
      * indicates that the node links to an internal resource.
      */
-    const NODE_TYPE_INTERNAL_LINK = 2;
+    public const NODE_TYPE_INTERNAL_LINK = 2;
 
     /**
      * indicates that the node links to an external resource.
      */
-    const NODE_TYPE_EXTERNAL_LINK = 4;
+    public const NODE_TYPE_EXTERNAL_LINK = 4;
 
     /**
      * Structure type page.
      */
-    const TYPE_PAGE = 'page';
+    public const TYPE_PAGE = 'page';
 
     /**
      * Structure type page.
      */
-    const TYPE_SNIPPET = 'snippet';
+    public const TYPE_SNIPPET = 'snippet';
 
     /**
      * webspaceKey of node.

--- a/src/Sulu/Component/Content/Compat/StructureInterface.php
+++ b/src/Sulu/Component/Content/Compat/StructureInterface.php
@@ -19,9 +19,9 @@ use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
  */
 interface StructureInterface extends \JsonSerializable
 {
-    const STATE_TEST = 1;
+    public const STATE_TEST = 1;
 
-    const STATE_PUBLISHED = 2;
+    public const STATE_PUBLISHED = 2;
 
     /**
      * @param string $language

--- a/src/Sulu/Component/Content/Document/LocalizationState.php
+++ b/src/Sulu/Component/Content/Document/LocalizationState.php
@@ -19,15 +19,15 @@ class LocalizationState
     /**
      * Document is loaded in requested locale.
      */
-    const LOCALIZED = 'localized';
+    public const LOCALIZED = 'localized';
 
     /**
      * Document is using a fallback.
      */
-    const GHOST = 'ghost';
+    public const GHOST = 'ghost';
 
     /**
      * Document is using the content of a different localization.
      */
-    const SHADOW = 'shadow';
+    public const SHADOW = 'shadow';
 }

--- a/src/Sulu/Component/Content/Document/RedirectType.php
+++ b/src/Sulu/Component/Content/Document/RedirectType.php
@@ -19,15 +19,15 @@ final class RedirectType
     /**
      * indicates that the node is a content node.
      */
-    const NONE = 1;
+    public const NONE = 1;
 
     /**
      * indicates that the node links to an internal resource.
      */
-    const INTERNAL = 2;
+    public const INTERNAL = 2;
 
     /**
      * indicates that the node links to an external resource.
      */
-    const EXTERNAL = 4;
+    public const EXTERNAL = 4;
 }

--- a/src/Sulu/Component/Content/Document/Subscriber/AuthorSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/AuthorSubscriber.php
@@ -26,9 +26,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class AuthorSubscriber implements EventSubscriberInterface
 {
-    const AUTHORED_PROPERTY_NAME = 'authored';
+    public const AUTHORED_PROPERTY_NAME = 'authored';
 
-    const AUTHOR_PROPERTY_NAME = 'author';
+    public const AUTHOR_PROPERTY_NAME = 'author';
 
     /**
      * @var PropertyEncoder

--- a/src/Sulu/Component/Content/Document/Subscriber/BlameSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/BlameSubscriber.php
@@ -28,9 +28,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class BlameSubscriber implements EventSubscriberInterface
 {
-    const CREATOR = 'creator';
+    public const CREATOR = 'creator';
 
-    const CHANGER = 'changer';
+    public const CHANGER = 'changer';
 
     /**
      * @var PropertyEncoder

--- a/src/Sulu/Component/Content/Document/Subscriber/NavigationContextSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/NavigationContextSubscriber.php
@@ -18,7 +18,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class NavigationContextSubscriber implements EventSubscriberInterface
 {
-    const FIELD = 'navContexts';
+    public const FIELD = 'navContexts';
 
     public static function getSubscribedEvents()
     {

--- a/src/Sulu/Component/Content/Document/Subscriber/OrderSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/OrderSubscriber.php
@@ -26,7 +26,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class OrderSubscriber implements EventSubscriberInterface
 {
-    const FIELD = 'order';
+    public const FIELD = 'order';
 
     /**
      * @var DocumentInspector

--- a/src/Sulu/Component/Content/Document/Subscriber/RedirectTypeSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/RedirectTypeSubscriber.php
@@ -20,11 +20,11 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class RedirectTypeSubscriber implements EventSubscriberInterface
 {
-    const REDIRECT_TYPE_FIELD = 'nodeType';
+    public const REDIRECT_TYPE_FIELD = 'nodeType';
 
-    const INTERNAL_FIELD = 'internal_link';
+    public const INTERNAL_FIELD = 'internal_link';
 
-    const EXTERNAL_FIELD = 'external';
+    public const EXTERNAL_FIELD = 'external';
 
     public static function getSubscribedEvents()
     {

--- a/src/Sulu/Component/Content/Document/Subscriber/RouteSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/RouteSubscriber.php
@@ -33,9 +33,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class RouteSubscriber implements EventSubscriberInterface
 {
-    const DOCUMENT_HISTORY_FIELD = 'history';
+    public const DOCUMENT_HISTORY_FIELD = 'history';
 
-    const NODE_HISTORY_FIELD = 'sulu:history';
+    public const NODE_HISTORY_FIELD = 'sulu:history';
 
     /**
      * @var DocumentManagerInterface

--- a/src/Sulu/Component/Content/Document/Subscriber/SecuritySubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/SecuritySubscriber.php
@@ -31,9 +31,9 @@ class SecuritySubscriber implements EventSubscriberInterface
     /**
      * @deprecated use the SECURITY_PERMISSION_PROPERTY to access the permissions
      */
-    const SECURITY_PROPERTY_PREFIX = 'sec:role-';
+    public const SECURITY_PROPERTY_PREFIX = 'sec:role-';
 
-    const SECURITY_PERMISSION_PROPERTY = 'sec:permissions';
+    public const SECURITY_PERMISSION_PROPERTY = 'sec:permissions';
 
     /**
      * @var array

--- a/src/Sulu/Component/Content/Document/Subscriber/ShadowCopyPropertiesSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ShadowCopyPropertiesSubscriber.php
@@ -24,13 +24,13 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class ShadowCopyPropertiesSubscriber implements EventSubscriberInterface
 {
-    const SHADOW_BASE_PROPERTY = 'i18n:*-shadow-base';
+    public const SHADOW_BASE_PROPERTY = 'i18n:*-shadow-base';
 
-    const TAGS_PROPERTY = 'i18n:%s-excerpt-tags';
+    public const TAGS_PROPERTY = 'i18n:%s-excerpt-tags';
 
-    const CATEGORIES_PROPERTY = 'i18n:%s-excerpt-categories';
+    public const CATEGORIES_PROPERTY = 'i18n:%s-excerpt-categories';
 
-    const NAVIGATION_CONTEXT_PROPERTY = 'i18n:%s-navContexts';
+    public const NAVIGATION_CONTEXT_PROPERTY = 'i18n:%s-navContexts';
 
     /**
      * @var PropertyEncoder

--- a/src/Sulu/Component/Content/Document/Subscriber/ShadowLocaleSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ShadowLocaleSubscriber.php
@@ -25,9 +25,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ShadowLocaleSubscriber implements EventSubscriberInterface
 {
-    const SHADOW_ENABLED_FIELD = 'shadow-on';
+    public const SHADOW_ENABLED_FIELD = 'shadow-on';
 
-    const SHADOW_LOCALE_FIELD = 'shadow-base';
+    public const SHADOW_LOCALE_FIELD = 'shadow-base';
 
     /**
      * @var DocumentInspector

--- a/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
@@ -33,7 +33,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class StructureSubscriber implements EventSubscriberInterface
 {
-    const STRUCTURE_TYPE_FIELD = 'template';
+    public const STRUCTURE_TYPE_FIELD = 'template';
 
     /**
      * @var ContentTypeManagerInterface

--- a/src/Sulu/Component/Content/Document/Subscriber/TargetSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/TargetSubscriber.php
@@ -21,7 +21,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class TargetSubscriber implements EventSubscriberInterface
 {
-    const DOCUMENT_TARGET_FIELD = 'content';
+    public const DOCUMENT_TARGET_FIELD = 'content';
 
     public static function getSubscribedEvents()
     {

--- a/src/Sulu/Component/Content/Document/Subscriber/TitleSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/TitleSubscriber.php
@@ -21,7 +21,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class TitleSubscriber implements EventSubscriberInterface
 {
-    const PROPERTY_NAME = 'title';
+    public const PROPERTY_NAME = 'title';
 
     /**
      * @var PropertyEncoder

--- a/src/Sulu/Component/Content/Document/Subscriber/WorkflowStageSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/WorkflowStageSubscriber.php
@@ -30,9 +30,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class WorkflowStageSubscriber implements EventSubscriberInterface
 {
-    const WORKFLOW_STAGE_FIELD = 'state';
+    public const WORKFLOW_STAGE_FIELD = 'state';
 
-    const PUBLISHED_FIELD = 'published';
+    public const PUBLISHED_FIELD = 'published';
 
     /**
      * @var DocumentInspector

--- a/src/Sulu/Component/Content/Document/WorkflowStage.php
+++ b/src/Sulu/Component/Content/Document/WorkflowStage.php
@@ -28,10 +28,10 @@ final class WorkflowStage
     /**
      * Document is published.
      */
-    const PUBLISHED = 2;
+    public const PUBLISHED = 2;
 
     /**
      * Document is not published.
      */
-    const TEST = 1;
+    public const TEST = 1;
 }

--- a/src/Sulu/Component/Content/Mapper/ContentEvents.php
+++ b/src/Sulu/Component/Content/Mapper/ContentEvents.php
@@ -21,40 +21,40 @@ final class ContentEvents
      *
      * @var string
      */
-    const NODE_POST_SAVE = 'sulu.content.node.post_save';
+    public const NODE_POST_SAVE = 'sulu.content.node.post_save';
 
     /**
      * Thrown before a structure node is persisted in the PHPCR session.
      *
      * @var string
      */
-    const NODE_PRE_SAVE = 'sulu.content.node.pre_save';
+    public const NODE_PRE_SAVE = 'sulu.content.node.pre_save';
 
     /**
      * Thrown after a node has been order. Note. Thrown before session is saved.
      *
      * @var string
      */
-    const NODE_ORDER = 'sulu.content.node.order';
+    public const NODE_ORDER = 'sulu.content.node.order';
 
     /**
      * Thrown before structure node is loaded.
      *
      * @var string
      */
-    const NODE_LOAD = 'sulu.content.node.load';
+    public const NODE_LOAD = 'sulu.content.node.load';
 
     /**
      * Thrown before a structure node is deleted.
      *
      * @var string
      */
-    const NODE_PRE_DELETE = 'sulu.content.node.pre_delete';
+    public const NODE_PRE_DELETE = 'sulu.content.node.pre_delete';
 
     /**
      * Thrown after a structure node is deleted.
      *
      * @var string
      */
-    const NODE_POST_DELETE = 'sulu.content.node.post_delete';
+    public const NODE_POST_DELETE = 'sulu.content.node.post_delete';
 }

--- a/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
@@ -31,9 +31,9 @@ class StructureXmlLoader extends AbstractLoader
 {
     use XmlParserTrait;
 
-    const SCHEME_PATH = '/schema/template-1.0.xsd';
+    public const SCHEME_PATH = '/schema/template-1.0.xsd';
 
-    const SCHEMA_NAMESPACE_URI = 'http://schemas.sulu.io/template/template';
+    public const SCHEMA_NAMESPACE_URI = 'http://schemas.sulu.io/template/template';
 
     /**
      * Tags that are required in template.

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/FallbackLocalizationSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/FallbackLocalizationSubscriberTest.php
@@ -24,9 +24,9 @@ use Sulu\Component\Webspace\Webspace;
 
 class FallbackLocalizationSubscriberTest extends SubscriberTestCase
 {
-    const FIX_LOCALE = 'en';
+    public const FIX_LOCALE = 'en';
 
-    const FIX_WEBSPACE = 'sulu_io';
+    public const FIX_WEBSPACE = 'sulu_io';
 
     /**
      * @var WebspaceManagerInterface

--- a/src/Sulu/Component/Content/Tests/Unit/Types/TextEditorTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Types/TextEditorTest.php
@@ -20,9 +20,9 @@ use Sulu\Component\Content\Types\TextEditor;
 
 class TextEditorTest extends TestCase
 {
-    const VALIDATE_REMOVED = 'removed';
+    public const VALIDATE_REMOVED = 'removed';
 
-    const VALIDATE_UNPUBLISHED = 'unpublished';
+    public const VALIDATE_UNPUBLISHED = 'unpublished';
 
     /**
      * @var MarkupParserInterface

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/ResourceLocatorStrategyInterface.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/ResourceLocatorStrategyInterface.php
@@ -19,9 +19,9 @@ use Sulu\Component\Content\Types\ResourceLocator\ResourceLocatorInformation;
  */
 interface ResourceLocatorStrategyInterface
 {
-    const INPUT_TYPE_LEAF = 'leaf';
+    public const INPUT_TYPE_LEAF = 'leaf';
 
-    const INPUT_TYPE_FULL = 'full';
+    public const INPUT_TYPE_FULL = 'full';
 
     /**
      * Returns the child part from the given resource segment.

--- a/src/Sulu/Component/Content/Types/TextEditor.php
+++ b/src/Sulu/Component/Content/Types/TextEditor.php
@@ -22,7 +22,7 @@ use Sulu\Component\Content\SimpleContentType;
  */
 class TextEditor extends SimpleContentType
 {
-    const INVALID_REGEX = '/(<%s-[a-z]+\b[^\/>]*)(\/>|>[^<]*<\/%s-[^\/>]*>)/';
+    public const INVALID_REGEX = '/(<%s-[a-z]+\b[^\/>]*)(\/>|>[^<]*<\/%s-[^\/>]*>)/';
 
     /**
      * @var MarkupParserInterface

--- a/src/Sulu/Component/CustomUrl/Generator/Generator.php
+++ b/src/Sulu/Component/CustomUrl/Generator/Generator.php
@@ -19,9 +19,9 @@ use Sulu\Component\Webspace\Url\ReplacerInterface;
  */
 class Generator implements GeneratorInterface
 {
-    const PREFIX_REGEX = '/^([^\/]*)(\*)(.*)$/';
+    public const PREFIX_REGEX = '/^([^\/]*)(\*)(.*)$/';
 
-    const POSTFIX_REGEX = '/^.*\/.*\*.*$/';
+    public const POSTFIX_REGEX = '/^.*\/.*\*.*$/';
 
     /**
      * @var ReplacerInterface

--- a/src/Sulu/Component/DocumentManager/Events.php
+++ b/src/Sulu/Component/DocumentManager/Events.php
@@ -19,32 +19,32 @@ class Events
      * Fired both when a document is updated and when it is persisted
      * for the first time.
      */
-    const PERSIST = 'sulu_document_manager.persist';
+    public const PERSIST = 'sulu_document_manager.persist';
 
     /**
      * Fired when a node is hydrated (a PHPCR node is mapped to a document).
      */
-    const HYDRATE = 'sulu_document_manager.hydrate';
+    public const HYDRATE = 'sulu_document_manager.hydrate';
 
     /**
      * Fired when a document is removed via. the document manager.
      */
-    const REMOVE = 'sulu_document_manager.remove';
+    public const REMOVE = 'sulu_document_manager.remove';
 
     /**
      * Fired when a document should be refreshed.
      */
-    const REFRESH = 'sulu_document_manager.refresh';
+    public const REFRESH = 'sulu_document_manager.refresh';
 
     /**
      * Fired when a document is copied via. the document manager.
      */
-    const COPY = 'sulu_document_manager.copy';
+    public const COPY = 'sulu_document_manager.copy';
 
     /**
      * Fired when a document is moved via. the document manager.
      */
-    const MOVE = 'sulu_document_manager.move';
+    public const MOVE = 'sulu_document_manager.move';
 
     /**
      * Fired when a document is created via. the document manager.
@@ -53,70 +53,70 @@ class Events
      *       it is fired when a NEW INSTANCE of a document is created from the document
      *       manager, look at the PERSIST event instead.
      */
-    const CREATE = 'sulu_document_manager.create';
+    public const CREATE = 'sulu_document_manager.create';
 
     /**
      * Fired when the document manager should be cleared (i.e. detach all documents).
      */
-    const CLEAR = 'sulu_document_manager.clear';
+    public const CLEAR = 'sulu_document_manager.clear';
 
     /**
      * Fired when the document manager find method is called.
      */
-    const FIND = 'sulu_document_manager.find';
+    public const FIND = 'sulu_document_manager.find';
 
     /**
      * Fired when the document manager reorder method is called.
      */
-    const REORDER = 'sulu_document_manager.reorder';
+    public const REORDER = 'sulu_document_manager.reorder';
 
     /**
      * Fired when the document manager publish method is called.
      */
-    const PUBLISH = 'sulu_document_manager.publish';
+    public const PUBLISH = 'sulu_document_manager.publish';
 
     /**
      * Fired when the document manager unpublish method is called.
      */
-    const UNPUBLISH = 'sulu_document_manager.unpublish';
+    public const UNPUBLISH = 'sulu_document_manager.unpublish';
 
     /**
      * Fired when the document discardDraft method is called.
      */
-    const REMOVE_DRAFT = 'sulu_document_manager.remove_draft';
+    public const REMOVE_DRAFT = 'sulu_document_manager.remove_draft';
 
     /**
      * Fired when the document manager requests that are flush to persistent storage happen.
      */
-    const FLUSH = 'sulu_document_manager.flush';
+    public const FLUSH = 'sulu_document_manager.flush';
 
     /**
      * Fired when a query should be created from a query string.
      */
-    const QUERY_CREATE = 'sulu_document_manager.query.create';
+    public const QUERY_CREATE = 'sulu_document_manager.query.create';
 
     /**
      * Fired when a new query builder should be created.
      */
-    const QUERY_CREATE_BUILDER = 'sulu_document_manager.query.create_builder';
+    public const QUERY_CREATE_BUILDER = 'sulu_document_manager.query.create_builder';
 
     /**
      * Fired when a PHPCR query should be executed.
      */
-    const QUERY_EXECUTE = 'sulu_document_manager.query.execute';
+    public const QUERY_EXECUTE = 'sulu_document_manager.query.execute';
 
     /**
      * Enables subscribers to define options.
      */
-    const CONFIGURE_OPTIONS = 'sulu_document_manager.configure_options';
+    public const CONFIGURE_OPTIONS = 'sulu_document_manager.configure_options';
 
     /**
      * Enables fields to be added to the mapping.
      */
-    const METADATA_LOAD = 'sulu_document_manager.metadata_load';
+    public const METADATA_LOAD = 'sulu_document_manager.metadata_load';
 
     /**
      * Fired when an old version of the document should be restored.
      */
-    const RESTORE = 'sulu_document_manager.restore';
+    public const RESTORE = 'sulu_document_manager.restore';
 }

--- a/src/Sulu/Component/DocumentManager/Query/Query.php
+++ b/src/Sulu/Component/DocumentManager/Query/Query.php
@@ -27,9 +27,9 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class Query
 {
-    const HYDRATE_DOCUMENT = 'document';
+    public const HYDRATE_DOCUMENT = 'document';
 
-    const HYDRATE_PHPCR = 'phpcr_node';
+    public const HYDRATE_PHPCR = 'phpcr_node';
 
     /**
      * @var QueryInterface

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Audit/TimestampSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Audit/TimestampSubscriber.php
@@ -29,9 +29,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class TimestampSubscriber implements EventSubscriberInterface
 {
-    const CREATED = 'created';
+    public const CREATED = 'created';
 
-    const CHANGED = 'changed';
+    public const CHANGED = 'changed';
 
     /**
      * @var PropertyEncoder

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/VersionSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/VersionSubscriber.php
@@ -32,7 +32,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class VersionSubscriber implements EventSubscriberInterface
 {
-    const VERSION_PROPERTY = 'sulu:versions';
+    public const VERSION_PROPERTY = 'sulu:versions';
 
     /**
      * @var SessionInterface

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/NodeManagerTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/NodeManagerTest.php
@@ -21,13 +21,13 @@ use Sulu\Component\DocumentManager\NodeManager;
 
 class NodeManagerTest extends TestCase
 {
-    const UUID1 = '0dd2270d-c1e1-4d4e-9b7c-6da0efb6e91d';
+    public const UUID1 = '0dd2270d-c1e1-4d4e-9b7c-6da0efb6e91d';
 
-    const PATH1 = '/path/to';
+    public const PATH1 = '/path/to';
 
-    const UUID2 = '1dd2270d-c1e1-4d4e-9b7c-6da0efb6e91d';
+    public const UUID2 = '1dd2270d-c1e1-4d4e-9b7c-6da0efb6e91d';
 
-    const PATH2 = '/path/to/this';
+    public const PATH2 = '/path/to/this';
 
     /**
      * @var NodeManager

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
@@ -28,7 +28,7 @@ use Symfony\Cmf\Api\Slugifier\SlugifierInterface;
 
 class AutoNameSubscriberTest extends TestCase
 {
-    const DEFAULT_LOCALE = 'en';
+    public const DEFAULT_LOCALE = 'en';
 
     /**
      * @var DocumentRegistry

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/InstantiatorSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/InstantiatorSubscriberTest.php
@@ -22,7 +22,7 @@ use Sulu\Component\DocumentManager\Subscriber\Core\InstantiatorSubscriber;
 
 class InstantiatorSubscriberTest extends TestCase
 {
-    const ALIAS = 'alias';
+    public const ALIAS = 'alias';
 
     private $subscriber;
 

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/GeneralSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/GeneralSubscriberTest.php
@@ -25,11 +25,11 @@ use Sulu\Component\DocumentManager\Subscriber\Phpcr\GeneralSubscriber;
 
 class GeneralSubscriberTest extends TestCase
 {
-    const SRC_PATH = '/path/to';
+    public const SRC_PATH = '/path/to';
 
-    const DST_PATH = '/dest/path';
+    public const DST_PATH = '/dest/path';
 
-    const DST_NAME = 'foo';
+    public const DST_NAME = 'foo';
 
     /**
      * @var NodeManager

--- a/src/Sulu/Component/HttpKernel/SuluKernel.php
+++ b/src/Sulu/Component/HttpKernel/SuluKernel.php
@@ -27,9 +27,9 @@ abstract class SuluKernel extends Kernel
 {
     use MicroKernelTrait;
 
-    const CONTEXT_ADMIN = 'admin';
+    public const CONTEXT_ADMIN = 'admin';
 
-    const CONTEXT_WEBSITE = 'website';
+    public const CONTEXT_WEBSITE = 'website';
 
     /**
      * @var string

--- a/src/Sulu/Component/Localization/Localization.php
+++ b/src/Sulu/Component/Localization/Localization.php
@@ -20,13 +20,13 @@ use Sulu\Component\Util\ArrayableInterface;
  */
 class Localization implements \JsonSerializable, ArrayableInterface
 {
-    const UNDERSCORE = 'de_at';
+    public const UNDERSCORE = 'de_at';
 
-    const DASH = 'de-at';
+    public const DASH = 'de-at';
 
-    const ISO6391 = 'de-AT';
+    public const ISO6391 = 'de-AT';
 
-    const LCID = 'de_AT';
+    public const LCID = 'de_AT';
 
     /**
      * Create an instance of localization for given locale.

--- a/src/Sulu/Component/Media/SystemCollections/SystemCollectionManagerInterface.php
+++ b/src/Sulu/Component/Media/SystemCollections/SystemCollectionManagerInterface.php
@@ -16,9 +16,9 @@ namespace Sulu\Component\Media\SystemCollections;
  */
 interface SystemCollectionManagerInterface
 {
-    const COLLECTION_TYPE = 'collection.system';
+    public const COLLECTION_TYPE = 'collection.system';
 
-    const COLLECTION_KEY = 'system_collections';
+    public const COLLECTION_KEY = 'system_collections';
 
     /**
      * Builds cache for system collections.

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/TimestampableSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/TimestampableSubscriber.php
@@ -23,9 +23,9 @@ use Sulu\Component\Persistence\Model\TimestampableInterface;
  */
 class TimestampableSubscriber implements EventSubscriber
 {
-    const CREATED_FIELD = 'created';
+    public const CREATED_FIELD = 'created';
 
-    const CHANGED_FIELD = 'changed';
+    public const CHANGED_FIELD = 'changed';
 
     public function getSubscribedEvents()
     {

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
@@ -29,9 +29,9 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  */
 class UserBlameSubscriber implements EventSubscriber
 {
-    const CHANGER_FIELD = 'changer';
+    public const CHANGER_FIELD = 'changer';
 
-    const CREATOR_FIELD = 'creator';
+    public const CREATOR_FIELD = 'creator';
 
     /**
      * @var TokenStorageInterface

--- a/src/Sulu/Component/Rest/Exception/ConstraintViolationException.php
+++ b/src/Sulu/Component/Rest/Exception/ConstraintViolationException.php
@@ -16,7 +16,7 @@ namespace Sulu\Component\Rest\Exception;
  */
 class ConstraintViolationException extends RestException
 {
-    const UNIQUE = 'unique';
+    public const UNIQUE = 'unique';
 
     /**
      * @var string

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineJoinDescriptor.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineJoinDescriptor.php
@@ -20,13 +20,13 @@ class DoctrineJoinDescriptor
 {
     use EncodeAliasTrait;
 
-    const JOIN_METHOD_LEFT = 'LEFT';
+    public const JOIN_METHOD_LEFT = 'LEFT';
 
-    const JOIN_METHOD_INNER = 'INNER';
+    public const JOIN_METHOD_INNER = 'INNER';
 
-    const JOIN_CONDITION_METHOD_ON = 'ON';
+    public const JOIN_CONDITION_METHOD_ON = 'ON';
 
-    const JOIN_CONDITION_METHOD_WITH = 'WITH';
+    public const JOIN_CONDITION_METHOD_WITH = 'WITH';
 
     /**
      * The name of the entity to join.

--- a/src/Sulu/Component/Rest/ListBuilder/Event/ListBuilderEvents.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Event/ListBuilderEvents.php
@@ -22,7 +22,7 @@ final class ListBuilderEvents
      *
      * @var string
      */
-    const LISTBUILDER_CREATE = 'sulu.listbuilder.create';
+    public const LISTBUILDER_CREATE = 'sulu.listbuilder.create';
 
     private function __construct()
     {

--- a/src/Sulu/Component/Rest/ListBuilder/FieldDescriptorInterface.php
+++ b/src/Sulu/Component/Rest/ListBuilder/FieldDescriptorInterface.php
@@ -18,19 +18,19 @@ use Sulu\Component\Rest\ListBuilder\Metadata\AbstractPropertyMetadata;
  */
 interface FieldDescriptorInterface
 {
-    const VISIBILITY_ALWAYS = 'always';
+    public const VISIBILITY_ALWAYS = 'always';
 
-    const VISIBILITY_NEVER = 'never';
+    public const VISIBILITY_NEVER = 'never';
 
-    const VISIBILITY_YES = 'yes';
+    public const VISIBILITY_YES = 'yes';
 
-    const VISIBILITY_NO = 'no';
+    public const VISIBILITY_NO = 'no';
 
-    const SEARCHABILITY_NEVER = 'never';
+    public const SEARCHABILITY_NEVER = 'never';
 
-    const SEARCHABILITY_YES = 'yes';
+    public const SEARCHABILITY_YES = 'yes';
 
-    const SEARCHABILITY_NO = 'no';
+    public const SEARCHABILITY_NO = 'no';
 
     /**
      * Returns the name of the field.

--- a/src/Sulu/Component/Rest/ListBuilder/ListBuilderInterface.php
+++ b/src/Sulu/Component/Rest/ListBuilder/ListBuilderInterface.php
@@ -23,25 +23,25 @@ use Sulu\Component\Security\Authentication\UserInterface;
  */
 interface ListBuilderInterface
 {
-    const WHERE_COMPARATOR_EQUAL = '=';
+    public const WHERE_COMPARATOR_EQUAL = '=';
 
-    const WHERE_COMPARATOR_UNEQUAL = '!=';
+    public const WHERE_COMPARATOR_UNEQUAL = '!=';
 
-    const WHERE_COMPARATOR_GREATER = '>';
+    public const WHERE_COMPARATOR_GREATER = '>';
 
-    const WHERE_COMPARATOR_GREATER_THAN = '>=';
+    public const WHERE_COMPARATOR_GREATER_THAN = '>=';
 
-    const WHERE_COMPARATOR_LESS = '<';
+    public const WHERE_COMPARATOR_LESS = '<';
 
-    const WHERE_COMPARATOR_LESS_THAN = '<=';
+    public const WHERE_COMPARATOR_LESS_THAN = '<=';
 
-    const SORTORDER_ASC = 'ASC';
+    public const SORTORDER_ASC = 'ASC';
 
-    const SORTORDER_DESC = 'DESC';
+    public const SORTORDER_DESC = 'DESC';
 
-    const CONJUNCTION_AND = 'AND';
+    public const CONJUNCTION_AND = 'AND';
 
-    const CONJUNCTION_OR = 'OR';
+    public const CONJUNCTION_OR = 'OR';
 
     /**
      * Sets all the field descriptors for the ListBuilder at once.

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/JoinMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/JoinMetadata.php
@@ -16,13 +16,13 @@ namespace Sulu\Component\Rest\ListBuilder\Metadata;
  */
 class JoinMetadata
 {
-    const JOIN_METHOD_LEFT = 'LEFT';
+    public const JOIN_METHOD_LEFT = 'LEFT';
 
-    const JOIN_METHOD_INNER = 'INNER';
+    public const JOIN_METHOD_INNER = 'INNER';
 
-    const JOIN_CONDITION_METHOD_ON = 'ON';
+    public const JOIN_CONDITION_METHOD_ON = 'ON';
 
-    const JOIN_CONDITION_METHOD_WITH = 'WITH';
+    public const JOIN_CONDITION_METHOD_WITH = 'WITH';
 
     /**
      * @var string

--- a/src/Sulu/Component/Security/Authentication/RoleInterface.php
+++ b/src/Sulu/Component/Security/Authentication/RoleInterface.php
@@ -23,7 +23,7 @@ use Sulu\Component\Persistence\Model\AuditableInterface;
  */
 interface RoleInterface extends AuditableInterface, SecurityIdentityInterface
 {
-    const IS_SULU_ANONYMOUS = 'IS_SULU_ANONYMOUS';
+    public const IS_SULU_ANONYMOUS = 'IS_SULU_ANONYMOUS';
 
     /**
      * Set name.

--- a/src/Sulu/Component/Security/Authorization/PermissionTypes.php
+++ b/src/Sulu/Component/Security/Authorization/PermissionTypes.php
@@ -16,17 +16,17 @@ namespace Sulu\Component\Security\Authorization;
  */
 final class PermissionTypes
 {
-    const VIEW = 'view';
+    public const VIEW = 'view';
 
-    const ADD = 'add';
+    public const ADD = 'add';
 
-    const EDIT = 'edit';
+    public const EDIT = 'edit';
 
-    const DELETE = 'delete';
+    public const DELETE = 'delete';
 
-    const ARCHIVE = 'archive';
+    public const ARCHIVE = 'archive';
 
-    const LIVE = 'live';
+    public const LIVE = 'live';
 
-    const SECURITY = 'security';
+    public const SECURITY = 'security';
 }

--- a/src/Sulu/Component/Security/Event/SecurityEvents.php
+++ b/src/Sulu/Component/Security/Event/SecurityEvents.php
@@ -16,5 +16,5 @@ namespace Sulu\Component\Security\Event;
  */
 final class SecurityEvents
 {
-    const PERMISSION_UPDATE = 'sulu_security.permission_update';
+    public const PERMISSION_UPDATE = 'sulu_security.permission_update';
 }

--- a/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
+++ b/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
  */
 class RequestAnalyzer implements RequestAnalyzerInterface
 {
-    const SULU_ATTRIBUTE = '_sulu';
+    public const SULU_ATTRIBUTE = '_sulu';
 
     /**
      * @var RequestProcessorInterface[]

--- a/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzerInterface.php
+++ b/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzerInterface.php
@@ -29,28 +29,28 @@ interface RequestAnalyzerInterface
      *
      * A full match is when the URL completely starts with the given URL
      */
-    const MATCH_TYPE_FULL = 1;
+    public const MATCH_TYPE_FULL = 1;
 
     /**
      * Type for a partial match.
      *
      * A partial match is when only the partial URL matches the given URL
      */
-    const MATCH_TYPE_PARTIAL = 2;
+    public const MATCH_TYPE_PARTIAL = 2;
 
     /**
      * Type for a redirect.
      *
      * A redirect is when the given URL is just defined to be a redirect
      */
-    const MATCH_TYPE_REDIRECT = 3;
+    public const MATCH_TYPE_REDIRECT = 3;
 
     /**
      * Type for a wildcard url.
      *
      * The url contains a wildcard, which can be replaced with anything.
      */
-    const MATCH_TYPE_WILDCARD = 4;
+    public const MATCH_TYPE_WILDCARD = 4;
 
     /**
      * Analyzes the current request, and saves the values for portal, language, country and segment for further usage.

--- a/src/Sulu/Component/Webspace/Loader/BaseXmlFileLoader.php
+++ b/src/Sulu/Component/Webspace/Loader/BaseXmlFileLoader.php
@@ -21,9 +21,9 @@ use Symfony\Component\Config\Util\XmlUtils;
  */
 abstract class BaseXmlFileLoader extends FileLoader
 {
-    const SCHEMA_IDENTIFIER = 'http://schemas.sulu.io/webspace/webspace';
+    public const SCHEMA_IDENTIFIER = 'http://schemas.sulu.io/webspace/webspace';
 
-    const SCHEMA_URI = '';
+    public const SCHEMA_URI = '';
 
     public function supports($resource, $type = null)
     {

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
@@ -44,9 +44,9 @@ use Symfony\Component\Config\Util\XmlUtils;
  */
 class XmlFileLoader10 extends BaseXmlFileLoader
 {
-    const SCHEMA_LOCATION = '/schema/webspace/webspace-1.0.xsd';
+    public const SCHEMA_LOCATION = '/schema/webspace/webspace-1.0.xsd';
 
-    const SCHEMA_URI = 'http://schemas.sulu.io/webspace/webspace-1.0.xsd';
+    public const SCHEMA_URI = 'http://schemas.sulu.io/webspace/webspace-1.0.xsd';
 
     /**
      * @var \DOMXPath

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader11.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader11.php
@@ -20,9 +20,9 @@ use Sulu\Component\Webspace\Webspace;
  */
 class XmlFileLoader11 extends XmlFileLoader10
 {
-    const SCHEMA_LOCATION = '/schema/webspace/webspace-1.1.xsd';
+    public const SCHEMA_LOCATION = '/schema/webspace/webspace-1.1.xsd';
 
-    const SCHEMA_URI = 'http://schemas.sulu.io/webspace/webspace-1.1.xsd';
+    public const SCHEMA_URI = 'http://schemas.sulu.io/webspace/webspace-1.1.xsd';
 
     protected function parseXml($file)
     {

--- a/src/Sulu/Component/Webspace/Url/ReplacerInterface.php
+++ b/src/Sulu/Component/Webspace/Url/ReplacerInterface.php
@@ -16,15 +16,15 @@ namespace Sulu\Component\Webspace\Url;
  */
 interface ReplacerInterface
 {
-    const REPLACER_LANGUAGE = '{language}';
+    public const REPLACER_LANGUAGE = '{language}';
 
-    const REPLACER_COUNTRY = '{country}';
+    public const REPLACER_COUNTRY = '{country}';
 
-    const REPLACER_LOCALIZATION = '{localization}';
+    public const REPLACER_LOCALIZATION = '{localization}';
 
-    const REPLACER_SEGMENT = '{segment}';
+    public const REPLACER_SEGMENT = '{segment}';
 
-    const REPLACER_HOST = '{host}';
+    public const REPLACER_HOST = '{host}';
 
     /**
      * Returns true if language replacer exists.


### PR DESCRIPTION
#### What's in this PR?

This PR updates the `friendsofphp/php-cs-fixer` to version 3. The currently used version 2.19 is deprecated.

See https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/tag/v3.0.0
