### PR TITLE
Fix rectangle selection if container is smaller than given minValues

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/RectangleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/RectangleSelection.js
@@ -88,13 +88,12 @@ class RawRectangleSelectionComponent extends React.Component<Props> {
                 minWidth,
                 minHeight
             ),
-            new PositionNormalizer(
-                containerWidth,
-                containerHeight
-            ),
         ];
 
         if (minWidth && minHeight) {
+            // It's important that the RatioNormalizer is added before the PositionNormalizer, because it may alter the
+            // width and height of the selection and the PositionNormalizer needs the final calculated width and height
+            // to correctly calculate all valid positions
             normalizers.push(
                 new RatioNormalizer(
                     containerWidth,
@@ -104,6 +103,13 @@ class RawRectangleSelectionComponent extends React.Component<Props> {
                 )
             );
         }
+
+        normalizers.push(
+            new PositionNormalizer(
+                containerWidth,
+                containerHeight
+            )
+        );
 
         if (round) {
             normalizers.push(new RoundingNormalizer());

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/tests/RectangleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/tests/RectangleSelection.test.js
@@ -192,6 +192,36 @@ test('The component should enforce a ratio on the selection if minWidth and minH
     expect(changeSpy).toBeCalledWith(expect.objectContaining({width: 55, height: 110}));
 });
 
+test(
+    'The component should allow selections across the whole container' +
+    'even if a minValue is bigger than actual container size',
+    () => {
+        const changeSpy = jest.fn();
+
+        const view = mount(
+            <RectangleSelection
+                // containerHeight={360}
+                // containerWidth={640}
+                minHeight={180}
+                minWidth={1280}
+                onChange={changeSpy}
+                onFinish={jest.fn()}
+                value={{height: 90, left: 0, top: 0, width: 640}}
+            >
+                <p>Lorem ipsum</p>
+            </RectangleSelection>
+        );
+
+        view.find('RawRectangleSelectionComponent').first().instance().handleRectangleChange({
+            width: 0,
+            height: 0,
+            left: 0,
+            top: 360,
+        });
+        expect(changeSpy).toBeCalledWith(expect.objectContaining({top: 360 - 90}));
+    }
+);
+
 test('The component should not round if told by the properties', () => {
     const changeSpy = jest.fn();
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix rectangle selection if container is smaller than given minValues

#### Why?

It's important that the `RatioNormalizer` is added before the `PositionNormalizer`, because it may alter the width and height of the selection and the PositionNormalizer needs the final calculated width and height to correctly calculate all valid positions

#### Example Usage

```jsx
let image = new Image();
image.src = 'https://unsplash.it/640/360';

const [imageLoaded, setImageLoaded] = React.useState(image.complete);
const [selection, setSelection] = React.useState({width: 100, height: 100, top: 50, left: 50});

image.onload = () => setImageLoaded(true);

imageLoaded
    ? <div>
        <RectangleSelection
            minWidth={1280}
            minHeight={180}
            onChange={setSelection}
            value={selection}
        >
            <img src="https://unsplash.it/640/360"/>
        </RectangleSelection>

        <p>
            Width: {selection.width},
            Height: {selection.height},
            Top: {selection.top},
            Left: {selection.left}
        </p>
    </div>
    : null
```
