### PR TITLE
Fix PHP 8 deprecation notice

### DIFF
--- a/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/EventSubscriber/TagsSubscriberTest.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/EventSubscriber/TagsSubscriberTest.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\HttpCacheBundle\Tests\Unit\EventListener;
 use FOS\HttpCacheBundle\Http\SymfonyResponseTagger;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Ramsey\Uuid\Uuid;
 use Sulu\Bundle\HttpCacheBundle\EventSubscriber\TagsSubscriber;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
@@ -30,32 +31,32 @@ class TagsSubscriberTest extends TestCase
     private $tagsSubscriber;
 
     /**
-     * @var ReferenceStorePoolInterface
+     * @var ReferenceStorePoolInterface|ObjectProphecy
      */
     private $referenceStorePool;
 
     /**
-     * @var SymfonyResponseTagger
+     * @var SymfonyResponseTagger|ObjectProphecy
      */
     private $symfonyResponseTagger;
 
     /**
-     * @var Request
+     * @var Request|ObjectProphecy
      */
     private $request;
 
     /**
-     * @var RequestStack
+     * @var RequestStack|ObjectProphecy
      */
     private $requestStack;
 
     /**
-     * @var ReferenceStoreInterface[]
+     * @var (ReferenceStoreInterface|ObjectProphecy)[]
      */
     private $referenceStores;
 
     /**
-     * @var StructureInterface
+     * @var StructureInterface|ObjectProphecy
      */
     private $structure;
 

--- a/src/Sulu/Bundle/RouteBundle/Document/Subscriber/RoutableSubscriber.php
+++ b/src/Sulu/Bundle/RouteBundle/Document/Subscriber/RoutableSubscriber.php
@@ -164,6 +164,7 @@ class RoutableSubscriber implements EventSubscriberInterface
 
         $document->setUuid($event->getNode()->getIdentifier());
 
+        // TODO: maybe read route path from document
         $propertyName = $this->getRoutePathPropertyName($document, $event->getLocale());
         $routePath = $event->getNode()->getPropertyValueWithDefault($propertyName, null);
 

--- a/src/Sulu/Component/Content/Metadata/Parser/SchemaXmlParser.php
+++ b/src/Sulu/Component/Content/Metadata/Parser/SchemaXmlParser.php
@@ -77,7 +77,7 @@ class SchemaXmlParser
     {
         $value = $this->getValueFromXPath('@value', $xpath, $contextNode);
 
-        if ($value) {
+        if (null !== $value) {
             return new PropertyMetadata(
                 $this->getValueFromXPath('@name', $xpath, $contextNode),
                 $this->getValueFromXPath('@mandatory', $xpath, $contextNode, false),

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\Content\Tests\Unit\Metadata\Loader;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeResolverInterface;
 use Sulu\Component\Content\ContentTypeManagerInterface;
 use Sulu\Component\Content\Exception\InvalidDefaultTypeException;
@@ -38,7 +39,7 @@ class StructureXmlLoaderTest extends TestCase
     ];
 
     /**
-     * @var TranslatorInterface
+     * @var TranslatorInterface|ObjectProphecy
      */
     private $translator;
 
@@ -48,12 +49,12 @@ class StructureXmlLoaderTest extends TestCase
     private $loader;
 
     /**
-     * @var ContentTypeManagerInterface
+     * @var ContentTypeManagerInterface|ObjectProphecy
      */
     private $contentTypeManager;
 
     /**
-     * @var CacheLifetimeResolverInterface
+     * @var CacheLifetimeResolverInterface|ObjectProphecy
      */
     private $cacheLifetimeResolver;
 
@@ -103,6 +104,7 @@ class StructureXmlLoaderTest extends TestCase
         $this->contentTypeManager->has('text_area')->willReturn(true);
         $this->contentTypeManager->has('smart_content_selection')->willReturn(true);
         $this->contentTypeManager->has('image_selection')->willReturn(true);
+        $this->contentTypeManager->has('checkbox')->willReturn(true);
 
         $this->cacheLifetimeResolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, Argument::any())
             ->willReturn(true);
@@ -123,6 +125,17 @@ class StructureXmlLoaderTest extends TestCase
                             'article2',
                         ],
                         'type' => 'object',
+                    ],
+                    [
+                        'type' => 'object',
+                        'properties' => [
+                            'checkbox1' => [
+                                'const' => true,
+                            ],
+                            'checkbox2' => [
+                                'const' => false,
+                            ],
+                        ],
                     ],
                 ],
             ],

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
@@ -65,10 +65,10 @@ class WebsiteRequestProcessor implements RequestProcessorInterface
             $portalInformations,
             function(PortalInformation $a, PortalInformation $b) {
                 if ($a->getPriority() === $b->getPriority()) {
-                    return \strlen($a->getUrl()) < \strlen($b->getUrl());
+                    return \strlen($a->getUrl()) < \strlen($b->getUrl()) ? 1 : -1;
                 }
 
-                return $a->getPriority() < $b->getPriority();
+                return $a->getPriority() < $b->getPriority() ? 1 : -1;
             }
         );
 

--- a/tests/Resources/DataFixtures/Page/template_with_schema.xml
+++ b/tests/Resources/DataFixtures/Page/template_with_schema.xml
@@ -26,6 +26,12 @@
                     <property name="article2" mandatory="true"/>
                 </properties>
             </schema>
+            <schema>
+                <properties>
+                    <property name="checkbox1" value="true"/>
+                    <property name="checkbox2" value="false"/>
+                </properties>
+            </schema>
         </anyOf>
     </schema>
 
@@ -53,5 +59,7 @@
 
         <property name="article1" type="text_area"/>
         <property name="article2" type="text_area"/>
+        <property name="checkbox1" type="checkbox"/>
+        <property name="checkbox2" type="checkbox"/>
     </properties>
 </template>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fixes these deprecation errors in PHP 8 (see https://wiki.php.net/rfc/stable_sorting): 

```
Deprecated: usort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero
```
