### PR TITLE
Fix sideffect to messenger FlattenExceptionNormalizer

### DIFF
--- a/src/Sulu/Component/Rest/FlattenExceptionNormalizer.php
+++ b/src/Sulu/Component/Rest/FlattenExceptionNormalizer.php
@@ -13,13 +13,14 @@ namespace Sulu\Component\Rest;
 
 use Sulu\Component\Rest\Exception\TranslationErrorMessageExceptionInterface;
 use Symfony\Component\ErrorHandler\Exception\FlattenException;
+use Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @internal the following class is only for internal use don't use it in your project
  */
-class FlattenExceptionNormalizer implements NormalizerInterface
+class FlattenExceptionNormalizer implements ContextAwareNormalizerInterface
 {
     /**
      * @var NormalizerInterface
@@ -67,8 +68,8 @@ class FlattenExceptionNormalizer implements NormalizerInterface
         return $data;
     }
 
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, string $format = null, array $context = [])
     {
-        return $data instanceof FlattenException;
+        return $data instanceof FlattenException && !($context['messenger_serialization'] ?? false);
     }
 }

--- a/src/Sulu/Component/Rest/FlattenExceptionNormalizer.php
+++ b/src/Sulu/Component/Rest/FlattenExceptionNormalizer.php
@@ -68,7 +68,7 @@ class FlattenExceptionNormalizer implements ContextAwareNormalizerInterface
         return $data;
     }
 
-    public function supportsNormalization($data, string $format = null, array $context = [])
+    public function supportsNormalization($data, $format = null, array $context = [])
     {
         return $data instanceof FlattenException && !($context['messenger_serialization'] ?? false);
     }


### PR DESCRIPTION
Checks whether the normalizer is used in messenger context and returns false if it is.

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | 
| License | MIT
| Documentation PR | 

#### What's in this PR?

Checks for messenger context in the FlattenExceptionNormalizer supportsNormalization() fuction.

#### Why?

Currently your implementation of the FlattenExceptionNormalizer serializes exceptions for the messenger consumer. 
Basicly the same issue as described here https://github.com/FriendsOfSymfony/FOSRestBundle/issues/2292

Since Serializer::MESSENGER_SERIALIZATION_CONTEXT is possibly not available I've opted to use a string instead

```php

    public function supportsNormalization($data, string $format = null, array $context = [])
    {
        return $data instanceof FlattenException && !($context['messenger_serialization'] ?? false);
    }

```

