### PR TITLE
Update friendsofphp/php-cs-fixer package to version 3

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -146,7 +146,7 @@ jobs:
             - name: Run php-cs-fixer
               if: ${{ matrix.php-cs-fixer }}
               run: |
-                  composer global require friendsofphp/php-cs-fixer:^2.17 --prefer-dist --no-interaction
+                  composer global require friendsofphp/php-cs-fixer:^3.0 --prefer-dist --no-interaction
                   GLOBAL_BIN_DIR=$(composer global config bin-dir --absolute --quiet)
                   $GLOBAL_BIN_DIR/php-cs-fixer fix --dry-run --diff
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@
 
 npm-debug.log
 package-lock.json
-.php_cs.cache
+.php-cs-fixer.cache
 .env.local
 
 # .DS_Store

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -12,8 +12,8 @@ EOF;
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__);
 
-return PhpCsFixer\Config::create()
-    ->setRiskyAllowed(true)
+$config = new PhpCsFixer\Config();
+$config->setRiskyAllowed(true)
     ->setRules([
         '@Symfony' => true,
         'array_syntax' => ['syntax' => 'short'],
@@ -23,7 +23,7 @@ return PhpCsFixer\Config::create()
         'header_comment' => ['header' => $header],
         'native_constant_invocation' => true,
         'native_function_casing' => true,
-        'native_function_invocation' => true,
+        'native_function_invocation' => ['include' => ['@internal']],
         'no_superfluous_phpdoc_tags' => ['allow_mixed' => true, 'remove_inheritdoc' => true],
         'ordered_imports' => true,
         'phpdoc_align' => ['align' => 'left'],
@@ -31,3 +31,5 @@ return PhpCsFixer\Config::create()
         'single_line_throw' => false,
     ])
     ->setFinder($finder);
+
+return $config;

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/AddAdminPass.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/AddAdminPass.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class AddAdminPass implements CompilerPassInterface
 {
-    const ADMIN_TAG = 'sulu.admin';
+    public const ADMIN_TAG = 'sulu.admin';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/AddJsConfigPass.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/AddJsConfigPass.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class AddJsConfigPass implements CompilerPassInterface
 {
-    const CONFIG_TAG = 'sulu.js_config';
+    public const CONFIG_TAG = 'sulu.js_config';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/AdminBundle/Navigation/ContentNavigationItem.php
+++ b/src/Sulu/Bundle/AdminBundle/Navigation/ContentNavigationItem.php
@@ -16,9 +16,9 @@ namespace Sulu\Bundle\AdminBundle\Navigation;
  */
 class ContentNavigationItem
 {
-    const DISPLAY_NEW = 'new';
+    public const DISPLAY_NEW = 'new';
 
-    const DISPLAY_EDIT = 'edit';
+    public const DISPLAY_EDIT = 'edit';
 
     /**
      * The id of the navigation item.

--- a/src/Sulu/Bundle/AdminBundle/Navigation/DisplayCondition.php
+++ b/src/Sulu/Bundle/AdminBundle/Navigation/DisplayCondition.php
@@ -16,9 +16,9 @@ namespace Sulu\Bundle\AdminBundle\Navigation;
  */
 class DisplayCondition implements \JsonSerializable
 {
-    const OPERATOR_EQUAL = 'eq';
+    public const OPERATOR_EQUAL = 'eq';
 
-    const OPERATOR_NOT_EQUAL = 'neq';
+    public const OPERATOR_NOT_EQUAL = 'neq';
 
     /**
      * @var string

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Admin/AudienceTargetingAdmin.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Admin/AudienceTargetingAdmin.php
@@ -22,7 +22,7 @@ use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
  */
 class AudienceTargetingAdmin extends Admin
 {
-    const SECURITY_CONTEXT = 'sulu.settings.target-groups';
+    public const SECURITY_CONTEXT = 'sulu.settings.target-groups';
 
     /**
      * @var SecurityCheckerInterface

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroupRuleInterface.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroupRuleInterface.php
@@ -16,17 +16,17 @@ namespace Sulu\Bundle\AudienceTargetingBundle\Entity;
  */
 interface TargetGroupRuleInterface
 {
-    const FREQUENCY_HIT = 1;
+    public const FREQUENCY_HIT = 1;
 
-    const FREQUENCY_SESSION = 2;
+    public const FREQUENCY_SESSION = 2;
 
-    const FREQUENCY_VISITOR = 3;
+    public const FREQUENCY_VISITOR = 3;
 
-    const FREQUENCY_HIT_NAME = 'hit';
+    public const FREQUENCY_HIT_NAME = 'hit';
 
-    const FREQUENCY_SESSION_NAME = 'session';
+    public const FREQUENCY_SESSION_NAME = 'session';
 
-    const FREQUENCY_VISITOR_NAME = 'visitor';
+    public const FREQUENCY_VISITOR_NAME = 'visitor';
 
     /**
      * @return int

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Rule/BrowserRule.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Rule/BrowserRule.php
@@ -18,7 +18,7 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class BrowserRule implements RuleInterface
 {
-    const BROWSER = 'browser';
+    public const BROWSER = 'browser';
 
     private static $browsers = ['Chrome', 'Firefox', 'Internet Explorer', 'Opera', 'Safari'];
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Rule/DeviceTypeRule.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Rule/DeviceTypeRule.php
@@ -20,13 +20,13 @@ use Symfony\Component\Translation\TranslatorInterface;
  */
 class DeviceTypeRule implements RuleInterface
 {
-    const DEVICE_TYPE = 'device_type';
+    public const DEVICE_TYPE = 'device_type';
 
-    const SMARTPHONE = 'smartphone';
+    public const SMARTPHONE = 'smartphone';
 
-    const TABLET = 'tablet';
+    public const TABLET = 'tablet';
 
-    const DESKTOP = 'desktop';
+    public const DESKTOP = 'desktop';
 
     private static $deviceTypes = [self::SMARTPHONE, self::TABLET, self::DESKTOP];
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Rule/LocaleRule.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Rule/LocaleRule.php
@@ -20,7 +20,7 @@ use Symfony\Component\Translation\TranslatorInterface;
  */
 class LocaleRule implements RuleInterface
 {
-    const LOCALE = 'locale';
+    public const LOCALE = 'locale';
 
     /**
      * @var RequestStack

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Rule/OperatingSystemRule.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Rule/OperatingSystemRule.php
@@ -18,7 +18,7 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class OperatingSystemRule implements RuleInterface
 {
-    const OPERATING_SYSTEM = 'os';
+    public const OPERATING_SYSTEM = 'os';
 
     private static $operatingSystems = ['Android', 'iOS', 'GNU/Linux', 'Mac', 'Windows'];
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Rule/ReferrerRule.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Rule/ReferrerRule.php
@@ -17,7 +17,7 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class ReferrerRule implements RuleInterface
 {
-    const REFERRER = 'referrer';
+    public const REFERRER = 'referrer';
 
     /**
      * @var RequestStack

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Functional/Controller/TargetGroupControllerTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Functional/Controller/TargetGroupControllerTest.php
@@ -20,7 +20,7 @@ use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
 class TargetGroupControllerTest extends SuluTestCase
 {
-    const BASE_URL = 'api/target-groups';
+    public const BASE_URL = 'api/target-groups';
 
     /**
      * @var TargetGroupInterface

--- a/src/Sulu/Bundle/CategoryBundle/Category/KeywordManagerInterface.php
+++ b/src/Sulu/Bundle/CategoryBundle/Category/KeywordManagerInterface.php
@@ -19,11 +19,11 @@ use Sulu\Bundle\CategoryBundle\Entity\KeywordInterface;
  */
 interface KeywordManagerInterface
 {
-    const FORCE_OVERWRITE = 'overwrite';
+    public const FORCE_OVERWRITE = 'overwrite';
 
-    const FORCE_DETACH = 'detach';
+    public const FORCE_DETACH = 'detach';
 
-    const FORCE_MERGE = 'merge';
+    public const FORCE_MERGE = 'merge';
 
     /**
      * Add given keyword to the category.

--- a/src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
@@ -35,11 +35,11 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class KeywordController extends RestController implements ClassResourceInterface, SecuredControllerInterface
 {
-    const FORCE_OVERWRITE = 'overwrite';
+    public const FORCE_OVERWRITE = 'overwrite';
 
-    const FORCE_DETACH = 'detach';
+    public const FORCE_DETACH = 'detach';
 
-    const FORCE_MERGE = 'merge';
+    public const FORCE_MERGE = 'merge';
 
     protected static $entityKey = 'keywords';
 

--- a/src/Sulu/Bundle/CategoryBundle/Event/CategoryEvents.php
+++ b/src/Sulu/Bundle/CategoryBundle/Event/CategoryEvents.php
@@ -19,5 +19,5 @@ final class CategoryEvents
      *
      * @var string
      */
-    const CATEGORY_DELETE = 'sulu.category.delete';
+    public const CATEGORY_DELETE = 'sulu.category.delete';
 }

--- a/src/Sulu/Bundle/ContactBundle/Api/Account.php
+++ b/src/Sulu/Bundle/ContactBundle/Api/Account.php
@@ -43,7 +43,7 @@ use Sulu\Component\Rest\ApiWrapper;
  */
 class Account extends ApiWrapper
 {
-    const TYPE = 'account';
+    public const TYPE = 'account';
 
     /**
      * @var Media

--- a/src/Sulu/Bundle/ContactBundle/Api/Contact.php
+++ b/src/Sulu/Bundle/ContactBundle/Api/Contact.php
@@ -42,7 +42,7 @@ use Sulu\Component\Security\Authentication\UserInterface;
  */
 class Contact extends ApiWrapper
 {
-    const TYPE = 'contact';
+    public const TYPE = 'contact';
 
     /**
      * @var Media

--- a/src/Sulu/Bundle/ContactBundle/Content/Types/ContactSelectionContentType.php
+++ b/src/Sulu/Bundle/ContactBundle/Content/Types/ContactSelectionContentType.php
@@ -31,9 +31,9 @@ use Sulu\Component\Content\PreResolvableContentTypeInterface;
  */
 class ContactSelectionContentType extends ComplexContentType implements ContentTypeExportInterface, PreResolvableContentTypeInterface
 {
-    const PREFIX_CONTACT = 'c';
+    public const PREFIX_CONTACT = 'c';
 
-    const PREFIX_ACCOUNT = 'a';
+    public const PREFIX_ACCOUNT = 'a';
 
     /**
      * @var string

--- a/src/Sulu/Bundle/ContentBundle/Admin/ContentAdmin.php
+++ b/src/Sulu/Bundle/ContentBundle/Admin/ContentAdmin.php
@@ -27,14 +27,14 @@ class ContentAdmin extends Admin
      *
      * @var string
      */
-    const SECURITY_CONTEXT_PREFIX = 'sulu.webspaces.';
+    public const SECURITY_CONTEXT_PREFIX = 'sulu.webspaces.';
 
     /**
      * The prefix for the settings security context, the key of the webspace has to be appended.
      *
      * @var string
      */
-    const SECURITY_SETTINGS_CONTEXT_PREFIX = 'sulu.webspace_settings.';
+    public const SECURITY_SETTINGS_CONTEXT_PREFIX = 'sulu.webspace_settings.';
 
     /**
      * @var WebspaceManagerInterface

--- a/src/Sulu/Bundle/ContentBundle/Admin/TextEditorJsConfig.php
+++ b/src/Sulu/Bundle/ContentBundle/Admin/TextEditorJsConfig.php
@@ -20,7 +20,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  */
 class TextEditorJsConfig implements JsConfigInterface
 {
-    const SETTING_KEY = 'texteditor-toolbar';
+    public const SETTING_KEY = 'texteditor-toolbar';
 
     /**
      * @var TokenStorageInterface

--- a/src/Sulu/Bundle/ContentBundle/Content/Structure/ExcerptStructureExtension.php
+++ b/src/Sulu/Bundle/ContentBundle/Content/Structure/ExcerptStructureExtension.php
@@ -32,7 +32,7 @@ class ExcerptStructureExtension extends AbstractExtension implements ExportExten
     /**
      * name of structure extension.
      */
-    const EXCERPT_EXTENSION_NAME = 'excerpt';
+    public const EXCERPT_EXTENSION_NAME = 'excerpt';
 
     /**
      * will be filled with data in constructor

--- a/src/Sulu/Bundle/ContentBundle/Content/Structure/SeoStructureExtension.php
+++ b/src/Sulu/Bundle/ContentBundle/Content/Structure/SeoStructureExtension.php
@@ -23,7 +23,7 @@ class SeoStructureExtension extends AbstractExtension implements ExportExtension
     /**
      * name of structure extension.
      */
-    const SEO_EXTENSION_NAME = 'seo';
+    public const SEO_EXTENSION_NAME = 'seo';
 
     protected $seoAttributes = [
         'hideInSitemap',

--- a/src/Sulu/Bundle/ContentBundle/Controller/NodeController.php
+++ b/src/Sulu/Bundle/ContentBundle/Controller/NodeController.php
@@ -51,9 +51,9 @@ class NodeController extends RestController implements ClassResourceInterface, S
 {
     use RequestParametersTrait;
 
-    const WEBSPACE_NODE_SINGLE = 'single';
+    public const WEBSPACE_NODE_SINGLE = 'single';
 
-    const WEBSPACE_NODES_ALL = 'all';
+    public const WEBSPACE_NODES_ALL = 'all';
 
     private static $relationName = 'nodes';
 

--- a/src/Sulu/Bundle/ContentBundle/DependencyInjection/Compiler/ContentExportCompilerPass.php
+++ b/src/Sulu/Bundle/ContentBundle/DependencyInjection/Compiler/ContentExportCompilerPass.php
@@ -20,9 +20,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class ContentExportCompilerPass implements CompilerPassInterface
 {
-    const CONTENT_EXPORT_SERVICE_ID = 'sulu_content.export.manager';
+    public const CONTENT_EXPORT_SERVICE_ID = 'sulu_content.export.manager';
 
-    const STRUCTURE_EXTENSION_TAG = 'sulu.content.export';
+    public const STRUCTURE_EXTENSION_TAG = 'sulu.content.export';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/ContentBundle/DependencyInjection/Compiler/SmartContentDataProviderCompilerPass.php
+++ b/src/Sulu/Bundle/ContentBundle/DependencyInjection/Compiler/SmartContentDataProviderCompilerPass.php
@@ -20,9 +20,9 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class SmartContentDataProviderCompilerPass implements CompilerPassInterface
 {
-    const POOL_SERVICE_ID = 'sulu_content.smart_content.data_provider_pool';
+    public const POOL_SERVICE_ID = 'sulu_content.smart_content.data_provider_pool';
 
-    const STRUCTURE_EXTENSION_TAG = 'sulu.smart_content.data_provider';
+    public const STRUCTURE_EXTENSION_TAG = 'sulu.smart_content.data_provider';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/ContentBundle/DependencyInjection/Compiler/StructureExtensionCompilerPass.php
+++ b/src/Sulu/Bundle/ContentBundle/DependencyInjection/Compiler/StructureExtensionCompilerPass.php
@@ -20,9 +20,9 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class StructureExtensionCompilerPass implements CompilerPassInterface
 {
-    const STRUCTURE_MANAGER_ID = 'sulu_content.extension.manager';
+    public const STRUCTURE_MANAGER_ID = 'sulu_content.extension.manager';
 
-    const STRUCTURE_EXTENSION_TAG = 'sulu.structure.extension';
+    public const STRUCTURE_EXTENSION_TAG = 'sulu.structure.extension';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/ContentBundle/Markup/LinkTag.php
+++ b/src/Sulu/Bundle/ContentBundle/Markup/LinkTag.php
@@ -20,11 +20,11 @@ use Sulu\Bundle\MarkupBundle\Tag\TagInterface;
  */
 class LinkTag implements TagInterface
 {
-    const VALIDATE_UNPUBLISHED = 'unpublished';
+    public const VALIDATE_UNPUBLISHED = 'unpublished';
 
-    const VALIDATE_REMOVED = 'removed';
+    public const VALIDATE_REMOVED = 'removed';
 
-    const DEFAULT_PROVIDER = 'page';
+    public const DEFAULT_PROVIDER = 'page';
 
     /**
      * @var LinkProviderPoolInterface

--- a/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201507231648.php
+++ b/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201507231648.php
@@ -20,15 +20,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class Version201507231648 implements VersionInterface, ContainerAwareInterface
 {
-    const SHADOW_ON_PROPERTY = 'i18n:%s-shadow-on';
+    public const SHADOW_ON_PROPERTY = 'i18n:%s-shadow-on';
 
-    const SHADOW_BASE_PROPERTY = 'i18n:%s-shadow-base';
+    public const SHADOW_BASE_PROPERTY = 'i18n:%s-shadow-base';
 
-    const TAGS_PROPERTY = 'i18n:%s-excerpt-tags';
+    public const TAGS_PROPERTY = 'i18n:%s-excerpt-tags';
 
-    const CATEGORIES_PROPERTY = 'i18n:%s-excerpt-categories';
+    public const CATEGORIES_PROPERTY = 'i18n:%s-excerpt-categories';
 
-    const NAVIGATION_CONTEXT_PROPERTY = 'i18n:%s-navContexts';
+    public const NAVIGATION_CONTEXT_PROPERTY = 'i18n:%s-navContexts';
 
     /**
      * @var ContainerInterface

--- a/src/Sulu/Bundle/ContentBundle/Rule/PageRule.php
+++ b/src/Sulu/Bundle/ContentBundle/Rule/PageRule.php
@@ -22,7 +22,7 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class PageRule implements RuleInterface
 {
-    const PAGE = 'page';
+    public const PAGE = 'page';
 
     /**
      * @var RequestStack

--- a/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureProvider.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureProvider.php
@@ -42,11 +42,11 @@ use Sulu\Component\DocumentManager\Metadata\MetadataFactory;
  */
 class StructureProvider implements ProviderInterface
 {
-    const FIELD_STRUCTURE_TYPE = '_structure_type';
+    public const FIELD_STRUCTURE_TYPE = '_structure_type';
 
-    const FIELD_TEASER_DESCRIPTION = '_teaser_description';
+    public const FIELD_TEASER_DESCRIPTION = '_teaser_description';
 
-    const FIELD_TEASER_MEDIA = '_teaser_media';
+    public const FIELD_TEASER_MEDIA = '_teaser_media';
 
     /**
      * @var Factory

--- a/src/Sulu/Bundle/ContentBundle/Tests/Fixtures/DefaultStructureCache.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Fixtures/DefaultStructureCache.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Bundle\ContentBundle\Tests\Fixtures;
 
-use Sulu\Component\Content\Block\BlockProperty;
-use Sulu\Component\Content\Block\BlockPropertyType;
 use Sulu\Component\Content\Compat\Property;
 use Sulu\Component\Content\Compat\PropertyTag;
 use Sulu\Component\Content\Compat\Structure\Page;

--- a/src/Sulu/Bundle/ContentBundle/Tests/Fixtures/SecondStructureCache.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Fixtures/SecondStructureCache.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Bundle\ContentBundle\Tests\Fixtures;
 
-use Sulu\Component\Content\Block\BlockProperty;
-use Sulu\Component\Content\Block\BlockPropertyType;
 use Sulu\Component\Content\Compat\Property;
 use Sulu\Component\Content\Compat\PropertyTag;
 use Sulu\Component\Content\Compat\Structure\Page;

--- a/src/Sulu/Bundle/ContentBundle/Twig/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/ContentBundle/Twig/ContentTwigExtension.php
@@ -79,7 +79,7 @@ class ContentTwigExtension extends \Twig_Extension
 
         foreach ($arrays as $array) {
             \reset($base);
-            while (list($key, $value) = @\each($array)) {
+            while (list($key, $value) = @each($array)) {
                 if (\is_array($value) && @\is_array($base[$key])) {
                     $base[$key] = $this->mergeRecursive($base[$key], $value);
                 } else {

--- a/src/Sulu/Bundle/CoreBundle/Composer/ScriptHandler.php
+++ b/src/Sulu/Bundle/CoreBundle/Composer/ScriptHandler.php
@@ -16,7 +16,7 @@ namespace Sulu\Bundle\CoreBundle\Composer;
  */
 class ScriptHandler
 {
-    const GIT_IGNORE_FILE = '.gitignore';
+    public const GIT_IGNORE_FILE = '.gitignore';
 
     /**
      * Removes the composer.lock file from .gitignore, because we don't want the composer.lock to be included in our

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/ListBuilderMetadataProviderCompilerPass.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/ListBuilderMetadataProviderCompilerPass.php
@@ -20,9 +20,9 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class ListBuilderMetadataProviderCompilerPass implements CompilerPassInterface
 {
-    const CHAIN_PROVIDER_ID = 'sulu_core.list_builder.metadata.provider.chain';
+    public const CHAIN_PROVIDER_ID = 'sulu_core.list_builder.metadata.provider.chain';
 
-    const PROVIDER_TAG_ID = 'sulu.list-builder.metadata.provider';
+    public const PROVIDER_TAG_ID = 'sulu.list-builder.metadata.provider';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RegisterContentTypesCompilerPass.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RegisterContentTypesCompilerPass.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class RegisterContentTypesCompilerPass implements CompilerPassInterface
 {
-    const CONTENT_TYPE_TAG = 'sulu.content.type';
+    public const CONTENT_TYPE_TAG = 'sulu.content.type';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RegisterLocalizationProvidersPass.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RegisterLocalizationProvidersPass.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class RegisterLocalizationProvidersPass implements CompilerPassInterface
 {
-    const LOCALIZATION_PROVIDER_TAG = 'sulu.localization_provider';
+    public const LOCALIZATION_PROVIDER_TAG = 'sulu.localization_provider';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RemoveForeignContextServicesPass.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RemoveForeignContextServicesPass.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class RemoveForeignContextServicesPass implements CompilerPassInterface
 {
-    const SULU_CONTEXT_TAG = 'sulu.context';
+    public const SULU_CONTEXT_TAG = 'sulu.context';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/SubscriberDebugCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/SubscriberDebugCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SubscriberDebugCommand extends ContainerAwareCommand
 {
-    const PREFIX = 'sulu_document_manager.';
+    public const PREFIX = 'sulu_document_manager.';
 
     public function configure()
     {

--- a/src/Sulu/Bundle/DocumentManagerBundle/Document/Subscriber/SecuritySubscriber.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Document/Subscriber/SecuritySubscriber.php
@@ -23,7 +23,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  */
 class SecuritySubscriber implements EventSubscriberInterface
 {
-    const USER_OPTION = 'user';
+    public const USER_OPTION = 'user';
 
     /**
      * @var TokenStorageInterface

--- a/src/Sulu/Bundle/LocationBundle/Geolocator/Service/GoogleGeolocator.php
+++ b/src/Sulu/Bundle/LocationBundle/Geolocator/Service/GoogleGeolocator.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
  */
 class GoogleGeolocator implements GeolocatorInterface
 {
-    const ENDPOINT = 'https://maps.googleapis.com/maps/api/geocode/json';
+    public const ENDPOINT = 'https://maps.googleapis.com/maps/api/geocode/json';
 
     /**
      * @var ClientInterface

--- a/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/ParserCompilerPass.php
+++ b/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/ParserCompilerPass.php
@@ -20,11 +20,11 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class ParserCompilerPass implements CompilerPassInterface
 {
-    const SERVICE_ID = 'sulu_markup.response_listener';
+    public const SERVICE_ID = 'sulu_markup.response_listener';
 
-    const TAG_NAME = 'sulu_markup.parser';
+    public const TAG_NAME = 'sulu_markup.parser';
 
-    const TYPE_ATTRIBUTE = 'type';
+    public const TYPE_ATTRIBUTE = 'type';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/TagCompilerPass.php
+++ b/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/TagCompilerPass.php
@@ -20,15 +20,15 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class TagCompilerPass implements CompilerPassInterface
 {
-    const SERVICE_ID = 'sulu_markup.tag.registry';
+    public const SERVICE_ID = 'sulu_markup.tag.registry';
 
-    const TAG_NAME = 'sulu_markup.tag';
+    public const TAG_NAME = 'sulu_markup.tag';
 
-    const NAMESPACE_ATTRIBUTE = 'namespace';
+    public const NAMESPACE_ATTRIBUTE = 'namespace';
 
-    const TAG_ATTRIBUTE = 'tag';
+    public const TAG_ATTRIBUTE = 'tag';
 
-    const TYPE_ATTRIBUTE = 'type';
+    public const TYPE_ATTRIBUTE = 'type';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/MarkupBundle/Markup/HtmlTagExtractor.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/HtmlTagExtractor.php
@@ -16,11 +16,11 @@ namespace Sulu\Bundle\MarkupBundle\Markup;
  */
 class HtmlTagExtractor implements TagExtractorInterface
 {
-    const COUNT_REGEX = '/<%1$s:[a-z]+/';
+    public const COUNT_REGEX = '/<%1$s:[a-z]+/';
 
-    const ATTRIBUTE_REGEX = '/(?<name>\b[\w-]+\b)\s*=\s*"(?<value>[^"]*)"/';
+    public const ATTRIBUTE_REGEX = '/(?<name>\b[\w-]+\b)\s*=\s*"(?<value>[^"]*)"/';
 
-    const TAG_REGEX = '/(?<tag><%1$s:(?<name>[a-z]+)(?<attributes>(?:(?!>|\/>).)*)(?:\/>|>(?<content>(?:(?!<\/%1$s:\2>).)*)<\/%1$s:\2>))/s';
+    public const TAG_REGEX = '/(?<tag><%1$s:(?<name>[a-z]+)(?<attributes>(?:(?!>|\/>).)*)(?:\/>|>(?<content>(?:(?!<\/%1$s:\2>).)*)<\/%1$s:\2>))/s';
 
     /**
      * @var string

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlMarkupParserTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlMarkupParserTest.php
@@ -21,9 +21,9 @@ use Sulu\Bundle\MarkupBundle\Tag\TagRegistryInterface;
 
 class HtmlMarkupParserTest extends \PHPUnit_Framework_TestCase
 {
-    const VALIDATE_UNPUBLISHED = 'unpublished';
+    public const VALIDATE_UNPUBLISHED = 'unpublished';
 
-    const VALIDATE_REMOVED = 'removed';
+    public const VALIDATE_REMOVED = 'removed';
 
     /**
      * @var TagInterface

--- a/src/Sulu/Bundle/MediaBundle/Api/Media.php
+++ b/src/Sulu/Bundle/MediaBundle/Api/Media.php
@@ -42,22 +42,22 @@ class Media extends ApiWrapper
     /**
      * @var string
      */
-    const MEDIA_TYPE_IMAGE = 'image';
+    public const MEDIA_TYPE_IMAGE = 'image';
 
     /**
      * @var string
      */
-    const MEDIA_TYPE_VIDEO = 'video';
+    public const MEDIA_TYPE_VIDEO = 'video';
 
     /**
      * @var string
      */
-    const MEDIA_TYPE_AUDIO = 'audio';
+    public const MEDIA_TYPE_AUDIO = 'audio';
 
     /**
      * @var string
      */
-    const MEDIA_TYPE_DOCUMENT = 'document';
+    public const MEDIA_TYPE_DOCUMENT = 'document';
 
     /**
      * @var string

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/ImageTransformationCompilerPass.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/ImageTransformationCompilerPass.php
@@ -20,9 +20,9 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class ImageTransformationCompilerPass implements CompilerPassInterface
 {
-    const POOL_SERVICE_ID = 'sulu_media.image.transformation_pool';
+    public const POOL_SERVICE_ID = 'sulu_media.image.transformation_pool';
 
-    const TAG = 'sulu_media.image.transformation';
+    public const TAG = 'sulu_media.image.transformation';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/MediaBundle/Markup/MediaTag.php
+++ b/src/Sulu/Bundle/MediaBundle/Markup/MediaTag.php
@@ -20,7 +20,7 @@ use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
  */
 class MediaTag implements TagInterface
 {
-    const VALIDATE_REMOVED = 'removed';
+    public const VALIDATE_REMOVED = 'removed';
 
     /**
      * @var string

--- a/src/Sulu/Bundle/MediaBundle/Media/Exception/MediaException.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Exception/MediaException.php
@@ -23,175 +23,175 @@ class MediaException extends Exception
      *
      * @var int
      */
-    const EXCEPTION_CODE_UPLOAD_ERROR = 5001;
+    public const EXCEPTION_CODE_UPLOAD_ERROR = 5001;
 
     /**
      * The uploaded file was not found.
      *
      * @var int
      */
-    const EXCEPTION_CODE_UPLOADED_FILE_NOT_FOUND = 5002;
+    public const EXCEPTION_CODE_UPLOADED_FILE_NOT_FOUND = 5002;
 
     /**
      * The file is bigger as the max file size in the config.
      *
      * @var int
      */
-    const EXCEPTION_CODE_MAX_FILE_SIZE = 5003;
+    public const EXCEPTION_CODE_MAX_FILE_SIZE = 5003;
 
     /**
      * The file mime type is not supported.
      *
      * @var int
      */
-    const EXCEPTION_CODE_BLOCKED_FILE_TYPE = 5004;
+    public const EXCEPTION_CODE_BLOCKED_FILE_TYPE = 5004;
 
     /**
      * The collection was not found.
      *
      * @var int
      */
-    const EXCEPTION_CODE_COLLECTION_NOT_FOUND = 5005;
+    public const EXCEPTION_CODE_COLLECTION_NOT_FOUND = 5005;
 
     /**
      * The file version was not found.
      *
      * @var int
      */
-    const EXCEPTION_CODE_FILE_VERSION_NOT_FOUND = 5006;
+    public const EXCEPTION_CODE_FILE_VERSION_NOT_FOUND = 5006;
 
     /**
      * The file has not the correct media type as the followed file versions.
      *
      * @var int
      */
-    const EXCEPTION_CODE_INVALID_MEDIA_TYPE = 5007;
+    public const EXCEPTION_CODE_INVALID_MEDIA_TYPE = 5007;
 
     /**
      * Image id was not found in request.
      *
      * @var int
      */
-    const EXCEPTION_CODE_IMAGE_PROXY_MEDIA_ID_NOT_FOUND = 5008;
+    public const EXCEPTION_CODE_IMAGE_PROXY_MEDIA_ID_NOT_FOUND = 5008;
 
     /**
      * Media not loaded by proxy id.
      *
      * @var int
      */
-    const EXCEPTION_CODE_IMAGE_PROXY_MEDIA_NOT_FOUND = 5009;
+    public const EXCEPTION_CODE_IMAGE_PROXY_MEDIA_NOT_FOUND = 5009;
 
     /**
      * Original image not found.
      *
      * @var int
      */
-    const EXCEPTION_CODE_IMAGE_PROXY_ORIGINAL_NOT_FOUND = 5010;
+    public const EXCEPTION_CODE_IMAGE_PROXY_ORIGINAL_NOT_FOUND = 5010;
 
     /**
      * The image url was not found.
      *
      * @var int
      */
-    const EXCEPTION_CODE_IMAGE_PROXY_URL_NOT_FOUND = 5011;
+    public const EXCEPTION_CODE_IMAGE_PROXY_URL_NOT_FOUND = 5011;
 
     /**
      * The image url was not valid.
      *
      * @var int
      */
-    const EXCEPTION_CODE_IMAGE_PROXY_INVALID_URL = 5012;
+    public const EXCEPTION_CODE_IMAGE_PROXY_INVALID_URL = 5012;
 
     /**
      * the image format was not found.
      *
      * @var int
      */
-    const EXCEPTION_CODE_IMAGE_PROXY_INVALID_IMAGE_FORMAT = 5013;
+    public const EXCEPTION_CODE_IMAGE_PROXY_INVALID_IMAGE_FORMAT = 5013;
 
     /**
      * The configured format options are invalid.
      *
      * @var int
      */
-    const EXCEPTION_CODE_IMAGE_PROXY_INVALID_FORMAT_OPTIONS = 5014;
+    public const EXCEPTION_CODE_IMAGE_PROXY_INVALID_FORMAT_OPTIONS = 5014;
 
     /**
      * The media was not found.
      *
      * @var int
      */
-    const EXCEPTION_CODE_MEDIA_NOT_FOUND = 5015;
+    public const EXCEPTION_CODE_MEDIA_NOT_FOUND = 5015;
 
     /**
      * The collection type was not found.
      *
      * @var int
      */
-    const EXCEPTION_CODE_COLLECTION_TYPE_NOT_FOUND = 5016;
+    public const EXCEPTION_CODE_COLLECTION_TYPE_NOT_FOUND = 5016;
 
     /**
      * The media type was not found.
      *
      * @var int
      */
-    const EXCEPTION_CODE_MEDIA_TYPE_NOT_FOUND = 5017;
+    public const EXCEPTION_CODE_MEDIA_TYPE_NOT_FOUND = 5017;
 
     /**
      * No previews are generated for this extension.
      *
      * @var int
      */
-    const EXCEPTION_INVALID_MIMETYPE_FOR_PREVIEW = 5018;
+    public const EXCEPTION_INVALID_MIMETYPE_FOR_PREVIEW = 5018;
 
     /**
      * Ghostscript was not found at location.
      *
      * @var int
      */
-    const EXCEPTION_CODE_GHOST_SCRIPT_NOT_FOUND = 5019;
+    public const EXCEPTION_CODE_GHOST_SCRIPT_NOT_FOUND = 5019;
 
     /**
      * A file with this name exists.
      *
      * @var int
      */
-    const EXCEPTION_FILENAME_ALREADY_EXISTS = 5020;
+    public const EXCEPTION_FILENAME_ALREADY_EXISTS = 5020;
 
     /**
      * File is not found in media object.
      *
      * @var int
      */
-    const EXCEPTION_CODE_FILE_NOT_FOUND = 5021;
+    public const EXCEPTION_CODE_FILE_NOT_FOUND = 5021;
 
     /**
      * Format cache is not found.
      *
      * @var int
      */
-    const EXCEPTION_CACHE_NOT_FOUND = 5022;
+    public const EXCEPTION_CACHE_NOT_FOUND = 5022;
 
     /**
      * Systemfile is not found.
      *
      * @var int
      */
-    const EXCEPTION_CODE_ORIGINAL_FILE_NOT_FOUND = 5027;
+    public const EXCEPTION_CODE_ORIGINAL_FILE_NOT_FOUND = 5027;
 
     /**
      * Format is not found.
      *
      * @var int
      */
-    const EXCEPTION_FORMAT_NOT_FOUND = 5028;
+    public const EXCEPTION_FORMAT_NOT_FOUND = 5028;
 
     /**
      * Format options parameter is missing.
      *
      * @var int
      */
-    const EXCEPTION_FORMAT_OPTIONS_MISSING_PARAMETER = 5029;
+    public const EXCEPTION_FORMAT_OPTIONS_MISSING_PARAMETER = 5029;
 
     public function toArray()
     {

--- a/src/Sulu/Bundle/MediaBundle/Media/FileValidator/FileValidatorInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FileValidator/FileValidatorInterface.php
@@ -19,13 +19,13 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
  */
 interface FileValidatorInterface
 {
-    const VALIDATOR_FILE_SET = 'FILE_SET';
+    public const VALIDATOR_FILE_SET = 'FILE_SET';
 
-    const VALIDATOR_FILE_ERRORS = 'FILE_ERRORS';
+    public const VALIDATOR_FILE_ERRORS = 'FILE_ERRORS';
 
-    const VALIDATOR_BLOCK_FILE_TYPES = 'BLOCK_FILE_TYPES';
+    public const VALIDATOR_BLOCK_FILE_TYPES = 'BLOCK_FILE_TYPES';
 
-    const VALIDATOR_MAX_FILE_SIZE = 'MAX_FILE_SIZE';
+    public const VALIDATOR_MAX_FILE_SIZE = 'MAX_FILE_SIZE';
 
     /**
      * Validated a given file.

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/BaseXmlFormatLoader.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/BaseXmlFormatLoader.php
@@ -20,15 +20,15 @@ use Symfony\Component\Config\Util\XmlUtils;
  */
 abstract class BaseXmlFormatLoader extends FileLoader
 {
-    const XML_NAMESPACE_URI = 'http://schemas.sulu.io/media/formats';
+    public const XML_NAMESPACE_URI = 'http://schemas.sulu.io/media/formats';
 
-    const SCHEMA_URI = '';
+    public const SCHEMA_URI = '';
 
-    const SCALE_MODE_DEFAULT = 'outbound';
+    public const SCALE_MODE_DEFAULT = 'outbound';
 
-    const SCALE_RETINA_DEFAULT = false;
+    public const SCALE_RETINA_DEFAULT = false;
 
-    const SCALE_FORCE_RATIO_DEFAULT = true;
+    public const SCALE_FORCE_RATIO_DEFAULT = true;
 
     /**
      * @var \DOMXPath

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader10.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader10.php
@@ -20,9 +20,9 @@ use Sulu\Bundle\MediaBundle\Media\FormatLoader\Exception\MissingScaleDimensionEx
  */
 class XmlFormatLoader10 extends BaseXmlFormatLoader
 {
-    const SCHEMA_URI = 'http://schemas.sulu.io/media/formats-1.0.xsd';
+    public const SCHEMA_URI = 'http://schemas.sulu.io/media/formats-1.0.xsd';
 
-    const SCHEME_PATH = '/schema/formats/formats-1.0.xsd';
+    public const SCHEME_PATH = '/schema/formats/formats-1.0.xsd';
 
     public function load($resource, $type = null)
     {

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader11.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader11.php
@@ -18,9 +18,9 @@ use Sulu\Bundle\MediaBundle\Media\FormatLoader\Exception\MissingScaleDimensionEx
  */
 class XmlFormatLoader11 extends BaseXmlFormatLoader
 {
-    const SCHEMA_URI = 'http://schemas.sulu.io/media/formats-1.1.xsd';
+    public const SCHEMA_URI = 'http://schemas.sulu.io/media/formats-1.1.xsd';
 
-    const SCHEME_PATH = '/schema/formats/formats-1.1.xsd';
+    public const SCHEME_PATH = '/schema/formats/formats-1.1.xsd';
 
     protected function getKeyFromFormatNode(\DOMNode $formatNode)
     {

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Focus/Focus.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Focus/Focus.php
@@ -23,32 +23,32 @@ class Focus implements FocusInterface
     /**
      * 0 is the x value if the focus point is set on the most left column.
      */
-    const FOCUS_LEFT = 0;
+    public const FOCUS_LEFT = 0;
 
     /**
      * 1 is the x value if the focus point is set on the center column.
      */
-    const FOCUS_CENTER = 1;
+    public const FOCUS_CENTER = 1;
 
     /**
      * 2 is the x value if the focus point is set on the most right column.
      */
-    const FOCUS_RIGHT = 2;
+    public const FOCUS_RIGHT = 2;
 
     /**
      * 0 is the y value if the focus point is set on the most top row.
      */
-    const FOCUS_TOP = 0;
+    public const FOCUS_TOP = 0;
 
     /**
      * 1 is the y value if the focus point is set on the middle row.
      */
-    const FOCUS_MIDDLE = 1;
+    public const FOCUS_MIDDLE = 1;
 
     /**
      * 2 is the y value if the focus point is set on the most bottom row.
      */
-    const FOCUS_BOTTOM = 2;
+    public const FOCUS_BOTTOM = 2;
 
     public function focus(ImageInterface $image, $x, $y, $width, $height)
     {

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -49,7 +49,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  */
 class MediaManager implements MediaManagerInterface
 {
-    const ENTITY_NAME_COLLECTION = 'SuluMediaBundle:Collection';
+    public const ENTITY_NAME_COLLECTION = 'SuluMediaBundle:Collection';
 
     /**
      * The repository for communication with the database.

--- a/src/Sulu/Bundle/MediaBundle/Media/TypeManager/TypeManagerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/TypeManager/TypeManagerInterface.php
@@ -19,9 +19,9 @@ use Sulu\Bundle\MediaBundle\Entity\MediaType;
  */
 interface TypeManagerInterface
 {
-    const ENTITY_CLASS_MEDIATYPE = 'Sulu\Bundle\MediaBundle\Entity\MediaType';
+    public const ENTITY_CLASS_MEDIATYPE = 'Sulu\Bundle\MediaBundle\Entity\MediaType';
 
-    const ENTITY_NAME_MEDIATYPE = 'SuluMediaBundle:MediaType';
+    public const ENTITY_NAME_MEDIATYPE = 'SuluMediaBundle:MediaType';
 
     /**
      * Returns a Media Type by a given ID.

--- a/src/Sulu/Bundle/MediaBundle/Tests/Fixtures/DefaultStructureCache.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Fixtures/DefaultStructureCache.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Bundle\MediaBundle\Tests\Fixtures;
 
-use Sulu\Component\Content\Block\BlockProperty;
-use Sulu\Component\Content\Block\BlockPropertyType;
 use Sulu\Component\Content\Property;
 use Sulu\Component\Content\PropertyTag;
 use Sulu\Component\Content\Section\SectionProperty;

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Events.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Events.php
@@ -19,7 +19,7 @@ final class Events
     /**
      * Will be raised right before preview rendering.
      */
-    const PRE_RENDER = 'sulu.preview.pre-render';
+    public const PRE_RENDER = 'sulu.preview.pre-render';
 
     /**
      * No object can be created for this class.

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Exception/PreviewRendererException.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Exception/PreviewRendererException.php
@@ -16,7 +16,7 @@ namespace Sulu\Bundle\PreviewBundle\Preview\Exception;
  */
 abstract class PreviewRendererException extends PreviewException
 {
-    const BASE_CODE = 9900;
+    public const BASE_CODE = 9900;
 
     /**
      * @var mixed

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
@@ -18,7 +18,7 @@ use Symfony\Component\Config\Loader\LoaderInterface;
  */
 class PreviewKernel extends \WebsiteKernel
 {
-    const CONTEXT_PREVIEW = 'preview';
+    public const CONTEXT_PREVIEW = 'preview';
 
     /**
      * @var string

--- a/src/Sulu/Bundle/ResourceBundle/Entity/Condition.php
+++ b/src/Sulu/Bundle/ResourceBundle/Entity/Condition.php
@@ -16,11 +16,11 @@ namespace Sulu\Bundle\ResourceBundle\Entity;
  */
 class Condition
 {
-    const TYPE_STRING = 1;
+    public const TYPE_STRING = 1;
 
-    const TYPE_NUMBER = 2;
+    public const TYPE_NUMBER = 2;
 
-    const TYPE_DATETIME = 3;
+    public const TYPE_DATETIME = 3;
 
     /**
      * @var string

--- a/src/Sulu/Bundle/ResourceBundle/Resource/DataTypes.php
+++ b/src/Sulu/Bundle/ResourceBundle/Resource/DataTypes.php
@@ -18,19 +18,19 @@ namespace Sulu\Bundle\ResourceBundle\Resource;
 final class DataTypes
 {
     /** Types used by operators and conditions */
-    const UNDEFINED_TYPE = 0;
+    public const UNDEFINED_TYPE = 0;
 
-    const STRING_TYPE = 1;
+    public const STRING_TYPE = 1;
 
-    const NUMBER_TYPE = 2;
+    public const NUMBER_TYPE = 2;
 
-    const DATETIME_TYPE = 3;
+    public const DATETIME_TYPE = 3;
 
-    const BOOLEAN_TYPE = 4;
+    public const BOOLEAN_TYPE = 4;
 
-    const TAGS_TYPE = 5;
+    public const TAGS_TYPE = 5;
 
-    const AUTO_COMPLETE_TYPE = 6;
+    public const AUTO_COMPLETE_TYPE = 6;
 
     /**
      * Types constructor.

--- a/src/Sulu/Bundle/RouteBundle/DependencyInjection/RouteGeneratorCompilerPass.php
+++ b/src/Sulu/Bundle/RouteBundle/DependencyInjection/RouteGeneratorCompilerPass.php
@@ -20,11 +20,11 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class RouteGeneratorCompilerPass implements CompilerPassInterface
 {
-    const TAG_NAME = 'sulu.route_generator';
+    public const TAG_NAME = 'sulu.route_generator';
 
-    const SERVICE_ID = 'sulu_route.chain_generator';
+    public const SERVICE_ID = 'sulu_route.chain_generator';
 
-    const PARAMETER_NAME = 'sulu_route.mappings';
+    public const PARAMETER_NAME = 'sulu_route.mappings';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
@@ -32,7 +32,7 @@ use Symfony\Component\Routing\RouteCollection;
  */
 class RouteProvider implements RouteProviderInterface
 {
-    const ROUTE_PREFIX = 'sulu_route_';
+    public const ROUTE_PREFIX = 'sulu_route_';
 
     /**
      * @var RouteRepositoryInterface

--- a/src/Sulu/Bundle/RouteBundle/Tests/Functional/Controller/RouteControllerTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Functional/Controller/RouteControllerTest.php
@@ -16,11 +16,11 @@ use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
 class RouteControllerTest extends SuluTestCase
 {
-    const TEST_ENTITY = 'AppBundle\\Entity\\Test';
+    public const TEST_ENTITY = 'AppBundle\\Entity\\Test';
 
-    const TEST_ID = 1;
+    public const TEST_ID = 1;
 
-    const TEST_LOCALE = 'de';
+    public const TEST_LOCALE = 'de';
 
     public function testCGetAction()
     {

--- a/src/Sulu/Bundle/SecurityBundle/Behat/SecurityContext.php
+++ b/src/Sulu/Bundle/SecurityBundle/Behat/SecurityContext.php
@@ -23,9 +23,9 @@ use Sulu\Bundle\TestBundle\Behat\BaseContext;
  */
 class SecurityContext extends BaseContext implements SnippetAcceptingContext
 {
-    const ADMIN_USERNAME = 'admin';
+    public const ADMIN_USERNAME = 'admin';
 
-    const ADMIN_PASSWORD = 'admin';
+    public const ADMIN_PASSWORD = 'admin';
 
     /**
      * @Given the user :username exists with password :password

--- a/src/Sulu/Bundle/SecurityBundle/Controller/GroupController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/GroupController.php
@@ -42,7 +42,7 @@ class GroupController extends RestController implements ClassResourceInterface, 
      */
     protected $fieldDescriptors;
 
-    const ENTITY_NAME_ROLE = 'SuluSecurityBundle:Role';
+    public const ENTITY_NAME_ROLE = 'SuluSecurityBundle:Role';
 
     // TODO: move the field descriptors to a manager
 

--- a/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
@@ -38,7 +38,7 @@ class RoleController extends RestController implements ClassResourceInterface, S
 {
     protected static $entityKey = 'roles';
 
-    const ENTITY_NAME_PERMISSION = 'SuluSecurityBundle:Permission';
+    public const ENTITY_NAME_PERMISSION = 'SuluSecurityBundle:Permission';
 
     protected $fieldsDefault = ['name'];
 

--- a/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Compiler/AccessControlProviderPass.php
+++ b/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Compiler/AccessControlProviderPass.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class AccessControlProviderPass implements CompilerPassInterface
 {
-    const ACCESS_CONTROL_TAG = 'sulu.access_control';
+    public const ACCESS_CONTROL_TAG = 'sulu.access_control';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/TagBundle/Controller/Exception/ConstraintViolationException.php
+++ b/src/Sulu/Bundle/TagBundle/Controller/Exception/ConstraintViolationException.php
@@ -24,7 +24,7 @@ class ConstraintViolationException extends RestException
      *
      * @var int
      */
-    const EXCEPTION_CODE_NON_UNIQUE_NAME = 1101;
+    public const EXCEPTION_CODE_NON_UNIQUE_NAME = 1101;
 
     /**
      * The field of the tag which is not unique.

--- a/src/Sulu/Bundle/TagBundle/Event/TagEvents.php
+++ b/src/Sulu/Bundle/TagBundle/Event/TagEvents.php
@@ -19,11 +19,11 @@ final class TagEvents
      *
      * @var string
      */
-    const TAG_DELETE = 'sulu.tag.delete';
+    public const TAG_DELETE = 'sulu.tag.delete';
 
     /**
      * The tag.merge event is thrown when a Tag gets merged into another one.
      * The event listener receives a TagMergeEvent instance.
      */
-    const TAG_MERGE = 'sulu.tag.merge';
+    public const TAG_MERGE = 'sulu.tag.merge';
 }

--- a/src/Sulu/Bundle/TestBundle/Behat/BaseContext.php
+++ b/src/Sulu/Bundle/TestBundle/Behat/BaseContext.php
@@ -28,9 +28,9 @@ use Symfony\Component\HttpKernel\KernelInterface;
  */
 abstract class BaseContext extends RawMinkContext implements Context, KernelAwareContext
 {
-    const LONG_WAIT_TIME = 30000;
+    public const LONG_WAIT_TIME = 30000;
 
-    const MEDIUM_WAIT_TIME = 5000;
+    public const MEDIUM_WAIT_TIME = 5000;
 
     /**
      * @var KernelInterface

--- a/src/Sulu/Bundle/TranslateBundle/Translate/Export.php
+++ b/src/Sulu/Bundle/TranslateBundle/Translate/Export.php
@@ -24,15 +24,15 @@ use Symfony\Component\Translation\Translator;
  */
 class Export
 {
-    const XLIFF = 0;
+    public const XLIFF = 0;
 
-    const JSON = 1;
+    public const JSON = 1;
 
-    const BACKEND_DOMAIN = 'backend';
+    public const BACKEND_DOMAIN = 'backend';
 
-    const FRONTEND_DOMAIN = 'frontend';
+    public const FRONTEND_DOMAIN = 'frontend';
 
-    const DEFAULT_LOCALE = 'en';
+    public const DEFAULT_LOCALE = 'en';
 
     /**
      * The locale of the catalogue to export.

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/AnalyticsController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/AnalyticsController.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class AnalyticsController extends RestController implements ClassResourceInterface, SecuredControllerInterface
 {
-    const RESULT_KEY = 'analytics';
+    public const RESULT_KEY = 'analytics';
 
     /**
      * Returns webspace analytics by webspace key.

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/RouterListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/RouterListener.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
  */
 class RouterListener implements EventSubscriberInterface
 {
-    const REQUEST_ANALYZER = '_requestAnalyzer';
+    public const REQUEST_ANALYZER = '_requestAnalyzer';
 
     /**
      * @var BaseRouterListener

--- a/src/Sulu/Bundle/WebsiteBundle/Events.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Events.php
@@ -19,5 +19,5 @@ final class Events
     /**
      * Will be raised after http caches have been cleared.
      */
-    const CACHE_CLEAR = 'sulu_website.cache_clear';
+    public const CACHE_CLEAR = 'sulu_website.cache_clear';
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapProviderInterface.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapProviderInterface.php
@@ -19,7 +19,7 @@ interface SitemapProviderInterface
     /**
      * Google limit for sitemap-url elements.
      */
-    const PAGE_SIZE = 50000;
+    public const PAGE_SIZE = 50000;
 
     /**
      * Returns sitemap-entries.

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapUrl.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapUrl.php
@@ -19,19 +19,19 @@ class SitemapUrl
     /**
      * Constants which indicates the change frequency (google will use them).
      */
-    const CHANGE_FREQUENCY_ALWAYS = 'always';
+    public const CHANGE_FREQUENCY_ALWAYS = 'always';
 
-    const CHANGE_FREQUENCY_HOURLY = 'hourly';
+    public const CHANGE_FREQUENCY_HOURLY = 'hourly';
 
-    const CHANGE_FREQUENCY_DAILY = 'daily';
+    public const CHANGE_FREQUENCY_DAILY = 'daily';
 
-    const CHANGE_FREQUENCY_WEEKLY = 'weekly';
+    public const CHANGE_FREQUENCY_WEEKLY = 'weekly';
 
-    const CHANGE_FREQUENCY_MONTHLY = 'monthly';
+    public const CHANGE_FREQUENCY_MONTHLY = 'monthly';
 
-    const CHANGE_FREQUENCY_YEARLY = 'yearly';
+    public const CHANGE_FREQUENCY_YEARLY = 'yearly';
 
-    const CHANGE_FREQUENCY_NEVER = 'never';
+    public const CHANGE_FREQUENCY_NEVER = 'never';
 
     /**
      * Relative URL.

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Navigation/NavigationTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Navigation/NavigationTest.php
@@ -505,7 +505,7 @@ class ExcerptStructureExtension extends AbstractExtension
     /**
      * name of structure extension.
      */
-    const EXCERPT_EXTENSION_NAME = 'excerpt';
+    public const EXCERPT_EXTENSION_NAME = 'excerpt';
 
     /**
      * will be filled with data in constructor

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapGeneratorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapGeneratorTest.php
@@ -372,7 +372,7 @@ class ExcerptStructureExtension extends AbstractExtension
     /**
      * name of structure extension.
      */
-    const EXCERPT_EXTENSION_NAME = 'excerpt';
+    public const EXCERPT_EXTENSION_NAME = 'excerpt';
 
     /**
      * will be filled with data in constructor

--- a/src/Sulu/Bundle/WebsocketBundle/Command/DumpWebsocketAppsCommand.php
+++ b/src/Sulu/Bundle/WebsocketBundle/Command/DumpWebsocketAppsCommand.php
@@ -24,7 +24,7 @@ class DumpWebsocketAppsCommand extends ContainerAwareCommand
     /**
      * Service id of websocket manager.
      */
-    const MANAGER_ID = 'sulu_websocket.manager';
+    public const MANAGER_ID = 'sulu_websocket.manager';
 
     protected function configure()
     {

--- a/src/Sulu/Bundle/WebsocketBundle/Command/RunWebsocketCommand.php
+++ b/src/Sulu/Bundle/WebsocketBundle/Command/RunWebsocketCommand.php
@@ -23,7 +23,7 @@ class RunWebsocketCommand extends ContainerAwareCommand
     /**
      * Service id of websocket manager.
      */
-    const MANAGER_ID = 'sulu_websocket.manager';
+    public const MANAGER_ID = 'sulu_websocket.manager';
 
     protected function configure()
     {

--- a/src/Sulu/Bundle/WebsocketBundle/DependencyInjection/Compiler/AddMessageDispatcherPass.php
+++ b/src/Sulu/Bundle/WebsocketBundle/DependencyInjection/Compiler/AddMessageDispatcherPass.php
@@ -23,12 +23,12 @@ class AddMessageDispatcherPass implements CompilerPassInterface
     /**
      * Service id of websocket manager.
      */
-    const DISPATCHER_TAG = 'sulu.websocket.message.dispatcher';
+    public const DISPATCHER_TAG = 'sulu.websocket.message.dispatcher';
 
     /**
      * Tag name for websocket apps.
      */
-    const HANDLER_TAG = 'sulu.websocket.message.handler';
+    public const HANDLER_TAG = 'sulu.websocket.message.handler';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Bundle/WebsocketBundle/DependencyInjection/Compiler/AddWebsocketAppPass.php
+++ b/src/Sulu/Bundle/WebsocketBundle/DependencyInjection/Compiler/AddWebsocketAppPass.php
@@ -23,12 +23,12 @@ class AddWebsocketAppPass implements CompilerPassInterface
     /**
      * Service id of websocket manager.
      */
-    const MANAGER_ID = 'sulu_websocket.manager';
+    public const MANAGER_ID = 'sulu_websocket.manager';
 
     /**
      * Tag name for websocket apps.
      */
-    const APP_TAG = 'sulu.websocket.app';
+    public const APP_TAG = 'sulu.websocket.app';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/Sulu/Component/Content/Compat/Structure.php
+++ b/src/Sulu/Component/Content/Compat/Structure.php
@@ -28,27 +28,27 @@ abstract class Structure implements StructureInterface
     /**
      * indicates that the node is a content node.
      */
-    const NODE_TYPE_CONTENT = 1;
+    public const NODE_TYPE_CONTENT = 1;
 
     /**
      * indicates that the node links to an internal resource.
      */
-    const NODE_TYPE_INTERNAL_LINK = 2;
+    public const NODE_TYPE_INTERNAL_LINK = 2;
 
     /**
      * indicates that the node links to an external resource.
      */
-    const NODE_TYPE_EXTERNAL_LINK = 4;
+    public const NODE_TYPE_EXTERNAL_LINK = 4;
 
     /**
      * Structure type page.
      */
-    const TYPE_PAGE = 'page';
+    public const TYPE_PAGE = 'page';
 
     /**
      * Structure type page.
      */
-    const TYPE_SNIPPET = 'snippet';
+    public const TYPE_SNIPPET = 'snippet';
 
     /**
      * webspaceKey of node.

--- a/src/Sulu/Component/Content/Compat/StructureInterface.php
+++ b/src/Sulu/Component/Content/Compat/StructureInterface.php
@@ -19,9 +19,9 @@ use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
  */
 interface StructureInterface extends \JsonSerializable
 {
-    const STATE_TEST = 1;
+    public const STATE_TEST = 1;
 
-    const STATE_PUBLISHED = 2;
+    public const STATE_PUBLISHED = 2;
 
     /**
      * @param string $language

--- a/src/Sulu/Component/Content/Document/LocalizationState.php
+++ b/src/Sulu/Component/Content/Document/LocalizationState.php
@@ -19,15 +19,15 @@ class LocalizationState
     /**
      * Document is loaded in requested locale.
      */
-    const LOCALIZED = 'localized';
+    public const LOCALIZED = 'localized';
 
     /**
      * Document is using a fallback.
      */
-    const GHOST = 'ghost';
+    public const GHOST = 'ghost';
 
     /**
      * Document is using the content of a different localization.
      */
-    const SHADOW = 'shadow';
+    public const SHADOW = 'shadow';
 }

--- a/src/Sulu/Component/Content/Document/RedirectType.php
+++ b/src/Sulu/Component/Content/Document/RedirectType.php
@@ -19,15 +19,15 @@ final class RedirectType
     /**
      * indicates that the node is a content node.
      */
-    const NONE = 1;
+    public const NONE = 1;
 
     /**
      * indicates that the node links to an internal resource.
      */
-    const INTERNAL = 2;
+    public const INTERNAL = 2;
 
     /**
      * indicates that the node links to an external resource.
      */
-    const EXTERNAL = 4;
+    public const EXTERNAL = 4;
 }

--- a/src/Sulu/Component/Content/Document/Subscriber/AuthorSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/AuthorSubscriber.php
@@ -26,9 +26,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class AuthorSubscriber implements EventSubscriberInterface
 {
-    const AUTHORED_PROPERTY_NAME = 'authored';
+    public const AUTHORED_PROPERTY_NAME = 'authored';
 
-    const AUTHOR_PROPERTY_NAME = 'author';
+    public const AUTHOR_PROPERTY_NAME = 'author';
 
     /**
      * @var PropertyEncoder

--- a/src/Sulu/Component/Content/Document/Subscriber/BlameSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/BlameSubscriber.php
@@ -28,9 +28,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class BlameSubscriber implements EventSubscriberInterface
 {
-    const CREATOR = 'creator';
+    public const CREATOR = 'creator';
 
-    const CHANGER = 'changer';
+    public const CHANGER = 'changer';
 
     /**
      * @var PropertyEncoder

--- a/src/Sulu/Component/Content/Document/Subscriber/NavigationContextSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/NavigationContextSubscriber.php
@@ -18,7 +18,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class NavigationContextSubscriber implements EventSubscriberInterface
 {
-    const FIELD = 'navContexts';
+    public const FIELD = 'navContexts';
 
     public static function getSubscribedEvents()
     {

--- a/src/Sulu/Component/Content/Document/Subscriber/OrderSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/OrderSubscriber.php
@@ -26,7 +26,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class OrderSubscriber implements EventSubscriberInterface
 {
-    const FIELD = 'order';
+    public const FIELD = 'order';
 
     /**
      * @var DocumentInspector

--- a/src/Sulu/Component/Content/Document/Subscriber/RedirectTypeSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/RedirectTypeSubscriber.php
@@ -20,11 +20,11 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class RedirectTypeSubscriber implements EventSubscriberInterface
 {
-    const REDIRECT_TYPE_FIELD = 'nodeType';
+    public const REDIRECT_TYPE_FIELD = 'nodeType';
 
-    const INTERNAL_FIELD = 'internal_link';
+    public const INTERNAL_FIELD = 'internal_link';
 
-    const EXTERNAL_FIELD = 'external';
+    public const EXTERNAL_FIELD = 'external';
 
     public static function getSubscribedEvents()
     {

--- a/src/Sulu/Component/Content/Document/Subscriber/RouteSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/RouteSubscriber.php
@@ -33,9 +33,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class RouteSubscriber implements EventSubscriberInterface
 {
-    const DOCUMENT_HISTORY_FIELD = 'history';
+    public const DOCUMENT_HISTORY_FIELD = 'history';
 
-    const NODE_HISTORY_FIELD = 'sulu:history';
+    public const NODE_HISTORY_FIELD = 'sulu:history';
 
     /**
      * @var DocumentManagerInterface

--- a/src/Sulu/Component/Content/Document/Subscriber/ShadowCopyPropertiesSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ShadowCopyPropertiesSubscriber.php
@@ -24,13 +24,13 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class ShadowCopyPropertiesSubscriber implements EventSubscriberInterface
 {
-    const SHADOW_BASE_PROPERTY = 'i18n:*-shadow-base';
+    public const SHADOW_BASE_PROPERTY = 'i18n:*-shadow-base';
 
-    const TAGS_PROPERTY = 'i18n:%s-excerpt-tags';
+    public const TAGS_PROPERTY = 'i18n:%s-excerpt-tags';
 
-    const CATEGORIES_PROPERTY = 'i18n:%s-excerpt-categories';
+    public const CATEGORIES_PROPERTY = 'i18n:%s-excerpt-categories';
 
-    const NAVIGATION_CONTEXT_PROPERTY = 'i18n:%s-navContexts';
+    public const NAVIGATION_CONTEXT_PROPERTY = 'i18n:%s-navContexts';
 
     /**
      * @var PropertyEncoder

--- a/src/Sulu/Component/Content/Document/Subscriber/ShadowLocaleSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ShadowLocaleSubscriber.php
@@ -25,9 +25,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ShadowLocaleSubscriber implements EventSubscriberInterface
 {
-    const SHADOW_ENABLED_FIELD = 'shadow-on';
+    public const SHADOW_ENABLED_FIELD = 'shadow-on';
 
-    const SHADOW_LOCALE_FIELD = 'shadow-base';
+    public const SHADOW_LOCALE_FIELD = 'shadow-base';
 
     /**
      * @var DocumentInspector

--- a/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
@@ -33,7 +33,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class StructureSubscriber implements EventSubscriberInterface
 {
-    const STRUCTURE_TYPE_FIELD = 'template';
+    public const STRUCTURE_TYPE_FIELD = 'template';
 
     /**
      * @var ContentTypeManagerInterface

--- a/src/Sulu/Component/Content/Document/Subscriber/TargetSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/TargetSubscriber.php
@@ -21,7 +21,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class TargetSubscriber implements EventSubscriberInterface
 {
-    const DOCUMENT_TARGET_FIELD = 'content';
+    public const DOCUMENT_TARGET_FIELD = 'content';
 
     public static function getSubscribedEvents()
     {

--- a/src/Sulu/Component/Content/Document/Subscriber/TitleSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/TitleSubscriber.php
@@ -21,7 +21,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class TitleSubscriber implements EventSubscriberInterface
 {
-    const PROPERTY_NAME = 'title';
+    public const PROPERTY_NAME = 'title';
 
     /**
      * @var PropertyEncoder

--- a/src/Sulu/Component/Content/Document/Subscriber/WorkflowStageSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/WorkflowStageSubscriber.php
@@ -30,9 +30,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class WorkflowStageSubscriber implements EventSubscriberInterface
 {
-    const WORKFLOW_STAGE_FIELD = 'state';
+    public const WORKFLOW_STAGE_FIELD = 'state';
 
-    const PUBLISHED_FIELD = 'published';
+    public const PUBLISHED_FIELD = 'published';
 
     /**
      * @var DocumentInspector

--- a/src/Sulu/Component/Content/Document/WorkflowStage.php
+++ b/src/Sulu/Component/Content/Document/WorkflowStage.php
@@ -28,10 +28,10 @@ final class WorkflowStage
     /**
      * Document is published.
      */
-    const PUBLISHED = 2;
+    public const PUBLISHED = 2;
 
     /**
      * Document is not published.
      */
-    const TEST = 1;
+    public const TEST = 1;
 }

--- a/src/Sulu/Component/Content/Mapper/ContentEvents.php
+++ b/src/Sulu/Component/Content/Mapper/ContentEvents.php
@@ -21,40 +21,40 @@ final class ContentEvents
      *
      * @var string
      */
-    const NODE_POST_SAVE = 'sulu.content.node.post_save';
+    public const NODE_POST_SAVE = 'sulu.content.node.post_save';
 
     /**
      * Thrown before a structure node is persisted in the PHPCR session.
      *
      * @var string
      */
-    const NODE_PRE_SAVE = 'sulu.content.node.pre_save';
+    public const NODE_PRE_SAVE = 'sulu.content.node.pre_save';
 
     /**
      * Thrown after a node has been order. Note. Thrown before session is saved.
      *
      * @var string
      */
-    const NODE_ORDER = 'sulu.content.node.order';
+    public const NODE_ORDER = 'sulu.content.node.order';
 
     /**
      * Thrown before structure node is loaded.
      *
      * @var string
      */
-    const NODE_LOAD = 'sulu.content.node.load';
+    public const NODE_LOAD = 'sulu.content.node.load';
 
     /**
      * Thrown before a structure node is deleted.
      *
      * @var string
      */
-    const NODE_PRE_DELETE = 'sulu.content.node.pre_delete';
+    public const NODE_PRE_DELETE = 'sulu.content.node.pre_delete';
 
     /**
      * Thrown after a structure node is deleted.
      *
      * @var string
      */
-    const NODE_POST_DELETE = 'sulu.content.node.post_delete';
+    public const NODE_POST_DELETE = 'sulu.content.node.post_delete';
 }

--- a/src/Sulu/Component/Content/Metadata/Loader/XmlLegacyLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/XmlLegacyLoader.php
@@ -27,7 +27,7 @@ use Symfony\Component\Config\Util\XmlUtils;
  */
 class XmlLegacyLoader implements LoaderInterface
 {
-    const SCHEME_PATH = '/schema/template-1.0.xsd';
+    public const SCHEME_PATH = '/schema/template-1.0.xsd';
 
     /**
      * tags that are required in template

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/FallbackLocalizationSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/FallbackLocalizationSubscriberTest.php
@@ -23,9 +23,9 @@ use Sulu\Component\Webspace\Webspace;
 
 class FallbackLocalizationSubscriberTest extends SubscriberTestCase
 {
-    const FIX_LOCALE = 'en';
+    public const FIX_LOCALE = 'en';
 
-    const FIX_WEBSPACE = 'sulu_io';
+    public const FIX_WEBSPACE = 'sulu_io';
 
     /**
      * @var WebspaceManagerInterface

--- a/src/Sulu/Component/Content/Tests/Unit/Types/TextEditorTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Types/TextEditorTest.php
@@ -18,9 +18,9 @@ use Sulu\Component\Content\Types\TextEditor;
 
 class TextEditorTest extends \PHPUnit_Framework_TestCase
 {
-    const VALIDATE_REMOVED = 'removed';
+    public const VALIDATE_REMOVED = 'removed';
 
-    const VALIDATE_UNPUBLISHED = 'unpublished';
+    public const VALIDATE_UNPUBLISHED = 'unpublished';
 
     /**
      * @var string

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/ResourceLocatorStrategyInterface.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/ResourceLocatorStrategyInterface.php
@@ -19,9 +19,9 @@ use Sulu\Component\Content\Types\ResourceLocator\ResourceLocatorInformation;
  */
 interface ResourceLocatorStrategyInterface
 {
-    const INPUT_TYPE_LEAF = 'leaf';
+    public const INPUT_TYPE_LEAF = 'leaf';
 
-    const INPUT_TYPE_FULL = 'full';
+    public const INPUT_TYPE_FULL = 'full';
 
     /**
      * Returns the child part from the given resource segment.

--- a/src/Sulu/Component/Content/Types/TextEditor.php
+++ b/src/Sulu/Component/Content/Types/TextEditor.php
@@ -22,7 +22,7 @@ use Sulu\Component\Content\SimpleContentType;
  */
 class TextEditor extends SimpleContentType
 {
-    const INVALID_REGEX = '/(<%s:[a-z]+\b[^\/>]*)(\/>|>[^<]*<\/%s:[^\/>]*>)/';
+    public const INVALID_REGEX = '/(<%s:[a-z]+\b[^\/>]*)(\/>|>[^<]*<\/%s:[^\/>]*>)/';
 
     /**
      * @var string

--- a/src/Sulu/Component/CustomUrl/Generator/Generator.php
+++ b/src/Sulu/Component/CustomUrl/Generator/Generator.php
@@ -19,9 +19,9 @@ use Sulu\Component\Webspace\Url\ReplacerInterface;
  */
 class Generator implements GeneratorInterface
 {
-    const PREFIX_REGEX = '/^([^\/]*)(\*)(.*)$/';
+    public const PREFIX_REGEX = '/^([^\/]*)(\*)(.*)$/';
 
-    const POSTFIX_REGEX = '/^.*\/.*\*.*$/';
+    public const POSTFIX_REGEX = '/^.*\/.*\*.*$/';
 
     /**
      * @var ReplacerInterface

--- a/src/Sulu/Component/HttpCache/CacheLifetimeResolverInterface.php
+++ b/src/Sulu/Component/HttpCache/CacheLifetimeResolverInterface.php
@@ -20,12 +20,12 @@ interface CacheLifetimeResolverInterface
     /**
      * Cache lifetime in seconds.
      */
-    const TYPE_SECONDS = 'seconds';
+    public const TYPE_SECONDS = 'seconds';
 
     /**
      * Cache lifetime as cron expression.
      */
-    const TYPE_EXPRESSION = 'expression';
+    public const TYPE_EXPRESSION = 'expression';
 
     /**
      * Get cache lifetime in seconds.

--- a/src/Sulu/Component/HttpCache/Handler/DebugHandler.php
+++ b/src/Sulu/Component/HttpCache/Handler/DebugHandler.php
@@ -22,15 +22,15 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class DebugHandler implements HandlerUpdateResponseInterface
 {
-    const HEADER_HANDLERS = 'X-Sulu-Handlers';
+    public const HEADER_HANDLERS = 'X-Sulu-Handlers';
 
-    const HEADER_CLIENT_NAME = 'X-Sulu-Proxy-Client';
+    public const HEADER_CLIENT_NAME = 'X-Sulu-Proxy-Client';
 
-    const HEADER_STRUCTURE_TYPE = 'X-Sulu-Structure-Type';
+    public const HEADER_STRUCTURE_TYPE = 'X-Sulu-Structure-Type';
 
-    const HEADER_STRUCTURE_UUID = 'X-Sulu-Structure-UUID';
+    public const HEADER_STRUCTURE_UUID = 'X-Sulu-Structure-UUID';
 
-    const HEADER_STRUCTURE_TTL = 'X-Sulu-Page-TTL';
+    public const HEADER_STRUCTURE_TTL = 'X-Sulu-Page-TTL';
 
     /**
      * @var CacheLifetimeResolverInterface

--- a/src/Sulu/Component/HttpCache/Handler/TagsHandler.php
+++ b/src/Sulu/Component/HttpCache/Handler/TagsHandler.php
@@ -27,7 +27,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class TagsHandler implements HandlerInvalidateStructureInterface, HandlerInvalidateReferenceInterface, HandlerUpdateResponseInterface, HandlerFlushInterface
 {
-    const TAGS_HEADER = 'X-Cache-Tags';
+    public const TAGS_HEADER = 'X-Cache-Tags';
 
     /**
      * @var ProxyClientInterface

--- a/src/Sulu/Component/HttpCache/HttpCache.php
+++ b/src/Sulu/Component/HttpCache/HttpCache.php
@@ -23,19 +23,19 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  */
 class HttpCache extends AbstractHttpCache
 {
-    const HEADER_REVERSE_PROXY_TTL = 'X-Reverse-Proxy-TTL';
+    public const HEADER_REVERSE_PROXY_TTL = 'X-Reverse-Proxy-TTL';
 
-    const TARGET_GROUP_URL = '/_sulu_target_group';
+    public const TARGET_GROUP_URL = '/_sulu_target_group';
 
-    const TARGET_GROUP_HEADER = 'X-Sulu-Target-Group';
+    public const TARGET_GROUP_HEADER = 'X-Sulu-Target-Group';
 
-    const TARGET_GROUP_COOKIE = '_svtg';
+    public const TARGET_GROUP_COOKIE = '_svtg';
 
-    const TARGET_GROUP_COOKIE_LIFETIME = 2147483647;
+    public const TARGET_GROUP_COOKIE_LIFETIME = 2147483647;
 
-    const VISITOR_SESSION_COOKIE = '_svs';
+    public const VISITOR_SESSION_COOKIE = '_svs';
 
-    const USER_CONTEXT_URL_HEADER = 'X-Forwarded-URL';
+    public const USER_CONTEXT_URL_HEADER = 'X-Forwarded-URL';
 
     /**
      * @var bool

--- a/src/Sulu/Component/HttpCache/ProxyClient/Symfony.php
+++ b/src/Sulu/Component/HttpCache/ProxyClient/Symfony.php
@@ -30,7 +30,7 @@ use Psr\Http\Message\ResponseInterface;
  */
 class Symfony implements ProxyClientInterface, PurgeInterface
 {
-    const HTTP_METHOD_PURGE = 'PURGE';
+    public const HTTP_METHOD_PURGE = 'PURGE';
 
     /**
      * HTTP client.

--- a/src/Sulu/Component/HttpKernel/SuluKernel.php
+++ b/src/Sulu/Component/HttpKernel/SuluKernel.php
@@ -20,9 +20,9 @@ abstract class SuluKernel extends Kernel
 {
     private $context = null;
 
-    const CONTEXT_ADMIN = 'admin';
+    public const CONTEXT_ADMIN = 'admin';
 
-    const CONTEXT_WEBSITE = 'website';
+    public const CONTEXT_WEBSITE = 'website';
 
     /**
      * Overload the parent constructor method to add an additional

--- a/src/Sulu/Component/Localization/Localization.php
+++ b/src/Sulu/Component/Localization/Localization.php
@@ -19,13 +19,13 @@ use Sulu\Component\Util\ArrayableInterface;
  */
 class Localization implements \JsonSerializable, ArrayableInterface
 {
-    const UNDERSCORE = 'de_at';
+    public const UNDERSCORE = 'de_at';
 
-    const DASH = 'de-at';
+    public const DASH = 'de-at';
 
-    const ISO6391 = 'de-AT';
+    public const ISO6391 = 'de-AT';
 
-    const LCID = 'de_AT';
+    public const LCID = 'de_AT';
 
     /**
      * Create an instance of localization for given locale.

--- a/src/Sulu/Component/Media/SystemCollections/SystemCollectionManagerInterface.php
+++ b/src/Sulu/Component/Media/SystemCollections/SystemCollectionManagerInterface.php
@@ -16,9 +16,9 @@ namespace Sulu\Component\Media\SystemCollections;
  */
 interface SystemCollectionManagerInterface
 {
-    const COLLECTION_TYPE = 'collection.system';
+    public const COLLECTION_TYPE = 'collection.system';
 
-    const COLLECTION_KEY = 'system_collections';
+    public const COLLECTION_KEY = 'system_collections';
 
     /**
      * Builds cache for system collections.

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/TimestampableSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/TimestampableSubscriber.php
@@ -23,9 +23,9 @@ use Sulu\Component\Persistence\Model\TimestampableInterface;
  */
 class TimestampableSubscriber implements EventSubscriber
 {
-    const CREATED_FIELD = 'created';
+    public const CREATED_FIELD = 'created';
 
-    const CHANGED_FIELD = 'changed';
+    public const CHANGED_FIELD = 'changed';
 
     public function getSubscribedEvents()
     {

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
@@ -29,9 +29,9 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  */
 class UserBlameSubscriber implements EventSubscriber
 {
-    const CHANGER_FIELD = 'changer';
+    public const CHANGER_FIELD = 'changer';
 
-    const CREATOR_FIELD = 'creator';
+    public const CREATOR_FIELD = 'creator';
 
     /**
      * @var TokenStorage

--- a/src/Sulu/Component/Rest/Exception/ConstraintViolationException.php
+++ b/src/Sulu/Component/Rest/Exception/ConstraintViolationException.php
@@ -16,7 +16,7 @@ namespace Sulu\Component\Rest\Exception;
  */
 class ConstraintViolationException extends RestException
 {
-    const UNIQUE = 'unique';
+    public const UNIQUE = 'unique';
 
     /**
      * @var string

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineJoinDescriptor.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineJoinDescriptor.php
@@ -20,13 +20,13 @@ class DoctrineJoinDescriptor
 {
     use EncodeAliasTrait;
 
-    const JOIN_METHOD_LEFT = 'LEFT';
+    public const JOIN_METHOD_LEFT = 'LEFT';
 
-    const JOIN_METHOD_INNER = 'INNER';
+    public const JOIN_METHOD_INNER = 'INNER';
 
-    const JOIN_CONDITION_METHOD_ON = 'ON';
+    public const JOIN_CONDITION_METHOD_ON = 'ON';
 
-    const JOIN_CONDITION_METHOD_WITH = 'WITH';
+    public const JOIN_CONDITION_METHOD_WITH = 'WITH';
 
     /**
      * The name of the entity to join.

--- a/src/Sulu/Component/Rest/ListBuilder/Event/ListBuilderEvents.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Event/ListBuilderEvents.php
@@ -22,7 +22,7 @@ final class ListBuilderEvents
      *
      * @var string
      */
-    const LISTBUILDER_CREATE = 'sulu.listbuilder.create';
+    public const LISTBUILDER_CREATE = 'sulu.listbuilder.create';
 
     private function __construct()
     {

--- a/src/Sulu/Component/Rest/ListBuilder/ListBuilderInterface.php
+++ b/src/Sulu/Component/Rest/ListBuilder/ListBuilderInterface.php
@@ -20,25 +20,25 @@ use Sulu\Component\Security\Authentication\UserInterface;
  */
 interface ListBuilderInterface
 {
-    const WHERE_COMPARATOR_EQUAL = '=';
+    public const WHERE_COMPARATOR_EQUAL = '=';
 
-    const WHERE_COMPARATOR_UNEQUAL = '!=';
+    public const WHERE_COMPARATOR_UNEQUAL = '!=';
 
-    const WHERE_COMPARATOR_GREATER = '>';
+    public const WHERE_COMPARATOR_GREATER = '>';
 
-    const WHERE_COMPARATOR_GREATER_THAN = '>=';
+    public const WHERE_COMPARATOR_GREATER_THAN = '>=';
 
-    const WHERE_COMPARATOR_LESS = '<';
+    public const WHERE_COMPARATOR_LESS = '<';
 
-    const WHERE_COMPARATOR_LESS_THAN = '<=';
+    public const WHERE_COMPARATOR_LESS_THAN = '<=';
 
-    const SORTORDER_ASC = 'ASC';
+    public const SORTORDER_ASC = 'ASC';
 
-    const SORTORDER_DESC = 'DESC';
+    public const SORTORDER_DESC = 'DESC';
 
-    const CONJUNCTION_AND = 'AND';
+    public const CONJUNCTION_AND = 'AND';
 
-    const CONJUNCTION_OR = 'OR';
+    public const CONJUNCTION_OR = 'OR';
 
     /**
      * Sets all the field descriptors for the ListBuilder at once.

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/Doctrine/Driver/XmlDriver.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/Doctrine/Driver/XmlDriver.php
@@ -33,7 +33,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
  */
 class XmlDriver extends AbstractFileDriver implements DriverInterface
 {
-    const SCHEME_PATH = '/../../Resources/schema/metadata/list-builder-doctrine-1.0.xsd';
+    public const SCHEME_PATH = '/../../Resources/schema/metadata/list-builder-doctrine-1.0.xsd';
 
     /**
      * @var ParameterBagInterface

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/Doctrine/JoinMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/Doctrine/JoinMetadata.php
@@ -16,13 +16,13 @@ namespace Sulu\Component\Rest\ListBuilder\Metadata\Doctrine;
  */
 class JoinMetadata
 {
-    const JOIN_METHOD_LEFT = 'LEFT';
+    public const JOIN_METHOD_LEFT = 'LEFT';
 
-    const JOIN_METHOD_INNER = 'INNER';
+    public const JOIN_METHOD_INNER = 'INNER';
 
-    const JOIN_CONDITION_METHOD_ON = 'ON';
+    public const JOIN_CONDITION_METHOD_ON = 'ON';
 
-    const JOIN_CONDITION_METHOD_WITH = 'WITH';
+    public const JOIN_CONDITION_METHOD_WITH = 'WITH';
 
     /**
      * @var string

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/General/Driver/XmlDriver.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/General/Driver/XmlDriver.php
@@ -25,7 +25,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
  */
 class XmlDriver extends AbstractFileDriver implements DriverInterface
 {
-    const SCHEME_PATH = '/../../Resources/schema/metadata/list-builder-general-1.0.xsd';
+    public const SCHEME_PATH = '/../../Resources/schema/metadata/list-builder-general-1.0.xsd';
 
     /**
      * @var ParameterBagInterface

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/General/PropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/General/PropertyMetadata.php
@@ -18,13 +18,13 @@ use Metadata\PropertyMetadata as BasePropertyMetadata;
  */
 class PropertyMetadata extends BasePropertyMetadata
 {
-    const DISPLAY_ALWAYS = 'always';
+    public const DISPLAY_ALWAYS = 'always';
 
-    const DISPLAY_NEVER = 'never';
+    public const DISPLAY_NEVER = 'never';
 
-    const DISPLAY_YES = 'yes';
+    public const DISPLAY_YES = 'yes';
 
-    const DISPLAY_NO = 'no';
+    public const DISPLAY_NO = 'no';
 
     /**
      * @var string

--- a/src/Sulu/Component/Security/Authorization/PermissionTypes.php
+++ b/src/Sulu/Component/Security/Authorization/PermissionTypes.php
@@ -16,17 +16,17 @@ namespace Sulu\Component\Security\Authorization;
  */
 final class PermissionTypes
 {
-    const VIEW = 'view';
+    public const VIEW = 'view';
 
-    const ADD = 'add';
+    public const ADD = 'add';
 
-    const EDIT = 'edit';
+    public const EDIT = 'edit';
 
-    const DELETE = 'delete';
+    public const DELETE = 'delete';
 
-    const ARCHIVE = 'archive';
+    public const ARCHIVE = 'archive';
 
-    const LIVE = 'live';
+    public const LIVE = 'live';
 
-    const SECURITY = 'security';
+    public const SECURITY = 'security';
 }

--- a/src/Sulu/Component/Security/Event/SecurityEvents.php
+++ b/src/Sulu/Component/Security/Event/SecurityEvents.php
@@ -16,5 +16,5 @@ namespace Sulu\Component\Security\Event;
  */
 final class SecurityEvents
 {
-    const PERMISSION_UPDATE = 'sulu_security.permission_update';
+    public const PERMISSION_UPDATE = 'sulu_security.permission_update';
 }

--- a/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzerInterface.php
+++ b/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzerInterface.php
@@ -29,28 +29,28 @@ interface RequestAnalyzerInterface
      *
      * A full match is when the URL completely starts with the given URL
      */
-    const MATCH_TYPE_FULL = 1;
+    public const MATCH_TYPE_FULL = 1;
 
     /**
      * Type for a partial match.
      *
      * A partial match is when only the partial URL matches the given URL
      */
-    const MATCH_TYPE_PARTIAL = 2;
+    public const MATCH_TYPE_PARTIAL = 2;
 
     /**
      * Type for a redirect.
      *
      * A redirect is when the given URL is just defined to be a redirect
      */
-    const MATCH_TYPE_REDIRECT = 3;
+    public const MATCH_TYPE_REDIRECT = 3;
 
     /**
      * Type for a wildcard url.
      *
      * The url contains a wildcard, which can be replaced with anything.
      */
-    const MATCH_TYPE_WILDCARD = 4;
+    public const MATCH_TYPE_WILDCARD = 4;
 
     /**
      * Analyzes the current request, and saves the values for portal, language, country and segment for further usage.

--- a/src/Sulu/Component/Webspace/Loader/BaseXmlFileLoader.php
+++ b/src/Sulu/Component/Webspace/Loader/BaseXmlFileLoader.php
@@ -21,9 +21,9 @@ use Symfony\Component\Config\Util\XmlUtils;
  */
 abstract class BaseXmlFileLoader extends FileLoader
 {
-    const SCHEMA_IDENTIFIER = 'http://schemas.sulu.io/webspace/webspace';
+    public const SCHEMA_IDENTIFIER = 'http://schemas.sulu.io/webspace/webspace';
 
-    const SCHEMA_URI = '';
+    public const SCHEMA_URI = '';
 
     public function supports($resource, $type = null)
     {

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
@@ -44,9 +44,9 @@ use Symfony\Component\Config\Util\XmlUtils;
  */
 class XmlFileLoader10 extends BaseXmlFileLoader
 {
-    const SCHEMA_LOCATION = '/schema/webspace/webspace-1.0.xsd';
+    public const SCHEMA_LOCATION = '/schema/webspace/webspace-1.0.xsd';
 
-    const SCHEMA_URI = 'http://schemas.sulu.io/webspace/webspace-1.0.xsd';
+    public const SCHEMA_URI = 'http://schemas.sulu.io/webspace/webspace-1.0.xsd';
 
     /**
      * @var \DOMXPath

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader11.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader11.php
@@ -20,9 +20,9 @@ use Sulu\Component\Webspace\Webspace;
  */
 class XmlFileLoader11 extends XmlFileLoader10
 {
-    const SCHEMA_LOCATION = '/schema/webspace/webspace-1.1.xsd';
+    public const SCHEMA_LOCATION = '/schema/webspace/webspace-1.1.xsd';
 
-    const SCHEMA_URI = 'http://schemas.sulu.io/webspace/webspace-1.1.xsd';
+    public const SCHEMA_URI = 'http://schemas.sulu.io/webspace/webspace-1.1.xsd';
 
     protected function parseXml($file)
     {

--- a/src/Sulu/Component/Webspace/Url/ReplacerInterface.php
+++ b/src/Sulu/Component/Webspace/Url/ReplacerInterface.php
@@ -16,15 +16,15 @@ namespace Sulu\Component\Webspace\Url;
  */
 interface ReplacerInterface
 {
-    const REPLACER_LANGUAGE = '{language}';
+    public const REPLACER_LANGUAGE = '{language}';
 
-    const REPLACER_COUNTRY = '{country}';
+    public const REPLACER_COUNTRY = '{country}';
 
-    const REPLACER_LOCALIZATION = '{localization}';
+    public const REPLACER_LOCALIZATION = '{localization}';
 
-    const REPLACER_SEGMENT = '{segment}';
+    public const REPLACER_SEGMENT = '{segment}';
 
-    const REPLACER_HOST = '{host}';
+    public const REPLACER_HOST = '{host}';
 
     /**
      * Returns true if language replacer exists.


### PR DESCRIPTION
#### What's in this PR?

This PR updates the `friendsofphp/php-cs-fixer` to version 3. The currently used version 2.19 is deprecated.

See https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/tag/v3.0.0
