### PR TITLE
Improve consistency of colors used in admin UI

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/item.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/item.scss
@@ -1,7 +1,7 @@
 @import '../../containers/Application/colors.scss';
 
 $itemColor: $black;
-$itemColorActive: $blueZodiac;
+$itemColorHover: $shakespeare;
 $disabledColor: $silver;
 
 .item {
@@ -20,10 +20,12 @@ $disabledColor: $silver;
         margin-bottom: 0;
     }
 
-    &.active,
-    &:hover:not([disabled]) {
+    &.active {
         font-weight: bold;
-        color: $itemColorActive;
+    }
+
+    &:hover:not([disabled]) {
+        color: $itemColorHover;
     }
 
     &:disabled {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/suggestion.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/suggestion.scss
@@ -1,6 +1,6 @@
 @import '../../containers/Application/colors.scss';
 
-$suggestionTextColor: $blueZodiac;
+$suggestionTextColor: $black;
 $suggestionTextColorActive: $shakespeare;
 $suggestionTextColorDisabled: rgba($suggestionTextColor, .3);
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/checkbox.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/checkbox.scss
@@ -7,12 +7,14 @@ $disabledColor: $silver;
 
 .checkbox.dark {
     input + span {
-        border-color: $primaryColor;
-        color: $secondaryColor;
+        border-color: currentColor;
+        color: currentColor;
     }
 
     input:checked + span {
         background: $primaryColor;
+        border-color: $primaryColor;
+        color: $white;
     }
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/action.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/action.scss
@@ -1,7 +1,7 @@
 @import '../../containers/Application/colors.scss';
 
 $focusColor: $shakespeare;
-$fontColor: $blueZodiac;
+$fontColor: $black;
 
 .action {
     width: 100%;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/option.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/option.scss
@@ -1,7 +1,7 @@
 @import '../../containers/Application/colors.scss';
 
 $focusColor: $shakespeare;
-$fontColor: $blueZodiac;
+$fontColor: $black;
 $fontSize: 12px;
 
 .option {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/table.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/table.scss
@@ -6,7 +6,7 @@ $headerButtonCellDarkBorderColor: rgba($silverChalice, .25);
 $headerTextBrightColor: $black;
 $headerCellBrightBackgroundColor: $alto;
 $headerButtonCellBrightBorderColor: $silver;
-$cellTextColor: $blueZodiac;
+$cellTextColor: $black;
 $cellTextColorActive: $white;
 $cellBackgroundColor: $white;
 $cellBorderColor: $cellBackgroundColor;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/global.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/global.scss
@@ -3,7 +3,7 @@
 @import './fonts.scss';
 
 $bodyBackgroundColor: $wildSand;
-$h1TextColor: $blueZodiac;
+$h1TextColor: $black;
 $h2TextColor: $black;
 $h3TextColor: $scorpion;
 $inputBackgroundColor: $white;
@@ -35,7 +35,7 @@ h1 {
     color: $h1TextColor;
     margin: 0 0 20px;
     font-size: 24px;
-    font-weight: 600;
+    font-weight: normal;
 }
 
 h2 {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Improve consistents of used colors in admin UI.

 - Text Color:
   - h1 black
   - table content black
 - Select / Arrow Menu:
    - Active Bold
    - Hover shakespeare
    - Option Black

Text should be black inside the content view and color should be consistent between select and arrow menu how active stats are set.

#### Why?

Currently color usage is inconsistent.
