### PR TITLE
Fix username for password_resetted event in activity list

### DIFF
--- a/src/Sulu/Bundle/ActivityBundle/UserInterface/Controller/ActivityController.php
+++ b/src/Sulu/Bundle/ActivityBundle/UserInterface/Controller/ActivityController.php
@@ -383,7 +383,7 @@ class ActivityController extends AbstractRestController implements ClassResource
             : $this->translator->trans('sulu_activity.someone', [], 'admin', $translationLocale);
 
         $translationParameters['{resourceTitle}'] = $this->getLocalizedValue(
-            $activity['resourceTitle'] ?? '',
+            $activity['resourceTitle'],
             $activity['resourceTitleLocale'] ?? null,
             $translationLocale
         );
@@ -400,13 +400,13 @@ class ActivityController extends AbstractRestController implements ClassResource
         );
     }
 
-    private function getLocalizedValue(string $value, ?string $valueLocale, string $translationLocale): string
+    private function getLocalizedValue(?string $value, ?string $valueLocale, string $translationLocale): string
     {
         if (null !== $valueLocale && $translationLocale !== $valueLocale) {
             return $value . ' [' . \strtoupper($valueLocale) . ']';
         }
 
-        return $value;
+        return $value ?: '';
     }
 
     /**

--- a/src/Sulu/Bundle/ActivityBundle/UserInterface/Controller/ActivityController.php
+++ b/src/Sulu/Bundle/ActivityBundle/UserInterface/Controller/ActivityController.php
@@ -383,7 +383,7 @@ class ActivityController extends AbstractRestController implements ClassResource
             : $this->translator->trans('sulu_activity.someone', [], 'admin', $translationLocale);
 
         $translationParameters['{resourceTitle}'] = $this->getLocalizedValue(
-            $activity['resourceTitle'],
+            $activity['resourceTitle'] ?? '',
             $activity['resourceTitleLocale'] ?? null,
             $translationLocale
         );

--- a/src/Sulu/Bundle/SecurityBundle/Domain/Event/UserPasswordResettedEvent.php
+++ b/src/Sulu/Bundle/SecurityBundle/Domain/Event/UserPasswordResettedEvent.php
@@ -44,6 +44,11 @@ class UserPasswordResettedEvent extends DomainEvent
         return (string) $this->resourceUser->getId();
     }
 
+    public function getResourceTitle(): ?string
+    {
+        return $this->resourceUser->getUsername();
+    }
+
     public function getResourceSecurityContext(): ?string
     {
         return SecurityAdmin::USER_SECURITY_CONTEXT;

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Domain/Event/UserPasswordResettedEventTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Domain/Event/UserPasswordResettedEventTest.php
@@ -42,6 +42,15 @@ class UserPasswordResettedEventTest extends TestCase
         $this->assertSame('1', $event->getResourceId());
     }
 
+    public function testGetResourceTitle(): void
+    {
+        $user = $this->prophesize(UserInterface::class);
+        $user->getUsername()->shouldBeCalled()->willReturn('username');
+        $event = new UserPasswordResettedEvent($user->reveal());
+
+        $this->assertSame('username', $event->getResourceTitle());
+    }
+
     public function testGetResourceSecurityContext(): void
     {
         $user = $this->prophesize(UserInterface::class);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix activity list without resourceTitle.

#### Why?

It can be that there is no resourceTitle which can cause the method `getLocalizedValue` to crash as it expects a string instead of null.