### PR TITLE
Adjust ArrowMenu to not overflow browser window

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/arrowMenu.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/arrowMenu.scss
@@ -6,6 +6,12 @@ $arrowMenuBoxShadow: 0 0 14px 0 rgba($doveGray, .5);
 .arrowMenuContainer {
     margin: 0;
     position: relative;
+
+    /*
+    * the popover component sets a max-height to this element. we use flexbox to make sure that the children do not
+    * overflow the container and exceed the max-height: https://stackoverflow.com/a/23300532/16151545
+    */
+    display: flex;
 }
 
 .arrowMenu {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/PopoverPositioner.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/PopoverPositioner.js
@@ -79,8 +79,9 @@ export default class PopoverPositioner {
             dimensions.top = anchorTop + verticalOffset;
         }
 
-        // If the bottom border is touched, it gets positioned from the anchor upwards.
-        if (crop.touchesBottomBorder) {
+        // If the bottom border is touched and there is more space above the popover than below, the popover gets
+        // positioned from the anchor upwards.
+        if (crop.touchesBottomBorder && crop.dimensions.top > windowHeight - crop.dimensions.top) {
             if (alignOnVerticalAnchorEdges) {
                 dimensions.top = anchorTop - popoverHeight - verticalOffset;
             } else {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #6257
| Related issues/PRs | replaces #6269
| License | MIT

#### What's in this PR?

This PR adjusts the `ArrowMenu` component to not overflow the browser window. The component already set an appropriate `max-width` to the container of the menu, but the menu itself was rendered as a child of this container and did not respect this `max-height` (https://stackoverflow.com/questions/14262938/child-with-max-height-100-overflows-parent).

Additionally, this PR adjusts the `PopoverPositioner` to position the popover from the anchor upwards only if there is more space above the current position than below.