### PR TITLE
Fix warnings that are generated when running javascript tests (2.x)

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/UserSection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/UserSection.test.js
@@ -3,6 +3,10 @@ import {mount} from 'enzyme';
 import React from 'react';
 import UserSection from '../UserSection';
 
+jest.mock('../../../utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
+
 test('The component should render with all available props and handle clicks correctly', () => {
     const handleLogoutClick = jest.fn();
     const handleProfileClick = jest.fn();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/Link.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/Link.test.js
@@ -7,6 +7,10 @@ import linkTypeRegistry from '../registries/linkTypeRegistry';
 import LinkTypeOverlay from '../overlays/LinkTypeOverlay';
 import type {LinkValue} from '../types';
 
+jest.mock('../../../utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
+
 jest.mock('../registries/linkTypeRegistry', () => ({
     getKeys: jest.fn(),
     getOverlay: jest.fn(),

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/LinkTypeOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/LinkTypeOverlay.test.js
@@ -7,17 +7,11 @@ jest.mock('../../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 
+jest.mock('../../../SingleListOverlay', () => jest.fn(function() {
+    return <div>single list overlay</div>;
+}));
+
 test('Render overlay with minimal config', () => {
-    const response = {
-        ok: true,
-        json: jest.fn(),
-    };
-    response.json.mockReturnValue(Promise.resolve({}));
-    const promise = new Promise((resolve) => resolve(response));
-
-    window.fetch = jest.fn();
-    window.fetch.mockReturnValue(promise);
-
     const linkOverlay = mount(
         <LinkTypeOverlay
             href={undefined}
@@ -55,15 +49,6 @@ test('Render overlay without options', () => {
 });
 
 test('Render overlay with anchor enabled', () => {
-    const response = {
-        ok: true,
-        json: jest.fn(),
-    };
-    const promise = new Promise((resolve) => resolve(response));
-
-    window.fetch = jest.fn();
-    window.fetch.mockReturnValue(promise);
-
     const linkOverlay = mount(
         <LinkTypeOverlay
             href={undefined}
@@ -89,15 +74,6 @@ test('Render overlay with anchor enabled', () => {
 });
 
 test('Render overlay with target enabled', () => {
-    const response = {
-        ok: true,
-        json: jest.fn(),
-    };
-    const promise = new Promise((resolve) => resolve(response));
-
-    window.fetch = jest.fn();
-    window.fetch.mockReturnValue(promise);
-
     const linkOverlay = mount(
         <LinkTypeOverlay
             href={undefined}
@@ -123,15 +99,6 @@ test('Render overlay with target enabled', () => {
 });
 
 test('Render overlay with title enabled', () => {
-    const response = {
-        ok: true,
-        json: jest.fn(),
-    };
-    const promise = new Promise((resolve) => resolve(response));
-
-    window.fetch = jest.fn();
-    window.fetch.mockReturnValue(promise);
-
     const linkOverlay = mount(
         <LinkTypeOverlay
             href={undefined}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/__snapshots__/LinkTypeOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/__snapshots__/LinkTypeOverlay.test.js.snap
@@ -42,6 +42,9 @@ exports[`Render overlay with anchor enabled 1`] = `
           </div>
         </div>
       </div>
+      <div>
+        single list overlay
+      </div>
       <label
         class="errorLabel"
       />
@@ -116,6 +119,9 @@ exports[`Render overlay with minimal config 1`] = `
           </div>
         </div>
       </div>
+      <div>
+        single list overlay
+      </div>
       <label
         class="errorLabel"
       />
@@ -165,6 +171,9 @@ exports[`Render overlay with target enabled 1`] = `
             </div>
           </div>
         </div>
+      </div>
+      <div>
+        single list overlay
       </div>
       <label
         class="errorLabel"
@@ -270,6 +279,9 @@ exports[`Render overlay with title enabled 1`] = `
             </div>
           </div>
         </div>
+      </div>
+      <div>
+        single list overlay
       </div>
       <label
         class="errorLabel"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/tests/overlays/MediaLinkTypeOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/tests/overlays/MediaLinkTypeOverlay.test.js
@@ -7,16 +7,11 @@ jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 
+jest.mock('../../../SingleMediaSelectionOverlay', () => jest.fn(function() {
+    return <div>single media selection overlay</div>;
+}));
+
 test('Render overlay with minimal config', () => {
-    const response = {
-        ok: true,
-        json: jest.fn(),
-    };
-    const promise = new Promise((resolve) => resolve(response));
-
-    window.fetch = jest.fn();
-    window.fetch.mockReturnValue(promise);
-
     const mediaLinkTypeOverlay = mount(
         <MediaLinkTypeOverlay
             href={undefined}
@@ -44,15 +39,6 @@ test('Render overlay with invalid href type', () => {
 });
 
 test('Render overlay with target enabled', () => {
-    const response = {
-        ok: true,
-        json: jest.fn(),
-    };
-    const promise = new Promise((resolve) => resolve(response));
-
-    window.fetch = jest.fn();
-    window.fetch.mockReturnValue(promise);
-
     const mediaLinkTypeOverlay = mount(
         <MediaLinkTypeOverlay
             href={undefined}
@@ -68,15 +54,6 @@ test('Render overlay with target enabled', () => {
 });
 
 test('Render overlay with title enabled', () => {
-    const response = {
-        ok: true,
-        json: jest.fn(),
-    };
-    const promise = new Promise((resolve) => resolve(response));
-
-    window.fetch = jest.fn();
-    window.fetch.mockReturnValue(promise);
-
     const mediaLinkTypeOverlay = mount(
         <MediaLinkTypeOverlay
             href={undefined}
@@ -92,15 +69,6 @@ test('Render overlay with title enabled', () => {
 });
 
 test('Delegate only id to onHrefChange method', () => {
-    const response = {
-        ok: true,
-        json: jest.fn(),
-    };
-    const promise = new Promise((resolve) => resolve(response));
-
-    window.fetch = jest.fn();
-    window.fetch.mockReturnValue(promise);
-
     const hrefChangeSpy = jest.fn();
 
     const mediaLinkTypeOverlay = mount(

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/tests/overlays/__snapshots__/MediaLinkTypeOverlay.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/tests/overlays/__snapshots__/MediaLinkTypeOverlay.test.js.snap
@@ -42,6 +42,9 @@ exports[`Render overlay with minimal config 1`] = `
           </div>
         </div>
       </div>
+      <div>
+        single media selection overlay
+      </div>
       <label
         class="errorLabel"
       />
@@ -91,6 +94,9 @@ exports[`Render overlay with target enabled 1`] = `
             </div>
           </div>
         </div>
+      </div>
+      <div>
+        single media selection overlay
       </div>
       <label
         class="errorLabel"
@@ -196,6 +202,9 @@ exports[`Render overlay with title enabled 1`] = `
             </div>
           </div>
         </div>
+      </div>
+      <div>
+        single media selection overlay
       </div>
       <label
         class="errorLabel"


### PR DESCRIPTION
This PR fixes the warnings that are printed to the console when running the javascript tests on the `2.3` branch.
I already created a similar pull request for the `2.2` and `2.3` branch: https://github.com/sulu/sulu/pull/6340, https://github.com/sulu/sulu/pull/6341

For example, see the following test run: https://github.com/sulu/sulu/runs/4078689274?check_suite_focus=true