### PR TITLE
Integrate the TrashBundle functionality for the Media entity

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,12 @@
 
 ## 2.x
 
+### StorageInterface was changed
+
+A new method has been added to the `StorageInterface` to allow for moving files:
+
+- `move`
+
 ### MediaInterface was changed
 
 A new method has been added to the `MediaInterface`:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,13 @@
 
 ## 2.x
 
+### MediaInterface was changed
+
+A new method has been added to the `MediaInterface`:
+
+- `setCreated`
+
+
 ### CategoryInterface was changed
 
 A new method has been added to the `CategoryInterface`:
@@ -16,6 +23,7 @@ call to pass the correct parameters:
 
 - `Sulu\Bundle\TagBundle\Tag\TagManager`
 - `Sulu\Bundle\CategoryBundle\Category\CategoryManager`
+- `Sulu\Bundle\MediaBundle\Media\Manager\MediaManager`
 
 ### Added SuluTrashBundle to make resources trashable/restorable
 

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -216,6 +216,17 @@ class SuluMediaExtension extends Extension implements PrependExtensionInterface
                 ]
             );
         }
+
+        if ($container->hasExtension('sulu_trash')) {
+            $container->prependExtensionConfig(
+                'sulu_trash',
+                [
+                    'restore_form' => [
+                        MediaInterface::RESOURCE_KEY => 'restore_media',
+                    ],
+                ]
+            );
+        }
     }
 
     public function load(array $configs, ContainerBuilder $container)

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -359,6 +359,10 @@ class SuluMediaExtension extends Extension implements PrependExtensionInterface
             $loader->load('audience_targeting.xml');
         }
 
+        if (\array_key_exists('SuluTrashBundle', $bundles)) {
+            $loader->load('services_trash.xml');
+        }
+
         $ffmpegBinary = $container->resolveEnvPlaceholders($config['ffmpeg']['ffmpeg_binary'] ?? null, true);
         $ffprobeBinary = $container->resolveEnvPlaceholders($config['ffmpeg']['ffprobe_binary'] ?? null, true);
 

--- a/src/Sulu/Bundle/MediaBundle/Domain/Event/MediaRestoredEvent.php
+++ b/src/Sulu/Bundle/MediaBundle/Domain/Event/MediaRestoredEvent.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Domain\Event;
+
+use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
+use Sulu\Bundle\MediaBundle\Admin\MediaAdmin;
+use Sulu\Bundle\MediaBundle\Entity\Collection;
+use Sulu\Bundle\MediaBundle\Entity\FileVersionMeta;
+use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
+
+class MediaRestoredEvent extends DomainEvent
+{
+    /**
+     * @var MediaInterface
+     */
+    private $media;
+
+    /**
+     * @var mixed[]
+     */
+    private $payload;
+
+    /**
+     * @param mixed[] $payload
+     */
+    public function __construct(
+        MediaInterface $media,
+        array $payload
+    ) {
+        parent::__construct();
+
+        $this->media = $media;
+        $this->payload = $payload;
+    }
+
+    public function getMedia(): MediaInterface
+    {
+        return $this->media;
+    }
+
+    public function getEventType(): string
+    {
+        return 'restored';
+    }
+
+    public function getEventPayload(): ?array
+    {
+        return $this->payload;
+    }
+
+    public function getResourceKey(): string
+    {
+        return MediaInterface::RESOURCE_KEY;
+    }
+
+    public function getResourceId(): string
+    {
+        return (string) $this->media->getId();
+    }
+
+    public function getResourceTitle(): ?string
+    {
+        $fileVersionMeta = $this->getFileVersionMeta();
+
+        return $fileVersionMeta ? $fileVersionMeta->getTitle() : null;
+    }
+
+    public function getResourceTitleLocale(): ?string
+    {
+        $fileVersionMeta = $this->getFileVersionMeta();
+
+        return $fileVersionMeta ? $fileVersionMeta->getLocale() : null;
+    }
+
+    public function getResourceSecurityContext(): ?string
+    {
+        return MediaAdmin::SECURITY_CONTEXT;
+    }
+
+    public function getResourceSecurityObjectType(): ?string
+    {
+        return Collection::class;
+    }
+
+    public function getResourceSecurityObjectId(): ?string
+    {
+        return (string) $this->getMedia()->getCollection()->getId();
+    }
+
+    private function getFileVersionMeta(): ?FileVersionMeta
+    {
+        $file = $this->media->getFiles()[0] ?? null;
+        $fileVersion = $file ? $file->getLatestFileVersion() : null;
+
+        return $fileVersion ? $fileVersion->getDefaultMeta() : null;
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaInterface.php
@@ -30,6 +30,15 @@ interface MediaInterface extends AuditableInterface
     public function getId();
 
     /**
+     * Set created.
+     *
+     * @param \DateTime $created
+     *
+     * @return $this
+     */
+    public function setCreated($created);
+
+    /**
      * Set changed.
      *
      * @param \DateTime $changed

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
@@ -77,13 +77,13 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
                 if (isset($query->getArrayResult()[0])) {
                     return $query->getArrayResult()[0];
                 } else {
-                    return;
+                    return null;
                 }
             } else {
                 return $query->getSingleResult();
             }
         } catch (NoResultException $ex) {
-            return;
+            return null;
         }
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepositoryInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepositoryInterface.php
@@ -28,7 +28,7 @@ interface MediaRepositoryInterface extends RepositoryInterface
      *
      * @param int $id
      *
-     * @return Media
+     * @return Media|null
      */
     public function findMediaById($id);
 

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -46,6 +46,7 @@ use Sulu\Bundle\MediaBundle\Media\PropertiesProvider\VideoPropertiesProvider;
 use Sulu\Bundle\MediaBundle\Media\Storage\StorageInterface;
 use Sulu\Bundle\MediaBundle\Media\TypeManager\TypeManagerInterface;
 use Sulu\Bundle\TagBundle\Tag\TagManagerInterface;
+use Sulu\Bundle\TrashBundle\Application\TrashManager\TrashManagerInterface;
 use Sulu\Component\PHPCR\PathCleanupInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authentication\UserRepositoryInterface;
@@ -168,6 +169,11 @@ class MediaManager implements MediaManagerInterface
     private $mediaPropertiesProviders;
 
     /**
+     * @var TrashManagerInterface|null
+     */
+    private $trashManager;
+
+    /**
      * @param CollectionRepository $collectionRepository
      * @param null|FFprobe|MediaPropertiesProviderInterface[] $mediaPropertiesProviders
      * @param string $downloadPath
@@ -191,7 +197,8 @@ class MediaManager implements MediaManagerInterface
         $mediaPropertiesProviders,
         $downloadPath,
         ?TargetGroupRepositoryInterface $targetGroupRepository,
-        $adminDownloadPath = null
+        $adminDownloadPath = null,
+        ?TrashManagerInterface $trashManager = null
     ) {
         $this->mediaRepository = $mediaRepository;
         $this->collectionRepository = $collectionRepository;
@@ -209,6 +216,7 @@ class MediaManager implements MediaManagerInterface
         $this->tokenStorage = $tokenStorage;
         $this->securityChecker = $securityChecker;
         $this->downloadPath = $downloadPath;
+        $this->trashManager = $trashManager;
 
         if (!$adminDownloadPath) {
             @\trigger_error(
@@ -742,6 +750,10 @@ class MediaManager implements MediaManagerInterface
                 ),
                 PermissionTypes::DELETE
             );
+        }
+
+        if (null !== $this->trashManager) {
+            $this->trashManager->store(MediaInterface::RESOURCE_KEY, $mediaEntity);
         }
 
         /** @var File $file */

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/AzureBlobStorage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/AzureBlobStorage.php
@@ -52,10 +52,8 @@ class AzureBlobStorage extends FlysystemStorage
 
     public function getPath(array $storageOptions): string
     {
-        $segment = $this->getStorageOption($storageOptions, 'segment');
-        $fileName = $this->getStorageOption($storageOptions, 'fileName');
-
-        $blob = $this->adapter->applyPathPrefix($segment . '/' . $fileName);
+        $filePath = $this->getFilePath($storageOptions);
+        $blob = $this->adapter->applyPathPrefix($filePath);
 
         return $this->client->getBlobUrl($this->container, $blob);
     }

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/FlysystemStorage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/FlysystemStorage.php
@@ -48,7 +48,7 @@ abstract class FlysystemStorage implements StorageInterface
 
         $this->createDirectories($storageOptions);
 
-        $parentPath = \implode('/', \array_filter([$storageOptions['directory'], $storageOptions['segment']]));
+        $parentPath = $this->getFilePath(\array_merge($storageOptions, ['fileName' => null]));
         $storageOptions['fileName'] = $this->getUniqueFileName($parentPath, $fileName);
 
         $filePath = $this->getFilePath($storageOptions);
@@ -91,9 +91,12 @@ abstract class FlysystemStorage implements StorageInterface
         }
     }
 
-    public function move(array $sourceStorageOptions, array $targetStorageOptions): void
+    public function move(array $sourceStorageOptions, array $targetStorageOptions): array
     {
         $this->createDirectories($targetStorageOptions);
+
+        $targetParentPath = $this->getFilePath(\array_merge($targetStorageOptions, ['fileName' => null]));
+        $targetStorageOptions['fileName'] = $this->getUniqueFileName($targetParentPath, $targetStorageOptions['fileName']);
 
         $targetFilePath = $this->getFilePath($targetStorageOptions);
         if ($this->filesystem->has($targetFilePath)) {
@@ -101,6 +104,8 @@ abstract class FlysystemStorage implements StorageInterface
         }
 
         $this->filesystem->rename($this->getFilePath($sourceStorageOptions), $targetFilePath);
+
+        return $targetStorageOptions;
     }
 
     protected function getUniqueFileName(string $parentPath, string $fileName, int $counter = 0): string

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/FlysystemStorage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/FlysystemStorage.php
@@ -38,10 +38,6 @@ abstract class FlysystemStorage implements StorageInterface
 
     public function save(string $tempPath, string $fileName, array $storageOptions = []): array
     {
-        if (!\array_key_exists('directory', $storageOptions)) {
-            $storageOptions['directory'] = null;
-        }
-
         if (!\array_key_exists('segment', $storageOptions)) {
             $storageOptions['segment'] = \sprintf('%0' . \strlen($this->segments) . 'd', \rand(1, $this->segments));
         }
@@ -139,7 +135,19 @@ abstract class FlysystemStorage implements StorageInterface
     /**
      * @param array<string, string|null> $storageOptions
      */
-    protected function createDirectories(array $storageOptions): void
+    protected function getFilePath(array $storageOptions): string
+    {
+        $directory = $this->getStorageOption($storageOptions, 'directory');
+        $segment = $this->getStorageOption($storageOptions, 'segment');
+        $fileName = $this->getStorageOption($storageOptions, 'fileName');
+
+        return \implode('/', \array_filter([$directory, $segment, $fileName]));
+    }
+
+    /**
+     * @param array<string, string|null> $storageOptions
+     */
+    private function createDirectories(array $storageOptions): void
     {
         $directory = $this->getStorageOption($storageOptions, 'directory');
         $directoryPath = \implode('/', \array_filter([$directory]));
@@ -154,17 +162,5 @@ abstract class FlysystemStorage implements StorageInterface
         if ($segmentPath && !$this->filesystem->has($segmentPath)) {
             $this->filesystem->createDir($segmentPath);
         }
-    }
-
-    /**
-     * @param array<string, string|null> $storageOptions
-     */
-    protected function getFilePath(array $storageOptions): string
-    {
-        $directory = $this->getStorageOption($storageOptions, 'directory');
-        $segment = $this->getStorageOption($storageOptions, 'segment');
-        $fileName = $this->getStorageOption($storageOptions, 'fileName');
-
-        return \implode('/', \array_filter([$directory, $segment, $fileName]));
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/GoogleCloudStorage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/GoogleCloudStorage.php
@@ -35,10 +35,9 @@ class GoogleCloudStorage extends FlysystemStorage
 
     public function getPath(array $storageOptions): string
     {
-        $segment = $this->getStorageOption($storageOptions, 'segment');
-        $fileName = $this->getStorageOption($storageOptions, 'fileName');
+        $filePath = $this->getFilePath($storageOptions);
 
-        return $this->adapter->getUrl($segment . '/' . $fileName);
+        return $this->adapter->getUrl($filePath);
     }
 
     public function getType(array $storageOptions): string

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
@@ -53,32 +53,28 @@ class LocalStorage implements StorageInterface
 
     public function save(string $tempPath, string $fileName, array $storageOptions = []): array
     {
-        $segment = $this->getStorageOption($storageOptions, 'segment');
-        if (!$segment) {
-            $segment = \sprintf('%0' . \strlen($this->segments) . 'd', \rand(1, $this->segments));
+        if (!\array_key_exists('directory', $storageOptions)) {
+            $storageOptions['directory'] = null;
         }
 
-        $segmentPath = $this->createPath($segment);
-        $fileName = $this->getUniqueFileName($segmentPath, $fileName);
-
-        $filePath = $this->createPath($segment, $fileName);
-        $this->logger->debug('Check FilePath: ' . $filePath);
-
-        if (!$this->filesystem->exists($segmentPath)) {
-            $this->logger->debug('Try Create Folder: ' . $segmentPath);
-            $this->filesystem->mkdir($segmentPath, 0777);
+        if (!\array_key_exists('segment', $storageOptions)) {
+            $storageOptions['segment'] = \sprintf('%0' . \strlen($this->segments) . 'd', \rand(1, $this->segments));
         }
 
+        $this->createDirectories($storageOptions);
+
+        $parentPath = $this->getFilesystemPath($storageOptions['directory'], $storageOptions['segment']);
+        $storageOptions['fileName'] = $this->getUniqueFileName($parentPath, $fileName);
+
+        $filePath = $this->getFilesystemPath($storageOptions['directory'], $storageOptions['segment'], $storageOptions['fileName']);
         $this->logger->debug('Try to copy File "' . $tempPath . '" to "' . $filePath . '"');
+
         if ($this->filesystem->exists($filePath)) {
             throw new FilenameAlreadyExistsException($filePath);
         }
         $this->filesystem->copy($tempPath, $filePath);
 
-        return [
-            'segment' => $segment,
-            'fileName' => $fileName,
-        ];
+        return $storageOptions;
     }
 
     public function load(array $storageOptions)
@@ -88,6 +84,7 @@ class LocalStorage implements StorageInterface
 
     public function getPath(array $storageOptions): string
     {
+        $directory = $this->getStorageOption($storageOptions, 'directory');
         $segment = $this->getStorageOption($storageOptions, 'segment');
         $fileName = $this->getStorageOption($storageOptions, 'fileName');
 
@@ -95,7 +92,7 @@ class LocalStorage implements StorageInterface
             throw new \RuntimeException();
         }
 
-        return $this->createPath($segment, $fileName);
+        return $this->getFilesystemPath($directory, $segment, $fileName);
     }
 
     public function getType(array $storageOptions): string
@@ -103,17 +100,22 @@ class LocalStorage implements StorageInterface
         return self::TYPE_LOCAL;
     }
 
-    public function remove(array $storageOptions): void
+    public function move(array $sourceStorageOptions, array $targetStorageOptions): void
     {
-        $segment = $this->getStorageOption($storageOptions, 'segment');
-        $fileName = $this->getStorageOption($storageOptions, 'fileName');
+        $this->createDirectories($targetStorageOptions);
 
-        if (!$segment || !$fileName) {
-            throw new \RuntimeException();
+        $targetPath = $this->getPath($targetStorageOptions);
+        if ($this->filesystem->exists($targetPath)) {
+            throw new FilenameAlreadyExistsException($targetPath);
         }
 
+        $this->filesystem->rename($this->getPath($sourceStorageOptions), $targetPath);
+    }
+
+    public function remove(array $storageOptions): void
+    {
         try {
-            $this->filesystem->remove($this->uploadPath . '/' . $segment . '/' . $fileName);
+            $this->filesystem->remove($this->getPath($storageOptions));
         } catch (IOException $ex) {
         }
     }
@@ -121,7 +123,7 @@ class LocalStorage implements StorageInterface
     /**
      * Get a unique filename in path.
      */
-    private function getUniqueFileName(string $folder, string $fileName, int $counter = 0): string
+    private function getUniqueFileName(string $parentPath, string $fileName, int $counter = 0): string
     {
         $newFileName = $fileName;
 
@@ -134,7 +136,7 @@ class LocalStorage implements StorageInterface
             }
         }
 
-        $filePath = $this->getPathByFolderAndFileName($folder, $newFileName);
+        $filePath = \rtrim($parentPath, '/') . '/' . \ltrim($newFileName, '/');
 
         $this->logger->debug('Check FilePath: ' . $filePath);
 
@@ -144,21 +146,41 @@ class LocalStorage implements StorageInterface
 
         ++$counter;
 
-        return $this->getUniqueFileName($folder, $fileName, $counter);
+        return $this->getUniqueFileName($parentPath, $fileName, $counter);
     }
 
-    private function getPathByFolderAndFileName(string $folder, string $fileName): string
+    private function getFilesystemPath(?string $directory, ?string $segment = null, ?string $fileName = null): string
     {
-        return \rtrim($folder, '/') . '/' . \ltrim($fileName, '/');
+        return \implode('/', \array_filter([$this->uploadPath, $directory, $segment, $fileName]));
     }
 
-    private function createPath(string $segment, ?string $fileName = null): string
+    /**
+     * @param array<string, string|null> $storageOptions
+     */
+    private function getStorageOption(array $storageOptions, string $key): ?string
     {
-        return \implode('/', \array_filter([$this->uploadPath, $segment, $fileName]));
+        return \array_key_exists($key, $storageOptions) ? $storageOptions[$key] : null;
     }
 
-    private function getStorageOption(array $storageOption, string $key): ?string
+    /**
+     * @param array<string, string|null> $storageOptions
+     */
+    private function createDirectories(array $storageOptions): void
     {
-        return \array_key_exists($key, $storageOption) ? $storageOption[$key] : null;
+        $directory = $this->getStorageOption($storageOptions, 'directory');
+        $directoryPath = $this->getFilesystemPath($directory);
+
+        if (!$this->filesystem->exists($directoryPath)) {
+            $this->logger->debug('Try Create Folder: ' . $directoryPath);
+            $this->filesystem->mkdir($directoryPath, 0777);
+        }
+
+        $segment = $this->getStorageOption($storageOptions, 'segment');
+        $segmentPath = $this->getFilesystemPath($directory, $segment);
+
+        if (!$this->filesystem->exists($segmentPath)) {
+            $this->logger->debug('Try Create Folder: ' . $segmentPath);
+            $this->filesystem->mkdir($segmentPath, 0777);
+        }
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
@@ -104,8 +104,12 @@ class LocalStorage implements StorageInterface
     {
         $this->createDirectories($targetStorageOptions);
 
-        $parentPath = $this->getFilesystemPath($targetStorageOptions['directory'], $targetStorageOptions['segment']);
-        $targetStorageOptions['fileName'] = $this->getUniqueFileName($parentPath, $targetStorageOptions['fileName']);
+        $targetDirectory = $this->getStorageOption($targetStorageOptions, 'directory');
+        $targetSegment = $this->getStorageOption($targetStorageOptions, 'segment');
+        $targetFileName = $this->getStorageOption($targetStorageOptions, 'fileName');
+
+        $targetParentPath = $this->getFilesystemPath($targetDirectory, $targetSegment);
+        $targetStorageOptions['fileName'] = $this->getUniqueFileName($targetParentPath, $targetFileName);
 
         $targetPath = $this->getPath($targetStorageOptions);
         if ($this->filesystem->exists($targetPath)) {

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
@@ -53,20 +53,18 @@ class LocalStorage implements StorageInterface
 
     public function save(string $tempPath, string $fileName, array $storageOptions = []): array
     {
-        if (!\array_key_exists('directory', $storageOptions)) {
-            $storageOptions['directory'] = null;
-        }
-
         if (!\array_key_exists('segment', $storageOptions)) {
             $storageOptions['segment'] = \sprintf('%0' . \strlen($this->segments) . 'd', \rand(1, $this->segments));
         }
 
         $this->createDirectories($storageOptions);
 
-        $parentPath = $this->getFilesystemPath($storageOptions['directory'], $storageOptions['segment']);
+        $directory = $this->getStorageOption($storageOptions, 'directory');
+        $segment = $this->getStorageOption($storageOptions, 'segment');
+        $parentPath = $this->getFilesystemPath($directory, $segment);
         $storageOptions['fileName'] = $this->getUniqueFileName($parentPath, $fileName);
 
-        $filePath = $this->getFilesystemPath($storageOptions['directory'], $storageOptions['segment'], $storageOptions['fileName']);
+        $filePath = $this->getFilesystemPath($directory, $segment, $storageOptions['fileName']);
         $this->logger->debug('Try to copy File "' . $tempPath . '" to "' . $filePath . '"');
 
         if ($this->filesystem->exists($filePath)) {
@@ -177,13 +175,6 @@ class LocalStorage implements StorageInterface
     private function createDirectories(array $storageOptions): void
     {
         $directory = $this->getStorageOption($storageOptions, 'directory');
-        $directoryPath = $this->getFilesystemPath($directory);
-
-        if (!$this->filesystem->exists($directoryPath)) {
-            $this->logger->debug('Try Create Folder: ' . $directoryPath);
-            $this->filesystem->mkdir($directoryPath, 0777);
-        }
-
         $segment = $this->getStorageOption($storageOptions, 'segment');
         $segmentPath = $this->getFilesystemPath($directory, $segment);
 

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
@@ -100,9 +100,12 @@ class LocalStorage implements StorageInterface
         return self::TYPE_LOCAL;
     }
 
-    public function move(array $sourceStorageOptions, array $targetStorageOptions): void
+    public function move(array $sourceStorageOptions, array $targetStorageOptions): array
     {
         $this->createDirectories($targetStorageOptions);
+
+        $parentPath = $this->getFilesystemPath($targetStorageOptions['directory'], $targetStorageOptions['segment']);
+        $targetStorageOptions['fileName'] = $this->getUniqueFileName($parentPath, $targetStorageOptions['fileName']);
 
         $targetPath = $this->getPath($targetStorageOptions);
         if ($this->filesystem->exists($targetPath)) {
@@ -110,6 +113,8 @@ class LocalStorage implements StorageInterface
         }
 
         $this->filesystem->rename($this->getPath($sourceStorageOptions), $targetPath);
+
+        return $targetStorageOptions;
     }
 
     public function remove(array $storageOptions): void

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/S3Storage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/S3Storage.php
@@ -48,10 +48,8 @@ class S3Storage extends FlysystemStorage
 
     public function getPath(array $storageOptions): string
     {
-        $segment = $this->getStorageOption($storageOptions, 'segment');
-        $fileName = $this->getStorageOption($storageOptions, 'fileName');
-
-        $path = $this->adapter->applyPathPrefix($segment . '/' . $fileName);
+        $filePath = $this->getFilePath($storageOptions);
+        $path = $this->adapter->applyPathPrefix($filePath);
 
         return $this->endpoint . '/' . $this->bucketName . '/' . \ltrim($path, '/');
     }

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/StorageInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/StorageInterface.php
@@ -25,6 +25,8 @@ interface StorageInterface
      * Save the document in the storage and return storage options of the stored document.
      *
      * @param array<string, string|null> $storageOptions
+     *
+     * @return array<string, string|null>
      */
     public function save(string $tempPath, string $fileName, array $storageOptions = []): array;
 
@@ -56,8 +58,10 @@ interface StorageInterface
      *
      * @param array<string, string|null> $sourceStorageOptions
      * @param array<string, string|null> $targetStorageOptions
+     *
+     * @return array<string, string|null>
      */
-    public function move(array $sourceStorageOptions, array $targetStorageOptions): void;
+    public function move(array $sourceStorageOptions, array $targetStorageOptions): array;
 
     /**
      * Removes the file from storage.

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/StorageInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/StorageInterface.php
@@ -22,12 +22,16 @@ interface StorageInterface
     public const TYPE_LOCAL = 'local';
 
     /**
-     * Save the document in a storage and give back the path to the document.
+     * Save the document in the storage and return storage options of the stored document.
+     *
+     * @param array<string, string|null> $storageOptions
      */
     public function save(string $tempPath, string $fileName, array $storageOptions = []): array;
 
     /**
      * Returns the content for the given file as a resource.
+     *
+     * @param array<string, string|null> $storageOptions
      *
      * @return resource
      */
@@ -35,16 +39,30 @@ interface StorageInterface
 
     /**
      * Returns the path for the given file.
+     *
+     * @param array<string, string|null> $storageOptions
      */
     public function getPath(array $storageOptions): string;
 
     /**
      * Returns the type for the given file.
+     *
+     * @param array<string, string|null> $storageOptions
      */
     public function getType(array $storageOptions): string;
 
     /**
+     * Moves a file on the storage.
+     *
+     * @param array<string, string|null> $sourceStorageOptions
+     * @param array<string, string|null> $targetStorageOptions
+     */
+    public function move(array $sourceStorageOptions, array $targetStorageOptions): void;
+
+    /**
      * Removes the file from storage.
+     *
+     * @param array<string, string|null> $storageOptions
      */
     public function remove(array $storageOptions): void;
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/forms/restore_media.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/forms/restore_media.xml
@@ -6,7 +6,7 @@
     <key>restore_media</key>
 
     <properties>
-        <property name="collectionId" type="single_collection_selection">
+        <property name="collectionId" type="single_collection_selection" mandatory="true">
             <meta>
                 <title>sulu_media.collection</title>
             </meta>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/forms/restore_media.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/forms/restore_media.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<form xmlns="http://schemas.sulu.io/template/template"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd"
+>
+    <key>restore_media</key>
+
+    <properties>
+        <property name="collectionId" type="single_collection_selection">
+            <meta>
+                <title>sulu_media.collection</title>
+            </meta>
+        </property>
+    </properties>
+</form>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -271,7 +271,7 @@
             <argument type="string">%sulu_media.media_manager.media_download_path%</argument>
             <argument type="service" id="sulu.repository.target_group" on-invalid="null"/>
             <argument type="string">%sulu_media.media_manager.media_download_path_admin%</argument>
-            <argument type="service" id="sulu_media.adapter"/>
+            <argument type="service" id="sulu_trash.trash_manager" on-invalid="null"/>
         </service>
 
         <service id="Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface" alias="sulu_media.media_manager"/>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services_trash.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services_trash.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sulu_media.media_trash_item_handler"
+                 class="Sulu\Bundle\MediaBundle\Trash\MediaTrashItemHandler">
+            <argument type="service" id="sulu_trash.trash_item_repository"/>
+            <argument type="service" id="sulu.repository.media"/>
+            <argument type="service" id="doctrine.orm.entity_manager"/>
+            <argument type="service" id="sulu_trash.doctrine_restore_helper"/>
+            <argument type="service" id="sulu_activity.domain_event_collector"/>
+
+            <tag name="sulu_trash.store_trash_item_handler"/>
+            <tag name="sulu_trash.restore_trash_item_handler"/>
+        </service>
+    </services>
+</container>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services_trash.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services_trash.xml
@@ -10,9 +10,11 @@
             <argument type="service" id="doctrine.orm.entity_manager"/>
             <argument type="service" id="sulu_trash.doctrine_restore_helper"/>
             <argument type="service" id="sulu_activity.domain_event_collector"/>
+            <argument type="service" id="sulu_media.storage"/>
 
             <tag name="sulu_trash.store_trash_item_handler"/>
             <tag name="sulu_trash.restore_trash_item_handler"/>
+            <tag name="sulu_trash.remove_trash_item_handler"/>
         </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
@@ -1,5 +1,6 @@
 {
     "sulu_media.media": "Medien",
+    "sulu_media.collection": "Ordner",
     "sulu_media.all_media": "Alle Medien",
     "sulu_media.audio": "Audio",
     "sulu_media.document": "Dokument",

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
@@ -88,6 +88,7 @@
     "sulu_activity.description.media.modified": "{userFullName} hat das Medium \"{resourceTitle}\" geändert",
     "sulu_activity.description.media.moved": "{userFullName} hat das Medium \"{resourceTitle}\" von \"{context_previousCollectionTitle}\" nach \"{context_newCollectionTitle}\" verschoben",
     "sulu_activity.description.media.removed": "{userFullName} hat das Medium \"{resourceTitle}\" gelöscht",
+    "sulu_activity.description.media.restored": "{userFullName} hat das Medium \"{resourceTitle}\" wiederhergestellt",
     "sulu_activity.description.media.translation_added": "{userFullName} hat eine Übersetzung für \"{resourceLocale}\" zum Medium \"{resourceTitle}\" hinzugefügt",
     "sulu_activity.description.media.crop_modified": "{userFullName} hat den Ausschnitt für das Format \"{context_formatKey}\" des Mediums \"{resourceTitle}\" geändert",
     "sulu_activity.description.media.crop_removed": "{userFullName} hat den Ausschnitt für das Format \"{context_formatKey}\" des Mediums \"{resourceTitle}\" gelöscht",

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
@@ -1,5 +1,6 @@
 {
     "sulu_media.media": "Media",
+    "sulu_media.collection": "Collection",
     "sulu_media.all_media": "All media",
     "sulu_media.audio": "Audio",
     "sulu_media.document": "Document",

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
@@ -88,6 +88,7 @@
     "sulu_activity.description.media.modified": "{userFullName} has changed the media \"{resourceTitle}\"",
     "sulu_activity.description.media.moved": "{userFullName} has moved the media \"{resourceTitle}\" from \"{context_previousCollectionTitle}\" to \"{context_newCollectionTitle}\"",
     "sulu_activity.description.media.removed": "{userFullName} has removed the media \"{resourceTitle}\"",
+    "sulu_activity.description.media.restored": "{userFullName} has restored the media \"{resourceTitle}\"",
     "sulu_activity.description.media.translation_added": "{userFullName} has added a translation \"{resourceLocale}\" to the media \"{resourceTitle}\"",
     "sulu_activity.description.media.crop_modified": "{userFullName} has changed the crop for the \"{context_formatKey}\" format of the media \"{resourceTitle}\"",
     "sulu_activity.description.media.crop_removed": "{userFullName} has removed the crop for the \"{context_formatKey}\" format from the media \"{resourceTitle}\"",

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Media/Storage/S3StorageTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Media/Storage/S3StorageTest.php
@@ -25,6 +25,7 @@ class S3StorageTest extends SuluTestCase
     {
         $kernel = self::bootKernel();
 
+        /** @var S3AdapterMock $adapter */
         $adapter = $kernel->getContainer()->get('sulu_media.storage.s3.adapter');
         $storage = $kernel->getContainer()->get('sulu_media.storage.s3');
         $this->assertInstanceOf(S3Storage::class, $storage);
@@ -73,6 +74,27 @@ class S3StorageTest extends SuluTestCase
         $storage->remove(['segment' => '02', 'fileName' => 'sulu.jpg']);
 
         $this->assertFalse($adapter->has('02/sulu.jpg'));
+    }
+
+    public function testMove(): void
+    {
+        $kernel = self::bootKernel();
+
+        /** @var S3AdapterMock $adapter */
+        $adapter = $kernel->getContainer()->get('sulu_media.storage.s3.adapter');
+        $storage = $kernel->getContainer()->get('sulu_media.storage.s3');
+        $this->assertInstanceOf(S3Storage::class, $storage);
+
+        $sourceStorageOptions = $storage->save($this->getImagePath(), 'sulu.jpg', []);
+        $sourceFilePath = $sourceStorageOptions['segment'] . '/' . $sourceStorageOptions['fileName'];
+
+        $this->assertTrue($adapter->has($sourceFilePath));
+
+        $targetStorageOptions = ['directory' => 'trash', 'segment' => '5', 'fileName' => 'new-name.jpg'];
+        $storage->move($sourceStorageOptions, $targetStorageOptions);
+
+        $this->assertFalse($adapter->has($sourceFilePath));
+        $this->assertTrue($adapter->has('trash/5/new-name.jpg'));
     }
 
     public function testGetPath(): void

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Media/Storage/S3StorageTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Media/Storage/S3StorageTest.php
@@ -34,6 +34,7 @@ class S3StorageTest extends SuluTestCase
 
         $this->assertArrayHasKey('segment', $result);
         $this->assertSame('sulu.jpg', $result['fileName']);
+        $this->assertNotNull($result['segment']);
         $this->assertTrue($adapter->has($result['segment']));
         $this->assertTrue($adapter->has($result['segment'] . '/sulu.jpg'));
     }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Mock/S3AdapterMock.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Mock/S3AdapterMock.php
@@ -79,6 +79,9 @@ class S3AdapterMock extends AwsS3Adapter implements AdapterInterface
 
     public function rename($path, $newpath)
     {
+        $this->objectMap[$newpath] = $this->objectMap[$path];
+        unset($this->objectMap[$path]);
+
         return false;
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Trash/MediaTrashItemHandlerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Trash/MediaTrashItemHandlerTest.php
@@ -1,0 +1,482 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Functional\Trash;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroup;
+use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupInterface;
+use Sulu\Bundle\CategoryBundle\Entity\Category;
+use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
+use Sulu\Bundle\CategoryBundle\Trash\CategoryTrashItemHandler;
+use Sulu\Bundle\MediaBundle\Entity\Collection;
+use Sulu\Bundle\MediaBundle\Entity\CollectionInterface;
+use Sulu\Bundle\MediaBundle\Entity\CollectionType;
+use Sulu\Bundle\MediaBundle\Entity\File;
+use Sulu\Bundle\MediaBundle\Entity\FileVersion;
+use Sulu\Bundle\MediaBundle\Entity\FileVersionContentLanguage;
+use Sulu\Bundle\MediaBundle\Entity\FileVersionMeta;
+use Sulu\Bundle\MediaBundle\Entity\FileVersionPublishLanguage;
+use Sulu\Bundle\MediaBundle\Entity\FormatOptions;
+use Sulu\Bundle\MediaBundle\Entity\Media;
+use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
+use Sulu\Bundle\MediaBundle\Entity\MediaType;
+use Sulu\Bundle\MediaBundle\Media\Storage\StorageInterface;
+use Sulu\Bundle\MediaBundle\Tests\Functional\Traits\CreateUploadedFileTrait;
+use Sulu\Bundle\MediaBundle\Trash\MediaTrashItemHandler;
+use Sulu\Bundle\TagBundle\Entity\Tag;
+use Sulu\Bundle\TagBundle\Tag\TagInterface;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Symfony\Component\Filesystem\Filesystem;
+
+class MediaTrashItemHandlerTest extends SuluTestCase
+{
+    use CreateUploadedFileTrait;
+
+    /**
+     * @var MediaTrashItemHandler
+     */
+    private $mediaTrashItemHandler;
+
+    /**
+     * @var StorageInterface
+     */
+    private $storage;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    public function setUp(): void
+    {
+        static::purgeDatabase();
+        $this->bootKernelAndSetServices();
+    }
+
+    public function bootKernelAndSetServices(): void
+    {
+        static::bootKernel();
+
+        $this->mediaTrashItemHandler = static::getContainer()->get('sulu_media.media_trash_item_handler');
+        $this->storage = static::getContainer()->get('sulu_media.storage');
+        $this->filesystem = new Filesystem();
+        $this->entityManager = static::getEntityManager();
+    }
+
+    public function testStoreAndRestore(): void
+    {
+        $tag1 = $this->createTag('tag-1');
+        $tag2 = $this->createTag('tag-2');
+
+        $category1 = $this->createCategory('category-1');
+        $category2 = $this->createCategory('category-2');
+
+        $targetGroup1 = $this->createTargetGroup('target-group-1');
+        $targetGroup2 = $this->createTargetGroup('target-group-2');
+
+        $collection1 = $this->createCollection();
+        $collection2 = $this->createCollection();
+
+        $mediaType = new MediaType();
+        $mediaType->setId(2);
+        $mediaType->setName('image');
+
+        $uploadedFile1 = $this->createUploadedFileImage();
+        $file1StorageOptions = $this->storage->save($uploadedFile1->getPathname(), 'testStoreAndRestore-1');
+
+        $uploadedFile2 = $this->createUploadedFileImage();
+        $file2StorageOptions = $this->storage->save($uploadedFile2->getPathname(), 'testStoreAndRestore-2');
+
+        $previewImageMedia = new Media();
+        $previewImageMedia->setCollection($collection1);
+        $previewImageMedia->setType($mediaType);
+
+        $media1 = new Media();
+        $media1->setCollection($collection1);
+        $media1->setType($mediaType);
+        $media1->setPreviewImage($previewImageMedia);
+
+        $media1File1 = new File();
+        $media1->addFile($media1File1);
+        $media1File1->setMedia($media1);
+        $media1File1->setVersion(2);
+
+        $media1File1Version1 = new FileVersion();
+        $media1File1->addFileVersion($media1File1Version1);
+        $media1File1Version1->setFile($media1File1);
+        $media1File1Version1->setName('file-version-1');
+        $media1File1Version1->setVersion(1);
+        $media1File1Version1->setSize(456);
+        $media1File1Version1->setDownloadCounter(22);
+        $media1File1Version1->setStorageOptions($file1StorageOptions);
+        $media1File1Version1->setMimeType('mime-type-1');
+        $media1File1Version1->setFocusPointX(101);
+        $media1File1Version1->setFocusPointY(202);
+
+        $media1File1Version1Meta1 = new FileVersionMeta();
+        $media1File1Version1->addMeta($media1File1Version1Meta1);
+        $media1File1Version1->setDefaultMeta($media1File1Version1Meta1);
+        $media1File1Version1Meta1->setFileVersion($media1File1Version1);
+        $media1File1Version1Meta1->setTitle('file-version-1-title-de');
+        $media1File1Version1Meta1->setLocale('de');
+
+        $media1File1Version2 = new FileVersion();
+        $media1File1->addFileVersion($media1File1Version2);
+        $media1File1Version2->setFile($media1File1);
+        $media1File1Version2->setName('file-version-2');
+        $media1File1Version2->setVersion(2);
+        $media1File1Version2->setSize(123);
+        $media1File1Version2->setDownloadCounter(33);
+        $media1File1Version2->setStorageOptions($file2StorageOptions);
+        $media1File1Version2->setMimeType('mime-type-2');
+        $media1File1Version2->setProperties(['property-1' => 'value-1']);
+        $media1File1Version2->setFocusPointX(35);
+        $media1File1Version2->setFocusPointY(45);
+
+        $media1File1Version2->addTag($tag1);
+        $media1File1Version2->addTag($tag2);
+        $media1File1Version2->addCategory($category1);
+        $media1File1Version2->addCategory($category2);
+        $media1File1Version2->addTargetGroup($targetGroup1);
+        $media1File1Version2->addTargetGroup($targetGroup2);
+
+        $media1File1Version2ContentLanguage1 = new FileVersionContentLanguage();
+        $media1File1Version2->addContentLanguage($media1File1Version2ContentLanguage1);
+        $media1File1Version2ContentLanguage1->setFileVersion($media1File1Version2);
+        $media1File1Version2ContentLanguage1->setLocale('de');
+
+        $media1File1Version2ContentLanguage2 = new FileVersionContentLanguage();
+        $media1File1Version2->addContentLanguage($media1File1Version2ContentLanguage2);
+        $media1File1Version2ContentLanguage2->setFileVersion($media1File1Version2);
+        $media1File1Version2ContentLanguage2->setLocale('ru');
+
+        $media1File1Version2PublishLanguage1 = new FileVersionPublishLanguage();
+        $media1File1Version2->addPublishLanguage($media1File1Version2PublishLanguage1);
+        $media1File1Version2PublishLanguage1->setFileVersion($media1File1Version2);
+        $media1File1Version2PublishLanguage1->setLocale('de');
+
+        $media1File1Version2Meta1 = new FileVersionMeta();
+        $media1File1Version2->addMeta($media1File1Version2Meta1);
+        $media1File1Version2->setDefaultMeta($media1File1Version2Meta1);
+        $media1File1Version2Meta1->setFileVersion($media1File1Version2);
+        $media1File1Version2Meta1->setTitle('file-version-2-title-de');
+        $media1File1Version2Meta1->setDescription('file-version-2-description-de');
+        $media1File1Version2Meta1->setCopyright('file-version-2-copyright-de');
+        $media1File1Version2Meta1->setCredits('file-version-2-credits-de');
+        $media1File1Version2Meta1->setLocale('de');
+
+        $media1File1Version2Meta2 = new FileVersionMeta();
+        $media1File1Version2->addMeta($media1File1Version2Meta2);
+        $media1File1Version2Meta2->setFileVersion($media1File1Version2);
+        $media1File1Version2Meta2->setTitle('file-version-2-title-en');
+        $media1File1Version2Meta2->setDescription('file-version-2-description-en');
+        $media1File1Version2Meta2->setCopyright('file-version-2-copyright-en');
+        $media1File1Version2Meta2->setCredits('file-version-2-credits-en');
+        $media1File1Version2Meta2->setLocale('en');
+
+        $media1File1Version2FormatOptions1 = new FormatOptions();
+        $media1File1Version2->addFormatOptions($media1File1Version2FormatOptions1);
+        $media1File1Version2FormatOptions1->setFileVersion($media1File1Version2);
+        $media1File1Version2FormatOptions1->setFormatKey('format-key-1');
+        $media1File1Version2FormatOptions1->setCropHeight(200);
+        $media1File1Version2FormatOptions1->setCropWidth(100);
+        $media1File1Version2FormatOptions1->setCropX(50);
+        $media1File1Version2FormatOptions1->setCropY(75);
+
+        $media1File1Version2FormatOptions2 = new FormatOptions();
+        $media1File1Version2->addFormatOptions($media1File1Version2FormatOptions2);
+        $media1File1Version2FormatOptions2->setFileVersion($media1File1Version2);
+        $media1File1Version2FormatOptions2->setFormatKey('format-key-2');
+        $media1File1Version2FormatOptions2->setCropHeight(2000);
+        $media1File1Version2FormatOptions2->setCropWidth(1000);
+        $media1File1Version2FormatOptions2->setCropX(500);
+        $media1File1Version2FormatOptions2->setCropY(750);
+
+        $this->entityManager->persist($mediaType);
+        $this->entityManager->persist($previewImageMedia);
+        $this->entityManager->persist($media1);
+        $this->entityManager->flush();
+
+        $originalMediaId = $media1->getId();
+        static::assertCount(2, $this->entityManager->getRepository(MediaInterface::class)->findAll());
+        static::assertTrue($this->filesystem->exists($this->storage->getPath($file1StorageOptions)));
+        static::assertTrue($this->filesystem->exists($this->storage->getPath($file2StorageOptions)));
+
+        $trashItem = $this->mediaTrashItemHandler->store($media1);
+        $this->entityManager->remove($media1);
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        static::assertSame($originalMediaId, (int) $trashItem->getResourceId());
+        static::assertSame('file-version-2-title-de', $trashItem->getResourceTitle());
+        static::assertSame('file-version-2-title-de', $trashItem->getResourceTitle('de'));
+        static::assertSame('file-version-2-title-en', $trashItem->getResourceTitle('en'));
+        static::assertCount(1, $this->entityManager->getRepository(MediaInterface::class)->findAll());
+        static::assertFalse($this->filesystem->exists($this->storage->getPath($file1StorageOptions)));
+        static::assertFalse($this->filesystem->exists($this->storage->getPath($file2StorageOptions)));
+
+        // the CategoryTrashItemHandler::restore method changes the id generator for the entity to restore the original id
+        // this works only if no entity of the same type was persisted before, because doctrine caches the insert sql
+        // to clear the cached insert statement, we need to reboot the kernel of the application
+        // this problem does not occur during normal usage because restoring is a separate request with a fresh kernel
+        $this->bootKernelAndSetServices();
+
+        /** @var MediaInterface $restoredMedia */
+        $restoredMedia = $this->mediaTrashItemHandler->restore($trashItem, ['collectionId' => $collection2->getId()]);
+        static::assertCount(2, $this->entityManager->getRepository(MediaInterface::class)->findAll());
+        static::assertSame($originalMediaId, $restoredMedia->getId());
+        static::assertSame($collection2->getId(), $restoredMedia->getCollection()->getId());
+        static::assertSame($mediaType->getId(), $restoredMedia->getType()->getId());
+        static::assertTrue($this->filesystem->exists($this->storage->getPath($file1StorageOptions)));
+        static::assertTrue($this->filesystem->exists($this->storage->getPath($file2StorageOptions)));
+
+        /** @var File $restoredFile1 */
+        $restoredFile1 = $restoredMedia->getFiles()[0];
+        static::assertSame(2, $restoredFile1->getVersion());
+        static::assertCount(2, $restoredFile1->getFileVersions());
+
+        /** @var FileVersion $restoredFile1Version1 */
+        $restoredFile1Version1 = $restoredFile1->getFileVersion(1);
+        static::assertSame('file-version-1', $restoredFile1Version1->getName());
+        static::assertSame(1, $restoredFile1Version1->getVersion());
+        static::assertSame(456, $restoredFile1Version1->getSize());
+        static::assertSame(22, $restoredFile1Version1->getDownloadCounter());
+        static::assertSame($file1StorageOptions, $restoredFile1Version1->getStorageOptions());
+        static::assertSame('mime-type-1', $restoredFile1Version1->getMimeType());
+        static::assertSame([], $restoredFile1Version1->getProperties());
+        static::assertSame(101, $restoredFile1Version1->getFocusPointX());
+        static::assertSame(202, $restoredFile1Version1->getFocusPointY());
+        static::assertSame('de', $restoredFile1Version1->getDefaultMeta()->getLocale());
+        static::assertCount(0, $restoredFile1Version1->getTags());
+        static::assertCount(0, $restoredFile1Version1->getCategories());
+        static::assertCount(0, $restoredFile1Version1->getTargetGroups());
+        static::assertCount(0, $restoredFile1Version1->getContentLanguages());
+        static::assertCount(0, $restoredFile1Version1->getPublishLanguages());
+        static::assertCount(1, $restoredFile1Version1->getMeta());
+        static::assertCount(0, $restoredFile1Version1->getFormatOptions());
+
+        /** @var FileVersionMeta $restoredFile1Version1Meta1 */
+        $restoredFile1Version1Meta1 = $restoredFile1Version1->getMeta()[0];
+        static::assertSame('de', $restoredFile1Version1Meta1->getLocale());
+        static::assertSame('file-version-1-title-de', $restoredFile1Version1Meta1->getTitle());
+
+        /** @var FileVersion $restoredFile1Version2 */
+        $restoredFile1Version2 = $restoredFile1->getFileVersion(2);
+        static::assertSame('file-version-2', $restoredFile1Version2->getName());
+        static::assertSame(2, $restoredFile1Version2->getVersion());
+        static::assertSame(123, $restoredFile1Version2->getSize());
+        static::assertSame(33, $restoredFile1Version2->getDownloadCounter());
+        static::assertSame($file2StorageOptions, $restoredFile1Version2->getStorageOptions());
+        static::assertSame('mime-type-2', $restoredFile1Version2->getMimeType());
+        static::assertSame(['property-1' => 'value-1'], $restoredFile1Version2->getProperties());
+        static::assertSame(35, $restoredFile1Version2->getFocusPointX());
+        static::assertSame(45, $restoredFile1Version2->getFocusPointY());
+        static::assertCount(2, $restoredFile1Version2->getMeta());
+        static::assertSame('de', $restoredFile1Version2->getDefaultMeta()->getLocale());
+        static::assertCount(2, $restoredFile1Version2->getFormatOptions());
+
+        static::assertCount(2, $restoredFile1Version2->getTags());
+        static::assertNotNull($restoredFile1Version2->getTags()[0]);
+        static::assertNotNull($restoredFile1Version2->getTags()[1]);
+        static::assertSame($tag1->getId(), $restoredFile1Version2->getTags()[0]->getId());
+        static::assertSame($tag2->getId(), $restoredFile1Version2->getTags()[1]->getId());
+
+        static::assertCount(2, $restoredFile1Version2->getCategories());
+        static::assertNotNull($restoredFile1Version2->getCategories()[0]);
+        static::assertNotNull($restoredFile1Version2->getCategories()[1]);
+        static::assertSame($category1->getId(), $restoredFile1Version2->getCategories()[0]->getId());
+        static::assertSame($category2->getId(), $restoredFile1Version2->getCategories()[1]->getId());
+
+        static::assertCount(2, $restoredFile1Version2->getTargetGroups());
+        static::assertNotNull($restoredFile1Version2->getTargetGroups()[0]);
+        static::assertNotNull($restoredFile1Version2->getTargetGroups()[1]);
+        static::assertSame($targetGroup1->getId(), $restoredFile1Version2->getTargetGroups()[0]->getId());
+        static::assertSame($targetGroup2->getId(), $restoredFile1Version2->getTargetGroups()[1]->getId());
+
+        static::assertCount(2, $restoredFile1Version2->getContentLanguages());
+        static::assertNotNull($restoredFile1Version2->getContentLanguages()[0]);
+        static::assertNotNull($restoredFile1Version2->getContentLanguages()[1]);
+        static::assertSame('de', $restoredFile1Version2->getContentLanguages()[0]->getLocale());
+        static::assertSame('ru', $restoredFile1Version2->getContentLanguages()[1]->getLocale());
+
+        static::assertCount(1, $restoredFile1Version2->getPublishLanguages());
+        static::assertNotNull($restoredFile1Version2->getContentLanguages()[0]);
+        static::assertSame('de', $restoredFile1Version2->getContentLanguages()[0]->getLocale());
+
+        /** @var FileVersionMeta $restoredFile1Version2Meta1 */
+        $restoredFile1Version2Meta1 = $restoredFile1Version2->getMeta()[0];
+        static::assertSame('file-version-2-title-de', $restoredFile1Version2Meta1->getTitle());
+        static::assertSame('file-version-2-description-de', $restoredFile1Version2Meta1->getDescription());
+        static::assertSame('file-version-2-copyright-de', $restoredFile1Version2Meta1->getCopyright());
+        static::assertSame('file-version-2-credits-de', $restoredFile1Version2Meta1->getCredits());
+        static::assertSame('de', $restoredFile1Version2Meta1->getLocale());
+
+        /** @var FileVersionMeta $restoredFile1Version2Meta2 */
+        $restoredFile1Version2Meta2 = $restoredFile1Version2->getMeta()[1];
+        static::assertSame('file-version-2-title-en', $restoredFile1Version2Meta2->getTitle());
+        static::assertSame('file-version-2-description-en', $restoredFile1Version2Meta2->getDescription());
+        static::assertSame('file-version-2-copyright-en', $restoredFile1Version2Meta2->getCopyright());
+        static::assertSame('file-version-2-credits-en', $restoredFile1Version2Meta2->getCredits());
+        static::assertSame('en', $restoredFile1Version2Meta2->getLocale());
+
+        /** @var FormatOptions $restoredFile1Version2FormatOptions1 */
+        $restoredFile1Version2FormatOptions1 = $restoredFile1Version2->getFormatOptions()['format-key-1'];
+        static::assertSame('format-key-1', $restoredFile1Version2FormatOptions1->getFormatKey());
+        static::assertSame(200, $restoredFile1Version2FormatOptions1->getCropHeight());
+        static::assertSame(100, $restoredFile1Version2FormatOptions1->getCropWidth());
+        static::assertSame(50, $restoredFile1Version2FormatOptions1->getCropX());
+        static::assertSame(75, $restoredFile1Version2FormatOptions1->getCropY());
+
+        /** @var FormatOptions $restoredFile1Version2FormatOptions2 */
+        $restoredFile1Version2FormatOptions2 = $restoredFile1Version2->getFormatOptions()['format-key-2'];
+        static::assertSame('format-key-2', $restoredFile1Version2FormatOptions2->getFormatKey());
+        static::assertSame(2000, $restoredFile1Version2FormatOptions2->getCropHeight());
+        static::assertSame(1000, $restoredFile1Version2FormatOptions2->getCropWidth());
+        static::assertSame(500, $restoredFile1Version2FormatOptions2->getCropX());
+        static::assertSame(750, $restoredFile1Version2FormatOptions2->getCropY());
+    }
+
+    public function testStoreAndRemove(): void
+    {
+        $collection1 = $this->createCollection();
+
+        $mediaType = new MediaType();
+        $mediaType->setId(2);
+        $mediaType->setName('image');
+
+        $uploadedFile1 = $this->createUploadedFileImage();
+        $file1StorageOptions = $this->storage->save($uploadedFile1->getPathname(), 'testStoreAndRemove-1');
+        $file1TrashStorageOptions = \array_merge($file1StorageOptions, ['directory' => 'trash']);
+
+        $uploadedFile2 = $this->createUploadedFileImage();
+        $file2StorageOptions = $this->storage->save($uploadedFile2->getPathname(), 'testStoreAndRemove-2');
+        $file2TrashStorageOptions = \array_merge($file2StorageOptions, ['directory' => 'trash']);
+
+        $media1 = new Media();
+        $media1->setCollection($collection1);
+        $media1->setType($mediaType);
+
+        $media1File1 = new File();
+        $media1->addFile($media1File1);
+        $media1File1->setMedia($media1);
+        $media1File1->setVersion(2);
+
+        $media1File1Version1 = new FileVersion();
+        $media1File1->addFileVersion($media1File1Version1);
+        $media1File1Version1->setFile($media1File1);
+        $media1File1Version1->setName('file-version-1');
+        $media1File1Version1->setVersion(1);
+        $media1File1Version1->setSize(100);
+        $media1File1Version1->setStorageOptions($file1StorageOptions);
+
+        $media1File1Version1Meta1 = new FileVersionMeta();
+        $media1File1Version1->addMeta($media1File1Version1Meta1);
+        $media1File1Version1->setDefaultMeta($media1File1Version1Meta1);
+        $media1File1Version1Meta1->setFileVersion($media1File1Version1);
+        $media1File1Version1Meta1->setTitle('file-version-1-title-de');
+        $media1File1Version1Meta1->setLocale('de');
+
+        $media1File1Version2 = new FileVersion();
+        $media1File1->addFileVersion($media1File1Version2);
+        $media1File1Version2->setFile($media1File1);
+        $media1File1Version2->setName('file-version-2');
+        $media1File1Version2->setVersion(1);
+        $media1File1Version2->setSize(100);
+        $media1File1Version2->setStorageOptions($file2StorageOptions);
+
+        $media1File1Version2Meta1 = new FileVersionMeta();
+        $media1File1Version2->addMeta($media1File1Version2Meta1);
+        $media1File1Version2->setDefaultMeta($media1File1Version2Meta1);
+        $media1File1Version2Meta1->setFileVersion($media1File1Version2);
+        $media1File1Version2Meta1->setTitle('file-version-2-title-de');
+        $media1File1Version2Meta1->setLocale('de');
+
+        $this->entityManager->persist($mediaType);
+        $this->entityManager->persist($media1);
+        $this->entityManager->flush();
+
+        static::assertTrue($this->filesystem->exists($this->storage->getPath($file1StorageOptions)));
+        static::assertTrue($this->filesystem->exists($this->storage->getPath($file2StorageOptions)));
+        static::assertFalse($this->filesystem->exists($this->storage->getPath($file1TrashStorageOptions)));
+        static::assertFalse($this->filesystem->exists($this->storage->getPath($file2TrashStorageOptions)));
+
+        $trashItem = $this->mediaTrashItemHandler->store($media1);
+
+        static::assertFalse($this->filesystem->exists($this->storage->getPath($file1StorageOptions)));
+        static::assertFalse($this->filesystem->exists($this->storage->getPath($file2StorageOptions)));
+        static::assertTrue($this->filesystem->exists($this->storage->getPath($file1TrashStorageOptions)));
+        static::assertTrue($this->filesystem->exists($this->storage->getPath($file2TrashStorageOptions)));
+
+        $this->mediaTrashItemHandler->remove($trashItem);
+
+        static::assertFalse($this->filesystem->exists($this->storage->getPath($file1StorageOptions)));
+        static::assertFalse($this->filesystem->exists($this->storage->getPath($file2StorageOptions)));
+        static::assertFalse($this->filesystem->exists($this->storage->getPath($file1TrashStorageOptions)));
+        static::assertFalse($this->filesystem->exists($this->storage->getPath($file2TrashStorageOptions)));
+    }
+
+    protected function createCollection(): CollectionInterface
+    {
+        $collectionType = new CollectionType();
+        $collectionType->setName('Default Collection Type');
+        $collectionType->setDescription('Default Collection Type');
+
+        $collection = new Collection();
+        $collection->setType($collectionType);
+
+        $this->entityManager->persist($collection);
+        $this->entityManager->persist($collectionType);
+        $this->entityManager->flush();
+
+        return $collection;
+    }
+
+    protected function createTag(string $name): TagInterface
+    {
+        $tag = new Tag();
+        $tag->setName($name);
+
+        $this->entityManager->persist($tag);
+        $this->entityManager->flush();
+
+        return $tag;
+    }
+
+    protected function createCategory(string $key): CategoryInterface
+    {
+        $category = new Category();
+        $category->setKey($key);
+        $category->setDefaultLocale('en');
+
+        $this->entityManager->persist($category);
+        $this->entityManager->flush();
+
+        return $category;
+    }
+
+    protected function createTargetGroup(string $name): TargetGroupInterface
+    {
+        $targetGroup = new TargetGroup();
+        $targetGroup->setTitle($name);
+        $targetGroup->setPriority(1);
+
+        $this->entityManager->persist($targetGroup);
+        $this->entityManager->flush();
+
+        return $targetGroup;
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/ImagineImageConverterTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/ImagineImageConverterTest.php
@@ -116,10 +116,10 @@ class ImagineImageConverterTest extends TestCase
         $fileVersion = new FileVersion();
         $fileVersion->setName('test.jpg');
         $fileVersion->setVersion(1);
-        $fileVersion->setStorageOptions(['option' => 1]);
+        $fileVersion->setStorageOptions(['option' => 'value']);
         $fileVersion->setMimeType('image/jpeg');
 
-        $this->storage->load(['option' => 1])->willReturn('image-resource');
+        $this->storage->load(['option' => 'value'])->willReturn('image-resource');
         $this->mediaImageExtractor->extract('image-resource', 'image/jpeg')->willReturn('image-resource');
         $this->imagine->read('image-resource')->willReturn($imagineImage->reveal());
 
@@ -145,10 +145,10 @@ class ImagineImageConverterTest extends TestCase
         $fileVersion = new FileVersion();
         $fileVersion->setName('test.svg');
         $fileVersion->setVersion(1);
-        $fileVersion->setStorageOptions(['option' => 1]);
+        $fileVersion->setStorageOptions(['option' => 'value']);
         $fileVersion->setMimeType('image/svg+xml');
 
-        $this->storage->load(['option' => 1])->willReturn('image-resource');
+        $this->storage->load(['option' => 'value'])->willReturn('image-resource');
         $this->mediaImageExtractor->extract('image-resource', 'image/svg+xml')->willReturn('image-resource');
         $this->svgImagine->read('image-resource')->willReturn($imagineImage->reveal());
 
@@ -174,10 +174,10 @@ class ImagineImageConverterTest extends TestCase
         $fileVersion = new FileVersion();
         $fileVersion->setName('test.jpg');
         $fileVersion->setVersion(1);
-        $fileVersion->setStorageOptions(['option' => 1]);
+        $fileVersion->setStorageOptions(['option' => 'value']);
         $fileVersion->setMimeType('image/jpeg');
 
-        $this->storage->load(['option' => 1])->willReturn('image-resource');
+        $this->storage->load(['option' => 'value'])->willReturn('image-resource');
         $this->mediaImageExtractor->extract('image-resource', 'image/jpeg')->willReturn('image-resource');
         $this->imagine->read('image-resource')->willReturn($imagineImage->reveal());
 
@@ -202,10 +202,10 @@ class ImagineImageConverterTest extends TestCase
         $fileVersion = new FileVersion();
         $fileVersion->setName('test.svg');
         $fileVersion->setVersion(1);
-        $fileVersion->setStorageOptions(['option' => 1]);
+        $fileVersion->setStorageOptions(['option' => 'value']);
         $fileVersion->setMimeType('image/svg+xml');
 
-        $this->storage->load(['option' => 1])->willReturn('image-resource');
+        $this->storage->load(['option' => 'value'])->willReturn('image-resource');
         $this->mediaImageExtractor->extract('image-resource', 'image/svg+xml')->willReturn('image-resource');
         $this->imagine->read('image-resource')->willReturn($imagineImage->reveal());
 
@@ -229,10 +229,10 @@ class ImagineImageConverterTest extends TestCase
         $fileVersion = new FileVersion();
         $fileVersion->setName('test.jpg');
         $fileVersion->setVersion(1);
-        $fileVersion->setStorageOptions(['option' => 1]);
+        $fileVersion->setStorageOptions(['option' => 'value']);
         $fileVersion->setMimeType('image/jpeg');
 
-        $this->storage->load(['option' => 1])->willReturn('image-resource');
+        $this->storage->load(['option' => 'value'])->willReturn('image-resource');
         $this->mediaImageExtractor->extract('image-resource', 'image/jpeg')->willReturn('image-resource');
         $this->imagine->read('image-resource')->willReturn($imagineImage->reveal());
 
@@ -255,9 +255,9 @@ class ImagineImageConverterTest extends TestCase
         $fileVersion = new FileVersion();
         $fileVersion->setName('test.jpg');
         $fileVersion->setVersion(1);
-        $fileVersion->setStorageOptions(['option' => 1]);
+        $fileVersion->setStorageOptions(['option' => 'value']);
 
-        $this->storage->load(['option' => 1])->willThrow(ImageProxyMediaNotFoundException::class);
+        $this->storage->load(['option' => 'value'])->willThrow(ImageProxyMediaNotFoundException::class);
 
         $this->imagineImageConverter->convert($fileVersion, '640x480', 'jpg');
     }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/AzureBlobStorageTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/AzureBlobStorageTest.php
@@ -53,7 +53,7 @@ class AzureBlobStorageTest extends TestCase
         $flysystem->createDir('1')->shouldBeCalled();
 
         $storageOptions = $storage->save(\tempnam(\sys_get_temp_dir(), 'test'), 'test.jpg');
-        $this->assertEquals(['directory' => null, 'segment' => '1', 'fileName' => 'test.jpg'], $storageOptions);
+        $this->assertEquals(['segment' => '1', 'fileName' => 'test.jpg'], $storageOptions);
     }
 
     public function testSaveDirectoryExists(): void
@@ -74,7 +74,7 @@ class AzureBlobStorageTest extends TestCase
         $flysystem->createDir(Argument::any())->shouldNotBeCalled();
 
         $storageOptions = $storage->save(\tempnam(\sys_get_temp_dir(), 'test'), 'test.jpg');
-        $this->assertEquals(['directory' => null, 'segment' => '1', 'fileName' => 'test.jpg'], $storageOptions);
+        $this->assertEquals(['segment' => '1', 'fileName' => 'test.jpg'], $storageOptions);
     }
 
     public function testSaveUniqueFileName(): void
@@ -97,7 +97,7 @@ class AzureBlobStorageTest extends TestCase
         $flysystem->createDir('1')->shouldBeCalled();
 
         $storageOptions = $storage->save(\tempnam(\sys_get_temp_dir(), 'test'), 'test.jpg');
-        $this->assertEquals(['directory' => null, 'segment' => '1', 'fileName' => 'test-2.jpg'], $storageOptions);
+        $this->assertEquals(['segment' => '1', 'fileName' => 'test-2.jpg'], $storageOptions);
     }
 
     public function testLoad(): void

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/GoogleCloudStorageTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/GoogleCloudStorageTest.php
@@ -16,7 +16,6 @@ use League\Flysystem\FileNotFoundException;
 use League\Flysystem\Filesystem;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
-use Sulu\Bundle\MediaBundle\Media\Exception\FilenameAlreadyExistsException;
 use Sulu\Bundle\MediaBundle\Media\Exception\ImageProxyMediaNotFoundException;
 use Superbalist\Flysystem\GoogleStorage\GoogleStorageAdapter;
 
@@ -205,10 +204,12 @@ class GoogleCloudStorageTest extends TestCase
         $flysystem->has('trash/1/test.jpg')->wilLReturn(false);
         $flysystem->rename('1/test.jpg', 'trash/1/test.jpg')->shouldBeCalled();
 
-        $storage->move(
+        $result = $storage->move(
             ['segment' => '1', 'fileName' => 'test.jpg'],
             ['directory' => 'trash', 'segment' => '1', 'fileName' => 'test.jpg']
         );
+
+        $this->assertSame(['directory' => 'trash', 'segment' => '1', 'fileName' => 'test.jpg'], $result);
     }
 
     public function testMoveTargetDirectoryExists(): void
@@ -226,10 +227,12 @@ class GoogleCloudStorageTest extends TestCase
         $flysystem->has('trash/1/test.jpg')->wilLReturn(false);
         $flysystem->rename('1/test.jpg', 'trash/1/test.jpg')->shouldBeCalled();
 
-        $storage->move(
+        $result = $storage->move(
             ['segment' => '1', 'fileName' => 'test.jpg'],
             ['directory' => 'trash', 'segment' => '1', 'fileName' => 'test.jpg']
         );
+
+        $this->assertSame(['directory' => 'trash', 'segment' => '1', 'fileName' => 'test.jpg'], $result);
     }
 
     public function testMoveTargetFileExists(): void
@@ -243,14 +246,18 @@ class GoogleCloudStorageTest extends TestCase
 
         $flysystem->has('trash')->wilLReturn(true);
         $flysystem->has('trash/1')->wilLReturn(true);
+
         $flysystem->has('trash/1/test.jpg')->wilLReturn(true);
+        $flysystem->has('trash/1/test-1.jpg')->wilLReturn(true);
+        $flysystem->has('trash/1/test-2.jpg')->wilLReturn(false);
+        $flysystem->rename('1/test.jpg', 'trash/1/test-2.jpg')->shouldBeCalled();
 
-        $this->expectException(FilenameAlreadyExistsException::class);
-
-        $storage->move(
+        $result = $storage->move(
             ['segment' => '1', 'fileName' => 'test.jpg'],
             ['directory' => 'trash', 'segment' => '1', 'fileName' => 'test.jpg']
         );
+
+        $this->assertSame(['directory' => 'trash', 'segment' => '1', 'fileName' => 'test-2.jpg'], $result);
     }
 
     public function testGetPath(): void

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/GoogleCloudStorageTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/GoogleCloudStorageTest.php
@@ -50,7 +50,7 @@ class GoogleCloudStorageTest extends TestCase
         $flysystem->createDir('1')->shouldBeCalled();
 
         $storageOptions = $storage->save(\tempnam(\sys_get_temp_dir(), 'test'), 'test.jpg');
-        $this->assertEquals(['directory' => null, 'segment' => '1', 'fileName' => 'test.jpg'], $storageOptions);
+        $this->assertEquals(['segment' => '1', 'fileName' => 'test.jpg'], $storageOptions);
     }
 
     public function testSaveDirectoryExists(): void
@@ -70,7 +70,7 @@ class GoogleCloudStorageTest extends TestCase
         $flysystem->createDir(Argument::any())->shouldNotBeCalled();
 
         $storageOptions = $storage->save(\tempnam(\sys_get_temp_dir(), 'test'), 'test.jpg');
-        $this->assertEquals(['directory' => null, 'segment' => '1', 'fileName' => 'test.jpg'], $storageOptions);
+        $this->assertEquals(['segment' => '1', 'fileName' => 'test.jpg'], $storageOptions);
     }
 
     public function testSaveUniqueFileName(): void
@@ -91,7 +91,7 @@ class GoogleCloudStorageTest extends TestCase
         $flysystem->createDir('1')->shouldBeCalled();
 
         $storageOptions = $storage->save(\tempnam(\sys_get_temp_dir(), 'test'), 'test.jpg');
-        $this->assertEquals(['directory' => null, 'segment' => '1', 'fileName' => 'test-1.jpg'], $storageOptions);
+        $this->assertEquals(['segment' => '1', 'fileName' => 'test-1.jpg'], $storageOptions);
     }
 
     public function testLoad(): void

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/S3StorageTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/S3StorageTest.php
@@ -18,6 +18,7 @@ use League\Flysystem\FileNotFoundException;
 use League\Flysystem\Filesystem;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Sulu\Bundle\MediaBundle\Media\Exception\FilenameAlreadyExistsException;
 use Sulu\Bundle\MediaBundle\Media\Exception\ImageProxyMediaNotFoundException;
 
 class S3StorageTest extends TestCase
@@ -56,7 +57,7 @@ class S3StorageTest extends TestCase
         $flysystem->createDir('1')->shouldBeCalled();
 
         $storageOptions = $storage->save(\tempnam(\sys_get_temp_dir(), 'test'), 'test.jpg');
-        $this->assertEquals(['segment' => '1', 'fileName' => 'test.jpg'], $storageOptions);
+        $this->assertEquals(['directory' => null, 'segment' => '1', 'fileName' => 'test.jpg'], $storageOptions);
     }
 
     public function testSaveDirectoryExists(): void
@@ -81,7 +82,7 @@ class S3StorageTest extends TestCase
         $flysystem->createDir(Argument::any())->shouldNotBeCalled();
 
         $storageOptions = $storage->save(\tempnam(\sys_get_temp_dir(), 'test'), 'test.jpg');
-        $this->assertEquals(['segment' => '1', 'fileName' => 'test.jpg'], $storageOptions);
+        $this->assertEquals(['directory' => null, 'segment' => '1', 'fileName' => 'test.jpg'], $storageOptions);
     }
 
     public function testSaveUniqueFileName(): void
@@ -107,7 +108,7 @@ class S3StorageTest extends TestCase
         $flysystem->createDir('1')->shouldBeCalled();
 
         $storageOptions = $storage->save(\tempnam(\sys_get_temp_dir(), 'test'), 'test.jpg');
-        $this->assertEquals(['segment' => '1', 'fileName' => 'test-1.jpg'], $storageOptions);
+        $this->assertEquals(['directory' => null, 'segment' => '1', 'fileName' => 'test-1.jpg'], $storageOptions);
     }
 
     public function testLoad(): void
@@ -128,6 +129,27 @@ class S3StorageTest extends TestCase
         $flysystem->readStream('1/test.jpg')->willReturn($handle)->shouldBeCalled();
 
         $result = $storage->load(['segment' => '1', 'fileName' => 'test.jpg']);
+        $this->assertEquals($handle, $result);
+    }
+
+    public function testLoadWithDirectory(): void
+    {
+        $adapter = $this->prophesize(AwsS3Adapter::class);
+        $flysystem = $this->prophesize(Filesystem::class);
+
+        $flysystem->getAdapter()->willReturn($adapter->reveal());
+
+        $client = $this->prophesize(S3Client::class);
+        $client->getEndpoint()->willReturn('http://aws.com');
+        $adapter->getClient()->willReturn($client->reveal());
+        $adapter->getBucket()->willReturn('test');
+
+        $storage = new S3Storage($flysystem->reveal(), 1);
+
+        $handle = \tmpfile();
+        $flysystem->readStream('trash/1/test.jpg')->willReturn($handle)->shouldBeCalled();
+
+        $result = $storage->load(['directory' => 'trash', 'segment' => '1', 'fileName' => 'test.jpg']);
         $this->assertEquals($handle, $result);
     }
 
@@ -173,6 +195,25 @@ class S3StorageTest extends TestCase
         $storage->remove(['segment' => '1', 'fileName' => 'test.jpg']);
     }
 
+    public function testRemoveWithDirectory(): void
+    {
+        $adapter = $this->prophesize(AwsS3Adapter::class);
+        $flysystem = $this->prophesize(Filesystem::class);
+
+        $flysystem->getAdapter()->willReturn($adapter->reveal());
+
+        $client = $this->prophesize(S3Client::class);
+        $client->getEndpoint()->willReturn('http://aws.com');
+        $adapter->getClient()->willReturn($client->reveal());
+        $adapter->getBucket()->willReturn('test');
+
+        $storage = new S3Storage($flysystem->reveal(), 1);
+
+        $flysystem->delete('trash/1/test.jpg')->shouldBeCalled();
+
+        $storage->remove(['directory' => 'trash', 'segment' => '1', 'fileName' => 'test.jpg']);
+    }
+
     public function testRemoveNotFound(): void
     {
         $adapter = $this->prophesize(AwsS3Adapter::class);
@@ -192,6 +233,87 @@ class S3StorageTest extends TestCase
         $storage->remove(['segment' => '1', 'fileName' => 'test.jpg']);
     }
 
+    public function testMove(): void
+    {
+        $adapter = $this->prophesize(AwsS3Adapter::class);
+        $flysystem = $this->prophesize(Filesystem::class);
+
+        $flysystem->getAdapter()->willReturn($adapter->reveal());
+
+        $client = $this->prophesize(S3Client::class);
+        $client->getEndpoint()->willReturn('http://aws.com');
+        $adapter->getClient()->willReturn($client->reveal());
+        $adapter->getBucket()->willReturn('test');
+
+        $storage = new S3Storage($flysystem->reveal(), 1);
+
+        $flysystem->has('trash')->wilLReturn(false);
+        $flysystem->createDir('trash')->shouldBeCalled();
+
+        $flysystem->has('trash/1')->wilLReturn(false);
+        $flysystem->createDir('trash/1')->shouldBeCalled();
+
+        $flysystem->has('trash/1/test.jpg')->wilLReturn(false);
+        $flysystem->rename('1/test.jpg', 'trash/1/test.jpg')->shouldBeCalled();
+
+        $storage->move(
+            ['segment' => '1', 'fileName' => 'test.jpg'],
+            ['directory' => 'trash', 'segment' => '1', 'fileName' => 'test.jpg']
+        );
+    }
+
+    public function testMoveTargetDirectoryExists(): void
+    {
+        $adapter = $this->prophesize(AwsS3Adapter::class);
+        $flysystem = $this->prophesize(Filesystem::class);
+
+        $flysystem->getAdapter()->willReturn($adapter->reveal());
+
+        $client = $this->prophesize(S3Client::class);
+        $client->getEndpoint()->willReturn('http://aws.com');
+        $adapter->getClient()->willReturn($client->reveal());
+        $adapter->getBucket()->willReturn('test');
+
+        $storage = new S3Storage($flysystem->reveal(), 1);
+
+        $flysystem->has('trash')->wilLReturn(true);
+        $flysystem->has('trash/1')->wilLReturn(true);
+
+        $flysystem->has('trash/1/test.jpg')->wilLReturn(false);
+        $flysystem->rename('1/test.jpg', 'trash/1/test.jpg')->shouldBeCalled();
+
+        $storage->move(
+            ['segment' => '1', 'fileName' => 'test.jpg'],
+            ['directory' => 'trash', 'segment' => '1', 'fileName' => 'test.jpg']
+        );
+    }
+
+    public function testMoveTargetFileExists(): void
+    {
+        $adapter = $this->prophesize(AwsS3Adapter::class);
+        $flysystem = $this->prophesize(Filesystem::class);
+
+        $flysystem->getAdapter()->willReturn($adapter->reveal());
+
+        $client = $this->prophesize(S3Client::class);
+        $client->getEndpoint()->willReturn('http://aws.com');
+        $adapter->getClient()->willReturn($client->reveal());
+        $adapter->getBucket()->willReturn('test');
+
+        $storage = new S3Storage($flysystem->reveal(), 1);
+
+        $flysystem->has('trash')->wilLReturn(true);
+        $flysystem->has('trash/1')->wilLReturn(true);
+        $flysystem->has('trash/1/test.jpg')->wilLReturn(true);
+
+        $this->expectException(FilenameAlreadyExistsException::class);
+
+        $storage->move(
+            ['segment' => '1', 'fileName' => 'test.jpg'],
+            ['directory' => 'trash', 'segment' => '1', 'fileName' => 'test.jpg']
+        );
+    }
+
     public function testGetPath(): void
     {
         $adapter = $this->prophesize(AwsS3Adapter::class);
@@ -209,6 +331,25 @@ class S3StorageTest extends TestCase
 
         $path = $storage->getPath(['segment' => '1', 'fileName' => 'test.jpg']);
         $this->assertEquals('http://aws.com/test/xxx/1/test.jpg', $path);
+    }
+
+    public function testGetPathWithDirectory(): void
+    {
+        $adapter = $this->prophesize(AwsS3Adapter::class);
+        $flysystem = $this->prophesize(Filesystem::class);
+
+        $flysystem->getAdapter()->willReturn($adapter->reveal());
+
+        $client = $this->prophesize(S3Client::class);
+        $client->getEndpoint()->willReturn('http://aws.com');
+        $adapter->getClient()->willReturn($client->reveal());
+        $adapter->getBucket()->willReturn('test');
+        $adapter->applyPathPrefix('trash/1/test.jpg')->willReturn('xxx/trash/1/test.jpg');
+
+        $storage = new S3Storage($flysystem->reveal(), 1);
+
+        $path = $storage->getPath(['directory' => 'trash', 'segment' => '1', 'fileName' => 'test.jpg']);
+        $this->assertEquals('http://aws.com/test/xxx/trash/1/test.jpg', $path);
     }
 
     public function testGetType(): void

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/S3StorageTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/S3StorageTest.php
@@ -18,7 +18,6 @@ use League\Flysystem\FileNotFoundException;
 use League\Flysystem\Filesystem;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
-use Sulu\Bundle\MediaBundle\Media\Exception\FilenameAlreadyExistsException;
 use Sulu\Bundle\MediaBundle\Media\Exception\ImageProxyMediaNotFoundException;
 
 class S3StorageTest extends TestCase
@@ -256,10 +255,12 @@ class S3StorageTest extends TestCase
         $flysystem->has('trash/1/test.jpg')->wilLReturn(false);
         $flysystem->rename('1/test.jpg', 'trash/1/test.jpg')->shouldBeCalled();
 
-        $storage->move(
+        $result = $storage->move(
             ['segment' => '1', 'fileName' => 'test.jpg'],
             ['directory' => 'trash', 'segment' => '1', 'fileName' => 'test.jpg']
         );
+
+        $this->assertSame(['directory' => 'trash', 'segment' => '1', 'fileName' => 'test.jpg'], $result);
     }
 
     public function testMoveTargetDirectoryExists(): void
@@ -282,10 +283,12 @@ class S3StorageTest extends TestCase
         $flysystem->has('trash/1/test.jpg')->wilLReturn(false);
         $flysystem->rename('1/test.jpg', 'trash/1/test.jpg')->shouldBeCalled();
 
-        $storage->move(
+        $result = $storage->move(
             ['segment' => '1', 'fileName' => 'test.jpg'],
             ['directory' => 'trash', 'segment' => '1', 'fileName' => 'test.jpg']
         );
+
+        $this->assertSame(['directory' => 'trash', 'segment' => '1', 'fileName' => 'test.jpg'], $result);
     }
 
     public function testMoveTargetFileExists(): void
@@ -304,14 +307,18 @@ class S3StorageTest extends TestCase
 
         $flysystem->has('trash')->wilLReturn(true);
         $flysystem->has('trash/1')->wilLReturn(true);
+
         $flysystem->has('trash/1/test.jpg')->wilLReturn(true);
+        $flysystem->has('trash/1/test-1.jpg')->wilLReturn(true);
+        $flysystem->has('trash/1/test-2.jpg')->wilLReturn(false);
+        $flysystem->rename('1/test.jpg', 'trash/1/test-2.jpg')->shouldBeCalled();
 
-        $this->expectException(FilenameAlreadyExistsException::class);
-
-        $storage->move(
+        $result = $storage->move(
             ['segment' => '1', 'fileName' => 'test.jpg'],
             ['directory' => 'trash', 'segment' => '1', 'fileName' => 'test.jpg']
         );
+
+        $this->assertSame(['directory' => 'trash', 'segment' => '1', 'fileName' => 'test-2.jpg'], $result);
     }
 
     public function testGetPath(): void

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/S3StorageTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/S3StorageTest.php
@@ -56,7 +56,7 @@ class S3StorageTest extends TestCase
         $flysystem->createDir('1')->shouldBeCalled();
 
         $storageOptions = $storage->save(\tempnam(\sys_get_temp_dir(), 'test'), 'test.jpg');
-        $this->assertEquals(['directory' => null, 'segment' => '1', 'fileName' => 'test.jpg'], $storageOptions);
+        $this->assertEquals(['segment' => '1', 'fileName' => 'test.jpg'], $storageOptions);
     }
 
     public function testSaveDirectoryExists(): void
@@ -81,7 +81,7 @@ class S3StorageTest extends TestCase
         $flysystem->createDir(Argument::any())->shouldNotBeCalled();
 
         $storageOptions = $storage->save(\tempnam(\sys_get_temp_dir(), 'test'), 'test.jpg');
-        $this->assertEquals(['directory' => null, 'segment' => '1', 'fileName' => 'test.jpg'], $storageOptions);
+        $this->assertEquals(['segment' => '1', 'fileName' => 'test.jpg'], $storageOptions);
     }
 
     public function testSaveUniqueFileName(): void
@@ -107,7 +107,7 @@ class S3StorageTest extends TestCase
         $flysystem->createDir('1')->shouldBeCalled();
 
         $storageOptions = $storage->save(\tempnam(\sys_get_temp_dir(), 'test'), 'test.jpg');
-        $this->assertEquals(['directory' => null, 'segment' => '1', 'fileName' => 'test-1.jpg'], $storageOptions);
+        $this->assertEquals(['segment' => '1', 'fileName' => 'test-1.jpg'], $storageOptions);
     }
 
     public function testLoad(): void

--- a/src/Sulu/Bundle/MediaBundle/Trash/MediaTrashItemHandler.php
+++ b/src/Sulu/Bundle/MediaBundle/Trash/MediaTrashItemHandler.php
@@ -1,0 +1,345 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Trash;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
+use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
+use Sulu\Bundle\MediaBundle\Admin\MediaAdmin;
+use Sulu\Bundle\MediaBundle\Domain\Event\MediaRestoredEvent;
+use Sulu\Bundle\MediaBundle\Entity\Collection;
+use Sulu\Bundle\MediaBundle\Entity\CollectionInterface;
+use Sulu\Bundle\MediaBundle\Entity\File;
+use Sulu\Bundle\MediaBundle\Entity\FileVersion;
+use Sulu\Bundle\MediaBundle\Entity\FileVersionContentLanguage;
+use Sulu\Bundle\MediaBundle\Entity\FileVersionMeta;
+use Sulu\Bundle\MediaBundle\Entity\FileVersionPublishLanguage;
+use Sulu\Bundle\MediaBundle\Entity\FormatOptions;
+use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
+use Sulu\Bundle\MediaBundle\Entity\MediaRepositoryInterface;
+use Sulu\Bundle\MediaBundle\Entity\MediaType;
+use Sulu\Bundle\TagBundle\Tag\TagInterface;
+use Sulu\Bundle\TrashBundle\Application\DoctrineRestoreHelper\DoctrineRestoreHelperInterface;
+use Sulu\Bundle\TrashBundle\Application\TrashItemHandler\RestoreTrashItemHandlerInterface;
+use Sulu\Bundle\TrashBundle\Application\TrashItemHandler\StoreTrashItemHandlerInterface;
+use Sulu\Bundle\TrashBundle\Domain\Model\TrashItemInterface;
+use Sulu\Bundle\TrashBundle\Domain\Repository\TrashItemRepositoryInterface;
+use Sulu\Component\Security\Authentication\UserInterface;
+use Webmozart\Assert\Assert;
+
+final class MediaTrashItemHandler implements StoreTrashItemHandlerInterface, RestoreTrashItemHandlerInterface
+{
+    /**
+     * @var TrashItemRepositoryInterface
+     */
+    private $trashItemRepository;
+
+    /**
+     * @var MediaRepositoryInterface
+     */
+    private $mediaRepository;
+
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
+     * @var DoctrineRestoreHelperInterface
+     */
+    private $doctrineRestoreHelper;
+
+    /**
+     * @var DomainEventCollectorInterface
+     */
+    private $domainEventCollector;
+
+    public function __construct(
+        TrashItemRepositoryInterface $trashItemRepository,
+        MediaRepositoryInterface $mediaRepository,
+        EntityManagerInterface $entityManager,
+        DoctrineRestoreHelperInterface $doctrineRestoreHelper,
+        DomainEventCollectorInterface $domainEventCollector
+    ) {
+        $this->trashItemRepository = $trashItemRepository;
+        $this->mediaRepository = $mediaRepository;
+        $this->entityManager = $entityManager;
+        $this->doctrineRestoreHelper = $doctrineRestoreHelper;
+        $this->domainEventCollector = $domainEventCollector;
+    }
+
+    /**
+     * @param MediaInterface $media
+     */
+    public function store(object $media): TrashItemInterface
+    {
+        Assert::isInstanceOf($media, MediaInterface::class);
+
+        // TODO: move original image file
+
+        $creator = $media->getCreator();
+        $previewImage = $media->getPreviewImage();
+
+        $data = [
+            'collectionId' => $media->getCollection()->getId(),
+            'typeId' => $media->getType()->getId(),
+            'previewImageId' => $previewImage ? $previewImage->getId() : null,
+            'created' => $media->getCreated()->format('c'),
+            'creatorId' => $creator ? $creator->getId() : null,
+            'files' => [],
+        ];
+        $mediaTitles = [];
+
+        /** @var File $file */
+        foreach ($media->getFiles() as $file) {
+            $creator = $file->getCreator();
+
+            $fileData = [
+                'version' => $file->getVersion(),
+                'created' => $file->getCreated()->format('c'),
+                'creatorId' => $creator ? $creator->getId() : null,
+                'fileVersions' => [],
+            ];
+
+            /** @var FileVersion $fileVersion */
+            foreach ($file->getFileVersions() as $fileVersion) {
+                $creator = $fileVersion->getCreator();
+
+                $fileVersionData = [
+                    'name' => $fileVersion->getName(),
+                    'version' => $fileVersion->getVersion(),
+                    'size' => $fileVersion->getSize(),
+                    'downloadCounter' => $fileVersion->getDownloadCounter(),
+                    'storageOptions' => $fileVersion->getStorageOptions(),
+                    'mimeType' => $fileVersion->getMimeType(),
+                    'properties' => $fileVersion->getProperties(),
+                    'focusPointX' => $fileVersion->getFocusPointX(),
+                    'focusPointY' => $fileVersion->getFocusPointY(),
+                    'created' => $file->getCreated()->format('c'),
+                    'creatorId' => $creator ? $creator->getId() : null,
+                    'contentLanguageLocales' => [],
+                    'publishLanguageLocales' => [],
+                    'meta' => [],
+                    'defaultMetaLocale' => $fileVersion->getDefaultMeta()->getLocale(),
+                    'formatOptions' => [],
+                    'tagIds' => [],
+                    'categoryIds' => [],
+                ];
+
+                /** @var FileVersionContentLanguage $contentLanguage */
+                foreach ($fileVersion->getContentLanguages() as $contentLanguage) {
+                    $fileVersionData['contentLanguageLocales'][] = $contentLanguage->getLocale();
+                }
+
+                /** @var FileVersionPublishLanguage $publishLanguage */
+                foreach ($fileVersion->getPublishLanguages() as $publishLanguage) {
+                    $fileVersionData['publishLanguageLocales'][] = $publishLanguage->getLocale();
+                }
+
+                /** @var FileVersionMeta $meta */
+                foreach ($fileVersion->getMeta() as $meta) {
+                    $mediaTitles[$meta->getLocale()] = $meta->getTitle();
+
+                    $fileVersionData['meta'][] = [
+                        'title' => $meta->getTitle(),
+                        'description' => $meta->getDescription(),
+                        'copyright' => $meta->getCopyright(),
+                        'credits' => $meta->getCredits(),
+                        'locale' => $meta->getLocale(),
+                    ];
+                }
+
+                /** @var FormatOptions $formatOption */
+                foreach ($fileVersion->getFormatOptions() as $formatOption) {
+                    $fileVersionData['formatOptions'][] = [
+                        'formatKey' => $formatOption->getFormatKey(),
+                        'cropHeight' => $formatOption->getCropHeight(),
+                        'cropWidth' => $formatOption->getCropWidth(),
+                        'cropX' => $formatOption->getCropX(),
+                        'cropY' => $formatOption->getCropY(),
+                    ];
+                }
+
+                /** @var TagInterface $tag */
+                foreach ($fileVersion->getTags() as $tag) {
+                    $fileVersionData['tagIds'][] = $tag->getId();
+                }
+
+                /** @var CategoryInterface $category */
+                foreach ($fileVersion->getCategories() as $category) {
+                    $fileVersionData['categoryIds'][] = $category->getId();
+                }
+
+                $fileData['fileVersions'][] = $fileVersionData;
+            }
+
+            $data['files'][] = $fileData;
+        }
+
+        return $this->trashItemRepository->create(
+            MediaInterface::RESOURCE_KEY,
+            (string) $media->getId(),
+            $data,
+            $mediaTitles,
+            MediaAdmin::SECURITY_CONTEXT,
+            Collection::class,
+            (string) $media->getCollection()->getId()
+        );
+    }
+
+    public function restore(TrashItemInterface $trashItem, array $restoreFormData): object
+    {
+        $id = (int) $trashItem->getResourceId();
+        $data = $trashItem->getRestoreData();
+
+        // TODO: select collection for restoring in restore form
+        $collection = $this->findEntity(CollectionInterface::class, 9);
+        Assert::isInstanceOf($collection, CollectionInterface::class);
+
+        $type = $this->findEntity(MediaType::class, $data['typeId']);
+        Assert::isInstanceOf($type, MediaType::class);
+
+        $media = $this->mediaRepository->createNew();
+        $media->setCollection($collection);
+        $media->setType($type);
+        $media->setPreviewImage($this->findEntity(MediaInterface::class, $data['previewImageId']));
+        $media->setCreated(new \DateTime($data['created']));
+        $media->setCreator($this->findEntity(UserInterface::class, $data['creatorId']));
+
+        foreach ($data['files'] as $fileData) {
+            $file = new File();
+            $file->setMedia($media);
+            $media->addFile($file);
+            $this->entityManager->persist($file);
+
+            $file->setVersion($fileData['version']);
+            $file->setCreated(new \DateTime($fileData['created']));
+            $file->setCreator($this->findEntity(UserInterface::class, $fileData['creatorId']));
+
+            foreach ($fileData['fileVersions'] as $fileVersionData) {
+                $fileVersion = new FileVersion();
+                $fileVersion->setFile($file);
+                $file->addFileVersion($fileVersion);
+                $this->entityManager->persist($fileVersion);
+
+                $fileVersion->setName($fileVersionData['name']);
+                $fileVersion->setVersion($fileVersionData['version']);
+                $fileVersion->setSize($fileVersionData['size']);
+                $fileVersion->setDownloadCounter($fileVersionData['downloadCounter']);
+                $fileVersion->setStorageOptions($fileVersionData['storageOptions']);
+                $fileVersion->setMimeType($fileVersionData['mimeType']);
+                $fileVersion->setProperties($fileVersionData['properties']);
+                $fileVersion->setFocusPointX($fileVersionData['focusPointX']);
+                $fileVersion->setFocusPointY($fileVersionData['focusPointY']);
+                $fileVersion->setCreated(new \DateTime($fileVersionData['created']));
+                $fileVersion->setCreator($this->findEntity(UserInterface::class, $fileVersionData['creatorId']));
+
+                foreach ($fileVersionData['contentLanguageLocales'] as $contentLanguageLocale) {
+                    $contentLanguage = new FileVersionContentLanguage();
+                    $contentLanguage->setFileVersion($fileVersion);
+                    $fileVersion->addContentLanguage($contentLanguage);
+                    $this->entityManager->persist($contentLanguage);
+
+                    $contentLanguage->setLocale($contentLanguageLocale);
+                }
+
+                foreach ($fileVersionData['publishLanguageLocales'] as $publishLanguageLocale) {
+                    $publishLanguage = new FileVersionPublishLanguage();
+                    $publishLanguage->setFileVersion($fileVersion);
+                    $fileVersion->addPublishLanguage($publishLanguage);
+                    $this->entityManager->persist($publishLanguage);
+
+                    $publishLanguage->setLocale($publishLanguageLocale);
+                }
+
+                foreach ($fileVersionData['meta'] as $metaData) {
+                    $meta = new FileVersionMeta();
+                    $meta->setFileVersion($fileVersion);
+                    $fileVersion->addMeta($meta);
+                    $this->entityManager->persist($meta);
+
+                    if ($metaData['locale'] === $fileVersionData['defaultMetaLocale']) {
+                        $fileVersion->setDefaultMeta($meta);
+                    }
+
+                    $meta->setTitle($metaData['title']);
+                    $meta->setDescription($metaData['description']);
+                    $meta->setCopyright($metaData['copyright']);
+                    $meta->setCredits($metaData['credits']);
+                    $meta->setLocale($metaData['locale']);
+                }
+
+                foreach ($fileVersionData['formatOptions'] as $formatOptionData) {
+                    $formatOption = new FormatOptions();
+                    $formatOption->setFileVersion($fileVersion);
+                    $fileVersion->addFormatOptions($formatOption);
+                    $this->entityManager->persist($formatOption);
+
+                    $formatOption->setFormatKey($formatOptionData['formatKey']);
+                    $formatOption->setCropHeight($formatOptionData['cropHeight']);
+                    $formatOption->setCropWidth($formatOptionData['cropWidth']);
+                    $formatOption->setCropX($formatOptionData['cropX']);
+                    $formatOption->setCropY($formatOptionData['cropY']);
+                }
+
+                foreach ($fileVersionData['tagIds'] as $tagId) {
+                    if ($tag = $this->findEntity(TagInterface::class, $tagId)) {
+                        $fileVersion->addTag($tag);
+                    }
+                }
+
+                foreach ($fileVersionData['categoryIds'] as $categoryId) {
+                    if ($category = $this->findEntity(CategoryInterface::class, $categoryId)) {
+                        $fileVersion->addCategory($category);
+                    }
+                }
+            }
+        }
+
+        $this->domainEventCollector->collect(
+            new MediaRestoredEvent($media, $data)
+        );
+
+        if (null === $this->mediaRepository->findMediaById($id)) {
+            $this->doctrineRestoreHelper->persistAndFlushWithId($media, $id);
+        } else {
+            $this->entityManager->persist($media);
+            $this->entityManager->flush();
+        }
+
+        return $media;
+    }
+
+    public static function getResourceKey(): string
+    {
+        return MediaInterface::RESOURCE_KEY;
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param class-string<T> $className
+     * @param mixed|null $id
+     *
+     * @return T|null
+     */
+    private function findEntity(string $className, $id)
+    {
+        if ($id) {
+            return $this->entityManager->find($className, $id);
+        }
+
+        return null;
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Trash/MediaTrashItemHandler.php
+++ b/src/Sulu/Bundle/MediaBundle/Trash/MediaTrashItemHandler.php
@@ -203,8 +203,7 @@ final class MediaTrashItemHandler implements StoreTrashItemHandlerInterface, Res
         $id = (int) $trashItem->getResourceId();
         $data = $trashItem->getRestoreData();
 
-        // TODO: select collection for restoring in restore form
-        $collection = $this->findEntity(CollectionInterface::class, 9);
+        $collection = $this->findEntity(CollectionInterface::class, $restoreFormData['collectionId']);
         Assert::isInstanceOf($collection, CollectionInterface::class);
 
         $type = $this->findEntity(MediaType::class, $data['typeId']);

--- a/src/Sulu/Bundle/TrashBundle/Application/TrashItemHandler/RemoveTrashItemHandlerInterface.php
+++ b/src/Sulu/Bundle/TrashBundle/Application/TrashItemHandler/RemoveTrashItemHandlerInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\TrashBundle\Application\TrashItemHandler;
+
+use Sulu\Bundle\TrashBundle\Domain\Model\TrashItemInterface;
+
+interface RemoveTrashItemHandlerInterface
+{
+    public function remove(TrashItemInterface $trashItem): void;
+
+    public static function getResourceKey(): string;
+}

--- a/src/Sulu/Bundle/TrashBundle/Infrastructure/Symfony/DependencyInjection/SuluTrashExtension.php
+++ b/src/Sulu/Bundle/TrashBundle/Infrastructure/Symfony/DependencyInjection/SuluTrashExtension.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Bundle\TrashBundle\Infrastructure\Symfony\DependencyInjection;
 
 use Sulu\Bundle\PersistenceBundle\DependencyInjection\PersistenceExtensionTrait;
+use Sulu\Bundle\TrashBundle\Application\TrashItemHandler\RemoveTrashItemHandlerInterface;
 use Sulu\Bundle\TrashBundle\Application\TrashItemHandler\RestoreTrashItemHandlerInterface;
 use Sulu\Bundle\TrashBundle\Application\TrashItemHandler\StoreTrashItemHandlerInterface;
 use Sulu\Bundle\TrashBundle\Domain\Exception\TrashItemNotFoundException;
@@ -115,5 +116,8 @@ class SuluTrashExtension extends Extension implements PrependExtensionInterface
 
         $container->registerForAutoconfiguration(RestoreTrashItemHandlerInterface::class)
             ->addTag('sulu_trash.restore_trash_item_handler');
+
+        $container->registerForAutoconfiguration(RemoveTrashItemHandlerInterface::class)
+            ->addTag('sulu_trash.remove_trash_item_handler');
     }
 }

--- a/src/Sulu/Bundle/TrashBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/TrashBundle/Resources/config/services.xml
@@ -16,6 +16,7 @@
             <argument type="service" id="sulu_activity.domain_event_collector"/>
             <argument type="tagged_locator" tag="sulu_trash.store_trash_item_handler" index-by="resourceKey" default-index-method="getResourceKey"/>
             <argument type="tagged_locator" tag="sulu_trash.restore_trash_item_handler" index-by="resourceKey" default-index-method="getResourceKey"/>
+            <argument type="tagged_locator" tag="sulu_trash.remove_trash_item_handler" index-by="resourceKey" default-index-method="getResourceKey"/>
         </service>
         <service id="Sulu\Bundle\TrashBundle\Application\TrashManager\TrashManagerInterface" alias="sulu_trash.trash_manager"/>
 

--- a/src/Sulu/Bundle/TrashBundle/Resources/js/containers/RestoreFormOverlay/RestoreFormOverlay.js
+++ b/src/Sulu/Bundle/TrashBundle/Resources/js/containers/RestoreFormOverlay/RestoreFormOverlay.js
@@ -91,7 +91,7 @@ class RestoreFormOverlay extends React.Component<Props> {
                 onClose={onClose}
                 onConfirm={this.handleConfirm}
                 open={open}
-                size="large"
+                size="small"
                 title={translate('sulu_trash.restore_element')}
             />
         );

--- a/src/Sulu/Bundle/TrashBundle/Resources/js/containers/RestoreFormOverlay/tests/__snapshots__/RestoreFormOverlay.test.js.snap
+++ b/src/Sulu/Bundle/TrashBundle/Resources/js/containers/RestoreFormOverlay/tests/__snapshots__/RestoreFormOverlay.test.js.snap
@@ -14,7 +14,7 @@ Array [
     class="container isDown"
   >
     <div
-      class="overlay large"
+      class="overlay small"
     >
       <section
         class="content"


### PR DESCRIPTION
| Q | A
| --- | ---
| New feature? | yes
| Fixed tickets | fixes #5512
| Related issues/PRs | builds upon #6213
| License | MIT

#### What's in this PR?

This PR integrates the `SuluTrashBundle` with the build in media entity. With the changes in this PR, media entities will be moved into the trash when being deleted and can be restored from the trash at a later point in time.
