### PR TITLE
Index and deindex shadow documents

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Resources/config/search.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/search.xml
@@ -41,6 +41,13 @@
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 
+        <service id="sulu_page.search.event_subscriber.shadow_structure" class="Sulu\Bundle\PageBundle\Search\EventSubscriber\ShadowStructureSubscriber">
+            <argument type="service" id="sulu_document_manager.document_manager" />
+            <argument type="service" id="sulu_document_manager.document_inspector" />
+            <argument type="service" id="massive_search.search_manager" />
+            <tag name="sulu_document_manager.event_subscriber" />
+        </service>
+
         <service id="sulu_search.event_listener.hit" class="%sulu_search.event_listener.hit.class%">
             <argument type="service" id="sulu_core.webspace.request_analyzer" />
             <tag name="kernel.event_listener" event="massive_search.hit" method="onHit" />

--- a/src/Sulu/Bundle/PageBundle/Search/EventSubscriber/ShadowStructureSubscriber.php
+++ b/src/Sulu/Bundle/PageBundle/Search/EventSubscriber/ShadowStructureSubscriber.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PageBundle\Search\EventSubscriber;
+
+use Massive\Bundle\SearchBundle\Search\SearchManagerInterface;
+use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
+use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
+use Sulu\Component\Content\Document\Behavior\ShadowLocaleBehavior;
+use Sulu\Component\Content\Document\Behavior\StructureBehavior;
+use Sulu\Component\DocumentManager\Behavior\Mapping\UuidBehavior;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Sulu\Component\DocumentManager\Event\PublishEvent;
+use Sulu\Component\DocumentManager\Event\RemoveDraftEvent;
+use Sulu\Component\DocumentManager\Event\RemoveEvent;
+use Sulu\Component\DocumentManager\Event\RemoveLocaleEvent;
+use Sulu\Component\DocumentManager\Event\UnpublishEvent;
+use Sulu\Component\DocumentManager\Events;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class ShadowStructureSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var DocumentManagerInterface
+     */
+    private $documentManager;
+    /**
+     * @var DocumentInspector
+     */
+    private $documentInspector;
+    /**
+     * @var SearchManagerInterface
+     */
+    private $searchManager;
+
+    public function __construct(
+        DocumentManagerInterface $documentManager,
+        DocumentInspector $documentInspector,
+        SearchManagerInterface $searchManager
+    ) {
+        $this->documentManager = $documentManager;
+        $this->documentInspector = $documentInspector;
+        $this->searchManager = $searchManager;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::PUBLISH => ['indexPublishedShadowDocuments', -256],
+            Events::REMOVE => ['deindexRemovedShadowDocuments', 600],
+            Events::UNPUBLISH => ['deindexUnpublishedShadowDocuments', -1024],
+            Events::REMOVE_DRAFT => ['indexShadowDocumentsAfterRemoveDraft', -1024],
+            Events::REMOVE_LOCALE => ['deindexRemovedLocaleShadowDocuments', -1024],
+        ];
+    }
+
+    public function indexPublishedShadowDocuments(PublishEvent $event): void
+    {
+        $this->indexShadowDocuments($event->getDocument());
+    }
+
+    public function indexShadowDocumentsAfterRemoveDraft(RemoveDraftEvent $event): void
+    {
+        $this->indexShadowDocuments($event->getDocument());
+    }
+
+    public function deindexRemovedShadowDocuments(RemoveEvent $event): void
+    {
+        $this->deindexShadowDocuments($event->getDocument());
+    }
+
+    public function deindexUnpublishedShadowDocuments(UnpublishEvent $event): void
+    {
+        $this->deindexShadowDocuments($event->getDocument());
+    }
+
+    public function deindexRemovedLocaleShadowDocuments(RemoveLocaleEvent $event): void
+    {
+        $this->deindexShadowDocuments($event->getDocument());
+    }
+
+    /**
+     * Index shadow documents in search implementation depending
+     * on the publish state.
+     *
+     * @param object $document
+     */
+    private function indexShadowDocuments($document): void
+    {
+        if (!$document instanceof StructureBehavior) {
+            return;
+        }
+
+        if ($document instanceof SecurityBehavior && !empty($document->getPermissions())) {
+            return;
+        }
+
+        if (!$document instanceof ShadowLocaleBehavior || !$document instanceof UuidBehavior) {
+            return;
+        }
+
+        $locales = $this->documentInspector->getShadowLocales($document);
+        foreach ($locales as $locale => $shadowLocale) {
+            $shadowDocument = $this->documentManager->find($document->getUuid(), $locale);
+            $this->searchManager->index($shadowDocument);
+        }
+    }
+
+    /**
+     * Deindex shadow documents in search implementation depending
+     * on the publish state.
+     *
+     * @param object $document
+     */
+    private function deindexShadowDocuments($document): void
+    {
+        if (!$document instanceof StructureBehavior) {
+            return;
+        }
+
+        if (!$document instanceof ShadowLocaleBehavior || !$document instanceof UuidBehavior) {
+            return;
+        }
+
+        $locales = $this->documentInspector->getShadowLocales($document);
+        foreach ($locales as $locale => $shadowLocale) {
+            $shadowDocument = $this->documentManager->find($document->getUuid(), $locale);
+            $this->searchManager->deindex($shadowDocument);
+        }
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | yes
| Deprecations? | -
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Index or reindex shadow documents with original locale

#### Why?

Shadow pages are not being indexed

- Go to sulu.rocks
- Unpublish **coyoos** page in 'de'
- Set shadow page with 'en'
- Change something in English version
- https://sulu.rocks/de/search?q=coyoos ( 0 results )


I don't know if WorkflowStageBehavior must be taken in count in this case