### PR TITLE
Use webspace permissions for hiding toolbar actions only when creating new page

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -119,13 +119,13 @@ class PageAdmin extends Admin
         /** @var Webspace $firstWebspace */
         $firstWebspace = \current($this->webspaceManager->getWebspaceCollection()->getWebspaces());
 
-        $webspaceSaveVisibleCondition = ' (!__webspace || __webspace._permissions.edit)';
-        $pageSaveVisibleCondition = '(!_permissions || _permissions.edit)';
-        $saveVisibleCondition = '(' . $webspaceSaveVisibleCondition . ') && (' . $pageSaveVisibleCondition . ')';
+        $createPageSaveVisibleCondition = '!_permissions && (!__webspace || __webspace._permissions.edit)';
+        $editPageSaveVisibleCondition = '_permissions && _permissions.edit';
+        $saveVisibleCondition = '(' . $createPageSaveVisibleCondition . ') || (' . $editPageSaveVisibleCondition . ')';
 
-        $webspacePublishVisibleCondition = '(!__webspace || __webspace._permissions.live)';
-        $pagePublishVisibleCondition = '(!_permissions || _permissions.live)';
-        $publishVisibleCondition = '(' . $webspacePublishVisibleCondition . ') && (' . $pagePublishVisibleCondition . ')';
+        $createPagePublishVisibleCondition = '!_permissions  && (!__webspace || __webspace._permissions.live)';
+        $editPagePublishVisibleCondition = '(!_permissions || _permissions.live)';
+        $publishVisibleCondition = '(' . $createPagePublishVisibleCondition . ') || (' . $editPagePublishVisibleCondition . ')';
 
         $saveWithPublishingDropdown = new DropdownToolbarAction(
             'sulu_admin.save',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| Related issues/PRs | #6221
| License | MIT

#### What's in this PR?

This PR adjusts the conditions that are used for hiding toolbar action on the page create/edit form. Previously, webspace permissions were checked even for existing pages that contain a `_permissions` property. After this change, webspace permissions are only checked when creating a new page (the `_permissions` property is not set in this case). For existing pages, only the values of the `_permissions` property are used.

Without this change, the publish toolbar action is hidden if the user does not have publish permissions for the webspace, even if he has publish permission for that specific page (object specific permissions that are set on the permissions tab). This behaviour was wrong, because object specific permissions overwrite the more general webspace permissions.