### PR TITLE
Configure babel to automatically add polyfills based on usage in code and targets in .browserslistrc

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -2,8 +2,9 @@
     "presets": ["@babel/preset-env", "@babel/preset-react"],
     "plugins": [
         ["@babel/plugin-proposal-decorators", {"legacy": true}],
-        "@babel/plugin-proposal-object-rest-spread",
-        "@babel/plugin-transform-flow-strip-types",
-        ["@babel/plugin-proposal-class-properties", {"loose": true}]
-    ]
+        "@babel/plugin-transform-flow-strip-types"
+    ],
+    "assumptions": {
+        "setPublicClassFields": true
+    }
 }

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,5 +1,8 @@
 {
-    "presets": ["@babel/preset-env", "@babel/preset-react"],
+    "presets": [
+        ["@babel/preset-env", {"useBuiltIns": "usage", "corejs": "3.18"}],
+        "@babel/preset-react"
+    ],
     "plugins": [
         ["@babel/plugin-proposal-decorators", {"legacy": true}],
         "@babel/plugin-transform-flow-strip-types"

--- a/index.js
+++ b/index.js
@@ -1,8 +1,5 @@
 // @flow
 
-// Polyfills
-import 'regenerator-runtime/runtime';
-
 // Bundles
 import {startAdmin} from 'sulu-admin-bundle';
 import 'sulu-audience-targeting-bundle';

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "babel-jest": "^26.3.0",
         "babel-loader": "^8.0.6",
         "clean-webpack-plugin": "^3.0.0",
+        "core-js": "^3.18.0",
         "css-loader": "^3.2.0",
         "dependency-cruiser": "^8.1.0",
         "empty": "^0.10.1",

--- a/package.json
+++ b/package.json
@@ -32,9 +32,7 @@
     },
     "devDependencies": {
         "@babel/core": "^7.5.5",
-        "@babel/plugin-proposal-class-properties": "^7.5.5",
         "@babel/plugin-proposal-decorators": "^7.4.4",
-        "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
         "@babel/plugin-transform-flow-strip-types": "^7.4.4",
         "@babel/preset-env": "^7.5.5",
         "@babel/preset-react": "^7.0.0",

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -33,7 +33,6 @@ const javaScriptFileExists = (path, fileName) => {
 module.exports = { // eslint-disable-line
     title: 'Sulu Javascript Docs',
     require: [
-        'regenerator-runtime/runtime',
         './src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/global.scss',
         './src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/styleguidist.scss',
     ],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

This pull request adjusts the `babel.config.json` to automatically add corejs polyfills for features used in the source code based on the targets in our `.browserslistrc` file.
