### PR TITLE
Rename queryBuilder "system" parameter to "roleSystem"

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Entity/RoleRepository.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/RoleRepository.php
@@ -77,8 +77,8 @@ class RoleRepository extends EntityRepository implements RoleRepositoryInterface
             }
 
             if (isset($filters['system'])) {
-                $queryBuilder->andWhere('role.system = :system')
-                    ->setParameter('system', $filters['system']);
+                $queryBuilder->andWhere('role.system = :roleSystem')
+                    ->setParameter('roleSystem', $filters['system']);
             }
 
             $query = $queryBuilder->getQuery();
@@ -107,8 +107,8 @@ class RoleRepository extends EntityRepository implements RoleRepositoryInterface
     {
         $result = $this->createQueryBuilder('role')
             ->select('role.id')
-            ->where('role.system = :system')
-            ->setParameter('system', $system)
+            ->where('role.system = :roleSystem')
+            ->setParameter('roleSystem', $system)
             ->getQuery()
             ->getResult();
 


### PR DESCRIPTION
Rename querybuilder "system" parameter to "roleSystem" to avoid reserved keywords issues (see issue 6412)

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| Fixed tickets | fixes #6412
| Related issues/PRs | #6412
| License | MIT

#### What's in this PR?

Rename the querybuilder "system" paramter to "roleSystem".

#### Why?

Workaround for reserved keywords issues. See issue #6412.
