### PR TITLE
Update jest to version 29

### DIFF
--- a/flow-typed/npm/jest_v26.x.x.js
+++ b/flow-typed/npm/jest_v26.x.x.js
@@ -823,6 +823,8 @@ declare var expect: {
     SnapshotDiffType,
   /** Add additional Jasmine matchers to Jest's roster */
   extend(matchers: { [name: string]: JestMatcher, ... }): void,
+  /** Add custom equality testers (Jest Circus / Jasmine compatibility API). */
+  addEqualityTesters(testers: Array<Function>): void,
   /** Add a module that formats application-specific data structures. */
   addSnapshotSerializer(pluginModule: JestPrettyFormatPlugin): void,
   assertions(expectedAssertions: number): void,

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
         "webpack-manifest-plugin": "^5.0.0"
     },
     "jest": {
+        "testEnvironment": "jsdom",
         "moduleNameMapper": {
             "\\.(scss|css)$": "identity-obj-proxy",
             "\\.svg$": "<rootDir>/tests/js/mocks/svg.js",

--- a/package.json
+++ b/package.json
@@ -46,12 +46,12 @@
         "@testing-library/user-event": "^14.5.2",
         "@wojtekmaj/enzyme-adapter-react-17": "^0.6.1",
         "autoprefixer": "^10.4.7",
-        "babel-jest": "^26.6.3",
+        "babel-jest": "^29.7.0",
         "babel-loader": "^9.1.0",
+        "cheerio": "1.0.0-rc.12",
         "core-js": "^3.18.0",
         "css-loader": "^6.10.0",
         "css-minimizer-webpack-plugin": "^6.0.0",
-        "cheerio": "1.0.0-rc.12",
         "dependency-cruiser": "^16.2.0",
         "empty": "^0.10.1",
         "enzyme": "^3.3.0",
@@ -67,8 +67,9 @@
         "flow-bin": "^0.142.0",
         "glob": "^10.3.10",
         "identity-obj-proxy": "^3.0.0",
-        "jest": "^26.6.3",
+        "jest": "^29.7.0",
         "jest-canvas-mock": "^2.1.1",
+        "jest-environment-jsdom": "^29.7.0",
         "mini-css-extract-plugin": "^2.7.1",
         "mobx": "^4.0.0",
         "mobx-react": "^5.0.0",
@@ -94,6 +95,9 @@
     },
     "jest": {
         "testEnvironment": "jsdom",
+        "testEnvironmentOptions": {
+            "url": "http://localhost"
+        },
         "moduleNameMapper": {
             "\\.(scss|css)$": "identity-obj-proxy",
             "\\.svg$": "<rootDir>/tests/js/mocks/svg.js",
@@ -101,8 +105,7 @@
         },
         "setupFiles": [
             "jest-canvas-mock",
-            "regenerator-runtime/runtime",
-            "core-js/features/string/replace-all"
+            "regenerator-runtime/runtime"
         ],
         "setupFilesAfterEnv": [
             "./tests/js/testSetup.config.js"
@@ -110,13 +113,16 @@
         "snapshotSerializers": [
             "enzyme-to-json/serializer"
         ],
+        "snapshotFormat": {
+            "escapeString": true,
+            "printBasicPrototype": true
+        },
         "clearMocks": true,
         "transformIgnorePatterns": [
             "node_modules/(?!(@ckeditor|ckeditor5|array-move|lodash-es|vanilla-colorful)/)"
         ],
         "testPathIgnorePatterns": [
             "vendor/friendsofsymfony"
-        ],
-        "testURL": "http://localhost"
+        ]
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/memoryFormStoreFactory.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/memoryFormStoreFactory.test.js
@@ -9,7 +9,7 @@ jest.mock('../../stores/metadataStore', () => ({
     getSchema: jest.fn(),
 }));
 
-test('Create a MemoryFormStore with schema', (done) => {
+test('Create a MemoryFormStore with schema', () => {
     const schema = {
         title: {},
     };
@@ -35,6 +35,5 @@ test('Create a MemoryFormStore with schema', (done) => {
         expect(memoryFormStore.innerFormStore).toBeInstanceOf(MemoryFormStore);
         expect(memoryFormStore.schema).toEqual(schema);
         expect(memoryFormStore.metadataOptions).toEqual(metadataOptions);
-        done();
     });
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/metadataStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/metadataStore.test.js
@@ -144,7 +144,7 @@ test('Return schema for given resourceKey and type', () => {
     });
 });
 
-test('Throw if a type is requested, but the given resourceKey does not have type support', (done) => {
+test('Throw if a type is requested, but the given resourceKey does not have type support', () => {
     const snippetMetadata = {
         form: {
             title: {},
@@ -161,11 +161,10 @@ test('Throw if a type is requested, but the given resourceKey does not have type
         expect(generalMetadataStore.loadMetadata).toBeCalledWith('form', 'snippets', undefined);
         expect(error.toString()).toEqual(expect.stringContaining('does not support types'));
         expect(error.toString()).toEqual(expect.stringContaining('"snippets"'));
-        done();
     });
 });
 
-test('Throw if a schema for a type is requested, but the given resourceKey does not have type support', (done) => {
+test('Throw if a schema for a type is requested, but the given resourceKey does not have type support', () => {
     const snippetMetadata = {
         form: {
             title: {},
@@ -182,11 +181,10 @@ test('Throw if a schema for a type is requested, but the given resourceKey does 
         expect(generalMetadataStore.loadMetadata).toBeCalledWith('form', 'snippets', undefined);
         expect(error.toString()).toEqual(expect.stringContaining('does not support types'));
         expect(error.toString()).toEqual(expect.stringContaining('"snippets"'));
-        done();
     });
 });
 
-test('Throw if a type is omitted, but the given reosurceKey has type support', (done) => {
+test('Throw if a type is omitted, but the given reosurceKey has type support', () => {
     const snippetMetadata = {
         types: {
             sidebar: {
@@ -207,11 +205,10 @@ test('Throw if a type is omitted, but the given reosurceKey has type support', (
         expect(generalMetadataStore.loadMetadata).toBeCalledWith('form', 'snippets', undefined);
         expect(error.toString()).toEqual(expect.stringContaining('requires a type'));
         expect(error.toString()).toEqual(expect.stringContaining('"snippets"'));
-        done();
     });
 });
 
-test('Throw if a type is omitted when loading the JSON Schema, but the given reosurceKey has type support', (done) => {
+test('Throw if a type is omitted when loading the JSON Schema, but the given reosurceKey has type support', () => {
     const snippetMetadata = {
         types: {
             sidebar: {
@@ -232,7 +229,6 @@ test('Throw if a type is omitted when loading the JSON Schema, but the given reo
         expect(generalMetadataStore.loadMetadata).toBeCalledWith('form', 'snippets', undefined);
         expect(error.toString()).toEqual(expect.stringContaining('requires a type'));
         expect(error.toString()).toEqual(expect.stringContaining('"snippets"'));
-        done();
     });
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/Link.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/Link.test.js
@@ -24,7 +24,7 @@ jest.mock('../registries/linkTypeRegistry', () => ({
     getTitle: jest.fn((key) => key.charAt(0).toUpperCase() + (key.slice(1))),
 }));
 
-test('Render Link container incl. loading a selected value', async(resolve) => {
+test('Render Link container incl. loading a selected value', () => {
     const changeSpy = jest.fn();
     const finishSpy = jest.fn();
 
@@ -51,13 +51,11 @@ test('Render Link container incl. loading a selected value', async(resolve) => {
         <Link locale={observable.box('en')} onChange={changeSpy} onFinish={finishSpy} value={value} />
     );
 
-    getPromise.finally(() => {
-        setTimeout(() => {
+    return getPromise
+        .then(() => new Promise((resolve) => setTimeout(resolve, 0)))
+        .then(() => {
             expect(link).toMatchSnapshot();
-
-            resolve();
-        }, 0);
-    });
+        });
 });
 
 test('Open overlay on input click', () => {
@@ -251,7 +249,7 @@ test('Update values on overlay confirm with ExternalLinkTypeOverlay', () => {
     );
 });
 
-test('Invalidate values on RemoveButton click', async(resolve) => {
+test('Invalidate values on RemoveButton click', () => {
     const changeSpy = jest.fn();
     const finishSpy = jest.fn();
 
@@ -288,8 +286,9 @@ test('Invalidate values on RemoveButton click', async(resolve) => {
         value={value}
     />);
 
-    getPromise.finally(() => {
-        setTimeout(() => {
+    return getPromise
+        .then(() => new Promise((resolve) => setTimeout(resolve, 0)))
+        .then(() => {
             const removeButton = link.find('.removeButton');
             removeButton.simulate('click');
 
@@ -305,10 +304,7 @@ test('Invalidate values on RemoveButton click', async(resolve) => {
                     rel: undefined,
                 }
             );
-
-            resolve();
-        }, 0);
-    });
+        });
 });
 
 test('Display providers with "types" property', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
@@ -1237,7 +1237,7 @@ test('ListStore should delete linked item when onRequestItemDelete callback is i
     expect(list.find('Dialog').at(1).prop('open')).toEqual(true);
 
     list.find('Dialog').at(1).prop('onConfirm')();
-    return requestDeletePromise.then(() => {
+    requestDeletePromise.then(() => {
         expect(listStore.delete).toBeCalledWith(5);
 
         setTimeout(() => {
@@ -1296,7 +1296,7 @@ test('ListStore should not delete linked item when onRequestItemDelete callback 
     expect(list.find('Dialog').at(1).prop('open')).toEqual(true);
 
     list.find('Dialog').at(1).prop('onConfirm')();
-    return requestDeletePromise.then(() => {
+    requestDeletePromise.then(() => {
         expect(listStore.delete).toBeCalledWith(5);
         // $FlowFixMe
         listStore.delete.mockReset();
@@ -1475,7 +1475,7 @@ test('ListStore should delete item with dependants when onFinish callback called
     expect(list.find('Dialog').at(1).prop('open')).toEqual(true);
 
     list.find('Dialog').at(1).prop('onConfirm')();
-    return requestDeletePromise.then(() => {
+    requestDeletePromise.then(() => {
         expect(listStore.delete).toHaveBeenCalledWith(5);
 
         setTimeout(() => {
@@ -1535,7 +1535,7 @@ test('ListStore should not delete item with dependants when onCancel callback ca
     expect(list.find('Dialog').at(1).prop('open')).toEqual(true);
 
     list.find('Dialog').at(1).prop('onConfirm')();
-    return requestDeletePromise.then(() => {
+    requestDeletePromise.then(() => {
         expect(listStore.delete).toHaveBeenCalledWith(5);
 
         setTimeout(() => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/SelectionFieldFilterType.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/SelectionFieldFilterType.test.js
@@ -169,7 +169,7 @@ test('Return value node without a value', () => {
     });
 });
 
-test('Return value node with a value', (done) => {
+test('Return value node with a value', () => {
     const selectionFieldFilterType = new SelectionFieldFilterType(
         jest.fn(),
         {displayProperty: 'name', resourceKey: 'accounts'},
@@ -195,6 +195,5 @@ test('Return value node with a value', (done) => {
     return valueNodePromise.then((valueNode) => {
         expect(selectionFieldFilterType.selectionStore.loadItems).not.toBeCalled();
         expect(valueNode).toEqual('Max, Erika, John');
-        done();
     });
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
@@ -1055,7 +1055,7 @@ test('Set loading flag to true before request', () => {
     listStore.destroy();
 });
 
-test('Set loading flag to false after request', (done) => {
+test('Set loading flag to false after request', () => {
     const page = observable.box();
     const listStore = new ListStore('tests', 'tests', 'list_test', {page});
     listStore.schema = {};
@@ -1071,7 +1071,6 @@ test('Set loading flag to false after request', (done) => {
     return promise.then(() => {
         expect(listStore.loading).toEqual(false);
         listStore.destroy();
-        done();
     });
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
@@ -342,7 +342,7 @@ test('Saving and dirty flag should be set to false when creating has failed', (d
 
     const savePromise = resourceStore.save();
 
-    return savePromise.catch((promiseError) => {
+    savePromise.catch((promiseError) => {
         expect(promiseError).toBe(error);
         when(
             () => !resourceStore.saving,
@@ -558,7 +558,7 @@ test('Saving and dirty flag should be set to false when updating has failed', (d
 
     resourceStore.locale.set('en');
 
-    return loadingPromise.then(() => {
+    loadingPromise.then(() => {
         resourceStore.saving = true;
         resourceStore.dirty = true;
         const savePromise = resourceStore.save();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -1429,7 +1429,7 @@ test('Should show warning when form is submitted but already changed on the serv
     resourceStore.loading = false;
     resourceStore.destroy = jest.fn();
 
-    return Promise.all([schemaTypesPromise, schemaPromise, jsonSchemaPromise]).then(() => {
+    Promise.all([schemaTypesPromise, schemaPromise, jsonSchemaPromise]).then(() => {
         form.find('Form').at(1).instance().submit({action: 'publish'});
         expect(resourceStore.destroy).not.toBeCalled();
         expect(ResourceRequester.put).toBeCalledWith(
@@ -1500,7 +1500,7 @@ test('Should show warning when form is submitted but already changed on the serv
     resourceStore.loading = false;
     resourceStore.destroy = jest.fn();
 
-    return Promise.all([schemaTypesPromise, schemaPromise, jsonSchemaPromise]).then(() => {
+    Promise.all([schemaTypesPromise, schemaPromise, jsonSchemaPromise]).then(() => {
         form.find('Form').at(1).instance().submit({action: 'publish'});
         expect(resourceStore.destroy).not.toBeCalled();
         expect(ResourceRequester.put).toBeCalledWith(

--- a/tests/js/testSetup.config.js
+++ b/tests/js/testSetup.config.js
@@ -1,9 +1,27 @@
 // @flow
+import 'core-js/features/string/replace-all';
 import Enzyme from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import {isObservableArray, toJS} from 'mobx';
 import '@testing-library/jest-dom';
 
 Enzyme.configure({adapter: new Adapter()});
+
+function mobxAwareEqualityTester(a, b, customTesters) {
+    const isAObservable = isObservableArray(a);
+    const isBObservable = isObservableArray(b);
+
+    if (!isAObservable && !isBObservable) {
+        return undefined;
+    }
+
+    const normalizedA = isAObservable ? toJS(a) : a;
+    const normalizedB = isBObservable ? toJS(b) : b;
+
+    return this.equals(normalizedA, normalizedB, customTesters);
+}
+
+expect.addEqualityTesters([mobxAwareEqualityTester]);
 
 jest.mock('sulu-admin-bundle/services/Config', () => ({
     endpoints: {


### PR DESCRIPTION
#### What's in this PR?

This PR updates the `jest` package from version 26 to version 27. See the [official release blog](https://jestjs.io/blog/2021/05/25/jest-27) for a list of changes between the versions.

Core Team Update 2026: Adjusted to go with [Jest 29 and `addEqualityTesters` (Support custom equality testers) feature](https://github.com/jestjs/jest/releases/tag/v29.4.0).