### PR TITLE
Fix setting default template for new pages by using mobx object API in ResourceFormStore

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
@@ -1,5 +1,5 @@
 // @flow
-import {action, autorun, computed, get, observable, when} from 'mobx';
+import {action, autorun, computed, get, set, observable, when} from 'mobx';
 import Ajv from 'ajv';
 import jsonpointer from 'json-pointer';
 import log from 'loglevel';
@@ -62,10 +62,8 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
             when(
                 () => !this.resourceStore.loading,
                 (): void => {
-                    this.changeType(
-                        this.resourceStore.data[TYPE_PROPERTY] || defaultType || Object.keys(this.types)[0],
-                        {isDefaultValue: true}
-                    );
+                    const type = this.resourceStore.data[TYPE_PROPERTY] || defaultType || Object.keys(this.types)[0];
+                    set(this.data, {[TYPE_PROPERTY]: type});
                 }
             );
         }
@@ -117,7 +115,7 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
     }
 
     @computed get type(): string {
-        return this.data[TYPE_PROPERTY];
+        return get(this.data, TYPE_PROPERTY);
     }
 
     @action save(options: Object = {}): Promise<Object> {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
@@ -32,7 +32,6 @@ jest.mock('../../../../stores/ResourceStore', () => function(resourceKey, id, op
         this.data = {...this.data, ...data};
     });
     this.copyFromLocale = jest.fn();
-    this.loading = false;
 
     if (options) {
         this.locale = options.locale;
@@ -40,6 +39,7 @@ jest.mock('../../../../stores/ResourceStore', () => function(resourceKey, id, op
 
     mockExtendObservable(this, {
         data: {},
+        loading: false,
     });
 });
 
@@ -479,7 +479,7 @@ test('Set template property of ResourceStore from the loaded data', () => {
     const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets');
 
     return Promise.all([schemaTypesPromise, metadataPromise]).then(() => {
-        expect(resourceStore.set).toBeCalledWith('template', 'type2');
+        expect(resourceFormStore.type).toEqual('type2');
         resourceFormStore.destroy();
     });
 });
@@ -1579,7 +1579,7 @@ test('HasTypes return false when types are not set', () => {
     });
 });
 
-test.each(['sidebar', 'footer'])('Set type to default "%s" if data has no template set', (defaultType) => {
+test.each(['sidebar', 'footer'])('Set type to default "%s" if loaded data has no template set', (defaultType, done) => {
     const schemaTypesPromise = Promise.resolve({
         types: {
             sidebar: {key: 'sidebar', title: 'Sidebar'},
@@ -1590,12 +1590,23 @@ test.each(['sidebar', 'footer'])('Set type to default "%s" if data has no templa
 
     metadataStore.getSchemaTypes.mockReturnValue(schemaTypesPromise);
 
-    const resourceStore = new ResourceStore('test', 5);
+    const resourceStore = new ResourceStore('test');
+    resourceStore.loading = true;
+
     const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets');
 
-    return schemaTypesPromise.then(() => {
-        expect(resourceStore.set).toBeCalledWith('template', defaultType);
-        expect(resourceFormStore.type).toEqual(defaultType);
+    expect(resourceFormStore.type).toEqual(undefined);
+
+    schemaTypesPromise.then(() => {
+        // type should not be set until ResourceStore is loaded completely
+        expect(resourceFormStore.type).toEqual(undefined);
+        resourceStore.loading = false;
+
+        setTimeout(() => {
+            expect(resourceFormStore.type).toEqual(defaultType);
+            resourceFormStore.destroy();
+            done();
+        }, 0);
     });
 });
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| License | MIT

#### What's in this PR?

This PR adjusts the `ResourceFormStore` to use the mobx object API for setting and accessing the `template` property of the `ResourceStore::data` object. This is needed to detect that the `template` property is changed if the initial `ResourceStore::data` object does not contain a `template` property.

#### Why?

At the moment, when creating a new page, the computed `ResourceFormStore::type` property is not updated after the default type is set. Because of this, the `Form` view does not render any fields when creating a new page.

The reason for this is that the `ResourceStore::data` object does not have a `template` property in the case of a new page. Unfortunately, mobx 4 only detects changes of existing properties per default. Because of this, mobx does not detect the change of the `template` property and therefore the computed  `ResourceFormStore::type` property is never updated.
