### PR TITLE
Add possibility to add additional data to login request

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/ForgotPasswordForm.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/ForgotPasswordForm.js
@@ -12,7 +12,7 @@ import type {ElementRef} from 'react';
 type Props = {|
     loading: boolean,
     onChangeForm: () => void,
-    onSubmit: (user: string) => void,
+    onSubmit: (data: string | Object) => void,
     success: boolean,
 |};
 
@@ -54,7 +54,7 @@ class ForgotPasswordForm extends React.Component<Props> {
 
         const {onSubmit} = this.props;
 
-        onSubmit(this.user);
+        onSubmit({user: this.user});
     };
 
     render() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/ForgotPasswordForm.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/ForgotPasswordForm.js
@@ -12,7 +12,7 @@ import type {ElementRef} from 'react';
 type Props = {|
     loading: boolean,
     onChangeForm: () => void,
-    onSubmit: (data: string | Object) => void,
+    onSubmit: (data: Object) => void,
     success: boolean,
 |};
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/ForgotPasswordForm.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/ForgotPasswordForm.js
@@ -8,11 +8,12 @@ import Input from '../../components/Input/index';
 import Header from './Header';
 import formStyles from './form.scss';
 import type {ElementRef} from 'react';
+import type {ForgotPasswordFormData} from './types';
 
 type Props = {|
     loading: boolean,
     onChangeForm: () => void,
-    onSubmit: (data: Object) => void,
+    onSubmit: (data: ForgotPasswordFormData) => void,
     success: boolean,
 |};
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/Login.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/Login.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import log from 'loglevel';
 import {action, computed, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import Icon from '../../components/Icon/index';
@@ -60,17 +61,40 @@ class Login extends React.Component<Props> {
         this.visibleForm = 'forgot-password';
     };
 
-    handleLoginFormSubmit = (user: string, password: string) => {
-        userStore.login(user, password).then(() => {
+    handleLoginFormSubmit = (data: string | Object, password?: string) => {
+        if (typeof data === 'string') {
+            log.warn(
+                'The "handleLoginFormSubmit" method called with user and password string'
+                + 'is deprecated give object instead.'
+            );
+
+            data = {
+                username: data,
+                password,
+            };
+        }
+
+        userStore.login(data).then(() => {
             this.props.onLoginSuccess();
         });
     };
 
-    handleForgotPasswordFormSubmit = (user: string) => {
-        userStore.forgotPassword(user);
+    handleForgotPasswordFormSubmit = (data: string | Object) => {
+        if (typeof data === 'string') {
+            log.warn(
+                'The "handleForgotPasswordFormSubmit" method called with user and password string'
+                + 'is deprecated give object instead.'
+            );
+
+            data = {
+                user: data,
+            };
+        }
+
+        userStore.forgotPassword(data);
     };
 
-    handleResetPasswordFormSubmit = (password: string) => {
+    handleResetPasswordFormSubmit = (data: string | Object) => {
         const {
             onLoginSuccess,
             router,
@@ -82,7 +106,21 @@ class Login extends React.Component<Props> {
             throw new Error('The "forgotPasswordToken" router attribute must be a string!');
         }
 
-        userStore.resetPassword(password, forgotPasswordToken)
+        if (typeof data === 'string') {
+            log.warn(
+                'The "handleResetPasswordFormSubmit" method called with user and password string'
+                + 'is deprecated give object instead.'
+            );
+
+            data = {
+                password: data,
+            };
+        }
+
+        userStore.resetPassword({
+            token: forgotPasswordToken,
+            ...data,
+        })
             .then(() => {
                 router.reset();
                 onLoginSuccess();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/Login.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/Login.js
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react';
-import log from 'loglevel';
 import {action, computed, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import Icon from '../../components/Icon/index';
@@ -61,40 +60,17 @@ class Login extends React.Component<Props> {
         this.visibleForm = 'forgot-password';
     };
 
-    handleLoginFormSubmit = (data: string | Object, password?: string) => {
-        if (typeof data === 'string') {
-            log.warn(
-                'The "handleLoginFormSubmit" method called with user and password string'
-                + 'is deprecated give object instead.'
-            );
-
-            data = {
-                username: data,
-                password,
-            };
-        }
-
+    handleLoginFormSubmit = (data: Object) => {
         userStore.login(data).then(() => {
             this.props.onLoginSuccess();
         });
     };
 
-    handleForgotPasswordFormSubmit = (data: string | Object) => {
-        if (typeof data === 'string') {
-            log.warn(
-                'The "handleForgotPasswordFormSubmit" method called with user and password string'
-                + 'is deprecated give object instead.'
-            );
-
-            data = {
-                user: data,
-            };
-        }
-
+    handleForgotPasswordFormSubmit = (data: Object) => {
         userStore.forgotPassword(data);
     };
 
-    handleResetPasswordFormSubmit = (data: string | Object) => {
+    handleResetPasswordFormSubmit = (data: Object) => {
         const {
             onLoginSuccess,
             router,
@@ -104,17 +80,6 @@ class Login extends React.Component<Props> {
 
         if (typeof forgotPasswordToken !== 'string') {
             throw new Error('The "forgotPasswordToken" router attribute must be a string!');
-        }
-
-        if (typeof data === 'string') {
-            log.warn(
-                'The "handleResetPasswordFormSubmit" method called with user and password string'
-                + 'is deprecated give object instead.'
-            );
-
-            data = {
-                password: data,
-            };
         }
 
         userStore.resetPassword({

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/Login.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/Login.js
@@ -11,7 +11,7 @@ import ForgotPasswordForm from './ForgotPasswordForm';
 import LoginForm from './LoginForm';
 import ResetPasswordForm from './ResetPasswordForm';
 import loginStyles from './login.scss';
-import type {FormTypes} from './types';
+import type {FormTypes, ForgotPasswordFormData, LoginFormData, ResetPasswordFormData} from './types';
 
 const BACK_LINK_ARROW_LEFT_ICON = 'su-angle-left';
 
@@ -60,17 +60,17 @@ class Login extends React.Component<Props> {
         this.visibleForm = 'forgot-password';
     };
 
-    handleLoginFormSubmit = (data: Object) => {
+    handleLoginFormSubmit = (data: LoginFormData) => {
         userStore.login(data).then(() => {
             this.props.onLoginSuccess();
         });
     };
 
-    handleForgotPasswordFormSubmit = (data: Object) => {
+    handleForgotPasswordFormSubmit = (data: ForgotPasswordFormData) => {
         userStore.forgotPassword(data);
     };
 
-    handleResetPasswordFormSubmit = (data: Object) => {
+    handleResetPasswordFormSubmit = (data: ResetPasswordFormData) => {
         const {
             onLoginSuccess,
             router,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/Login.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/Login.js
@@ -83,8 +83,8 @@ class Login extends React.Component<Props> {
         }
 
         userStore.resetPassword({
-            token: forgotPasswordToken,
             ...data,
+            token: forgotPasswordToken,
         })
             .then(() => {
                 router.reset();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/LoginForm.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/LoginForm.js
@@ -14,7 +14,7 @@ type Props = {|
     error: boolean,
     loading: boolean,
     onChangeForm: () => void,
-    onSubmit: (user: string, password: string) => void,
+    onSubmit: (user: string | Object, password?: string) => void,
 |};
 
 @observer
@@ -60,7 +60,10 @@ class LoginForm extends React.Component<Props> {
 
         const {onSubmit} = this.props;
 
-        onSubmit(this.user, this.password);
+        onSubmit({
+            username: this.user,
+            password: this.password,
+        });
     };
 
     render() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/LoginForm.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/LoginForm.js
@@ -14,7 +14,7 @@ type Props = {|
     error: boolean,
     loading: boolean,
     onChangeForm: () => void,
-    onSubmit: (user: string | Object, password?: string) => void,
+    onSubmit: (user: Object) => void,
 |};
 
 @observer

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/LoginForm.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/LoginForm.js
@@ -9,12 +9,13 @@ import Input from '../../components/Input/index';
 import formStyles from './form.scss';
 import Header from './Header';
 import type {ElementRef} from 'react';
+import type {LoginFormData} from './types';
 
 type Props = {|
     error: boolean,
     loading: boolean,
     onChangeForm: () => void,
-    onSubmit: (user: Object) => void,
+    onSubmit: (data: LoginFormData) => void,
 |};
 
 @observer

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/ResetPasswordForm.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/ResetPasswordForm.js
@@ -9,11 +9,12 @@ import Input from '../../components/Input/index';
 import formStyles from './form.scss';
 import Header from './Header';
 import type {ElementRef} from 'react';
+import type {ResetPasswordFormData} from './types';
 
 type Props = {|
     loading: boolean,
     onChangeForm: () => void,
-    onSubmit: (data: Object) => void,
+    onSubmit: (data: ResetPasswordFormData) => void,
 |};
 
 @observer

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/ResetPasswordForm.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/ResetPasswordForm.js
@@ -13,11 +13,11 @@ import type {ElementRef} from 'react';
 type Props = {|
     loading: boolean,
     onChangeForm: () => void,
-    onSubmit: (password: string) => void,
+    onSubmit: (data: string | Object) => void,
 |};
 
 @observer
-class ForgotPasswordForm extends React.Component<Props> {
+class ResetPasswordForm extends React.Component<Props> {
     static defaultProps = {
         loading: false,
     };
@@ -68,7 +68,7 @@ class ForgotPasswordForm extends React.Component<Props> {
 
         const {onSubmit} = this.props;
 
-        onSubmit(this.password1);
+        onSubmit({password: this.password1});
     };
 
     render() {
@@ -133,4 +133,4 @@ class ForgotPasswordForm extends React.Component<Props> {
     }
 }
 
-export default ForgotPasswordForm;
+export default ResetPasswordForm;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/ResetPasswordForm.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/ResetPasswordForm.js
@@ -13,7 +13,7 @@ import type {ElementRef} from 'react';
 type Props = {|
     loading: boolean,
     onChangeForm: () => void,
-    onSubmit: (data: string | Object) => void,
+    onSubmit: (data: Object) => void,
 |};
 
 @observer

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/ForgotPasswordForm.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/ForgotPasswordForm.test.js
@@ -83,9 +83,9 @@ test('Should trigger onSubmit correctly', () => {
         preventDefault: jest.fn(),
     };
 
-    resetForm.find('Input[icon="su-user"]').prop('onChange')('Max');
+    resetForm.find('Input[icon="su-user"]').prop('onChange')('testusername');
     resetForm.find('form').prop('onSubmit')(event);
 
     expect(event.preventDefault).toBeCalledWith();
-    expect(onSubmit).toBeCalledWith('Max');
+    expect(onSubmit).toBeCalledWith({user: 'testusername'});
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/Login.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/Login.test.js
@@ -31,16 +31,16 @@ jest.mock('../../../stores/userStore', () => {
             return mockUserStoreClear();
         }
 
-        login(user, password) {
-            return mockUserStoreLogin(user, password);
+        login(data) {
+            return mockUserStoreLogin(data);
         }
 
-        forgotPassword(user) {
-            return mockUserStoreForgotPassword(user);
+        forgotPassword(data) {
+            return mockUserStoreForgotPassword(data);
         }
 
-        resetPassword(password) {
-            return mockUserStoreResetPassword(password);
+        resetPassword(data) {
+            return mockUserStoreResetPassword(data);
         }
 
         setLoginError(value) {
@@ -137,7 +137,7 @@ test('Should call the submit handler of the login view', () => {
 
     login.find('form').prop('onSubmit')(eventMock);
 
-    expect(mockUserStoreLogin).toBeCalledWith('testUser', 'testPassword');
+    expect(mockUserStoreLogin).toBeCalledWith({username: 'testUser', password: 'testPassword'});
 });
 
 test('Should call the submit handler of the forgot password view', () => {
@@ -154,7 +154,7 @@ test('Should call the submit handler of the forgot password view', () => {
     login.find('Input[icon="su-user"]').prop('onChange')('testUser');
     login.find('form').prop('onSubmit')(eventMock);
 
-    expect(mockUserStoreForgotPassword).toBeCalledWith('testUser');
+    expect(mockUserStoreForgotPassword).toBeCalledWith({user: 'testUser'});
 });
 
 test('Should call the submit handler of the reset password view', () => {
@@ -169,11 +169,14 @@ test('Should call the submit handler of the reset password view', () => {
         <Login initialized={true} onLoginSuccess={jest.fn()} router={router} />
     );
 
-    login.find('Input[icon="su-lock"]').at(0).prop('onChange')('test');
-    login.find('Input[icon="su-lock"]').at(1).prop('onChange')('test');
+    login.find('Input[icon="su-lock"]').at(0).prop('onChange')('testpassword');
+    login.find('Input[icon="su-lock"]').at(1).prop('onChange')('testpassword');
     login.find('form').prop('onSubmit')(eventMock);
 
-    expect(mockUserStoreResetPassword).toBeCalledWith('test');
+    expect(mockUserStoreResetPassword).toBeCalledWith({
+        password: 'testpassword',
+        token: 'some-uuid',
+    });
 
     return promise.then(() => {
         expect(router.reset).toBeCalled();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/LoginForm.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/LoginForm.test.js
@@ -90,5 +90,5 @@ test('Should trigger onSubmit correctly', () => {
     loginForm.find('form').prop('onSubmit')(event);
 
     expect(event.preventDefault).toBeCalledWith();
-    expect(onSubmit).toBeCalledWith('Max', 'max');
+    expect(onSubmit).toBeCalledWith({username: 'Max', password: 'max'});
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/ResetPasswordForm.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/ResetPasswordForm.test.js
@@ -73,12 +73,12 @@ test('Should trigger onSubmit correctly', () => {
         preventDefault: jest.fn(),
     };
 
-    resetForm.find('Input[icon="su-lock"]').at(0).prop('onChange')('max');
-    resetForm.find('Input[icon="su-lock"]').at(1).prop('onChange')('max');
+    resetForm.find('Input[icon="su-lock"]').at(0).prop('onChange')('testpassword');
+    resetForm.find('Input[icon="su-lock"]').at(1).prop('onChange')('testpassword');
     resetForm.find('form').prop('onSubmit')(event);
 
     expect(event.preventDefault).toBeCalledWith();
-    expect(onSubmit).toBeCalledWith('max');
+    expect(onSubmit).toBeCalledWith({password: 'testpassword'});
 });
 
 test('Should not trigger onSubmit if one password is missing', () => {
@@ -94,7 +94,7 @@ test('Should not trigger onSubmit if one password is missing', () => {
         preventDefault: jest.fn(),
     };
 
-    resetForm.find('Input[icon="su-lock"]').at(0).prop('onChange')('max');
+    resetForm.find('Input[icon="su-lock"]').at(0).prop('onChange')('testpassword');
     resetForm.find('form').prop('onSubmit')(event);
 
     expect(event.preventDefault).toBeCalledWith();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/types.js
@@ -1,3 +1,16 @@
 // @flow
 
 export type FormTypes = 'login' | 'reset-password' | 'forgot-password';
+
+export type ResetPasswordFormData = {|
+    password: string,
+|};
+
+export type ForgotPasswordFormData = {|
+    user: string,
+|};
+
+export type LoginFormData = {|
+    password: string,
+    username: string,
+|};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/types.js
@@ -2,15 +2,15 @@
 
 export type FormTypes = 'login' | 'reset-password' | 'forgot-password';
 
-export type ResetPasswordFormData = {|
+export type ResetPasswordFormData = {
     password: string,
-|};
+};
 
-export type ForgotPasswordFormData = {|
+export type ForgotPasswordFormData = {
     user: string,
-|};
+};
 
-export type LoginFormData = {|
+export type LoginFormData = {
     password: string,
     username: string,
-|};
+};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/tests/userStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/tests/userStore.test.js
@@ -155,7 +155,7 @@ test('Should login', () => {
     Requester.post.mockReturnValue(loginPromise);
     initializer.initialize.mockReturnValue(initializePromise);
 
-    userStore.login('test', 'password');
+    userStore.login({username: 'test', password: 'password'});
     expect(userStore.loading).toBe(true);
 
     return loginPromise.then(() => {
@@ -175,7 +175,7 @@ test('Should login after the password was reset', () => {
     Requester.post.mockReturnValue(resetPromise);
     initializer.initialize.mockReturnValue(initializePromise);
 
-    userStore.resetPassword('test', 'some-uuid');
+    userStore.resetPassword({password: 'test', token: 'some-uuid'});
     expect(userStore.loading).toBe(true);
 
     return resetPromise.then(() => {
@@ -194,7 +194,7 @@ test('Should login without initializing when it`s the same user', () => {
     Requester.post.mockReturnValue(loginPromise);
     userStore.setUser(user);
 
-    userStore.login('test', 'password');
+    userStore.login({username: 'test', password: 'password'});
     expect(userStore.loading).toBe(true);
 
     return loginPromise.then(() => {
@@ -213,7 +213,7 @@ test('Should login with initializing when it`s not the same user', () => {
 
     expect(Requester.post).not.toBeCalled();
 
-    userStore.login('other-user-than-test', 'password');
+    userStore.login({username: 'other-user-than-test', password: 'password'});
     expect(userStore.loading).toBe(true);
 
     return loginPromise.then(() => {
@@ -238,7 +238,7 @@ test('Should login with initializing when it`s not the same user', () => {
 test('Should show error when login is not working and error status is 401', () => {
     Requester.post.mockReturnValue(Promise.reject({status: 401}));
 
-    const loginPromise = userStore.login('test', 'password');
+    const loginPromise = userStore.login({username: 'test', password: 'password'});
     expect(userStore.loading).toBe(true);
 
     return loginPromise
@@ -254,7 +254,7 @@ test('Should show error when login is not working and error status is 401', () =
 test('Should send an email when the password is forgotten', () => {
     Requester.post.mockReturnValue(Promise.resolve({}));
 
-    const promise = userStore.forgotPassword('test');
+    const promise = userStore.forgotPassword({user: 'test'});
     expect(userStore.loading).toBe(true);
 
     return promise.then(() => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/types.js
@@ -21,16 +21,16 @@ export type Avatar = {
     url: string,
 };
 
-export type ForgotPasswordData = {|
+export type ForgotPasswordData = {
     user: string,
-|};
+};
 
-export type ResetPasswordData = {|
+export type ResetPasswordData = {
     password: string,
     token: string,
-|};
+};
 
-export type LoginData = {|
+export type LoginData = {
     password: string,
     username: string,
-|};
+};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/types.js
@@ -20,3 +20,17 @@ export type Avatar = {
     thumbnails: {[string]: string},
     url: string,
 };
+
+export type ForgotPasswordData = {|
+    user: string,
+|};
+
+export type ResetPasswordData = {|
+    password: string,
+    token: string,
+|};
+
+export type LoginData = {|
+    password: string,
+    username: string,
+|};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/userStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/userStore.js
@@ -1,6 +1,5 @@
 // @flow
 import {action, computed, observable} from 'mobx';
-import log from 'loglevel';
 import debounce from 'debounce';
 import {Config, Requester} from '../../services';
 import initializer from '../../services/initializer';
@@ -113,17 +112,8 @@ class UserStore {
         });
     };
 
-    login = (data: string | Object, password?: string) => {
+    login = (data: Object) => {
         this.setLoading(true);
-
-        if (typeof data === 'string') {
-            log.warn('The "login" method called with user and password string is deprecated give object instead.');
-
-            data = {
-                username: data,
-                password,
-            };
-        }
 
         return Requester.post(Config.endpoints.loginCheck, data)
             .then(() => this.handleLogin(data))
@@ -137,16 +127,8 @@ class UserStore {
             });
     };
 
-    forgotPassword(data: string | Object) {
+    forgotPassword(data: Object) {
         this.setLoading(true);
-
-        if (typeof data === 'string') {
-            log.warn('The "forgotPassword" method called with user string is deprecated give object instead.');
-
-            data = {
-                user: data,
-            };
-        }
 
         return Requester.post(Config.endpoints.forgotPasswordReset, data)
             .then(() => {
@@ -162,19 +144,8 @@ class UserStore {
             });
     }
 
-    resetPassword(data: string | Object, token?: string) {
+    resetPassword(data: Object) {
         this.setLoading(true);
-
-        if (typeof data === 'string') {
-            log.warn(
-                'The "resetPassword" method called with user and password string is deprecated give object instead.'
-            );
-
-            data = {
-                password: data,
-                token,
-            };
-        }
 
         return Requester.post(Config.endpoints.resetPassword, data)
             .then(({user}) => this.handleLogin({username: user}))

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/userStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/userStore.js
@@ -4,7 +4,7 @@ import debounce from 'debounce';
 import {Config, Requester} from '../../services';
 import initializer from '../../services/initializer';
 import localizationStore from '../localizationStore';
-import type {Contact, User} from './types';
+import type {Contact, ForgotPasswordData, LoginData, ResetPasswordData, User} from './types';
 
 const UPDATE_PERSISTENT_SETTINGS_DELAY = 2500;
 const CONTENT_LOCALE_SETTING_KEY = 'sulu_admin.content_locale';
@@ -112,7 +112,7 @@ class UserStore {
         });
     };
 
-    login = (data: Object) => {
+    login = (data: LoginData) => {
         this.setLoading(true);
 
         return Requester.post(Config.endpoints.loginCheck, data)
@@ -127,7 +127,7 @@ class UserStore {
             });
     };
 
-    forgotPassword(data: Object) {
+    forgotPassword(data: ForgotPasswordData) {
         this.setLoading(true);
 
         return Requester.post(Config.endpoints.forgotPasswordReset, data)
@@ -144,7 +144,7 @@ class UserStore {
             });
     }
 
-    resetPassword(data: Object) {
+    resetPassword(data: ResetPasswordData) {
         this.setLoading(true);
 
         return Requester.post(Config.endpoints.resetPassword, data)


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? |  yes
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add possibility to add additional data to login request.

#### Why?

If you add some valdidation to the login example csrf token, captcha or additional fields the user need to fill out there is currently needed to overwrite many components. For this the submit methods of login, reset, forget forms should expected an object instead of strings so any additional data can be send to this api endpoints.

#### Example Usage

Overwrittenn LoginForm.js:

```js
    @action handleSubmit = (event) => {
        event.preventDefault();

        if (!this.user || !this.password) {
            return;
        }

        const {onSubmit} = this.props;

        onSubmit({
            user: this.user,
            password: this.password,
            moreKey: 'test',
        });
    };
```

Same I added to the `ForgotPasswordForm` and `ResetPasswordForm`.
