### PR TITLE
Add reset tag for document manager services

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,7 +2,7 @@
 
 ## 2.2.17
 
-### Add missing `kernel.reset` event to document manager cache
+### Add missing kernel.reset tag for document manager cache services
 
 The configured `doctrine_phpcr.meta_cache_provider` and `doctrine_phpcr.nodes_cache_provider`
 in the `config/packages/prod/sulu_document_manager.yaml` should be tagged with `kernel.reset`

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,37 @@
 
 ## 2.2.17
 
+### Add missing `kernel.reset` event to document manager cache
+
+The configured `doctrine_phpcr.meta_cache_provider` and `doctrine_phpcr.nodes_cache_provider`
+in the `config/packages/prod/sulu_document_manager.yaml` should be tagged with `kernel.reset`
+to be correctly be reseted:
+
+```diff
+# config/packages/prod/sulu_document_manager.yaml
+
+# ...
+
+services:
+    doctrine_phpcr.meta_cache_provider:
+        class: Symfony\Component\Cache\DoctrineProvider
+        public: false
+        arguments:
+            - '@doctrine_phpcr.meta_cache_pool'
++        tags:
++            - { name: 'kernel.reset', method: 'reset' }
+
+    doctrine_phpcr.nodes_cache_provider:
+        class: Symfony\Component\Cache\DoctrineProvider
+        public: false
+        arguments:
+            - '@doctrine_phpcr.nodes_cache_pool'
++        tags:
++            - { name: 'kernel.reset', method: 'reset' }
+
+# ...
+```
+
 ### Add missing on delete cascade on CategoryTranslation to Keyword relation
 
 The relation table `ca_category_translation_keywords` is missing a `ON DELETE CASCADE`

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,7 +2,7 @@
 
 ## 2.2.17
 
-### Add missing kernel.reset tag for document manager cache services
+### Add missing `kernel.reset` tag for document manager cache services
 
 The configured `doctrine_phpcr.meta_cache_provider` and `doctrine_phpcr.nodes_cache_provider`
 in the `config/packages/prod/sulu_document_manager.yaml` should be tagged with `kernel.reset`

--- a/config/packages/prod/sulu_document_manager.yaml
+++ b/config/packages/prod/sulu_document_manager.yaml
@@ -17,12 +17,16 @@ services:
         public: false
         arguments:
             - '@doctrine_phpcr.meta_cache_pool'
+        tags:
+            - { name: 'kernel.reset', method: 'reset' }
 
     doctrine_phpcr.nodes_cache_provider:
         class: Symfony\Component\Cache\DoctrineProvider
         public: false
         arguments:
             - '@doctrine_phpcr.nodes_cache_pool'
+        tags:
+            - { name: 'kernel.reset', method: 'reset' }
 
 framework:
     cache:


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/skeleton/pull/141 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add UPGRADE for kernel.reset for the custom document manager caches. 

#### Why?

The caches need to be reseted between runs with example roadrunner or swoole. See also skeleton changes: https://github.com/sulu/skeleton/pull/141.
