### PR TITLE
Fix resolving of structure author for non pages

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
@@ -89,11 +89,11 @@ class StructureResolver implements StructureResolverInterface
             $data['published'] = $structure->getPublished();
             $data['shadowBaseLocale'] = $structure->getShadowBaseLanguage();
             $data['webspaceKey'] = $structure->getWebspaceKey();
+        }
 
-            if ($document instanceof LocalizedAuthorBehavior) {
-                $data['authored'] = $document->getAuthored();
-                $data['author'] = $document->getAuthor();
-            }
+        if ($document instanceof LocalizedAuthorBehavior) {
+            $data['authored'] = $document->getAuthored();
+            $data['author'] = $document->getAuthor();
         }
 
         // pre-resolve content-types


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the resolving of none page structures with an author.

#### Why?

When using Articles the function `sulu_content_load` should also return the author
