### PR TITLE
Add userConditionDataProvider to allow for checking user roles in conditions

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/conditionDataProviders/userConditionDataProvider.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/conditionDataProviders/userConditionDataProvider.js
@@ -1,0 +1,7 @@
+// @flow
+import {toJS} from 'mobx';
+import userStore from '../../../stores/userStore';
+
+export default function(): {[string]: any} {
+    return {__user: toJS(userStore.user)};
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/index.js
@@ -4,6 +4,7 @@ import FormInspector from './FormInspector';
 import bundlesConditionDataProvider from './conditionDataProviders/bundlesConditionDataProvider';
 import localeConditionDataProvider from './conditionDataProviders/localeConditionDataProvider';
 import parentConditionDataProvider from './conditionDataProviders/parentConditionDataProvider';
+import userConditionDataProvider from './conditionDataProviders/userConditionDataProvider';
 import conditionDataProviderRegistry from './registries/conditionDataProviderRegistry';
 import fieldRegistry from './registries/fieldRegistry';
 import MemoryFormStore from './stores/MemoryFormStore';
@@ -38,6 +39,7 @@ export {
     bundlesConditionDataProvider,
     localeConditionDataProvider,
     parentConditionDataProvider,
+    userConditionDataProvider,
     conditionDataProviderRegistry,
     fieldRegistry,
     Selection,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/conditionDataProviders/userConditionDataProvider.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/conditionDataProviders/userConditionDataProvider.test.js
@@ -1,0 +1,48 @@
+// @flow
+import {observable} from 'mobx';
+import jexl from 'jexl';
+import userConditionDataProvider from '../../conditionDataProviders/userConditionDataProvider';
+import userStore from '../../../../stores/userStore';
+
+jest.mock('../../../../stores/userStore', () => ({
+}));
+
+test('Return user from userStore', () => {
+    userStore.user = undefined;
+    expect(userConditionDataProvider()).toEqual({__user: undefined});
+
+    userStore.user = {
+        id: 1,
+        username: 'admin',
+        locale: 'en',
+        fullName: 'Adam Ministrator',
+        roles: ['ROLE_USER'],
+        settings: {},
+    };
+
+    expect(userConditionDataProvider()).toEqual({
+        __user: {
+            id: 1,
+            username: 'admin',
+            locale: 'en',
+            fullName: 'Adam Ministrator',
+            roles: ['ROLE_USER'],
+            settings: {},
+        },
+    });
+});
+
+test('Roles of user can be used in jexl expression', () => {
+    userStore.user = observable({
+        id: 1,
+        username: 'admin',
+        locale: 'en',
+        fullName: 'Adam Ministrator',
+        roles: ['ROLE_USER', 'ROLE_SULU_DESIGNER'],
+        settings: {},
+    } );
+
+    const conditionData = userConditionDataProvider();
+    expect(jexl.evalSync('"ROLE_SULU_DESIGNER" in __user.roles', conditionData)).toBeTruthy();
+    expect(jexl.evalSync('"ROLE_SULU_TESTER" in __user.roles', conditionData)).toBeFalsy();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/conditionDataProviders/userConditionDataProvider.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/conditionDataProviders/userConditionDataProvider.test.js
@@ -40,7 +40,7 @@ test('Roles of user can be used in jexl expression', () => {
         fullName: 'Adam Ministrator',
         roles: ['ROLE_USER', 'ROLE_SULU_DESIGNER'],
         settings: {},
-    } );
+    });
 
     const conditionData = userConditionDataProvider();
     expect(jexl.evalSync('"ROLE_SULU_DESIGNER" in __user.roles', conditionData)).toBeTruthy();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -84,6 +84,7 @@ import {
     Select,
     Number,
     parentConditionDataProvider,
+    userConditionDataProvider,
     PasswordConfirmation,
     Phone,
     Selection,
@@ -165,6 +166,7 @@ initializer.addUpdateConfigHook('sulu_admin', (config: Object, initialized: bool
         conditionDataProviderRegistry.add(bundlesConditionDataProvider);
         conditionDataProviderRegistry.add(localeConditionDataProvider);
         conditionDataProviderRegistry.add(parentConditionDataProvider);
+        conditionDataProviderRegistry.add(userConditionDataProvider);
     }
 
     processConfig(config);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/tests/userStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/tests/userStore.test.js
@@ -25,7 +25,7 @@ beforeEach(() => {
 });
 
 test('Should clear the user store', () => {
-    const user = {id: 1, locale: 'cool_locale', settings: {}, username: 'test'};
+    const user = {id: 1, locale: 'cool_locale', settings: {}, username: 'test', roles: []};
     const contact = {id: 12, avatar: undefined, firstName: 'Firsti', lastName: 'Lasti', fullName: 'Firsti Lasti'};
     userStore.setLoggedIn(true);
     userStore.setLoading(true);
@@ -58,6 +58,7 @@ test('Should return the locale of the user as system-locale', () => {
         locale: 'de',
         settings: {},
         username: 'test',
+        roles: [],
     });
 
     expect(userStore.systemLocale).toEqual('de');
@@ -83,6 +84,7 @@ test('Should load and set first default-localization as content-locale when user
         locale: 'de',
         settings: {},
         username: 'test',
+        roles: [],
     });
 
     expect(userStore.contentLocale).toEqual('ru');
@@ -100,6 +102,7 @@ test('Should load and set first localization as content-locale if there is no de
         locale: 'de',
         settings: {},
         username: 'test',
+        roles: [],
     });
 
     expect(userStore.contentLocale).toEqual('cz');
@@ -113,6 +116,7 @@ test('Should return initial persistent settings', () => {
             test1: 'value1',
         },
         username: 'test',
+        roles: [],
     });
 
     expect(userStore.getPersistentSetting('test1')).toEqual('value1');
@@ -189,7 +193,7 @@ test('Should login after the password was reset', () => {
 });
 
 test('Should login without initializing when it`s the same user', () => {
-    const user = {id: 1, locale: 'cool_locale', settings: {}, username: 'test'};
+    const user = {id: 1, locale: 'cool_locale', settings: {}, username: 'test', roles: []};
     const loginPromise = Promise.resolve({});
     Requester.post.mockReturnValue(loginPromise);
     userStore.setUser(user);
@@ -206,7 +210,7 @@ test('Should login without initializing when it`s the same user', () => {
 });
 
 test('Should login with initializing when it`s not the same user', () => {
-    const user = {id: 1, locale: 'cool_locale', settings: {}, username: 'test'};
+    const user = {id: 1, locale: 'cool_locale', settings: {}, username: 'test', roles: []};
     const loginPromise = Promise.resolve({});
     const initializePromise = Promise.resolve({});
     userStore.setUser(user);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/types.js
@@ -3,6 +3,7 @@
 export type User = {
     id: number,
     locale: string,
+    roles: string[],
     settings: {[string]: string},
     username: string,
 };

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/formatStore/tests/FormatStore.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/formatStore/tests/FormatStore.test.js
@@ -25,6 +25,7 @@ test('Load localizations', () => {
         locale: 'de',
         settings: {},
         username: 'test',
+        roles: [],
     };
 
     const response = {

--- a/src/Sulu/Bundle/SecurityBundle/Entity/User.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/User.php
@@ -587,6 +587,7 @@ class User extends ApiEntity implements UserInterface, Serializable, EquatableIn
 
     /**
      * @VirtualProperty
+     * @Groups({"frontend"})
      */
     public function getRoles()
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Fixed tickets | fixes #5606
| License | MIT

#### What's in this PR?

This PR adds a `userConditionDataProvider` to allow for checking the data of the logged in user inside of conditions. For example, this allows to check the roles of the current user to hide a specific form field:

```xml
<property name="article" type="text_editor" disabledCondition="'ROLE_SULU_TEXTER' in __user.roles">
    <meta>
        <title lang="en">Article</title>
    </meta>
</property>
```
