### PR TITLE
Provide a more sulu based progressbar styling

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ProgressBar/progressBar.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ProgressBar/progressBar.scss
@@ -1,10 +1,6 @@
 @import '../../containers/Application/colors.scss';
 
-$width: 250px;
-$height: 20px;
-$borderRadius: 3px;
 $backgroundColor: $white;
-$borderColor: $silver;
 $progressColor: $shakespeare;
 $progressColorError: $roman;
 $progressColorWarning: $gold;
@@ -12,12 +8,13 @@ $progressColorSuccess: $mantis;
 
 .progressBar {
     appearance: none;
-    width: $width;
-    height: $height;
-    overflow: hidden;
-    border: 1px solid $borderColor;
-    border-radius: $borderRadius;
     background-color: $backgroundColor;
+    border: none;
+    border-radius: 5px;
+    height: 10px;
+    max-width: 250px;
+    overflow: hidden;
+    width: 100%;
 
     --progress-color: $progressColor;
 
@@ -39,50 +36,11 @@ $progressColorSuccess: $mantis;
     }
 
     &::-webkit-progress-value {
-        background-image:
-            -webkit-linear-gradient(
-                -45deg,
-                transparent 33%,
-                rgba(0, 0, 0, .1) 33%,
-                rgba(0, 0, 0, .1) 66%,
-                transparent 66%
-            ),
-            -webkit-linear-gradient(
-                top,
-                rgba(255, 255, 255, .25),
-                rgba(0, 0, 0, .25)
-            ),
-            -webkit-linear-gradient(
-                left,
-                var(--progress-color),
-                var(--progress-color)
-            );
-        border-radius: $borderRadius;
-        background-size: 35px 20px, 100% 100%, 100% 100%;
+        background: var(--progress-color);
         transform: scale(1.05, 1.05);
     }
 
     &::-moz-progress-bar {
-        background-image:
-            -moz-linear-gradient(
-                135deg,
-                transparent 33%,
-                rgba(0, 0, 0, .1) 33%,
-                rgba(0, 0, 0, .1) 66%,
-                transparent 66%
-            ),
-            -moz-linear-gradient(
-                top,
-                rgba(255, 255, 255, .25),
-                rgba(0, 0, 0, .25)
-            ),
-            -moz-linear-gradient(
-                left,
-                var(--progress-color),
-                var(--progress-color)
-            );
-        border-radius: $borderRadius;
-        background-size: 35px 20px, 100% 100%, 100% 100%;
-        transform: scale(1.05, 1.05);
+        background: var(--progress-color);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Provide a more sulu based progressbar styling.

#### Why?

The current progress bar does not match the design of sulu.

<details>

<summary>
Before:
</summary>

<img width="664" alt="Bildschirmfoto 2021-10-31 um 17 22 34" src="https://user-images.githubusercontent.com/1698337/139593005-fbedda88-2ac1-4181-868b-61000b5ea041.png">

</details>

After:

<img width="664" alt="Bildschirmfoto 2021-10-31 um 17 21 35" src="https://user-images.githubusercontent.com/1698337/139593009-8c8beff7-c394-41f8-b96a-9d99f2d74a92.png">



