### PR TITLE
Update array-move package to new major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
         ],
         "clearMocks": true,
         "transformIgnorePatterns": [
-            "node_modules/(?!(@ckeditor|ckeditor5|lodash-es|@react-leaflet|react-leaflet)/)"
+            "node_modules/(?!(@ckeditor|ckeditor5|array-move|lodash-es|@react-leaflet|react-leaflet)/)"
         ],
         "testPathIgnorePatterns": [
             "vendor/friendsofsymfony"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
@@ -17,7 +17,7 @@
         "@ckeditor/ckeditor5-ui": "^31.0.0",
         "ajv": "^8.2.0",
         "ajv-formats": "^2.1.0",
-        "array-move": "3.0.1",
+        "array-move": "^4.0.0",
         "classnames": "^2.2.5",
         "debounce": "^1.0.2",
         "fast-deep-equal": "^3.1.1",

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/index.js
@@ -1,5 +1,5 @@
 // @flow
-import arrayMove from 'array-move';
+import {arrayMoveImmutable as arrayMove} from 'array-move';
 import {buildQueryString} from './Request';
 import {createAjv} from './Ajv';
 import {transformBytesToReadableString} from './Bytes';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -81,7 +81,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                 {
                     test: /\.js$/,
                     // eslint-disable-next-line max-len
-                    exclude: /node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5|lodash-es|@react-leaflet|react-leaflet)[/\\])/,
+                    exclude: /node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5|array-move|lodash-es|@react-leaflet|react-leaflet)[/\\])/,
                     use: {
                         loader: 'babel-loader',
                         options: {


### PR DESCRIPTION
#### What's in this PR?

this PR updates the `array-move` package that is used in the `SuluAdminBundle` to the newly released version 4.

#### Why?

Because we try to keep our dependencies up-to-date if possible 🙂 
