### PR TITLE
Allow jms serializer bundle 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "handcraftedinthealps/rest-routing-bundle": "^1.0",
         "imagine/imagine": "^0.6.1 || ^0.7.0 || ^1.0",
         "jms/serializer": "^3.0",
-        "jms/serializer-bundle": "^3.0",
+        "jms/serializer-bundle": "^3.0 || ^4.0",
         "massive/build-bundle": "^0.3 || ^0.4 || ^0.5",
         "massive/search-bundle": "^2.0",
         "matomo/device-detector": "^3.7 || ^4.0.1",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? |  yes
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Allow jms serializer bundle 4.0.

#### Why?

Future Symfony 6 support.
