### PR TITLE
Add PasswordAuthenticatedUserInterface to User

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Entity/PasswordAuthenticatedUserInterface.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/PasswordAuthenticatedUserInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\Entity;
+
+if (\interface_exists(\Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface::class)) {
+    /**
+     * @internal Backward compatibility Interface for Symfony Versions since 5.3.
+     */
+    interface PasswordAuthenticatedUserInterface extends \Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface
+    {
+    }
+} else {
+    /**
+     * @internal Backward compatibility Interface for Symfony Versions 4.4 - 5.2.
+     */
+    interface PasswordAuthenticatedUserInterface
+    {
+        public function getPassword(): ?string;
+    }
+}

--- a/src/Sulu/Bundle/SecurityBundle/Entity/User.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/User.php
@@ -30,7 +30,7 @@ use Symfony\Component\Security\Core\User\UserInterface as SymfonyUserInterface;
  *
  * @ExclusionPolicy("all")
  */
-class User extends ApiEntity implements UserInterface, Serializable, EquatableInterface
+class User extends ApiEntity implements UserInterface, Serializable, EquatableInterface, PasswordAuthenticatedUserInterface
 {
     /**
      * @var int
@@ -193,6 +193,11 @@ class User extends ApiEntity implements UserInterface, Serializable, EquatableIn
         return $this->username;
     }
 
+    public function getUserIdentifier(): string
+    {
+        return $this->username;
+    }
+
     /**
      * Set password.
      *
@@ -212,7 +217,7 @@ class User extends ApiEntity implements UserInterface, Serializable, EquatableIn
      *
      * @return string
      */
-    public function getPassword()
+    public function getPassword(): ?string
     {
         return $this->password;
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? |  yes
| BC breaks? | yes 
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add PasswordAuthenticatedUserInterface to User with backward compatibility to older Symfony  versions.

#### Why?

For Future Symfony 6 compatibility.
