### PR TITLE
Create routes for internal link and external link pages

### DIFF
--- a/src/Sulu/Component/Content/Document/Subscriber/ResourceSegmentSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ResourceSegmentSubscriber.php
@@ -15,7 +15,6 @@ use PHPCR\NodeInterface;
 use PHPCR\SessionInterface;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Bundle\PageBundle\Document\HomeDocument;
-use Sulu\Component\Content\Document\Behavior\RedirectTypeBehavior;
 use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
 use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\Content\Document\RedirectType;
@@ -179,10 +178,6 @@ class ResourceSegmentSubscriber implements EventSubscriberInterface
         }
 
         if ($document instanceof HomeDocument) {
-            return;
-        }
-
-        if ($document instanceof RedirectTypeBehavior && RedirectType::NONE !== $document->getRedirectType()) {
             return;
         }
 

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/ResourceSegmentSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/ResourceSegmentSubscriberTest.php
@@ -15,6 +15,7 @@ use PHPCR\NodeInterface;
 use PHPCR\SessionInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
@@ -38,47 +39,47 @@ use Sulu\Component\DocumentManager\PropertyEncoder;
 class ResourceSegmentSubscriberTest extends TestCase
 {
     /**
-     * @var PropertyEncoder
+     * @var PropertyEncoder|ObjectProphecy
      */
     private $encoder;
 
     /**
-     * @var DocumentManagerInterface
+     * @var DocumentManagerInterface|ObjectProphecy
      */
     private $documentManager;
 
     /**
-     * @var DocumentInspector
+     * @var DocumentInspector|ObjectProphecy
      */
     private $documentInspector;
 
     /**
-     * @var ResourceLocatorStrategyInterface
+     * @var ResourceLocatorStrategyInterface|ObjectProphecy
      */
     private $resourceLocatorStrategy;
 
     /**
-     * @var ResourceLocatorStrategyPoolInterface
+     * @var ResourceLocatorStrategyPoolInterface|ObjectProphecy
      */
     private $resourceLocatorStrategyPool;
 
     /**
-     * @var ResourceSegmentBehavior
+     * @var ResourceSegmentBehavior|ObjectProphecy
      */
     private $document;
 
     /**
-     * @var StructureMetadata
+     * @var StructureMetadata|ObjectProphecy
      */
     private $structureMetadata;
 
     /**
-     * @var SessionInterface
+     * @var SessionInterface|ObjectProphecy
      */
     private $defaultSession;
 
     /**
-     * @var SessionInterface
+     * @var SessionInterface|ObjectProphecy
      */
     private $liveSession;
 
@@ -88,7 +89,7 @@ class ResourceSegmentSubscriberTest extends TestCase
     private $resourceSegmentSubscriber;
 
     /**
-     * @var PropertyMetadata
+     * @var PropertyMetadata|ObjectProphecy
      */
     private $propertyMetaData;
 
@@ -204,10 +205,12 @@ class ResourceSegmentSubscriberTest extends TestCase
         $event = $this->prophesize(PublishEvent::class);
         $event->getLocale()->willReturn('de');
 
+        $this->documentInspector->getWebspace($this->document->reveal())->willReturn('sulu_io');
+
         $this->document->getRedirectType()->willReturn(RedirectType::INTERNAL);
         $event->getDocument()->willReturn($this->document->reveal());
 
-        $this->resourceLocatorStrategy->save(Argument::any())->shouldNotBeCalled();
+        $this->resourceLocatorStrategy->save($this->document->reveal(), null)->shouldBeCalled();
         $this->resourceSegmentSubscriber->handlePersistRoute($event->reveal());
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| Fixed tickets | fixes #4979
| License | MIT

#### What's in this PR?

This PR adjusts the `ResourceSegmentSubscriber` to create a route when publishing internal and external link pages.

#### Why?

At the moment, the behaviour is inconsistent:

- If a page that is already published is changed to the external link type, a route for the page exists
- If a page that was not published is changed to the external link type, no route for the page exists

This causes problems when using such a page with the `<sulu-link>` tag:

1. Create new page and save as draft
2. Change page type to `External Link`
3. Save and publish external link page
4. Use external link page in a `<sulu-link>` tag
5. **The sulu link tag will render a link that leads to a 404 response for the page**

This issue is also described in #4979
