### PR TITLE
Fix CacheLifetimeEnhancerInterface usage in WebsiteController

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\WebsiteBundle\Controller;
 
-use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeEnhancer;
 use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeEnhancerInterface;
 use Sulu\Bundle\PreviewBundle\Preview\Preview;
 use Sulu\Bundle\WebsiteBundle\Resolver\ParameterResolverInterface;

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
@@ -168,7 +168,7 @@ abstract class WebsiteController extends AbstractController
             return null;
         }
 
-        /** @var CacheLifetimeEnhancer $cacheLifetimeEnhancer */
+        /** @var CacheLifetimeEnhancerInterface $cacheLifetimeEnhancer */
         $cacheLifetimeEnhancer = $this->get('sulu_http_cache.cache_lifetime.enhancer');
 
         return $cacheLifetimeEnhancer;

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
@@ -162,7 +162,7 @@ abstract class WebsiteController extends AbstractController
         return $this->get('request_stack')->getCurrentRequest();
     }
 
-    protected function getCacheTimeLifeEnhancer(): ?CacheLifetimeEnhancer
+    protected function getCacheTimeLifeEnhancer(): ?CacheLifetimeEnhancerInterface
     {
         if (!$this->has('sulu_http_cache.cache_lifetime.enhancer')) {
             return null;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | #6301
| License | MIT

#### What's in this PR?

CacheLifetimeEnhancer use interface instead of class

#### Why?

To make it easier to overwrite.
