### PR TITLE
Add alias for fos-jsrouting package to allow for building react-styleguidist without installing composer dependencies

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -51,6 +51,9 @@ jobs:
             - name: Test JavaScript code
               run: npm test -- --maxWorkers=4
 
+            - name: Test Styleguidist build
+              run: npm run styleguide:build
+
             - name: Install and configure PHP
               uses: shivammathur/setup-php@v2
               with:
@@ -59,9 +62,6 @@ jobs:
 
             - name: Install php dependencies
               run: rm composer.json && composer require friendsofsymfony/jsrouting-bundle:^2.3 --no-interaction
-
-            - name: Test Styleguidist build
-              run: npm run styleguide:build
 
             - name: Test application build
               run: npm run build

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -135,6 +135,11 @@ module.exports = { // eslint-disable-line
             })
         );
 
+        // set alias for "fos-jsrouting" package to allow for building styleguide without composer dependencies
+        delete config.resolve.alias['fos-jsrouting'];
+        // eslint-disable-next-line no-undef
+        config.resolve.alias['fos-jsrouting/router'] = path.resolve(__dirname, 'tests/js/mocks/empty.js');
+
         return config;
     },
 };


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes

#### What's in this PR?

This PR adds an alias for the `fos-jsrouting` package in the `styleguide.config.js` to allow for building react-styleguidist without installing composer dependencies.

I have removed this alias in https://github.com/sulu/sulu/pull/6225. Unfortunately, this broke the build of the `sulu/sulu-javascript-docs`: https://github.com/sulu/sulu-javascript-docs/runs/3608782035
