### PR TITLE
Improve performance of access control query enhancer

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
+++ b/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
@@ -66,7 +66,6 @@ class AccessControlQueryEnhancer
             $queryBuilder,
             $user,
             $permission,
-            $this->getEntityIdCondition($entityClass, $entityAlias),
             $entityClass,
             $entityAlias
         );
@@ -125,7 +124,6 @@ class AccessControlQueryEnhancer
         QueryBuilder $queryBuilder,
         ?UserInterface $user,
         int $permission,
-        string $entityIdCondition,
         string $entityClass,
         string $entityAlias
     ): void {
@@ -137,7 +135,7 @@ class AccessControlQueryEnhancer
             AccessControl::class,
             'accessControl',
             'WITH',
-            'accessControl.entityClass = :entityClass AND ' . $entityIdCondition
+            'accessControl.entityClass = :entityClass AND ' . $this->getEntityIdCondition($entityClass, 'entity')
         );
         $subQueryBuilder->leftJoin('accessControl.role', 'role', 'WITH', 'role.system = :system');
         $subQueryBuilder->andWhere(

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -466,9 +466,10 @@ class DoctrineListBuilder extends AbstractListBuilder
                     $queryBuilder,
                     $this->user,
                     $this->permissions[$this->permission],
+                    $this->securedEntityName,
+                    $this->encodeAlias($this->securedEntityName),
                     $this->securedEntityClassField,
-                    $this->securedEntityIdField,
-                    $this->encodeAlias($this->entityName)
+                    $this->securedEntityIdField
                 );
             } elseif ($this->accessControlQueryEnhancer) {
                 $this->accessControlQueryEnhancer->enhance(

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -221,7 +221,7 @@ class DoctrineListBuilder extends AbstractListBuilder
 
     public function count()
     {
-        $subQueryBuilder = $this->createSubQueryBuilder('COUNT(' . $this->idField->getSelect() . ')', true);
+        $subQueryBuilder = $this->createSubQueryBuilder('COUNT(' . $this->idField->getSelect() . ')');
 
         $this->assignParameters($subQueryBuilder);
 
@@ -446,7 +446,7 @@ class DoctrineListBuilder extends AbstractListBuilder
      *
      * @return QueryBuilder
      */
-    protected function createSubQueryBuilder(string $select, bool $isCount = false)
+    protected function createSubQueryBuilder(string $select)
     {
         // get all filter-fields
         $filterFields = $this->getAllFields(true);
@@ -470,16 +470,8 @@ class DoctrineListBuilder extends AbstractListBuilder
                     $this->securedEntityIdField,
                     $this->encodeAlias($this->entityName)
                 );
-            } elseif ($this->accessControlQueryEnhancer && !$isCount) {
+            } elseif ($this->accessControlQueryEnhancer) {
                 $this->accessControlQueryEnhancer->enhance(
-                    $queryBuilder,
-                    $this->user,
-                    $this->permissions[$this->permission],
-                    $this->securedEntityName,
-                    $this->encodeAlias($this->securedEntityName)
-                );
-            } elseif ($this->accessControlQueryEnhancer && $isCount) {
-                $this->accessControlQueryEnhancer->enhanceCount(
                     $queryBuilder,
                     $this->user,
                     $this->permissions[$this->permission],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Improve performance of access control query enhancer.

The change removes the subquery and selects all IDs which are not accessible by the user and exclude them from the real result.

#### Why?

Currently the queries with a lot of medias are taken a lot of time:

This will improve the list query `7462.32 ms` -> `2.34 ms + 2.64 ms`. 
The count query will also improve from `4872.34 ms`-> `2.83 ms + 635.06 ms`.

So its an over all improvement from `12361.82 ms` -> `659.44 ms`.

To implement this performance improvement we use an own query to load the restricted (not accessible) ids. This is faster as embedding the query as subquery (as it was before). Also loading the "accessible" ids would be more performance intense because sulu has more "accessible" entities that not accessible. Optimized embedded queries are mostly not compatible for MySQL 5.7 because of restrictions.

 As long as we dont have thousands of not "accessible" ids this approach should be faster.