### PR TITLE
Include security context in message of AccessDeniedException

### DIFF
--- a/src/Sulu/Component/Security/Authorization/AbstractSecurityChecker.php
+++ b/src/Sulu/Component/Security/Authorization/AbstractSecurityChecker.php
@@ -25,9 +25,10 @@ abstract class AbstractSecurityChecker implements SecurityCheckerInterface
         if (!$this->hasPermission($subject, $permission)) {
             if ($subject instanceof SecurityCondition) {
                 $message = \sprintf(
-                    'Permission "%s" in localization "%s" for object with id "%s" and of type "%s" not granted',
+                    'Permission "%s" in localization "%s" for context "%s" and object with id "%s" and type "%s" not granted',
                     $permission,
                     $subject->getLocale(),
+                    $subject->getSecurityContext(),
                     $subject->getObjectId(),
                     $subject->getObjectType()
                 );


### PR DESCRIPTION
This PR adjusts the error message that is passed to the `AccessDeniedException` in the `SecurityChecker` to include the security context of the given `SecurityCondition`. The `SecurityChecker` is used by the `SuluSecurityListener` to check the permissions when accessing a `SecuredControllerInterface`. 

A lot of `SecuredControllerInterface` instances do not use object security and therefore the `SecurityCondition` contains a security context only (eg. the [`TagController`](https://github.com/sulu/sulu/blob/206afbf7e510daa688dfd7735c69551a988f9be3/src/Sulu/Bundle/TagBundle/Controller/TagController.php#L41). In these cases, the error message looks like this at the moment:

```
Permission \"view\" in localization \"en\" for object with id \"\" and of type \"\" not granted
```

After this change, the error looks like this:

```
Permission \"view\" in localization \"en\" for context "sulu.settings.tags" and object with id \"\" and of type \"\" not granted
```