### PR TITLE
Skip if findAvailableLocale does not return any webspace

### DIFF
--- a/src/Sulu/Component/Content/Compat/LocalizationFinder.php
+++ b/src/Sulu/Component/Content/Compat/LocalizationFinder.php
@@ -32,15 +32,20 @@ class LocalizationFinder implements LocalizationFinderInterface
     public function findAvailableLocale($webspaceName, array $availableLocales, $locale)
     {
         if (!$webspaceName) {
-            return;
+            return null;
         }
 
         // get localization object for querying parent localizations
         $webspace = $this->webspaceManager->findWebspaceByKey($webspaceName);
+
+        if (!$webspace) {
+            return null;
+        }
+
         $localization = $webspace->getLocalization($locale);
 
         if (null === $localization) {
-            return;
+            return null;
         }
 
         $resultLocalization = null;
@@ -68,7 +73,7 @@ class LocalizationFinder implements LocalizationFinderInterface
         }
 
         if (!$resultLocalization) {
-            return;
+            return null;
         }
 
         return $resultLocalization->getLocale();
@@ -93,7 +98,7 @@ class LocalizationFinder implements LocalizationFinderInterface
             $localization = $localization->getParent();
         } while (null != $localization);
 
-        return;
+        return null;
     }
 
     /**
@@ -121,7 +126,7 @@ class LocalizationFinder implements LocalizationFinderInterface
         }
 
         // return null if nothing was found
-        return;
+        return null;
     }
 
     /**
@@ -150,6 +155,6 @@ class LocalizationFinder implements LocalizationFinderInterface
             }
         }
 
-        return;
+        return null;
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add better error message when webspace is not found in reindex.

#### Why?

If you are doing a reindex it will reindex all documents from the database, if there still exists old webspace data it show error calling `getLocalization` on null. Instead we show here a clear message that the webspace could not found.