### PR TITLE
Move http cache directory before deleting it to prevent new requests from writing into old directory

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Cache/CacheClearer.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Cache/CacheClearer.php
@@ -91,7 +91,10 @@ class CacheClearer implements CacheClearerInterface
         );
 
         if ($this->filesystem->exists($path)) {
-            $this->filesystem->remove($path);
+            // rename directory before removing it to prevent new requests from writing into the old directory
+            $invalidatedPath = $path . '_invalidated';
+            $this->filesystem->rename($path, $invalidatedPath, true);
+            $this->filesystem->remove($invalidatedPath);
         }
 
         $this->eventDispatcher->dispatch(new CacheClearEvent(), Events::CACHE_CLEAR);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #6289
| License | MIT

#### What's in this PR?

This PR moves the directory used for the http cache before removing it. This prevents new requests from writing into the old directory during deletion (see #6289)

#### Why?

Moving the directory might be faster than recursively removing it (especially if the directory contains a lot of files).
