### PR TITLE
Add jms/metadata as conflict in version 2.5.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -148,6 +148,7 @@
         "jackalope/jackalope": "< 1.3.4",
         "jackalope/jackalope-doctrine-dbal": "< 1.3.0",
         "jackalope/jackalope-jackrabbit": "< 1.3.0",
+        "jms/metadata": "2.5.2",
         "jms/serializer-bundle": "3.9.0",
         "php-http/discovery": "< 1.8.0",
         "phpcr/phpcr-utils": "1.2.0 - 1.2.10 || 1.3.0 - 1.3.2",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs |  none
| License | MIT
| Documentation PR | none

#### What's in this PR?

The new release of `jms/metadata` causes a segfault in all of our workflows.