### PR TITLE
Set route path property on live node in RoutableSubscriber when article is published

### DIFF
--- a/src/Sulu/Bundle/RouteBundle/Document/Subscriber/RoutableSubscriber.php
+++ b/src/Sulu/Bundle/RouteBundle/Document/Subscriber/RoutableSubscriber.php
@@ -212,8 +212,6 @@ class RoutableSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $node = $this->documentInspector->getNode($document);
-
         try {
             $route = $this->createOrUpdateRoute($document, $event->getLocale());
         } catch (RouteIsNotUniqueException $exception) {
@@ -223,7 +221,7 @@ class RoutableSubscriber implements EventSubscriberInterface
         $document->setRoutePath($route->getPath());
         $this->entityManager->persist($route);
 
-        $node->setProperty(
+        $event->getNode()->setProperty(
             $this->getRoutePathPropertyName($document, $event->getLocale()),
             $route->getPath()
         );
@@ -257,10 +255,6 @@ class RoutableSubscriber implements EventSubscriberInterface
                 $this->getRoutePathPropertyName($localizedDocument, $locale),
                 $route->getPath()
             );
-
-            $propertyName = $this->getRoutePathPropertyName($localizedDocument, $locale);
-            $node = $this->documentInspector->getNode($localizedDocument);
-            $node->setProperty($propertyName, $route->getPath());
         }
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no yes
| Fixed tickets | fixes https://github.com/sulu/SuluArticleBundle/issues/593
| License | MIT>

#### What's in this PR?

This PR adjusts the `RoutableSubscriber` to set the route path property on the live node instead of the draft node in the `handlePublish` method. This is done by using the node of the event instead of fetching the node via the `DocumentInspector::getNode()` method.

#### Why?

At the moment, the route path property is only saved on the draft node if an article is created and published in the same step. See https://github.com/sulu/SuluArticleBundle/issues/593 for more information.

