### PR TITLE
Fix windows video thumbnail generation

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/MediaImageExtractor.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/MediaImageExtractor.php
@@ -90,7 +90,7 @@ class MediaImageExtractor implements MediaImageExtractorInterface
 
         $command = $this->ghostScriptPath .
             ' -dNOPAUSE -sDEVICE=jpeg -dFirstPage=1 -dLastPage=1 -sOutputFile=' . $temporaryFilePath . ' ' .
-            '-dJPEGQ=100 -r300x300 -q ' . $temporaryFilePath . ' -c quit 2> /dev/null';
+            '-dJPEGQ=100 -r300x300 -q ' . $temporaryFilePath . ' -c quit';
 
         \shell_exec($command);
         $output = \file_get_contents($temporaryFilePath);

--- a/src/Sulu/Bundle/MediaBundle/Media/Video/VideoThumbnailService.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Video/VideoThumbnailService.php
@@ -36,8 +36,6 @@ class VideoThumbnailService implements VideoThumbnailServiceInterface
             return false;
         }
 
-        $destination = $this->normalizeFilename($destination);
-
         try {
             $video = $this->ffmpeg->open($file);
 
@@ -60,7 +58,7 @@ class VideoThumbnailService implements VideoThumbnailServiceInterface
         if (null !== $this->ffmpeg) {
             $failed = [];
             foreach ($times as $time) {
-                $filename = $destinationPath . \DIRECTORY_SEPARATOR . $time . '.jpg';
+                $filename = $destinationPath . \DIRECTORY_SEPARATOR . $this->normalizeFilename($time) . '.jpg';
                 $success = $this->generate($video, $time, $filename);
 
                 if (!$success) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | no
| Related issues/PRs | n/a
| License | MIT
| Documentation PR | n/a

#### What's in this PR?

This PR fixes two issues in the SuluMediaBundle that prevent thumbnails of PDF and video files from being created on Windows systems.

1) The ghostscript command syntax in `MediaImageExtractor.php->convertPdfToImage` is hard-coded to pipe errors to `/dev/null`. That syntax is not compatible with Windows where the comparable folder is simply `NUL`. Rather than create platform-specific code, this PR removes the piping altogether as it is unnecessary.

2) The `VideoThumbnailService.php` normalizes filenames to prevent the possibility that colons `:` could be included in a filename (temporary filenames are created from time values which contain colons). However, the normalization code is called from the `generate` method where the entire file path is normalized rather than just the filename. This causes ffmpeg calls to fail on Windows where the drive letter syntax (e.g. C:\) includes a colon. This PR moves the normalization call to the outer `batchGenerate` method where it is only applied to the filename.