### PR TITLE
Fix CI script for installing composer dependencies in correct step

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -171,7 +171,7 @@ jobs:
 
             - name: Install handcraftedinthealps/goodby-csv
               if: ${{ matrix.php-version == '8.1' }}
-              run: composer require handcraftedinthealps/goodby-csv:^1.4
+              run: composer require handcraftedinthealps/goodby-csv:^1.4 --no-update
 
             - name: Install composer dependencies
               uses: ramsey/composer-install@v1


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix CI script for installing composer dependencies.

#### Why?

This step should not install any dependencies, dependencies should be installed in the composer install step.
