### PR TITLE
Initialize reflection on parent metadata in MetadataSubscriber of PersistenceBundle

### DIFF
--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/MetadataSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/MetadataSubscriber.php
@@ -91,12 +91,12 @@ class MetadataSubscriber implements EventSubscriber
         }
 
         foreach (\class_parents($metadata->getName()) as $parent) {
-            /** @var ClassMetadata $parentMetadata */
-            $parentMetadata = $classMetadataFactory->getMetadataFor($parent);
-
             if (!\in_array($parent, $this->getAllClassNames($configuration))) {
                 continue;
             }
+            
+            /** @var ClassMetadata $parentMetadata */
+            $parentMetadata = $classMetadataFactory->getMetadataFor($parent);
 
             $configuration->getMetadataDriverImpl()->loadMetadataForClass($parent, $parentMetadata);
             if (!$parentMetadata->isMappedSuperclass) {

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/MetadataSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/MetadataSubscriber.php
@@ -17,7 +17,6 @@ use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
-use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\Persistence\Mapping\ReflectionService;
 
 /**

--- a/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/MetadataSubscriberTest.php
+++ b/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/MetadataSubscriberTest.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Persistence\Mapping\ReflectionService;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sulu\Bundle\ContactBundle\Entity\ContactRepository;
@@ -53,6 +54,11 @@ class MetadataSubscriberTest extends TestCase
      * @var \Doctrine\ORM\Mapping\ClassMetadataFactory
      */
     protected $classMetadataFactory;
+
+    /**
+     * @var \Doctrine\Persistence\Mapping\ReflectionService
+     */
+    protected $reflectionService;
 
     /**
      * @var \Doctrine\ORM\Configuration
@@ -102,6 +108,7 @@ class MetadataSubscriberTest extends TestCase
         $this->reflection = $this->prophesize(\ReflectionClass::class);
         $this->entityManager = $this->prophesize(EntityManager::class);
         $this->classMetadataFactory = $this->prophesize(ClassMetadataFactory::class);
+        $this->reflectionService = $this->prophesize(ReflectionService::class);
         $this->configuration = $this->prophesize(Configuration::class);
 
         $this->subscriber = new MetadataSubscriber($objects);
@@ -118,6 +125,7 @@ class MetadataSubscriberTest extends TestCase
         $this->loadClassMetadataEvent->getEntityManager()->willReturn($this->entityManager->reveal());
         $this->entityManager->getConfiguration()->willReturn($this->configuration->reveal());
         $this->entityManager->getMetadataFactory()->willReturn($this->classMetadataFactory->reveal());
+        $this->classMetadataFactory->getReflectionService()->willReturn($this->reflectionService->reveal());
 
         $this->subscriber->loadClassMetadata($this->loadClassMetadataEvent->reveal());
     }
@@ -133,6 +141,7 @@ class MetadataSubscriberTest extends TestCase
         $this->loadClassMetadataEvent->getEntityManager()->willReturn($this->entityManager->reveal());
         $this->entityManager->getConfiguration()->willReturn($this->configuration->reveal());
         $this->entityManager->getMetadataFactory()->willReturn($this->classMetadataFactory->reveal());
+        $this->classMetadataFactory->getReflectionService()->willReturn($this->reflectionService->reveal());
 
         $this->subscriber->loadClassMetadata($this->loadClassMetadataEvent->reveal());
     }
@@ -151,7 +160,7 @@ class MetadataSubscriberTest extends TestCase
         $this->entityManager->getConfiguration()->willReturn($this->configuration->reveal());
         $this->entityManager->getMetadataFactory()->willReturn($this->classMetadataFactory->reveal());
         $this->configuration->getNamingStrategy()->willReturn(null);
-        $this->classMetadataFactory->getMetadataFor(\stdClass::class)->willReturn($this->parentClassMetadata->reveal());
+        $this->classMetadataFactory->getReflectionService()->willReturn($this->reflectionService->reveal());
 
         /** @var MappingDriver $mappingDriver */
         $mappingDriver = $this->prophesize(MappingDriver::class);

--- a/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/MetadataSubscriberTest.php
+++ b/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/MetadataSubscriberTest.php
@@ -20,48 +20,44 @@ use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\Mapping\ReflectionService;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\ContactBundle\Entity\ContactRepository;
 use Sulu\Component\Persistence\EventSubscriber\ORM\MetadataSubscriber;
 
 class MetadataSubscriberTest extends TestCase
 {
     /**
-     * @var \Doctrine\ORM\Event\LoadClassMetadataEventArgs
+     * @var LoadClassMetadataEventArgs|ObjectProphecy
      */
     protected $loadClassMetadataEvent;
 
     /**
-     * @var \Doctrine\ORM\Mapping\ClassMetadata
+     * @var ClassMetadata|ObjectProphecy
      */
     protected $classMetadata;
 
     /**
-     * @var \Doctrine\ORM\Mapping\ClassMetadata
-     */
-    protected $parentClassMetadata;
-
-    /**
-     * @var \ReflectionClass
+     * @var \ReflectionClass|ObjectProphecy
      */
     protected $reflection;
 
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var EntityManager|ObjectProphecy
      */
     protected $entityManager;
 
     /**
-     * @var \Doctrine\ORM\Mapping\ClassMetadataFactory
+     * @var ClassMetadataFactory|ObjectProphecy
      */
     protected $classMetadataFactory;
 
     /**
-     * @var \Doctrine\Persistence\Mapping\ReflectionService
+     * @var ReflectionService|ObjectProphecy
      */
     protected $reflectionService;
 
     /**
-     * @var \Doctrine\ORM\Configuration
+     * @var Configuration|ObjectProphecy
      */
     protected $configuration;
 
@@ -71,12 +67,12 @@ class MetadataSubscriberTest extends TestCase
     protected $subscriber;
 
     /**
-     * @var \stdClass
+     * @var \stdClass|ObjectProphecy
      */
     protected $object;
 
     /**
-     * @var \stdClass
+     * @var \stdClass|ObjectProphecy
      */
     protected $parentObject;
 
@@ -103,7 +99,6 @@ class MetadataSubscriberTest extends TestCase
             ],
         ];
 
-        $this->parentClassMetadata = $this->prophesize(ClassMetadata::class);
         $this->classMetadata = $this->prophesize(ClassMetadata::class);
         $this->reflection = $this->prophesize(\ReflectionClass::class);
         $this->entityManager = $this->prophesize(EntityManager::class);
@@ -162,7 +157,7 @@ class MetadataSubscriberTest extends TestCase
         $this->configuration->getNamingStrategy()->willReturn(null);
         $this->classMetadataFactory->getReflectionService()->willReturn($this->reflectionService->reveal());
 
-        /** @var MappingDriver $mappingDriver */
+        /** @var MappingDriver|ObjectProphecy $mappingDriver */
         $mappingDriver = $this->prophesize(MappingDriver::class);
         $this->configuration->getMetadataDriverImpl()->willReturn($mappingDriver->reveal());
         $mappingDriver->getAllClassNames()->willReturn([\get_class($this->parentObject->reveal())]);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #6279
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Make `MetadataSubscriber` utilize `ClassMetadataFactory` to create `ClassMetadata` objects of parent classes instead of creating them via `ClassMetadata::__construct`.
#### Why?

`MetadataSubscriber` created `ClassMetadata` objects of parent classes without a `$reflClass` property value. As of now, while Doctrine's `AnnotationDriver` has a hacky workaround, the new `AttributeDriver` for PHP8 attributes strictly requires the reflection class to exist in the metadata object (see #6279 for more details).
Creating a `ClassMetadata` object with `ClassMetadataFactory::getMetadataFor` initializes a `ReflectionClass` object as the `$reflClass` property value, preventing an exception from being thrown.
