### PR TITLE
Fix startup performance and ckeditor styling of react-styleguidist integration

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -178,6 +178,7 @@ module.exports = { // eslint-disable-line
                                 injectType: 'singletonStyleTag',
                             },
                         },
+                        'css-loader',
                         {
                             loader: 'postcss-loader',
                             options: styles.getPostCssConfig({


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Related issues/PRs | #6217
| License | MIT

#### What's in this PR?

This PR adds the `css-loader` before the `style-loader` for processing ckeditor css files in the webspace configuration of the `react-styleguidist` package.

I looks the processing of the ckeditor css files worked without the `css-loader` while we were using `style-loader@v1`, but fails and leads to a big performance penalty when using `style-loader@v2` (see #6217).