### PR TITLE
Add External link in admin navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
     </a>
 </p>
 <br/>
-
+test
 [Sulu](https://sulu.io/) is a highly extensible open-source **PHP content management system based** on the [Symfony](https://symfony.com/) framework. Sulu is developed to deliver robust **multi-lingual and multi-portal websites** while providing an **intuitive and extensible administration interface** to manage the full content lifecycle. 
 
 Have a look at the official [Sulu website](https://sulu.io/) for a comprehensive list of Sulu's features, core values and use cases. 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@
     </a>
 </p>
 <br/>
-test
 [Sulu](https://sulu.io/) is a highly extensible open-source **PHP content management system based** on the [Symfony](https://symfony.com/) framework. Sulu is developed to deliver robust **multi-lingual and multi-portal websites** while providing an **intuitive and extensible administration interface** to manage the full content lifecycle. 
 
 Have a look at the official [Sulu website](https://sulu.io/) for a comprehensive list of Sulu's features, core values and use cases. 

--- a/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationExternalItem.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationExternalItem.php
@@ -276,7 +276,7 @@ class NavigationExternalItem implements \Iterator, NavigationItemInterface
     public function copyChildless()
     {
         $new = $this->copyWithName();
-        $new->setView($this->getView());
+        $new->setUrl($this->getUrl());
         $new->setChildViews($this->getChildViews());
         $new->setIcon($this->getIcon());
         $new->setId($this->getId());
@@ -449,14 +449,5 @@ class NavigationExternalItem implements \Iterator, NavigationItemInterface
 
         return $array;
     }
-
-    public function hasLink(): bool
-    {
-        return $this->getUrl() !== null;
-    }
-
-    public function getView()
-    {
-        return null;
-    }
+    
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationExternalItem.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationExternalItem.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Bundle\AdminBundle\Admin\Navigation;
 
-class NavigationItem implements \Iterator, NavigationItemInterface
+class NavigationExternalItem implements \Iterator, NavigationItemInterface
 {
     /**
      * The id of the NavigationItem.
@@ -42,7 +42,7 @@ class NavigationItem implements \Iterator, NavigationItemInterface
     /**
      * @var string
      */
-    protected $view;
+    protected $url;
 
     /**
      * @var string[]
@@ -162,14 +162,14 @@ class NavigationItem implements \Iterator, NavigationItemInterface
         return $this->icon;
     }
 
-    public function setView(string $view = null): void
+    public function setUrl(string $url = null): void
     {
-        $this->view = $view;
+        $this->url = $url;
     }
 
-    public function getView(): ?string
+    public function getUrl(): ?string
     {
-        return $this->view;
+        return $this->url;
     }
 
     public function setChildViews(array $childViews): void
@@ -420,7 +420,7 @@ class NavigationItem implements \Iterator, NavigationItemInterface
             'title' => $this->getName(),
             'label' => $this->getLabel(),
             'icon' => $this->getIcon(),
-            'view' => $this->getView(),
+            'url' => $this->getUrl(),
             'disabled' => $this->getDisabled(),
             'visible' => $this->getVisible(),
             'id' => (null != $this->getId()) ? $this->getId() : \str_replace('.', '', \uniqid('', true)), //FIXME don't use uniqid()
@@ -449,9 +449,14 @@ class NavigationItem implements \Iterator, NavigationItemInterface
 
         return $array;
     }
-    
+
     public function hasLink(): bool
     {
-        return $this->getView() !== null;
+        return $this->getUrl() !== null;
+    }
+
+    public function getView()
+    {
+        return null;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItem.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItem.php
@@ -449,9 +449,4 @@ class NavigationItem implements \Iterator, NavigationItemInterface
 
         return $array;
     }
-    
-    public function hasLink(): bool
-    {
-        return $this->getView() !== null;
-    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItemCollection.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItemCollection.php
@@ -16,16 +16,16 @@ use Sulu\Bundle\AdminBundle\Exception\NavigationItemNotFoundException;
 class NavigationItemCollection
 {
     /**
-     * @var NavigationItem[]
+     * @var NavigationItemInterface[]
      */
     private $navigationItems = [];
 
-    public function add(NavigationItem $navigationItem): void
+    public function add(NavigationItemInterface $navigationItem): void
     {
         $this->navigationItems[$navigationItem->getName()] = $navigationItem;
     }
 
-    public function get(string $navigationItemName): NavigationItem
+    public function get(string $navigationItemName): NavigationItemInterface
     {
         if (!\array_key_exists($navigationItemName, $this->navigationItems)) {
             throw new NavigationItemNotFoundException($navigationItemName);
@@ -40,7 +40,7 @@ class NavigationItemCollection
     }
 
     /**
-     * @return NavigationItem[]
+     * @return NavigationItemInterface[]
      */
     public function all(): array
     {

--- a/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItemInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItemInterface.php
@@ -29,6 +29,4 @@ interface NavigationItemInterface
     public function setVisible($visible);
     public function getVisible();
     public function toArray();
-    public function hasLink();
-    public function getView();
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItemInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItemInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Admin\Navigation;
+
+interface NavigationItemInterface
+{
+    public function setId($id);
+    public function getId();
+    public function setName($name);
+    public function getName();
+    public function setLabel(string $label = null): void;
+    public function getLabel(): ?string;
+    public function setIcon($icon);
+    public function getIcon();
+    public function setPosition($position);
+    public function getPosition();
+    public function hasChildren();
+    public function setDisabled($disabled);
+    public function getDisabled();
+    public function setVisible($visible);
+    public function getVisible();
+    public function toArray();
+    public function hasLink();
+    public function getView();
+}

--- a/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationRegistry.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationRegistry.php
@@ -75,9 +75,7 @@ class NavigationRegistry
             $admin->configureNavigationItems($navigationItemCollection);
         }
 
-        $navigationItems = \array_filter($navigationItemCollection->all(), function($navigationItem) {
-            return $navigationItem->getChildren() || $navigationItem->hasLink();
-        });
+        $navigationItems = $navigationItemCollection->all();
 
         foreach ($navigationItems as $navigationItem) {
             $this->processNavigationItem($navigationItem);

--- a/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationRegistry.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationRegistry.php
@@ -76,7 +76,7 @@ class NavigationRegistry
         }
 
         $navigationItems = \array_filter($navigationItemCollection->all(), function($navigationItem) {
-            return $navigationItem->getChildren() || $navigationItem->getView();
+            return $navigationItem->getChildren() || $navigationItem->hasLink();
         });
 
         foreach ($navigationItems as $navigationItem) {
@@ -85,7 +85,7 @@ class NavigationRegistry
 
         \usort(
             $navigationItems,
-            function(NavigationItem $a, NavigationItem $b) {
+            function(NavigationItemInterface $a, NavigationItemInterface $b) {
                 $aPosition = $a->getPosition() ?? \PHP_INT_MAX;
                 $bPosition = $b->getPosition() ?? \PHP_INT_MAX;
 
@@ -99,7 +99,7 @@ class NavigationRegistry
     /**
      * Adds the translation and the child views to the given navigation item.
      */
-    private function processNavigationItem(NavigationItem $navigationItem): void
+    private function processNavigationItem(NavigationItemInterface $navigationItem): void
     {
         // create label from name when no label is set
         if (!$navigationItem->getLabel()) {

--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -17,6 +17,7 @@ use FOS\RestBundle\View\ViewHandlerInterface;
 use JMS\Serializer\SerializerInterface;
 use Sulu\Bundle\AdminBundle\Admin\AdminPool;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItem;
+use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemInterface;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationRegistry;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewRegistry;
 use Sulu\Bundle\AdminBundle\FieldType\FieldTypeOptionRegistryInterface;
@@ -256,7 +257,7 @@ class AdminController
                 'fieldTypeOptions' => $this->fieldTypeOptionRegistry->toArray(),
                 'internalLinkTypes' => $this->linkProviderPool->getConfiguration(),
                 'localizations' => \array_values($this->localizationManager->getLocalizations()),
-                'navigation' => \array_map(function(NavigationItem $navigationItem) {
+                'navigation' => \array_map(function(NavigationItemInterface $navigationItem) {
                     return $navigationItem->toArray();
                 }, \array_values($this->navigationRegistry->getNavigationItems())),
                 'routes' => $this->viewRegistry->getViews(),

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Item.js
@@ -9,6 +9,7 @@ type Props = {
     active?: boolean,
     children?: ChildrenArray<Element<typeof Item> | false>,
     expanded?: boolean,
+    url?: string,
     icon?: string,
     onClick?: (value: string) => void,
     title: string,
@@ -17,19 +18,23 @@ type Props = {
 
 export default class Item extends React.PureComponent<Props> {
     handleClick = () => {
-        const {onClick, value} = this.props;
+        const {onClick, value, url} = this.props;
 
         if (!onClick) {
             return;
         }
-
+        
+        if (url) {
+            window.location = url;
+            return;
+        }
+        
         onClick(value);
     };
 
     render() {
-        const {title, children, expanded, icon} = this.props;
+        const {title, children, expanded, icon, url} = this.props;
         let {active} = this.props;
-
         // check for active children
         if (children) {
             React.Children.forEach(children, (child: Element<typeof Item>) => {
@@ -57,6 +62,11 @@ export default class Item extends React.PureComponent<Props> {
                             name={expanded ? 'su-angle-down' : 'su-angle-right'}
                             onClick={this.handleClick}
                         />
+                    }
+                    {url &&
+                    <Icon name="su-link"
+                        className={itemStyles.childrenIndicator}
+                    />
                     }
                 </div>
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/Navigation.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/Navigation.js
@@ -93,6 +93,7 @@ class Navigation extends React.Component<Props> {
                         active={this.isItemActive(item)}
                         icon={item.icon}
                         key={item.id}
+                        url={item.url}
                         title={item.label}
                         value={item.id}
                     >
@@ -102,6 +103,7 @@ class Navigation extends React.Component<Props> {
                                 <NavigationComponent.Item
                                     active={this.isItemActive(subItem)}
                                     key={subItem.id}
+                                    url={subItem.url}
                                     title={subItem.label}
                                     value={subItem.id}
                                 />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/types.js
@@ -6,5 +6,6 @@ export type NavigationItem = {
     items?: Array<NavigationItem>,
     label: string,
     view?: string,
+    url?: string,
     visible: boolean,
 };


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no 
| Fixed tickets | fixes #5207
| Related issues/PRs | #5207
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Permit the admin navitation to link to external url

#### Why?

Link to external tools ( google analytics, or other web companion )

#### Example Usage

<!--
```php
class GoogleAnalyticsAdmin extends Admin
{

    public function configureNavigationItems(NavigationItemCollection $navigationItemCollection): void
    {
        $analytics = new NavigationExternalItem('app.googleanalytics');
        $analytics->setPosition(11);
        $analytics->setIcon("su-web");
        $analytics->setUrl("https://admin.googleanalytics.com");
        $navigationItemCollection->add($analytics);
    }

}
```
-->

#### To Do

- [ ] Create a documentation PR
