### PR TITLE
Add serialization group for trash item

### DIFF
--- a/src/Sulu/Bundle/TrashBundle/Domain/Model/TrashItem.php
+++ b/src/Sulu/Bundle/TrashBundle/Domain/Model/TrashItem.php
@@ -15,27 +15,47 @@ namespace Sulu\Bundle\TrashBundle\Domain\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use JMS\Serializer\Annotation\ExclusionPolicy;
+use JMS\Serializer\Annotation\Expose;
+use JMS\Serializer\Annotation\Groups;
+use JMS\Serializer\Annotation\SerializedName;
+use JMS\Serializer\Annotation\VirtualProperty;
 use Sulu\Bundle\TrashBundle\Domain\Exception\TrashItemTranslationNotFoundException;
 use Sulu\Component\Security\Authentication\UserInterface;
 
+/**
+ * @ExclusionPolicy("all")
+ */
 class TrashItem implements TrashItemInterface
 {
     /**
+     * @Expose
+     * @Groups({"trash_item_admin_api"})
+     *
      * @var int
      */
     private $id;
 
     /**
+     * @Expose
+     * @Groups({"trash_item_admin_api"})
+     *
      * @var string
      */
     private $resourceKey;
 
     /**
+     * @Expose
+     * @Groups({"trash_item_admin_api"})
+     *
      * @var string
      */
     private $resourceId;
 
     /**
+     * @Expose
+     * @Groups({"trash_item_admin_api"})
+     *
      * @var mixed[]
      */
     private $restoreData = [];
@@ -44,6 +64,9 @@ class TrashItem implements TrashItemInterface
      * The restoreType can be used to indicate a sub entity.
      *     e.g.: Store and Restore a single translation of a page.
      *          -> "translation".
+     *
+     * @Expose
+     * @Groups({"trash_item_admin_api"})
      *
      * @var string|null
      */
@@ -54,26 +77,40 @@ class TrashItem implements TrashItemInterface
      *     e.g.: Store and Restore a single translation of a page.
      *          -> ["locale" => "en"].
      *
+     * @Expose
+     * @Groups({"trash_item_admin_api"})
+     *
      * @var mixed[]
      */
     private $restoreOptions = [];
 
     /**
+     * @Expose
+     * @Groups({"trash_item_admin_api"})
+     *
      * @var string|null
      */
     private $resourceSecurityContext;
 
     /**
+     * @Expose
+     *
      * @var string|null
      */
     private $resourceSecurityObjectType;
 
     /**
+     * @Expose
+     * @Groups({"trash_item_admin_api"})
+     *
      * @var string|null
      */
     private $resourceSecurityObjectId;
 
     /**
+     * @Expose
+     * @Groups({"trash_item_admin_api"})
+     *
      * @var \DateTimeImmutable
      */
     private $storeTimestamp;
@@ -235,6 +272,16 @@ class TrashItem implements TrashItemInterface
     public function getUser(): ?UserInterface
     {
         return $this->user;
+    }
+
+    /**
+     * @VirtualProperty
+     * @SerializedName("userId")
+     * @Groups({"trash_item_api"})
+     */
+    public function getUserId(): ?int
+    {
+        return $this->user ? $this->user->getId() : null;
     }
 
     public function setUser(?UserInterface $user): TrashItemInterface

--- a/src/Sulu/Bundle/TrashBundle/Domain/Model/TrashItemInterface.php
+++ b/src/Sulu/Bundle/TrashBundle/Domain/Model/TrashItemInterface.php
@@ -74,6 +74,8 @@ interface TrashItemInterface
 
     public function getUser(): ?UserInterface;
 
+    public function getUserId(): ?int;
+
     public function setUser(?UserInterface $user): self;
 
     public function getTranslation(?string $locale = null, bool $fallback = false): TrashItemTranslation;

--- a/src/Sulu/Bundle/TrashBundle/Domain/Model/TrashItemTranslation.php
+++ b/src/Sulu/Bundle/TrashBundle/Domain/Model/TrashItemTranslation.php
@@ -13,6 +13,13 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\TrashBundle\Domain\Model;
 
+use JMS\Serializer\Annotation\ExclusionPolicy;
+use JMS\Serializer\Annotation\Expose;
+use JMS\Serializer\Annotation\Groups;
+
+/**
+ * @ExclusionPolicy("all")
+ */
 class TrashItemTranslation
 {
     /**
@@ -26,11 +33,17 @@ class TrashItemTranslation
     private $trashItem;
 
     /**
+     * @Expose
+     * @Groups({"trash_item_admin_api"})
+     *
      * @var string|null
      */
     private $locale;
 
     /**
+     * @Expose
+     * @Groups({"trash_item_admin_api"})
+     *
      * @var string
      */
     private $title;

--- a/src/Sulu/Bundle/TrashBundle/UserInterface/Controller/Admin/TrashItemController.php
+++ b/src/Sulu/Bundle/TrashBundle/UserInterface/Controller/Admin/TrashItemController.php
@@ -241,8 +241,11 @@ class TrashItemController extends AbstractRestController implements ClassResourc
             PermissionTypes::VIEW
         );
 
+        $context = new Context();
+        $context->setGroups(['trash_item_admin_api']);
+
         return $this->handleView(
-            $this->view($trashItem)
+            $this->view($trashItem)->setContext($context)
         );
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add serialization group for trash item.

#### Why?

Trash items currently serialized all its properties includes the user with all its properties.