### PR TITLE
Update design of navigation and pin icon

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/UserSection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/UserSection.js
@@ -47,11 +47,12 @@ class UserSection extends React.Component<Props> {
         const {username, userImage} = this.props;
 
         const menuClass = classNames(userSectionStyles.menu, this.open && userSectionStyles.open);
+        const buttonClass = classNames(userSectionStyles.button, this.open && userSectionStyles.active);
 
         return (
             <div className={userSectionStyles.userSection}>
                 <div
-                    className={userSectionStyles.button}
+                    className={buttonClass}
                     onClick={this.handleButtonClick}
                     role="button"
                 >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/item.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/item.scss
@@ -1,8 +1,9 @@
 @import '../../containers/Application/colors.scss';
 
-$color: $silver;
-$activeColor: $shakespeare;
+$color: $wildSand;
+$activeBorderColor: $shakespeare;
 $activeBackgroundColor: $ebonyClay;
+$hoverColor: $shakespeare;
 
 .item {
     font-size: 14px;
@@ -13,7 +14,7 @@ $activeBackgroundColor: $ebonyClay;
     position: relative;
 
     &.active {
-        border-left: 4px solid $activeColor;
+        border-left: 4px solid $activeBorderColor;
         background: $activeBackgroundColor;
         font-weight: bold;
         padding-left: 0;
@@ -26,7 +27,7 @@ $activeBackgroundColor: $ebonyClay;
         padding: 20px;
 
         &:hover {
-            color: $activeColor;
+            color: $hoverColor;
         }
 
         .icon {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/navigation.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/navigation.scss
@@ -1,10 +1,12 @@
 @import './variables.scss';
 @import '../../containers/Application/colors.scss';
 
-$color: $white;
-$activeColor: $shakespeare;
+$color: $silver;
+$headerColor: $white;
+$activeColor: $wildSand;
 $backgroundColor: $pickledBluewood;
 $darkBackgroundColor: $ebonyClay;
+$hoverColor: $shakespeare;
 
 .navigation {
     width: $navigationWidth;
@@ -18,9 +20,10 @@ $darkBackgroundColor: $ebonyClay;
 }
 
 .header {
+    color: $headerColor;
     flex: 0 0 60px;
     height: 60px;
-    padding-inline: 20px;
+    padding: 0 20px;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -33,15 +36,27 @@ $darkBackgroundColor: $ebonyClay;
     display: block;
     font-size: 90px;
     line-height: 1;
+    transform: translateY(2px); /* visual centering the logo */
 }
 
 .pin {
     flex: 0 0 auto;
     color: $color;
     cursor: pointer;
+    padding: 20px;
+    margin-right: -20px;
+    transition: .3s;
 
     &.active {
         color: $activeColor;
+
+        &:hover {
+            transform: rotateZ(180deg);
+        }
+    }
+
+    &:hover {
+        color: $hoverColor;
     }
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/userSection.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/userSection.scss
@@ -1,6 +1,7 @@
 @import '../../containers/Application/colors.scss';
 
 $color: $white;
+$hoverColor: $shakespeare;
 $lightColor: $silver;
 
 .user-section {
@@ -15,10 +16,14 @@ $lightColor: $silver;
     align-items: center;
     height: 60px;
     cursor: pointer;
-    color: $lightColor;
+    color: $color;
 
     &:hover {
-        color: $color;
+        color: $hoverColor;
+    }
+
+    &.active {
+        font-weight: bold;
     }
 }
 
@@ -79,6 +84,6 @@ $lightColor: $silver;
     padding-block: 10px;
 
     &:hover {
-        color: $color;
+        color: $hoverColor;
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #6391 fixes #6390  <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Update colors from the design and make so the navigation better contrast. Update the pin icon behaviour to show close animation when hovered.

#### Why?

Currently the pin icon was inconsistent to the navigation item state, in this case I did also see that the false gray was used and now we also have a better contrast in the navigation.
