### PR TITLE
Add sortable schema option to Selection field

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -377,6 +377,9 @@ class Selection extends React.Component<Props> {
                 allow_deselect_for_disabled_items: {
                     value: allowDeselectForDisabledItems = true,
                 } = {},
+                sortable: {
+                    value: sortable = true,
+                } = {},
             },
         } = this.props;
 
@@ -390,6 +393,10 @@ class Selection extends React.Component<Props> {
 
         if (allowDeselectForDisabledItems !== undefined && typeof allowDeselectForDisabledItems !== 'boolean') {
             throw new Error('The "allow_deselect_for_disabled_items" schema option must be a boolean if given!');
+        }
+
+        if (sortable !== undefined && typeof sortable !== 'boolean') {
+            throw new Error('The "sortable" schema option must be a boolean if given!');
         }
 
         if (!adapter) {
@@ -418,6 +425,7 @@ class Selection extends React.Component<Props> {
                 options={options}
                 overlayTitle={translate(overlayTitle)}
                 resourceKey={resourceKey}
+                sortable={sortable}
                 value={this.value || []}
             />
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -147,6 +147,7 @@ test('Should pass props correctly to MultiSelection component', () => {
         allowDeselectForDisabledItems: true,
         listKey: 'snippets_list',
         disabled: true,
+        sortable: true,
         displayProperties: ['id', 'title'],
         itemDisabledCondition: undefined,
         label: 'sulu_snippet.selection_label',
@@ -281,6 +282,10 @@ test('Should pass props with schema-options correctly to MultiSelection componen
             name: 'item_disabled_condition',
             value: 'status == "inactive"',
         },
+        sortable: {
+            name: 'sortable',
+            value: false
+        },
         request_parameters: {
             name: 'request_parameters',
             value: [
@@ -332,6 +337,7 @@ test('Should pass props with schema-options correctly to MultiSelection componen
         adapter: 'table',
         allowDeselectForDisabledItems: false,
         disabled: true,
+        sortable: false,
         displayProperties: ['id', 'title'],
         itemDisabledCondition: 'status == "inactive"',
         label: 'sulu_snippet.selection_label',
@@ -689,6 +695,32 @@ test('Should throw an error if "allow_deselect_for_disabled_items" schema option
             schemaOptions={schemaOptions}
         />
     )).toThrowError(/"allow_deselect_for_disabled_items"/);
+});
+
+test('Should throw an error if "sortable" schema option is not a boolean', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('snippets'), 'pages'));
+    const fieldTypeOptions = {
+        default_type: 'list_overlay',
+        resource_key: 'test',
+        types: {
+            list_overlay: {},
+        },
+    };
+    const schemaOptions = {
+        sortable: {
+            name: 'sortable',
+            value: 'not-boolean',
+        },
+    };
+
+    expect(() => shallow(
+        <Selection
+            {...fieldTypeDefaultProps}
+            fieldTypeOptions={fieldTypeOptions}
+            formInspector={formInspector}
+            schemaOptions={schemaOptions}
+        />
+    )).toThrowError(/"sortable"/);
 });
 
 test('Should throw an error if "request_parameters" schema option is not an array', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -284,7 +284,7 @@ test('Should pass props with schema-options correctly to MultiSelection componen
         },
         sortable: {
             name: 'sortable',
-            value: false
+            value: false<span class="x x-first x-last">,</span>
         },
         request_parameters: {
             name: 'request_parameters',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -284,7 +284,7 @@ test('Should pass props with schema-options correctly to MultiSelection componen
         },
         sortable: {
             name: 'sortable',
-            value: false<span class="x x-first x-last">,</span>
+            value: false,
         },
         request_parameters: {
             name: 'request_parameters',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
@@ -29,6 +29,7 @@ type Props = {|
     options: Object,
     overlayTitle: string,
     resourceKey: string,
+    sortable: boolean,
     value: Array<string | number>,
 |};
 
@@ -41,6 +42,7 @@ class MultiSelection extends React.Component<Props> {
         displayProperties: [],
         icon: 'su-plus',
         options: {},
+        sortable: true,
         value: [],
     };
 
@@ -140,6 +142,7 @@ class MultiSelection extends React.Component<Props> {
             options,
             overlayTitle,
             resourceKey,
+            sortable,
         } = this.props;
 
         const {items, loading} = this.selectionStore;
@@ -158,6 +161,7 @@ class MultiSelection extends React.Component<Props> {
                     onItemClick={onItemClick}
                     onItemRemove={this.handleRemove}
                     onItemsSorted={this.handleSorted}
+                    sortable={sortable}
                 >
                     {items.map((item, index) => {
                         const itemDisabled = disabledIds.includes(item.id) ||

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/MultiSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/MultiSelection.test.js
@@ -76,7 +76,7 @@ test('Show with passed icon and label and open overlay', () => {
     expect(selection.render()).toMatchSnapshot();
 });
 
-test('Show disbaled in disabled state', () => {
+test('Pass correct props to MultiItemSelection component', () => {
     const multiSelection = mount(
         <MultiSelection
             adapter="table"
@@ -85,10 +85,12 @@ test('Show disbaled in disabled state', () => {
             onChange={jest.fn()}
             overlayTitle="Selection"
             resourceKey="snippets"
+            sortable={false}
         />
     );
 
     expect(multiSelection.find('MultiItemSelection').prop('disabled')).toEqual(true);
+    expect(multiSelection.find('MultiItemSelection').prop('sortable')).toEqual(false);
 });
 
 test('Render with disabled item', () => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
@@ -99,6 +99,9 @@ class MediaSelection extends React.Component<FieldTypeProps<Value>> {
             types: {
                 value: mediaTypes,
             } = {},
+            sortable: {
+                value: sortable = true,
+            } = {},
         } = schemaOptions;
 
         const locale = formInspector.locale ? formInspector.locale : observable.box(userStore.contentLocale);
@@ -115,6 +118,10 @@ class MediaSelection extends React.Component<FieldTypeProps<Value>> {
 
         const mediaTypeValues = convertMediaTypesFromParams(mediaTypes);
 
+        if (sortable !== undefined && typeof sortable !== 'boolean') {
+            throw new Error('The "sortable" schema option must be a boolean if given!');
+        }
+
         return (
             <MultiMediaSelection
                 disabled={!!disabled}
@@ -122,6 +129,7 @@ class MediaSelection extends React.Component<FieldTypeProps<Value>> {
                 locale={locale}
                 onChange={this.handleChange}
                 onItemClick={this.handleItemClick}
+                sortable={sortable}
                 types={mediaTypeValues}
                 value={this.value ? this.value : undefined}
             />

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/MediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/MediaSelection.test.js
@@ -73,6 +73,7 @@ test('Pass correct props to MultiMediaSelection component', () => {
 
     expect(mediaSelection.find(MultiMediaSelection).props().displayOptions).toEqual([]);
     expect(mediaSelection.find(MultiMediaSelection).props().disabled).toEqual(true);
+    expect(mediaSelection.find(MultiMediaSelection).props().sortable).toEqual(true);
     expect(mediaSelection.find(MultiMediaSelection).props().locale.get()).toEqual('en');
     expect(mediaSelection.find(MultiMediaSelection).props().value).toEqual({ids: [55, 66, 77]});
 });
@@ -128,12 +129,16 @@ test('Set default display option if no value is passed', () => {
     expect(changeSpy).toBeCalledWith({displayOption: 'left', ids: []}, {'isDefaultValue': true});
 });
 
-test('Set types on MultiMediaSelection', () => {
+test('Pass correct props for given schema-options to MultiMediaSelection component', () => {
     const changeSpy = jest.fn();
     const schemaOptions = {
         types: {
             name: 'types',
             value: 'image,video',
+        },
+        sortable: {
+            name: 'sortable',
+            value: false,
         },
     };
 
@@ -154,6 +159,7 @@ test('Set types on MultiMediaSelection', () => {
     );
 
     expect(mediaSelection.find(MultiMediaSelection).props().types).toEqual(['image', 'video']);
+    expect(mediaSelection.find(MultiMediaSelection).props().sortable).toEqual(false);
 });
 
 test('Do not set default display option if value is passed', () => {
@@ -359,6 +365,23 @@ test('Should throw an error if displayOptions schemaOption is given but contains
             schemaOptions={{displayOptions: {name: 'displayOptions', value: [{name: 'test', value: true}]}}}
         />
     )).toThrow(/"test"/);
+});
+
+test('Should throw an error if types schemaOption is given but not an array', () => {
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            new ResourceStore('test', undefined, {locale: observable.box('en')}),
+            'test'
+        )
+    );
+
+    expect(() => shallow(
+        <MediaSelection
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            schemaOptions={{types: {name: 'types', value: true}}}
+        />
+    )).toThrow(/"types"/);
 });
 
 test('Should throw an error if types schemaOption is given but not an array', () => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/MultiMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/MultiMediaSelection.js
@@ -20,6 +20,7 @@ type Props = {|
     locale: IObservableValue<string>,
     onChange: (selectedIds: Value) => void,
     onItemClick?: (itemId: number, value: ?Media) => void,
+    sortable: boolean,
     types: Array<string>,
     value: Value,
 |}
@@ -32,6 +33,7 @@ class MultiMediaSelection extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
         displayOptions: [],
+        sortable: true,
         types: [],
         value: {displayOption: undefined, ids: []},
     };
@@ -130,7 +132,7 @@ class MultiMediaSelection extends React.Component<Props> {
     };
 
     render() {
-        const {locale, disabled, displayOptions, types, value} = this.props;
+        const {locale, disabled, displayOptions, sortable, types, value} = this.props;
 
         const {loading, items: medias} = this.mediaSelectionStore;
         const label = (loading) ? '' : this.getLabel(medias.length);
@@ -161,6 +163,7 @@ class MultiMediaSelection extends React.Component<Props> {
                     onItemRemove={this.handleRemove}
                     onItemsSorted={this.handleSorted}
                     rightButton={rightButton}
+                    sortable={sortable}
                 >
                     {medias.map((media, index) => {
                         return (

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/tests/MultiMediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/tests/MultiMediaSelection.test.js
@@ -362,8 +362,9 @@ test('Should call the onItemClick handler if an item is clicked', () => {
 
 test('Pass correct props to MultiItemSelection component', () => {
     const mediaSelection = mount(
-        <MultiMediaSelection disabled={true} locale={observable.box('en')} onChange={jest.fn()} />
+        <MultiMediaSelection disabled={true} locale={observable.box('en')} onChange={jest.fn()} sortable={false} />
     );
 
     expect(mediaSelection.find('MultiItemSelection').prop('disabled')).toEqual(true);
+    expect(mediaSelection.find('MultiItemSelection').prop('sortable')).toEqual(false);
 });


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #6220
| Related issues/PRs | https://github.com/sulu/sulu-docs/pull/685
| License | MIT

#### What's in this PR?

This pull request adds a `sortable` schema option to the `Selection` field component. The option allows to make selection non-sortable in the XML configuration:

```xml
<property name="contacts" type="contact_selection">
    <param>
         <param name="sortable" value="false" />
    </param>
</property>
```

#### Why?

This might be a desired feature when using a selection field type for a custom entity (see #6220).