### PR TITLE
Add missig description in Category API

### DIFF
--- a/src/Sulu/Bundle/CategoryBundle/Api/Category.php
+++ b/src/Sulu/Bundle/CategoryBundle/Api/Category.php
@@ -492,6 +492,7 @@ class Category extends ApiEntityWrapper
             'id' => $this->getId(),
             'key' => $this->getKey(),
             'name' => $this->getName(),
+            'description' => $this->getDescription(),
             'meta' => $this->getMeta(),
             'keywords' => $this->getKeywords(),
             'defaultLocale' => $this->getDefaultLocale(),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | N/A
| Related issues/PRs | N/A
| License | MIT
| Documentation PR | N/A

#### What's in this PR?
This PR contains a fix to the Category Bundle.

#### Why?

The description was missing into the Category API, so it was impossible to use the description in the template.


#### Example Usage

```twig
// Now we can do
{{ dump(content.your_single_category_selection.description) }}
```

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
