### PR TITLE
Fix application crash if autocomplete query is not a valid regular expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
         },
         "setupFiles": [
             "jest-canvas-mock",
-            "regenerator-runtime/runtime"
+            "regenerator-runtime/runtime",
+            "core-js/features/string/replace-all"
         ],
         "setupFilesAfterEnv": [
             "./tests/js/testSetup.config.js"

--- a/package.json
+++ b/package.json
@@ -105,20 +105,6 @@
             "enzyme-to-json/serializer"
         ],
         "clearMocks": true,
-        "transform": {
-            "\\.js$": [
-                "babel-jest",
-                {
-                    "babelrcRoots": [
-                        ".",
-                        "./src/Sulu/Bundle/*/Resource/js"
-                    ],
-                    "presets": [
-                        "@babel/preset-env"
-                    ]
-                }
-            ]
-        },
         "transformIgnorePatterns": [
             "node_modules/(?!(@ckeditor|lodash-es)/)"
         ],

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/Suggestion.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/Suggestion.js
@@ -37,6 +37,7 @@ export default class Suggestion extends React.PureComponent<Props> {
             matcher = this.props.query;
         }
 
+        // $FlowFixMe: flow does not recognize the replaceAll method: https://github.com/facebook/flow/issues/560
         const highlightedText = text.replaceAll(matcher, '<strong>$&</strong>');
 
         return (

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/Suggestion.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/Suggestion.js
@@ -37,7 +37,7 @@ export default class Suggestion extends React.PureComponent<Props> {
             matcher = this.props.query;
         }
 
-        const highlightedText = text.replace(matcher, '<strong>$&</strong>');
+        const highlightedText = text.replaceAll(matcher, '<strong>$&</strong>');
 
         return (
             <span dangerouslySetInnerHTML={{__html: highlightedText}} />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/Suggestion.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/Suggestion.js
@@ -24,21 +24,23 @@ export default class Suggestion extends React.PureComponent<Props> {
             return null;
         }
 
-        const query = this.props.query || '';
-        const regex = new RegExp(query, 'gi');
-        const matches = text.match(regex);
-
-        if (!matches || query.length === 0) {
+        if (!this.props.query) {
             return text;
         }
 
-        let matchIndex = 0;
-        const highlightedMatches = text.replace(regex, () => {
-            return `<strong>${matches[matchIndex++]}</strong>`;
-        });
+        let matcher;
+        try {
+            // try to match all highlighted parts using case insensitive regular expression
+            matcher = new RegExp(this.props.query, 'gi');
+        } catch (e) {
+            // fallback to highlight first exact match if given query is an invalid regular expression like "*"
+            matcher = this.props.query;
+        }
+
+        const highlightedText = text.replace(matcher, '<strong>$&</strong>');
 
         return (
-            <span dangerouslySetInnerHTML={{__html: highlightedMatches}} />
+            <span dangerouslySetInnerHTML={{__html: highlightedText}} />
         );
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/tests/Suggestion.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/tests/Suggestion.test.js
@@ -28,6 +28,19 @@ test('Suggestion should render strong-tags around found chars', () => {
     )).toMatchSnapshot();
 });
 
+test('Suggestion should render if given query is not a valid regular expression', () => {
+    expect(render(
+        <Suggestion
+            icon="fa-ticket"
+            onSelect={jest.fn()}
+            query="*+"
+            value={{name: 'suggestion-1'}}
+        >
+            Suggestion 2
+        </Suggestion>
+    )).toMatchSnapshot();
+});
+
 test('Clicking on a suggestion should call the onClick handler', () => {
     const selectSpy = jest.fn();
     const suggestion = shallow(

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/tests/__snapshots__/Suggestion.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/tests/__snapshots__/Suggestion.test.js.snap
@@ -41,6 +41,25 @@ exports[`Suggestion should render 1`] = `
 </li>
 `;
 
+exports[`Suggestion should render if given query is not a valid regular expression 1`] = `
+<li
+  class="suggestionItem"
+  style="min-width:0px"
+>
+  <button
+    class="suggestion"
+  >
+    <span
+      aria-label="fa-ticket"
+      class="fa fa-ticket icon"
+    />
+    <span>
+      Suggestion 2
+    </span>
+  </button>
+</li>
+`;
+
 exports[`Suggestion should render strong-tags around found chars 1`] = `
 <li
   class="suggestionItem"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
@@ -48,7 +48,9 @@ Array [
           <span
             class="column"
           >
-            Suggestion 1
+            <span>
+              Suggestion 1
+            </span>
           </span>
         </button>
       </li>
@@ -62,7 +64,9 @@ Array [
           <span
             class="column"
           >
-            Suggestion 2
+            <span>
+              Suggestion 2
+            </span>
           </span>
         </button>
       </li>
@@ -76,7 +80,9 @@ Array [
           <span
             class="column"
           >
-            Suggestion 3
+            <span>
+              Suggestion 3
+            </span>
           </span>
         </button>
       </li>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #5441
| License | MIT

#### What's in this PR?

This pull request adjusts the `Suggestion` component that is used by the `AutoComplete` components to be able to handle a query that is not a valid regular expression.

#### Why?

At the moment, the `Suggestion` component throws an error that crashes the administration interface, if the user enters a query that is not a valid regular expression like `*`. See #5441
