### PR TITLE
Add noIndex and noFollow to preview link

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -169,6 +169,11 @@ class PreviewRenderer implements PreviewRendererInterface
             ]
         );
 
+        $attributes['_seo'] = [
+            'noIndex' => true,
+            'noFollow' => true,
+        ];
+
         // get server parameters
         $server = $this->createServerAttributes($portalInformation, $currentRequest);
 

--- a/src/Sulu/Bundle/PreviewBundle/Resources/views/PreviewLink/base.html.twig
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/views/PreviewLink/base.html.twig
@@ -6,7 +6,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
         <title>{% block title %}{{ 'sulu_preview.title'|trans({}, 'admin') }}{% endblock %}</title>
-        <meta name="robots" content="noindex,nofollow">
+        <meta name="robots" content="noIndex,noFollow">
 
         <link rel="stylesheet" href="{{ asset('main.css', 'sulu_admin') }}">
     </head>

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
@@ -647,6 +647,7 @@ class PreviewRendererTest extends TestCase
 
                     $this->assertTrue($request->attributes->get('preview'));
                     $this->assertTrue($request->attributes->get('partial'));
+                    $this->assertSame(['noIndex' => true, 'noFollow' => true],$request->attributes->get('_seo'));
                     $this->assertEquals('sulu-preview-test.io', $requestAttributes->getAttribute('host'));
                     $this->assertEquals(8080, $requestAttributes->getAttribute('port'));
                     $this->assertEqualsWithDelta(new \DateTime(), $requestAttributes->getAttribute('dateTime'), 1);

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
@@ -647,7 +647,7 @@ class PreviewRendererTest extends TestCase
 
                     $this->assertTrue($request->attributes->get('preview'));
                     $this->assertTrue($request->attributes->get('partial'));
-                    $this->assertSame(['noIndex' => true, 'noFollow' => true],$request->attributes->get('_seo'));
+                    $this->assertSame(['noIndex' => true, 'noFollow' => true], $request->attributes->get('_seo'));
                     $this->assertEquals('sulu-preview-test.io', $requestAttributes->getAttribute('host'));
                     $this->assertEquals(8080, $requestAttributes->getAttribute('port'));
                     $this->assertEqualsWithDelta(new \DateTime(), $requestAttributes->getAttribute('dateTime'), 1);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add noIndex and noFollow to preview link

#### Why?

Preview Links (Admin and Public) should not be indexed or followed. The following changes in PreviewRender will achieve this.
