### PR TITLE
Fix doctrine/dbal 3 and doctrine/orm 2.10 compatibility

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -20,7 +20,8 @@ x/UPGRADE.md#upgrade-to-30).
 Else you should define the doctrine/dbal version to ^2.10 with:
 
 ```bash
-composer require doctrine/dbal:^2.10
+composer require doctrine/dbal:^2.10 --no-update
+composer update
 ```
 
 ## 2.2.11

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -14,7 +14,14 @@ ALTER TABLE we_analytics CHANGE content content JSON NOT NULL;
 ALTER TABLE at_target_group_conditions CHANGE condition condition JSON NOT NULL
 ```
 
-If you upgrade doctrine/dbal to Version 3 see there [UPGRADE.md](https://github.com/doctrine/dbal/blob/3.1.x/UPGRADE.md#upgrade-to-30).
+If you upgrade doctrine/dbal to Version 3 see the [DBAL 3.0 UPGRADE.md](https://github.com/doctrine/dbal/blob/3.1.
+x/UPGRADE.md#upgrade-to-30).
+
+Else you should define the doctrine/dbal version to ^2.10 with:
+
+```bash
+composer require doctrine/dbal:^2.10
+```
 
 ## 2.2.11
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,7 +4,7 @@
 
 ### Add doctrine/dbal 3 and doctrine/orm 2.10 support
 
-The doctrine/orm 2.10 did remove the json_array type which need to be patched.
+The doctrine/orm 2.10 did remove the deprecated `json_array` type which need to be patched to `json` type.
 
 ```sql
 ALTER TABLE se_role_settings CHANGE value value JSON NOT NULL;
@@ -13,6 +13,8 @@ ALTER TABLE we_analytics CHANGE content content JSON NOT NULL;
 -- if you use audience targeting also the following is required:
 ALTER TABLE at_target_group_conditions CHANGE condition condition JSON NOT NULL
 ```
+
+If you upgrade doctrine/dbal to Version 3 see there [UPGRADE.md](https://github.com/doctrine/dbal/blob/3.1.x/UPGRADE.md#upgrade-to-30).
 
 ## 2.2.11
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,19 @@
 # Upgrade
 
+## 2.2.15
+
+### Add doctrine/dbal 3 and doctrine/orm 2.10 support
+
+The doctrine/orm 2.10 did remove the json_array type which need to be patched.
+
+```sql
+ALTER TABLE se_role_settings CHANGE value value JSON NOT NULL;
+ALTER TABLE we_analytics CHANGE content content JSON NOT NULL;
+
+-- if you use audience targeting also the following is required:
+ALTER TABLE at_target_group_conditions CHANGE condition condition JSON NOT NULL
+```
+
 ## 2.2.11
 
 ### Migrate permissions properties for pages

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroupCondition.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroupCondition.php
@@ -11,6 +11,8 @@
 
 namespace Sulu\Bundle\AudienceTargetingBundle\Entity;
 
+use JMS\Serializer\Annotation\Type;
+
 /**
  * Entity that holds conditions for target group rules.
  */
@@ -28,6 +30,7 @@ class TargetGroupCondition implements TargetGroupConditionInterface
 
     /**
      * @var mixed[]
+     * @Type("array")
      */
     private $condition;
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroupCondition.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroupCondition.php
@@ -27,7 +27,7 @@ class TargetGroupCondition implements TargetGroupConditionInterface
     private $type;
 
     /**
-     * @var string
+     * @var mixed[]
      */
     private $condition;
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroupConditionInterface.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroupConditionInterface.php
@@ -34,12 +34,12 @@ interface TargetGroupConditionInterface
     public function setType($type);
 
     /**
-     * @return array
+     * @return mixed[]
      */
     public function getCondition();
 
     /**
-     * @param string $condition
+     * @param mixed[] $condition
      *
      * @return $this
      */

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/doctrine/TargetGroupCondition.orm.xml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/doctrine/TargetGroupCondition.orm.xml
@@ -11,7 +11,7 @@
         </id>
 
         <field name="type" column="`type`" type="string" length="255" nullable="false"/>
-        <field name="condition" column="`condition`" type="json_array" nullable="false"/>
+        <field name="condition" column="`condition`" type="json" nullable="false"/>
 
         <many-to-one field="rule"
                      inversed-by="conditions"

--- a/src/Sulu/Bundle/CategoryBundle/Command/RecoverCommand.php
+++ b/src/Sulu/Bundle/CategoryBundle/Command/RecoverCommand.php
@@ -181,7 +181,8 @@ class RecoverCommand extends Command
         $result = $statement->execute();
 
         if ($result) {
-            return method_exists($statement, 'rowCount') ? $statement->rowCount() : $result->rowCount();
+            // DBAL 2 to 3 BC Layer
+            return \method_exists($statement, 'rowCount') ? $statement->rowCount() : $result->rowCount();
         }
 
         return false;

--- a/src/Sulu/Bundle/CategoryBundle/Command/RecoverCommand.php
+++ b/src/Sulu/Bundle/CategoryBundle/Command/RecoverCommand.php
@@ -178,8 +178,10 @@ class RecoverCommand extends Command
                 WHERE ( c2.depth - 1 ) <> c1.depth';
 
         $statement = $this->entityManager->getConnection()->prepare($sql);
-        if ($statement->execute()) {
-            return $statement->rowCount();
+        $result = $statement->execute();
+
+        if ($result) {
+            return method_exists($statement, 'rowCount') ? $statement->rowCount() : $result->rowCount();
         }
 
         return false;

--- a/src/Sulu/Bundle/ContactBundle/Command/AccountRecoverCommand.php
+++ b/src/Sulu/Bundle/ContactBundle/Command/AccountRecoverCommand.php
@@ -178,8 +178,10 @@ class AccountRecoverCommand extends Command
                 WHERE ( c2.depth - 1 ) <> c1.depth';
 
         $statement = $this->entityManager->getConnection()->prepare($sql);
-        if ($statement->execute()) {
-            return $statement->rowCount();
+        $result = $statement->execute();
+
+        if ($result) {
+            return method_exists($statement, 'rowCount') ? $statement->rowCount() : $result->rowCount();
         }
 
         return false;

--- a/src/Sulu/Bundle/ContactBundle/Command/AccountRecoverCommand.php
+++ b/src/Sulu/Bundle/ContactBundle/Command/AccountRecoverCommand.php
@@ -181,7 +181,8 @@ class AccountRecoverCommand extends Command
         $result = $statement->execute();
 
         if ($result) {
-            return method_exists($statement, 'rowCount') ? $statement->rowCount() : $result->rowCount();
+            // DBAL 2 to 3 BC Layer
+            return \method_exists($statement, 'rowCount') ? $statement->rowCount() : $result->rowCount();
         }
 
         return false;

--- a/src/Sulu/Bundle/ContactBundle/Entity/ContactRepository.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/ContactRepository.php
@@ -324,8 +324,12 @@ class ContactRepository extends EntityRepository implements DataProviderReposito
     private function addPagination($qb, $offset, $limit)
     {
         // Add pagination
-        $qb->setFirstResult($offset);
-        $qb->setMaxResults($limit);
+        if ($offset) {
+            $qb->setFirstResult((int) $offset);
+        }
+        if ($limit) {
+            $qb->setMaxResults((int) $limit);
+        }
 
         return $qb;
     }

--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
@@ -536,25 +536,21 @@ class CollectionManager implements CollectionManagerInterface
 
     public function move($id, $locale, $destinationId = null)
     {
-        try {
-            $collectionEntity = $this->collectionRepository->findCollectionById($id);
+        $collectionEntity = $this->collectionRepository->findCollectionById($id);
 
-            if (null === $collectionEntity) {
-                throw new CollectionNotFoundException($id);
-            }
-
-            $destinationEntity = null;
-            if (null !== $destinationId) {
-                $destinationEntity = $this->collectionRepository->findCollectionById($destinationId);
-            }
-
-            $collectionEntity->setParent($destinationEntity);
-            $this->em->flush();
-
-            return $this->getApiEntity($collectionEntity, $locale);
-        } catch (DBALException $ex) {
-            throw new CollectionNotFoundException($destinationId);
+        if (null === $collectionEntity) {
+            throw new CollectionNotFoundException($id);
         }
+
+        $destinationEntity = null;
+        if (null !== $destinationId) {
+            $destinationEntity = $this->collectionRepository->findCollectionById($destinationId);
+        }
+
+        $collectionEntity->setParent($destinationEntity);
+        $this->em->flush();
+
+        return $this->getApiEntity($collectionEntity, $locale);
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\MediaBundle\Collection\Manager;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Sulu\Bundle\MediaBundle\Api\Collection;

--- a/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
@@ -204,10 +204,10 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
                 $qb->setParameter('search', '%' . $search . '%');
             }
             if (null !== $offset) {
-                $qb->setFirstResult($offset);
+                $qb->setFirstResult((int) $offset);
             }
             if (null !== $limit) {
-                $qb->setMaxResults($limit);
+                $qb->setMaxResults((int) $limit);
             }
 
             return new Paginator($qb->getQuery());

--- a/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
@@ -361,11 +361,11 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
 
         $queryBuilder->addOrderBy('collection.id', 'ASC');
 
-        if (\array_key_exists('limit', $filter)) {
-            $queryBuilder->setMaxResults($filter['limit']);
+        if (isset($filter['limit'])) {
+            $queryBuilder->setMaxResults((int) $filter['limit']);
         }
-        if (\array_key_exists('offset', $filter)) {
-            $queryBuilder->setFirstResult($filter['offset']);
+        if (isset($filter['offset'])) {
+            $queryBuilder->setFirstResult((int) $filter['offset']);
         }
 
         return $queryBuilder->getQuery();

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
@@ -302,8 +302,8 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
 
     /**
      * @param int $collectionId
-     * @param int $limit
-     * @param int $offset
+     * @param int|null $limit
+     * @param int|null $offset
      *
      * @return array
      */
@@ -321,9 +321,14 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
             ->innerJoin('files.fileVersions', 'versions', 'WITH', 'versions.version = files.version')
             ->join('media.collection', 'collection')
             ->where('collection.id = :collectionId')
-            ->setFirstResult($offset)
-            ->setMaxResults($limit)
             ->setParameter('collectionId', $collectionId);
+
+        if ($offset) {
+            $queryBuilder->setFirstResult((int) $offset);
+        }
+        if ($limit) {
+            $queryBuilder->setMaxResults((int) $limit);
+        }
 
         $query = $queryBuilder->getQuery();
         $paginator = new Paginator($query);

--- a/src/Sulu/Bundle/MediaBundle/Media/Exception/CollectionNotFoundException.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Exception/CollectionNotFoundException.php
@@ -14,7 +14,7 @@ namespace Sulu\Bundle\MediaBundle\Media\Exception;
 class CollectionNotFoundException extends MediaException
 {
     /**
-     * @param string $id
+     * @param string|int $id
      */
     public function __construct($id)
     {

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\MediaBundle\Media\Manager;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\ORM\EntityManager;
 use FFMpeg\Exception\ExecutableNotFoundException;
 use FFMpeg\FFProbe;

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -718,21 +718,17 @@ class MediaManager implements MediaManagerInterface
 
     public function move($id, $locale, $destCollection)
     {
-        try {
-            $mediaEntity = $this->mediaRepository->findMediaById($id);
+        $mediaEntity = $this->mediaRepository->findMediaById($id);
 
-            if (null === $mediaEntity) {
-                throw new MediaNotFoundException($id);
-            }
-
-            $mediaEntity->setCollection($this->em->getReference(self::ENTITY_NAME_COLLECTION, $destCollection));
-
-            $this->em->flush();
-
-            return $this->addFormatsAndUrl(new Media($mediaEntity, $locale, null));
-        } catch (DBALException $ex) {
-            throw new CollectionNotFoundException($destCollection);
+        if (null === $mediaEntity) {
+            throw new MediaNotFoundException($id);
         }
+
+        $mediaEntity->setCollection($this->em->getReference(self::ENTITY_NAME_COLLECTION, $destCollection));
+
+        $this->em->flush();
+
+        return $this->addFormatsAndUrl(new Media($mediaEntity, $locale, null));
     }
 
     public function increaseDownloadCounter($fileVersionId)

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
@@ -330,7 +330,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertFalse($response->_hasPermissions);
     }
 
-    public function testCGet()
+    public function testCGet(): void
     {
         for ($i = 1; $i <= 15; ++$i) {
             $this->createCollection(
@@ -355,7 +355,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertCount(16, $response->_embedded->collections);
     }
 
-    public function testCGetPageAndLimit()
+    public function testCGetPaginatedFlat(): void
     {
         for ($i = 1; $i < 8; ++$i) {
             $this->createCollection(
@@ -366,15 +366,16 @@ class CollectionControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'GET',
-            '/api/collections?page=3&limit=3',
+            '/api/collections?page=3&limit=3&flat=true',
             [
                 'locale' => 'en-gb',
             ]
         );
 
-        $response = \json_decode($this->client->getResponse()->getContent());
         $this->assertHttpStatusCode(200, $this->client->getResponse());
+        $response = \json_decode($this->client->getResponse()->getContent());
 
+        $this->assertInstanceOf(\stdClass::class, $response);
         $this->assertNotEmpty($response->_embedded->collections);
 
         $this->assertCount(2, $response->_embedded->collections);
@@ -383,7 +384,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertSame(3, $response->pages);
     }
 
-    public function testCGetFlatWithRootParent()
+    public function testCGetFlatWithRootParent(): void
     {
         $collection = $this->createCollection($this->collectionType1);
 
@@ -405,7 +406,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertCount(2, $response->_embedded->collections);
     }
 
-    public function testCGetFlatWithRootParentAndIncludeRoot()
+    public function testCGetFlatWithRootParentAndIncludeRoot(): void
     {
         $collection = $this->createCollection($this->collectionType1);
 
@@ -428,7 +429,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertCount(2, $response->_embedded->collections);
     }
 
-    public function testCGetFlatWithParent()
+    public function testCGetFlatWithParent(): void
     {
         $collection = $this->createCollection($this->collectionType1);
 
@@ -458,7 +459,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertCount(5, $response->_embedded->collections);
     }
 
-    public function testcGetPaginated()
+    public function testcGetPaginated(): void
     {
         $this->createCollection(
             $this->collectionType1,
@@ -518,7 +519,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertEquals('Test Collection', $response->_embedded->collections[0]->_embedded->collections[0]->title);
     }
 
-    public function testcGetPaginatedWithParentAndIgnoredRoot()
+    public function testcGetPaginatedWithParentAndIgnoredRoot(): void
     {
         $this->client->jsonRequest(
             'GET',
@@ -577,7 +578,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertEquals(1, $response->_embedded->collections[1]->objectCount);
     }
 
-    public function testGetByIdNotExisting()
+    public function testGetByIdNotExisting(): void
     {
         $this->client->jsonRequest(
             'GET',
@@ -591,7 +592,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertTrue(isset($response->message));
     }
 
-    public function testPost()
+    public function testPost(): void
     {
         $generateColor = '#ffcc00';
 
@@ -688,7 +689,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertEquals('This Description 2 is only for testing', $responseSecondEntity->description);
     }
 
-    public function testPostNested()
+    public function testPostNested(): void
     {
         $this->getContainer()->get('sulu_media.system_collections.manager')->warmUp();
         $this->client->getContainer()->get('sulu_media.system_collections.manager')->warmUp();
@@ -783,7 +784,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertEquals(2 + $this->getAmountOfSystemCollections(), $response->total);
     }
 
-    public function testPostWithPermissions()
+    public function testPostWithPermissions(): void
     {
         $this->getContainer()->get('sulu_media.system_collections.manager')->warmUp();
         $this->client->getContainer()->get('sulu_media.system_collections.manager')->warmUp();
@@ -836,7 +837,7 @@ class CollectionControllerTest extends SuluTestCase
         );
     }
 
-    public function testPostWithoutDetails()
+    public function testPostWithoutDetails(): void
     {
         $this->client->jsonRequest(
             'POST',
@@ -954,7 +955,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertEquals('Test Collection 2', $responseSecondEntity->title);
     }
 
-    public function testPostWithNotExistingType()
+    public function testPostWithNotExistingType(): void
     {
         $generateColor = '#ffcc00';
 
@@ -984,7 +985,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertTrue(isset($response->message));
     }
 
-    public function testPut()
+    public function testPut(): void
     {
         $this->getContainer()->get('sulu_media.system_collections.manager')->warmUp();
         $this->client->getContainer()->get('sulu_media.system_collections.manager')->warmUp();
@@ -1069,7 +1070,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertEquals('en-gb', $responseFirstEntity->locale);
     }
 
-    public function testPutWithoutLocale()
+    public function testPutWithoutLocale(): void
     {
         $this->client->jsonRequest(
             'PUT',
@@ -1088,7 +1089,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(400, $this->client->getResponse());
     }
 
-    public function testPutWithChildCollection()
+    public function testPutWithChildCollection(): void
     {
         $childCollection = $this->createCollection(
             $this->collectionType1,
@@ -1121,7 +1122,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertEquals($this->collection1->getId(), $response->_embedded->breadcrumb[0]->id);
     }
 
-    public function testPutWithoutBreadcrumb()
+    public function testPutWithoutBreadcrumb(): void
     {
         $childCollection = $this->createCollection(
             $this->collectionType1,
@@ -1153,7 +1154,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertNull($response['_embedded']['breadcrumb']);
     }
 
-    public function testPutNoDetails()
+    public function testPutNoDetails(): void
     {
         // Add New Collection Type
         $collectionType = new CollectionType();
@@ -1199,7 +1200,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertNotNull($response->type->id);
     }
 
-    public function testPutNotExisting()
+    public function testPutNotExisting(): void
     {
         $this->client->jsonRequest(
             'PUT',
@@ -1217,7 +1218,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(404, $this->client->getResponse());
     }
 
-    public function testDeleteById()
+    public function testDeleteById(): void
     {
         $collection1Id = $this->collection1->getId();
 
@@ -1236,7 +1237,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertTrue(isset($response->message));
     }
 
-    public function testDeleteByIdNotExisting()
+    public function testDeleteByIdNotExisting(): void
     {
         $this->client->jsonRequest('DELETE', '/api/collections/404');
         $this->assertHttpStatusCode(404, $this->client->getResponse());
@@ -1246,7 +1247,10 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertEquals(2, $response->total);
     }
 
-    private function prepareTree()
+    /**
+     * @return mixed[]
+     */
+    private function prepareTree(): array
     {
         $collection1 = $this->collection1;
         $collection2 = $this->createCollection(
@@ -1310,7 +1314,7 @@ class CollectionControllerTest extends SuluTestCase
         ];
     }
 
-    public function testCGetNestedFlat()
+    public function testCGetNestedFlat(): void
     {
         list($titles) = $this->prepareTree();
 
@@ -1381,7 +1385,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertContains(['title' => $titles[6], 'parent' => $titles[5], 'collections' => []], $items);
     }
 
-    public function testCGetNestedTree()
+    public function testCGetNestedTree(): void
     {
         list($titles) = $this->prepareTree();
 
@@ -1486,7 +1490,7 @@ class CollectionControllerTest extends SuluTestCase
         );
     }
 
-    public function testGetBreadcrumb()
+    public function testGetBreadcrumb(): void
     {
         list($titles, $ids) = $this->prepareTree();
 
@@ -1510,7 +1514,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertEquals($ids[5], $breadcrumb[1]['id']);
     }
 
-    public function testGetByIdWithDepth()
+    public function testGetByIdWithDepth(): void
     {
         list($titles, $ids) = $this->prepareTree();
 
@@ -1580,7 +1584,7 @@ class CollectionControllerTest extends SuluTestCase
         );
     }
 
-    public function testMove()
+    public function testMove(): void
     {
         list($titles, $ids) = $this->prepareTree();
 
@@ -1626,7 +1630,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertContains(['title' => $titles[6], 'parent' => $titles[5], 'collections' => []], $items);
     }
 
-    public function testPostParentIsSystemCollection()
+    public function testPostParentIsSystemCollection(): void
     {
         $collectionId = $this->client->getContainer()->get('sulu_media.system_collections.manager')->getSystemCollection(
             'sulu_media'
@@ -1649,7 +1653,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(403, $this->client->getResponse());
     }
 
-    public function testPutSystemCollection()
+    public function testPutSystemCollection(): void
     {
         $collectionId = $this->client->getContainer()->get('sulu_media.system_collections.manager')->getSystemCollection(
             'sulu_media'
@@ -1671,7 +1675,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(403, $this->client->getResponse());
     }
 
-    public function testDeleteSystemCollection()
+    public function testDeleteSystemCollection(): void
     {
         $collectionId = $this->client->getContainer()->get('sulu_media.system_collections.manager')->getSystemCollection(
             'sulu_media'

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
@@ -355,6 +355,34 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertCount(16, $response->_embedded->collections);
     }
 
+    public function testCGetPageAndLimit()
+    {
+        for ($i = 1; $i < 8; ++$i) {
+            $this->createCollection(
+                $this->collectionType1,
+                ['en-gb' => 'Test Collection ' . $i, 'de' => 'Test Kollektion ' . $i]
+            );
+        }
+
+        $this->client->jsonRequest(
+            'GET',
+            '/api/collections?page=3&limit=3',
+            [
+                'locale' => 'en-gb',
+            ]
+        );
+
+        $response = \json_decode($this->client->getResponse()->getContent());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+
+        $this->assertNotEmpty($response->_embedded->collections);
+
+        $this->assertCount(2, $response->_embedded->collections);
+        $this->assertSame(8, $response->total);
+        $this->assertSame(3, $response->page);
+        $this->assertSame(3, $response->pages);
+    }
+
     public function testCGetFlatWithRootParent()
     {
         $collection = $this->createCollection($this->collectionType1);

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/RoleSetting.orm.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/RoleSetting.orm.xml
@@ -17,12 +17,11 @@
         </id>
 
         <field name="key" type="string" column="settingKey" length="191"/>
-        <field name="value" type="json_array" column="value"/>
+        <field name="value" type="json" column="value"/>
 
         <many-to-one field="role" target-entity="Sulu\Component\Security\Authentication\RoleInterface"
                      inversed-by="settings">
             <join-column name="roleId" referenced-column-name="id" on-delete="CASCADE" />
         </many-to-one>
-
     </entity>
 </doctrine-mapping>

--- a/src/Sulu/Bundle/TagBundle/Controller/TagController.php
+++ b/src/Sulu/Bundle/TagBundle/Controller/TagController.php
@@ -168,12 +168,8 @@ class TagController extends AbstractRestController implements ClassResourceInter
     /**
      * Inserts a new tag.
      *
-     * @throws \Doctrine\DBAL\DBALException
-     * @throws \Exception
-     *
      * @return \Symfony\Component\HttpFoundation\Response
      *
-     * @throws \Doctrine\DBAL\DBALException
      * @throws \Exception
      */
     public function postAction(Request $request)
@@ -211,7 +207,6 @@ class TagController extends AbstractRestController implements ClassResourceInter
      *
      * @return \Symfony\Component\HttpFoundation\Response
      *
-     * @throws \Doctrine\DBAL\DBALException
      * @throws \Exception
      */
     public function putAction(Request $request, $id)
@@ -258,7 +253,7 @@ class TagController extends AbstractRestController implements ClassResourceInter
             try {
                 $this->tagManager->delete($id);
             } catch (TagNotFoundException $tnfe) {
-                throw new EntityNotFoundException(self::$entityName, $id);
+                throw new EntityNotFoundException(self::$entityName, $id, $tnfe);
             }
         };
 

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/doctrine/Analytics.orm.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/doctrine/Analytics.orm.xml
@@ -16,7 +16,7 @@
         <field name="title" type="string" column="title" length="255"/>
         <field name="webspaceKey" type="string" column="webspace_key" length="191"/>
         <field name="allDomains" type="boolean" column="all_domains"/>
-        <field name="content" type="json_array" column="content"/>
+        <field name="content" type="json" column="content"/>
         <field name="type" type="string" column="type" length="60"/>
 
         <many-to-many target-entity="Sulu\Bundle\WebsiteBundle\Entity\Domain" field="domains">

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -321,7 +321,9 @@ class ContentMapper implements ContentMapperInterface
     public function loadBySql2($sql2, $locale, $webspaceKey, $limit = null)
     {
         $query = $this->documentManager->createQuery($sql2, $locale);
-        $query->setMaxResults($limit);
+        if (null !== $limit) {
+            $query->setMaxResults($limit);
+        }
 
         $documents = $query->execute();
 

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -270,7 +270,7 @@ class DoctrineListBuilder extends AbstractListBuilder
 
         $subQueryBuilder = $this->createSubQueryBuilder($select);
         if (null != $this->limit) {
-            $subQueryBuilder->setMaxResults($this->limit)->setFirstResult($this->limit * ($this->page - 1));
+            $subQueryBuilder->setMaxResults((int) $this->limit)->setFirstResult((int) ($this->limit * ($this->page - 1)));
         }
 
         foreach ($this->sortFields as $index => $sortField) {

--- a/src/Sulu/Component/Rest/Listing/ListRepository.php
+++ b/src/Sulu/Component/Rest/Listing/ListRepository.php
@@ -82,8 +82,14 @@ class ListRepository extends EntityRepository
             ->createQuery($dql);
 
         if (!$justCount) {
-            $query->setFirstResult($this->helper->getOffset())
-                ->setMaxResults($this->helper->getLimit());
+            $offset = $this->helper->getOffset();
+            if (null !== $offset) {
+                $query->setFirstResult($offset);
+            }
+            $limit = $this->helper->getLimit();
+            if (null !== $limit) {
+                $query->setMaxResults($limit);
+            }
         }
         if (null != $searchPattern && '' != $searchPattern) {
             if (\count($searchFields) > 0) {

--- a/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
+++ b/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\SmartContent\Orm;
 
 use Doctrine\ORM\QueryBuilder;
+use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancer;
 use Sulu\Component\Security\Authentication\UserInterface;
 
 /**
@@ -19,9 +20,16 @@ use Sulu\Component\Security\Authentication\UserInterface;
  */
 trait DataProviderRepositoryTrait
 {
+    /**
+     * @var AccessControlQueryEnhancer|null
+     */
     private $accessControlQueryEnhancer = null;
 
     /**
+     * @param string|null $entityClass
+     * @param string|null $entityAlias
+     * @param int|null $permission
+     *
      * @see DataProviderRepositoryInterface::findByFilters
      */
     public function findByFilters(

--- a/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
@@ -33,8 +33,9 @@ class Query extends AbstractQuery
     {
     }
 
-    public function _doExecute()
+    public function _doExecute(): int
     {
+        return 0;
     }
 }
 
@@ -95,20 +96,31 @@ class DataProviderRepositoryTraitTest extends TestCase
         $dataProviderRepositoryTrait = new class($accessControlQueryEnhancer->reveal(), $queryBuilder->reveal()) {
             use DataProviderRepositoryTrait;
 
+            /**
+             * @var QueryBuilder
+             */
             private $queryBuilder;
 
-            public function __construct($accessControlQueryEnhancer, $queryBuilder)
+            public function __construct(AccessControlQueryEnhancer $accessControlQueryEnhancer, QueryBuilder $queryBuilder)
             {
                 $this->accessControlQueryEnhancer = $accessControlQueryEnhancer;
                 $this->queryBuilder = $queryBuilder;
             }
 
-            public function createQueryBuilder($alias, $indexBy = null)
+            /**
+             * @param string $alias
+             * @param string|null $indexBy
+             */
+            public function createQueryBuilder($alias, $indexBy = null): QueryBuilder
             {
                 return $this->queryBuilder;
             }
 
-            public function appendJoins(QueryBuilder $queryBuilder, $alias, $locale)
+            /**
+             * @param string $alias
+             * @param string $locale
+             */
+            public function appendJoins(QueryBuilder $queryBuilder, $alias, $locale): void
             {
             }
         };


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Replace json_array types with json types for doctrine/orm 2.10 support.

#### Why?

The doctrine/orm 2.10 did remove the json_array type and so it should be replaced.
