### PR TITLE
Make main navigation keyboard operable

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Item.js
@@ -48,7 +48,7 @@ export default class Item extends React.PureComponent<Props> {
 
         return (
             <div className={itemClass}>
-                <button className={itemStyles.title} onClick={this.handleClick}>
+                <button className={itemStyles.title} onClick={this.handleClick} type="button">
                     {icon && <Icon className={itemStyles.icon} name={icon} />}
                     <span className={itemStyles.text}>{title}</span>
                     {children &&

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Item.js
@@ -48,17 +48,16 @@ export default class Item extends React.PureComponent<Props> {
 
         return (
             <div className={itemClass}>
-                <div className={itemStyles.title} onClick={this.handleClick} role="button">
+                <button className={itemStyles.title} onClick={this.handleClick}>
                     {icon && <Icon className={itemStyles.icon} name={icon} />}
                     <span className={itemStyles.text}>{title}</span>
                     {children &&
                         <Icon
                             className={itemStyles.childrenIndicator}
                             name={expanded ? 'su-angle-down' : 'su-angle-right'}
-                            onClick={this.handleClick}
                         />
                     }
-                </div>
+                </button>
 
                 {expanded && children &&
                     <div>{children}</div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Navigation.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Navigation.js
@@ -130,7 +130,7 @@ class Navigation extends React.Component<Props> {
                     </span>
 
                     {onPinToggle &&
-                        <button className={pinClass} onClick={this.handlePinToggle}>
+                        <button className={pinClass} onClick={this.handlePinToggle} type="button">
                             <Icon className={navigationStyles.pinIcon} name="su-stick-right" />
                         </button>
                     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Navigation.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Navigation.js
@@ -130,9 +130,9 @@ class Navigation extends React.Component<Props> {
                     </span>
 
                     {onPinToggle &&
-                        <div className={pinClass} onClick={this.handlePinToggle} role="button">
+                        <button className={pinClass} onClick={this.handlePinToggle}>
                             <Icon className={navigationStyles.pinIcon} name="su-stick-right" />
-                        </div>
+                        </button>
                     }
                 </div>
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/UserSection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/UserSection.js
@@ -49,10 +49,9 @@ class UserSection extends React.Component<Props> {
 
         return (
             <div className={userSectionStyles.userSection}>
-                <div
+                <button
                     className={buttonClass}
                     onClick={this.handleButtonClick}
-                    role="button"
                 >
                     <div className={userSectionStyles.userImage}>
                         {userImage && (
@@ -72,9 +71,9 @@ class UserSection extends React.Component<Props> {
                     </span>
 
                     <Icon name={this.open ? 'su-angle-down' : 'su-angle-up'} />
-                </div>
+                </button>
 
-                <div className={menuClass}>
+                <div className={menuClass} hidden={!this.open}>
                     <Button
                         className={userSectionStyles.menuButton}
                         icon="su-user"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/UserSection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/UserSection.js
@@ -52,6 +52,7 @@ class UserSection extends React.Component<Props> {
                 <button
                     className={buttonClass}
                     onClick={this.handleButtonClick}
+                    type="button"
                 >
                     <div className={userSectionStyles.userImage}>
                         {userImage && (

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/item.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/item.scss
@@ -8,7 +8,6 @@ $hoverColor: $shakespeare;
 .item {
     font-size: 14px;
     line-height: 16px;
-    cursor: pointer;
     box-sizing: border-box;
     padding-left: 4px;
     position: relative;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/item.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/item.scss
@@ -31,6 +31,7 @@ $hoverColor: $shakespeare;
         background-color: transparent;
         text-align: left;
         font-weight: inherit;
+        cursor: pointer;
 
         &:hover,
         &:focus {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/item.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/item.scss
@@ -23,10 +23,17 @@ $hoverColor: $shakespeare;
     .title {
         display: flex;
         align-items: center;
+        justify-content: flex-start;
+        width: 100%;
         color: $color;
         padding: 20px;
+        border: 0;
+        background-color: transparent;
+        text-align: left;
+        font-weight: inherit;
 
-        &:hover {
+        &:hover,
+        &:focus {
             color: $hoverColor;
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/navigation.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/navigation.scss
@@ -47,6 +47,8 @@ $hoverColor: $shakespeare;
     cursor: pointer;
     padding: 20px;
     margin-right: -20px;
+    border: 0;
+    background-color: transparent;
     transition: .3s;
 
     &.active {
@@ -57,7 +59,8 @@ $hoverColor: $shakespeare;
         }
     }
 
-    &:hover {
+    &:hover,
+    &:focus {
         color: $hoverColor;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/__snapshots__/Item.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/__snapshots__/Item.test.js.snap
@@ -4,9 +4,9 @@ exports[`The component should render 1`] = `
 <div
   class="item"
 >
-  <div
+  <button
     class="title"
-    role="button"
+    type="button"
   >
     <span
       aria-label="su-search"
@@ -17,7 +17,7 @@ exports[`The component should render 1`] = `
     >
       Test
     </span>
-  </div>
+  </button>
 </div>
 `;
 
@@ -25,9 +25,9 @@ exports[`The component should render active 1`] = `
 <div
   class="item active"
 >
-  <div
+  <button
     class="title"
-    role="button"
+    type="button"
   >
     <span
       aria-label="su-search"
@@ -38,7 +38,7 @@ exports[`The component should render active 1`] = `
     >
       Test
     </span>
-  </div>
+  </button>
 </div>
 `;
 
@@ -46,9 +46,9 @@ exports[`The component should render with children 1`] = `
 <div
   class="item"
 >
-  <div
+  <button
     class="title"
-    role="button"
+    type="button"
   >
     <span
       aria-label="su-cog"
@@ -61,11 +61,9 @@ exports[`The component should render with children 1`] = `
     </span>
     <span
       aria-label="su-angle-right"
-      class="su-angle-right clickable childrenIndicator"
-      role="button"
-      tabindex="0"
+      class="su-angle-right childrenIndicator"
     />
-  </div>
+  </button>
 </div>
 `;
 
@@ -73,9 +71,9 @@ exports[`The component should render with children an active child and expanded 
 <div
   class="item active"
 >
-  <div
+  <button
     class="title"
-    role="button"
+    type="button"
   >
     <span
       aria-label="su-cog"
@@ -88,39 +86,37 @@ exports[`The component should render with children an active child and expanded 
     </span>
     <span
       aria-label="su-angle-down"
-      class="su-angle-down clickable childrenIndicator"
-      role="button"
-      tabindex="0"
+      class="su-angle-down childrenIndicator"
     />
-  </div>
+  </button>
   <div>
     <div
       class="item"
     >
-      <div
+      <button
         class="title"
-        role="button"
+        type="button"
       >
         <span
           class="text"
         >
           Settings 1
         </span>
-      </div>
+      </button>
     </div>
     <div
       class="item active"
     >
-      <div
+      <button
         class="title"
-        role="button"
+        type="button"
       >
         <span
           class="text"
         >
           Settings 2
         </span>
-      </div>
+      </button>
     </div>
   </div>
 </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/__snapshots__/Navigation.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/__snapshots__/Navigation.test.js.snap
@@ -23,9 +23,9 @@ exports[`The component should render and handle clicks correctly 1`] = `
     <div
       class="item"
     >
-      <div
+      <button
         class="title"
-        role="button"
+        type="button"
       >
         <span
           aria-label="su-search"
@@ -36,14 +36,14 @@ exports[`The component should render and handle clicks correctly 1`] = `
         >
           Search
         </span>
-      </div>
+      </button>
     </div>
     <div
       class="item"
     >
-      <div
+      <button
         class="title"
-        role="button"
+        type="button"
       >
         <span
           aria-label="fa-bullseye"
@@ -54,7 +54,7 @@ exports[`The component should render and handle clicks correctly 1`] = `
         >
           Webspaces
         </span>
-      </div>
+      </button>
     </div>
   </div>
   <div
@@ -63,9 +63,9 @@ exports[`The component should render and handle clicks correctly 1`] = `
     <div
       class="userSection"
     >
-      <div
+      <button
         class="button"
-        role="button"
+        type="button"
       >
         <div
           class="userImage"
@@ -84,9 +84,10 @@ exports[`The component should render and handle clicks correctly 1`] = `
           aria-label="su-angle-up"
           class="su-angle-up"
         />
-      </div>
+      </button>
       <div
         class="menu"
+        hidden=""
       >
         <button
           class="button text hasText menuButton"
@@ -138,15 +139,15 @@ exports[`The component should render with all available props and handle clicks 
         class="su-sulu-logo"
       />
     </span>
-    <div
+    <button
       class="pin"
-      role="button"
+      type="button"
     >
       <span
         aria-label="su-stick-right"
         class="su-stick-right pinIcon"
       />
-    </div>
+    </button>
   </div>
   <div
     class="items"
@@ -154,9 +155,9 @@ exports[`The component should render with all available props and handle clicks 
     <div
       class="item"
     >
-      <div
+      <button
         class="title"
-        role="button"
+        type="button"
       >
         <span
           aria-label="su-search"
@@ -167,14 +168,14 @@ exports[`The component should render with all available props and handle clicks 
         >
           Search
         </span>
-      </div>
+      </button>
     </div>
     <div
       class="item"
     >
-      <div
+      <button
         class="title"
-        role="button"
+        type="button"
       >
         <span
           aria-label="su-webspace"
@@ -185,14 +186,14 @@ exports[`The component should render with all available props and handle clicks 
         >
           Webspaces
         </span>
-      </div>
+      </button>
     </div>
     <div
       class="item"
     >
-      <div
+      <button
         class="title"
-        role="button"
+        type="button"
       >
         <span
           aria-label="fa-image"
@@ -203,14 +204,14 @@ exports[`The component should render with all available props and handle clicks 
         >
           Media
         </span>
-      </div>
+      </button>
     </div>
     <div
       class="item"
     >
-      <div
+      <button
         class="title"
-        role="button"
+        type="button"
       >
         <span
           aria-label="fa-newspaper-o"
@@ -221,14 +222,14 @@ exports[`The component should render with all available props and handle clicks 
         >
           Article
         </span>
-      </div>
+      </button>
     </div>
     <div
       class="item"
     >
-      <div
+      <button
         class="title"
-        role="button"
+        type="button"
       >
         <span
           aria-label="fa-sticky-note-o"
@@ -239,14 +240,14 @@ exports[`The component should render with all available props and handle clicks 
         >
           Snippets
         </span>
-      </div>
+      </button>
     </div>
     <div
       class="item active"
     >
-      <div
+      <button
         class="title"
-        role="button"
+        type="button"
       >
         <span
           aria-label="su-user-1"
@@ -259,62 +260,60 @@ exports[`The component should render with all available props and handle clicks 
         </span>
         <span
           aria-label="su-angle-down"
-          class="su-angle-down clickable childrenIndicator"
-          role="button"
-          tabindex="0"
+          class="su-angle-down childrenIndicator"
         />
-      </div>
+      </button>
       <div>
         <div
           class="item"
         >
-          <div
+          <button
             class="title"
-            role="button"
+            type="button"
           >
             <span
               class="text"
             >
               Contact 1
             </span>
-          </div>
+          </button>
         </div>
         <div
           class="item active"
         >
-          <div
+          <button
             class="title"
-            role="button"
+            type="button"
           >
             <span
               class="text"
             >
               Contact 2
             </span>
-          </div>
+          </button>
         </div>
         <div
           class="item"
         >
-          <div
+          <button
             class="title"
-            role="button"
+            type="button"
           >
             <span
               class="text"
             >
               Contact 3
             </span>
-          </div>
+          </button>
         </div>
       </div>
     </div>
     <div
       class="item"
     >
-      <div
+      <button
         class="title"
-        role="button"
+        type="button"
       >
         <span
           aria-label="fa-gear"
@@ -327,11 +326,9 @@ exports[`The component should render with all available props and handle clicks 
         </span>
         <span
           aria-label="su-angle-right"
-          class="su-angle-right clickable childrenIndicator"
-          role="button"
-          tabindex="0"
+          class="su-angle-right childrenIndicator"
         />
-      </div>
+      </button>
     </div>
   </div>
   <div
@@ -340,9 +337,9 @@ exports[`The component should render with all available props and handle clicks 
     <div
       class="userSection"
     >
-      <div
+      <button
         class="button"
-        role="button"
+        type="button"
       >
         <div
           class="userImage"
@@ -363,9 +360,10 @@ exports[`The component should render with all available props and handle clicks 
           aria-label="su-angle-up"
           class="su-angle-up"
         />
-      </div>
+      </button>
       <div
         class="menu"
+        hidden=""
       >
         <button
           class="button text hasText menuButton"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/__snapshots__/UserSection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/__snapshots__/UserSection.test.js.snap
@@ -4,9 +4,9 @@ exports[`The component should render with all available props and handle clicks 
 <div
   class="userSection"
 >
-  <div
+  <button
     class="button"
-    role="button"
+    type="button"
   >
     <div
       class="userImage"
@@ -27,9 +27,10 @@ exports[`The component should render with all available props and handle clicks 
       aria-label="su-angle-up"
       class="su-angle-up"
     />
-  </div>
+  </button>
   <div
     class="menu"
+    hidden=""
   >
     <button
       class="button text hasText menuButton"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/userSection.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/userSection.scss
@@ -17,8 +17,11 @@ $lightColor: $silver;
     height: 60px;
     cursor: pointer;
     color: $color;
+    border: 0;
+    background-color: transparent;
 
-    &:hover {
+    &:hover,
+    &:focus {
         color: $hoverColor;
     }
 
@@ -83,7 +86,8 @@ $lightColor: $silver;
     color: $lightColor;
     padding-block: 10px;
 
-    &:hover {
+    &:hover,
+    &:focus {
         color: $hoverColor;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/global.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/global.scss
@@ -55,7 +55,6 @@ h3 {
 button {
     border-radius: 0;
     padding: 0;
-    cursor: pointer;
 }
 
 input {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/global.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/global.scss
@@ -55,6 +55,7 @@ h3 {
 button {
     border-radius: 0;
     padding: 0;
+    cursor: pointer;
 }
 
 input {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/__snapshots__/Application.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/__snapshots__/Application.test.js.snap
@@ -23,15 +23,15 @@ Array [
               class="su-sulu-logo"
             />
           </span>
-          <div
+          <button
             class="pin"
-            role="button"
+            type="button"
           >
             <span
               aria-label="su-stick-right"
               class="su-stick-right pinIcon"
             />
-          </div>
+          </button>
         </div>
         <div
           class="items"
@@ -42,9 +42,9 @@ Array [
           <div
             class="userSection"
           >
-            <div
+            <button
               class="button"
-              role="button"
+              type="button"
             >
               <div
                 class="userImage"
@@ -63,9 +63,10 @@ Array [
                 aria-label="su-angle-up"
                 class="su-angle-up"
               />
-            </div>
+            </button>
             <div
               class="menu"
+              hidden=""
             >
               <button
                 class="button text hasText menuButton"
@@ -211,15 +212,15 @@ Array [
               class="su-sulu-logo"
             />
           </span>
-          <div
+          <button
             class="pin"
-            role="button"
+            type="button"
           >
             <span
               aria-label="su-stick-right"
               class="su-stick-right pinIcon"
             />
-          </div>
+          </button>
         </div>
         <div
           class="items"
@@ -230,9 +231,9 @@ Array [
           <div
             class="userSection"
           >
-            <div
+            <button
               class="button"
-              role="button"
+              type="button"
             >
               <div
                 class="userImage"
@@ -251,9 +252,10 @@ Array [
                 aria-label="su-angle-up"
                 class="su-angle-up"
               />
-            </div>
+            </button>
             <div
               class="menu"
+              hidden=""
             >
               <button
                 class="button text hasText menuButton"
@@ -741,15 +743,15 @@ Array [
               class="su-sulu-logo"
             />
           </span>
-          <div
+          <button
             class="pin"
-            role="button"
+            type="button"
           >
             <span
               aria-label="su-stick-right"
               class="su-stick-right pinIcon"
             />
-          </div>
+          </button>
         </div>
         <div
           class="items"
@@ -760,9 +762,9 @@ Array [
           <div
             class="userSection"
           >
-            <div
+            <button
               class="button"
-              role="button"
+              type="button"
             >
               <div
                 class="userImage"
@@ -781,9 +783,10 @@ Array [
                 aria-label="su-angle-up"
                 class="su-angle-up"
               />
-            </div>
+            </button>
             <div
               class="menu"
+              hidden=""
             >
               <button
                 class="button text hasText menuButton"
@@ -933,15 +936,15 @@ Array [
               class="su-sulu-logo"
             />
           </span>
-          <div
+          <button
             class="pin"
-            role="button"
+            type="button"
           >
             <span
               aria-label="su-stick-right"
               class="su-stick-right pinIcon"
             />
-          </div>
+          </button>
         </div>
         <div
           class="items"
@@ -952,9 +955,9 @@ Array [
           <div
             class="userSection"
           >
-            <div
+            <button
               class="button"
-              role="button"
+              type="button"
             >
               <div
                 class="userImage"
@@ -973,9 +976,10 @@ Array [
                 aria-label="su-angle-up"
                 class="su-angle-up"
               />
-            </div>
+            </button>
             <div
               class="menu"
+              hidden=""
             >
               <button
                 class="button text hasText menuButton"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/tests/__snapshots__/Navigation.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/tests/__snapshots__/Navigation.test.js.snap
@@ -16,15 +16,15 @@ exports[`Should render navigation 1`] = `
         class="su-sulu-logo"
       />
     </span>
-    <div
+    <button
       class="pin"
-      role="button"
+      type="button"
     >
       <span
         aria-label="su-stick-right"
         class="su-stick-right pinIcon"
       />
-    </div>
+    </button>
   </div>
   <div
     class="items"
@@ -32,9 +32,9 @@ exports[`Should render navigation 1`] = `
     <div
       class="item active"
     >
-      <div
+      <button
         class="title"
-        role="button"
+        type="button"
       >
         <span
           aria-label="su-options"
@@ -43,14 +43,14 @@ exports[`Should render navigation 1`] = `
         <span
           class="text"
         />
-      </div>
+      </button>
     </div>
     <div
       class="item"
     >
-      <div
+      <button
         class="title"
-        role="button"
+        type="button"
       >
         <span
           aria-label="su-article"
@@ -59,14 +59,14 @@ exports[`Should render navigation 1`] = `
         <span
           class="text"
         />
-      </div>
+      </button>
     </div>
     <div
       class="item active"
     >
-      <div
+      <button
         class="title"
-        role="button"
+        type="button"
       >
         <span
           aria-label="su-options"
@@ -77,35 +77,33 @@ exports[`Should render navigation 1`] = `
         />
         <span
           aria-label="su-angle-down"
-          class="su-angle-down clickable childrenIndicator"
-          role="button"
-          tabindex="0"
+          class="su-angle-down childrenIndicator"
         />
-      </div>
+      </button>
       <div>
         <div
           class="item active"
         >
-          <div
+          <button
             class="title"
-            role="button"
+            type="button"
           >
             <span
               class="text"
             />
-          </div>
+          </button>
         </div>
         <div
           class="item"
         >
-          <div
+          <button
             class="title"
-            role="button"
+            type="button"
           >
             <span
               class="text"
             />
-          </div>
+          </button>
         </div>
       </div>
     </div>
@@ -116,9 +114,9 @@ exports[`Should render navigation 1`] = `
     <div
       class="userSection"
     >
-      <div
+      <button
         class="button"
-        role="button"
+        type="button"
       >
         <div
           class="userImage"
@@ -135,9 +133,10 @@ exports[`Should render navigation 1`] = `
           aria-label="su-angle-up"
           class="su-angle-up"
         />
-      </div>
+      </button>
       <div
         class="menu"
+        hidden=""
       >
         <button
           class="button text hasText menuButton"
@@ -189,15 +188,15 @@ exports[`Should render navigation without appVersion 1`] = `
         class="su-sulu-logo"
       />
     </span>
-    <div
+    <button
       class="pin"
-      role="button"
+      type="button"
     >
       <span
         aria-label="su-stick-right"
         class="su-stick-right pinIcon"
       />
-    </div>
+    </button>
   </div>
   <div
     class="items"
@@ -205,9 +204,9 @@ exports[`Should render navigation without appVersion 1`] = `
     <div
       class="item active"
     >
-      <div
+      <button
         class="title"
-        role="button"
+        type="button"
       >
         <span
           aria-label="su-options"
@@ -216,14 +215,14 @@ exports[`Should render navigation without appVersion 1`] = `
         <span
           class="text"
         />
-      </div>
+      </button>
     </div>
     <div
       class="item"
     >
-      <div
+      <button
         class="title"
-        role="button"
+        type="button"
       >
         <span
           aria-label="su-article"
@@ -232,14 +231,14 @@ exports[`Should render navigation without appVersion 1`] = `
         <span
           class="text"
         />
-      </div>
+      </button>
     </div>
     <div
       class="item active"
     >
-      <div
+      <button
         class="title"
-        role="button"
+        type="button"
       >
         <span
           aria-label="su-options"
@@ -250,35 +249,33 @@ exports[`Should render navigation without appVersion 1`] = `
         />
         <span
           aria-label="su-angle-down"
-          class="su-angle-down clickable childrenIndicator"
-          role="button"
-          tabindex="0"
+          class="su-angle-down childrenIndicator"
         />
-      </div>
+      </button>
       <div>
         <div
           class="item active"
         >
-          <div
+          <button
             class="title"
-            role="button"
+            type="button"
           >
             <span
               class="text"
             />
-          </div>
+          </button>
         </div>
         <div
           class="item"
         >
-          <div
+          <button
             class="title"
-            role="button"
+            type="button"
           >
             <span
               class="text"
             />
-          </div>
+          </button>
         </div>
       </div>
     </div>
@@ -289,9 +286,9 @@ exports[`Should render navigation without appVersion 1`] = `
     <div
       class="userSection"
     >
-      <div
+      <button
         class="button"
-        role="button"
+        type="button"
       >
         <div
           class="userImage"
@@ -308,9 +305,10 @@ exports[`Should render navigation without appVersion 1`] = `
           aria-label="su-angle-up"
           class="su-angle-up"
         />
-      </div>
+      </button>
       <div
         class="menu"
+        hidden=""
       >
         <button
           class="button text hasText menuButton"


### PR DESCRIPTION
Every option in the menu is now accessible by keyboard and present in tab order. A few minor changes to the styles were necessary.

| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets |
| Related issues/PRs | #6444
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

- A little refactoring of the navigation. The navigation now uses native button elements for interactive elements.
- Child elements of the UserSection are removed from the tab order with the hidden attribute if they are not visible.

#### Why?

The navigation items could not be focused and triggered with the keyboard.

#### To Do

- [x] Update Snapshots
