### PR TITLE
Add trash handling for custom urls

### DIFF
--- a/src/Sulu/Bundle/CustomUrlBundle/Admin/CustomUrlAdmin.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Admin/CustomUrlAdmin.php
@@ -27,6 +27,8 @@ use Sulu\Component\Webspace\Webspace;
  */
 class CustomUrlAdmin extends Admin
 {
+    public const LIST_VIEW = 'sulu_custom_url.custom_urls_list';
+
     /**
      * Returns security context for custom-urls in given webspace.
      *
@@ -76,7 +78,7 @@ class CustomUrlAdmin extends Admin
         if ($this->hasSomeWebspaceCustomUrlPermission()) {
             $viewCollection->add(
                 $this->viewBuilderFactory
-                    ->createFormOverlayListViewBuilder('sulu_custom_url.custom_urls_list', '/custom-urls')
+                    ->createFormOverlayListViewBuilder(static::LIST_VIEW, '/custom-urls')
                     ->setResourceKey(CustomUrlDocument::RESOURCE_KEY)
                     ->setListKey('custom_urls')
                     ->addListAdapters(['table'])

--- a/src/Sulu/Bundle/CustomUrlBundle/DependencyInjection/SuluCustomUrlExtension.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/DependencyInjection/SuluCustomUrlExtension.php
@@ -30,11 +30,17 @@ class SuluCustomUrlExtension extends Extension implements PrependExtensionInterf
 {
     public function load(array $configs, ContainerBuilder $container)
     {
+        $bundles = $container->getParameter('kernel.bundles');
+
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('admin.xml');
         $loader->load('document.xml');
         $loader->load('routing.xml');
         $loader->load('event_listener.xml');
+
+        if (\array_key_exists('SuluTrashBundle', $bundles)) {
+            $loader->load('services_trash.xml');
+        }
     }
 
     public function prepend(ContainerBuilder $container)

--- a/src/Sulu/Bundle/CustomUrlBundle/Domain/Event/CustomUrlRestoredEvent.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Domain/Event/CustomUrlRestoredEvent.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CustomUrlBundle\Domain\Event;
+
+use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
+use Sulu\Bundle\CustomUrlBundle\Admin\CustomUrlAdmin;
+use Sulu\Component\CustomUrl\Document\CustomUrlDocument;
+
+class CustomUrlRestoredEvent extends DomainEvent
+{
+    /**
+     * @var CustomUrlDocument
+     */
+    private $customUrlDocument;
+
+    /**
+     * @var string
+     */
+    private $webspaceKey;
+
+    /**
+     * @var mixed[]
+     */
+    private $payload;
+
+    /**
+     * @param mixed[] $payload
+     */
+    public function __construct(
+        CustomUrlDocument $customUrlDocument,
+        string $webspaceKey,
+        array $payload
+    ) {
+        parent::__construct();
+
+        $this->customUrlDocument = $customUrlDocument;
+        $this->webspaceKey = $webspaceKey;
+        $this->payload = $payload;
+    }
+
+    public function getCustomUrlDocument(): CustomUrlDocument
+    {
+        return $this->customUrlDocument;
+    }
+
+    public function getEventType(): string
+    {
+        return 'restored';
+    }
+
+    public function getEventPayload(): ?array
+    {
+        return $this->payload;
+    }
+
+    public function getResourceKey(): string
+    {
+        return CustomUrlDocument::RESOURCE_KEY;
+    }
+
+    public function getResourceId(): string
+    {
+        return (string) $this->customUrlDocument->getUuid();
+    }
+
+    public function getResourceWebspaceKey(): ?string
+    {
+        return $this->webspaceKey;
+    }
+
+    public function getResourceTitle(): ?string
+    {
+        return $this->customUrlDocument->getTitle();
+    }
+
+    public function getResourceSecurityContext(): ?string
+    {
+        return CustomUrlAdmin::getCustomUrlSecurityContext($this->webspaceKey);
+    }
+}

--- a/src/Sulu/Bundle/CustomUrlBundle/EventListener/CustomUrlSerializeEventSubscriber.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/EventListener/CustomUrlSerializeEventSubscriber.php
@@ -17,6 +17,7 @@ use JMS\Serializer\EventDispatcher\ObjectEvent;
 use JMS\Serializer\Metadata\StaticPropertyMetadata;
 use JMS\Serializer\Visitor\SerializationVisitorInterface;
 use Sulu\Bundle\AdminBundle\UserManager\UserManagerInterface;
+use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Component\CustomUrl\Document\CustomUrlDocument;
 use Sulu\Component\CustomUrl\Generator\GeneratorInterface;
 
@@ -35,10 +36,19 @@ class CustomUrlSerializeEventSubscriber implements EventSubscriberInterface
      */
     private $userManager;
 
-    public function __construct(GeneratorInterface $generator, UserManagerInterface $userManager)
-    {
+    /**
+     * @var DocumentInspector
+     */
+    private $documentInspector;
+
+    public function __construct(
+        GeneratorInterface $generator,
+        UserManagerInterface $userManager,
+        DocumentInspector $documentInspector
+    ) {
         $this->generator = $generator;
         $this->userManager = $userManager;
+        $this->documentInspector = $documentInspector;
     }
 
     public static function getSubscribedEvents()
@@ -83,6 +93,12 @@ class CustomUrlSerializeEventSubscriber implements EventSubscriberInterface
         $visitor->visitProperty(
             new StaticPropertyMetadata('', 'customUrl', $customUrlProperty),
             $customUrlProperty
+        );
+
+        $webspaceKey = $this->documentInspector->getWebspace($customUrl);
+        $visitor->visitProperty(
+            new StaticPropertyMetadata('', 'webspace', $webspaceKey),
+            $webspaceKey
         );
 
         $creatorFullName = null;

--- a/src/Sulu/Bundle/CustomUrlBundle/EventListener/CustomUrlTrashSubscriber.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/EventListener/CustomUrlTrashSubscriber.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CustomUrlBundle\EventListener;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\TrashBundle\Application\TrashManager\TrashManagerInterface;
+use Sulu\Component\CustomUrl\Document\CustomUrlDocument;
+use Sulu\Component\DocumentManager\Event\ClearEvent;
+use Sulu\Component\DocumentManager\Event\FlushEvent;
+use Sulu\Component\DocumentManager\Event\RemoveEvent;
+use Sulu\Component\DocumentManager\Events;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @internal
+ */
+final class CustomUrlTrashSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var TrashManagerInterface
+     */
+    private $trashManager;
+
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
+     * @var bool
+     */
+    private $hasPendingTrashItem = false;
+
+    public function __construct(
+        TrashManagerInterface $trashManager,
+        EntityManagerInterface $entityManager
+    ) {
+        $this->trashManager = $trashManager;
+        $this->entityManager = $entityManager;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            Events::REMOVE => ['storeCustomUrlToTrash', 1024],
+            Events::FLUSH => 'flushTrashItem',
+            Events::CLEAR => 'clearPendingTrashItem',
+        ];
+    }
+
+    public function storeCustomUrlToTrash(RemoveEvent $event): void
+    {
+        $document = $event->getDocument();
+
+        if (!$document instanceof CustomUrlDocument) {
+            return;
+        }
+
+        $this->trashManager->store(CustomUrlDocument::RESOURCE_KEY, $document);
+        $this->hasPendingTrashItem = true;
+    }
+
+    public function flushTrashItem(FlushEvent $event): void
+    {
+        if (!$this->hasPendingTrashItem) {
+            return;
+        }
+
+        $this->entityManager->flush();
+        $this->hasPendingTrashItem = false;
+    }
+
+    public function clearPendingTrashItem(ClearEvent $event): void
+    {
+        $this->hasPendingTrashItem = false;
+    }
+}

--- a/src/Sulu/Bundle/CustomUrlBundle/Resources/config/event_listener.xml
+++ b/src/Sulu/Bundle/CustomUrlBundle/Resources/config/event_listener.xml
@@ -8,6 +8,7 @@
                  class="Sulu\Bundle\CustomUrlBundle\EventListener\CustomUrlSerializeEventSubscriber">
             <argument type="service" id="sulu_custom_urls.domain_generator"/>
             <argument type="service" id="sulu_security.user_manager"/>
+            <argument type="service" id="sulu_document_manager.document_inspector"/>
 
             <tag name="jms_serializer.event_subscriber" />
             <tag name="sulu.context" context="admin"/>

--- a/src/Sulu/Bundle/CustomUrlBundle/Resources/config/services_trash.xml
+++ b/src/Sulu/Bundle/CustomUrlBundle/Resources/config/services_trash.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sulu_custom_urls.custom_url_trash_subscriber"
+                 class="Sulu\Bundle\CustomUrlBundle\EventListener\CustomUrlTrashSubscriber">
+            <argument type="service" id="sulu_trash.trash_manager"/>
+            <argument type="service" id="doctrine.orm.entity_manager"/>
+
+            <tag name="sulu_document_manager.event_subscriber" />
+        </service>
+
+        <service id="sulu_custom_urls.custom_url_trash_item_handler"
+                 class="Sulu\Bundle\CustomUrlBundle\Trash\CustomUrlTrashItemHandler">
+            <argument type="service" id="sulu_trash.trash_item_repository"/>
+            <argument type="service" id="sulu_document_manager.document_manager"/>
+            <argument type="service" id="sulu_document_manager.document_inspector"/>
+            <argument type="service" id="sulu_document_manager.document_domain_event_collector"/>
+
+            <tag name="sulu_trash.store_trash_item_handler"/>
+            <tag name="sulu_trash.restore_trash_item_handler"/>
+            <tag name="sulu_trash.restore_configuration_provider"/>
+        </service>
+    </services>
+</container>

--- a/src/Sulu/Bundle/CustomUrlBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/CustomUrlBundle/Resources/translations/admin.de.json
@@ -19,5 +19,6 @@
     "sulu_activity.description.custom_urls.created": "{userFullName} hat die benutzerdefinierte URL \"{resourceTitle}\" erstellt",
     "sulu_activity.description.custom_urls.modified": "{userFullName} hat die benutzerdefinierte URL \"{resourceTitle}\" geändert",
     "sulu_activity.description.custom_urls.removed": "{userFullName} hat die benutzerdefinierte URL \"{resourceTitle}\" gelöscht",
+    "sulu_activity.description.custom_urls.restored": "{userFullName} hat die benutzerdefinierte URL \"{resourceTitle}\" wiederhergestellt",
     "sulu_activity.description.custom_urls.route_removed": "{userFullName} hat eine Route von der benutzerdefinierten URL \"{resourceTitle}\" gelöscht"
 }

--- a/src/Sulu/Bundle/CustomUrlBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/CustomUrlBundle/Resources/translations/admin.en.json
@@ -19,5 +19,6 @@
     "sulu_activity.description.custom_urls.created": "{userFullName} has created the custom url \"{resourceTitle}\"",
     "sulu_activity.description.custom_urls.modified": "{userFullName} has changed the custom url \"{resourceTitle}\"",
     "sulu_activity.description.custom_urls.removed": "{userFullName} has removed the custom url \"{resourceTitle}\"",
+    "sulu_activity.description.custom_urls.restored": "{userFullName} has restored the custom url \"{resourceTitle}\"",
     "sulu_activity.description.custom_urls.route_removed": "{userFullName} has removed a route from the custom url \"{resourceTitle}\""
 }

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Functional/Trash/CustomUrlTrashItemHandlerTest.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Functional/Trash/CustomUrlTrashItemHandlerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CustomUrlBundle\Tests\Functional\Trash;
+
+use Sulu\Bundle\CustomUrlBundle\Trash\CustomUrlTrashItemHandler;
+use Sulu\Bundle\PageBundle\Document\HomeDocument;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Component\CustomUrl\Document\CustomUrlDocument;
+use Sulu\Component\DocumentManager\Document\UnknownDocument;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Sulu\Component\DocumentManager\PathBuilder;
+
+class CustomUrlTrashItemHandlerTest extends SuluTestCase
+{
+    /**
+     * @var DocumentManagerInterface
+     */
+    private $documentManager;
+
+    /**
+     * @var CustomUrlTrashItemHandler
+     */
+    private $customUrlTrashItemHandler;
+
+    /**
+     * @var PathBuilder
+     */
+    private $pathBuilder;
+
+    public function setUp(): void
+    {
+        static::purgeDatabase();
+        static::initPhpcr();
+
+        $this->documentManager = static::getContainer()->get('sulu_document_manager.document_manager');
+        $this->customUrlTrashItemHandler = static::getContainer()->get('sulu_custom_urls.custom_url_trash_item_handler');
+        $this->pathBuilder = static::getContainer()->get('sulu_document_manager.path_builder');
+    }
+
+    public function testStoreAndRestore(): void
+    {
+        /** @var HomeDocument $homepageDocument */
+        $homepageDocument = $this->documentManager->find('/cmf/sulu_io/contents');
+
+        /** @var UnknownDocument $customUrlItemsDocument */
+        $customUrlItemsDocument = $this->documentManager->find(
+            $this->pathBuilder->build(['%base%', 'sulu_io', '%custom_urls%', '%custom_urls_items%'])
+        );
+
+        /** @var CustomUrlDocument $customUrl1 */
+        $customUrl1 = $this->documentManager->create('custom_url');
+        $customUrl1->setTitle('test-title-1');
+        $customUrl1->setParent($customUrlItemsDocument);
+        $customUrl1->setCreator(101);
+        $customUrl1->setCreated(new \DateTime('1999-04-20'));
+        $customUrl1->setBaseDomain('sulu-test.localhost/*/*');
+        $customUrl1->setDomainParts(['custom-path-1', 'custom-path-2']);
+        $customUrl1->setCanonical(true);
+        $customUrl1->setRedirect(false);
+        $customUrl1->setNoFollow(true);
+        $customUrl1->setNoIndex(false);
+        $customUrl1->setTargetDocument($homepageDocument);
+        $customUrl1->setTargetLocale('de');
+        $customUrl1->setPublished(true);
+        $this->documentManager->persist($customUrl1, CustomUrlDocument::DOCUMENT_LOCALE);
+
+        /** @var CustomUrlDocument $customUrl2 */
+        $customUrl2 = $this->documentManager->create('custom_url');
+        $customUrl2->setTitle('test-title-2');
+        $customUrl2->setBaseDomain('sulu-test.localhost/*/*');
+        $customUrl2->setDomainParts(['abcde', 'fghij']);
+        $customUrl2->setTargetDocument($homepageDocument);
+        $customUrl2->setTargetLocale('de');
+        $this->documentManager->persist($customUrl1, CustomUrlDocument::DOCUMENT_LOCALE);
+
+        $this->documentManager->flush();
+        $originalCustomUrlUuid = $customUrl1->getUuid();
+
+        $trashItem = $this->customUrlTrashItemHandler->store($customUrl1);
+        $this->documentManager->remove($customUrl1);
+        $this->documentManager->flush();
+        $this->documentManager->clear();
+
+        static::assertSame($originalCustomUrlUuid, $trashItem->getResourceId());
+        static::assertSame('test-title-1', $trashItem->getResourceTitle());
+        static::assertSame('sulu.webspaces.sulu_io.custom-urls', $trashItem->getResourceSecurityContext());
+
+        /** @var CustomUrlDocument $restoredCustomUrl */
+        $restoredCustomUrl = $this->customUrlTrashItemHandler->restore($trashItem, []);
+
+        /** @var UnknownDocument $restoredCustomUrlParent */
+        $restoredCustomUrlParent = $restoredCustomUrl->getParent();
+
+        /** @var UnknownDocument $restoredCustomUrlTarget */
+        $restoredCustomUrlTarget = $restoredCustomUrl->getTargetDocument();
+
+        static::assertSame('test-title-1', $restoredCustomUrl->getTitle());
+        static::assertSame($customUrlItemsDocument->getUuid(), $restoredCustomUrlParent->getUuid());
+        static::assertSame(101, $restoredCustomUrl->getCreator());
+        static::assertSame('1999-04-20T00:00:00+00:00', $restoredCustomUrl->getCreated()->format('c'));
+        static::assertSame('sulu-test.localhost/*/*', $restoredCustomUrl->getBaseDomain());
+        static::assertSame(['custom-path-1', 'custom-path-2'], $restoredCustomUrl->getDomainParts());
+        static::assertTrue($restoredCustomUrl->isCanonical());
+        static::assertFalse($restoredCustomUrl->isRedirect());
+        static::assertTrue($restoredCustomUrl->isNoFollow());
+        static::assertFalse($restoredCustomUrl->isNoIndex());
+        static::assertSame($homepageDocument->getUuid(), $restoredCustomUrlTarget->getUuid());
+        static::assertSame('de', $restoredCustomUrl->getTargetLocale());
+        static::assertFalse($restoredCustomUrl->isPublished());
+    }
+}

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/CustomUrlSerializeEventSubscriberTest.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/CustomUrlSerializeEventSubscriberTest.php
@@ -79,6 +79,8 @@ class CustomUrlSerializeEventSubscriberTest extends TestCase
 
         $generator->generate('*.sulu.io', ['prefix' => 'test', 'suffix' => []])->willReturn('test.sulu.io');
 
+        $documentInspector->getWebspace($document->reveal())->willReturn('test-webspace');
+
         $event->getObject()->willReturn($document->reveal());
         $event->getVisitor()->willReturn($visitor->reveal());
 
@@ -95,6 +97,10 @@ class CustomUrlSerializeEventSubscriberTest extends TestCase
         $visitor->visitProperty(Argument::that(function(StaticPropertyMetadata $metadata) {
             return 'customUrl' === $metadata->name;
         }), 'test.sulu.io')->shouldBeCalled();
+
+        $visitor->visitProperty(Argument::that(function(StaticPropertyMetadata $metadata) {
+            return 'webspace' === $metadata->name;
+        }), 'test-webspace')->shouldBeCalled();
 
         $visitor->visitProperty(Argument::that(function(StaticPropertyMetadata $metadata) {
             return 'creatorFullName' === $metadata->name;
@@ -154,6 +160,8 @@ class CustomUrlSerializeEventSubscriberTest extends TestCase
 
         $generator->generate('*.sulu.io', ['prefix' => 'test', 'suffix' => []])->willReturn('test.sulu.io');
 
+        $documentInspector->getWebspace($document->reveal())->willReturn('test-webspace');
+
         $event->getObject()->willReturn($document->reveal());
         $event->getVisitor()->willReturn($visitor->reveal());
 
@@ -166,6 +174,10 @@ class CustomUrlSerializeEventSubscriberTest extends TestCase
         $visitor->visitProperty(Argument::that(function(StaticPropertyMetadata $metadata) {
             return 'customUrl' === $metadata->name;
         }), 'test.sulu.io')->shouldBeCalled();
+
+        $visitor->visitProperty(Argument::that(function(StaticPropertyMetadata $metadata) {
+            return 'webspace' === $metadata->name;
+        }), 'test-webspace')->shouldBeCalled();
 
         $visitor->visitProperty(Argument::that(function(StaticPropertyMetadata $metadata) {
             return 'creatorFullName' === $metadata->name;
@@ -204,6 +216,8 @@ class CustomUrlSerializeEventSubscriberTest extends TestCase
 
         $generator->generate('*.sulu.io', ['prefix' => 'test', 'suffix' => []])->willReturn('test.sulu.io');
 
+        $documentInspector->getWebspace($document->reveal())->willReturn('test-webspace');
+
         $event->getObject()->willReturn($document->reveal());
         $event->getVisitor()->willReturn($visitor->reveal());
 
@@ -220,6 +234,10 @@ class CustomUrlSerializeEventSubscriberTest extends TestCase
         $visitor->visitProperty(Argument::that(function(StaticPropertyMetadata $metadata) {
             return 'customUrl' === $metadata->name;
         }), 'test.sulu.io')->shouldBeCalled();
+
+        $visitor->visitProperty(Argument::that(function(StaticPropertyMetadata $metadata) {
+            return 'webspace' === $metadata->name;
+        }), 'test-webspace')->shouldBeCalled();
 
         $visitor->visitProperty(Argument::that(function(StaticPropertyMetadata $metadata) {
             return 'creatorFullName' === $metadata->name;

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/CustomUrlSerializeEventSubscriberTest.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/CustomUrlSerializeEventSubscriberTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sulu\Bundle\AdminBundle\UserManager\UserManagerInterface;
 use Sulu\Bundle\CustomUrlBundle\EventListener\CustomUrlSerializeEventSubscriber;
+use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Bundle\PageBundle\Document\PageDocument;
 use Sulu\Component\CustomUrl\Document\CustomUrlDocument;
 use Sulu\Component\CustomUrl\Generator\GeneratorInterface;
@@ -29,7 +30,12 @@ class CustomUrlSerializeEventSubscriberTest extends TestCase
     {
         $generator = $this->prophesize(GeneratorInterface::class);
         $userManager = $this->prophesize(UserManagerInterface::class);
-        $subscriber = new CustomUrlSerializeEventSubscriber($generator->reveal(), $userManager->reveal());
+        $documentInspector = $this->prophesize(DocumentInspector::class);
+        $subscriber = new CustomUrlSerializeEventSubscriber(
+            $generator->reveal(),
+            $userManager->reveal(),
+            $documentInspector->reveal()
+        );
 
         $events = $subscriber->getSubscribedEvents();
 
@@ -49,7 +55,12 @@ class CustomUrlSerializeEventSubscriberTest extends TestCase
     {
         $generator = $this->prophesize(GeneratorInterface::class);
         $userManager = $this->prophesize(UserManagerInterface::class);
-        $subscriber = new CustomUrlSerializeEventSubscriber($generator->reveal(), $userManager->reveal());
+        $documentInspector = $this->prophesize(DocumentInspector::class);
+        $subscriber = new CustomUrlSerializeEventSubscriber(
+            $generator->reveal(),
+            $userManager->reveal(),
+            $documentInspector->reveal()
+        );
 
         $event = $this->prophesize(ObjectEvent::class);
         $document = $this->prophesize(CustomUrlDocument::class);
@@ -98,7 +109,12 @@ class CustomUrlSerializeEventSubscriberTest extends TestCase
     {
         $generator = $this->prophesize(GeneratorInterface::class);
         $userManager = $this->prophesize(UserManagerInterface::class);
-        $subscriber = new CustomUrlSerializeEventSubscriber($generator->reveal(), $userManager->reveal());
+        $documentInspector = $this->prophesize(DocumentInspector::class);
+        $subscriber = new CustomUrlSerializeEventSubscriber(
+            $generator->reveal(),
+            $userManager->reveal(),
+            $documentInspector->reveal()
+        );
 
         $event = $this->prophesize(ObjectEvent::class);
         $document = $this->prophesize(\stdClass::class);
@@ -117,7 +133,12 @@ class CustomUrlSerializeEventSubscriberTest extends TestCase
     {
         $generator = $this->prophesize(GeneratorInterface::class);
         $userManager = $this->prophesize(UserManagerInterface::class);
-        $subscriber = new CustomUrlSerializeEventSubscriber($generator->reveal(), $userManager->reveal());
+        $documentInspector = $this->prophesize(DocumentInspector::class);
+        $subscriber = new CustomUrlSerializeEventSubscriber(
+            $generator->reveal(),
+            $userManager->reveal(),
+            $documentInspector->reveal()
+        );
 
         $event = $this->prophesize(ObjectEvent::class);
         $document = $this->prophesize(CustomUrlDocument::class);
@@ -159,7 +180,12 @@ class CustomUrlSerializeEventSubscriberTest extends TestCase
     {
         $generator = $this->prophesize(GeneratorInterface::class);
         $userManager = $this->prophesize(UserManagerInterface::class);
-        $subscriber = new CustomUrlSerializeEventSubscriber($generator->reveal(), $userManager->reveal());
+        $documentInspector = $this->prophesize(DocumentInspector::class);
+        $subscriber = new CustomUrlSerializeEventSubscriber(
+            $generator->reveal(),
+            $userManager->reveal(),
+            $documentInspector->reveal()
+        );
 
         $event = $this->prophesize(ObjectEvent::class);
         $document = $this->prophesize(CustomUrlDocument::class);

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/Domain/Event/CustomUrlRestoredEventTest.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/Domain/Event/CustomUrlRestoredEventTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CustomUrlBundle\Tests\Unit\Domain\Event;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\CustomUrlBundle\Domain\Event\CustomUrlRestoredEvent;
+use Sulu\Component\CustomUrl\Document\CustomUrlDocument;
+
+class CustomUrlRestoredEventTest extends TestCase
+{
+    /**
+     * @var CustomUrlDocument|ObjectProphecy
+     */
+    private $customUrlDocument;
+
+    public function setUp(): void
+    {
+        $this->customUrlDocument = $this->prophesize(CustomUrlDocument::class);
+    }
+
+    public function testGetCustomUrlDocument(): void
+    {
+        $event = $this->createCustomUrlRestoredEvent();
+
+        static::assertSame($this->customUrlDocument->reveal(), $event->getCustomUrlDocument());
+    }
+
+    public function testGetEventType(): void
+    {
+        $event = $this->createCustomUrlRestoredEvent();
+
+        static::assertSame('restored', $event->getEventType());
+    }
+
+    public function testGetEventPayload(): void
+    {
+        $event = $this->createCustomUrlRestoredEvent('sulu-io', ['name' => 'test-name']);
+
+        static::assertSame(['name' => 'test-name'], $event->getEventPayload());
+    }
+
+    public function testGetResourceKey(): void
+    {
+        $event = $this->createCustomUrlRestoredEvent();
+
+        static::assertSame('custom_urls', $event->getResourceKey());
+    }
+
+    public function testGetResourceId(): void
+    {
+        $event = $this->createCustomUrlRestoredEvent();
+        $this->customUrlDocument->getUuid()->willReturn('1234-1234-1234-1234');
+
+        static::assertSame('1234-1234-1234-1234', $event->getResourceId());
+    }
+
+    public function testGetResourceWebspaceKey(): void
+    {
+        $event = $this->createCustomUrlRestoredEvent('test-io');
+
+        static::assertSame('test-io', $event->getResourceWebspaceKey());
+    }
+
+    public function testGetResourceTitle(): void
+    {
+        $event = $this->createCustomUrlRestoredEvent();
+        $this->customUrlDocument->getTitle()->willReturn('custom-url-title');
+
+        static::assertSame('custom-url-title', $event->getResourceTitle());
+    }
+
+    public function testGetResourceTitleLocale(): void
+    {
+        $event = $this->createCustomUrlRestoredEvent();
+
+        static::assertNull($event->getResourceTitleLocale());
+    }
+
+    public function testGetResourceSecurityContext(): void
+    {
+        $event = $this->createCustomUrlRestoredEvent('test-io');
+
+        static::assertSame('sulu.webspaces.test-io.custom-urls', $event->getResourceSecurityContext());
+    }
+
+    /**
+     * @param mixed[] $payload
+     */
+    private function createCustomUrlRestoredEvent(
+        string $webspaceKey = 'sulu-io',
+        array $payload = []
+    ): CustomUrlRestoredEvent {
+        return new CustomUrlRestoredEvent(
+            $this->customUrlDocument->reveal(),
+            $webspaceKey,
+            $payload
+        );
+    }
+}

--- a/src/Sulu/Bundle/CustomUrlBundle/Trash/CustomUrlTrashItemHandler.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Trash/CustomUrlTrashItemHandler.php
@@ -89,8 +89,6 @@ final class CustomUrlTrashItemHandler implements
 
         $webspaceKey = $this->documentInspector->getWebspace($customUrl);
 
-        // TODO: test security context
-
         return $this->trashItemRepository->create(
             CustomUrlDocument::RESOURCE_KEY,
             (string) $customUrl->getUuid(),

--- a/src/Sulu/Bundle/CustomUrlBundle/Trash/CustomUrlTrashItemHandler.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Trash/CustomUrlTrashItemHandler.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CustomUrlBundle\Trash;
+
+use Sulu\Bundle\CustomUrlBundle\Admin\CustomUrlAdmin;
+use Sulu\Bundle\CustomUrlBundle\Domain\Event\CustomUrlRestoredEvent;
+use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
+use Sulu\Bundle\DocumentManagerBundle\Collector\DocumentDomainEventCollectorInterface;
+use Sulu\Bundle\TrashBundle\Application\RestoreConfigurationProvider\RestoreConfiguration;
+use Sulu\Bundle\TrashBundle\Application\RestoreConfigurationProvider\RestoreConfigurationProviderInterface;
+use Sulu\Bundle\TrashBundle\Application\TrashItemHandler\RestoreTrashItemHandlerInterface;
+use Sulu\Bundle\TrashBundle\Application\TrashItemHandler\StoreTrashItemHandlerInterface;
+use Sulu\Bundle\TrashBundle\Domain\Model\TrashItemInterface;
+use Sulu\Bundle\TrashBundle\Domain\Repository\TrashItemRepositoryInterface;
+use Sulu\Component\CustomUrl\Document\CustomUrlDocument;
+use Sulu\Component\DocumentManager\DocumentAccessor;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Webmozart\Assert\Assert;
+
+final class CustomUrlTrashItemHandler implements
+    StoreTrashItemHandlerInterface,
+    RestoreTrashItemHandlerInterface,
+    RestoreConfigurationProviderInterface
+{
+    /**
+     * @var TrashItemRepositoryInterface
+     */
+    private $trashItemRepository;
+
+    /**
+     * @var DocumentManagerInterface
+     */
+    private $documentManager;
+
+    /**
+     * @var DocumentInspector
+     */
+    private $documentInspector;
+
+    /**
+     * @var DocumentDomainEventCollectorInterface
+     */
+    private $documentDomainEventCollector;
+
+    public function __construct(
+        TrashItemRepositoryInterface $trashItemRepository,
+        DocumentManagerInterface $documentManager,
+        DocumentInspector $documentInspector,
+        DocumentDomainEventCollectorInterface $documentDomainEventCollector
+    ) {
+        $this->trashItemRepository = $trashItemRepository;
+        $this->documentManager = $documentManager;
+        $this->documentInspector = $documentInspector;
+        $this->documentDomainEventCollector = $documentDomainEventCollector;
+    }
+
+    /**
+     * @param CustomUrlDocument $customUrl
+     */
+    public function store(object $customUrl): TrashItemInterface
+    {
+        Assert::isInstanceOf($customUrl, CustomUrlDocument::class);
+
+        $data = [
+            'title' => $customUrl->getTitle(),
+            'parentUuid' => $this->documentInspector->getUuid($customUrl->getParent()),
+            'creator' => $customUrl->getCreator(),
+            'created' => $customUrl->getCreated()->format('c'),
+            'baseDomain' => $customUrl->getBaseDomain(),
+            'domainParts' => $customUrl->getDomainParts(),
+            'canonical' => $customUrl->isCanonical(),
+            'redirect' => $customUrl->isRedirect(),
+            'noFollow' => $customUrl->isNoFollow(),
+            'noIndex' => $customUrl->isNoIndex(),
+            'targetUuid' => $this->documentInspector->getUuid($customUrl->getTargetDocument()),
+            'targetLocale' => $customUrl->getTargetLocale(),
+        ];
+
+        $webspaceKey = $this->documentInspector->getWebspace($customUrl);
+
+        // TODO: test security context
+
+        return $this->trashItemRepository->create(
+            CustomUrlDocument::RESOURCE_KEY,
+            (string) $customUrl->getUuid(),
+            $data,
+            $customUrl->getTitle(),
+            CustomUrlAdmin::getCustomUrlSecurityContext($webspaceKey),
+            null,
+            null
+        );
+    }
+
+    public function restore(TrashItemInterface $trashItem, array $restoreFormData): object
+    {
+        $uuid = $trashItem->getResourceId();
+        $data = $trashItem->getRestoreData();
+
+        /** @var CustomUrlDocument $customUrl */
+        $customUrl = $this->documentManager->create('custom_url');
+        $customUrlAccessor = new DocumentAccessor($customUrl);
+        $customUrlAccessor->set('uuid', $uuid);
+
+        $customUrl->setTitle($data['title']);
+        $customUrl->setParent($this->documentManager->find($data['parentUuid']));
+        $customUrl->setCreator($data['creator']);
+        $customUrl->setCreated(new \DateTime($data['created']));
+        $customUrl->setBaseDomain($data['baseDomain']);
+        $customUrl->setDomainParts($data['domainParts']);
+        $customUrl->setCanonical($data['canonical']);
+        $customUrl->setRedirect($data['redirect']);
+        $customUrl->setNoFollow($data['noFollow']);
+        $customUrl->setNoIndex($data['noIndex']);
+        $customUrl->setTargetDocument($this->documentManager->find($data['targetUuid']));
+        $customUrl->setTargetLocale($data['targetLocale']);
+        $customUrl->setPublished(false);
+
+        $this->documentManager->persist($customUrl, CustomUrlDocument::DOCUMENT_LOCALE);
+        $this->documentManager->publish($customUrl, CustomUrlDocument::DOCUMENT_LOCALE);
+
+        $webspaceKey = $this->documentInspector->getWebspace($customUrl);
+        $this->documentDomainEventCollector->collect(new CustomUrlRestoredEvent($customUrl, $webspaceKey, $data));
+
+        $this->documentManager->flush();
+
+        return $customUrl;
+    }
+
+    public static function getResourceKey(): string
+    {
+        return CustomUrlDocument::RESOURCE_KEY;
+    }
+
+    public function getConfiguration(): RestoreConfiguration
+    {
+        return new RestoreConfiguration(
+            null,
+            CustomUrlAdmin::LIST_VIEW,
+            ['webspace' => 'webspace']
+        );
+    }
+}

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Trash/SnippetTrashItemHandlerTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Trash/SnippetTrashItemHandlerTest.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\SnippetBundle\Tests\Functional\Trash;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Sulu\Bundle\SnippetBundle\Trash\SnippetTrashItemHandler;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
@@ -30,11 +29,6 @@ class SnippetTrashItemHandlerTest extends SuluTestCase
      */
     private $snippetTrashItemHandler;
 
-    /**
-     * @var EntityManagerInterface
-     */
-    private $entityManager;
-
     public function setUp(): void
     {
         static::purgeDatabase();
@@ -42,7 +36,6 @@ class SnippetTrashItemHandlerTest extends SuluTestCase
 
         $this->documentManager = static::getContainer()->get('sulu_document_manager.document_manager');
         $this->snippetTrashItemHandler = static::getContainer()->get('sulu_snippet.snippet_trash_item_handler');
-        $this->entityManager = static::getEntityManager();
     }
 
     public function testStoreAndRestore(): void

--- a/src/Sulu/Component/CustomUrl/Document/CustomUrlBehavior.php
+++ b/src/Sulu/Component/CustomUrl/Document/CustomUrlBehavior.php
@@ -31,7 +31,7 @@ interface CustomUrlBehavior extends UuidBehavior, PathBehavior, RobotBehavior, T
     /**
      * Returns state of custom-url.
      *
-     * @return string
+     * @return bool
      */
     public function isPublished();
 
@@ -45,7 +45,7 @@ interface CustomUrlBehavior extends UuidBehavior, PathBehavior, RobotBehavior, T
     /**
      * Returns domain parts of custom-url.
      *
-     * @return array
+     * @return string[]
      */
     public function getDomainParts();
 

--- a/src/Sulu/Component/CustomUrl/Document/CustomUrlDocument.php
+++ b/src/Sulu/Component/CustomUrl/Document/CustomUrlDocument.php
@@ -32,6 +32,9 @@ class CustomUrlDocument implements
 {
     public const RESOURCE_KEY = 'custom_urls';
 
+    // custom urls are not localized, but the DocumentManager needs a locale to work
+    public const DOCUMENT_LOCALE = 'en';
+
     /**
      * @var string
      */
@@ -108,7 +111,7 @@ class CustomUrlDocument implements
     protected $changed;
 
     /**
-     * @var int
+     * @var int|null
      */
     protected $creator;
 
@@ -318,6 +321,16 @@ class CustomUrlDocument implements
         return $this->created;
     }
 
+    /**
+     * @param \DateTime $created
+     *
+     * @return void
+     */
+    public function setCreated($created)
+    {
+        $this->created = $created;
+    }
+
     public function getChanged()
     {
         return $this->changed;
@@ -326,6 +339,16 @@ class CustomUrlDocument implements
     public function getCreator()
     {
         return $this->creator;
+    }
+
+    /**
+     * @param int|null $userId
+     *
+     * @return void
+     */
+    public function setCreator($userId)
+    {
+        $this->creator = $userId;
     }
 
     public function getChanger()

--- a/src/Sulu/Component/CustomUrl/Generator/GeneratorInterface.php
+++ b/src/Sulu/Component/CustomUrl/Generator/GeneratorInterface.php
@@ -23,7 +23,7 @@ interface GeneratorInterface
      * If locales are passed the urls will be localized by replacers after generation.
      *
      * @param string $baseDomain
-     * @param string $domainParts
+     * @param string[] $domainParts
      * @param Localization $locale
      *
      * @return string

--- a/src/Sulu/Component/CustomUrl/Manager/CustomUrlManager.php
+++ b/src/Sulu/Component/CustomUrl/Manager/CustomUrlManager.php
@@ -31,8 +31,6 @@ use Sulu\Component\Webspace\CustomUrl;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
-const LOCALE = 'en'; // actually custom urls are not localized, but the DocumentManager needs a locale to work
-
 /**
  * Manages custom-url documents and their routes.
  */
@@ -107,14 +105,14 @@ class CustomUrlManager implements CustomUrlManagerInterface
         try {
             $this->documentManager->persist(
                 $document,
-                LOCALE,
+                CustomUrlDocument::DOCUMENT_LOCALE,
                 [
                     'parent_path' => $this->getItemsPath($webspaceKey),
                     'load_ghost_content' => true,
                     'auto_rename' => false,
                 ]
             );
-            $this->documentManager->publish($document, LOCALE);
+            $this->documentManager->publish($document, CustomUrlDocument::DOCUMENT_LOCALE);
             $this->documentDomainEventCollector->collect(new CustomUrlCreatedEvent($document, $webspaceKey, $data));
         } catch (NodeNameAlreadyExistsException $ex) {
             throw new TitleAlreadyExistsException($document->getTitle());
@@ -178,7 +176,7 @@ class CustomUrlManager implements CustomUrlManagerInterface
 
     public function find($uuid)
     {
-        return $this->documentManager->find($uuid, LOCALE, ['load_ghost_content' => true]);
+        return $this->documentManager->find($uuid, CustomUrlDocument::DOCUMENT_LOCALE, ['load_ghost_content' => true]);
     }
 
     public function findByUrl($url, $webspaceKey, $locale = null)
@@ -250,15 +248,15 @@ class CustomUrlManager implements CustomUrlManagerInterface
         try {
             $this->documentManager->persist(
                 $document,
-                LOCALE,
+                CustomUrlDocument::DOCUMENT_LOCALE,
                 [
                     'parent_path' => PathHelper::getParentPath($document->getPath()),
                     'load_ghost_content' => true,
                     'auto_rename' => false,
-                    'auto_name_locale' => LOCALE,
+                    'auto_name_locale' => CustomUrlDocument::DOCUMENT_LOCALE,
                 ]
             );
-            $this->documentManager->publish($document, LOCALE);
+            $this->documentManager->publish($document, CustomUrlDocument::DOCUMENT_LOCALE);
             $this->documentDomainEventCollector->collect(
                 new CustomUrlModifiedEvent($document, $this->documentInspector->getWebspace($document), $data)
             );
@@ -339,7 +337,7 @@ class CustomUrlManager implements CustomUrlManagerInterface
 
             $value = $data[$fieldName];
             if (\array_key_exists('type', $mapping) && 'reference' === $mapping['type']) {
-                $value = $this->documentManager->find($value, LOCALE, ['load_ghost_content' => true]);
+                $value = $this->documentManager->find($value, CustomUrlDocument::DOCUMENT_LOCALE, ['load_ghost_content' => true]);
             }
 
             $accessor->setValue($document, $fieldName, $value);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| Related issues/PRs | #5150
| License | MIT

#### What's in this PR?

This PR integrates the `SuluTrashBundle` with the built-in `CustomUrl` entity. With the changes in this PR, custom urls will be moved into the trash when being deleted and can be restored from the trash at a later point in time.