### PR TITLE
Fix on delete cascade on category translation keyword relation

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,19 @@
 # Upgrade
 
+## 2.2.17
+
+### Add missing on delete cascade on CategoryTranslation to Keyword relation
+
+The relation table `ca_category_translation_keywords` is missing a `ON DELETE CASCADE`
+to the related entities.
+
+```sql
+ALTER TABLE ca_category_translation_keywords DROP FOREIGN KEY FK_D15FBE3717CA14DA;
+ALTER TABLE ca_category_translation_keywords DROP FOREIGN KEY FK_D15FBE37F9FC9F05;
+ALTER TABLE ca_category_translation_keywords ADD CONSTRAINT FK_D15FBE3717CA14DA FOREIGN KEY (idCategoryTranslations) REFERENCES ca_category_translations (id) ON DELETE CASCADE;
+ALTER TABLE ca_category_translation_keywords ADD CONSTRAINT FK_D15FBE37F9FC9F05 FOREIGN KEY (idKeywords) REFERENCES ca_keywords (id) ON DELETE CASCADE;
+```
+
 ## 2.2.15
 
 ### Add doctrine/dbal 3 and doctrine/orm 2.10 support
@@ -7,11 +21,11 @@
 The doctrine/orm 2.10 did remove the deprecated `json_array` type which need to be patched to `json` type.
 
 ```sql
-ALTER TABLE se_role_settings CHANGE value value JSON NOT NULL;
-ALTER TABLE we_analytics CHANGE content content JSON NOT NULL;
+ALTER TABLE se_role_settings CHANGE `value` `value` JSON NOT NULL;
+ALTER TABLE we_analytics CHANGE `content` `content` JSON NOT NULL;
 
 -- if you use audience targeting also the following is required:
-ALTER TABLE at_target_group_conditions CHANGE condition condition JSON NOT NULL
+ALTER TABLE at_target_group_conditions CHANGE `condition` `condition` JSON NOT NULL
 ```
 
 If you upgrade doctrine/dbal to Version 3 see the [DBAL 3.0 UPGRADE.md](https://github.com/doctrine/dbal/blob/3.1.x/UPGRADE.md#upgrade-to-30).

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/Keyword.orm.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/Keyword.orm.xml
@@ -23,10 +23,10 @@
                       inversed-by="keywords">
             <join-table name="ca_category_translation_keywords">
                 <join-columns>
-                    <join-column name="idKeywords" referenced-column-name="id"/>
+                    <join-column name="idKeywords" referenced-column-name="id" on-delete="CASCADE"/>
                 </join-columns>
                 <inverse-join-columns>
-                    <join-column name="idCategoryTranslations" referenced-column-name="id"/>
+                    <join-column name="idCategoryTranslations" referenced-column-name="id" on-delete="CASCADE"/>
                 </inverse-join-columns>
             </join-table>
         </many-to-many>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #6304 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix on delete cascade on category translation keyword relation.

#### Why?

Currently deletion was done over doctrine in the memory which did end an error see #6304 also it ended in lazy loaded entities when deletion. To this it correctly on database level the following change is required, currently tests fail on 2.x because of the change in #6304.