### PR TITLE
Fix warnings that are generated when running javascript tests (2.2)

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/Navigation.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/Navigation.test.js
@@ -3,6 +3,10 @@ import {mount} from 'enzyme';
 import React from 'react';
 import Navigation from '../Navigation';
 
+jest.mock('../../../utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
+
 test('The component should render and handle clicks correctly', () => {
     const handleNavigationClick = jest.fn();
     const handleLogoutClick = jest.fn();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/Overlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/Overlay.test.js
@@ -4,6 +4,10 @@ import Mousetrap from 'mousetrap';
 import React from 'react';
 import Overlay from '../Overlay';
 
+jest.mock('../../../utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
+
 test('The component should render in body when open', () => {
     const actions = [
         {title: 'Action 1', onClick: () => {}},

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
@@ -18,7 +18,7 @@ jest.mock('../registries/fieldRegistry', () => ({
     getOptions: jest.fn(),
 }));
 
-jest.mock('../../../utils', () => ({
+jest.mock('../../../utils/Translator', () => ({
     translate: (key) => key,
 }));
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/MemoryFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/MemoryFormStore.test.js
@@ -801,19 +801,19 @@ test('Remember fields being finished as modified fields', () => {
 });
 
 test('Validate should return true if no errors occured', () => {
-    const memoryFormStore = new MemoryFormStore({title: 'Test'}, {}, {required: ['title']});
+    const memoryFormStore = new MemoryFormStore({title: 'Test'}, {}, {type: 'object', required: ['title']});
 
     expect(memoryFormStore.validate()).toEqual(true);
 });
 
 test('Validate should return false if errors occured', () => {
-    const memoryFormStore = new MemoryFormStore({}, {}, {required: ['title']});
+    const memoryFormStore = new MemoryFormStore({}, {}, {type: 'object', required: ['title']});
 
     expect(memoryFormStore.validate()).toEqual(false);
 });
 
 test('Forbidden flag should always be set to false', () => {
-    const memoryFormStore = new MemoryFormStore({}, {}, {required: ['title']});
+    const memoryFormStore = new MemoryFormStore({}, {}, {type: 'object', required: ['title']});
 
     expect(memoryFormStore.forbidden).toEqual(false);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldTransformers/DateTimeFieldTransformer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldTransformers/DateTimeFieldTransformer.test.js
@@ -13,6 +13,10 @@ jest.mock('loglevel', () => ({
     error: jest.fn(),
 }));
 
+jest.mock('../../../../utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
+
 test('Test undefined', () => {
     expect(dateTimeFieldTransformer.transform(undefined)).toBe(null);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/loadingStrategies/FullLoadingStrategy.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/loadingStrategies/FullLoadingStrategy.test.js
@@ -3,6 +3,10 @@ import 'url-search-params-polyfill';
 import FullLoadingStrategy from '../../loadingStrategies/FullLoadingStrategy';
 import ResourceRequester from '../../../../services/ResourceRequester';
 
+jest.mock('loglevel', () => ({
+    warn: jest.fn(),
+}));
+
 jest.mock('../../../../services/ResourceRequester', () => ({
     getList: jest.fn().mockReturnValue(Promise.resolve({
         _embedded: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/loadingStrategies/PaginatedLoadingStrategy.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/loadingStrategies/PaginatedLoadingStrategy.test.js
@@ -3,6 +3,10 @@ import 'url-search-params-polyfill';
 import PaginatedLoadingStrategy from '../../loadingStrategies/PaginatedLoadingStrategy';
 import ResourceRequester from '../../../../services/ResourceRequester';
 
+jest.mock('loglevel', () => ({
+    warn: jest.fn(),
+}));
+
 jest.mock('../../../../services/ResourceRequester', () => ({
     getList: jest.fn().mockReturnValue(Promise.resolve({
         _embedded: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ListOverlay/tests/ListOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ListOverlay/tests/ListOverlay.test.js
@@ -8,7 +8,7 @@ import List from '../../../containers/List';
 import ListStore from '../../../containers/List/stores/ListStore';
 import ListOverlay from '../ListOverlay';
 
-jest.mock('../../../utils', () => ({
+jest.mock('../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/tests/MultiListOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/tests/MultiListOverlay.test.js
@@ -6,7 +6,7 @@ import ListStore from '../../../containers/List/stores/ListStore';
 import ListOverlay from '../../../containers/ListOverlay';
 import MultiListOverlay from '../MultiListOverlay';
 
-jest.mock('../../../utils', () => ({
+jest.mock('../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/MultiSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/MultiSelection.test.js
@@ -6,7 +6,7 @@ import MultiSelection from '../MultiSelection';
 import MultiSelectionStore from '../../../stores/MultiSelectionStore';
 import MultiItemSelection from '../../../components/MultiItemSelection';
 
-jest.mock('../../../utils', () => ({
+jest.mock('../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/tests/Navigation.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/tests/Navigation.test.js
@@ -5,6 +5,10 @@ import Navigation from '../Navigation';
 import Router, {Route} from '../../../services/Router';
 import type {NavigationItem} from '../types';
 
+jest.mock('../../../utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
+
 jest.mock('../../../services/Router/Router', () => jest.fn(function() {
     this.navigate = jest.fn();
 }));

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/tests/SingleListOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/tests/SingleListOverlay.test.js
@@ -6,7 +6,7 @@ import ListStore from '../../../containers/List/stores/ListStore';
 import ListOverlay from '../../../containers/ListOverlay';
 import SingleListOverlay from '../SingleListOverlay';
 
-jest.mock('../../../utils', () => ({
+jest.mock('../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -1622,7 +1622,7 @@ test('Should show error if form has been tried to save although it is not valid'
     const schemaPromise = Promise.resolve({});
     metadataStore.getSchema.mockReturnValue(schemaPromise);
 
-    const jsonSchemaPromise = Promise.resolve({required: ['title']});
+    const jsonSchemaPromise = Promise.resolve({type: 'object', required: ['title']});
     metadataStore.getJsonSchema.mockReturnValue(jsonSchemaPromise);
 
     const route = {
@@ -1674,7 +1674,7 @@ test('Should clear errors if form has been saved', () => {
     const schemaPromise = Promise.resolve({});
     metadataStore.getSchema.mockReturnValue(schemaPromise);
 
-    const jsonSchemaPromise = Promise.resolve({required: []});
+    const jsonSchemaPromise = Promise.resolve({type: 'object', required: []});
     metadataStore.getJsonSchema.mockReturnValue(jsonSchemaPromise);
 
     const route = {

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/components/AddressCardPreview/tests/AddressCardPreview.test.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/components/AddressCardPreview/tests/AddressCardPreview.test.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {render} from 'enzyme';
 import AddressCardPreview from '../AddressCardPreview';
 
-jest.mock('sulu-admin-bundle/utils', () => ({
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/views/List/tests/toolbarActions/AddContactToolbarAction.test.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/views/List/tests/toolbarActions/AddContactToolbarAction.test.js
@@ -7,7 +7,7 @@ import {ResourceStore} from 'sulu-admin-bundle/stores';
 import {List} from 'sulu-admin-bundle/views';
 import AddContactToolbarAction from '../../toolbarActions/AddContactToolbarAction';
 
-jest.mock('sulu-admin-bundle/utils', () => ({
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/views/List/tests/toolbarActions/AddMediaToolbarAction.test.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/views/List/tests/toolbarActions/AddMediaToolbarAction.test.js
@@ -7,7 +7,7 @@ import {ResourceStore} from 'sulu-admin-bundle/stores';
 import {List} from 'sulu-admin-bundle/views';
 import AddMediaToolbarAction from '../../toolbarActions/AddMediaToolbarAction';
 
-jest.mock('sulu-admin-bundle/utils', () => ({
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/views/List/tests/toolbarActions/DeleteMediaToolbarAction.test.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/views/List/tests/toolbarActions/DeleteMediaToolbarAction.test.js
@@ -7,7 +7,7 @@ import {ResourceStore} from 'sulu-admin-bundle/stores';
 import {List} from 'sulu-admin-bundle/views';
 import DeleteMediaToolbarAction from '../../toolbarActions/DeleteMediaToolbarAction';
 
-jest.mock('sulu-admin-bundle/utils', () => ({
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 

--- a/src/Sulu/Bundle/CustomUrlBundle/Resources/js/containers/Form/tests/fields/CustomUrlsDomainSelect.test.js
+++ b/src/Sulu/Bundle/CustomUrlBundle/Resources/js/containers/Form/tests/fields/CustomUrlsDomainSelect.test.js
@@ -20,7 +20,7 @@ jest.mock('sulu-admin-bundle/stores', () => ({
     ResourceStore: jest.fn(),
 }));
 
-jest.mock('sulu-admin-bundle/utils', () => ({
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 

--- a/src/Sulu/Bundle/CustomUrlBundle/Resources/js/containers/Form/tests/fields/CustomUrlsLocaleSelect.test.js
+++ b/src/Sulu/Bundle/CustomUrlBundle/Resources/js/containers/Form/tests/fields/CustomUrlsLocaleSelect.test.js
@@ -20,7 +20,7 @@ jest.mock('sulu-admin-bundle/stores', () => ({
     ResourceStore: jest.fn(),
 }));
 
-jest.mock('sulu-admin-bundle/utils', () => ({
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/MediaCardAdapter.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/MediaCardAdapter.test.js
@@ -4,7 +4,7 @@ import React from 'react';
 import {listAdapterDefaultProps} from 'sulu-admin-bundle/utils/TestHelper';
 import MediaCardAdapter from '../../adapters/MediaCardAdapter';
 
-jest.mock('sulu-admin-bundle/utils', () => ({
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate(key) {
         switch (key) {
             case 'sulu_media.copy_url':

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/MediaCardOverviewAdapter.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/MediaCardOverviewAdapter.test.js
@@ -6,7 +6,7 @@ import MediaCardOverviewAdapter from '../../adapters/MediaCardOverviewAdapter';
 
 jest.mock('sulu-admin-bundle/services/initializer', () => jest.fn());
 
-jest.mock('sulu-admin-bundle/utils', () => ({
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate(key) {
         switch (key) {
             case 'sulu_media.copy_url':

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
@@ -188,7 +188,7 @@ jest.mock('sulu-admin-bundle/stores', () => {
     };
 });
 
-jest.mock('sulu-admin-bundle/utils', () => ({
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: (key) => key,
 }));
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaVersionUpload/tests/CropOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaVersionUpload/tests/CropOverlay.test.js
@@ -5,7 +5,7 @@ import formatStore from '../../../stores/formatStore';
 import MediaFormatStore from '../../../stores/MediaFormatStore';
 import CropOverlay from '../CropOverlay';
 
-jest.mock('sulu-admin-bundle/utils', () => ({
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaVersionUpload/tests/FocusPointOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaVersionUpload/tests/FocusPointOverlay.test.js
@@ -13,7 +13,7 @@ jest.mock('sulu-admin-bundle/stores', () => ({
     }),
 }));
 
-jest.mock('sulu-admin-bundle/utils', () => ({
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/tests/SingleMediaUpload.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/tests/SingleMediaUpload.test.js
@@ -15,7 +15,7 @@ jest.mock('../../../stores/MediaUploadStore', () => jest.fn(function(media) {
     this.media = media;
 }));
 
-jest.mock('sulu-admin-bundle/utils', () => ({
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/tests/MediaFormats.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/tests/MediaFormats.test.js
@@ -21,7 +21,7 @@ jest.mock('sulu-admin-bundle/stores', () => ({
     }),
 }));
 
-jest.mock('sulu-admin-bundle/utils', () => ({
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: (key) => key,
 }));
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaHistory/tests/MediaHistory.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaHistory/tests/MediaHistory.test.js
@@ -23,7 +23,7 @@ jest.mock('sulu-admin-bundle/services/ResourceRequester', () => ({
     delete: jest.fn(),
 }));
 
-jest.mock('sulu-admin-bundle/utils', () => ({
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: (key) => key,
 }));
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -129,7 +129,7 @@ jest.mock('sulu-admin-bundle/stores', () => ({
     }),
 }));
 
-jest.mock('sulu-admin-bundle/utils', () => ({
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: (key) => key,
 }));
 

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/tests/fields/PageSettingsNavigationSelect.test.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/tests/fields/PageSettingsNavigationSelect.test.js
@@ -20,7 +20,7 @@ jest.mock('sulu-admin-bundle/stores', () => ({
     ResourceStore: jest.fn(),
 }));
 
-jest.mock('sulu-admin-bundle/utils', () => ({
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/tests/fields/PageSettingsShadowLocaleSelect.test.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/tests/fields/PageSettingsShadowLocaleSelect.test.js
@@ -25,7 +25,7 @@ jest.mock('sulu-admin-bundle/stores', () => ({
     }),
 }));
 
-jest.mock('sulu-admin-bundle/utils', () => ({
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/Preview.test.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/Preview.test.js
@@ -59,7 +59,7 @@ jest.mock('sulu-admin-bundle/services/Router/Router', () => jest.fn(function(his
     this.route = {options: {}};
 }));
 
-jest.mock('sulu-admin-bundle/utils', () => ({
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/PermissionMatrix.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/PermissionMatrix.test.js
@@ -6,7 +6,7 @@ import type {MatrixValues} from 'sulu-admin-bundle/components/Matrix/types';
 import type {ContextPermission} from '../types';
 import type {SecurityContexts} from '../../../stores/securityContextStore/types';
 
-jest.mock('sulu-admin-bundle/utils', () => ({
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: (key) => key,
 }));
 

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/RoleAssignments.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/RoleAssignments.test.js
@@ -35,7 +35,7 @@ jest.mock('sulu-admin-bundle/stores', () => ({
     },
 }));
 
-jest.mock('sulu-admin-bundle/utils', () => ({
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: (key) => key,
 }));
 

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/tests/toolbarActions/EnableUserToolbarAction.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/tests/toolbarActions/EnableUserToolbarAction.test.js
@@ -6,7 +6,7 @@ import {ResourceFormStore} from 'sulu-admin-bundle/containers/Form';
 import {ResourceRequester} from 'sulu-admin-bundle/services';
 import EnableUserToolbarAction from '../../toolbarActions/EnableUserToolbarAction';
 
-jest.mock('sulu-admin-bundle/utils', () => ({
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/SnippetAreas.test.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/SnippetAreas.test.js
@@ -8,7 +8,7 @@ jest.mock('sulu-admin-bundle/containers', () => ({
     SingleListOverlay: jest.fn(() => null),
     withToolbar: jest.fn((Component) => Component),
 }));
-jest.mock('sulu-admin-bundle/utils', () => ({
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: jest.fn((key) =>key),
 }));
 jest.mock('../stores/SnippetAreaStore', () => jest.fn());

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/Form/tests/fields/AnalyticsDomainSelect.test.js
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/Form/tests/fields/AnalyticsDomainSelect.test.js
@@ -20,7 +20,7 @@ jest.mock('sulu-admin-bundle/stores', () => ({
     ResourceStore: jest.fn(),
 }));
 
-jest.mock('sulu-admin-bundle/utils', () => ({
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 


### PR DESCRIPTION
This PR fixes the warnings that are printed to the console when running the javascript tests on the `2.2` branch. 

For example, see the following test run: https://github.com/sulu/sulu/runs/4080029666?check_suite_focus=true