### PR TITLE
Using the DocumentMangerInterface in every constructor

### DIFF
--- a/src/Sulu/Bundle/DocumentManagerBundle/DataFixtures/DocumentExecutor.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/DataFixtures/DocumentExecutor.php
@@ -13,7 +13,7 @@ namespace Sulu\Bundle\DocumentManagerBundle\DataFixtures;
 
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Sulu\Bundle\DocumentManagerBundle\Initializer\Initializer;
-use Sulu\Component\DocumentManager\DocumentManager;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -27,7 +27,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class DocumentExecutor
 {
     /**
-     * @var DocumentManager
+     * @var DocumentManagerInterface
      */
     private $documentManager;
 
@@ -37,7 +37,7 @@ class DocumentExecutor
     private $initializer;
 
     public function __construct(
-        DocumentManager $documentManager,
+        DocumentManagerInterface $documentManager,
         Initializer $initializer
     ) {
         $this->documentManager = $documentManager;

--- a/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
@@ -24,7 +24,7 @@ use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\Content\Metadata\BlockMetadata;
 use Sulu\Component\Content\Metadata\ItemMetadata;
 use Sulu\Component\Content\Metadata\PropertyMetadata;
-use Sulu\Component\DocumentManager\DocumentManager;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
 use Symfony\Component\Console\Command\Command;
@@ -48,7 +48,7 @@ class WebspaceCopyCommand extends Command
     private $output;
 
     /**
-     * @var DocumentManager
+     * @var DocumentManagerInterface
      */
     private $documentManager;
 
@@ -78,7 +78,7 @@ class WebspaceCopyCommand extends Command
     protected $webspaceKeyDestination;
 
     public function __construct(
-        DocumentManager $documentManager,
+        DocumentManagerInterface $documentManager,
         SessionManagerInterface $sessionManager,
         DocumentInspector $documentInspector,
         HtmlTagExtractor $htmlTagExtractor

--- a/src/Sulu/Bundle/PageBundle/Form/Type/PageDocumentType.php
+++ b/src/Sulu/Bundle/PageBundle/Form/Type/PageDocumentType.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\PageBundle\Form\Type;
 
 use Sulu\Component\Content\Form\Type\DocumentObjectType;
-use Sulu\Component\DocumentManager\DocumentManager;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Metadata\MetadataFactory;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
@@ -40,7 +39,7 @@ class PageDocumentType extends BasePageDocumentType
 
     public function __construct(
         SessionManagerInterface $sessionManager,
-        DocumentManager $documentManager,
+        DocumentManagerInterface $documentManager,
         MetadataFactory $metadataFactory
     ) {
         $this->sessionManager = $sessionManager;

--- a/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
@@ -23,7 +23,7 @@ use Sulu\Component\Content\Compat\StructureManagerInterface;
 use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\Content\Form\Exception\InvalidFormException;
 use Sulu\Component\Content\Mapper\ContentMapper;
-use Sulu\Component\DocumentManager\DocumentManager;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\MetadataFactoryInterface;
 use Sulu\Component\Hash\RequestHashChecker;
 use Sulu\Component\Rest\Exception\RestException;
@@ -82,7 +82,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
     private $defaultSnippetManager;
 
     /**
-     * @var DocumentManager
+     * @var DocumentManagerInterface
      */
     private $documentManager;
 
@@ -119,7 +119,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
         TokenStorageInterface $tokenStorage,
         UrlGeneratorInterface $urlGenerator,
         DefaultSnippetManagerInterface $defaultSnippetManager,
-        DocumentManager $documentManager,
+        DocumentManagerInterface $documentManager,
         FormFactory $formFactory,
         RequestHashChecker $requestHashChecker,
         ListRestHelper $listRestHelper,

--- a/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetRepository.php
+++ b/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetRepository.php
@@ -18,7 +18,7 @@ use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Sulu\Component\Content\Compat\Structure;
 use Sulu\Component\Content\Compat\Structure\SnippetBridge;
 use Sulu\Component\Content\Mapper\ContentMapper;
-use Sulu\Component\DocumentManager\DocumentManager;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 use Sulu\Component\PHPCR\SessionManager\SessionManager;
 
@@ -44,11 +44,11 @@ class SnippetRepository
     private $contentMapper;
 
     /**
-     * @var DocumentManager
+     * @var DocumentManagerInterface
      */
     private $documentManager;
 
-    public function __construct(SessionManager $sessionManager, ContentMapper $contentMapper, DocumentManager $documentManager)
+    public function __construct(SessionManager $sessionManager, ContentMapper $contentMapper, DocumentManagerInterface $documentManager)
     {
         $this->contentMapper = $contentMapper;
         $this->sessionManager = $sessionManager;

--- a/src/Sulu/Component/Content/Form/DataTransformer/DocumentToUuidTransformer.php
+++ b/src/Sulu/Component/Content/Form/DataTransformer/DocumentToUuidTransformer.php
@@ -60,7 +60,6 @@ class DocumentToUuidTransformer implements DataTransformerInterface
         }
 
         $document = $this->documentManager->find($uuid);
-
         if (null === $document) {
             throw new TransformationFailedException(\sprintf(
                 'Could not find document with UUID "%s"', $uuid

--- a/src/Sulu/Component/Content/Form/DataTransformer/DocumentToUuidTransformer.php
+++ b/src/Sulu/Component/Content/Form/DataTransformer/DocumentToUuidTransformer.php
@@ -13,15 +13,18 @@ namespace Sulu\Component\Content\Form\DataTransformer;
 
 use PHPCR\Util\UUIDHelper;
 use Sulu\Component\DocumentManager\Behavior\Mapping\UuidBehavior;
-use Sulu\Component\DocumentManager\DocumentManager;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 
 class DocumentToUuidTransformer implements DataTransformerInterface
 {
+    /**
+     * @var DocumentManagerInterface
+     */
     private $documentManager;
 
-    public function __construct(DocumentManager $documentManager)
+    public function __construct(DocumentManagerInterface $documentManager)
     {
         $this->documentManager = $documentManager;
     }

--- a/src/Sulu/Component/Content/Form/Type/DocumentObjectType.php
+++ b/src/Sulu/Component/Content/Form/Type/DocumentObjectType.php
@@ -12,7 +12,7 @@
 namespace Sulu\Component\Content\Form\Type;
 
 use Sulu\Component\Content\Form\DataTransformer\DocumentToUuidTransformer;
-use Sulu\Component\DocumentManager\DocumentManager;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -23,11 +23,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class DocumentObjectType extends AbstractType
 {
     /**
-     * @var DocumentManager
+     * @var DocumentManagerInterface
      */
     private $documentManager;
 
-    public function __construct(DocumentManager $documentManager)
+    public function __construct(DocumentManagerInterface $documentManager)
     {
         $this->documentManager = $documentManager;
     }

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -54,7 +54,7 @@ use Sulu\Component\Content\Types\ResourceLocator\Strategy\ResourceLocatorStrateg
 use Sulu\Component\DocumentManager\Behavior\Mapping\ParentBehavior;
 use Sulu\Component\DocumentManager\Document\UnknownDocument;
 use Sulu\Component\DocumentManager\DocumentAccessor;
-use Sulu\Component\DocumentManager\DocumentManager;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 use Sulu\Component\DocumentManager\NamespaceRegistry;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
@@ -112,7 +112,7 @@ class ContentMapper implements ContentMapperInterface
     private $resourceLocatorStrategyPool;
 
     /**
-     * @var DocumentManager
+     * @var DocumentManagerInterface
      */
     private $documentManager;
 
@@ -152,7 +152,7 @@ class ContentMapper implements ContentMapperInterface
     private $security;
 
     public function __construct(
-        DocumentManager $documentManager,
+        DocumentManagerInterface $documentManager,
         WebspaceManagerInterface $webspaceManager,
         FormFactoryInterface $formFactory,
         DocumentInspector $inspector,

--- a/src/Sulu/Component/DocumentManager/DocumentManagerInterface.php
+++ b/src/Sulu/Component/DocumentManager/DocumentManagerInterface.php
@@ -74,9 +74,10 @@ interface DocumentManagerInterface
 
     /**
      * Re-Order node before or after a specific node.
+     * If the destId is null, then the document will be sorted at the end.
      *
      * @param object $document
-     * @param string $destId
+     * @param string|null $destId
      */
     public function reorder($document, $destId);
 

--- a/src/Sulu/Component/DocumentManager/Event/ReorderEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/ReorderEvent.php
@@ -16,13 +16,15 @@ use PHPCR\NodeInterface;
 class ReorderEvent extends AbstractMappingEvent
 {
     /**
-     * @var string
+     * @var string|null
      */
     private $destId;
 
     /**
+     * Creates a re-ordering event. If the destId is null then the element will be sorted to the end.
+     *
      * @param object $document
-     * @param string $destId
+     * @param string|null $destId
      */
     public function __construct($document, $destId)
     {
@@ -40,7 +42,7 @@ class ReorderEvent extends AbstractMappingEvent
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getDestId()
     {

--- a/src/Sulu/Component/Snippet/Export/SnippetExport.php
+++ b/src/Sulu/Component/Snippet/Export/SnippetExport.php
@@ -14,7 +14,7 @@ namespace Sulu\Component\Snippet\Export;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Sulu\Bundle\SnippetBundle\Snippet\SnippetRepository;
-use Sulu\Component\DocumentManager\DocumentManager;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
 use Sulu\Component\Export\Export;
 use Sulu\Component\Export\Manager\ExportManagerInterface;
@@ -41,7 +41,7 @@ class SnippetExport extends Export implements SnippetExportInterface
     public function __construct(
         Environment $templating,
         SnippetRepository $snippetManager,
-        DocumentManager $documentManager,
+        DocumentManagerInterface $documentManager,
         DocumentInspector $documentInspector,
         ExportManagerInterface $exportManager,
         $formatFilePaths

--- a/src/Sulu/Component/Snippet/Import/SnippetImport.php
+++ b/src/Sulu/Component/Snippet/Import/SnippetImport.php
@@ -17,7 +17,6 @@ use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Sulu\Component\Content\Compat\Structure;
 use Sulu\Component\Content\Compat\Structure\LegacyPropertyFactory;
 use Sulu\Component\Content\Compat\StructureManagerInterface;
-use Sulu\Component\DocumentManager\DocumentManager;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\DocumentRegistry;
 use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
@@ -55,7 +54,7 @@ class SnippetImport extends Import implements SnippetImportInterface
     protected $logger;
 
     public function __construct(
-        DocumentManager $documentManager,
+        DocumentManagerInterface $documentManager,
         StructureManagerInterface $structureManager,
         DocumentRegistry $documentRegistry,
         ImportManagerInterface $importManager,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no (maintenance)
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?
This pull request replaces all usages of the Sulu hardcoded document manger with the respective interface. I have only changed the constructor calls as changing the interface in the fixtures for example would cause a BC break.

#### Why?
I was trying to add debug information to the DocumentManager by decorating it and noticed that the application hard hard dependencies on the Sulu class and not the correct interface.

#### Example Usage
Use code like this:
```php
use Sulu\Component\DocumentManager\DocumentManagerInterface

class SomeClass {
    public function __construct(DocumentManagerInterface $documentManager) {
    }
}
```
And not like this:
```php
use Sulu\Component\DocumentManager\DocumentManager;

class SomeClass {
    public function __construct(DocumentManager $documentManager) {
    }
}
```

#### To Do
In the future there should be more classes that need to be abstracted away by interfaces to make the system easier to extend.
