### PR TITLE
Add alternate title to link content type

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Link.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Link.js
@@ -65,7 +65,7 @@ export default class Link extends React.Component<FieldTypeProps<LinkValue>> {
         }
 
         if (enableTitle !== undefined && enableTitle !== null && typeof enableTitle !== 'boolean') {
-            throw new Error('The "target" schema option must be a boolean if given!');
+            throw new Error('The "title" schema option must be a boolean if given!');
         }
 
         return (

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Link.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Link.js
@@ -22,6 +22,9 @@ export default class Link extends React.Component<FieldTypeProps<LinkValue>> {
                 enable_target: {
                     value: enableTarget,
                 } = {},
+                enable_title: {
+                    value: enableTitle,
+                } = {},
                 types: {
                     value: unvalidatedTypes,
                 } = {},
@@ -61,11 +64,16 @@ export default class Link extends React.Component<FieldTypeProps<LinkValue>> {
             throw new Error('The "target" schema option must be a boolean if given!');
         }
 
+        if (enableTitle !== undefined && enableTitle !== null && typeof enableTitle !== 'boolean') {
+            throw new Error('The "target" schema option must be a boolean if given!');
+        }
+
         return (
             <LinkContainer
                 disabled={!!disabled}
                 enableAnchor={enableAnchor}
                 enableTarget={enableTarget}
+                enableTitle={enableTitle}
                 locale={locale}
                 onChange={onChange}
                 onFinish={onFinish}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Link.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Link.test.js
@@ -44,6 +44,10 @@ test('Pass props correctly to Link component', () => {
             name: 'anchor',
             value: true,
         },
+        enable_title: {
+            name: 'title',
+            value: true,
+        },
     };
 
     const link = shallow(
@@ -62,6 +66,7 @@ test('Pass props correctly to Link component', () => {
         'disabled': true,
         'enableAnchor': true,
         'enableTarget': true,
+        'enableTitle': true,
         locale,
         'onChange': changeSpy,
         'onFinish': finishSpy,
@@ -104,6 +109,10 @@ test('Pass props correctly to Link component filtered types', () => {
             name: 'anchor',
             value: true,
         },
+        enable_title: {
+            name: 'title',
+            value: true,
+        },
         types: {
             name: 'types',
             value: [
@@ -129,6 +138,7 @@ test('Pass props correctly to Link component filtered types', () => {
         'disabled': true,
         'enableAnchor': true,
         'enableTarget': true,
+        'enableTitle': true,
         locale,
         'onChange': changeSpy,
         'onFinish': finishSpy,
@@ -188,6 +198,7 @@ test('Pass props correctly to Link component disabled anchor and target', () => 
         'disabled': true,
         'enableAnchor': false,
         'enableTarget': false,
+        'enableTitle': false,
         locale,
         'onChange': changeSpy,
         'onFinish': finishSpy,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/Link.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/Link.js
@@ -14,6 +14,7 @@ type Props = {
     disabled?: boolean,
     enableAnchor?: ?boolean,
     enableTarget?: ?boolean,
+    enableTitle?: ?boolean,
     locale: IObservableValue<string>,
     onChange: (value: LinkValue) => void,
     onFinish: () => void,
@@ -29,6 +30,7 @@ class Link extends Component<Props> {
         disabled: false,
         enableAnchor: false,
         enableTarget: false,
+        enableTitle: false,
         types: [],
     };
 
@@ -79,6 +81,10 @@ class Link extends Component<Props> {
         this.overlayTarget = target;
     };
 
+    @action handleOverlayTitleChange = (title: ?string) => {
+        this.overlayTitle = title;
+    };
+
     @action handleOverlayHrefChange = (href: ?string | number, item: ?Object) => {
         this.overlayHref = href;
         this.overlayTitle = item?.title ?? String(href);
@@ -101,7 +107,7 @@ class Link extends Component<Props> {
     };
 
     changeValue = (provider: ?string, href: ?string | number, title: ?string, target: ?string, anchor: ?string) => {
-        const {onChange, onFinish, enableTarget, enableAnchor, locale} = this.props;
+        const {onChange, onFinish, enableTarget, enableTitle, enableAnchor, locale} = this.props;
 
         onChange(
             {
@@ -109,7 +115,7 @@ class Link extends Component<Props> {
                 target: enableTarget ? target : undefined,
                 anchor: enableAnchor ? anchor : undefined,
                 href,
-                title,
+                title: enableTitle ? title : undefined,
                 locale: toJS(locale),
             }
         );
@@ -122,6 +128,7 @@ class Link extends Component<Props> {
             locale,
             enableAnchor,
             enableTarget,
+            enableTitle,
             types,
             value,
         } = this.props;
@@ -187,9 +194,11 @@ class Link extends Component<Props> {
                             onConfirm={this.handleOverlayConfirm}
                             onHrefChange={this.handleOverlayHrefChange}
                             onTargetChange={enableTarget ? this.handleOverlayTargetChange : undefined}
+                            onTitleChange={enableTitle ? this.handleOverlayTitleChange : undefined}
                             open={this.openedOverlayProvider === key}
                             options={linkTypeRegistry.getOptions(key)}
                             target={this.overlayTarget}
+                            title={this.overlayTitle}
                         />
                     );
                 })}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/Link.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/Link.test.js
@@ -64,6 +64,7 @@ test('Pass correct props to overlay', () => {
         <Link
             enableAnchor={true}
             enableTarget={true}
+            enableTitle={true}
             locale={observable.box('en')}
             onChange={changeSpy}
             onFinish={finishSpy}
@@ -107,6 +108,7 @@ test('Open overlay on input click', () => {
         <Link
             enableAnchor={true}
             enableTarget={true}
+            enableTitle={true}
             locale={observable.box('en')}
             onChange={changeSpy}
             onFinish={finishSpy}
@@ -145,6 +147,7 @@ test('Open overlay on provider change', () => {
         <Link
             enableAnchor={true}
             enableTarget={true}
+            enableTitle={true}
             locale={observable.box('en')}
             onChange={changeSpy}
             onFinish={finishSpy}
@@ -181,6 +184,7 @@ test('Update values on overlay confirm', () => {
         <Link
             enableAnchor={true}
             enableTarget={true}
+            enableTitle={true}
             locale={observable.box('en')}
             onChange={changeSpy}
             onFinish={finishSpy}
@@ -193,12 +197,13 @@ test('Update values on overlay confirm', () => {
     overlayProps.onHrefChange('10');
     overlayProps.onAnchorChange('newAnchor');
     overlayProps.onTargetChange('newTarget');
+    overlayProps.onTitleChange('newTitle');
 
     overlayProps.onConfirm();
 
     expect(changeSpy).toBeCalledWith(
         {
-            title: '10',
+            title: 'newTitle',
             href: '10',
             provider: 'media',
             locale: 'en',
@@ -233,6 +238,7 @@ test('Invalidate values on RemoveButton click', () => {
         <Link
             enableAnchor={true}
             enableTarget={true}
+            enableTitle={true}
             locale={observable.box('en')}
             onChange={changeSpy}
             onFinish={finishSpy}

--- a/src/Sulu/Component/Content/Tests/Unit/Types/LinkTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Types/LinkTest.php
@@ -60,6 +60,7 @@ class LinkTest extends TestCase
                 'provider' => 'pages',
                 'locale' => 'de',
                 'target' => 'testTarget',
+                'title' => 'testTitle',
                 'anchor' => 'testAnchor',
             ]);
 
@@ -69,6 +70,7 @@ class LinkTest extends TestCase
             'provider' => 'pages',
             'locale' => 'de',
             'target' => 'testTarget',
+            'title' => 'testTitle',
         ], $result);
     }
 

--- a/src/Sulu/Component/Content/Types/Link.php
+++ b/src/Sulu/Component/Content/Types/Link.php
@@ -78,6 +78,10 @@ class Link extends SimpleContentType
             $result['target'] = $value['target'];
         }
 
+        if (isset($value['title'])) {
+            $result['title'] = $value['title'];
+        }
+
         return $result;
     }
 
@@ -100,7 +104,14 @@ class Link extends SimpleContentType
         if (0 === \count($linkItems)) {
             return null;
         }
-        $url = \reset($linkItems)->getUrl();
+
+        $linkItem = \reset($linkItems);
+
+        if (!$linkItem) {
+            return null;
+        }
+
+        $url = $linkItem->getUrl();
         if (isset($value['anchor'])) {
             $url = \sprintf('%s#%s', $url, $value['anchor']);
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | yes
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #6372 <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add alternate title to link content type.

#### Why?

A title should be available like the title in the ckeditor overlay. Like the other things we hide the title field behind a flag.
