### PR TITLE
Remove duplicate event handler

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Action.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Action.js
@@ -31,14 +31,6 @@ export default class Action<T> extends React.PureComponent<Props<T>> {
         this.triggerButton();
     };
 
-    handleButtonKeyDown = (event: KeyboardEvent) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-            event.preventDefault();
-            event.stopPropagation();
-            this.triggerButton();
-        }
-    };
-
     setButtonRef = (ref: ?ElementRef<'button'>) => {
         const {buttonRef} = this.props;
 
@@ -59,7 +51,6 @@ export default class Action<T> extends React.PureComponent<Props<T>> {
                 <button
                     className={actionStyles.action}
                     onClick={this.handleButtonClick}
-                    onKeyDown={this.handleButtonKeyDown}
                     ref={this.setButtonRef}
                 >
                     {this.props.children}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Action.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Action.js
@@ -52,6 +52,7 @@ export default class Action<T> extends React.PureComponent<Props<T>> {
                     className={actionStyles.action}
                     onClick={this.handleButtonClick}
                     ref={this.setButtonRef}
+                    type="button"
                 >
                     {this.props.children}
                 </button>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Action.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Action.js
@@ -31,6 +31,14 @@ export default class Action<T> extends React.PureComponent<Props<T>> {
         this.triggerButton();
     };
 
+    handleButtonKeyDown = (event: KeyboardEvent) => {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            event.stopPropagation();
+            this.triggerButton();
+        }
+    };
+
     setButtonRef = (ref: ?ElementRef<'button'>) => {
         const {buttonRef} = this.props;
 
@@ -51,6 +59,7 @@ export default class Action<T> extends React.PureComponent<Props<T>> {
                 <button
                     className={actionStyles.action}
                     onClick={this.handleButtonClick}
+                    onKeyDown={this.handleButtonKeyDown}
                     ref={this.setButtonRef}
                     type="button"
                 >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Option.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Option.js
@@ -40,14 +40,6 @@ export default class Option<T> extends React.PureComponent<Props<T>> {
         this.triggerButton();
     };
 
-    handleButtonKeyDown = (event: KeyboardEvent) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-            event.preventDefault();
-            event.stopPropagation();
-            this.triggerButton();
-        }
-    };
-
     setItemRef = (ref: ?ElementRef<'li'>) => {
         const {
             optionRef,
@@ -110,7 +102,6 @@ export default class Option<T> extends React.PureComponent<Props<T>> {
                     className={optionClass}
                     disabled={disabled}
                     onClick={this.handleButtonClick}
-                    onKeyDown={this.handleButtonKeyDown}
                     ref={this.setButtonRef}
                     style={{minWidth: anchorWidth + ANCHOR_WIDTH_DIFFERENCE}}
                 >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Option.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Option.js
@@ -104,6 +104,7 @@ export default class Option<T> extends React.PureComponent<Props<T>> {
                     onClick={this.handleButtonClick}
                     ref={this.setButtonRef}
                     style={{minWidth: anchorWidth + ANCHOR_WIDTH_DIFFERENCE}}
+                    type="button"
                 >
                     {this.renderSelectedVisualization()}
                     {children}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Option.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Option.js
@@ -40,6 +40,14 @@ export default class Option<T> extends React.PureComponent<Props<T>> {
         this.triggerButton();
     };
 
+    handleButtonKeyDown = (event: KeyboardEvent) => {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            event.stopPropagation();
+            this.triggerButton();
+        }
+    };
+
     setItemRef = (ref: ?ElementRef<'li'>) => {
         const {
             optionRef,
@@ -102,6 +110,7 @@ export default class Option<T> extends React.PureComponent<Props<T>> {
                     className={optionClass}
                     disabled={disabled}
                     onClick={this.handleButtonClick}
+                    onKeyDown={this.handleButtonKeyDown}
                     ref={this.setButtonRef}
                     style={{minWidth: anchorWidth + ANCHOR_WIDTH_DIFFERENCE}}
                     type="button"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/Action.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/Action.test.js
@@ -19,24 +19,6 @@ test('The component should call the callbacks after a click', () => {
     expect(afterAction).toBeCalled();
 });
 
-test('The component should call the callbacks after press enter', () => {
-    const onClick = jest.fn();
-    const afterAction = jest.fn();
-    const action = shallow(<Action afterAction={afterAction} onClick={onClick} value="my-option">My action</Action>);
-    action.find('button').simulate('keydown', {key: 'Enter', preventDefault: jest.fn(), stopPropagation: jest.fn()});
-    expect(onClick).toBeCalled();
-    expect(afterAction).toBeCalled();
-});
-
-test('The component should call the callbacks after press space', () => {
-    const onClick = jest.fn();
-    const afterAction = jest.fn();
-    const action = shallow(<Action afterAction={afterAction} onClick={onClick} value="my-option">My action</Action>);
-    action.find('button').simulate('keydown', {key: ' ', preventDefault: jest.fn(), stopPropagation: jest.fn()});
-    expect(onClick).toBeCalled();
-    expect(afterAction).toBeCalled();
-});
-
 test('The component should call the onClick callbacks without a value', () => {
     const onClick = jest.fn();
     const action = shallow(<Action onClick={onClick}>My action</Action>);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/Option.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/Option.test.js
@@ -32,20 +32,6 @@ test('A click on the component should fire the callback', () => {
     expect(clickSpy).toBeCalled();
 });
 
-test('Pressing enter on the component should fire the callback', () => {
-    const clickSpy = jest.fn();
-    const option = shallow(<Option onClick={clickSpy}>My option</Option>);
-    option.find('button').simulate('keydown', {key: 'Enter', preventDefault: jest.fn(), stopPropagation: jest.fn()});
-    expect(clickSpy).toBeCalled();
-});
-
-test('Pressing space on the component should fire the callback', () => {
-    const clickSpy = jest.fn();
-    const option = shallow(<Option onClick={clickSpy}>My option</Option>);
-    option.find('button').simulate('keydown', {key: ' ', preventDefault: jest.fn(), stopPropagation: jest.fn()});
-    expect(clickSpy).toBeCalled();
-});
-
 test('A hover on the component should fire the callback', () => {
     const requestFocusSpy = jest.fn();
     const option = shallow(<Option requestFocus={requestFocusSpy}>My option</Option>);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/__snapshots__/Action.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/__snapshots__/Action.test.js.snap
@@ -4,6 +4,7 @@ exports[`The component should render 1`] = `
 <li>
   <button
     class="action"
+    type="button"
   >
     My action
   </button>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/__snapshots__/Option.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/__snapshots__/Option.test.js.snap
@@ -5,6 +5,7 @@ exports[`The component should render 1`] = `
   <button
     class="option icon"
     style="min-width:10px"
+    type="button"
   >
     My option
   </button>
@@ -17,6 +18,7 @@ exports[`The component should render in disabled state 1`] = `
     class="option icon"
     disabled=""
     style="min-width:10px"
+    type="button"
   >
     My option
   </button>
@@ -28,6 +30,7 @@ exports[`The component should render in selected state 1`] = `
   <button
     class="option icon selected"
     style="min-width:10px"
+    type="button"
   >
     <span
       aria-label="su-check"
@@ -43,6 +46,7 @@ exports[`The component should render with checkbox 1`] = `
   <button
     class="option checkbox"
     style="min-width:10px"
+    type="button"
   >
     <label
       class="label"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/__snapshots__/Select.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/__snapshots__/Select.test.js.snap
@@ -55,6 +55,7 @@ exports[`The component should render with a dark skin 2`] = `
     <button
       class="option icon"
       style="min-width: 210px;"
+      type="button"
     >
       Option 1
     </button>
@@ -63,6 +64,7 @@ exports[`The component should render with a dark skin 2`] = `
     <button
       class="option icon"
       style="min-width: 210px;"
+      type="button"
     >
       Option 2
     </button>
@@ -74,6 +76,7 @@ exports[`The component should render with a dark skin 2`] = `
     <button
       class="option icon"
       style="min-width: 210px;"
+      type="button"
     >
       Option 3
     </button>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceSingleSelect/tests/__snapshots__/ResourceSingleSelect.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceSingleSelect/tests/__snapshots__/ResourceSingleSelect.test.js.snap
@@ -150,6 +150,7 @@ exports[`Render with data 2`] = `
   <li>
     <button
       class="action"
+      type="button"
     >
       sulu_admin.please_choose
     </button>
@@ -158,6 +159,7 @@ exports[`Render with data 2`] = `
     <button
       class="option icon"
       style="min-width: 10px;"
+      type="button"
     >
       Test 1
     </button>
@@ -166,6 +168,7 @@ exports[`Render with data 2`] = `
     <button
       class="option icon"
       style="min-width: 10px;"
+      type="button"
     >
       Test 2
     </button>
@@ -223,6 +226,7 @@ exports[`Render with data with editable option 2`] = `
   <li>
     <button
       class="action"
+      type="button"
     >
       sulu_admin.please_choose
     </button>
@@ -231,6 +235,7 @@ exports[`Render with data with editable option 2`] = `
     <button
       class="option icon"
       style="min-width: 10px;"
+      type="button"
     >
       Test 1
     </button>
@@ -239,6 +244,7 @@ exports[`Render with data with editable option 2`] = `
     <button
       class="option icon"
       style="min-width: 10px;"
+      type="button"
     >
       Test 2
     </button>
@@ -249,6 +255,7 @@ exports[`Render with data with editable option 2`] = `
   <li>
     <button
       class="action"
+      type="button"
     >
       sulu_admin.edit
     </button>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets |
| Related issues/PRs |  #6444
| License | MIT
| Documentation PR |

#### What's in this PR?

While testing, I noticed that an onKeyDown handler was defined on these buttons in addition to the onClick handler. This is unnecessary because native button elements are already triggered by the click event. This redundancy is interesting because a wrong event key string was used for the space button ("Space" instead of " "), so these buttons already fall back to the onClick event handler when the space key is pressed.

#### Why?

An unnecessary duplication with a bug.