### PR TITLE
Fix accidently remove of category entity when one category translation is removed

### DIFF
--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/Category.orm.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/Category.orm.xml
@@ -29,13 +29,13 @@
         </many-to-one>
         <one-to-many field="meta" target-entity="Sulu\Bundle\CategoryBundle\Entity\CategoryMetaInterface" mapped-by="category">
             <cascade>
-                <cascade-all/>
+                <cascade-persist/>
             </cascade>
         </one-to-many>
         <one-to-many field="translations" target-entity="Sulu\Bundle\CategoryBundle\Entity\CategoryTranslationInterface"
                      mapped-by="category">
             <cascade>
-                <cascade-all/>
+                <cascade-persist/>
             </cascade>
         </one-to-many>
         <one-to-many field="children" target-entity="Sulu\Bundle\CategoryBundle\Entity\CategoryInterface" mapped-by="parent"/>

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/CategoryMeta.orm.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/CategoryMeta.orm.xml
@@ -13,9 +13,6 @@
         <field name="locale" column="locale" type="string" length="5" nullable="true"/>
 
         <many-to-one field="category" target-entity="Sulu\Bundle\CategoryBundle\Entity\CategoryInterface" inversed-by="meta">
-            <cascade>
-                <cascade-all/>
-            </cascade>
             <join-columns>
                 <join-column name="idCategories" on-delete="CASCADE" referenced-column-name="id" nullable="false"/>
             </join-columns>

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/CategoryTranslation.orm.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/CategoryTranslation.orm.xml
@@ -22,9 +22,6 @@
         </one-to-many>
 
         <many-to-one field="category" target-entity="Sulu\Bundle\CategoryBundle\Entity\CategoryInterface" inversed-by="translations">
-            <cascade>
-                <cascade-all/>
-            </cascade>
             <join-columns>
                 <join-column name="idCategories" on-delete="CASCADE" referenced-column-name="id" nullable="false"/>
             </join-columns>


### PR DESCRIPTION
…ntity is removed

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #6300 
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

Fixing cascading of category translation and category meta entity related to category entity

#### Why?

Allow deleting single category translation programmatically without deleting main category

#### Example Usage

```php
       $translationEntity = $category->findTranslationByLocale($locale);

        if ($translationEntity) {
            $this->entityManager->remove($translationEntity);
            $this->entityManager->flush();
        }
```
