### PR TITLE
Add better exception message for UrlMatchNotFoundException

### DIFF
--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
@@ -81,7 +81,21 @@ class WebsiteRequestProcessor implements RequestProcessorInterface
     public function validate(RequestAttributes $attributes)
     {
         if (null === $attributes->getAttribute('portalInformation')) {
-            throw new UrlMatchNotFoundException($attributes->getAttribute('requestUri'));
+            $portalUrls = [];
+            foreach ($this->webspaceManager->getPortalInformations() as $portalInformation) {
+                $portalUrls[] = $attributes->getAttribute('scheme') . '://'
+                    . $portalInformation->getUrl();
+            }
+
+            $fullUrl = $attributes->getAttribute('scheme') . '://'
+                . $attributes->getAttribute('host')
+                . (!in_array($attributes->getAttribute('port'), ['80', '443'], true) ? ':' . $attributes->getAttribute('port') : '')
+                    . $attributes->getAttribute('path');
+
+            throw new UrlMatchNotFoundException(
+                $fullUrl,
+                $portalUrls
+            );
         }
 
         return true;

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
@@ -89,7 +89,7 @@ class WebsiteRequestProcessor implements RequestProcessorInterface
 
             $fullUrl = $attributes->getAttribute('scheme') . '://'
                 . $attributes->getAttribute('host')
-                . (!in_array($attributes->getAttribute('port'), ['80', '443'], true) ? ':' . $attributes->getAttribute('port') : '')
+                . (!\in_array($attributes->getAttribute('port'), ['80', '443'], true) ? ':' . $attributes->getAttribute('port') : '')
                     . $attributes->getAttribute('path');
 
             throw new UrlMatchNotFoundException(

--- a/src/Sulu/Component/Webspace/Analyzer/Exception/UrlMatchNotFoundException.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Exception/UrlMatchNotFoundException.php
@@ -23,10 +23,18 @@ class UrlMatchNotFoundException extends \Exception
      */
     private $url;
 
-    public function __construct($url)
+    /**
+     * @param string[] $portalUrls
+     */
+    public function __construct($url, array $portalUrls = [])
     {
         $this->url = $url;
         $message = 'There exists no portal for the URL "' . $url . '"';
+
+        if (!empty($portalUrls)) {
+            $message .= ', the URL should begin with one of the following Portal URLs: "' . implode('", "', $portalUrls) . '"';
+        }
+
         parent::__construct($message, 0);
     }
 

--- a/src/Sulu/Component/Webspace/Analyzer/Exception/UrlMatchNotFoundException.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Exception/UrlMatchNotFoundException.php
@@ -32,7 +32,7 @@ class UrlMatchNotFoundException extends \Exception
         $message = 'There exists no portal for the URL "' . $url . '"';
 
         if (!empty($portalUrls)) {
-            $message .= ', the URL should begin with one of the following Portal URLs: "' . implode('", "', $portalUrls) . '"';
+            $message .= ', the URL should begin with one of the following Portal URLs: "' . \implode('", "', $portalUrls) . '"';
         }
 
         parent::__construct($message, 0);

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/WebsiteRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/WebsiteRequestProcessorTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\Webspace\Tests\Unit\Analyzer\Attributes;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
@@ -33,12 +34,12 @@ class WebsiteRequestProcessorTest extends TestCase
     private $provider;
 
     /**
-     * @var WebspaceManagerInterface
+     * @var ObjectProphecy<WebspaceManagerInterface>
      */
     private $webspaceManager;
 
     /**
-     * @var ContentMapperInterface
+     * @var ObjectProphecy<ContentMapperInterface>
      */
     private $contentMapper;
 
@@ -254,6 +255,8 @@ class WebsiteRequestProcessorTest extends TestCase
     }
 
     /**
+     * @param PortalInformation[] $portalInformations
+     *
      * @dataProvider provideValidateData
      */
     public function testValidate($attributes, $exception = null, $message = '', $portalInformations = [])

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/WebsiteRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/WebsiteRequestProcessorTest.php
@@ -248,8 +248,8 @@ class WebsiteRequestProcessorTest extends TestCase
                         false,
                         'sulu.lo',
                         5
-                    )
-                ]
+                    ),
+                ],
             ],
         ];
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add better exception message for UrlMatchNotFoundException

#### Why?

When having a false configured webspace the message should be better and show which configured webspaces exists.
