### PR TITLE
Remove separate webpack configuration in react-styleguidist configuration

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -51,19 +51,20 @@ jobs:
             - name: Test JavaScript code
               run: npm test -- --maxWorkers=4
 
-            - name: Test Styleguidist build
-              run: npm run styleguide:build
-
             - name: Install and configure PHP
               uses: shivammathur/setup-php@v2
               with:
                   php-version: '7.4'
                   tools: 'composer:v2'
 
+            - name: Install php dependencies
+              run: rm composer.json && composer require friendsofsymfony/jsrouting-bundle:^2.3 --no-interaction
+
+            - name: Test Styleguidist build
+              run: npm run styleguide:build
+
             - name: Test application build
-              run: |
-                  rm composer.json && composer require friendsofsymfony/jsrouting-bundle:^2.3 --no-interaction
-                  npm run build
+              run: npm run build
 
     php:
         name: "PHP ${{ matrix.php-version }} (${{ matrix.database }}, ${{ matrix.phpcr-transport }}, ${{ matrix.dependency-versions }})"

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -4,7 +4,7 @@ const path = require('path');
 const fs = require('fs');
 const webpack = require('webpack');
 const glob = require('glob');
-const {styles} = require('@ckeditor/ckeditor5-dev-utils'); // eslint-disable-line import/no-extraneous-dependencies
+const webpackConfig = require('./webpack.config.js');
 
 const firstLetterIsUppercase = (string) => {
     const first = string.charAt(0);
@@ -126,106 +126,15 @@ module.exports = { // eslint-disable-line
             },
         },
     ],
-    webpackConfig: {
-        devServer: {
-            disableHostCheck: true,
-        },
-        devtool: 'eval-source-map',
-        plugins: [
+    webpackConfig: (env, argv) => {
+        const config = webpackConfig(env, argv);
+
+        config.plugins.push(
             new webpack.DefinePlugin({
                 SULU_CONFIG: {},
-            }),
-        ],
-        resolve: {
-            alias: {
-                // eslint-disable-next-line no-undef
-                'fos-jsrouting/router': path.resolve(__dirname, 'tests/js/mocks/empty.js'),
-            },
-        },
-        module: {
-            rules: [
-                {
-                    test: /\.js$/,
-                    exclude: /node_modules\/(?!(sulu-(.*)-bundle|@ckeditor|lodash-es)\/)/,
-                    use: {
-                        loader: 'babel-loader',
-                        options: {
-                            cacheDirectory: true,
-                            cacheCompression: false,
-                        },
-                    },
-                },
-                {
-                    test: /\.css/,
-                    exclude: /ckeditor5-[^/]+\/theme\/[\w-/]+\.css$/,
-                    use: [
-                        'style-loader',
-                        {
-                            loader: 'css-loader',
-                            options: {
-                                modules: false,
-                            },
-                        },
-                    ],
-                },
-                {
-                    test: /ckeditor5-[^/]+\/theme\/[\w-/]+\.css$/,
-                    use: [
-                        {
-                            loader: 'style-loader',
-                            options: {
-                                injectType: 'singletonStyleTag',
-                            },
-                        },
-                        {
-                            loader: 'postcss-loader',
-                            options: styles.getPostCssConfig({
-                                themeImporter: {
-                                    themePath: require.resolve('@ckeditor/ckeditor5-theme-lark'),
-                                },
-                            }),
-                        },
-                    ],
-                },
-                {
-                    test: /\.(scss)$/,
-                    use: [
-                        'style-loader',
-                        {
-                            loader: 'css-loader',
-                            options: {
-                                importLoaders: 1,
-                                localsConvention: 'camelCase',
-                                modules: {
-                                    localIdentName: '[local]--[hash:base64:10]',
-                                },
-                            },
-                        },
-                        'postcss-loader',
-                    ],
-                },
-                {
-                    test: /ckeditor5-[^/]+\/theme\/icons\/[^/]+\.svg$/,
-                    use: 'raw-loader',
-                },
-                {
-                    test: /\.(jpg|gif|png)(\?.*$|$)/,
-                    use: [
-                        {
-                            loader: 'file-loader',
-                        },
-                    ],
-                },
-                {
-                    test: /\.(svg|ttf|woff|woff2|eot)(\?.*$|$)/,
-                    exclude: /ckeditor5-[^/]+\/theme\/icons\/[^/]+\.svg$/,
-                    use: [
-                        {
-                            loader: 'file-loader',
-                        },
-                    ],
-                },
-            ],
-        },
+            })
+        );
+
+        return config;
     },
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
     env = env ? env : {};
     argv = argv ? argv : {};
 
-    let publicDir = 'public';
+    const publicPath = env && env.public_path ? env.public_path : '/';
     const outputPath = env && env.output_path ? env.output_path : path.join('build', 'admin');
     // eslint-disable-next-line no-undef
     const projectRootPath = env && env.project_root_path ? env.project_root_path : __dirname;
@@ -16,6 +16,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
         ? env.node_modules_path
         : path.resolve(projectRootPath, 'node_modules');
 
+    let publicDir = 'public';
     const composerConfig = require(path.resolve(projectRootPath, 'composer.json'));
     if (composerConfig.extra && composerConfig.extra['public-dir']) {
         publicDir = composerConfig.extra['public-dir'];
@@ -42,6 +43,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
         output: {
             path: path.resolve(projectRootPath, publicDir),
             filename: outputPath + '/[name].[chunkhash].js',
+            publicPath,
         },
         devtool: argv.mode === 'development' ? 'eval-source-map' : 'source-map',
         plugins: [
@@ -94,7 +96,8 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                         {
                             loader: MiniCssExtractPlugin.loader,
                             options: {
-                                publicPath: '../../', // @see https://github.com/sulu/sulu/pull/6225
+                                // set path to public root from bundled css: https://github.com/sulu/sulu/pull/6225
+                                publicPath: path.relative(outputPath, '.'),
                             },
                         },
                         'css-loader',
@@ -106,7 +109,8 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                         {
                             loader: MiniCssExtractPlugin.loader,
                             options: {
-                                publicPath: '../../', // @see https://github.com/sulu/sulu/pull/6225
+                                // set path to public root from bundled css: https://github.com/sulu/sulu/pull/6225
+                                publicPath: path.relative(outputPath, '.'),
                             },
                         },
                         {
@@ -132,7 +136,8 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                         {
                             loader: MiniCssExtractPlugin.loader,
                             options: {
-                                publicPath: '../../', // @see https://github.com/sulu/sulu/pull/6225
+                                // set path to public root from bundled css: https://github.com/sulu/sulu/pull/6225
+                                publicPath: path.relative(outputPath, '.'),
                             },
                         },
                         {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,9 @@ const fs = require('fs');
 const path = require('path');
 
 module.exports = (env, argv) => { // eslint-disable-line no-undef
+    env = env ? env : {};
+    argv = argv ? argv : {};
+
     let publicDir = 'public';
     const outputPath = env && env.output_path ? env.output_path : path.join('build', 'admin');
     // eslint-disable-next-line no-undef
@@ -88,14 +91,26 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                     test: /\.css/,
                     exclude: /ckeditor5-[^/\\]+[/\\]theme[/\\].+\.css$/,
                     use: [
-                        MiniCssExtractPlugin.loader,
+                        {
+                            loader: MiniCssExtractPlugin.loader,
+                            options: {
+                                // https://github.com/webpack-contrib/mini-css-extract-plugin/issues/44#issuecomment-391009221
+                                publicPath: '../../',
+                            },
+                        },
                         'css-loader',
                     ],
                 },
                 {
                     test: /\.(scss)$/,
                     use: [
-                        MiniCssExtractPlugin.loader,
+                        {
+                            loader: MiniCssExtractPlugin.loader,
+                            options: {
+                                // https://github.com/webpack-contrib/mini-css-extract-plugin/issues/44#issuecomment-391009221
+                                publicPath: '../../',
+                            },
+                        },
                         {
                             loader: 'css-loader',
                             options: {
@@ -116,7 +131,13 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                 {
                     test: /ckeditor5-[^/\\]+[/\\]theme[/\\].+\.css$/,
                     use: [
-                        MiniCssExtractPlugin.loader,
+                        {
+                            loader: MiniCssExtractPlugin.loader,
+                            options: {
+                                // https://github.com/webpack-contrib/mini-css-extract-plugin/issues/44#issuecomment-391009221
+                                publicPath: '../../',
+                            },
+                        },
                         {
                             loader: 'css-loader',
                         },
@@ -140,7 +161,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                         {
                             loader: 'file-loader',
                             options: {
-                                name: '/' + outputPath + '/fonts/[name].[hash].[ext]',
+                                name: outputPath + '/fonts/[name].[hash].[ext]',
                             },
                         },
                     ],
@@ -151,7 +172,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                         {
                             loader: 'file-loader',
                             options: {
-                                name: '/' + outputPath + '/images/[name].[hash].[ext]',
+                                name: outputPath + '/images/[name].[hash].[ext]',
                             },
                         },
                     ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -94,8 +94,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                         {
                             loader: MiniCssExtractPlugin.loader,
                             options: {
-                                // https://github.com/webpack-contrib/mini-css-extract-plugin/issues/44#issuecomment-391009221
-                                publicPath: '../../',
+                                publicPath: '../../', // @see https://github.com/sulu/sulu/pull/6225
                             },
                         },
                         'css-loader',
@@ -107,8 +106,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                         {
                             loader: MiniCssExtractPlugin.loader,
                             options: {
-                                // https://github.com/webpack-contrib/mini-css-extract-plugin/issues/44#issuecomment-391009221
-                                publicPath: '../../',
+                                publicPath: '../../', // @see https://github.com/sulu/sulu/pull/6225
                             },
                         },
                         {
@@ -134,8 +132,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                         {
                             loader: MiniCssExtractPlugin.loader,
                             options: {
-                                // https://github.com/webpack-contrib/mini-css-extract-plugin/issues/44#issuecomment-391009221
-                                publicPath: '../../',
+                                publicPath: '../../', // @see https://github.com/sulu/sulu/pull/6225
                             },
                         },
                         {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Related issues/PRs | #6223
| License | MIT

#### What's in this PR?

This PR removes the separate webpack configuration in the `styleguide.config.js` and uses the default webpack configuration instead. This allows us to maintain a single webpack configuration and therefore prevents issues like #6223. 