### PR TITLE
Fix key and tags in form metadata merge

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
@@ -149,6 +149,7 @@ class FormMetadata extends AbstractMetadata
     public function merge(self $otherForm): FormMetadata
     {
         $mergedForm = new self();
+        $mergedForm->setKey($this->getKey());
         if ($this->name) {
             $mergedForm->setName($this->name);
         }
@@ -156,6 +157,7 @@ class FormMetadata extends AbstractMetadata
             $mergedForm->setTitle($this->title);
         }
 
+        $mergedForm->setTags(\array_merge($this->getTags(), $otherForm->getTags()));
         $mergedForm->setItems(\array_merge($this->getItems(), $otherForm->getItems()));
         $mergedForm->setSchema($this->getSchema()->merge($otherForm->getSchema()));
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no yes
| New feature? | no
| BC breaks? | no 
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the merge process of an extended form.

#### Why?

The key was null and an exception was thrown