### PR TITLE
Fix media properties width and height for svg

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Media/PropertiesProvider/ImagePropertiesProvider.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/PropertiesProvider/ImagePropertiesProvider.php
@@ -23,9 +23,12 @@ class ImagePropertiesProvider implements MediaPropertiesProviderInterface
      */
     private $imagine;
 
-    public function __construct(ImagineInterface $imagine)
-    {
+    public function __construct(
+        ImagineInterface $imagine,
+        ?ImagineInterface $svgImagine = null
+    ) {
         $this->imagine = $imagine;
+        $this->svgImagine = $svgImagine;
     }
 
     public function provide(File $file): array
@@ -36,10 +39,14 @@ class ImagePropertiesProvider implements MediaPropertiesProviderInterface
             return [];
         }
 
+        $imagine = \in_array($mimeType, ['image/svg', 'image/svg+xml']) && $this->svgImagine
+            ? $this->svgImagine
+            : $this->imagine;
+
         $properties = [];
 
         try {
-            $image = $this->imagine->open($file->getPathname());
+            $image = $imagine->open($file->getPathname());
             $size = $image->getSize();
             $properties['width'] = $size->getWidth();
             $properties['height'] = $size->getHeight();

--- a/src/Sulu/Bundle/MediaBundle/Media/PropertiesProvider/ImagePropertiesProvider.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/PropertiesProvider/ImagePropertiesProvider.php
@@ -23,6 +23,11 @@ class ImagePropertiesProvider implements MediaPropertiesProviderInterface
      */
     private $imagine;
 
+    /**
+     * @var ImagineInterface|null
+     */
+    private $svgImagine;
+
     public function __construct(
         ImagineInterface $imagine,
         ?ImagineInterface $svgImagine = null

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -278,6 +278,7 @@
 
         <service id="sulu_media.image_properties_provider" class="Sulu\Bundle\MediaBundle\Media\PropertiesProvider\ImagePropertiesProvider">
             <argument type="service" id="sulu_media.adapter"/>
+            <argument type="service" id="sulu_media.adapter.svg" on-invalid="null"/>
 
             <tag name="sulu_media.media_properties_provider"/>
         </service>

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Traits/CreateUploadedFileTrait.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Traits/CreateUploadedFileTrait.php
@@ -54,4 +54,35 @@ trait CreateUploadedFileTrait
 
         return $uploadedFile;
     }
+
+    private function createUploadedFileSvgImage(?int $width = null, ?int $height = null): UploadedFile
+    {
+        $tempFilePath = \tempnam(\sys_get_temp_dir(), 'sulu_test_image_');
+
+        if (!$tempFilePath) {
+            throw new \RuntimeException(\sprintf(
+                'Could not create temporary image in "%s".',
+                __CLASS__
+            ));
+        }
+
+        $attributess = [];
+        if ($width) {
+            $attributes[] = ' width="' . $width . '"';
+        }
+        if ($height) {
+            $attributes[] = ' height="' . $height . '"';
+        }
+
+        \file_put_contents(
+            $tempFilePath,
+            '<svg xmlns="http://www.w3.org/2000/svg"' . \implode(' ', $attributes) . ' viewBox="0 0 600 400">
+                <path xmlns="http://www.w3.org/2000/svg" fill="#eee" d="M0 0h600v400H0z"/>
+            </svg>'
+        );
+
+        $uploadedFile = new UploadedFile($tempFilePath, $width . 'x' . $height . '.svg');
+
+        return $uploadedFile;
+    }
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/PropertiesProvider/ImagePropertiesProviderTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/PropertiesProvider/ImagePropertiesProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\MediaBundle\Tests\Unit\Media\PropertiesProvider;
 
+use Contao\ImagineSvg\Imagine as SvgImagine;
 use Imagine\Image\Box;
 use Imagine\Image\ImageInterface;
 use Imagine\Image\ImagineInterface;
@@ -39,7 +40,8 @@ class ImagePropertiesProviderTest extends TestCase
         $this->imagine = $this->prophesize(ImagineInterface::class);
 
         $this->imagePropertiesProvider = new ImagePropertiesProvider(
-            $this->imagine->reveal()
+            $this->imagine->reveal(),
+            new SvgImagine()
         );
     }
 
@@ -76,6 +78,21 @@ class ImagePropertiesProviderTest extends TestCase
             [
                 'width' => 360,
                 'height' => 240,
+            ],
+            $this->imagePropertiesProvider->provide($uploadedFile)
+        );
+    }
+
+    public function testProvideSvgImage(): void
+    {
+        // prepare data
+        $uploadedFile = $this->createUploadedFileSvgImage(400, 200);
+
+        // test function
+        $this->assertSame(
+            [
+                'width' => 400,
+                'height' => 200,
             ],
             $this->imagePropertiesProvider->provide($uploadedFile)
         );


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix media properties width and height for svg

#### Why?

Currently it tries to use the none svg adapter for svg images which ends that in gd case it will fail to read the width and heights correctly.