### PR TITLE
Include properties inside of nested blocks in search index

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Search/Metadata/StructureProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Search/Metadata/StructureProvider.php
@@ -16,6 +16,7 @@ use Massive\Bundle\SearchBundle\Search\Factory;
 use Massive\Bundle\SearchBundle\Search\Metadata\ComplexMetadata;
 use Massive\Bundle\SearchBundle\Search\Metadata\Field\Expression;
 use Massive\Bundle\SearchBundle\Search\Metadata\Field\Value;
+use Massive\Bundle\SearchBundle\Search\Metadata\FieldInterface;
 use Massive\Bundle\SearchBundle\Search\Metadata\IndexMetadata;
 use Massive\Bundle\SearchBundle\Search\Metadata\IndexMetadataInterface;
 use Massive\Bundle\SearchBundle\Search\Metadata\ProviderInterface;

--- a/src/Sulu/Bundle/PageBundle/Search/Metadata/StructureProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Search/Metadata/StructureProvider.php
@@ -42,13 +42,13 @@ use Sulu\Component\DocumentManager\Metadata\MetadataFactory;
  */
 class StructureProvider implements ProviderInterface
 {
-    const FIELD_STRUCTURE_TYPE = '_structure_type';
+    public const FIELD_STRUCTURE_TYPE = '_structure_type';
 
-    const FIELD_TEASER_DESCRIPTION = '_teaser_description';
+    public const FIELD_TEASER_DESCRIPTION = '_teaser_description';
 
-    const FIELD_TEASER_MEDIA = '_teaser_media';
+    public const FIELD_TEASER_MEDIA = '_teaser_media';
 
-    const FIELD_WEBSPACE_KEY = 'webspace_key';
+    public const FIELD_WEBSPACE_KEY = 'webspace_key';
 
     /**
      * @var Factory


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

This PR allows properties inside nested blocks to be used as search fields

#### Why?

Currently only properties that are one level deep inside a block will be indexed if marked as search field