### PR TITLE
Remount List view on login to prevent infinite loading screen after 401 response

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/types.js
@@ -13,4 +13,8 @@ interface GetDerivedRouteAttributesInterface {
     +getDerivedRouteAttributes?: (route: Route, attributes: AttributeMap) => Object,
 }
 
-export type View = Class<Component<ViewProps & *>> & GetDerivedRouteAttributesInterface;
+interface RemountViewOnLoginInterface {
+    +remountViewOnLogin?: boolean,
+}
+
+export type View = Class<Component<ViewProps & *>> & GetDerivedRouteAttributesInterface & RemountViewOnLoginInterface;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -41,6 +41,8 @@ class List extends React.Component<Props> {
     @observable itemActions: Array<AbstractListItemAction> = [];
     @observable errors = [];
 
+    static remountViewOnLogin = true;
+
     static getDerivedRouteAttributes(route: Route) {
         const {
             options: {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -35,6 +35,8 @@ class MediaOverview extends React.Component<ViewProps> {
     @observable mediaMoving: boolean = false;
     disposer: () => void;
 
+    static remountViewOnLogin = true;
+
     static getDerivedRouteAttributes() {
         return {
             collectionLimit: ListStore.getLimitSetting(COLLECTIONS_RESOURCE_KEY, USER_SETTINGS_KEY),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #6199
| License | MIT

#### What's in this PR?

This pull request adds an optional `remountViewOnLogin` property on the `View` type definition. If the `remountViewOnLogin` property is set, the view will be remounted if a login happens. A remount will completely reinitialize the view.

#### Why?

To prevent an infinite loading screen in the `List` view when logging in after a 401 response. See #6199 for a full explanation.
