### PR TITLE
Upgrade font-awesome from 4.7 to 5.15

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/Icon.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/Icon.js
@@ -1,5 +1,6 @@
 // @flow
-import 'font-awesome/css/font-awesome.min.css';
+import '@fortawesome/fontawesome-free/js/all.js';
+import '@fortawesome/fontawesome-free/js/v4-shims.js';
 import './sulu-icon.css';
 import React from 'react';
 import classNames from 'classnames';
@@ -45,6 +46,10 @@ export default class Icon extends React.PureComponent<Props> {
                 break;
             case 'fa-':
                 fontClass = 'fa';
+                break;
+            case 'fas':
+            case 'fab':
+                fontClass = null;
                 break;
             default:
                 logInvalidIconWarning(name);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/Icon.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/Icon.js
@@ -1,6 +1,6 @@
 // @flow
-import '@fortawesome/fontawesome-free/js/all.js';
-import '@fortawesome/fontawesome-free/js/v4-shims.js';
+import '@fortawesome/fontawesome-free/css/all.css';
+import '@fortawesome/fontawesome-free/css/v4-shims.css';
 import './sulu-icon.css';
 import React from 'react';
 import classNames from 'classnames';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/README.md
@@ -1,8 +1,7 @@
-This is a simple component which renders icons. It uses the [Font Awesome Icon Toolkit](http://fontawesome.io/)
-and our own icon font.
+This is a simple component which renders icons. It supports items of the Sulu icon font (see list of icons below) and the [Font Awesome Icon Toolkit](http://fontawesome.io/).
 
-Pass a name (prefix `fa-` for Font Awesome or `su-` for Sulu) to the component,
-and it will render the corresponding icon:
+Pass an icon name to the component to render the corresponding icon.
+Make sure to specify the `"su-"` prefix for Sulu icons or the `"fa-"`/`"fas fa-"`/`"fab fa-"` for Font Awesome icons.
 
 ```
 <Icon name="fa-floppy-o" />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
@@ -21,7 +21,7 @@
         "classnames": "^2.2.5",
         "debounce": "^1.0.2",
         "fast-deep-equal": "^3.1.1",
-        "font-awesome": "^4.7.0",
+        "@fortawesome/fontawesome-free": "^5.15.4",
         "history": "^5.0.0",
         "imagesloaded": "^4.1.3",
         "intl-messageformat": "^9.3.9",

--- a/src/Sulu/Bundle/CategoryBundle/DependencyInjection/SuluCategoryExtension.php
+++ b/src/Sulu/Bundle/CategoryBundle/DependencyInjection/SuluCategoryExtension.php
@@ -153,7 +153,7 @@ class SuluCategoryExtension extends Extension implements PrependExtensionInterfa
                                         'list_key' => 'categories',
                                         'display_properties' => ['name'],
                                         'empty_text' => 'sulu_category.no_category_selected',
-                                        'icon' => 'fa-tags',
+                                        'icon' => 'su-tag',
                                         'overlay_title' => 'sulu_category.single_category_selection_overlay_title',
                                     ],
                                 ],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

Upgraded the font awesome library from version 4 to stable version 5. I've followed the [upgrade docs](https://fontawesome.com/v5.15/how-to-use/on-the-web/setup/upgrading-from-version-4) from font awesome themselves. I've made the `solid` and `brand` styles available. Version 4 just had one prefix — fa. Version 5 has four prefixes. 2 of them are free for commercial use: `fas` and `fab`. 

I've also added v4-shims to enable backwards compatibility for icons without prefix and changed icon names. This way it won't be a BC but just a deprecation of v4 icons. 

A list of icons that have changes (name or prefix) can be found [here](https://fontawesome.com/v5.15/how-to-use/on-the-web/setup/upgrading-from-version-4#name-changes).

#### Why?

Because new icons could not be used. Also upgrading to version 6 should be a piece of cake now when it comes available on npm. Version 6 is still in beta though.

#### Example Usage

```php
// If you want to use a font awesome icon with a 'fas' prefix
$navigationItem->setIcon('fas fa-door-open');

// If you want to use a font awesome icon with a 'fab' prefix
$navigationItem->setIcon('fab fa-facebook');

// Backwards compatible without 'fas' or 'fab' prefix
$navigationItem->setIcon('fa-facebook-f'); 
```


#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
