### PR TITLE
Add Link Type Constants to Link Content Type

### DIFF
--- a/src/Sulu/Component/Content/Types/Link.php
+++ b/src/Sulu/Component/Content/Types/Link.php
@@ -23,6 +23,8 @@ use Sulu\Component\Content\SimpleContentType;
 class Link extends SimpleContentType
 {
     public const LINK_TYPE_EXTERNAL = 'external';
+    public const LINK_TYPE_PAGE = 'page';
+    public const LINK_TYPE_MEDIA = 'media';
 
     /**
      * @var LinkProviderPoolInterface


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| License | MIT

#### What's in this PR?

Add Link Type Constants to Link Content Type

#### Why?

To be able to use them in the SuluHeadlessBundle in the LinkContentTypeResolver. To keep the Code Clean