### PR TITLE
Omit verbose webpack output and performance warnings when creating javascript build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,6 +45,10 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
             filename: outputPath + '/[name].[chunkhash].js',
             publicPath,
         },
+        stats: 'minimal',
+        performance: {
+            hints: false,
+        },
         devtool: argv.mode === 'development' ? 'eval-source-map' : 'source-map',
         plugins: [
             new CleanWebpackPlugin({


### PR DESCRIPTION
#### What's in this PR?

This PR adjusts the `webpack.config.js` to omit the build tree and performance warnings when creating a javascript build using the [`stats`](https://v4.webpack.js.org/configuration/stats/) and [`performance`](https://v4.webpack.js.org/configuration/performance/) configuration option.

#### Why?

The verbose output makes it hard to find the error message if an error happens during build.
