### PR TITLE
Fix preserving scroll-position in preview

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
@@ -204,14 +204,16 @@ class Preview extends React.Component<Props> {
 
     setContent = (previewContent: string) => {
         const previewDocument = this.getPreviewDocument();
-
         if (!previewDocument) {
             return;
         }
 
+        const preservedScrollPos=this.getPreviewScrollPos();
         previewDocument.open(); // This will lose in Firefox the and safari previewDocument.location
         previewDocument.write(previewContent);
         previewDocument.close();
+        setTimeout(() => this.setPreviewScrollPos(preservedScrollPos), 100);
+
     };
 
     componentWillUnmount() {
@@ -250,6 +252,32 @@ class Preview extends React.Component<Props> {
 
         return this.iframeRef.contentDocument;
     };
+
+    getPreviewWindow= (): ?Window => {
+        if (this.previewWindow) {
+            return this.previewWindow;
+        }
+
+        if (!(this.iframeRef instanceof HTMLIFrameElement)) {
+            return;
+        }
+        return this.iframeRef.contentWindow;
+    };
+
+
+    getPreviewScrollPos = ()  => {
+        const win=this.getPreviewWindow();
+        if(win) {
+            return win.document.documentElement.scrollTop || win.pageYOffset || win.document.body.scrollTop;
+        }
+    };
+
+    setPreviewScrollPos = (pos)  => {
+        const win=this.getPreviewWindow();
+        if(win) {
+            win.scrollTo({ top: pos});
+        }
+    }
 
     @action setIframe = (iframeRef: ?Object) => {
         this.iframeRef = iframeRef;

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
@@ -208,12 +208,11 @@ class Preview extends React.Component<Props> {
             return;
         }
 
-        const preservedScrollPos=this.getPreviewScrollPos();
+        const preservedScrollPosition = this.getPreviewScrollPosition();
         previewDocument.open(); // This will lose in Firefox the and safari previewDocument.location
         previewDocument.write(previewContent);
         previewDocument.close();
-        setTimeout(() => this.setPreviewScrollPos(preservedScrollPos), 100);
-
+        setTimeout(() => this.setPreviewScrollPosition(preservedScrollPosition), 0);
     };
 
     componentWillUnmount() {
@@ -253,7 +252,7 @@ class Preview extends React.Component<Props> {
         return this.iframeRef.contentDocument;
     };
 
-    getPreviewWindow= (): ?Window => {
+    getPreviewWindow = (): ?any => {
         if (this.previewWindow) {
             return this.previewWindow;
         }
@@ -261,23 +260,25 @@ class Preview extends React.Component<Props> {
         if (!(this.iframeRef instanceof HTMLIFrameElement)) {
             return;
         }
+
         return this.iframeRef.contentWindow;
     };
 
-
-    getPreviewScrollPos = ()  => {
-        const win=this.getPreviewWindow();
-        if(win) {
-            return win.document.documentElement.scrollTop || win.pageYOffset || win.document.body.scrollTop;
+    getPreviewScrollPosition = () => {
+        const previewWindow = this.getPreviewWindow();
+        if (previewWindow) {
+            return previewWindow.document.documentElement.scrollTop
+                || previewWindow.pageYOffset
+                || previewWindow.document.body.scrollTop;
         }
     };
 
-    setPreviewScrollPos = (pos)  => {
-        const win=this.getPreviewWindow();
-        if(win) {
-            win.scrollTo({ top: pos});
+    setPreviewScrollPosition = (pos) => {
+        const previewWindow = this.getPreviewWindow();
+        if (previewWindow) {
+            previewWindow.scrollTo({top: pos});
         }
-    }
+    };
 
     @action setIframe = (iframeRef: ?Object) => {
         this.iframeRef = iframeRef;

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
@@ -270,9 +270,9 @@ class Preview extends React.Component<Props> {
     getPreviewScrollPosition = (): ?number => {
         const previewWindow = this.getPreviewWindow();
         if (previewWindow) {
-            return previewWindow.document.documentElement.scrollTop
+            return previewWindow.document?.documentElement?.scrollTop
                 || previewWindow.pageYOffset
-                || previewWindow.document.body.scrollTop;
+                || previewWindow.document?.body?.scrollTop;
         }
     };
 

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
@@ -212,7 +212,10 @@ class Preview extends React.Component<Props> {
         previewDocument.open(); // This will lose in Firefox the and safari previewDocument.location
         previewDocument.write(previewContent);
         previewDocument.close();
-        setTimeout(() => this.setPreviewScrollPosition(preservedScrollPosition), 0);
+
+        if (preservedScrollPosition) {
+            setTimeout(() => this.setPreviewScrollPosition(preservedScrollPosition), 0);
+        }
     };
 
     componentWillUnmount() {
@@ -264,7 +267,7 @@ class Preview extends React.Component<Props> {
         return this.iframeRef.contentWindow;
     };
 
-    getPreviewScrollPosition = () => {
+    getPreviewScrollPosition = (): ?number => {
         const previewWindow = this.getPreviewWindow();
         if (previewWindow) {
             return previewWindow.document.documentElement.scrollTop

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/Preview.test.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/Preview.test.js
@@ -374,6 +374,11 @@ test('React and update preview in external window when data is changed', () => {
             close: jest.fn(),
             open: jest.fn(),
             write: jest.fn(),
+            document: {
+                body: {
+                    scrollTop: 10,
+                },
+            },
         },
     };
     window.open.mockReturnValue(previewWindow);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no 
| Fixed tickets | 
| Related issues/PRs | 
| License | MIT
| Documentation PR |

#### What's in this PR?

Scroll Position of Preview Pane is restored after each content-update.

#### Why?

When editing content or blocks on larger pages the editor needs to scroll down in the preview in order
to see the content one is working on.

Unfortunately on each consequent update, the preview-pane scrolls to the top, moving the interesing part of the preview out of sight.