### PR TITLE
Add version number to navigation logo

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Navigation.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Navigation.js
@@ -117,7 +117,6 @@ class Navigation extends React.Component<Props> {
             onLogoutClick,
             onProfileClick,
             suluVersion,
-            suluVersionLink,
             onPinToggle,
         } = this.props;
 
@@ -126,9 +125,7 @@ class Navigation extends React.Component<Props> {
         return (
             <div className={navigationStyles.navigation}>
                 <div className={navigationStyles.header}>
-                    <a className={navigationStyles.logo} href={suluVersionLink} title={suluVersion} target="_blank">
-                        <Icon name="su-sulu-logo" />
-                    </a>
+                    <Icon className={navigationStyles.logo} name="su-sulu-logo" title={suluVersion} />
 
                     {onPinToggle &&
                         <div className={pinClass} onClick={this.handlePinToggle} role="button">

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Navigation.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Navigation.js
@@ -126,7 +126,9 @@ class Navigation extends React.Component<Props> {
         return (
             <div className={navigationStyles.navigation}>
                 <div className={navigationStyles.header}>
-                    <Icon className={navigationStyles.logo} name="su-sulu-logo" />
+                    <a className={navigationStyles.logo} href={suluVersionLink} title={suluVersion} target="_blank">
+                        <Icon name="su-sulu-logo" />
+                    </a>
 
                     {onPinToggle &&
                         <div className={pinClass} onClick={this.handlePinToggle} role="button">
@@ -143,8 +145,6 @@ class Navigation extends React.Component<Props> {
                     <UserSection
                         onLogoutClick={onLogoutClick}
                         onProfileClick={onProfileClick}
-                        suluVersion={suluVersion}
-                        suluVersionLink={suluVersionLink}
                         userImage={userImage}
                         username={username}
                     />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/UserSection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/UserSection.js
@@ -11,8 +11,6 @@ import userSectionStyles from './userSection.scss';
 type Props = {
     onLogoutClick: () => void,
     onProfileClick: () => void,
-    suluVersion: string,
-    suluVersionLink: string,
     userImage: ?string,
     username: string,
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/navigation.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/navigation.scss
@@ -32,10 +32,12 @@ $hoverColor: $shakespeare;
 }
 
 .logo {
+    color: inherit;
     flex: 0 0 auto;
     display: block;
     font-size: 90px;
     line-height: 1;
+    text-decoration: none;
     transform: translateY(2px); /* visual centering the logo */
 }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #6387 <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add version number to navigation logo.

#### Why?

It was possible to find out the version number as content manager in 2.3 so this should also be possible in 2.4. We are adding it as a title hover attribute over the logo.

<img width="259" alt="Bildschirmfoto 2021-12-02 um 18 11 15" src="https://user-images.githubusercontent.com/1698337/144469996-5a9e40d6-ffce-4146-a3be-1ce3d9607b1a.png">


