### PR TITLE
Fix default operator for Tags and categories filters for smart content

### DIFF
--- a/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
+++ b/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
@@ -136,7 +136,7 @@ trait DataProviderRepositoryTrait
                     $queryBuilder,
                     $tagRelation,
                     $filters['tags'],
-                    \strtolower($filters['tagOperator']),
+                    (isset($filters['tagOperator'])) ? \strtolower($filters['tagOperator']) : 'or',
                     'adminTags'
                 )
             );
@@ -163,7 +163,7 @@ trait DataProviderRepositoryTrait
                     $queryBuilder,
                     $categoryRelation,
                     $filters['categories'],
-                    \strtolower($filters['categoryOperator']),
+                    (isset($filters['categoryOperator'])) ? \strtolower($filters['categoryOperator']) : 'or',
                     'adminCategories'
                 )
             );


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no 
| License | MIT

#### What's in this PR?

Add a default operator for tags and categories filters on smart content.


