### PR TITLE
Prevent duplicated contact list rows by joining position of main account only

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
@@ -15,11 +15,7 @@
         </join>
     </joins>
 
-    <joins name="position">
-        <join>
-            <entity-name>SuluContactBundle:AccountContact</entity-name>
-            <field-name>%sulu.model.contact.class%.accountContacts</field-name>
-        </join>
+    <joins name="position" ref="accountContact">
         <join>
             <entity-name>SuluContactBundle:Position</entity-name>
             <field-name>SuluContactBundle:AccountContact.position</field-name>

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
@@ -796,28 +796,43 @@ class ContactControllerTest extends SuluTestCase
 
     public function testGetListByAccountId()
     {
-        $account = $this->createAccount('Musterfirma');
-        $this->em->persist($account);
+        $account1 = $this->createAccount('Musterfirma 1');
+        $this->em->persist($account1);
+
+        $account2 = $this->createAccount('Musterfirma 2');
+        $this->em->persist($account2);
 
         $contact1 = new Contact();
         $contact1->setFirstName('Erika');
         $contact1->setLastName('Mustermann');
         $accountContact1 = new AccountContact();
-        $accountContact1->setMain(false);
+        $accountContact1->setMain(true);
         $accountContact1->setContact($contact1);
-        $accountContact1->setAccount($account);
+        $accountContact1->setAccount($account1);
         $contact1->addAccountContact($accountContact1);
+        $accountContact2 = new AccountContact();
+        $accountContact2->setMain(false);
+        $accountContact2->setContact($contact1);
+        $accountContact2->setAccount($account2);
+        $contact1->addAccountContact($accountContact2);
         $this->em->persist($accountContact1);
+        $this->em->persist($accountContact2);
         $this->em->persist($contact1);
 
         $contact2 = new Contact();
         $contact2->setFirstName('Max');
         $contact2->setLastName('Mustermann');
+        $accountContact3 = new AccountContact();
+        $accountContact3->setMain(true);
+        $accountContact3->setContact($contact2);
+        $accountContact3->setAccount($account2);
+        $contact2->addAccountContact($accountContact3);
+        $this->em->persist($accountContact3);
         $this->em->persist($contact2);
 
         $this->em->flush();
 
-        $this->client->jsonRequest('GET', '/api/contacts?flat=true&accountId=' . $account->getId());
+        $this->client->jsonRequest('GET', '/api/contacts?flat=true&accountId=' . $account1->getId());
 
         $this->assertHttpStatusCode(200, $this->client->getResponse());
         $response = \json_decode($this->client->getResponse()->getContent());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

This PR adjusts the contact list configuration to join the position of the main account only. Without this change, multiple positions are joined if a contact is assigned to more than one account and the position column is visible in the contact list. This leads to duplicated rows in the contact list and in contact selections:

![Bildschirmfoto 2021-09-27 um 12 52 41](https://user-images.githubusercontent.com/13310795/135085759-becdae1d-39dd-4816-9db8-8a2a8549216b.png)

