### PR TITLE
Set sulu_document_manager.path_segment_registry as public service for phpcr migration Version201504271608

### DIFF
--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/core.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/core.xml
@@ -63,7 +63,7 @@
         <service id="sulu_document_manager.name_resolver" class="Sulu\Component\DocumentManager\NameResolver" public="false" />
 
         <!-- Utilities -->
-        <service id="sulu_document_manager.path_segment_registry" class="Sulu\Component\DocumentManager\PathSegmentRegistry">
+        <service id="sulu_document_manager.path_segment_registry" class="Sulu\Component\DocumentManager\PathSegmentRegistry" public="true">
             <argument>%sulu_document_manager.segments%</argument>
         </service>
 
@@ -177,4 +177,3 @@
         </service>
     </services>
 </container>
-

--- a/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201504271608.php
+++ b/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201504271608.php
@@ -78,10 +78,15 @@ class Version201504271608 implements VersionInterface, ContainerAwareInterface
             }
 
             $session->save();
-            $homeNode->removeMixin($from);
-            $session->save();
-            $homeNode->addMixin($to);
-            $session->save();
+            if ($homeNode->isNodeType($from)) {
+                $homeNode->removeMixin($from);
+                $session->save();
+            }
+
+            if (!$homeNode->isNodeType($to)) {
+                $homeNode->addMixin($to);
+                $session->save();
+            }
 
             foreach ($homeNodeReferences as $homeNodeReference) {
                 $homeNodeReference->setValue(

--- a/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201607181533.php
+++ b/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201607181533.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\PageBundle;
 
 use PHPCR\ImportUUIDBehaviorInterface;
 use PHPCR\Migrations\VersionInterface;
+use PHPCR\RepositoryException;
 use PHPCR\SessionInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -32,7 +33,12 @@ class Version201607181533 implements VersionInterface, ContainerAwareInterface
     {
         $defaultSession = $this->container->get('sulu_document_manager.default_session');
         $liveSession = $this->container->get('sulu_document_manager.live_session');
-        $session->getWorkspace()->createWorkspace($liveSession->getWorkspace()->getName());
+        try {
+            $session->getWorkspace()->createWorkspace($liveSession->getWorkspace()->getName());
+        } catch (RepositoryException $e) {
+            // do nothing if workspace already exists
+            return;
+        }
         $queryManager = $liveSession->getWorkspace()->getQueryManager();
 
         $fileName = \tempnam(\sys_get_temp_dir(), 'sulu-publishing');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no yes
| New feature? | no yes
| BC breaks? | no yes
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Set sulu_document_manager.path_segment_registry as public service for phpcr migration Version201504271608.

#### Why?

The `Version201504271608` requires this service.