### PR TITLE
Fix permission check for document-webspace instead of passed webspace

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/SmartContent/QueryBuilderTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/SmartContent/QueryBuilderTest.php
@@ -463,7 +463,7 @@ class QueryBuilderTest extends SuluTestCase
         $request = new Request([], [], ['_sulu' => new RequestAttributes(['webspace' => $webspace])]);
         $this->getContainer()->get('request_stack')->push($request);
 
-        $root = $this->sessionManager->getContentNode('test_io');
+        $root = $this->sessionManager->getContentNode('sulu_io');
 
         /** @var PageDocument $document */
         $document = $this->documentManager->create('page');
@@ -471,7 +471,7 @@ class QueryBuilderTest extends SuluTestCase
         $document->setResourceSegment('/document');
         $document->setStructureType('simple');
         $document->setWorkflowStage(WorkflowStage::PUBLISHED);
-        $this->documentManager->persist($document, 'en', ['parent_path' => '/cmf/test_io/contents']);
+        $this->documentManager->persist($document, 'en', ['parent_path' => '/cmf/sulu_io/contents']);
         $this->documentManager->publish($document, 'en');
 
         $securedDocument = $this->documentManager->create('page');
@@ -480,7 +480,7 @@ class QueryBuilderTest extends SuluTestCase
         $securedDocument->setStructureType('simple');
         $securedDocument->setWorkflowStage(WorkflowStage::PUBLISHED);
         $securedDocument->setPermissions([$this->anonymousRoleSecurity->getId() => ['view' => false]]);
-        $this->documentManager->persist($securedDocument, 'en', ['parent_path' => '/cmf/test_io/contents']);
+        $this->documentManager->persist($securedDocument, 'en', ['parent_path' => '/cmf/sulu_io/contents']);
         $this->documentManager->publish($securedDocument, 'en');
 
         $this->documentManager->flush();

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -683,8 +683,6 @@ class ContentMapper implements ContentMapperInterface
         $onlyPublished = true,
         $permission = null
     ) {
-        $webspace = $this->webspaceManager->findWebspaceByKey($webspaceKey);
-
         // reset cache
         $this->initializeExtensionCache();
         $templateName = $this->encoder->localizedSystemName('template', $locale);
@@ -704,28 +702,27 @@ class ContentMapper implements ContentMapperInterface
             return false;
         }
 
-        if (
-            $document instanceof SecurityBehavior
+        if ($document instanceof SecurityBehavior
             && $this->security
             && $permission
-            && $webspace
-            && $webspace->hasWebsiteSecurity()
         ) {
             $permissionKey = \array_search($permission, $this->permissions);
             $documentWebspaceKey = $document->getWebspaceName();
             $documentWebspace = $this->webspaceManager->findWebspaceByKey($documentWebspaceKey);
-            $documentWebspaceSecurity = $documentWebspace->getSecurity();
 
-            $permissions = $this->accessControlManager->getUserPermissionByArray(
-                $document->getLocale(),
-                PageAdmin::SECURITY_CONTEXT_PREFIX . $documentWebspaceKey,
-                $document->getPermissions(),
-                $this->security->getUser(),
-                $documentWebspaceSecurity->getSystem()
-            );
+            if ($documentWebspace && $documentWebspace->hasWebsiteSecurity()) {
+                $documentWebspaceSecurity = $documentWebspace->getSecurity();
+                $permissions = $this->accessControlManager->getUserPermissionByArray(
+                    $document->getLocale(),
+                    PageAdmin::SECURITY_CONTEXT_PREFIX . $documentWebspaceKey,
+                    $document->getPermissions(),
+                    $this->security->getUser(),
+                    $documentWebspaceSecurity->getSystem()
+                );
 
-            if (isset($permissions[$permissionKey]) && !$permissions[$permissionKey]) {
-                return false;
+                if (isset($permissions[$permissionKey]) && !$permissions[$permissionKey]) {
+                    return false;
+                }
             }
         }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

As the PHPCRTeaserProvider does not pass any webspace - because it has no idea which webspace the selected documents have - the Permission check was deactivated.

But the place where the check is done has all the information which are needed todo the check. So we use the local information there instead of the passed webspace-key.

#### Why?

The teaser-selection should check the permissions.