### PR TITLE
Prevent installing version 3.1.0 of react-datetime package

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
@@ -36,7 +36,7 @@
         "path-to-regexp": "^6.1.0",
         "react-circular-progressbar": "^2.0.3",
         "react-color": "^2.14.1",
-        "react-datetime": "^3.0.0",
+        "react-datetime": ">=3.0.0 <3.1.0 || ^3.1.1",
         "react-dropzone": "^11.2.0",
         "react-portal": "^4.1.0",
         "react-sortable-hoc": "^2.0.0",


### PR DESCRIPTION
Unfortunately, version 3.1.0 of the `react-datetime` package crashes the application, if the input value is not a correctly formatted date (see https://github.com/arqex/react-datetime/issues/801). The bug causes the following error message:
```
TypeError: n.log is not a function
    at n.value (react-datetime.cjs.js:1)
    at n.value (react-datetime.cjs.js:1)
    at ha (react-dom.production.min.js:219)
    at El (react-dom.production.min.js:259)
    at t.unstable_runWithPriority (scheduler.production.min.js:18)
    at Br (react-dom.production.min.js:122)
    at Sl (react-dom.production.min.js:252)
    at hl (react-dom.production.min.js:243)
    at react-dom.production.min.js:123
    at t.unstable_runWithPriority (scheduler.production.min.js:18)
```

If you run into this problem in your project, you can add the following line to the `assets/admin/package.json` file as a workaround:
```
"react-datetime": ">=3.0.0 <3.1.0 || ^3.1.1"
```