### PR TITLE
Use generic DropdownToolbarAction instead of SaveWithPublishingToolbarAction in PageAdmin

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -102,6 +102,7 @@ import Form, {
     DeleteToolbarAction as FormDeleteToolbarAction,
     DropdownToolbarAction as FormDropdownToolbarAction,
     SaveToolbarAction as FormSaveToolbarAction,
+    PublishToolbarAction as FormPublishToolbarAction,
     SaveWithFormDialogToolbarAction as FormSaveWithFormDialogToolbarAction,
     SaveWithPublishingToolbarAction as FormSaveWithPublishingToolbarAction,
     SetUnpublishedToolbarAction as FormSetUnpublishedToolbarAction,
@@ -305,6 +306,7 @@ function registerFormToolbarActions() {
     formToolbarActionRegistry.add('sulu_admin.dropdown', FormDropdownToolbarAction);
     formToolbarActionRegistry.add('sulu_admin.save_with_publishing', FormSaveWithPublishingToolbarAction);
     formToolbarActionRegistry.add('sulu_admin.save', FormSaveToolbarAction);
+    formToolbarActionRegistry.add('sulu_admin.publish', FormPublishToolbarAction);
     formToolbarActionRegistry.add('sulu_admin.save_with_form_dialog', FormSaveWithFormDialogToolbarAction);
     formToolbarActionRegistry.add('sulu_admin.set_unpublished', FormSetUnpublishedToolbarAction);
     formToolbarActionRegistry.add('sulu_admin.type', FormTypeToolbarAction);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/index.js
@@ -9,6 +9,7 @@ import DropdownToolbarAction from './toolbarActions/DropdownToolbarAction';
 import SaveWithPublishingToolbarAction from './toolbarActions/SaveWithPublishingToolbarAction';
 import SaveWithFormDialogToolbarAction from './toolbarActions/SaveWithFormDialogToolbarAction';
 import SaveToolbarAction from './toolbarActions/SaveToolbarAction';
+import PublishToolbarAction from './toolbarActions/PublishToolbarAction';
 import SetUnpublishedToolbarAction from './toolbarActions/SetUnpublishedToolbarAction';
 import TypeToolbarAction from './toolbarActions/TypeToolbarAction';
 import TogglerToolbarAction from './toolbarActions/TogglerToolbarAction';
@@ -24,6 +25,7 @@ export {
     DropdownToolbarAction,
     SaveWithPublishingToolbarAction,
     SaveToolbarAction,
+    PublishToolbarAction,
     SaveWithFormDialogToolbarAction,
     SetUnpublishedToolbarAction,
     TypeToolbarAction,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DropdownToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DropdownToolbarAction.test.js
@@ -74,6 +74,7 @@ test('Return item config with an option for every action in array and skip undef
                         return {
                             label: 'Copy',
                             onClick: copyClickSpy,
+                            disabled: true,
                         };
                     }
                 };
@@ -99,6 +100,7 @@ test('Return item config with an option for every action in array and skip undef
     expect(dropdownToolbarAction.getToolbarItemConfig()).toEqual({
         icon: 'su-edit',
         label: 'edit',
+        loading: false,
         options: [
             {
                 label: 'Delete',
@@ -107,6 +109,7 @@ test('Return item config with an option for every action in array and skip undef
             {
                 label: 'Copy',
                 onClick: copyClickSpy,
+                disabled: true,
             },
         ],
         type: 'dropdown',
@@ -161,6 +164,7 @@ test('Return item config with options passed to child ToolbarActions', () => {
     expect(dropdownToolbarAction.getToolbarItemConfig()).toEqual({
         icon: 'su-edit',
         label: 'edit',
+        loading: false,
         options: [
             expect.objectContaining({
                 label: 'Delete',
@@ -171,6 +175,56 @@ test('Return item config with options passed to child ToolbarActions', () => {
         ],
         type: 'dropdown',
     });
+});
+
+test('Return item config with loading if one of the child ToolbarActions is loading', () => {
+    formToolbarActionRegistry.get.mockImplementation((key) => {
+        switch (key) {
+            case 'sulu_admin.not_loading':
+                return class {
+                    getToolbarItemConfig() {
+                        return {
+                            label: 'Not Loading',
+                            loading: false,
+                            onClick: jest.fn(),
+                        };
+                    }
+                };
+            case 'sulu_admin.loading':
+                return class {
+                    getToolbarItemConfig() {
+                        return {
+                            label: 'Loading',
+                            loading: true,
+                            onClick: jest.fn(),
+                        };
+                    }
+                };
+            case 'sulu_admin.nothing':
+                return class {
+                    getToolbarItemConfig() {
+
+                    }
+                };
+        }
+    });
+
+    const dropdownToolbarAction = createDropdownToolbarAction({
+        icon: 'su-edit',
+        label: 'edit',
+        toolbarActions: [
+            {type: 'sulu_admin.not_loading', options: {}},
+            {type: 'sulu_admin.loading', options: {}},
+            {type: 'sulu_admin.nothing', options: {}},
+        ],
+    });
+
+    expect(dropdownToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        icon: 'su-edit',
+        label: 'edit',
+        loading: true,
+        type: 'dropdown',
+    }));
 });
 
 test('Return no item config if all child ToolbarActions return nothing', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/PublishToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/PublishToolbarAction.test.js
@@ -1,0 +1,126 @@
+// @flow
+import {ResourceFormStore} from '../../../../containers/Form';
+import ResourceStore from '../../../../stores/ResourceStore';
+import Router from '../../../../services/Router';
+import Form from '../../../../views/Form';
+import PublishToolbarAction from '../../toolbarActions/PublishToolbarAction';
+
+jest.mock('../../../../utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
+
+jest.mock('../../../../stores/ResourceStore', () => jest.fn(function() {
+    this.data = {};
+}));
+
+jest.mock('../../../../containers/Form', () => ({
+    ResourceFormStore: class {
+        resourceStore;
+        constructor(resourceStore) {
+            this.resourceStore = resourceStore;
+        }
+
+        get dirty() {
+            return this.resourceStore.dirty;
+        }
+
+        get saving() {
+            return this.resourceStore.saving;
+        }
+
+        get data() {
+            return this.resourceStore.data;
+        }
+    },
+}));
+
+jest.mock('../../../../services/Router', () => jest.fn());
+
+jest.mock('../../../../views/Form', () => jest.fn(function() {
+    this.submit = jest.fn();
+}));
+
+function createPublishToolbarAction(options = {}) {
+    const resourceStore = new ResourceStore('test');
+    const resourceFormStore = new ResourceFormStore(resourceStore, 'test');
+    const router = new Router({});
+    const form = new Form({
+        locales: [],
+        resourceStore,
+        route: router.route,
+        router,
+    });
+
+    return new PublishToolbarAction(resourceFormStore, form, router, [], options, resourceStore);
+}
+
+test('Return item config with correct label, disabled, and type', () => {
+    const publishToolbarAction = createPublishToolbarAction();
+    publishToolbarAction.resourceFormStore.resourceStore.dirty = false;
+    publishToolbarAction.resourceFormStore.resourceStore.data.publishedState = true;
+
+    expect(publishToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        label: 'sulu_admin.publish',
+        disabled: true,
+        type: 'button',
+    }));
+});
+
+test('Return item config with enabled button when resource is not published and form is not dirty', () => {
+    const publishToolbarAction = createPublishToolbarAction();
+    publishToolbarAction.resourceFormStore.resourceStore.dirty = false;
+    publishToolbarAction.resourceFormStore.resourceStore.data.publishedState = false;
+
+    expect(publishToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        disabled: false,
+    }));
+});
+
+test('Return item config with disabled button when resource is not published but form is not dirty', () => {
+    const publishToolbarAction = createPublishToolbarAction();
+    publishToolbarAction.resourceFormStore.resourceStore.dirty = true;
+    publishToolbarAction.resourceFormStore.resourceStore.data.publishedState = false;
+
+    expect(publishToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        disabled: true,
+    }));
+});
+
+test('Return item config with disabled button when resource is not loaded yet', () => {
+    const publishToolbarAction = createPublishToolbarAction();
+    publishToolbarAction.resourceFormStore.resourceStore.dirty = false;
+    publishToolbarAction.resourceFormStore.resourceStore.data = {};
+
+    expect(publishToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        disabled: true,
+    }));
+});
+
+test('Return item config if passed visible_condition is met', () => {
+    const publishToolbarAction = createPublishToolbarAction({visible_condition: '_permission.live'});
+    publishToolbarAction.resourceFormStore.resourceStore.data._permission = {live: true};
+
+    expect(publishToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        label: 'sulu_admin.publish',
+    }));
+});
+
+test('Return empty item config if passed visible_condition is not met', () => {
+    const publishToolbarAction = createPublishToolbarAction({visible_condition: '_permission.live'});
+    publishToolbarAction.resourceFormStore.resourceStore.data._permission = {live: false};
+
+    expect(publishToolbarAction.getToolbarItemConfig()).toEqual(undefined);
+});
+
+test('Submit form with correct options when button is clicked', () => {
+    const publishToolbarAction = createPublishToolbarAction();
+    const toolbarItemConfig = publishToolbarAction.getToolbarItemConfig();
+
+    if (!toolbarItemConfig) {
+        throw new Error('The toolbarItemConfig should be a value!');
+    }
+
+    toolbarItemConfig.onClick();
+
+    expect(publishToolbarAction.form.submit).toBeCalledWith({action: 'publish'});
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithPublishingToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithPublishingToolbarAction.test.js
@@ -184,7 +184,9 @@ test('Return item config without publish specific options if passed publish_visi
             label: 'sulu_admin.save_draft',
         }),
     ]);
-    expect(log.warn).not.toBeCalled();
+    expect(log.warn).not.toBeCalledWith(
+        expect.stringContaining('The "publish_display_condition" option is deprecated')
+    );
 });
 
 test('Return item config without saving specific options if deprecated save_display_condition is not met', () => {
@@ -216,7 +218,7 @@ test('Return item config without saving specific options if passed save_visible_
             label: 'sulu_admin.publish',
         }),
     ]);
-    expect(log.warn).not.toBeCalled();
+    expect(log.warn).not.toBeCalledWith(expect.stringContaining('The "save_display_condition" option is deprecated'));
 });
 
 test('Return item config with publish specific options if passed publish_visible_condition is met', () => {
@@ -271,7 +273,6 @@ test('Return empty item config if no options are returned', () => {
 
     const toolbarItemConfig = editToolbarAction.getToolbarItemConfig();
     expect(toolbarItemConfig).toEqual(undefined);
-    expect(log.warn).not.toBeCalled();
 });
 
 test('Return item config with loading button when saving flag is set', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DropdownToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DropdownToolbarAction.js
@@ -83,9 +83,10 @@ export default class DropdownToolbarAction extends AbstractFormToolbarAction {
             throw new Error('The "icon" option must be a string!');
         }
 
+        // use "Boolean" to filter undefined: https://github.com/facebook/flow/issues/1414#issuecomment-251422935
         const childToolbarItemConfigs: Array<ToolbarItemConfig<*>> = this.toolbarActions
             .map((toolbarAction) => toolbarAction.getToolbarItemConfig())
-            .filter((toolbarItemConfig) => !!toolbarItemConfig);
+            .filter(Boolean);
 
         if (childToolbarItemConfigs.length === 0) {
             return undefined;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/PublishToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/PublishToolbarAction.js
@@ -1,0 +1,27 @@
+// @flow
+import jexl from 'jexl';
+import {translate} from '../../../utils/Translator';
+import AbstractFormToolbarAction from './AbstractFormToolbarAction';
+
+export default class PublishToolbarAction extends AbstractFormToolbarAction {
+    getToolbarItemConfig() {
+        const {
+            visible_condition: visibleCondition,
+        } = this.options;
+
+        const {dirty, data} = this.resourceFormStore;
+
+        const visibleConditionFulfilled = !visibleCondition || jexl.evalSync(visibleCondition, data);
+
+        if (visibleConditionFulfilled) {
+            return {
+                label: translate('sulu_admin.publish'),
+                disabled: dirty || data.publishedState === undefined || !!data.publishedState,
+                onClick: () => {
+                    this.form.submit({action: 'publish'});
+                },
+                type: 'button',
+            };
+        }
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveToolbarAction.js
@@ -1,18 +1,39 @@
 // @flow
+import jexl from 'jexl';
 import {translate} from '../../../utils/Translator';
 import AbstractFormToolbarAction from './AbstractFormToolbarAction';
 
 export default class SaveToolbarAction extends AbstractFormToolbarAction {
     getToolbarItemConfig() {
-        return {
-            disabled: !this.resourceFormStore.dirty,
-            icon: 'su-save',
-            label: translate('sulu_admin.save'),
-            loading: this.resourceFormStore.saving,
-            onClick: () => {
-                this.form.submit();
-            },
-            type: 'button',
-        };
+        const {
+            label = 'sulu_admin.save',
+            visible_condition: visibleCondition,
+            options: submitOptions,
+        } = this.options;
+
+        const {data, dirty, saving} = this.resourceFormStore;
+
+        if (typeof label !== 'string') {
+            throw new Error('The "label" option must be a string!');
+        }
+
+        if (submitOptions === null || typeof submitOptions !== 'object') {
+            throw new Error('The "options" option must be an object!');
+        }
+
+        const visibleConditionFulfilled = !visibleCondition || jexl.evalSync(visibleCondition, data);
+
+        if (visibleConditionFulfilled) {
+            return {
+                disabled: !dirty,
+                icon: 'su-save',
+                label: translate(label),
+                loading: saving,
+                onClick: () => {
+                    this.form.submit(submitOptions);
+                },
+                type: 'button',
+            };
+        }
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveToolbarAction.js
@@ -17,7 +17,7 @@ export default class SaveToolbarAction extends AbstractFormToolbarAction {
             throw new Error('The "label" option must be a string!');
         }
 
-        if (submitOptions === null || typeof submitOptions !== 'object') {
+        if (submitOptions && typeof submitOptions !== 'object') {
             throw new Error('The "options" option must be an object!');
         }
 
@@ -30,7 +30,7 @@ export default class SaveToolbarAction extends AbstractFormToolbarAction {
                 label: translate(label),
                 loading: saving,
                 onClick: () => {
-                    this.form.submit(submitOptions);
+                    this.form.submit((submitOptions: any));
                 },
                 type: 'button',
             };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveWithPublishingToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveWithPublishingToolbarAction.js
@@ -9,6 +9,7 @@ import Router from '../../../services/Router';
 import AbstractFormToolbarAction from './AbstractFormToolbarAction';
 
 export default class SaveWithPublishingToolbarAction extends AbstractFormToolbarAction {
+    // @deprecated
     constructor(
         resourceFormStore: ResourceFormStore,
         form: Form,
@@ -23,6 +24,11 @@ export default class SaveWithPublishingToolbarAction extends AbstractFormToolbar
             publish_visible_condition: publishVisibleCondition,
             save_visible_condition: saveVisibleCondition,
         } = options;
+
+        log.warn(
+            'The "SaveWithPublishingToolbarAction" is deprecated since 2.3 and will be removed. ' +
+            'Use a "DropdownToolbarAction" with a "SaveToolbarAction" and "PublishToolbarAction" instead.'
+        );
 
         if (publishDisplayCondition) {
             // @deprecated

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -118,16 +118,40 @@ class PageAdmin extends Admin
     {
         /** @var Webspace $firstWebspace */
         $firstWebspace = \current($this->webspaceManager->getWebspaceCollection()->getWebspaces());
-        $publishDisplayCondition = '(!_permissions || _permissions.live)';
+        $saveVisibleCondition = '(!_permissions || _permissions.edit)';
+        $publishVisibleCondition = '(!_permissions || _permissions.live)';
+
+        $saveWithPublishingDropdown = new DropdownToolbarAction(
+            'sulu_admin.save',
+            'su-save',
+            [
+                new ToolbarAction(
+                    'sulu_admin.save',
+                    [
+                        'label' => 'sulu_admin.save_draft',
+                        'options' => ['action' => 'draft'],
+                        'visible_condition' => $saveVisibleCondition,
+                    ]
+                ),
+                new ToolbarAction(
+                    'sulu_admin.save',
+                    [
+                        'label' => 'sulu_admin.save_publish',
+                        'options' => ['action' => 'publish'],
+                        'visible_condition' => '(' . $saveVisibleCondition . ') && (' . $publishVisibleCondition . ')',
+                    ]
+                ),
+                new ToolbarAction(
+                    'sulu_admin.publish',
+                    [
+                        'visible_condition' => $publishVisibleCondition,
+                    ]
+                ),
+            ]
+        );
 
         $formToolbarActionsWithType = [
-            new ToolbarAction(
-                'sulu_admin.save_with_publishing',
-                [
-                    'publish_visible_condition' => '(!_permissions || _permissions.live)',
-                    'save_visible_condition' => '(!_permissions || _permissions.edit)',
-                ]
-            ),
+            $saveWithPublishingDropdown,
             new ToolbarAction(
                 'sulu_admin.type',
                 [
@@ -169,13 +193,13 @@ class PageAdmin extends Admin
                     new ToolbarAction(
                         'sulu_admin.delete_draft',
                         [
-                            'visible_condition' => $publishDisplayCondition,
+                            'visible_condition' => $publishVisibleCondition,
                         ]
                     ),
                     new ToolbarAction(
                         'sulu_admin.set_unpublished',
                         [
-                            'visible_condition' => $publishDisplayCondition,
+                            'visible_condition' => $publishVisibleCondition,
                         ]
                     ),
                 ]
@@ -183,7 +207,7 @@ class PageAdmin extends Admin
         ];
 
         $formToolbarActionsWithoutType = [
-            new ToolbarAction('sulu_admin.save_with_publishing'),
+            $saveWithPublishingDropdown
         ];
 
         $routerAttributesToFormRequest = ['parentId', 'webspace'];

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -207,7 +207,7 @@ class PageAdmin extends Admin
         ];
 
         $formToolbarActionsWithoutType = [
-            $saveWithPublishingDropdown
+            $saveWithPublishingDropdown,
         ];
 
         $routerAttributesToFormRequest = ['parentId', 'webspace'];


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

This PR adjusts the `PageAdmin` to use a generic `DropdownToolbarAction` instead of the specific `SaveWithPublishingToolbarAction`. To do this, the PR adds a reusable `PublishToolbarAction`.

#### Why?

Using a `DropdownToolbarAction` makes it easier to add an additional item to the dropdown. Also, this change forces us to implement all dropdown options (save as draft, save and publish, publish) in a reusable manner. This makes it easier to use this functionality in other places.
