### PR TITLE
Add keypress handler for button icons

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/Icon.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/Icon.js
@@ -29,6 +29,19 @@ export default class Icon extends React.PureComponent<Props> {
         onClick();
     };
 
+    handleKeypress = (event: SyntheticEvent<HTMLElement>) => {
+        const {onClick} = this.props;
+
+        if (!onClick) {
+            return;
+        }
+
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.stopPropagation();
+            onClick();
+        }
+    };
+
     render() {
         const {className, name, onClick, style} = this.props;
         let fontClass = '';
@@ -64,6 +77,7 @@ export default class Icon extends React.PureComponent<Props> {
         const onClickProperties = onClick
             ? {
                 onClick: this.handleClick,
+                onKeyPress: this.handleKeypress,
                 role: 'button',
                 tabIndex: 0,
             }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/Icon.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/Icon.js
@@ -29,7 +29,7 @@ export default class Icon extends React.PureComponent<Props> {
         onClick();
     };
 
-    handleKeypress = (event: SyntheticEvent<HTMLElement>) => {
+    handleKeypress = (event: SyntheticKeyboardEvent<HTMLElement>) => {
         const {onClick} = this.props;
 
         if (!onClick) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/Icon.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/Icon.js
@@ -46,6 +46,14 @@ export default class Icon extends React.PureComponent<Props> {
         const {className, name, onClick, style} = this.props;
         let fontClass = '';
 
+        if (onClick) {
+            // @deprecated
+            log.warn(
+                'The "onClick" option is deprecated and will be removed. ' +
+                'Render icons in buttons instead.'
+            );
+        }
+
         if (!name || name.length <= 0) {
             logInvalidIconWarning(name);
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/Icon.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/Icon.js
@@ -46,14 +46,6 @@ export default class Icon extends React.PureComponent<Props> {
         const {className, name, onClick, style} = this.props;
         let fontClass = '';
 
-        if (onClick) {
-            // @deprecated
-            log.warn(
-                'The "onClick" option is deprecated and will be removed. ' +
-                'Render icons in buttons instead.'
-            );
-        }
-
         if (!name || name.length <= 0) {
             logInvalidIconWarning(name);
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/tests/Icon.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/tests/Icon.test.js
@@ -41,3 +41,21 @@ test('Icon should call the callback on click', () => {
     expect(onClick).toBeCalled();
     expect(stopPropagation).toBeCalled();
 });
+
+test('Icon should call the callback on when space is pressed', () => {
+    const onClick = jest.fn();
+    const stopPropagation = jest.fn();
+    const icon = shallow(<Icon className="test" name="su-pen" onClick={onClick} />);
+    icon.simulate('keypress', {key: ' ', stopPropagation});
+    expect(onClick).toBeCalled();
+    expect(stopPropagation).toBeCalled();
+});
+
+test('Icon should call the callback on when enter is pressed', () => {
+    const onClick = jest.fn();
+    const stopPropagation = jest.fn();
+    const icon = shallow(<Icon className="test" name="su-pen" onClick={onClick} />);
+    icon.simulate('keypress', {key: 'Enter', stopPropagation});
+    expect(onClick).toBeCalled();
+    expect(stopPropagation).toBeCalled();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Action.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Action.js
@@ -32,7 +32,7 @@ export default class Action<T> extends React.PureComponent<Props<T>> {
     };
 
     handleButtonKeyDown = (event: KeyboardEvent) => {
-        if (event.key === 'Enter' || event.key === 'Space') {
+        if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault();
             event.stopPropagation();
             this.triggerButton();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Option.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Option.js
@@ -41,7 +41,7 @@ export default class Option<T> extends React.PureComponent<Props<T>> {
     };
 
     handleButtonKeyDown = (event: KeyboardEvent) => {
-        if (event.key === 'Enter' || event.key === 'Space') {
+        if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault();
             event.stopPropagation();
             this.triggerButton();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/Action.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/Action.test.js
@@ -32,7 +32,7 @@ test('The component should call the callbacks after press space', () => {
     const onClick = jest.fn();
     const afterAction = jest.fn();
     const action = shallow(<Action afterAction={afterAction} onClick={onClick} value="my-option">My action</Action>);
-    action.find('button').simulate('keydown', {key: 'Space', preventDefault: jest.fn(), stopPropagation: jest.fn()});
+    action.find('button').simulate('keydown', {key: ' ', preventDefault: jest.fn(), stopPropagation: jest.fn()});
     expect(onClick).toBeCalled();
     expect(afterAction).toBeCalled();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/Option.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/Option.test.js
@@ -42,7 +42,7 @@ test('Pressing enter on the component should fire the callback', () => {
 test('Pressing space on the component should fire the callback', () => {
     const clickSpy = jest.fn();
     const option = shallow(<Option onClick={clickSpy}>My option</Option>);
-    option.find('button').simulate('keydown', {key: 'Space', preventDefault: jest.fn(), stopPropagation: jest.fn()});
+    option.find('button').simulate('keydown', {key: ' ', preventDefault: jest.fn(), stopPropagation: jest.fn()});
     expect(clickSpy).toBeCalled();
 });
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets |
| Related issues/PRs | #6444
| License | MIT
| Documentation PR | 

#### What's in this PR?

Adds keyboard events to the icon when an onclick function is passed as prop into the component.

#### Why?

The icon component acts as a button in some cases. The icon can be focused, but cannot be activated with the keyboard, because no keyboard events are registered.
