### PR TITLE
Fix CategoryController::cgetAction if ids param is empty

### DIFF
--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -135,7 +135,8 @@ class CategoryController extends AbstractRestController implements ClassResource
                 $defaultSort
             );
         } elseif ($request->query->has('ids')) {
-            $entities = $this->categoryManager->findByIds(\explode(',', $request->query->get('ids')));
+            $ids = \array_filter(\explode(',', $request->query->get('ids')));
+            $entities = $this->categoryManager->findByIds($ids);
             $categories = $this->categoryManager->getApiObjects($entities, $locale);
             $list = new CollectionRepresentation($categories, self::$entityKey);
         } else {

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
@@ -244,6 +244,34 @@ class CategoryControllerTest extends SuluTestCase
         $this->assertEquals('Fourth Category', $categories[1]->name);
     }
 
+    public function testCGetByEmptyIds(): void
+    {
+        $category1 = $this->createCategory('first-category-key', 'en');
+        $this->createCategoryTranslation($category1, 'en', 'First Category');
+        $category2 = $this->createCategory('second-category-key', 'en');
+        $this->createCategoryTranslation($category2, 'en', 'Second Category');
+        $category3 = $this->createCategory(null, 'en', $category1);
+        $this->createCategoryTranslation($category3, 'en', 'Third Category');
+        $category4 = $this->createCategory(null, 'en', $category3);
+        $this->createCategoryTranslation($category4, 'en', 'Fourth Category');
+
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->client->jsonRequest(
+            'GET',
+            '/api/categories?locale=en&ids='
+        );
+
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+
+        $response = \json_decode($this->client->getResponse()->getContent());
+
+        $categories = $response->_embedded->categories;
+
+        $this->assertCount(0, $categories);
+    }
+
     public function testCGetFlat()
     {
         $category1 = $this->createCategory('first-category-key', 'en');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

When using PostgreSQL, a request like `/admin/api/categories?locale=en&ids=` results in an exception, because the `CategoryController` transforms the `ids=` into an array like `[0 => ""]`
