### PR TITLE
Avoid exception media index on document

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Search/Subscriber/StructureMediaSearchSubscriber.php
+++ b/src/Sulu/Bundle/MediaBundle/Search/Subscriber/StructureMediaSearchSubscriber.php
@@ -108,6 +108,8 @@ class StructureMediaSearchSubscriber implements EventSubscriberInterface
      * @param array|MediaSelectionContainer $data
      * @param string $locale
      *
+     * @return string|null
+     *
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
      */
@@ -115,7 +117,7 @@ class StructureMediaSearchSubscriber implements EventSubscriberInterface
     {
         // new structures will container an instance of MediaSelectionContainer
         if ($data instanceof MediaSelectionContainer) {
-            $medias = $data->getData('de');
+            $medias = $data->getData();
         // old ones an array ...
         } else {
             $ids = [];
@@ -127,7 +129,7 @@ class StructureMediaSearchSubscriber implements EventSubscriberInterface
             }
 
             if (0 === \count($ids)) {
-                return;
+                return null;
             }
 
             $medias = $this->mediaManager->get($locale, [
@@ -137,16 +139,20 @@ class StructureMediaSearchSubscriber implements EventSubscriberInterface
 
         // no media, no thumbnail URL
         if (!$medias) {
-            return;
+            return null;
         }
 
         $media = \current($medias);
 
         if (!$media) {
-            return;
+            return null;
         }
 
         $formats = $media->getThumbnails();
+
+        if (empty($formats)) {
+            return null;
+        }
 
         if (!isset($formats[$this->searchImageFormat])) {
             throw new \InvalidArgumentException(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Avoid exception media index on document.

#### Why?

Currently an exception is thrown when a document is selected in a field which is marked as role="image". This should not thrown an exception just ignore and don't set the image.