### PR TITLE
Move legacy-peer-deps setting from UpdateBuildCommand to javascript setup of sulu/skeleton

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php
@@ -274,10 +274,7 @@ class UpdateBuildCommand extends Command
         $this->cleanupPreviouslyInstalledDependencies();
 
         $ui->section('Install npm dependencies');
-
-        // pass "--legacy-peer-deps" to npm to prevent confusing dependency tree error message when using npm 7
-        // https://github.com/sulu/skeleton/issues/133#issuecomment-907271497
-        if ($this->runProcess($ui, 'npm install --legacy-peer-deps')) {
+        if ($this->runProcess($ui, 'npm install')) {
             $ui->error('Unexpected error while installing npm dependencies.');
 
             return static::EXIT_CODE_COULD_NOT_INSTALL_NPM_PACKAGES;


### PR DESCRIPTION
| Q | A
| --- | ---
| Related issues/PRs | https://github.com/sulu/skeleton/issues/133 https://github.com/sulu/sulu/pull/6200 https://github.com/sulu/skeleton/pull/135

#### What's in this PR?

This PR reverts the changes from https://github.com/sulu/sulu/pull/6200 because setting the `legacy-peer-deps` in the `.npmrc` file of the `sulu/skeleton` /https://github.com/sulu/skeleton/pull/135) feels like the better solution.

#### Why?

Setting the `legacy-peer-deps` in the `.npmrc` file works when not using the `UpdateBuildCommand` too. Also, the `.npmrc` file is part of the project and people can remove the setting if they are sure the dont need it.

