### PR TITLE
Pass --legacy-peer-deps option to npm in UpdateBuildCommand to display helpful error message when using npm 7

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php
@@ -274,7 +274,10 @@ class UpdateBuildCommand extends Command
         $this->cleanupPreviouslyInstalledDependencies();
 
         $ui->section('Install npm dependencies');
-        if ($this->runProcess($ui, 'npm install')) {
+
+        // pass "--legacy-peer-deps" to npm to prevent confusing dependency tree error message when using npm 7
+        // https://github.com/sulu/skeleton/issues/133#issuecomment-907271497
+        if ($this->runProcess($ui, 'npm install --legacy-peer-deps')) {
             $ui->error('Unexpected error while installing npm dependencies.');
 
             return static::EXIT_CODE_COULD_NOT_INSTALL_NPM_PACKAGES;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes https://github.com/sulu/skeleton/issues/133
| License | MIT

#### What's in this PR?

This PR passes the `--legacy-peer-deps` option to `npm` when installing dependencies in the `UpdateBuildCommand`.

#### Why?

Because npm tries to resolve the dependency tree before validating the `engines` section of the `pacakge.json`. Because of this, users see a confusing dependency tree error message instead of the message that sulu is not compatible with npm 7. See https://github.com/sulu/skeleton/issues/133
