### PR TITLE
Check webspace permissions for hiding toolbar actions when creating new page

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteToolbarAction.test.js
@@ -21,8 +21,8 @@ jest.mock('../../../../stores/ResourceStore', () => jest.fn(function(resourceKey
     this.observableOptions = observableOptions;
 }));
 
-jest.mock('../../../../containers/Form', () => ({
-    ResourceFormStore: class {
+jest.mock('../../../../containers/Form/stores/ResourceFormStore', () => (
+    class {
         data = {};
         resourceStore;
 
@@ -39,8 +39,8 @@ jest.mock('../../../../containers/Form', () => ({
         }
 
         delete = jest.fn();
-    },
-}));
+    }
+));
 
 jest.mock('../../../../services/Router', () => jest.fn(function() {
     this.attributes = {};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/PublishToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/PublishToolbarAction.test.js
@@ -13,8 +13,8 @@ jest.mock('../../../../stores/ResourceStore', () => jest.fn(function() {
     this.data = {};
 }));
 
-jest.mock('../../../../containers/Form', () => ({
-    ResourceFormStore: class {
+jest.mock('../../../../containers/Form/stores/ResourceFormStore', () => (
+    class {
         resourceStore;
         constructor(resourceStore) {
             this.resourceStore = resourceStore;
@@ -31,8 +31,8 @@ jest.mock('../../../../containers/Form', () => ({
         get data() {
             return this.resourceStore.data;
         }
-    },
-}));
+    }
+));
 
 jest.mock('../../../../services/Router', () => jest.fn());
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithPublishingToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithPublishingToolbarAction.test.js
@@ -18,8 +18,8 @@ jest.mock('../../../../stores/ResourceStore', () => jest.fn(function() {
     this.data = {};
 }));
 
-jest.mock('../../../../containers/Form', () => ({
-    ResourceFormStore: class {
+jest.mock('../../../../containers/Form/stores/ResourceFormStore', () => (
+    class {
         resourceStore;
         constructor(resourceStore) {
             this.resourceStore = resourceStore;
@@ -36,8 +36,8 @@ jest.mock('../../../../containers/Form', () => ({
         get data() {
             return this.resourceStore.data;
         }
-    },
-}));
+    }
+));
 
 jest.mock('../../../../services/Router', () => jest.fn());
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TogglerToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TogglerToolbarAction.test.js
@@ -15,8 +15,8 @@ jest.mock('../../../../stores/ResourceStore', () => jest.fn(function(resourceKey
     this.data = {};
 }));
 
-jest.mock('../../../../containers/Form', () => ({
-    ResourceFormStore: class {
+jest.mock('../../../../containers/Form/stores/ResourceFormStore', () => (
+    class {
         resourceStore;
         resourceKey;
 
@@ -42,8 +42,8 @@ jest.mock('../../../../containers/Form', () => ({
         get loading() {
             return this.resourceStore.loading;
         }
-    },
-}));
+    }
+));
 
 jest.mock('../../../../services/Router', () => jest.fn());
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TypeToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TypeToolbarAction.test.js
@@ -12,8 +12,8 @@ jest.mock('../../../../utils/Translator', () => ({
 
 jest.mock('../../../../stores/ResourceStore', () => jest.fn());
 
-jest.mock('../../../../containers/Form', () => ({
-    ResourceFormStore: class {
+jest.mock('../../../../containers/Form/stores/ResourceFormStore', () => (
+    class {
         data = {};
         resourceStore;
         types = {};
@@ -36,8 +36,8 @@ jest.mock('../../../../containers/Form', () => ({
         }
 
         changeType = jest.fn();
-    },
-}));
+    }
+));
 
 jest.mock('../../../../services/Router', () => jest.fn());
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/AbstractFormToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/AbstractFormToolbarAction.js
@@ -1,6 +1,7 @@
 // @flow
+import {computed} from 'mobx';
 import ResourceStore from '../../../stores/ResourceStore';
-import {ResourceFormStore} from '../../../containers/Form';
+import {ResourceFormStore, FormInspector, conditionDataProviderRegistry} from '../../../containers/Form';
 import Router from '../../../services/Router';
 import Form from '../Form';
 import type {ToolbarItemConfig} from '../../../containers/Toolbar/types';
@@ -8,11 +9,24 @@ import type {Node} from 'react';
 
 export default class AbstractFormToolbarAction {
     resourceFormStore: ResourceFormStore;
+    formInspector: FormInspector;
     form: Form;
     router: Router;
     locales: ?Array<string>;
     options: {[key: string]: mixed};
     parentResourceStore: ResourceStore;
+
+    @computed get conditionData() {
+        const data = this.resourceFormStore.data;
+        const formInspector = this.formInspector;
+
+        return conditionDataProviderRegistry.getAll().reduce(
+            function(data, conditionDataProvider) {
+                return {...data, ...conditionDataProvider(data, undefined, formInspector)};
+            },
+            {...data}
+        );
+    }
 
     constructor(
         resourceFormStore: ResourceFormStore,
@@ -23,6 +37,7 @@ export default class AbstractFormToolbarAction {
         parentResourceStore: ResourceStore
     ) {
         this.resourceFormStore = resourceFormStore;
+        this.formInspector = new FormInspector(this.resourceFormStore);
         this.form = form;
         this.router = router;
         this.locales = locales;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/CopyLocaleToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/CopyLocaleToolbarAction.js
@@ -102,9 +102,9 @@ export default class CopyLocaleToolbarAction extends AbstractFormToolbarAction {
             visible_condition: visibleCondition,
         } = this.options;
 
-        const {id, data} = this.resourceFormStore;
+        const {id} = this.resourceFormStore;
 
-        const visibleConditionFulfilled = !visibleCondition || jexl.evalSync(visibleCondition, data);
+        const visibleConditionFulfilled = !visibleCondition || jexl.evalSync(visibleCondition, this.conditionData);
 
         if (visibleConditionFulfilled) {
             return {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteDraftToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteDraftToolbarAction.js
@@ -77,10 +77,9 @@ export default class DeleteDraftToolbarAction extends AbstractFormToolbarAction 
         } = this.options;
 
         const {id, data} = this.resourceFormStore;
-
         const {published, publishedState} = data;
 
-        const visibleConditionFulfilled = !visibleCondition || jexl.evalSync(visibleCondition, data);
+        const visibleConditionFulfilled = !visibleCondition || jexl.evalSync(visibleCondition, this.conditionData);
 
         if (visibleConditionFulfilled) {
             return {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteToolbarAction.js
@@ -104,14 +104,14 @@ export default class DeleteToolbarAction extends AbstractFormToolbarAction {
             delete_locale: deleteLocale = false,
         } = this.options;
 
-        const {id, data} = this.resourceFormStore;
+        const {id} = this.resourceFormStore;
 
-        const visibleConditionFulfilled = !visibleCondition || jexl.evalSync(visibleCondition, data);
-        const disableCondition = !id || (deleteLocale && jexl.evalSync('contentLocales.length == 1', data));
+        const visibleConditionFulfilled = !visibleCondition || jexl.evalSync(visibleCondition, this.conditionData);
+        const isDisabled = !id || (deleteLocale && jexl.evalSync('contentLocales.length == 1', this.conditionData));
 
         if (visibleConditionFulfilled) {
             return {
-                disabled: !!disableCondition,
+                disabled: !!isDisabled,
                 icon: 'su-trash-alt',
                 label: translate('sulu_admin.delete' + (deleteLocale ? '_locale' : '')),
                 onClick: action(() => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/PublishToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/PublishToolbarAction.js
@@ -11,7 +11,7 @@ export default class PublishToolbarAction extends AbstractFormToolbarAction {
 
         const {dirty, data} = this.resourceFormStore;
 
-        const visibleConditionFulfilled = !visibleCondition || jexl.evalSync(visibleCondition, data);
+        const visibleConditionFulfilled = !visibleCondition || jexl.evalSync(visibleCondition, this.conditionData);
 
         if (visibleConditionFulfilled) {
             return {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveToolbarAction.js
@@ -11,7 +11,7 @@ export default class SaveToolbarAction extends AbstractFormToolbarAction {
             options: submitOptions,
         } = this.options;
 
-        const {data, dirty, saving} = this.resourceFormStore;
+        const {dirty, saving} = this.resourceFormStore;
 
         if (typeof label !== 'string') {
             throw new Error('The "label" option must be a string!');
@@ -21,7 +21,7 @@ export default class SaveToolbarAction extends AbstractFormToolbarAction {
             throw new Error('The "options" option must be an object!');
         }
 
-        const visibleConditionFulfilled = !visibleCondition || jexl.evalSync(visibleCondition, data);
+        const visibleConditionFulfilled = !visibleCondition || jexl.evalSync(visibleCondition, this.conditionData);
 
         if (visibleConditionFulfilled) {
             return {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveWithFormDialogToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveWithFormDialogToolbarAction.js
@@ -93,7 +93,7 @@ export default class SaveWithFormDialogToolbarAction extends AbstractFormToolbar
                 if (
                     jexl.evalSync(
                         this.options.condition,
-                        {...this.resourceFormStore.data, __parent: this.parentResourceStore.data}
+                        {...this.conditionData, __parent: this.parentResourceStore.data}
                     )
                 ) {
                     this.showDialog = true;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveWithPublishingToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveWithPublishingToolbarAction.js
@@ -66,10 +66,10 @@ export default class SaveWithPublishingToolbarAction extends AbstractFormToolbar
         const {dirty, data, saving} = this.resourceFormStore;
 
         const publishVisibleConditionFulfilled = !publishVisibleCondition
-            || jexl.evalSync(publishVisibleCondition, data);
+            || jexl.evalSync(publishVisibleCondition, this.conditionData);
 
         const saveVisibleConditionFulfilled = !saveVisibleCondition
-            || jexl.evalSync(saveVisibleCondition, data);
+            || jexl.evalSync(saveVisibleCondition, this.conditionData);
 
         const options = [];
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SetUnpublishedToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SetUnpublishedToolbarAction.js
@@ -77,10 +77,9 @@ export default class SetUnpublishedToolbarAction extends AbstractFormToolbarActi
         } = this.options;
 
         const {id, data} = this.resourceFormStore;
-
         const {published} = data;
 
-        const visibleConditionFulfilled = !visibleCondition || jexl.evalSync(visibleCondition, data);
+        const visibleConditionFulfilled = !visibleCondition || jexl.evalSync(visibleCondition, this.conditionData);
 
         if (visibleConditionFulfilled) {
             return {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/TypeToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/TypeToolbarAction.js
@@ -26,7 +26,7 @@ export default class TypeToolbarAction extends AbstractFormToolbarAction {
             throw new Error('The "sort_by" option must be a string if given!');
         }
 
-        const isDisabled = disabledCondition ? jexl.evalSync(disabledCondition, this.resourceFormStore.data) : false;
+        const isDisabled = disabledCondition ? jexl.evalSync(disabledCondition, this.conditionData) : false;
 
         const sortedTypes = sortBy
             ? formTypes.sort((t1, t2) => String(t1[sortBy]).localeCompare(String(t2[sortBy])))

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -118,8 +118,14 @@ class PageAdmin extends Admin
     {
         /** @var Webspace $firstWebspace */
         $firstWebspace = \current($this->webspaceManager->getWebspaceCollection()->getWebspaces());
-        $saveVisibleCondition = '(!_permissions || _permissions.edit)';
-        $publishVisibleCondition = '(!_permissions || _permissions.live)';
+
+        $webspaceSaveVisibleCondition = ' (!__webspace || __webspace._permissions.edit)';
+        $pageSaveVisibleCondition = '(!_permissions || _permissions.edit)';
+        $saveVisibleCondition = '(' . $webspaceSaveVisibleCondition . ') && (' . $pageSaveVisibleCondition . ')';
+
+        $webspacePublishVisibleCondition = '(!__webspace || __webspace._permissions.live)';
+        $pagePublishVisibleCondition = '(!_permissions || _permissions.live)';
+        $publishVisibleCondition = '(' . $webspacePublishVisibleCondition . ') && (' . $pagePublishVisibleCondition . ')';
 
         $saveWithPublishingDropdown = new DropdownToolbarAction(
             'sulu_admin.save',

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/tests/toolbarActions/EnableUserToolbarAction.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/tests/toolbarActions/EnableUserToolbarAction.test.js
@@ -14,8 +14,8 @@ jest.mock('sulu-admin-bundle/stores/ResourceStore', () => jest.fn(function() {
     this.data = {};
 }));
 
-jest.mock('sulu-admin-bundle/containers/Form', () => ({
-    ResourceFormStore: class {
+jest.mock('sulu-admin-bundle/containers/Form/stores/ResourceFormStore', () => (
+    class {
         resourceStore;
 
         change = jest.fn();
@@ -39,8 +39,8 @@ jest.mock('sulu-admin-bundle/containers/Form', () => ({
         get loading() {
             return this.resourceStore.loading;
         }
-    },
-}));
+    }
+));
 
 jest.mock('sulu-admin-bundle/services/Router/Router', () => jest.fn());
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #5876
| License | MIT

#### What's in this PR?

This PR adjusts the form toolbar actions to include the data of the registered `ConditionDataProvider`s when evaluating conditions. This makes it possible to include things like `__webspace` inside of conditions that are passed to to toolbar actions.

#### Why?

Because we need to check the permissions of the selected webspace when creating a new page (see #5876). By including the data of the `webspaceConditionDataProvider`, we can just access `__webspace._permissions` in our condition to do this. 
