### PR TITLE
Add fixed height to arrowmenu to make sure the menu is scrollable and…

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/arrowMenu.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/arrowMenu.scss
@@ -15,6 +15,7 @@ $arrowMenuBoxShadow: 0 0 14px 0 rgba($doveGray, .5);
     box-shadow: $arrowMenuBoxShadow;
     overflow: auto;
     min-width: 200px;
+    max-height: 500px;
 }
 
 .arrow {


### PR DESCRIPTION
… won't overflow viewport

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #6257 <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #6257 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | - <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

This PR sets a fixed max height on the arrow menu to make sure the dropdown will not overflow viewport and be scrollable in case of long lists.

#### Why?

In e.g. the webspaces dropdown, in case of a large amount of webspaces, the list will overflow viewport on certain screen sizes and is not scrollable. This results in not being able to interact with several items in the dropdown.
