### PR TITLE
Fix InfiniteLoadingStrategy to prevent missing and duplicated list items

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/loadingStrategies/InfiniteLoadingStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/loadingStrategies/InfiniteLoadingStrategy.js
@@ -1,16 +1,51 @@
 // @flow
 import {action} from 'mobx';
 import ResourceRequester from '../../../services/ResourceRequester';
+import RequestPromise from '../../../services/Requester/RequestPromise';
 import AbstractLoadingStrategy from './AbstractLoadingStrategy';
 import type {LoadOptions} from '../types';
 
-export default class InfiniteLoadingStrategy extends AbstractLoadingStrategy {
-    load(resourceKey: string, options: LoadOptions, parentId: ?string | number) {
-        return ResourceRequester.getList(resourceKey, {...options, limit: 50}).then(action((response) => {
-            const responseData = response._embedded[resourceKey];
-            responseData.forEach((item) => this.structureStrategy.addItem(item, parentId));
+const LIMIT = 50;
 
-            return response;
+export default class InfiniteLoadingStrategy extends AbstractLoadingStrategy {
+    lastLoadedPage: number = 0;
+
+    load(resourceKey: string, options: LoadOptions, parentId: ?string | number) {
+        let previousPagesItemsPromise = new RequestPromise((resolve) => resolve(undefined));
+        previousPagesItemsPromise.setAbortController(new AbortController());
+
+        // make sure that list contains (only) items of previous pages if given page does not match the expected page:
+        // - prevent missing items if the application is refreshed with a query parameter like  "?mediaPage=4"
+        // - prevent duplicated items if the current page is reloaded (eg. after an item was deleted)
+        if (options.page && options.page - 1 !== this.lastLoadedPage) {
+            if (options.page === 1) {
+                previousPagesItemsPromise = new RequestPromise((resolve) => resolve([]));
+                previousPagesItemsPromise.setAbortController(new AbortController());
+            } else {
+                previousPagesItemsPromise = ResourceRequester.getList(
+                    resourceKey, {...options, page: 1, limit: (options.page - 1) * LIMIT}
+                ).then((previousPagesResponse) => previousPagesResponse._embedded[resourceKey]);
+            }
+        }
+
+        return previousPagesItemsPromise.then((previousPagesItems) => {
+            return ResourceRequester.getList(resourceKey, {...options, limit: LIMIT}).then((response) => {
+                return [previousPagesItems, response];
+            });
+        }).then(action(([previousPagesItems, currentPageResponse]) => {
+            if (previousPagesItems) {
+                this.structureStrategy.clear();
+                previousPagesItems.forEach((item) => this.structureStrategy.addItem(item, parentId));
+            }
+
+            const currentPageItems = currentPageResponse._embedded[resourceKey];
+            currentPageItems.forEach((item) => this.structureStrategy.addItem(item, parentId));
+
+            if (options.page) {
+                this.lastLoadedPage = options.page;
+            }
+
+            return currentPageResponse;
         }));
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
@@ -113,6 +113,8 @@ class CollectionSection extends React.Component<Props> {
     };
 
     handleSaveResponse = (resourceStore: ResourceStore) => {
+        this.closeCollectionOperationOverlay();
+
         if (this.openedCollectionOperationOverlayType === 'update') {
             this.props.resourceStore.setMultiple(resourceStore.data);
         } else {
@@ -120,7 +122,6 @@ class CollectionSection extends React.Component<Props> {
         }
 
         resourceStore.destroy();
-        this.closeCollectionOperationOverlay();
     };
 
     handleCollectionOverlayClose = () => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -47,7 +47,6 @@ class MediaCollection extends React.Component<Props> {
     @action handleUpload = (media: Array<Object>) => {
         const {mediaListStore} = this.props;
 
-        mediaListStore.reset();
         mediaListStore.reload();
 
         when(
@@ -63,7 +62,6 @@ class MediaCollection extends React.Component<Props> {
             onUploadError(errorResponses);
         }
 
-        mediaListStore.reset();
         mediaListStore.reload();
     };
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
@@ -640,7 +640,6 @@ test('Reload medias and fire onUploadError callback if an error happens while up
             },
         ]
     );
-    expect(mediaListStore.reset).toBeCalled();
     expect(mediaListStore.reload).toBeCalled();
 });
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| License | MIT

#### What's in this PR?

This PR improves the page handling of the `InfiniteLoadingStrategy` that is used in the media section of the administration interface. The `InfiniteLoadingStrategy` now remembers the last page that was loaded. If the strategy is called to load a page that is not the expected next page, it will reload the items of all previous pages to make sure that there are no missing or duplicated list items.

This change solves the following problems:

- If the administration interface is refreshed with a page query parameter like `?mediaPage=4`, the list will contain only items of the 4th page. Items from page 1 to 3 will be missing and will not be loaded while scrolling.
- If a list item is deleted, the current page is reloaded. Inside of the media section, this adds remaining items of the current page a second time and therefore leads to duplicate list items