### PR TITLE
Fix xliff import publish date in WebspaceImport

### DIFF
--- a/src/Sulu/Component/Content/Import/WebspaceImport.php
+++ b/src/Sulu/Component/Content/Import/WebspaceImport.php
@@ -235,7 +235,7 @@ class WebspaceImport extends Import implements WebspaceImportInterface
             // save document
             $this->documentManager->persist($document, $locale);
 
-            if (WorkflowStage::PUBLISHED === ((int) $data['workflowStage']['value'])) {
+            if (WorkflowStage::PUBLISHED === ((int) $this->getParser($format)->getPropertyData('workflowStage', $data))) {
                 $this->documentManager->publish($document, $locale);
             }
 

--- a/src/Sulu/Component/Content/Import/WebspaceImport.php
+++ b/src/Sulu/Component/Content/Import/WebspaceImport.php
@@ -233,7 +233,12 @@ class WebspaceImport extends Import implements WebspaceImportInterface
 
             // save document
             $this->documentManager->persist($document, $locale);
-            $this->documentManager->publish($document, $locale);
+            
+            // Only publish when workflowStage is set to published.
+            if (2 == $data['workflowStage']['value']){
+                $this->documentManager->publish($document, $locale);
+            }
+
             $this->documentManager->flush();
             $this->documentRegistry->clear(); // FIXME else it failed on multiple page import
 

--- a/src/Sulu/Component/Content/Import/WebspaceImport.php
+++ b/src/Sulu/Component/Content/Import/WebspaceImport.php
@@ -235,7 +235,6 @@ class WebspaceImport extends Import implements WebspaceImportInterface
             // save document
             $this->documentManager->persist($document, $locale);
 
-            // Only publish when workflowStage is set to published.
             if (WorkflowStage::PUBLISHED === ((int) $data['workflowStage']['value'])) {
                 $this->documentManager->publish($document, $locale);
             }

--- a/src/Sulu/Component/Content/Import/WebspaceImport.php
+++ b/src/Sulu/Component/Content/Import/WebspaceImport.php
@@ -236,7 +236,7 @@ class WebspaceImport extends Import implements WebspaceImportInterface
             $this->documentManager->persist($document, $locale);
 
             // Only publish when workflowStage is set to published.
-            if (WorkflowStage::PUBLISHED == ((int) $data['workflowStage']['value'])){
+            if (WorkflowStage::PUBLISHED === ((int) $data['workflowStage']['value'])) {
                 $this->documentManager->publish($document, $locale);
             }
 

--- a/src/Sulu/Component/Content/Import/WebspaceImport.php
+++ b/src/Sulu/Component/Content/Import/WebspaceImport.php
@@ -20,6 +20,7 @@ use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\Structure;
 use Sulu\Component\Content\Compat\Structure\LegacyPropertyFactory;
 use Sulu\Component\Content\Compat\StructureManagerInterface;
+use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\Content\Exception\ResourceLocatorGeneratorException;
 use Sulu\Component\Content\Extension\ExportExtensionInterface;
 use Sulu\Component\Content\Extension\ExtensionManagerInterface;
@@ -233,9 +234,9 @@ class WebspaceImport extends Import implements WebspaceImportInterface
 
             // save document
             $this->documentManager->persist($document, $locale);
-            
+
             // Only publish when workflowStage is set to published.
-            if (2 == $data['workflowStage']['value']){
+            if (WorkflowStage::PUBLISHED == ((int) $data['workflowStage']['value'])){
                 $this->documentManager->publish($document, $locale);
             }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no yes
| Deprecations? | no 
| Fixed tickets | I dont know
| Related issues/PRs | I dont know
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

This Pull Request fixes pages not keeping their correct workflowStage after and XLIFF import.

#### Why?
When exporting a webspace with unpublished pages and importing again the workflowStage is ignored and just set to published.
