### PR TITLE
Do not display edit button in table view of media selection overlay

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -40,14 +40,6 @@ class MediaCollection extends React.Component<Props> {
     static editable: boolean = true;
     static securable: boolean = true;
 
-    handleMediaClick = (mediaId: string | number) => {
-        const {onMediaNavigate} = this.props;
-
-        if (onMediaNavigate) {
-            onMediaNavigate(mediaId);
-        }
-    };
-
     handleCollectionNavigate = (collectionId: ?string | number) => {
         this.props.onCollectionNavigate(collectionId);
     };
@@ -85,6 +77,7 @@ class MediaCollection extends React.Component<Props> {
             mediaListAdapters,
             mediaListRef,
             mediaListStore,
+            onMediaNavigate,
             onUploadOverlayClose,
             onUploadOverlayOpen,
             uploadOverlayOpen,
@@ -127,7 +120,7 @@ class MediaCollection extends React.Component<Props> {
                         adapters={mediaListAdapters}
                         listStore={mediaListStore}
                         mediaListRef={mediaListRef}
-                        onMediaClick={this.handleMediaClick}
+                        onMediaClick={onMediaNavigate}
                     />
                 </div>
             </MultiMediaDropzone>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaSection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaSection.js
@@ -7,25 +7,22 @@ type Props = {|
     adapters: Array<string>,
     listStore: ListStore,
     mediaListRef?: (?ElementRef<typeof List>) => void,
-    onMediaClick: (mediaId: string | number) => void,
+    onMediaClick?: (mediaId: string | number) => void,
 |};
 
 export default class MediaSection extends React.PureComponent<Props> {
-    handleMediaClick = (mediaId: string | number) => {
-        this.props.onMediaClick(mediaId);
-    };
-
     render() {
         const {
             adapters,
             listStore,
             mediaListRef,
+            onMediaClick,
         } = this.props;
 
         return (
             <List
                 adapters={adapters}
-                onItemClick={this.handleMediaClick}
+                onItemClick={onMediaClick}
                 ref={mediaListRef}
                 store={listStore}
             />


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

This pull requests adjust the `MediaCollection` and `MediaSection` component to not pass any `onItemClick` prop to the `List` component if no `onMediaNavigate` is given.

At the moment, a `onItemClick` callback is passed to the `List` component always. Because of this, the `table` adapter displays an edit button (that has no functionality) in the media selection overlay:

![Screenshot 2021-09-15 at 17 29 48](https://user-images.githubusercontent.com/13310795/133463358-19d133e6-0ca3-4449-9285-c5254af8f506.png)
