### PR TITLE
Omit search metadata for blocks without indexed properties

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Search/Metadata/StructureProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Search/Metadata/StructureProvider.php
@@ -319,14 +319,17 @@ EOT;
                 }
             }
 
-            $metadata->addFieldMapping(
-                $propertyName,
-                [
-                    'type' => 'complex',
-                    'mapping' => $propertyMapping,
-                    'field' => $field,
-                ]
-            );
+            // add field for block only if block contains least one mapped field
+            if (!empty($propertyMapping->getFieldMapping())) {
+                $metadata->addFieldMapping(
+                    $propertyName,
+                    [
+                        'type' => 'complex',
+                        'mapping' => $propertyMapping,
+                        'field' => $field,
+                    ]
+                );
+            }
 
             return;
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| Related issues/PRs | improves #6277
| License | MIT

#### What's in this PR?

This pull request adjusts the `StructureProvider` to add search metadata for blocks only if they contain an indexed property.

#### Why?

At the moment, the search metadata contains alls blocks even if no property of the block is indexed. This causes problems when one block type contains a nested block and another block type contains a property with the same name but a different type (see #6277, #6272).

By omitting blocks that contain no indexed properties, we reduce the surface area for the problem described in #6277. Before this change, the problem occured for every nested block that has the same name as a property of a different type in another blocktype. After this change, the problem only occurs if the nested block contains a indexed property (which should be rare as indexing nested properties did not work until #6205)
