### PR TITLE
Fix import of empty value in Checkbox content type

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Content/Types/Checkbox.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/Checkbox.php
@@ -60,7 +60,7 @@ class Checkbox extends SimpleContentType
     ) {
         $preparedValue = true;
 
-        if ('0' === $value) {
+        if ('0' === $value || '' === $value) {
             $preparedValue = false;
         }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| Related issues/PRs | https://github.com/sulu/sulu/pull/6096
| License | MIT

#### What's in this PR?

This PR adjusts the `Checkbox` content type to import an empty value as `false` instead of `true`. This change was already included in https://github.com/sulu/sulu/pull/6096 but somehow got lost in my phpdoc commit (https://github.com/sulu/sulu/pull/6096/commits/28e94990eeb4652b968c72ecfc0a44a0af886432).