### PR TITLE
Replace sulu_trash configuration with RestoreConfigurationProviderInterface services

### DIFF
--- a/src/Sulu/Bundle/CategoryBundle/DependencyInjection/SuluCategoryExtension.php
+++ b/src/Sulu/Bundle/CategoryBundle/DependencyInjection/SuluCategoryExtension.php
@@ -164,17 +164,6 @@ class SuluCategoryExtension extends Extension implements PrependExtensionInterfa
             );
         }
 
-        if ($container->hasExtension('sulu_trash')) {
-            $container->prependExtensionConfig(
-                'sulu_trash',
-                [
-                    'restore_form' => [
-                        CategoryInterface::RESOURCE_KEY => 'restore_category',
-                    ],
-                ]
-            );
-        }
-
         if ($container->hasExtension('sulu_search')) {
             $container->prependExtensionConfig(
                 'sulu_search',

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/services_trash.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/services_trash.xml
@@ -16,6 +16,7 @@
 
             <tag name="sulu_trash.store_trash_item_handler"/>
             <tag name="sulu_trash.restore_trash_item_handler"/>
+            <tag name="sulu_trash.restore_configuration_provider"/>
         </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/CategoryBundle/Trash/CategoryTrashItemHandler.php
+++ b/src/Sulu/Bundle/CategoryBundle/Trash/CategoryTrashItemHandler.php
@@ -28,6 +28,8 @@ use Sulu\Bundle\CategoryBundle\Entity\KeywordRepositoryInterface;
 use Sulu\Bundle\CategoryBundle\Exception\CategoryKeyNotUniqueException;
 use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
 use Sulu\Bundle\TrashBundle\Application\DoctrineRestoreHelper\DoctrineRestoreHelperInterface;
+use Sulu\Bundle\TrashBundle\Application\RestoreConfigurationProvider\RestoreConfiguration;
+use Sulu\Bundle\TrashBundle\Application\RestoreConfigurationProvider\RestoreConfigurationProviderInterface;
 use Sulu\Bundle\TrashBundle\Application\TrashItemHandler\RestoreTrashItemHandlerInterface;
 use Sulu\Bundle\TrashBundle\Application\TrashItemHandler\StoreTrashItemHandlerInterface;
 use Sulu\Bundle\TrashBundle\Domain\Model\TrashItemInterface;
@@ -35,7 +37,10 @@ use Sulu\Bundle\TrashBundle\Domain\Repository\TrashItemRepositoryInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Webmozart\Assert\Assert;
 
-final class CategoryTrashItemHandler implements StoreTrashItemHandlerInterface, RestoreTrashItemHandlerInterface
+final class CategoryTrashItemHandler implements
+    StoreTrashItemHandlerInterface,
+    RestoreTrashItemHandlerInterface,
+    RestoreConfigurationProviderInterface
 {
     /**
      * @var TrashItemRepositoryInterface
@@ -276,5 +281,10 @@ final class CategoryTrashItemHandler implements StoreTrashItemHandlerInterface, 
         }
 
         return null;
+    }
+
+    public function getConfiguration(): RestoreConfiguration
+    {
+        return new RestoreConfiguration('restore_category');
     }
 }

--- a/src/Sulu/Bundle/CategoryBundle/Trash/CategoryTrashItemHandler.php
+++ b/src/Sulu/Bundle/CategoryBundle/Trash/CategoryTrashItemHandler.php
@@ -285,6 +285,6 @@ final class CategoryTrashItemHandler implements
 
     public function getConfiguration(): RestoreConfiguration
     {
-        return new RestoreConfiguration('restore_category');
+        return new RestoreConfiguration('restore_category', CategoryAdmin::EDIT_FORM_VIEW, ['id' => 'id']);
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -216,17 +216,6 @@ class SuluMediaExtension extends Extension implements PrependExtensionInterface
                 ]
             );
         }
-
-        if ($container->hasExtension('sulu_trash')) {
-            $container->prependExtensionConfig(
-                'sulu_trash',
-                [
-                    'restore_form' => [
-                        MediaInterface::RESOURCE_KEY => 'restore_media',
-                    ],
-                ]
-            );
-        }
     }
 
     public function load(array $configs, ContainerBuilder $container)

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services_trash.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services_trash.xml
@@ -15,6 +15,7 @@
             <tag name="sulu_trash.store_trash_item_handler"/>
             <tag name="sulu_trash.restore_trash_item_handler"/>
             <tag name="sulu_trash.remove_trash_item_handler"/>
+            <tag name="sulu_trash.restore_configuration_provider"/>
         </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/MediaBundle/Trash/MediaTrashItemHandler.php
+++ b/src/Sulu/Bundle/MediaBundle/Trash/MediaTrashItemHandler.php
@@ -33,6 +33,8 @@ use Sulu\Bundle\MediaBundle\Entity\MediaType;
 use Sulu\Bundle\MediaBundle\Media\Storage\StorageInterface;
 use Sulu\Bundle\TagBundle\Tag\TagInterface;
 use Sulu\Bundle\TrashBundle\Application\DoctrineRestoreHelper\DoctrineRestoreHelperInterface;
+use Sulu\Bundle\TrashBundle\Application\RestoreConfigurationProvider\RestoreConfiguration;
+use Sulu\Bundle\TrashBundle\Application\RestoreConfigurationProvider\RestoreConfigurationProviderInterface;
 use Sulu\Bundle\TrashBundle\Application\TrashItemHandler\RemoveTrashItemHandlerInterface;
 use Sulu\Bundle\TrashBundle\Application\TrashItemHandler\RestoreTrashItemHandlerInterface;
 use Sulu\Bundle\TrashBundle\Application\TrashItemHandler\StoreTrashItemHandlerInterface;
@@ -41,7 +43,11 @@ use Sulu\Bundle\TrashBundle\Domain\Repository\TrashItemRepositoryInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Webmozart\Assert\Assert;
 
-final class MediaTrashItemHandler implements StoreTrashItemHandlerInterface, RestoreTrashItemHandlerInterface, RemoveTrashItemHandlerInterface
+final class MediaTrashItemHandler implements
+    StoreTrashItemHandlerInterface,
+    RestoreTrashItemHandlerInterface,
+    RemoveTrashItemHandlerInterface,
+    RestoreConfigurationProviderInterface
 {
     /**
      * @var TrashItemRepositoryInterface
@@ -378,5 +384,10 @@ final class MediaTrashItemHandler implements StoreTrashItemHandlerInterface, Res
         }
 
         return null;
+    }
+
+    public function getConfiguration(): RestoreConfiguration
+    {
+        return new RestoreConfiguration('restore_media');
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Trash/MediaTrashItemHandler.php
+++ b/src/Sulu/Bundle/MediaBundle/Trash/MediaTrashItemHandler.php
@@ -388,6 +388,6 @@ final class MediaTrashItemHandler implements
 
     public function getConfiguration(): RestoreConfiguration
     {
-        return new RestoreConfiguration('restore_media');
+        return new RestoreConfiguration('restore_media', MediaAdmin::EDIT_FORM_VIEW, ['id' => 'id']);
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Teaser/Configuration/TeaserConfiguration.php
+++ b/src/Sulu/Bundle/PageBundle/Teaser/Configuration/TeaserConfiguration.php
@@ -46,17 +46,20 @@ class TeaserConfiguration
     private $overlayTitle;
 
     /**
-     * @var ?string
+     * @var string|null
      * @Groups({"frontend"})
      */
     private $view;
 
     /**
-     * @var ?string[]
+     * @var array<string, string>|null
      * @Groups({"frontend"})
      */
     private $resultToView;
 
+    /**
+     * @param array<string, string>|null $resultToView
+     */
     public function __construct(
         string $title,
         string $resourceKey,

--- a/src/Sulu/Bundle/TagBundle/Resources/config/services_trash.xml
+++ b/src/Sulu/Bundle/TagBundle/Resources/config/services_trash.xml
@@ -13,6 +13,7 @@
 
             <tag name="sulu_trash.store_trash_item_handler"/>
             <tag name="sulu_trash.restore_trash_item_handler"/>
+            <tag name="sulu_trash.restore_configuration_provider"/>
         </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/TagBundle/Trash/TagTrashItemHandler.php
+++ b/src/Sulu/Bundle/TagBundle/Trash/TagTrashItemHandler.php
@@ -22,6 +22,8 @@ use Sulu\Bundle\TagBundle\Tag\Exception\TagAlreadyExistsException;
 use Sulu\Bundle\TagBundle\Tag\TagInterface;
 use Sulu\Bundle\TagBundle\Tag\TagRepositoryInterface;
 use Sulu\Bundle\TrashBundle\Application\DoctrineRestoreHelper\DoctrineRestoreHelperInterface;
+use Sulu\Bundle\TrashBundle\Application\RestoreConfigurationProvider\RestoreConfiguration;
+use Sulu\Bundle\TrashBundle\Application\RestoreConfigurationProvider\RestoreConfigurationProviderInterface;
 use Sulu\Bundle\TrashBundle\Application\TrashItemHandler\RestoreTrashItemHandlerInterface;
 use Sulu\Bundle\TrashBundle\Application\TrashItemHandler\StoreTrashItemHandlerInterface;
 use Sulu\Bundle\TrashBundle\Domain\Model\TrashItemInterface;
@@ -29,7 +31,10 @@ use Sulu\Bundle\TrashBundle\Domain\Repository\TrashItemRepositoryInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Webmozart\Assert\Assert;
 
-final class TagTrashItemHandler implements StoreTrashItemHandlerInterface, RestoreTrashItemHandlerInterface
+final class TagTrashItemHandler implements
+    StoreTrashItemHandlerInterface,
+    RestoreTrashItemHandlerInterface,
+    RestoreConfigurationProviderInterface
 {
     /**
      * @var TrashItemRepositoryInterface
@@ -147,5 +152,10 @@ final class TagTrashItemHandler implements StoreTrashItemHandlerInterface, Resto
         }
 
         return null;
+    }
+
+    public function getConfiguration(): RestoreConfiguration
+    {
+        return new RestoreConfiguration(null, TagAdmin::EDIT_FORM_VIEW, ['id' => 'id']);
     }
 }

--- a/src/Sulu/Bundle/TrashBundle/Application/RestoreConfigurationProvider/RestoreConfiguration.php
+++ b/src/Sulu/Bundle/TrashBundle/Application/RestoreConfigurationProvider/RestoreConfiguration.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\TrashBundle\Application\RestoreConfigurationProvider;
+
+use JMS\Serializer\Annotation\Groups;
+
+class RestoreConfiguration
+{
+    /**
+     * @var string|null
+     * @Groups({"frontend"})
+     */
+    private $form;
+
+    /**
+     * @var string|null
+     * @Groups({"frontend"})
+     */
+    private $view;
+
+    /**
+     * @var array<string, string>|null
+     * @Groups({"frontend"})
+     */
+    private $resultToView;
+
+    /**
+     * @param array<string, string>|null $resultToView
+     */
+    public function __construct(
+        ?string $form = null,
+        ?string $view = null,
+        ?array $resultToView = null
+    ) {
+        $this->form = $form;
+        $this->view = $view;
+        $this->resultToView = $resultToView;
+    }
+}

--- a/src/Sulu/Bundle/TrashBundle/Application/RestoreConfigurationProvider/RestoreConfigurationProviderInterface.php
+++ b/src/Sulu/Bundle/TrashBundle/Application/RestoreConfigurationProvider/RestoreConfigurationProviderInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\TrashBundle\Application\RestoreConfigurationProvider;
+
+interface RestoreConfigurationProviderInterface
+{
+    public function getConfiguration(): RestoreConfiguration;
+
+    public static function getResourceKey(): string;
+}

--- a/src/Sulu/Bundle/TrashBundle/Infrastructure/Sulu/Admin/TrashAdmin.php
+++ b/src/Sulu/Bundle/TrashBundle/Infrastructure/Sulu/Admin/TrashAdmin.php
@@ -20,6 +20,7 @@ use Sulu\Bundle\AdminBundle\Admin\View\ListItemAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
+use Sulu\Bundle\TrashBundle\Application\RestoreConfigurationProvider\RestoreConfigurationProviderInterface;
 use Sulu\Bundle\TrashBundle\Domain\Model\TrashItemInterface;
 use Sulu\Component\Localization\Manager\LocalizationManagerInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
@@ -47,23 +48,23 @@ final class TrashAdmin extends Admin
     private $localizationManager;
 
     /**
-     * @var array<string, string>
+     * @var iterable<string, RestoreConfigurationProviderInterface>
      */
-    private $restoreFormMapping;
+    private $restoreConfigurationProviders;
 
     /**
-     * @param array<string, string> $restoreFormMapping
+     * @param iterable<string, RestoreConfigurationProviderInterface> $restoreConfigurationProviders
      */
     public function __construct(
         ViewBuilderFactoryInterface $viewBuilderFactory,
         SecurityCheckerInterface $securityChecker,
         LocalizationManagerInterface $localizationManager,
-        array $restoreFormMapping
+        iterable $restoreConfigurationProviders
     ) {
         $this->viewBuilderFactory = $viewBuilderFactory;
         $this->securityChecker = $securityChecker;
         $this->localizationManager = $localizationManager;
-        $this->restoreFormMapping = $restoreFormMapping;
+        $this->restoreConfigurationProviders = $restoreConfigurationProviders;
     }
 
     public function configureNavigationItems(NavigationItemCollection $navigationItemCollection): void
@@ -134,8 +135,14 @@ final class TrashAdmin extends Admin
      */
     public function getConfig(): array
     {
+        $restoreConfigurationMapping = [];
+        foreach ($this->restoreConfigurationProviders as $restoreConfigurationProvider) {
+            $resourceKey = $restoreConfigurationProvider::getResourceKey();
+            $restoreConfigurationMapping[$resourceKey] = $restoreConfigurationProvider->getConfiguration();
+        }
+
         return [
-            'restoreFormMapping' => $this->restoreFormMapping,
+            'restoreConfigurationMapping' => $restoreConfigurationMapping,
         ];
     }
 }

--- a/src/Sulu/Bundle/TrashBundle/Infrastructure/Symfony/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/TrashBundle/Infrastructure/Symfony/DependencyInjection/Configuration.php
@@ -25,10 +25,6 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder('sulu_trash');
         $rootNode = $treeBuilder->getRootNode();
         $rootNode->children()
-            ->arrayNode('restore_form')
-                ->useAttributeAsKey('resourceKey')
-                ->scalarPrototype()
-            ->end()
         ->end();
 
         $this->addObjectsSection($rootNode);

--- a/src/Sulu/Bundle/TrashBundle/Infrastructure/Symfony/DependencyInjection/SuluTrashExtension.php
+++ b/src/Sulu/Bundle/TrashBundle/Infrastructure/Symfony/DependencyInjection/SuluTrashExtension.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Bundle\TrashBundle\Infrastructure\Symfony\DependencyInjection;
 
 use Sulu\Bundle\PersistenceBundle\DependencyInjection\PersistenceExtensionTrait;
+use Sulu\Bundle\TrashBundle\Application\RestoreConfigurationProvider\RestoreConfigurationProviderInterface;
 use Sulu\Bundle\TrashBundle\Application\TrashItemHandler\RemoveTrashItemHandlerInterface;
 use Sulu\Bundle\TrashBundle\Application\TrashItemHandler\RestoreTrashItemHandlerInterface;
 use Sulu\Bundle\TrashBundle\Application\TrashItemHandler\StoreTrashItemHandlerInterface;
@@ -106,7 +107,6 @@ class SuluTrashExtension extends Extension implements PrependExtensionInterface
      */
     private function setParameters(ContainerBuilder $container, array $config): void
     {
-        $container->setParameter('sulu_trash.restore_form_mapping', $config['restore_form']);
     }
 
     private function registerInterfacesForAutoconfiguration(ContainerBuilder $container): void
@@ -119,5 +119,8 @@ class SuluTrashExtension extends Extension implements PrependExtensionInterface
 
         $container->registerForAutoconfiguration(RemoveTrashItemHandlerInterface::class)
             ->addTag('sulu_trash.remove_trash_item_handler');
+
+        $container->registerForAutoconfiguration(RestoreConfigurationProviderInterface::class)
+            ->addTag('sulu_trash.restore_configuration_provider');
     }
 }

--- a/src/Sulu/Bundle/TrashBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/TrashBundle/Resources/config/services.xml
@@ -31,7 +31,7 @@
             <argument type="service" id="sulu_admin.view_builder_factory"/>
             <argument type="service" id="sulu_security.security_checker"/>
             <argument type="service" id="sulu.core.localization_manager"/>
-            <argument>%sulu_trash.restore_form_mapping%</argument>
+            <argument type="tagged_iterator" tag="sulu_trash.restore_configuration_provider" index-by="resourceKey" default-index-method="getResourceKey"/>
 
             <tag name="sulu.admin"/>
             <tag name="sulu.context" context="admin"/>

--- a/src/Sulu/Bundle/TrashBundle/Resources/js/containers/RestoreFormOverlay/RestoreFormOverlay.js
+++ b/src/Sulu/Bundle/TrashBundle/Resources/js/containers/RestoreFormOverlay/RestoreFormOverlay.js
@@ -5,8 +5,9 @@ import React from 'react';
 import FormOverlay from 'sulu-admin-bundle/containers/FormOverlay';
 import {translate} from 'sulu-admin-bundle/utils/Translator';
 import {FormStoreInterface} from 'sulu-admin-bundle/containers/Form/types';
-import {memoryFormStoreFactory} from 'sulu-admin-bundle/containers/Form';
 import {ResourceRequester} from 'sulu-admin-bundle/services';
+import SchemaFormStoreDecorator from 'sulu-admin-bundle/containers/Form/stores/SchemaFormStoreDecorator';
+import MemoryFormStore from 'sulu-admin-bundle/containers/Form/stores/MemoryFormStore';
 
 type Props = {
     confirmLoading: boolean,
@@ -58,8 +59,15 @@ class RestoreFormOverlay extends React.Component<Props> {
             return;
         }
 
-        const formStore = memoryFormStoreFactory.createFromFormKey(formKey);
-        formStore.loading = true;
+        const formStore = new SchemaFormStoreDecorator(
+            (schema, jsonSchema) => {
+                const store = new MemoryFormStore({}, schema, jsonSchema);
+                store.loading = true;
+
+                return store;
+            },
+            formKey
+        );
 
         ResourceRequester.get('trash_items', {id: trashItemId}).then(action((response) => {
             formStore.changeMultiple(response.restoreData, {isServerValue: true});

--- a/src/Sulu/Bundle/TrashBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/TrashBundle/Resources/js/index.js
@@ -6,5 +6,10 @@ import RestoreItemAction from './views/List/itemActions/RestoreItemAction';
 listItemActionRegistry.add('sulu_trash.restore', RestoreItemAction);
 
 initializer.addUpdateConfigHook('sulu_trash', (config: Object) => {
-    RestoreItemAction.restoreFormMapping = config.restoreFormMapping;
+    if (!config) {
+        // config is undefined if SuluTrashBundle is not registered
+        return;
+    }
+
+    RestoreItemAction.restoreConfigurationMapping = config.restoreConfigurationMapping;
 });

--- a/src/Sulu/Bundle/TrashBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/TrashBundle/Resources/js/package.json
@@ -2,6 +2,9 @@
     "name": "sulu-trash-bundle",
     "license": "MIT",
     "repository": "https://github.com/sulu/sulu.git",
+    "dependencies": {
+        "json-pointer": "^0.6.0"
+    },
     "devDependencies": {
         "enzyme": "^3.3.0",
         "sulu-admin-bundle": "file:../../../AdminBundle/Resources/js"

--- a/src/Sulu/Bundle/TrashBundle/Resources/js/types.js
+++ b/src/Sulu/Bundle/TrashBundle/Resources/js/types.js
@@ -1,0 +1,7 @@
+// @flow
+
+export type RestoreConfiguration = {|
+    form?: string,
+    resultToView?: {[string]: string},
+    view?: string,
+|};

--- a/src/Sulu/Bundle/TrashBundle/UserInterface/Controller/Admin/TrashItemController.php
+++ b/src/Sulu/Bundle/TrashBundle/UserInterface/Controller/Admin/TrashItemController.php
@@ -47,7 +47,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  *
  * This controller cannot implement the SecuredControllerInterface, because then the SuluSecurityListener would check
  * for the "edit" permission in the "postTriggerAction", but the TrashAdmin::SECURITY_CONTEXT doesn't define an "edit" permission.
- * Therefore the "view" permissions are checked explicitly in this controller.
+ * Because of this, the controller needs to explicitly check the "view" permissions by itself.
  */
 class TrashItemController extends AbstractRestController implements ClassResourceInterface
 {
@@ -208,10 +208,6 @@ class TrashItemController extends AbstractRestController implements ClassResourc
         );
     }
 
-    /**
-     * This action is not used by sulu, but it still needs to be implemented, because the "detail" url of the TrashItem
-     * resource needs to be configured in order for the "deleteAction" and the "postTriggerAction" to work.
-     */
     public function getAction(int $id): Response
     {
         $this->securityChecker->checkPermission(

--- a/src/Sulu/Component/SmartContent/Configuration/BuilderInterface.php
+++ b/src/Sulu/Component/SmartContent/Configuration/BuilderInterface.php
@@ -95,6 +95,8 @@ interface BuilderInterface
 
     /**
      * Defines where the deep link when clicking on a smart content item should navigate to.
+     *
+     * @param array<string, string> $resultToView
      */
     public function enableView(string $view, array $resultToView);
 

--- a/src/Sulu/Component/SmartContent/Configuration/ProviderConfiguration.php
+++ b/src/Sulu/Component/SmartContent/Configuration/ProviderConfiguration.php
@@ -74,12 +74,12 @@ class ProviderConfiguration implements ProviderConfigurationInterface
     private $paginated = false;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $view;
 
     /**
-     * @var string[]
+     * @var array<string, string>|null
      */
     private $resultToView;
 
@@ -214,22 +214,22 @@ class ProviderConfiguration implements ProviderConfigurationInterface
         $this->paginated = $paginated;
     }
 
-    public function getView(): string
+    public function getView(): ?string
     {
         return $this->view;
     }
 
-    public function setView(string $view)
+    public function setView(?string $view)
     {
         $this->view = $view;
     }
 
-    public function getResultToView(): array
+    public function getResultToView(): ?array
     {
         return $this->resultToView;
     }
 
-    public function setResultToView(array $resultToView)
+    public function setResultToView(?array $resultToView)
     {
         $this->resultToView = $resultToView;
     }

--- a/src/Sulu/Component/SmartContent/Configuration/ProviderConfigurationInterface.php
+++ b/src/Sulu/Component/SmartContent/Configuration/ProviderConfigurationInterface.php
@@ -99,12 +99,12 @@ interface ProviderConfigurationInterface
     /**
      * Returns the name of the view to navigate to when a smart content item in the UI is clicked.
      */
-    public function getView(): string;
+    public function getView(): ?string;
 
     /**
      * Returns the mapping from smart content item properties to view.
      *
-     * @return string[]
+     * @return array<string, string>|null
      */
-    public function getResultToView(): array;
+    public function getResultToView(): ?array;
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Related issues/PRs | builds upon #6218
| License | MIT

#### What's in this PR?

This PR adds a `RestoreConfigurationProviderInterface` that allows to set the restore configuration for a specific resource key. This replaces the previously used `sulu_trash` symfony configuration.

Providing this configuration prevents bundles from needing to prepend the `sulu_trash` configuration. Furthermore, we use a similar approach for collecting [smart content provider configurations](https://github.com/sulu/sulu/blob/a5efc81b692a5723910a2ec86d2651b1b79f04c9/src/Sulu/Component/SmartContent/DataProviderInterface.php#L27) and [teaser provider configurations](https://github.com/sulu/sulu/blob/a5efc81b692a5723910a2ec86d2651b1b79f04c9/src/Sulu/Bundle/PageBundle/Teaser/Provider/TeaserProviderInterface.php#L27).