### PR TITLE
Fix scaler phpstan errors

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Scaler/Scaler.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Scaler/Scaler.php
@@ -98,11 +98,11 @@ class Scaler implements ScalerInterface
     }
 
     /**
-     * @param int $size1
-     * @param int $size2
-     * @param int $originalSize
+     * @param int|float $size1
+     * @param int|float $size2
+     * @param int|float $originalSize
      *
-     * @return array
+     * @return array{0: int|float, 1: int|float}
      */
     private function getSizeInSameRatio($size1, $size2, $originalSize)
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix scaler phpstan errors.

#### Why?

Scaler handles resizing with int and floats. Currently phpstan errors because it does define to only work with ints.
