### PR TITLE
Remove conflict to jms metadata 2.5.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -148,7 +148,6 @@
         "jackalope/jackalope": "< 1.3.4",
         "jackalope/jackalope-doctrine-dbal": "< 1.3.0",
         "jackalope/jackalope-jackrabbit": "< 1.3.0",
-        "jms/metadata": "2.5.2",
         "jms/serializer-bundle": "3.9.0",
         "php-http/discovery": "< 1.8.0",
         "phpcr/phpcr-utils": "1.2.0 - 1.2.10 || 1.3.0 - 1.3.2",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes https://github.com/sulu/sulu/issues/6374, fixes https://github.com/sulu/skeleton/issues/146 <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/massiveart/MassiveSearchBundle/pull/163, https://github.com/massiveart/MassiveSearchBundle/pull/164
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove conflict to jms metadata 2.5.2,

#### Why?

Fixed in massive search bundle.
