### PR TITLE
Backport convert VideoToImage to be able to work with any FFmpeg version on 1.6

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/MediaImageExtractor.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/MediaImageExtractor.php
@@ -152,11 +152,13 @@ class MediaImageExtractor implements MediaImageExtractorInterface
      */
     private function convertVideoToImage($content)
     {
-        $temporaryFilePath = $this->createTemporaryFile($content);
-        $this->videoThumbnail->generate($temporaryFilePath, '00:00:02:01', $temporaryFilePath);
+        $source = $this->createTemporaryFile($content);
+        $destination = \tempnam(\sys_get_temp_dir(), 'media');
+        $this->videoThumbnail->generate($source, '00:00:02:01', $destination);
 
-        $extractedImage = \file_get_contents($temporaryFilePath);
-        \unlink($temporaryFilePath);
+        $extractedImage = \file_get_contents($destination);
+        \unlink($source);
+        \unlink($destination);
 
         return $extractedImage;
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | #4733 
| License | MIT

#### What's in this PR?

Fixes the generation of video thumbnails for new ffmpeg versions.

#### Why?

Thumbnail generation didn't work with FFmpeg new version (problem reproduced with `ffmpeg version 4.1.6-1~deb10u1 `, was fine with `ffmpeg version 3.2.15-0+deb9u2`) because `source` and `output` file was the same file. As result, `ffmpeg` command was failed with `exit code 1` and `exception` was thrown.
With this fix, the thumbnail generation works for both old and new `ffmpeg` version.

#### Errors that happened

Errors were logged to `var/logs/website/prod.log`:
```
app.ERROR: ffmpeg failed to execute command '/usr/bin/ffmpeg' '-y' '-ss' '00:00:02.01' '-i' '/tmp/media3JKGvT' '-vframes' '1' '-f' 'image2' '/tmp/media3JKGvT' [] []
request.CRITICAL: Uncaught PHP Exception FFMpeg\Exception\RuntimeException: "Unable to save frame" at /var/www/project/application-b62-083bede5b96c5f6de19c16d7ea7e5a50368010b5/vendor/php-ffmpeg/php-ffmpeg/src/FFMpeg/Media/Frame.php line 119 {"exception":"[object] (FFMpeg\\Exception\\RuntimeException(code: 0): Unable to save frame at /var/www/project/application-b62-083bede5b96c5f6de19c16d7ea7e5a50368010b5/vendor/php-ffmpeg/php-ffmpeg/src/FFMpeg/Media/Frame.php:119, Alchemy\\BinaryDriver\\Exception\\ExecutionFailureException(code: 0): ffmpeg failed to execute command '/usr/bin/ffmpeg' '-y' '-ss' '00:00:02.01' '-i' '/tmp/media3JKGvT' '-vframes' '1' '-f' 'image2' '/tmp/media3JKGvT' at /var/www/project/application-b62-083bede5b96c5f6de19c16d7ea7e5a50368010b5/vendor/alchemy/binary-driver/src/Alchemy/BinaryDriver/ProcessRunner.php:100)"} []
```
Errors happened when explicitly run `ffmpeg` command (`ffmpeg version 4.1.6-1~deb10u1`) on server, screenshot:
![image](https://user-images.githubusercontent.com/881283/136099775-bea6f04e-8396-4bb1-8637-45e26ce44c28.png)

Error text:
```
Output /tmp/mediaBinaryVideo1 same as Input #0 - exiting
FFmpeg cannot edit existing files in-place.
```
