### PR TITLE
Add plugin-proposal-class-properties to babel configuration to prevent code that is incompatible with webpack 4

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -5,7 +5,8 @@
     ],
     "plugins": [
         ["@babel/plugin-proposal-decorators", {"legacy": true}],
-        "@babel/plugin-transform-flow-strip-types"
+        "@babel/plugin-transform-flow-strip-types",
+        "@babel/plugin-proposal-class-properties"
     ],
     "assumptions": {
         "setPublicClassFields": true

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     },
     "devDependencies": {
         "@babel/core": "^7.5.5",
+        "@babel/plugin-proposal-class-properties": "^7.16.5",
         "@babel/plugin-proposal-decorators": "^7.4.4",
         "@babel/plugin-transform-flow-strip-types": "^7.4.4",
         "@babel/preset-env": "^7.5.5",


### PR DESCRIPTION
See https://github.com/sulu/skeleton/pull/155 and https://github.com/babel/babel/issues/14059