### PR TITLE
Pass original request server parameters to target group request

### DIFF
--- a/src/Sulu/Bundle/AudienceTargetingBundle/Request/ForwardedUrlRequestProcessor.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Request/ForwardedUrlRequestProcessor.php
@@ -40,7 +40,7 @@ class ForwardedUrlRequestProcessor implements RequestProcessorInterface
             return new RequestAttributes();
         }
 
-        $originalRequest = Request::create($request->headers->get($this->urlHeader), 'GET', [], [], [], $request->server);
+        $originalRequest = Request::create($request->headers->get($this->urlHeader), 'GET', [], [], [], $request->server->getHeaders());
         $host = $originalRequest->getHost();
         $port = $originalRequest->getPort();
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Request/ForwardedUrlRequestProcessor.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Request/ForwardedUrlRequestProcessor.php
@@ -40,7 +40,7 @@ class ForwardedUrlRequestProcessor implements RequestProcessorInterface
             return new RequestAttributes();
         }
 
-        $originalRequest = Request::create($request->headers->get($this->urlHeader));
+        $originalRequest = Request::create($request->headers->get($this->urlHeader), 'GET', [], [], [], $request->server);
         $host = $originalRequest->getHost();
         $port = $originalRequest->getPort();
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Request/ForwardedUrlRequestProcessor.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Request/ForwardedUrlRequestProcessor.php
@@ -41,7 +41,6 @@ class ForwardedUrlRequestProcessor implements RequestProcessorInterface
         }
 
         $originalRequest = Request::create($request->headers->get($this->urlHeader), 'GET', [], [], [], $request->server->all());
-
         $host = $originalRequest->getHost();
         $port = $originalRequest->getPort();
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Request/ForwardedUrlRequestProcessor.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Request/ForwardedUrlRequestProcessor.php
@@ -40,7 +40,8 @@ class ForwardedUrlRequestProcessor implements RequestProcessorInterface
             return new RequestAttributes();
         }
 
-        $originalRequest = Request::create($request->headers->get($this->urlHeader), 'GET', [], [], [], $request->server->getHeaders());
+        $originalRequest = Request::create($request->headers->get($this->urlHeader), 'GET', [], [], [], $request->server->all());
+
         $host = $originalRequest->getHost();
         $port = $originalRequest->getPort();
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Request/ForwardedUrlRequestProcessor.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Request/ForwardedUrlRequestProcessor.php
@@ -40,6 +40,7 @@ class ForwardedUrlRequestProcessor implements RequestProcessorInterface
             return new RequestAttributes();
         }
 
+        // Pass original server headers to request, to make sure placeholders in webspaces work
         $originalRequest = Request::create($request->headers->get($this->urlHeader), 'GET', [], [], [], $request->server->all());
         $host = $originalRequest->getHost();
         $port = $originalRequest->getPort();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

This PR passes the original request server headers to the audience targeting request.

#### Why?

Requests handled through `_sulu_target_group` result in a `UrlMatchNotFoundException There exists no portal for the URL "_sulu_target_group"`. As the `ForwardedUrlRequestProcessor` creates a new request without passing the original requests `host` header it falls back to `localhost` which does not seem to work. Setting the URL to `localhost` in the webspace config "solves" the problem as it matches the default of `localhost`.