### PR TITLE
Add default value for search term in WebsiteSearchController to prevent MissingParameterException

### DIFF
--- a/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
+++ b/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
@@ -73,7 +73,7 @@ class WebsiteSearchController
      */
     public function queryAction(Request $request)
     {
-        $query = $this->getRequestParameter($request, 'q', true);
+        $query = $this->getRequestParameter($request, 'q', true, '');
 
         $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
         $webspace = $this->requestAnalyzer->getWebspace();

--- a/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
+++ b/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
@@ -73,7 +73,7 @@ class WebsiteSearchController
      */
     public function queryAction(Request $request)
     {
-        $query = $this->getRequestParameter($request, 'q', true, '');
+        $query = $this->getRequestParameter($request, 'q', false, '');
 
         $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
         $webspace = $this->requestAnalyzer->getWebspace();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #4874
| License | MIT

#### What's in this PR?

This PR adds `''` as default value for the search term in the `WebsiteSearchController`. This makes the URL `https://sulu.io/search` equivalent to `https://sulu.io/search?q=`.

#### Why

To prevent the following exception when a bot accesses `/search` (see #4874):

![Screenshot 2021-10-04 at 13 39 53](https://user-images.githubusercontent.com/13310795/135845277-0898e0a6-d1d2-450f-b12e-19c1f97288d0.png)

