### PR TITLE
Use TemplateAttributeResolver in WebsiteSearchController to set correct localizations attribute

### DIFF
--- a/src/Sulu/Bundle/SearchBundle/Resources/config/search.xml
+++ b/src/Sulu/Bundle/SearchBundle/Resources/config/search.xml
@@ -28,6 +28,7 @@
             <argument type="service" id="sulu_website.resolver.parameter"/>
             <argument type="service" id="twig"/>
             <argument>%sulu_search.website.indexes%</argument>
+            <argument type="service" id="sulu_website.resolver.template_attribute"/>
 
             <tag name="sulu.context" context="website"/>
         </service>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #6274
| License | MIT

#### What's in this PR?

This pull requests adjusts the `WebsiteSearchController` to use the `TemplateAttributeResolver` for resolving the attributes for the twig template. We already use the `TemplateAttributeResolver` in the `ErrorController` to do the same thing:
https://github.com/sulu/sulu/blob/1af4ee3cc12dd9ecca2a39f90ec57d136326e677/src/Sulu/Bundle/WebsiteBundle/Controller/ErrorController.php#L72-L82

This change adjusts the attributes that are passed to the twig template of the search page.

Before:
![Screenshot 2021-10-06 at 10 03 36](https://user-images.githubusercontent.com/13310795/136163775-6e01d527-1f21-40d1-b6bf-a3b8e8decdd9.png)

After:
![Screenshot 2021-10-06 at 10 04 10](https://user-images.githubusercontent.com/13310795/136163841-2468bdd4-8fe0-4c9b-802c-b837e65dc0b7.png)


#### Why?

Because the `localizations` parameter that is passed to the twig template does not contain useful urls at the moment. The `TemplateAttributeResolver` contains the logic for generating the correct urls for all localizations based on the webspace configuration:
https://github.com/sulu/sulu/blob/1af4ee3cc12dd9ecca2a39f90ec57d136326e677/src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php#L150-L177