### PR TITLE
Add restoreType and restoreOptions to TrashItem 

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -102,6 +102,7 @@ To update your database schema to include the tables that are used by the bundle
 
 ```sql
 CREATE TABLE tr_trash_items (id INT AUTO_INCREMENT NOT NULL, resourceKey VARCHAR(191) NOT NULL, resourceId VARCHAR(191) NOT NULL, restoreData JSON NOT NULL, resourceSecurityContext VARCHAR(191) DEFAULT NULL, resourceSecurityObjectType VARCHAR(191) DEFAULT NULL, resourceSecurityObjectId VARCHAR(191) DEFAULT NULL, storeTimestamp DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)', defaultLocale VARCHAR(191) DEFAULT NULL, userId INT DEFAULT NULL, INDEX IDX_102989B64B64DCC (userId), UNIQUE INDEX UNIQ_102989B5DAEB55C8CF57CB1 (resourceKey, resourceId), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB;
+ALTER TABLE tr_trash_items ADD restoreType VARCHAR(191) DEFAULT NULL, ADD restoreOptions JSON NOT NULL;
 CREATE TABLE tr_trash_item_translations (id INT AUTO_INCREMENT NOT NULL, locale VARCHAR(191) DEFAULT NULL, title VARCHAR(191) NOT NULL, trashItemId INT NOT NULL, INDEX IDX_8264DAF45C8D7CA (trashItemId), UNIQUE INDEX UNIQ_8264DAF45C8D7CA4180C698 (trashItemId, locale), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB;
 ALTER TABLE tr_trash_items ADD CONSTRAINT FK_102989B64B64DCC FOREIGN KEY (userId) REFERENCES se_users (id) ON DELETE SET NULL;
 ALTER TABLE tr_trash_item_translations ADD CONSTRAINT FK_8264DAF45C8D7CA FOREIGN KEY (trashItemId) REFERENCES tr_trash_items (id) ON DELETE CASCADE;

--- a/src/Sulu/Bundle/CategoryBundle/Trash/CategoryTrashItemHandler.php
+++ b/src/Sulu/Bundle/CategoryBundle/Trash/CategoryTrashItemHandler.php
@@ -105,7 +105,7 @@ final class CategoryTrashItemHandler implements
     /**
      * @param CategoryInterface $category
      */
-    public function store(object $category): TrashItemInterface
+    public function store(object $category, array $options = []): TrashItemInterface
     {
         Assert::isInstanceOf($category, CategoryInterface::class);
 
@@ -172,15 +172,17 @@ final class CategoryTrashItemHandler implements
         return $this->trashItemRepository->create(
             CategoryInterface::RESOURCE_KEY,
             (string) $category->getId(),
-            $data,
             $categoryTitles,
+            $data,
+            null,
+            $options,
             CategoryAdmin::SECURITY_CONTEXT,
             null,
             null
         );
     }
 
-    public function restore(TrashItemInterface $trashItem, array $restoreFormData): object
+    public function restore(TrashItemInterface $trashItem, array $restoreFormData = []): object
     {
         $id = (int) $trashItem->getResourceId();
         $data = $trashItem->getRestoreData();

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/Trash/AccountTrashItemHandlerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/Trash/AccountTrashItemHandlerTest.php
@@ -100,11 +100,13 @@ class AccountTrashItemHandlerTest extends TestCase
                 $trashItem = new TrashItem();
                 $trashItem->setResourceKey($args[0]);
                 $trashItem->setResourceId($args[1]);
-                $trashItem->setRestoreData($args[2]);
-                $trashItem->setResourceTitle($args[3]);
-                $trashItem->setResourceSecurityContext($args[4]);
-                $trashItem->setResourceSecurityObjectType($args[5]);
-                $trashItem->setResourceSecurityObjectId($args[6]);
+                $trashItem->setResourceTitle($args[2]);
+                $trashItem->setRestoreData($args[3]);
+                $trashItem->setRestoreType($args[4]);
+                $trashItem->setRestoreOptions($args[5]);
+                $trashItem->setResourceSecurityContext($args[6]);
+                $trashItem->setResourceSecurityObjectType($args[7]);
+                $trashItem->setResourceSecurityObjectId($args[8]);
 
                 return $trashItem;
             });

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/Trash/ContactTrashItemHandlerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/Trash/ContactTrashItemHandlerTest.php
@@ -102,11 +102,13 @@ class ContactTrashItemHandlerTest extends TestCase
                 $trashItem = new TrashItem();
                 $trashItem->setResourceKey($args[0]);
                 $trashItem->setResourceId($args[1]);
-                $trashItem->setRestoreData($args[2]);
-                $trashItem->setResourceTitle($args[3]);
-                $trashItem->setResourceSecurityContext($args[4]);
-                $trashItem->setResourceSecurityObjectType($args[5]);
-                $trashItem->setResourceSecurityObjectId($args[6]);
+                $trashItem->setResourceTitle($args[2]);
+                $trashItem->setRestoreData($args[3]);
+                $trashItem->setRestoreType($args[4]);
+                $trashItem->setRestoreOptions($args[5]);
+                $trashItem->setResourceSecurityContext($args[6]);
+                $trashItem->setResourceSecurityObjectType($args[7]);
+                $trashItem->setResourceSecurityObjectId($args[8]);
 
                 return $trashItem;
             });

--- a/src/Sulu/Bundle/ContactBundle/Trash/AccountTrashItemHandler.php
+++ b/src/Sulu/Bundle/ContactBundle/Trash/AccountTrashItemHandler.php
@@ -95,7 +95,7 @@ final class AccountTrashItemHandler implements
     /**
      * @param object|AccountInterface $resource
      */
-    public function store(object $resource): TrashItemInterface
+    public function store(object $resource, array $options = []): TrashItemInterface
     {
         Assert::isInstanceOf($resource, AccountInterface::class);
 
@@ -252,15 +252,17 @@ final class AccountTrashItemHandler implements
         return $this->trashItemRepository->create(
             AccountInterface::RESOURCE_KEY,
             (string) $data['id'],
-            \array_filter($data),
             $data['name'],
+            \array_filter($data),
+            null,
+            $options,
             ContactAdmin::ACCOUNT_SECURITY_CONTEXT,
             null,
             null
         );
     }
 
-    public function restore(TrashItemInterface $trashItem, array $restoreFormData): object
+    public function restore(TrashItemInterface $trashItem, array $restoreFormData = []): object
     {
         $id = (int) $trashItem->getResourceId();
         $data = $trashItem->getRestoreData();

--- a/src/Sulu/Bundle/ContactBundle/Trash/ContactTrashItemHandler.php
+++ b/src/Sulu/Bundle/ContactBundle/Trash/ContactTrashItemHandler.php
@@ -97,7 +97,7 @@ final class ContactTrashItemHandler implements
     /**
      * @param object|ContactInterface $resource
      */
-    public function store(object $resource): TrashItemInterface
+    public function store(object $resource, array $options = []): TrashItemInterface
     {
         Assert::isInstanceOf($resource, ContactInterface::class);
 
@@ -254,15 +254,17 @@ final class ContactTrashItemHandler implements
         return $this->trashItemRepository->create(
             ContactInterface::RESOURCE_KEY,
             (string) $data['id'],
-            \array_filter($data),
             \trim($resource->getFirstName() . ' ' . $resource->getLastName()),
+            \array_filter($data),
+            null,
+            $options,
             ContactAdmin::CONTACT_SECURITY_CONTEXT,
             null,
             null
         );
     }
 
-    public function restore(TrashItemInterface $trashItem, array $restoreFormData): object
+    public function restore(TrashItemInterface $trashItem, array $restoreFormData = []): object
     {
         $id = (int) $trashItem->getResourceId();
         $data = $trashItem->getRestoreData();

--- a/src/Sulu/Bundle/CustomUrlBundle/Trash/CustomUrlTrashItemHandler.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Trash/CustomUrlTrashItemHandler.php
@@ -68,7 +68,7 @@ final class CustomUrlTrashItemHandler implements
     /**
      * @param CustomUrlDocument $customUrl
      */
-    public function store(object $customUrl): TrashItemInterface
+    public function store(object $customUrl, array $options = []): TrashItemInterface
     {
         Assert::isInstanceOf($customUrl, CustomUrlDocument::class);
 
@@ -92,15 +92,17 @@ final class CustomUrlTrashItemHandler implements
         return $this->trashItemRepository->create(
             CustomUrlDocument::RESOURCE_KEY,
             (string) $customUrl->getUuid(),
-            $data,
             $customUrl->getTitle(),
+            $data,
+            null,
+            $options,
             CustomUrlAdmin::getCustomUrlSecurityContext($webspaceKey),
             null,
             null
         );
     }
 
-    public function restore(TrashItemInterface $trashItem, array $restoreFormData): object
+    public function restore(TrashItemInterface $trashItem, array $restoreFormData = []): object
     {
         $uuid = $trashItem->getResourceId();
         $data = $trashItem->getRestoreData();

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Trash/CollectionTrashItemHandlerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Trash/CollectionTrashItemHandlerTest.php
@@ -78,12 +78,14 @@ class CollectionTrashItemHandlerTest extends TestCase
                 $trashItem = new TrashItem();
                 $trashItem->setResourceKey($args[0]);
                 $trashItem->setResourceId($args[1]);
-                $trashItem->setRestoreData($args[2]);
-                $trashItem->setResourceSecurityContext($args[4]);
-                $trashItem->setResourceSecurityObjectType($args[5]);
-                $trashItem->setResourceSecurityObjectId($args[6]);
+                $trashItem->setRestoreData($args[3]);
+                $trashItem->setRestoreType($args[4]);
+                $trashItem->setRestoreOptions($args[5]);
+                $trashItem->setResourceSecurityContext($args[6]);
+                $trashItem->setResourceSecurityObjectType($args[7]);
+                $trashItem->setResourceSecurityObjectId($args[8]);
 
-                foreach ($args[3] as $locale => $title) {
+                foreach ($args[2] as $locale => $title) {
                     $trashItem->setResourceTitle($title, $locale);
                 }
 

--- a/src/Sulu/Bundle/MediaBundle/Trash/CollectionTrashItemHandler.php
+++ b/src/Sulu/Bundle/MediaBundle/Trash/CollectionTrashItemHandler.php
@@ -79,7 +79,7 @@ final class CollectionTrashItemHandler implements
     /**
      * @param CollectionInterface $resource
      */
-    public function store(object $resource): TrashItemInterface
+    public function store(object $resource, array $options = []): TrashItemInterface
     {
         Assert::isInstanceOf($resource, CollectionInterface::class);
 
@@ -128,15 +128,17 @@ final class CollectionTrashItemHandler implements
         return $this->trashItemRepository->create(
             CollectionInterface::RESOURCE_KEY,
             (string) $resource->getId(),
-            \array_filter($data),
             $collectionTitles,
+            \array_filter($data),
+            null,
+            $options,
             MediaAdmin::SECURITY_CONTEXT,
             null,
             null
         );
     }
 
-    public function restore(TrashItemInterface $trashItem, array $restoreFormData): object
+    public function restore(TrashItemInterface $trashItem, array $restoreFormData = []): object
     {
         $id = (int) $trashItem->getResourceId();
         $data = $trashItem->getRestoreData();

--- a/src/Sulu/Bundle/MediaBundle/Trash/MediaTrashItemHandler.php
+++ b/src/Sulu/Bundle/MediaBundle/Trash/MediaTrashItemHandler.php
@@ -98,7 +98,7 @@ final class MediaTrashItemHandler implements
     /**
      * @param MediaInterface $media
      */
-    public function store(object $media): TrashItemInterface
+    public function store(object $media, array $options = []): TrashItemInterface
     {
         Assert::isInstanceOf($media, MediaInterface::class);
 
@@ -217,15 +217,17 @@ final class MediaTrashItemHandler implements
         return $this->trashItemRepository->create(
             MediaInterface::RESOURCE_KEY,
             (string) $media->getId(),
-            $data,
             $mediaTitles,
+            $data,
+            null,
+            $options,
             MediaAdmin::SECURITY_CONTEXT,
             Collection::class,
             (string) $media->getCollection()->getId()
         );
     }
 
-    public function restore(TrashItemInterface $trashItem, array $restoreFormData): object
+    public function restore(TrashItemInterface $trashItem, array $restoreFormData = []): object
     {
         $id = (int) $trashItem->getResourceId();
         $data = $trashItem->getRestoreData();

--- a/src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
+++ b/src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
@@ -73,7 +73,7 @@ final class PageTrashItemHandler implements
     /**
      * @param PageDocument $page
      */
-    public function store(object $page): TrashItemInterface
+    public function store(object $page, array $options = []): TrashItemInterface
     {
         Assert::isInstanceOf($page, BasePageDocument::class);
 
@@ -126,15 +126,17 @@ final class PageTrashItemHandler implements
         return $this->trashItemRepository->create(
             BasePageDocument::RESOURCE_KEY,
             (string) $page->getUuid(),
-            $data,
             $pageTitles,
+            $data,
+            null,
+            $options,
             PageAdmin::getPageSecurityContext($page->getWebspaceName()),
             SecurityBehavior::class,
             (string) $page->getUuid()
         );
     }
 
-    public function restore(TrashItemInterface $trashItem, array $restoreFormData): object
+    public function restore(TrashItemInterface $trashItem, array $restoreFormData = []): object
     {
         $uuid = $trashItem->getResourceId();
         $data = $trashItem->getRestoreData();

--- a/src/Sulu/Bundle/SnippetBundle/Trash/SnippetTrashItemHandler.php
+++ b/src/Sulu/Bundle/SnippetBundle/Trash/SnippetTrashItemHandler.php
@@ -71,7 +71,7 @@ final class SnippetTrashItemHandler implements
     /**
      * @param SnippetDocument $snippet
      */
-    public function store(object $snippet): TrashItemInterface
+    public function store(object $snippet, array $options = []): TrashItemInterface
     {
         Assert::isInstanceOf($snippet, SnippetDocument::class);
 
@@ -105,15 +105,17 @@ final class SnippetTrashItemHandler implements
         return $this->trashItemRepository->create(
             SnippetDocument::RESOURCE_KEY,
             (string) $snippet->getUuid(),
-            $data,
             $snipetTitles,
+            $data,
+            null,
+            $options,
             SnippetAdmin::SECURITY_CONTEXT,
             null,
             null
         );
     }
 
-    public function restore(TrashItemInterface $trashItem, array $restoreFormData): object
+    public function restore(TrashItemInterface $trashItem, array $restoreFormData = []): object
     {
         $uuid = $trashItem->getResourceId();
         $data = $trashItem->getRestoreData();

--- a/src/Sulu/Bundle/TagBundle/Trash/TagTrashItemHandler.php
+++ b/src/Sulu/Bundle/TagBundle/Trash/TagTrashItemHandler.php
@@ -78,7 +78,7 @@ final class TagTrashItemHandler implements
     /**
      * @param TagInterface $tag
      */
-    public function store(object $tag): TrashItemInterface
+    public function store(object $tag, array $options = []): TrashItemInterface
     {
         Assert::isInstanceOf($tag, TagInterface::class);
 
@@ -87,19 +87,21 @@ final class TagTrashItemHandler implements
         return $this->trashItemRepository->create(
             TagInterface::RESOURCE_KEY,
             (string) $tag->getId(),
+            $tag->getName(),
             [
                 'name' => $tag->getName(),
                 'created' => $tag->getCreated()->format('c'),
                 'creatorId' => $creator ? $creator->getId() : null,
             ],
-            $tag->getName(),
+            null,
+            $options,
             TagAdmin::SECURITY_CONTEXT,
             null,
             null
         );
     }
 
-    public function restore(TrashItemInterface $trashItem, array $restoreFormData): object
+    public function restore(TrashItemInterface $trashItem, array $restoreFormData = []): object
     {
         $id = (int) $trashItem->getResourceId();
         $data = $trashItem->getRestoreData();

--- a/src/Sulu/Bundle/TrashBundle/Application/TrashItemHandler/RestoreTrashItemHandlerInterface.php
+++ b/src/Sulu/Bundle/TrashBundle/Application/TrashItemHandler/RestoreTrashItemHandlerInterface.php
@@ -20,7 +20,7 @@ interface RestoreTrashItemHandlerInterface
     /**
      * @param array<string, mixed> $restoreFormData
      */
-    public function restore(TrashItemInterface $trashItem, array $restoreFormData): object;
+    public function restore(TrashItemInterface $trashItem, array $restoreFormData = []): object;
 
     public static function getResourceKey(): string;
 }

--- a/src/Sulu/Bundle/TrashBundle/Application/TrashItemHandler/StoreTrashItemHandlerInterface.php
+++ b/src/Sulu/Bundle/TrashBundle/Application/TrashItemHandler/StoreTrashItemHandlerInterface.php
@@ -17,7 +17,10 @@ use Sulu\Bundle\TrashBundle\Domain\Model\TrashItemInterface;
 
 interface StoreTrashItemHandlerInterface
 {
-    public function store(object $resource): TrashItemInterface;
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function store(object $resource, array $options = []): TrashItemInterface;
 
     public static function getResourceKey(): string;
 }

--- a/src/Sulu/Bundle/TrashBundle/Application/TrashManager/TrashManager.php
+++ b/src/Sulu/Bundle/TrashBundle/Application/TrashManager/TrashManager.php
@@ -67,7 +67,7 @@ final class TrashManager implements TrashManagerInterface
         $this->removeTrashItemHandlerLocator = $removeTrashItemHandlerLocator;
     }
 
-    public function store(string $resourceKey, object $object): TrashItemInterface
+    public function store(string $resourceKey, object $object, array $options = []): TrashItemInterface
     {
         if (!$this->storeTrashItemHandlerLocator->has($resourceKey)) {
             throw new StoreTrashItemHandlerNotFoundException($resourceKey);
@@ -87,7 +87,7 @@ final class TrashManager implements TrashManagerInterface
         return $trashItem;
     }
 
-    public function restore(TrashItemInterface $trashItem, array $restoreFormData): object
+    public function restore(TrashItemInterface $trashItem, array $restoreFormData = []): object
     {
         $resourceKey = $trashItem->getResourceKey();
 

--- a/src/Sulu/Bundle/TrashBundle/Application/TrashManager/TrashManagerInterface.php
+++ b/src/Sulu/Bundle/TrashBundle/Application/TrashManager/TrashManagerInterface.php
@@ -15,12 +15,15 @@ use Sulu\Bundle\TrashBundle\Domain\Model\TrashItemInterface;
 
 interface TrashManagerInterface
 {
-    public function store(string $resourceKey, object $object): TrashItemInterface;
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function store(string $resourceKey, object $object, array $options = []): TrashItemInterface;
 
     /**
      * @param array<string, mixed> $restoreFormData
      */
-    public function restore(TrashItemInterface $trashItem, array $restoreFormData): object;
+    public function restore(TrashItemInterface $trashItem, array $restoreFormData = []): object;
 
     public function remove(TrashItemInterface $trashItem): void;
 }

--- a/src/Sulu/Bundle/TrashBundle/Domain/Model/TrashItem.php
+++ b/src/Sulu/Bundle/TrashBundle/Domain/Model/TrashItem.php
@@ -38,7 +38,25 @@ class TrashItem implements TrashItemInterface
     /**
      * @var mixed[]
      */
-    private $restoreData;
+    private $restoreData = [];
+
+    /**
+     * The restoreType can be used to indicate a sub entity.
+     *     e.g.: Store and Restore a single translation of a page.
+     *          -> "translation".
+     *
+     * @var string|null
+     */
+    private $restoreType;
+
+    /**
+     * The restoreOptions are used to change behaviour of store and restore handler.
+     *     e.g.: Store and Restore a single translation of a page.
+     *          -> ["locale" => "en"].
+     *
+     * @var mixed[]
+     */
+    private $restoreOptions = [];
 
     /**
      * @var string|null
@@ -78,6 +96,7 @@ class TrashItem implements TrashItemInterface
     public function __construct()
     {
         $this->translations = new ArrayCollection();
+        $this->storeTimestamp = new \DateTimeImmutable();
     }
 
     public function getId(): ?int
@@ -117,6 +136,30 @@ class TrashItem implements TrashItemInterface
     public function setRestoreData(array $restoreData): TrashItemInterface
     {
         $this->restoreData = $restoreData;
+
+        return $this;
+    }
+
+    public function getRestoreType(): ?string
+    {
+        return $this->restoreType;
+    }
+
+    public function setRestoreType(?string $restoreType): TrashItemInterface
+    {
+        $this->restoreType = $restoreType;
+
+        return $this;
+    }
+
+    public function getRestoreOptions(): array
+    {
+        return $this->restoreOptions;
+    }
+
+    public function setRestoreOptions(array $restoreOptions): TrashItemInterface
+    {
+        $this->restoreOptions = $restoreOptions;
 
         return $this;
     }

--- a/src/Sulu/Bundle/TrashBundle/Domain/Model/TrashItemInterface.php
+++ b/src/Sulu/Bundle/TrashBundle/Domain/Model/TrashItemInterface.php
@@ -28,6 +28,10 @@ interface TrashItemInterface
 
     public function setResourceId(string $resourceId): TrashItemInterface;
 
+    public function getRestoreType(): ?string;
+
+    public function setRestoreType(?string $subResourceKey): TrashItemInterface;
+
     /**
      * @return mixed[]
      */
@@ -37,6 +41,16 @@ interface TrashItemInterface
      * @param mixed[] $restoreData
      */
     public function setRestoreData(array $restoreData): self;
+
+    /**
+     * @return mixed[]
+     */
+    public function getRestoreOptions(): array;
+
+    /**
+     * @param mixed[] $options
+     */
+    public function setRestoreOptions(array $options): TrashItemInterface;
 
     public function getResourceTitle(?string $locale = null): string;
 

--- a/src/Sulu/Bundle/TrashBundle/Domain/Repository/TrashItemRepositoryInterface.php
+++ b/src/Sulu/Bundle/TrashBundle/Domain/Repository/TrashItemRepositoryInterface.php
@@ -18,14 +18,17 @@ use Sulu\Bundle\TrashBundle\Domain\Model\TrashItemInterface;
 interface TrashItemRepositoryInterface
 {
     /**
-     * @param mixed[] $restoreData
      * @param string|array<string, string> $resourceTitle
+     * @param mixed[] $restoreData
+     * @param mixed[] $restoreOptions
      */
     public function create(
         string $resourceKey,
         string $resourceId,
-        array $restoreData,
         $resourceTitle,
+        array $restoreData,
+        ?string $restoreType,
+        array $restoreOptions,
         ?string $resourceSecurityContext,
         ?string $resourceSecurityObjectType,
         ?string $resourceSecurityObjectId

--- a/src/Sulu/Bundle/TrashBundle/Infrastructure/Doctrine/Repository/TrashItemRepository.php
+++ b/src/Sulu/Bundle/TrashBundle/Infrastructure/Doctrine/Repository/TrashItemRepository.php
@@ -49,8 +49,10 @@ final class TrashItemRepository implements TrashItemRepositoryInterface
     public function create(
         string $resourceKey,
         string $resourceId,
-        array $restoreData,
         $resourceTitle,
+        array $restoreData,
+        ?string $restoreType,
+        array $restoreOptions,
         ?string $resourceSecurityContext,
         ?string $resourceSecurityObjectType,
         ?string $resourceSecurityObjectId
@@ -65,10 +67,11 @@ final class TrashItemRepository implements TrashItemRepositoryInterface
             ->setResourceKey($resourceKey)
             ->setResourceId($resourceId)
             ->setRestoreData($restoreData)
+            ->setRestoreType($restoreType)
+            ->setRestoreOptions($restoreOptions)
             ->setResourceSecurityContext($resourceSecurityContext)
             ->setResourceSecurityObjectType($resourceSecurityObjectType)
             ->setResourceSecurityObjectId($resourceSecurityObjectId)
-            ->setStoreTimestamp(new \DateTimeImmutable())
             ->setUser($this->getCurrentUser());
 
         if (\is_string($resourceTitle)) {

--- a/src/Sulu/Bundle/TrashBundle/Resources/config/doctrine/TrashItem.orm.xml
+++ b/src/Sulu/Bundle/TrashBundle/Resources/config/doctrine/TrashItem.orm.xml
@@ -10,6 +10,8 @@
         <field name="resourceKey" column="resourceKey" type="string" nullable="false" length="191"/>
         <field name="resourceId" column="resourceId" type="string" nullable="false" length="191"/>
         <field name="restoreData" column="restoreData" type="json" nullable="false"/>
+        <field name="restoreType" column="restoreType" type="string" nullable="true" length="191"/>
+        <field name="restoreOptions" column="restoreOptions" type="json" nullable="false"/>
         <field name="resourceSecurityContext" column="resourceSecurityContext" type="string" nullable="true" length="191"/>
         <field name="resourceSecurityObjectType" column="resourceSecurityObjectType" type="string" nullable="true" length="191"/>
         <field name="resourceSecurityObjectId" column="resourceSecurityObjectId" type="string" nullable="true" length="191"/>

--- a/src/Sulu/Bundle/TrashBundle/Resources/config/lists/trash_items.xml
+++ b/src/Sulu/Bundle/TrashBundle/Resources/config/lists/trash_items.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <property
-            name="resourceType"
+            name="resourceKey"
             visibility="yes"
             sortable="true"
             searchability="no"

--- a/src/Sulu/Bundle/TrashBundle/Tests/Application/Trash/TestTrashItemHandler.php
+++ b/src/Sulu/Bundle/TrashBundle/Tests/Application/Trash/TestTrashItemHandler.php
@@ -33,18 +33,20 @@ class TestTrashItemHandler implements StoreTrashItemHandlerInterface, RestoreTra
         $this->trashItemRepository = $trashItemRepository;
     }
 
-    public function restore(TrashItemInterface $trashItem, array $restoreFormData): object
+    public function restore(TrashItemInterface $trashItem, array $restoreFormData = []): object
     {
         return new TestResource();
     }
 
-    public function store(object $resource): TrashItemInterface
+    public function store(object $resource, array $options = []): TrashItemInterface
     {
         return $this->trashItemRepository->create(
             static::getResourceKey(),
             '1',
-            [],
             'Resource title',
+            [],
+            null,
+            $options,
             null,
             null,
             null

--- a/src/Sulu/Bundle/TrashBundle/Tests/Functional/Infrastructure/Doctrine/Repository/TrashItemRepositoryTest.php
+++ b/src/Sulu/Bundle/TrashBundle/Tests/Functional/Infrastructure/Doctrine/Repository/TrashItemRepositoryTest.php
@@ -48,8 +48,10 @@ class TrashItemRepositoryTest extends SuluTestCase
         $trashItem = $this->repository->create(
             'resourceKey',
             '1',
-            $restoreData,
             'Unlocalized resource title',
+            $restoreData,
+            'translation',
+            ['locale' => 'en'],
             'sulu.settings.test_context',
             'TestClass',
             '1'
@@ -57,7 +59,9 @@ class TrashItemRepositoryTest extends SuluTestCase
 
         static::assertSame('resourceKey', $trashItem->getResourceKey());
         static::assertSame('1', $trashItem->getResourceId());
+        static::assertSame('translation', $trashItem->getRestoreType());
         static::assertSame($restoreData, $trashItem->getRestoreData());
+        static::assertSame(['locale' => 'en'], $trashItem->getRestoreOptions());
         static::assertSame('Unlocalized resource title', $trashItem->getResourceTitle());
         static::assertSame('Unlocalized resource title', $trashItem->getResourceTitle('anything'));
         static::assertSame('sulu.settings.test_context', $trashItem->getResourceSecurityContext());
@@ -71,11 +75,13 @@ class TrashItemRepositoryTest extends SuluTestCase
         $trashItem = $this->repository->create(
             'resourceKey',
             '1',
-            [],
             [
                 'en' => 'English resource title',
                 'de' => 'German resource title',
             ],
+            [],
+            null,
+            [],
             null,
             null,
             null
@@ -92,8 +98,10 @@ class TrashItemRepositoryTest extends SuluTestCase
         $trashItem = $this->repository->create(
             'resourceKey',
             '1',
-            ['foo' => 'bar'],
             'Resource title',
+            ['foo' => 'bar'],
+            null,
+            [],
             null,
             null,
             null
@@ -112,7 +120,6 @@ class TrashItemRepositoryTest extends SuluTestCase
         $trashItem = static::createTrashItem(
             'test_resource',
             '1',
-            [],
             'Resource title'
         );
 
@@ -129,7 +136,6 @@ class TrashItemRepositoryTest extends SuluTestCase
         $trashItem = static::createTrashItem(
             'test_resource',
             '1',
-            [],
             'Resource title'
         );
 
@@ -150,7 +156,6 @@ class TrashItemRepositoryTest extends SuluTestCase
         $trashItem = static::createTrashItem(
             'test_resource',
             '1',
-            [],
             'Resource title'
         );
 

--- a/src/Sulu/Bundle/TrashBundle/Tests/Functional/Traits/CreateTrashItemTrait.php
+++ b/src/Sulu/Bundle/TrashBundle/Tests/Functional/Traits/CreateTrashItemTrait.php
@@ -22,13 +22,16 @@ trait CreateTrashItemTrait
 {
     /**
      * @param mixed[] $restoreData
+     * @param mixed[] $restoreOptions
      * @param string|array<string, string> $resourceTitle
      */
     protected static function createTrashItem(
         string $resourceKey = 'test_resource',
         string $resourceId = '1',
-        array $restoreData = [],
         $resourceTitle = '',
+        array $restoreData = [],
+        ?string $restoreType = null,
+        array $restoreOptions = [],
         ?string $resourceSecurityContext = null,
         ?string $resourceSecurityObjectType = null,
         ?string $resourceSecurityObjectId = null
@@ -36,8 +39,10 @@ trait CreateTrashItemTrait
         $trashItem = static::getTrashItemRepository()->create(
             $resourceKey,
             $resourceId,
-            $restoreData,
             $resourceTitle,
+            $restoreData,
+            $restoreType,
+            $restoreOptions,
             $resourceSecurityContext,
             $resourceSecurityObjectType,
             $resourceSecurityObjectId

--- a/src/Sulu/Bundle/TrashBundle/Tests/Functional/UserInterface/Controller/Admin/TrashItemControllerTest.php
+++ b/src/Sulu/Bundle/TrashBundle/Tests/Functional/UserInterface/Controller/Admin/TrashItemControllerTest.php
@@ -67,15 +67,17 @@ class TrashItemControllerTest extends SuluTestCase
         static::createTrashItem(
             'test-resource-key',
             'resource-id-1',
-            ['key1' => 'value1', 'key2' => 'value2'],
-            'unlocalized title'
+            'unlocalized title',
+            ['key1' => 'value1', 'key2' => 'value2']
         );
 
         static::createTrashItem(
             'test-resource-key',
             'resource-id-2',
+            ['de' => 'german title', 'en' => 'english title', 'fr' => 'french title'],
             ['key1' => 'value1', 'key2' => 'value2'],
-            ['de' => 'german title', 'en' => 'english title', 'fr' => 'french title']
+            'test-translation',
+            ['locale' => 'en']
         );
 
         $this->client->jsonRequest('GET', '/api/trash-items', ['locale' => 'de']);
@@ -109,8 +111,10 @@ class TrashItemControllerTest extends SuluTestCase
                 static::createTrashItem(
                     'test_resource',
                     $resourceId,
-                    [],
                     'Resource title',
+                    [],
+                    null,
+                    [],
                     $resourceSecurityContext,
                     $resourceSecurityObjectType,
                     $resourceSecurityObjectId

--- a/src/Sulu/Bundle/TrashBundle/UserInterface/Controller/Admin/TrashItemController.php
+++ b/src/Sulu/Bundle/TrashBundle/UserInterface/Controller/Admin/TrashItemController.php
@@ -190,8 +190,12 @@ class TrashItemController extends AbstractRestController implements ClassResourc
 
         $trashItems = \array_map(
             function(array $trashItem) use ($hiddenFieldDescriptors) {
-                if (isset($trashItem['resourceType'])) {
-                    $trashItem['resourceType'] = $this->getResourceTranslation($trashItem['resourceType']);
+                if (isset($trashItem['resourceKey'])) {
+                    $trashItem['resourceKey'] = $this->getResourceTranslation($trashItem['resourceKey']);
+
+                    if (!empty($trashItem['restoreType'])) {
+                        $trashItem['resourceKey'] .= ' (' . $this->getResourceTranslation($trashItem['restoreType']) . ')';
+                    }
                 }
 
                 foreach ($hiddenFieldDescriptors as $fieldDescriptor) {
@@ -398,6 +402,7 @@ class TrashItemController extends AbstractRestController implements ClassResourc
     private function getHiddenFieldDescriptors(): array
     {
         return [
+            'restoreType' => $this->createFieldDescriptor('restoreType'),
             'resourceSecurityContext' => $this->createFieldDescriptor('resourceSecurityContext'),
             'resourceSecurityObjectType' => $this->createFieldDescriptor('resourceSecurityObjectType'),
             'resourceSecurityObjectId' => $this->createFieldDescriptor('resourceSecurityObjectId'),

--- a/src/Sulu/Bundle/WebsiteBundle/Trash/AnalyticsTrashItemHandler.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Trash/AnalyticsTrashItemHandler.php
@@ -101,7 +101,7 @@ class AnalyticsTrashItemHandler implements StoreTrashItemHandlerInterface, Resto
     /**
      * @param AnalyticsInterface $analytics
      */
-    public function store(object $analytics): TrashItemInterface
+    public function store(object $analytics, array $options = []): TrashItemInterface
     {
         Assert::isInstanceOf($analytics, AnalyticsInterface::class);
 
@@ -114,6 +114,7 @@ class AnalyticsTrashItemHandler implements StoreTrashItemHandlerInterface, Resto
         return $this->trashItemRepository->create(
             AnalyticsInterface::RESOURCE_KEY,
             (string) $analytics->getId(),
+            $analytics->getTitle(),
             [
                 'title' => $analytics->getTitle(),
                 'type' => $analytics->getType(),
@@ -122,14 +123,15 @@ class AnalyticsTrashItemHandler implements StoreTrashItemHandlerInterface, Resto
                 'allDomains' => $analytics->isAllDomains(),
                 'domains' => $domains,
             ],
-            $analytics->getTitle(),
+            null,
+            $options,
             WebsiteAdmin::getAnalyticsSecurityContext($analytics->getWebspaceKey()),
             null,
             null
         );
     }
 
-    public function restore(TrashItemInterface $trashItem, array $restoreFormData): object
+    public function restore(TrashItemInterface $trashItem, array $restoreFormData = []): object
     {
         $id = (int) $trashItem->getResourceId();
         $data = $trashItem->getRestoreData();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? |  yes
| BC breaks? | yes 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | part of #5150 <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add subResourceKey and options to TrashItem .

#### Why?

Make it possible to remove a single page translation and restore a single page translation.
