### PR TITLE
Conflict phpcr-utils 1.6.0 for error on windows

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -150,7 +150,7 @@
         "jackalope/jackalope-jackrabbit": "< 1.3.0",
         "jms/serializer-bundle": "3.9.0",
         "php-http/discovery": "< 1.8.0",
-        "phpcr/phpcr-utils": "1.2.0 - 1.2.10 || 1.3.0 - 1.3.2",
+        "phpcr/phpcr-utils": "1.2.0 - 1.2.10 || 1.3.0 - 1.3.2 || 1.6.0",
         "phpdocumentor/reflection-docblock": "5.0.0",
         "phpstan/phpstan": "0.12.26",
         "rokka/imagine-vips": "<0.9.2",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/phpcr/phpcr-utils/issues/204
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Conflict php-utils 1.6.0

#### Why?

Some queries seems not longer work correctly when run on a windows based system.
