### PR TITLE
Set correct workflow stage and published date to shadow locale

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/SmartContent/QueryBuilderTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/SmartContent/QueryBuilderTest.php
@@ -1529,6 +1529,20 @@ class QueryBuilderTest extends SuluTestCase
                 Structure::STATE_TEST
             )
         );
+        $nodesEn = \array_merge(
+            $nodesEn,
+            $this->save(
+                [
+                    'title' => 'Alex',
+                    'url' => '/team/alex',
+                ],
+                'en',
+                null,
+                $nodesEn['/team']->getUuid(),
+                false,
+                null
+            )
+        );
 
         $nodesDe = \array_merge(
             $nodesDe,
@@ -1555,7 +1569,8 @@ class QueryBuilderTest extends SuluTestCase
                 $nodesEn['/team/thomas']->getUuid(),
                 null,
                 true,
-                'en'
+                'en',
+                Structure::STATE_TEST
             )
         );
         $nodesDe = \array_merge(
@@ -1581,6 +1596,21 @@ class QueryBuilderTest extends SuluTestCase
                 ],
                 'de',
                 $nodesEn['/team/johannes']->getUuid()
+            )
+        );
+        $nodesDe = \array_merge(
+            $nodesDe,
+            $this->save(
+                [
+                    'title' => 'not-important-2',
+                    'url' => '/team/alex',
+                ],
+                'de',
+                $nodesEn['/team/alex']->getUuid(),
+                null,
+                true,
+                'en',
+                Structure::STATE_TEST
             )
         );
 
@@ -1649,13 +1679,14 @@ class QueryBuilderTest extends SuluTestCase
                     $data['en']['/team/thomas']->getUuid(),
                     $data['en']['/team/daniel']->getUuid(),
                     $data['en']['/team/johannes']->getUuid(),
+                    $data['en']['/team/alex']->getUuid(),
                 ],
             ]
         );
 
         $result = $this->contentQuery->execute('sulu_io', ['en'], $builder);
 
-        $this->assertEquals(3, \count($result));
+        $this->assertEquals(4, \count($result));
         $this->assertEquals('/team/thomas', $result[0]['url']);
         $this->assertEquals('Thomas', $result[0]['title']);
         $this->assertEquals(false, $result[0]['publishedState']);
@@ -1668,10 +1699,13 @@ class QueryBuilderTest extends SuluTestCase
         $this->assertEquals('Johannes', $result[2]['title']);
         $this->assertEquals(false, $result[2]['publishedState']);
         $this->assertNull($result[2]['published']);
+        $this->assertEquals('/team/alex', $result[3]['url']);
+        $this->assertEquals('Alex', $result[3]['title']);
+        $this->assertEquals(true, $result[3]['publishedState']);
 
         $result = $this->contentQuery->execute('sulu_io', ['de'], $builder);
 
-        $this->assertEquals(3, \count($result));
+        $this->assertEquals(4, \count($result));
         $this->assertEquals('/team/thomas', $result[0]['url']);
         $this->assertEquals('Thomas', $result[0]['title']);
         $this->assertEquals(false, $result[0]['publishedState']);
@@ -1684,5 +1718,8 @@ class QueryBuilderTest extends SuluTestCase
         $this->assertEquals('Johannes DE', $result[2]['title']);
         $this->assertEquals(true, $result[2]['publishedState']);
         $this->assertNotNull($result[2]['published']);
+        $this->assertEquals('/team/alex', $result[3]['url']);
+        $this->assertEquals('Alex', $result[3]['title']);
+        $this->assertEquals(false, $result[3]['publishedState']);
     }
 }

--- a/src/Sulu/Component/Content/Document/Subscriber/WorkflowStageSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/WorkflowStageSubscriber.php
@@ -92,7 +92,7 @@ class WorkflowStageSubscriber implements EventSubscriberInterface
         }
 
         $node = $event->getNode();
-        $locale = $event->getLocale();
+        $locale = $this->documentInspector->getOriginalLocale($document);
 
         $document->setWorkflowStage(
             $node->getPropertyValueWithDefault(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| License | MIT

#### What's in this PR?

This PR adjusts the `WorkflowStageSubscriber` to use the original locale of the document to determine the workflow stage and the published date for a document.

#### Why?

At the moment, when loading a shadow page, the workflow stage and published date is set based on the data of the target locale.

#### How to reproduce

1. Create page in locale `de` and publish it
2. Switch to locale `en`, add a title and configure `en` as shadow page
3. Save the locale `en` as draft
3b. The form displays the correct draft status
4. Reload the administration interface
4b. The form now displays the locale as published, but the locale is not accessible on the website