### PR TITLE
Display suggestions when focusing input field of autocomplete even without search term

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/AutoCompletePopover.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/AutoCompletePopover.js
@@ -12,6 +12,7 @@ type Props = {
     anchorElement: ElementRef<*>,
     idProperty: string,
     minWidth: number,
+    onClose?: () => void,
     onSelect: (suggestion: Object) => void,
     open: boolean,
     query: ?string,
@@ -44,9 +45,8 @@ export default class AutoCompletePopover extends React.Component<Props> {
     };
 
     handlePopoverClose = () => {
-        const {onSelect, suggestions} = this.props;
-        if (suggestions.length > 0) {
-            onSelect(suggestions[0]);
+        if (this.props.onClose) {
+            this.props.onClose();
         }
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/tests/AutoCompletePopover.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/tests/AutoCompletePopover.test.js
@@ -59,17 +59,18 @@ test('Render with highlighted suggestions', () => {
     )).toMatchSnapshot();
 });
 
-test('Call onSelect with first suggestion on close', () => {
+test('Call onClose when Popover is closed', () => {
     const suggestions = [
         {id: 1, name: 'Test 1'},
         {id: 2, name: 'Test 2'},
     ];
 
-    const selectSpy = jest.fn();
+    const closeSpy = jest.fn();
     const autoCompletePopover = shallow(
         <AutoCompletePopover
             anchorElement={jest.fn()}
-            onSelect={selectSpy}
+            onClose={closeSpy()}
+            onSelect={jest.fn()}
             open={true}
             query="Test"
             searchProperties={['name']}
@@ -78,7 +79,7 @@ test('Call onSelect with first suggestion on close', () => {
     );
 
     autoCompletePopover.find(Popover).prop('onClose')();
-    expect(selectSpy).toBeCalledWith(suggestions[0]);
+    expect(closeSpy).toBeCalledWith();
 });
 
 test('Call onSelect with clicked suggestion', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
@@ -72,6 +72,7 @@ export default class Input<T: ?string | ?number> extends React.PureComponent<Inp
             onBlur,
             onIconClick,
             onClearClick,
+            onFocus,
             onKeyPress,
             segmentDelimiter,
             type,
@@ -152,6 +153,7 @@ export default class Input<T: ?string | ?number> extends React.PureComponent<Inp
                         name={name}
                         onBlur={onBlur}
                         onChange={this.handleChange}
+                        onFocus={onFocus}
                         onKeyPress={onKeyPress ? this.handleKeyPress : undefined}
                         placeholder={placeholder}
                         ref={inputRef ? this.setInputRef : undefined}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/Input.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/Input.test.js
@@ -109,6 +109,16 @@ test('Input should call the callback when icon was clicked', () => {
     expect(handleIconClick).toHaveBeenCalled();
 });
 
+test('Input should call the given focus callback', () => {
+    const onFocusSpy = jest.fn();
+
+    const input = mount(<Input icon="su-pen" onChange={jest.fn()} onFocus={onFocusSpy} value="My value" />);
+
+    expect(onFocusSpy).not.toHaveBeenCalled();
+    input.find('input').simulate('focus');
+    expect(onFocusSpy).toHaveBeenCalled();
+});
+
 test('Input should render with a loader', () => {
     const onChange = jest.fn();
     expect(render(<Input loading={true} onBlur={jest.fn()} onChange={onChange} value={undefined} />)).toMatchSnapshot();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/types.js
@@ -24,6 +24,7 @@ export type InputProps<T: ?string | ?number> = {|
     onBlur?: () => void,
     onChange: (value: ?string, event: SyntheticEvent<HTMLInputElement>) => void,
     onClearClick?: () => void,
+    onFocus?: () => void,
     onIconClick?: () => void,
     onKeyPress?: (key: ?string, event: SyntheticKeyboardEvent<HTMLInputElement>) => void,
     placeholder?: string,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
@@ -33,7 +33,7 @@ Array [
       </span>
       <input
         class="input mousetrap"
-        value="test"
+        value=""
       />
     </div>
   </label>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
@@ -3,6 +3,7 @@ import React, {Fragment} from 'react';
 import {Portal} from 'react-portal';
 import {observer} from 'mobx-react';
 import {action, computed, observable} from 'mobx';
+import Mousetrap from 'mousetrap';
 import {afterElementsRendered} from '../../utils/DOM';
 import Backdrop from '../Backdrop';
 import PopoverPositioner from './PopoverPositioner';
@@ -27,6 +28,8 @@ type Props = {
     popoverChildRef?: (ref: ?ElementRef<*>) => void,
     verticalOffset: number,
 };
+
+const CLOSE_KEY = 'esc';
 
 @observer
 class Popover extends React.Component<Props> {
@@ -54,21 +57,37 @@ class Popover extends React.Component<Props> {
             this.setPopoverSize(0, 0);
             this.updateDimensions();
         });
+
+        if (this.props.open) {
+            Mousetrap.bind(CLOSE_KEY, this.close);
+        }
     }
 
     componentWillUnmount() {
         window.removeEventListener('blur', this.close);
         window.removeEventListener('resize', this.close);
         this.mutationObserver.disconnect();
+
+        if (this.props.open) {
+            Mousetrap.unbind(CLOSE_KEY);
+        }
     }
 
-    componentDidUpdate() {
+    componentDidUpdate(prevProps: Props) {
         if (this.popoverChildRef) {
             this.updateDimensions();
 
             afterElementsRendered(() => {
                 this.popoverChildRef.scrollTop = this.dimensions.scrollTop;
             });
+        }
+
+        if (prevProps.open !== this.props.open) {
+            if (this.props.open) {
+                Mousetrap.bind(CLOSE_KEY, this.close);
+            } else {
+                Mousetrap.unbind(CLOSE_KEY);
+            }
         }
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/tests/Popover.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/tests/Popover.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 import {mount, shallow} from 'enzyme';
 import React from 'react';
+import Mousetrap from 'mousetrap';
 import Popover from '../Popover';
 import PopoverPositioner from '../PopoverPositioner';
 
@@ -142,6 +143,63 @@ test('The popover should request to be closed when the window is blurred', () =>
     expect(windowListeners.blur).toBeDefined();
     windowListeners.blur();
     expect(onCloseSpy).toBeCalled();
+});
+
+test('The popover should request to be closed when the esc key is pressed', () => {
+    const closeSpy = jest.fn();
+    mount(
+        <Popover
+            anchorElement={getMockedAnchorEl()}
+            onClose={closeSpy}
+            open={true}
+        >
+            {
+                (setPopoverRef, styles) => (
+                    <div ref={setPopoverRef} style={styles}>
+                        <div>My item 1</div>
+                    </div>
+                )
+            }
+        </Popover>
+    );
+
+    expect(closeSpy).not.toBeCalled();
+    Mousetrap.trigger('esc');
+    expect(closeSpy).toBeCalled();
+});
+
+test('The popover should bind and unbind the esc key when overlay is opened and closed', () => {
+    const closeSpy = jest.fn();
+    const popover = mount(
+        <Popover
+            anchorElement={getMockedAnchorEl()}
+            onClose={closeSpy}
+            open={true}
+        >
+            {
+                (setPopoverRef, styles) => (
+                    <div ref={setPopoverRef} style={styles}>
+                        <div>My item 1</div>
+                    </div>
+                )
+            }
+        </Popover>
+    );
+
+    expect(closeSpy).not.toBeCalled();
+    Mousetrap.trigger('esc');
+    expect(closeSpy).toBeCalled();
+    closeSpy.mockReset();
+
+    popover.setProps({open: false});
+    Mousetrap.trigger('esc');
+    expect(closeSpy).not.toBeCalled();
+    closeSpy.mockReset();
+
+    popover.setProps({open: true});
+    Mousetrap.trigger('esc');
+    expect(closeSpy).toBeCalled();
+    closeSpy.mockReset();
 });
 
 test('The popover should pass its child ref to the parent', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/SingleAutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/SingleAutoComplete.test.js
@@ -3,7 +3,9 @@ import React from 'react';
 import {mount, shallow} from 'enzyme';
 import SingleAutoComplete from '../SingleAutoComplete';
 
-test('SingleAutoComplete should render', () => {
+jest.mock('debounce', () => jest.fn((callback) => callback));
+
+test('SingleAutoComplete should render with suggestions', () => {
     const suggestions = [
         {id: 1, name: 'Suggestion 1'},
         {id: 2, name: 'Suggestion 2'},
@@ -21,6 +23,10 @@ test('SingleAutoComplete should render', () => {
             value={{name: 'Test'}}
         />
     );
+
+    // suggestions are displayed when input field is focused
+    singleAutoComplete.find('Input').prop('onFocus')();
+    singleAutoComplete.update();
 
     expect(singleAutoComplete.render()).toMatchSnapshot();
     expect(singleAutoComplete.find('AutoCompletePopover').render()).toMatchSnapshot();
@@ -69,6 +75,10 @@ test('Clicking on a suggestion should call the onChange handler with the value o
             value={{name: 'Test'}}
         />
     );
+
+    // suggestions are displayed when input field is focused
+    singleAutoComplete.find('Input').prop('onFocus')();
+    singleAutoComplete.update();
 
     singleAutoComplete.find('Suggestion button').at(0).simulate('click');
 
@@ -121,4 +131,60 @@ test('Should call the onFinish callback when the Input lost focus', () => {
     singleAutoComplete.find('Input').simulate('blur');
 
     expect(finishSpy).toBeCalledWith();
+});
+
+test('Should fire onSearch callback and open popover when input field is focused', () => {
+    const searchSpy = jest.fn();
+    const suggestions = [
+        {id: 1, name: 'Suggestion 1'},
+    ];
+
+    const singleAutoComplete = shallow(
+        <SingleAutoComplete
+            displayProperty="name"
+            onChange={jest.fn()}
+            onFinish={jest.fn()}
+            onSearch={searchSpy}
+            searchProperties={['name']}
+            suggestions={suggestions}
+            value={{name: 'Test'}}
+        />
+    );
+
+    expect(searchSpy).not.toBeCalled();
+    expect(singleAutoComplete.find('AutoCompletePopover').prop('open')).toEqual(false);
+
+    singleAutoComplete.find('Input').prop('onFocus')();
+    expect(searchSpy).toBeCalledWith('Test');
+    expect(singleAutoComplete.find('AutoCompletePopover').prop('open')).toEqual(true);
+});
+
+test('Should close popover when requested and reopen popover when input field is changed', () => {
+    const searchSpy = jest.fn();
+    const suggestions = [
+        {id: 1, name: 'Suggestion 1'},
+    ];
+
+    const singleAutoComplete = shallow(
+        <SingleAutoComplete
+            displayProperty="name"
+            onChange={jest.fn()}
+            onFinish={jest.fn()}
+            onSearch={searchSpy}
+            searchProperties={['name']}
+            suggestions={suggestions}
+            value={{name: 'Test'}}
+        />
+    );
+
+    singleAutoComplete.find('Input').prop('onFocus')();
+    expect(searchSpy).nthCalledWith(1, 'Test');
+    expect(singleAutoComplete.find('AutoCompletePopover').prop('open')).toEqual(true);
+
+    singleAutoComplete.find('AutoCompletePopover').prop('onClose')();
+    expect(singleAutoComplete.find('AutoCompletePopover').prop('open')).toEqual(false);
+
+    singleAutoComplete.find('Input').prop('onChange')('search term');
+    expect(searchSpy).nthCalledWith(2, 'search term');
+    expect(singleAutoComplete.find('AutoCompletePopover').prop('open')).toEqual(true);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SingleAutoComplete should render 1`] = `
+exports[`SingleAutoComplete should render with suggestions 1`] = `
 <div
   class="singleAutoComplete"
 >
@@ -25,7 +25,7 @@ exports[`SingleAutoComplete should render 1`] = `
 </div>
 `;
 
-exports[`SingleAutoComplete should render 2`] = `
+exports[`SingleAutoComplete should render with suggestions 2`] = `
 Array [
   <div
     class="backdrop fixed"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/tests/MultiAutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/tests/MultiAutoComplete.test.js
@@ -156,7 +156,7 @@ test('Render with loaded suggestions', () => {
         />
     );
 
-    multiAutoComplete.find(MultiAutoCompleteComponent).instance().inputValue = 'James';
+    multiAutoComplete.find(MultiAutoCompleteComponent).instance().displaySuggestions = true;
     multiAutoComplete.update();
 
     expect(multiAutoComplete.find('MultiAutoComplete').find('Suggestion').at(0).prop('value'))

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/tests/SingleAutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/tests/SingleAutoComplete.test.js
@@ -47,7 +47,7 @@ test('Render with loaded suggestions', () => {
         />
     );
 
-    singleAutoComplete.find(SingleAutoCompleteComponent).instance().inputValue = 'James';
+    singleAutoComplete.find(SingleAutoCompleteComponent).instance().displaySuggestions = true;
     singleAutoComplete.update();
 
     expect(singleAutoComplete.find('SingleAutoComplete').find('Suggestion').at(0).prop('value'))

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/SearchStore/SearchStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/SearchStore/SearchStore.js
@@ -22,11 +22,6 @@ export default class SearchStore {
     @action search = (query: string, excludedIds: ?Array<string | number> = undefined): Promise<Array<Object>> => {
         const {resourceKey, searchProperties} = this;
 
-        if (!query) {
-            this.clearSearchResults();
-            return Promise.resolve([]);
-        }
-
         this.loading = true;
 
         return ResourceRequester.getList(resourceKey, {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/SearchStore/tests/SearchStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/SearchStore/tests/SearchStore.test.js
@@ -41,6 +41,32 @@ test('Send a request using the ResourceRequester when something is being searche
     });
 });
 
+test('Send a request using the ResourceRequester when query is an empty string', () => {
+    const searchStore = new SearchStore('accounts', ['name', 'number']);
+    const searchResults = [{id: 1, name: 'Sulu'}];
+    const searchPromise = Promise.resolve({
+        _embedded: {
+            accounts: searchResults,
+        },
+    });
+
+    ResourceRequester.getList.mockReturnValue(searchPromise);
+
+    const autoCompletePromise = searchStore.search('');
+    expect(searchStore.loading).toEqual(true);
+
+    return autoCompletePromise.then(() => {
+        expect(ResourceRequester.getList).toBeCalledWith('accounts', {
+            limit: 10,
+            page: 1,
+            search: '',
+            searchFields: ['name', 'number'],
+        });
+        expect(searchStore.searchResults).toEqual(searchResults);
+        expect(searchStore.loading).toEqual(false);
+    });
+});
+
 test('Send a request using the ResourceRequester with given options when something is being searched', () => {
     const searchStore = new SearchStore('accounts', ['name', 'number'], {country: 'US'});
     const searchResults = [{id: 1, name: 'Sulu'}];


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes https://github.com/sulu/sulu/issues/5441
| License | MIT

#### What's in this PR?

This PR adjusts the behaviour of the `MultiAutoComplete` and `SingleAutoComplete` component to display suggestions as soon as the user focuses the respective input field. At the moment, suggestions are displayed only after the user have entered a search term that consists of at least one character.

#### Why?

Displaying suggestions as soon as the input field is focused shows the user how possible results look like. This makes it easier to formulate an appropriate search term. Moreover, if there are not man options, the initial suggestions will already contain the desired option and the user is able to select it without entering any search term.

