### PR TITLE
Set correct dataPath to fields rendered in ImageMap

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/ImageMap/ImageMap.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/ImageMap/ImageMap.js
@@ -112,7 +112,7 @@ class ImageMap extends React.Component<FieldTypeProps<Value>> {
         return (
             <FieldRenderer
                 data={data}
-                dataPath={dataPath + '/' + index}
+                dataPath={dataPath + '/hotspots/' + index}
                 errors={errors && errors.length > index && errors[index] ? errors[index] : undefined}
                 formInspector={formInspector}
                 index={index}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #6261
| License | MIT

#### What's in this PR?

This PR adjusts the `ImageMap` component to set the correct `dataPath` property to the rendered fields.

#### Why?

The `parentConditionDataProvider ` uses the `dataPath` to gather the data of the parent of the current field:
https://github.com/sulu/sulu/blob/02161cb45e0c7175c267ceaea3ed310a32c996fe/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/conditionDataProviders/parentConditionDataProvider.js#L15-L16

At the moment, a field inside of a `ImageMap` returns `/image_map/0/text_editor` instead of `/image_map/hotspots/0/text_editor`. Because of this, the `parentConditionDataProvider` tries to load the data with the path `/image_map/0` instead of `/image_map/hotspots/0`. This leads to an error because `/image_map/0` is not a valid path for the given data.

For more information, see https://github.com/sulu/sulu/issues/6261#issuecomment-932087685
