### PR TITLE
Create accept property for FileUploadButton

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/FileUploadButton/FileUploadButton.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/FileUploadButton/FileUploadButton.js
@@ -6,20 +6,20 @@ import type {Node} from 'react';
 import type {ButtonSkin} from '../Button';
 
 type Props = {|
+    accept?: string,
     children?: Node,
     disabled: boolean,
-    icon: string | typeof undefined,
+    icon?: string,
     onUpload: (file: File) => void,
-    skin: ButtonSkin | typeof undefined,
-    accept: string | typeof undefined,
+    skin?: ButtonSkin,
 |};
 
 export default class FileUploadButton extends React.Component<Props> {
     static defaultProps = {
+        accept: undefined,
         disabled: false,
         icon: undefined,
         skin: undefined,
-        accept: undefined,
     };
 
     handleDrop = (files: Array<File>) => {
@@ -30,12 +30,12 @@ export default class FileUploadButton extends React.Component<Props> {
 
     render() {
         const {children, disabled, icon, skin, accept} = this.props;
-        
+
         return (
             <Dropzone
+                accept={accept}
                 onDrop={this.handleDrop}
                 style={{}}
-                accept={accept}
             >
                 {({getInputProps, getRootProps}) => (
                     <div {...getRootProps()}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/FileUploadButton/FileUploadButton.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/FileUploadButton/FileUploadButton.js
@@ -11,6 +11,7 @@ type Props = {|
     icon: string | typeof undefined,
     onUpload: (file: File) => void,
     skin: ButtonSkin | typeof undefined,
+    accept: string | typeof undefined,
 |};
 
 export default class FileUploadButton extends React.Component<Props> {
@@ -18,6 +19,7 @@ export default class FileUploadButton extends React.Component<Props> {
         disabled: false,
         icon: undefined,
         skin: undefined,
+        accept: undefined,
     };
 
     handleDrop = (files: Array<File>) => {
@@ -27,8 +29,8 @@ export default class FileUploadButton extends React.Component<Props> {
     };
 
     render() {
-        const {children, disabled, icon, skin} = this.props;
-
+        const {children, disabled, icon, skin, accept} = this.props;
+        
         return (
             <Dropzone
                 onDrop={this.handleDrop}
@@ -39,7 +41,7 @@ export default class FileUploadButton extends React.Component<Props> {
                         <Button disabled={disabled} icon={icon} skin={skin}>
                             {children}
                         </Button>
-                        <input {...getInputProps()} />
+                        <input {...getInputProps()} accept={accept} />
                     </div>
                 )}
             </Dropzone>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/FileUploadButton/FileUploadButton.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/FileUploadButton/FileUploadButton.js
@@ -35,13 +35,14 @@ export default class FileUploadButton extends React.Component<Props> {
             <Dropzone
                 onDrop={this.handleDrop}
                 style={{}}
+                accept={accept}
             >
                 {({getInputProps, getRootProps}) => (
                     <div {...getRootProps()}>
                         <Button disabled={disabled} icon={icon} skin={skin}>
                             {children}
                         </Button>
-                        <input {...getInputProps()} accept={accept} />
+                        <input {...getInputProps()} />
                     </div>
                 )}
             </Dropzone>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/FileUploadButton/tests/FileUploadButton.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/FileUploadButton/tests/FileUploadButton.test.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {mount, render} from 'enzyme';
+import {mount, render, shallow} from 'enzyme';
 import Dropzone from 'react-dropzone';
 import FileUploadButton from '../FileUploadButton';
 
@@ -30,4 +30,14 @@ test('Call onUpload callback when a file is uploaded', () => {
 
     expect(uploadSpy).toBeCalledTimes(1);
     expect(uploadSpy).toBeCalledWith(testFileData);
+});
+
+test('Pass correct props to Dropzone component', () => {
+    const fileUploadButton = shallow(
+        <FileUploadButton accept="application/json" onUpload={jest.fn()}>Upload something!</FileUploadButton>
+    );
+
+    expect(fileUploadButton.find('Dropzone').props()).toEqual(expect.objectContaining({
+        accept: 'application/json',
+    }));
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/SingleMediaDropzone.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/SingleMediaDropzone.js
@@ -11,7 +11,7 @@ import singleMediaDropzoneStyles from './singleMediaDropzone.scss';
 const UPLOAD_ICON = 'su-upload';
 
 type Props = {|
-    accept: string,
+    accept?: string,
     disabled: boolean,
     emptyIcon: string,
     errorText?: ?string,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/SingleMediaDropzone.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/SingleMediaDropzone.js
@@ -11,6 +11,7 @@ import singleMediaDropzoneStyles from './singleMediaDropzone.scss';
 const UPLOAD_ICON = 'su-upload';
 
 type Props = {|
+    accept: string,
     disabled: boolean,
     emptyIcon: string,
     errorText?: ?string,
@@ -26,6 +27,7 @@ type Props = {|
 @observer
 class SingleMediaDropzone extends React.Component<Props> {
     static defaultProps = {
+        accept: undefined,
         disabled: false,
         emptyIcon: 'su-image',
         mimeType: '',
@@ -95,6 +97,7 @@ class SingleMediaDropzone extends React.Component<Props> {
 
     render() {
         const {
+            accept,
             disabled,
             emptyIcon,
             errorText,
@@ -118,6 +121,7 @@ class SingleMediaDropzone extends React.Component<Props> {
         return (
             <>
                 <Dropzone
+                    accept={accept}
                     disabled={disabled}
                     multiple={false}
                     noClick={uploading}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/tests/SingleMediaDropzone.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/tests/SingleMediaDropzone.test.js
@@ -114,6 +114,25 @@ test('Render img tag with key to avoid keeping old image on new upload', () => {
     expect(singleMediaDropzone.find('img').key()).not.toBe(null);
 });
 
+test('Component pass correct props to Dropzone component', () => {
+    const singleMediaDropzone = shallow(
+        <SingleMediaDropzone
+            accept="application/json"
+            disabled={true}
+            image="http://lorempixel.com/400/400"
+            onDrop={jest.fn()}
+            uploading={false}
+        />
+    );
+
+    expect(singleMediaDropzone.find('Dropzone').props()).toEqual(expect.objectContaining({
+        accept: 'application/json',
+        disabled: true,
+        noClick: false,
+        multiple: false,
+    }));
+});
+
 test('Dragging a file over the area will show the upload indicator', () => {
     const singleMediaDropzone = shallow(
         <SingleMediaDropzone

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
@@ -32,7 +32,7 @@ type Props = {
 @observer
 class MultiMediaDropzone extends React.Component<Props> {
     static defaultProps = {
-        accept, undefined,
+        accept: undefined,
         disabled: false,
     };
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
@@ -16,7 +16,7 @@ import type {ElementRef, Node} from 'react';
 const COLLECTIONS_RESOURCE_KEY = 'collections';
 
 type Props = {
-    accept: string,
+    accept?: string,
     children: Node,
     className?: string,
     collectionId: ?string | number,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
@@ -16,6 +16,7 @@ import type {ElementRef, Node} from 'react';
 const COLLECTIONS_RESOURCE_KEY = 'collections';
 
 type Props = {
+    accept: string,
     children: Node,
     className?: string,
     collectionId: ?string | number,
@@ -31,6 +32,7 @@ type Props = {
 @observer
 class MultiMediaDropzone extends React.Component<Props> {
     static defaultProps = {
+        accept, undefined,
         disabled: false,
     };
 
@@ -136,7 +138,7 @@ class MultiMediaDropzone extends React.Component<Props> {
     };
 
     render() {
-        const {children, className, disabled, locale, open} = this.props;
+        const {accept, children, className, disabled, locale, open} = this.props;
 
         const dropzoneClass = classNames(
             dropzoneStyles.dropzone,
@@ -146,6 +148,7 @@ class MultiMediaDropzone extends React.Component<Props> {
         return (
             <>
                 <Dropzone
+                    accept={accept}
                     disabled={disabled}
                     noClick={true}
                     onDragEnter={this.handleDragEnter}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/tests/MultiMediaDropzone.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/tests/MultiMediaDropzone.test.js
@@ -85,6 +85,30 @@ test('Render the DropzoneOverlay when the open prop is set to true', () => {
     expect(multiMediaDropzone.find('DropzoneOverlay').prop('open')).toBeTruthy();
 });
 
+test('Component pass correct props to Dropzone component', () => {
+    const multiMediaDropzone = shallow(
+        <MultiMediaDropzone
+            accept="application/json"
+            collectionId={3}
+            disabled={false}
+            locale={observable.box()}
+            onClose={jest.fn()}
+            onOpen={jest.fn()}
+            onUpload={jest.fn()}
+            onUploadError={jest.fn()}
+            open={true}
+        >
+            <div />
+        </MultiMediaDropzone>
+    );
+
+    expect(multiMediaDropzone.find('Dropzone').props()).toEqual(expect.objectContaining({
+        accept: 'application/json',
+        disabled: false,
+        noClick: true,
+    }));
+});
+
 test('Disable dropzone if disabled prop is set to true', () => {
     const multiMediaDropzone = mount(
         <MultiMediaDropzone


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

When the FileUploadButton component is used, it is possible to give an accept property to the component.

#### Why?

When using the FileUploadButton component in a custom view. It was not possible to add an accept parameter to the FileUploadButton.

#### Example Usage
```
import { FileUploadButton } from "sulu-admin-bundle/components";

export default class TestToolbarAction extends AbstractListToolbarAction {
   getNode() {
    return (
             <FileUploadButton accept={"application/json"} onUpload={this.handleUpload}>
             Upload JSON file
             </FileUploadButton>
             );
           }
}
```