### PR TITLE
Improve cache clearer to avoid remove directory directly for symfony cache proxy

### DIFF
--- a/src/Sulu/Bundle/HttpCacheBundle/Cache/CacheManager.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Cache/CacheManager.php
@@ -75,6 +75,15 @@ class CacheManager implements CacheManagerInterface
         );
     }
 
+    public function clear(): void
+    {
+        if (!$this->fosCacheManager->supports(FOSCacheManager::CLEAR)) {
+            return;
+        }
+
+        $this->fosCacheManager->clearCache();
+    }
+
     public function supportsInvalidate(): bool
     {
         return $this->fosCacheManager->supports(FOSCacheManager::INVALIDATE);
@@ -83,5 +92,10 @@ class CacheManager implements CacheManagerInterface
     public function supportsTags(): bool
     {
         return $this->fosCacheManager->supports(FOSCacheManager::TAGS);
+    }
+
+    public function supportsClear(): bool
+    {
+        return $this->fosCacheManager->supports(FOSCacheManager::CLEAR);
     }
 }

--- a/src/Sulu/Bundle/HttpCacheBundle/Cache/CacheManagerInterface.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Cache/CacheManagerInterface.php
@@ -29,6 +29,11 @@ interface CacheManagerInterface
     public function invalidateDomain(string $domain): void;
 
     /**
+     * Clear the whole cache.
+     */
+    public function clear(): void;
+
+    /**
      * Invalidates reference.
      */
     public function invalidateReference(string $alias, string $id): void;
@@ -42,4 +47,9 @@ interface CacheManagerInterface
      * Returns true if current proxy client supports tags-invalidation.
      */
     public function supportsTags(): bool;
+
+    /**
+     * Returns true if current proxy client supports clear.
+     */
+    public function supportsClear(): bool;
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -283,8 +283,8 @@
 
         <service id="sulu_website.event_subscriber.cache_clear"
                  class="Sulu\Bundle\WebsiteBundle\EventSubscriber\DomainEventEventSubscriber">
-            <argument type="service" id="sulu_activity.domain_event_collector"/>
-            <argument type="service" id="doctrine.orm.entity_manager"/>
+            <argument type="service" id="sulu_activity.domain_event_dispatcher"/>
+            <argument type="service" id="sulu_core.webspace.webspace_manager"/>
 
             <tag name="kernel.event_subscriber"/>
         </service>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR contains an improvement for the cache-clearer which enables tag purge for symfony cache proxy. This avoids delete the director directly.

#### Why?

Removing the directory can fail when in the same moment a user opens the page. But that moment is not really short when the cache is big - So for a bigger page this happens often.
