### PR TITLE
Fix PHP 8 deprecation notice

### DIFF
--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
@@ -65,10 +65,10 @@ class WebsiteRequestProcessor implements RequestProcessorInterface
             $portalInformations,
             function(PortalInformation $a, PortalInformation $b) {
                 if ($a->getPriority() === $b->getPriority()) {
-                    return \strlen($a->getUrl()) < \strlen($b->getUrl());
+                    return \strlen($a->getUrl()) < \strlen($b->getUrl()) ? 1 : -1;
                 }
 
-                return $a->getPriority() < $b->getPriority();
+                return $a->getPriority() < $b->getPriority() ? 1 : -1;
             }
         );
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fixes these deprecation errors in PHP 8 (see https://wiki.php.net/rfc/stable_sorting):

```
Deprecated: usort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero
```
