### PR TITLE
Support request_parameters and resource_store_properties_to_request param in auto_complete selection

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -464,6 +464,7 @@ class Selection extends React.Component<Props> {
                 displayProperty={displayProperty}
                 id={dataPath}
                 idProperty={this.autoCompleteIdProperty}
+                options={this.requestOptions}
                 searchProperties={searchProperties}
                 selectionStore={this.autoCompleteSelectionStore}
             />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -1345,10 +1345,31 @@ test('Should pass props with schema-options type correctly to MultiAutoComplete 
         )
     );
 
+    const formInspectorValues = {'/otherPropertyName': 'value-returned-by-form-inspector'};
+    formInspector.getValueByPath.mockImplementation((path) => formInspectorValues[path]);
+
     const schemaOptions = {
         type: {
             name: 'type',
             value: 'auto_complete',
+        },
+        request_parameters: {
+            name: 'request_parameters',
+            value: [
+                {
+                    name: 'staticKey',
+                    value: 'some-static-value',
+                },
+            ],
+        },
+        resource_store_properties_to_request: {
+            name: 'resource_store_properties_to_request',
+            value: [
+                {
+                    name: 'dynamicKey',
+                    value: 'otherPropertyName',
+                },
+            ],
         },
     };
 
@@ -1363,6 +1384,8 @@ test('Should pass props with schema-options type correctly to MultiAutoComplete 
         />
     );
 
+    expect(formInspector.getValueByPath).toBeCalledWith('/otherPropertyName');
+
     expect(selection.find('MultiAutoComplete').props()).toEqual(expect.objectContaining({
         allowAdd: false,
         disabled: true,
@@ -1370,6 +1393,10 @@ test('Should pass props with schema-options type correctly to MultiAutoComplete 
         idProperty: 'uuid',
         searchProperties: ['name'],
         selectionStore: selection.instance().autoCompleteSelectionStore,
+        options: {
+            staticKey: 'some-static-value',
+            dynamicKey: 'value-returned-by-form-inspector',
+        },
     }));
 });
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/666

#### What's in this PR?

This PR adds the `request_parameters` and `resource_store_properties_to_request` param to the `auto_complete` type of the `Selection` field-type.

#### Why?

For example, this allows to add parameters that are sent to the server to the `tag_selection` like this:

```xml
<property name="tag_selection" type="tag_selection">
    <meta>
        <title lang="en">Tag Selection</title>
        <title lang="de">Tag</title>
    </meta>

    <params>
        <param name="resource_store_properties_to_request" type="collection">
            <param name="dynamic-param" value="title" />
        </param>
        <param name="request_parameters" type="collection">
            <param name="static-param" value="static-value" />
        </param>
    </params>
</property>
```
