### PR TITLE
Revert setMaxResult and setFirstResult not set to avoid breaking change in unsetting pagination

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -143,6 +143,7 @@
     "conflict": {
         "doctrine/dbal": "2.7.0",
         "doctrine/lexer": "1.0.0",
+        "doctrine/orm": "2.10.0",
         "doctrine/doctrine-cache-bundle": "<1.3.1",
         "jackalope/jackalope": "< 1.3.4",
         "jackalope/jackalope-doctrine-dbal": "< 1.3.0",

--- a/src/Sulu/Bundle/ContactBundle/Entity/ContactRepository.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/ContactRepository.php
@@ -323,13 +323,8 @@ class ContactRepository extends EntityRepository implements DataProviderReposito
      */
     private function addPagination($qb, $offset, $limit)
     {
-        // Add pagination
-        if ($offset) {
-            $qb->setFirstResult((int) $offset);
-        }
-        if ($limit) {
-            $qb->setMaxResults((int) $limit);
-        }
+        $qb->setFirstResult($offset);
+        $qb->setMaxResults($limit);
 
         return $qb;
     }

--- a/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
@@ -204,10 +204,10 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
                 $qb->setParameter('search', '%' . $search . '%');
             }
             if (null !== $offset) {
-                $qb->setFirstResult((int) $offset);
+                $qb->setFirstResult($offset);
             }
             if (null !== $limit) {
-                $qb->setMaxResults((int) $limit);
+                $qb->setMaxResults($limit);
             }
 
             return new Paginator($qb->getQuery());
@@ -361,11 +361,11 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
 
         $queryBuilder->addOrderBy('collection.id', 'ASC');
 
-        if (isset($filter['limit'])) {
-            $queryBuilder->setMaxResults((int) $filter['limit']);
+        if (\array_key_exists('limit', $filter)) {
+            $queryBuilder->setMaxResults($filter['limit']);
         }
-        if (isset($filter['offset'])) {
-            $queryBuilder->setFirstResult((int) $filter['offset']);
+        if (\array_key_exists('offset', $filter)) {
+            $queryBuilder->setFirstResult($filter['offset']);
         }
 
         return $queryBuilder->getQuery();

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
@@ -320,15 +320,10 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
             ->innerJoin('media.files', 'files')
             ->innerJoin('files.fileVersions', 'versions', 'WITH', 'versions.version = files.version')
             ->join('media.collection', 'collection')
+            ->setFirstResult($offset)
+            ->setMaxResults($limit)
             ->where('collection.id = :collectionId')
             ->setParameter('collectionId', $collectionId);
-
-        if ($offset) {
-            $queryBuilder->setFirstResult((int) $offset);
-        }
-        if ($limit) {
-            $queryBuilder->setMaxResults((int) $limit);
-        }
 
         $query = $queryBuilder->getQuery();
         $paginator = new Paginator($query);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Revert some changes from #6271.

#### Why?

The things was fixed on doctrine/orm 2.10.1 and #6271 did include a breaking change that some setFirst and setMaxresults could not longer be unsetted when given null. 