### PR TITLE
Fix FixturesBuilder purging all documents

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/Build/FixturesBuilder.php
+++ b/src/Sulu/Bundle/CoreBundle/Build/FixturesBuilder.php
@@ -29,6 +29,6 @@ class FixturesBuilder extends SuluBuilder
     public function build()
     {
         $this->execCommand('Loading ORM fixtures', 'doctrine:fixtures:load', ['--no-interaction' => true, '--append' => true]);
-        $this->execCommand('Loading SULU fixtures', 'sulu:document:fixtures:load', ['--no-interaction' => true]);
+        $this->execCommand('Loading SULU fixtures', 'sulu:document:fixtures:load', ['--no-interaction' => true, '--append' => true]);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix FixturesBuilder purging all documents

#### Why?

When running `sulu:build` all data is getting purged of the documents. The Doctrine Fixtures should behave the same way as the sulu fixtures.
