### PR TITLE
Fix compatibility with fos/rest-bundle 3.1.0

### DIFF
--- a/src/Sulu/Component/Rest/FlattenExceptionNormalizer.php
+++ b/src/Sulu/Component/Rest/FlattenExceptionNormalizer.php
@@ -69,6 +69,6 @@ class FlattenExceptionNormalizer implements NormalizerInterface
 
     public function supportsNormalization($data, $format = null)
     {
-        return $this->decoratedNormalizer->supportsNormalization($data, $format);
+        return $data instanceof FlattenException;
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/FriendsOfSymfony/FOSRestBundle/issues/2342, https://github.com/FriendsOfSymfony/FOSRestBundle/pull/2294 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

In this PR we change the `supportsNormalization` to the old behaviour of the fos rest bundle, else our custom flatten exception normalizer will not be called or  handled correctly. This is a workaround for FriendsOfSymfony/FOSRestBundle#2342.

#### Why?

The fos/rest-bundle 3.1.0 is handling errors differently which does curently break the overwritten flatten exception normalizer

