### PR TITLE
Throw xdefault deprecation not when call be sulu itself

### DIFF
--- a/src/Sulu/Component/Localization/Localization.php
+++ b/src/Sulu/Component/Localization/Localization.php
@@ -331,7 +331,9 @@ class Localization implements \JsonSerializable, ArrayableInterface
      */
     public function isXDefault()
     {
-        @\trigger_error(\sprintf('The "%s" method is deprecated on "%s" use "isDefault" instead.', __METHOD__, __CLASS__), \E_USER_DEPRECATED);
+        if (\func_num_args() < 1 || \func_get_arg(0)) {
+            @\trigger_error(\sprintf('The "%s" method is deprecated on "%s" use "isDefault" instead.', __METHOD__, __CLASS__), \E_USER_DEPRECATED);
+        }
 
         return $this->xDefault;
     }
@@ -401,7 +403,7 @@ class Localization implements \JsonSerializable, ArrayableInterface
         $res['language'] = $this->getLanguage();
         $res['localization'] = $this->getLocale();
         $res['default'] = $this->isDefault();
-        $res['xDefault'] = $this->isXDefault();
+        $res['xDefault'] = $this->isXDefault(false);
         $res['children'] = [];
 
         $children = $this->getChildren();

--- a/src/Sulu/Component/Webspace/Portal.php
+++ b/src/Sulu/Component/Webspace/Portal.php
@@ -114,8 +114,8 @@ class Portal
             $this->setDefaultLocalization($localization);
         }
 
-        if ($localization->isXDefault()) {
-            $this->setXDefaultLocalization($localization);
+        if ($localization->isXDefault(false)) {
+            $this->setXDefaultLocalization($localization, false);
         }
     }
 
@@ -177,7 +177,9 @@ class Portal
      */
     public function setXDefaultLocalization($xDefaultLocalization)
     {
-        @\trigger_error(\sprintf('The "%s" method is deprecated on "%s" use "setDefaultLocalization" instead.', __METHOD__, __CLASS__), \E_USER_DEPRECATED);
+        if (\func_num_args() < 2 || \func_get_arg(1)) {
+            @\trigger_error(\sprintf('The "%s" method is deprecated on "%s" use "setDefaultLocalization" instead.', __METHOD__, __CLASS__), \E_USER_DEPRECATED);
+        }
 
         $this->xDefaultLocalization = $xDefaultLocalization;
     }

--- a/src/Sulu/Component/Webspace/Tests/Unit/PortalTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/PortalTest.php
@@ -89,7 +89,7 @@ class PortalTest extends TestCase
         $this->environment->getType()->willReturn('d');
         $this->localization->toArray()->willReturn($expected['localizations'][0]);
         $this->localization->isDefault()->willReturn(true);
-        $this->localization->isXDefault()->willReturn(false);
+        $this->localization->isXDefault(false)->willReturn(false);
         $this->environment->getUrls()->willReturn([]);
 
         $this->portal->addEnvironment($this->environment->reveal());

--- a/src/Sulu/Component/Webspace/Webspace.php
+++ b/src/Sulu/Component/Webspace/Webspace.php
@@ -153,7 +153,7 @@ class Webspace implements ArrayableInterface
             $this->setDefaultLocalization($localization);
         }
 
-        if ($localization->isXDefault()) {
+        if ($localization->isXDefault(false)) {
             $this->xDefaultLocalization = $localization;
         }
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Throw xdefault deprecation not when call be sulu itself.

#### Why?

Currently the deprecation is spaming the deprecation log by us.