### PR TITLE
Add possibility for query parameters in sulu link

### DIFF
--- a/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
@@ -224,7 +224,7 @@ class LinkTag implements TagInterface
         $hrefParts = $href ? \explode('#', $href, 2) : [];
         $anchor = $hrefParts[1] ?? null;
 
-        $hrefParts = \explode('?', $hrefParts[0], 2);
+        $hrefParts = $hrefParts ? \explode('?', $hrefParts[0], 2) : [];
         $uuid = $hrefParts[0] ?? null;
         $query = $hrefParts[1] ?? null;
 

--- a/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
@@ -78,12 +78,12 @@ class LinkTag implements TagInterface
                     $url = $this->urlHelper->getAbsoluteUrl($url);
                 }
 
-                if ($anchor) {
-                    $url .= '#' . $anchor;
-                }
-
                 if ($query) {
                     $url .= '?' . $query;
+                }
+
+                if ($anchor) {
+                    $url .= '#' . $anchor;
                 }
 
                 $title = $item->getTitle();
@@ -214,18 +214,34 @@ class LinkTag implements TagInterface
     /**
      * @param mixed $href
      *
-     * @return array{uuid: string|null, anchor: string|null, query: string|null}
+     * @return array{uuid: string|null, query: string|null, anchor: string|null}
      */
     private function getPartsFromHref($href): array
     {
         $href = (string) $href ?: null;
 
-        /** @var string[] $hrefParts */
-        \preg_match("/(?'uuid'[^#\?]+)(?>#(?'anchor'[^\?]*))?(?>\?(?'query'.*))?/", $href, $hrefParts, PREG_UNMATCHED_AS_NULL);
+        $query = null;
+        $anchor = null;
 
-        $uuid = $hrefParts['uuid'] ?? null;
-        $anchor = $hrefParts['anchor'] ?? null;
-        $query = $hrefParts['query'] ?? null;
+        $hasQuery = strpos($href, '?');
+        $hasAnchor = strpos($href, '#');
+        if ($hasQuery === false && $hasAnchor === false) {
+          $uuid = $href;
+        } else if ($hasQuery === false) { // and $hasAnchor !== false
+          $parts = \explode('#', $href, 2);
+          $uuid = $parts[0];
+          $anchor = $parts[1];
+        } else if ($hasAnchor === false) { // and $hasQuery !== false
+          $parts = \explode('?', $href, 2);
+          $uuid = $parts[0];
+          $query = $parts[1];
+        } else { // both !== false
+          $parts = \explode('?', $href, 2);
+          $uuid = $parts[0];
+          $parts = \explode('#', $parts[1], 2);
+          $query = $parts[0];
+          $anchor = $parts[1];
+        }
 
         return [
             'uuid' => $uuid,

--- a/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
@@ -220,28 +220,13 @@ class LinkTag implements TagInterface
     {
         $href = (string) $href ?: null;
 
-        $query = null;
-        $anchor = null;
+        /** @var string[] $hrefParts */
+        $hrefParts = $href ? \explode('#', $href, 2) : [];
+        $anchor = $hrefParts[1] ?? null;
 
-        $hasQuery = strpos($href, '?');
-        $hasAnchor = strpos($href, '#');
-        if ($hasQuery === false && $hasAnchor === false) {
-          $uuid = $href;
-        } else if ($hasQuery === false) { // and $hasAnchor !== false
-          $parts = \explode('#', $href, 2);
-          $uuid = $parts[0];
-          $anchor = $parts[1];
-        } else if ($hasAnchor === false) { // and $hasQuery !== false
-          $parts = \explode('?', $href, 2);
-          $uuid = $parts[0];
-          $query = $parts[1];
-        } else { // both !== false
-          $parts = \explode('?', $href, 2);
-          $uuid = $parts[0];
-          $parts = \explode('#', $parts[1], 2);
-          $query = $parts[0];
-          $anchor = $parts[1];
-        }
+        $hrefParts = \explode('?', $hrefParts[0], 2);
+        $uuid = $hrefParts[0] ?? null;
+        $query = $hrefParts[1] ?? null;
 
         return [
             'uuid' => $uuid,

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
@@ -152,6 +152,28 @@ class LinkTagTest extends TestCase
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
                 '<a href="http://sulu.lo/de/test#anchor" title="Test-Title">Test-Content</a>',
             ],
+            [
+                '<sulu-link href="123-123-123?query=parameter" provider="article" title="Test-Title">Test-Content</sulu-link>',
+                [
+                    'href' => '123-123-123?query=parameter',
+                    'title' => 'Test-Title',
+                    'provider' => 'article',
+                    'content' => 'Test-Content',
+                ],
+                [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
+                '<a href="http://sulu.lo/de/test?query=parameter" title="Test-Title">Test-Content</a>',
+            ],
+            [
+                '<sulu-link href="123-123-123?query=parameter#anchor" provider="article" title="Test-Title">Test-Content</sulu-link>',
+                [
+                    'href' => '123-123-123?query=parameter#anchor',
+                    'title' => 'Test-Title',
+                    'provider' => 'article',
+                    'content' => 'Test-Content',
+                ],
+                [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
+                '<a href="http://sulu.lo/de/test?query=parameter#anchor" title="Test-Title">Test-Content</a>',
+            ],
         ];
     }
 
@@ -161,7 +183,7 @@ class LinkTagTest extends TestCase
     public function testParseAll($tag, $attributes, $items, $expected)
     {
         $uuids = [
-            \explode('#', $attributes['href'], 2)[0],
+            \preg_split('/[#?]/', $attributes['href'], 2)[0],
         ];
 
         $this->providers[$attributes['provider']]->preload($uuids, 'de', true)->willReturn($items);

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
@@ -174,6 +174,17 @@ class LinkTagTest extends TestCase
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
                 '<a href="http://sulu.lo/de/test?query=parameter#anchor" title="Test-Title">Test-Content</a>',
             ],
+            [
+                '<sulu-link href="123-123-123#anchor?not=query" provider="article" title="Test-Title">Test-Content</sulu-link>',
+                [
+                  'href' => '123-123-123#anchor?not=query',
+                  'title' => 'Test-Title',
+                  'provider' => 'article',
+                  'content' => 'Test-Content',
+                ],
+                [new LinkItem('123-123-123', 'Page-Title', 'de/test', true)],
+                '<a href="http://sulu.lo/de/test#anchor?not=query" title="Test-Title">Test-Content</a>',
+            ],
         ];
     }
 

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
@@ -193,8 +193,9 @@ class LinkTagTest extends TestCase
      */
     public function testParseAll($tag, $attributes, $items, $expected)
     {
+        $uuid = \preg_split('/[#?]/', $attributes['href'], 2);
         $uuids = [
-            \preg_split('/[#?]/', $attributes['href'], 2)[0],
+            $uuid[0] ?: $attributes['href']
         ];
 
         $this->providers[$attributes['provider']]->preload($uuids, 'de', true)->willReturn($items);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #6418
| Related issues/PRs | #6418
| License | MIT
| Documentation PR | sulu/sulu-docs#692

#### What's in this PR?

This PR adds the possibility to use query parameters in the `sulu-link` tags.

#### To Do

- [x] Create a documentation PR
