### PR TITLE
Fix broken page extension forms by setting type of ResourceFormStore only when schema of form contains types

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
@@ -115,7 +115,7 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
     }
 
     @computed get type(): string {
-        return get(this.data, TYPE_PROPERTY);
+        return this.hasTypes ? get(this.data, TYPE_PROPERTY) : undefined;
     }
 
     @action save(options: Object = {}): Promise<Object> {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
@@ -74,7 +74,7 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
                 return;
             }
 
-            if (this.hasTypes && !this.types[this.type]) {
+            if (this.hasTypes && this.type && !this.types[this.type]) {
                 this.setSchemaLoading(false);
                 return;
             }
@@ -114,7 +114,7 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
         return this.resourceStore.data;
     }
 
-    @computed get type(): string {
+    @computed get type(): ?string {
         return this.hasTypes ? get(this.data, TYPE_PROPERTY) : undefined;
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
@@ -459,31 +459,6 @@ test('Set dirty flag from ResourceStore', () => {
     expect(resourceFormStore.dirty).toEqual(true);
 });
 
-test('Set template property of ResourceStore from the loaded data', () => {
-    const metadata = {};
-
-    const schemaTypesPromise = Promise.resolve({
-        defaultType: 'type1',
-        types: {
-            type1: {},
-            type2: {},
-        },
-    });
-    metadataStore.getSchemaTypes.mockReturnValue(schemaTypesPromise);
-
-    const metadataPromise = Promise.resolve(metadata);
-    metadataStore.getSchema.mockReturnValue(metadataPromise);
-
-    const resourceStore = new ResourceStore('snippets', '1');
-    resourceStore.data = observable({template: 'type2'});
-    const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets');
-
-    return Promise.all([schemaTypesPromise, metadataPromise]).then(() => {
-        expect(resourceFormStore.type).toEqual('type2');
-        resourceFormStore.destroy();
-    });
-});
-
 test('Create data object for schema with sections', () => {
     const metadata = {
         section1: {
@@ -643,6 +618,7 @@ test('type property should be returning type from ResourceStore', () => {
         defaultType: 'sidebar',
         types: {
             sidebar: {},
+            other: {},
         },
     });
     metadataStore.getSchemaTypes.mockReturnValue(schemaTypesPromise);
@@ -650,6 +626,24 @@ test('type property should be returning type from ResourceStore', () => {
 
     return schemaTypesPromise.then(() => {
         expect(resourceFormStore.type).toEqual('sidebar');
+    });
+});
+
+test('type property should return undefined if ResourceStore has a type but schema does not include any types', () => {
+    const resourceStore = new ResourceStore('snippets', '1');
+    resourceStore.data = observable({
+        template: 'sidebar',
+    });
+
+    const schemaTypesPromise = Promise.resolve({
+        defaultType: 'sidebar',
+        types: undefined,
+    });
+    metadataStore.getSchemaTypes.mockReturnValue(schemaTypesPromise);
+    const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets');
+
+    return schemaTypesPromise.then(() => {
+        expect(resourceFormStore.type).toBeUndefined()
     });
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
@@ -643,7 +643,7 @@ test('type property should return undefined if ResourceStore has a type but sche
     const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets');
 
     return schemaTypesPromise.then(() => {
-        expect(resourceFormStore.type).toBeUndefined()
+        expect(resourceFormStore.type).toBeUndefined();
     });
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/TypeToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/TypeToolbarAction.js
@@ -10,7 +10,7 @@ import type {ToolbarItemConfig} from '../../../containers/Toolbar/types';
 export default class TypeToolbarAction extends AbstractFormToolbarAction {
     @observable selectedTypeForUnsavedChangesDialog: ?string = undefined;
 
-    getToolbarItemConfig(): ?ToolbarItemConfig<string> {
+    getToolbarItemConfig(): ?ToolbarItemConfig<?string> {
         const formTypes = Object.keys(this.resourceFormStore.types).map((key) => this.resourceFormStore.types[key]);
 
         if (!this.resourceFormStore.typesLoading && formTypes.length === 0) {

--- a/src/Sulu/Component/Rest/Listing/ListRepository.php
+++ b/src/Sulu/Component/Rest/Listing/ListRepository.php
@@ -12,7 +12,7 @@
 namespace Sulu\Component\Rest\Listing;
 
 use Doctrine\ORM\EntityRepository;
-use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 
 /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #6179
| Related issues/PRs | problem is caused by the changes in #6169
| License | MIT

#### What's in this PR?

This PR adjusts the `ResourceFormStore` to return a value for the `ResourceFormStore::type` property only if the loaded schema contains types. This behaviour matches the behaviour before the changes in #6169 (`this.changeType()` was only called if `this.hasTypes` returned true).

#### Why?

Because the current behaviour (always return value from `ResourceFormStore::type` property if the `ResourecStore::template` property is set) breaks forms like the `page_seo` and `page_settings` form. See https://github.com/sulu/sulu/issues/6179
