### PR TITLE
Add sulu-trash-bundle to package.json and index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ import 'sulu-route-bundle';
 import 'sulu-search-bundle';
 import 'sulu-security-bundle';
 import 'sulu-snippet-bundle';
+import 'sulu-trash-bundle';
 import 'sulu-website-bundle';
 
 startAdmin();

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "sulu-search-bundle": "file:src/Sulu/Bundle/SearchBundle/Resources/js",
         "sulu-security-bundle": "file:src/Sulu/Bundle/SecurityBundle/Resources/js",
         "sulu-snippet-bundle": "file:src/Sulu/Bundle/SnippetBundle/Resources/js",
+        "sulu-trash-bundle": "file:src/Sulu/Bundle/TrashBundle/Resources/js",
         "sulu-website-bundle": "file:src/Sulu/Bundle/WebsiteBundle/Resources/js"
     },
     "devDependencies": {


### PR DESCRIPTION
#### What's in this PR?

This PR adds the `sulu-trash-bundle` package to the `package.json` and `index.js` in this repository.

#### Why?

We use the `package.json` and `index.js` to test the javascript application build in the CI of this repository.
