### PR TITLE
Fix warnings that are generated when running javascript tests (2.3)

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
@@ -225,18 +225,22 @@ test('Render data with skin', () => {
 test('Render data with shrunken cell', () => {
     const data = [
         {
+            id: 1,
             title: '1',
             description: 'planned',
         },
         {
+            id: 2,
             title: '2',
             description: 'running',
         },
         {
+            id: 3,
             title: '3',
             description: 'succeeded',
         },
         {
+            id: 4,
             title: '4',
             description: 'failed',
         },


### PR DESCRIPTION
This PR fixes the warnings that are printed to the console when running the javascript tests on the `2.3` branch.
I already created a similar pull request for the `2.2` branch: https://github.com/sulu/sulu/pull/6340

For example, see the following test run: https://github.com/sulu/sulu/runs/4078689274?check_suite_focus=true