### PR TITLE
Remove the previous mainAccountContact from the contact entity when contact changes from mainAccount

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
@@ -610,6 +610,7 @@ class ContactManager extends AbstractContactManager implements DataProviderRepos
                     new AccountContactRemovedEvent($mainAccountContact->getAccount(), $mainAccountContact->getContact())
                 );
 
+                $contact->removeAccountContact($mainAccountContact);
                 $this->em->remove($mainAccountContact);
             }
 


### PR DESCRIPTION
…ontact changes from mainAccount

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #6447
| License | MIT

#### What's in this PR?

When a contact changes from mainAccount, the removeAccountContact function from the contact entity is called to remove the existing mainAccountContact.

#### Why?

This PR will resolve the issue #6447. 
Else when a contact changes from mainAccount, the previous mainAccountContact from the contact entity is not removed.