### PR TITLE
Add routerAttributesToFormMetadata option to FormOverlayList view

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilder.php
@@ -234,6 +234,13 @@ class FormOverlayListViewBuilder implements FormOverlayListViewBuilderInterface
         return $this;
     }
 
+    public function addRouterAttributesToFormMetadata(array $routerAttributesToFormMetadata): FormOverlayListViewBuilderInterface
+    {
+        $this->addRouterAttributesToFormMetadataToView($this->view, $routerAttributesToFormMetadata);
+
+        return $this;
+    }
+
     public function addMetadataRequestParameters(array $metadataRequestParameters): FormOverlayListViewBuilderInterface
     {
         $this->addMetadataRequestParametersToView($this->view, $metadataRequestParameters);

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilderInterface.php
@@ -91,6 +91,9 @@ interface FormOverlayListViewBuilderInterface extends ViewBuilderInterface
 
     public function setOverlaySize(string $overlaySize): self;
 
+    /**
+     * @param array<int|string, string> $routerAttributesToFormMetadata
+     */
     public function addRouterAttributesToFormMetadata(array $routerAttributesToFormMetadata): self;
 
     public function addMetadataRequestParameters(array $metadataRequestParameters): self;

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilderInterface.php
@@ -91,6 +91,8 @@ interface FormOverlayListViewBuilderInterface extends ViewBuilderInterface
 
     public function setOverlaySize(string $overlaySize): self;
 
+    public function addRouterAttributesToFormMetadata(array $routerAttributesToFormMetadata): self;
+
     public function addMetadataRequestParameters(array $metadataRequestParameters): self;
 
     /**

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
@@ -54,6 +54,7 @@ class FormOverlayList extends React.Component<Props> {
                         resourceKey,
                         routerAttributesToFormRequest = {},
                         resourceStorePropertiesToFormRequest = {},
+                        routerAttributesToFormMetadata = {},
                         metadataRequestParameters = {},
                     },
                 },
@@ -76,12 +77,18 @@ class FormOverlayList extends React.Component<Props> {
             resourceStorePropertiesToFormRequest
         );
 
+        const formStoreMetadataOptions = this.buildFormStoreMetadataOptions(
+            metadataRequestParameters,
+            attributes,
+            routerAttributesToFormMetadata
+        );
+
         const resourceStore = new ResourceStore(resourceKey, itemId, observableOptions, formStoreOptions);
         this.formStore = resourceFormStoreFactory.createFromResourceStore(
             resourceStore,
             formKey,
             formStoreOptions,
-            metadataRequestParameters
+            formStoreMetadataOptions
         );
     };
 
@@ -122,6 +129,23 @@ class FormOverlayList extends React.Component<Props> {
         });
 
         return formStoreOptions;
+    }
+
+    buildFormStoreMetadataOptions(
+        metadataRequestParameters: Object,
+        attributes: Object,
+        routerAttributesToFormMetadata: {[string | number]: string}
+    ) {
+        const metadataOptions = metadataRequestParameters ? metadataRequestParameters : {};
+
+        Object.keys(toJS(routerAttributesToFormMetadata)).forEach((key) => {
+            const metadataOptionKey = routerAttributesToFormMetadata[key];
+            const attributeName = isNaN(key) ? key : toJS(routerAttributesToFormMetadata[key]);
+
+            metadataOptions[metadataOptionKey] = attributes[attributeName];
+        });
+
+        return metadataOptions;
     }
 
     setListRef = (listRef: ?ElementRef<typeof List>) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/FormOverlayList.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/FormOverlayList.test.js
@@ -193,22 +193,20 @@ test('Should construct ResourceStore and ResourceFormStore with correct paramete
     }, {});
 });
 
-test('Should pass metadataRequestParameters options to FormStore', () => {
-    const metadataRequestParameters = {
-        'testParam': 'testValue',
-    };
-
+test('Should construct ResourceFormStore with correct metadataOptions on item-add callback', () => {
     const route: Route = ({}: any);
     const router: Router = ({
         attributes: {
             id: 'test-id',
-            category: 'category-id',
+            webspace: 'webspace-attribute-value',
+            template: 'template-attribute-value',
         },
         route: {
             options: {
                 formKey: 'test-form-key',
                 resourceKey: 'test-resource-key',
-                metadataRequestParameters,
+                metadataRequestParameters: {'staticParam': 'staticValue'},
+                routerAttributesToFormMetadata: {'0': 'webspace', 'template': 'pageTemplate'},
             },
         },
     }: any);
@@ -218,10 +216,11 @@ test('Should pass metadataRequestParameters options to FormStore', () => {
     formOverlayList.instance().locale = observable.box('en');
     formOverlayList.find(List).props().onItemAdd();
 
-    expect(ResourceFormStore).toBeCalledWith(expect.anything(), 'test-form-key', {}, metadataRequestParameters);
-
-    const formStore = formOverlayList.instance().formStore;
-    expect(formStore.metadataOptions).toEqual(metadataRequestParameters);
+    expect(ResourceFormStore).toBeCalledWith(expect.anything(), 'test-form-key', {}, {
+        staticParam: 'staticValue',
+        webspace: 'webspace-attribute-value',
+        pageTemplate: 'template-attribute-value',
+    });
 });
 
 test('Should open FormOverlay with correct props when List fires the item-add callback', () => {

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormOverlayListViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormOverlayListViewBuilderTest.php
@@ -295,6 +295,23 @@ class FormOverlayListViewBuilderTest extends TestCase
         );
     }
 
+    public function testBuildFormWithRouterAttributesToFormMetadata()
+    {
+        $route = (new FormOverlayListViewBuilder('sulu_role.list', '/roles'))
+            ->setResourceKey('roles')
+            ->setListKey('roles')
+            ->setFormKey('role_details')
+            ->addListAdapters(['tree'])
+            ->addRouterAttributesToFormMetadata(['webspace' => 'webspaceId', 'parent' => 'parentId'])
+            ->addRouterAttributesToFormMetadata(['locale'])
+            ->getView();
+
+        $this->assertEquals(
+            ['webspace' => 'webspaceId', 'parent' => 'parentId', 'locale'],
+            $route->getOption('routerAttributesToFormMetadata')
+        );
+    }
+
     public function testBuildWithResourceStorePropertiesToListRequest()
     {
         $route = (new FormOverlayListViewBuilder('sulu_role.list', '/roles'))

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormOverlayListViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormOverlayListViewBuilderTest.php
@@ -295,7 +295,7 @@ class FormOverlayListViewBuilderTest extends TestCase
         );
     }
 
-    public function testBuildFormWithRouterAttributesToFormMetadata()
+    public function testBuildFormWithRouterAttributesToFormMetadata(): void
     {
         $route = (new FormOverlayListViewBuilder('sulu_role.list', '/roles'))
             ->setResourceKey('roles')


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #6203
| License | MIT

#### What's in this PR?

This PR adds the `routerAttributesToFormMetadata` option to the `FormOverlayList` view and the `FormOverlayListViewBuilder`. The same option is already implemented for the `Form` view (and in the `FormViewBuilder`).

#### Why?

See #6203