### PR TITLE
Allow return ghostLocale always

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/AbstractTableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/AbstractTableAdapter.js
@@ -45,7 +45,7 @@ export default class AbstractTableAdapter extends AbstractAdapter {
 
             const indicators = [];
             if (index === 0) {
-                if (item.ghostLocale) {
+                if (item.ghostLocale && item.ghostLocale !== item.locale) {
                     indicators.push(
                         <GhostIndicator
                             className={abstractTableAdapterStyles.ghostIndicator}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
@@ -102,7 +102,7 @@ class ColumnListAdapter extends AbstractAdapter {
     };
 
     getIndicators = (item: Object) => {
-        if (item.ghostLocale) {
+        if (item.ghostLocale && item.ghostLocale !== item.locale) {
             return [<GhostIndicator key="ghost" locale={item.ghostLocale} />];
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/ColumnListAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/ColumnListAdapter.test.js
@@ -94,6 +94,14 @@ test('Render different kind of data with edit button', () => {
                     view: false,
                 },
             },
+            {
+                id: 12,
+                title: 'Page 2.1.3',
+                hasChildren: false,
+                publishedState: false,
+                ghostLocale: 'nl',
+                locale: 'nl',
+            },
         ],
         [],
     ];

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
@@ -87,6 +87,14 @@ test('Render data with schema', () => {
             published: null,
             ghostLocale: 'de',
         },
+        {
+            id: 9,
+            title: 'Page 9',
+            publishedState: false,
+            published: null,
+            ghostLocale: 'de',
+            locale: 'de',
+        },
     ];
 
     const schema = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/ColumnListAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/ColumnListAdapter.test.js.snap
@@ -1143,7 +1143,7 @@ exports[`Render different kind of data with edit button 1`] = `
                   aria-hidden="true"
                   class="front"
                 >
-                  Page 
+                  Page
                 </div>
                 <div
                   aria-hidden="true"
@@ -1209,7 +1209,7 @@ exports[`Render different kind of data with edit button 1`] = `
                   aria-hidden="true"
                   class="front"
                 >
-                  Page 
+                  Page
                 </div>
                 <div
                   aria-hidden="true"
@@ -1233,6 +1233,53 @@ exports[`Render different kind of data with edit button 1`] = `
                 aria-label="su-shadow-page"
                 class="su-shadow-page"
               />
+            </span>
+            <span
+              class="children"
+            />
+          </div>
+          <div
+            class="item"
+            role="button"
+          >
+            <span
+              class="buttons"
+            >
+              <span
+                aria-label="su-pen"
+                class="su-pen clickable button"
+                role="button"
+                tabindex="0"
+              />
+            </span>
+            <span
+              class="text"
+            >
+              <div
+                aria-label="Page 2.1.3"
+                class="croppedText"
+                title="Page 2.1.3"
+              >
+                <div
+                  aria-hidden="true"
+                  class="front"
+                >
+                  Page
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="back"
+                >
+                  <span>
+                    2.1.3
+                  </span>
+                </div>
+                <div
+                  class="whole"
+                >
+                  Page 2.1.3
+                </div>
+              </div>
             </span>
             <span
               class="children"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TableAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TableAdapter.test.js.snap
@@ -1104,6 +1104,19 @@ exports[`Render data with schema 1`] = `
             </div>
           </td>
         </tr>
+        <tr
+          class="row"
+        >
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              Page 9
+            </div>
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | yes
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #6298 <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Allow return ghostLocale always.

#### Why?

Makes queries for the list simpler to return the ghostLocale and locale instead of filter out if ghostLocale should be set to null or not.
