### PR TITLE
Add check for shadow locale when loading the structure type

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
@@ -1193,7 +1193,7 @@ class PageControllerTest extends SuluTestCase
         $response = \json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertEquals(true, $response['shadowOn']);
-        $this->assertEquals('default', $response['template']);
+        $this->assertEquals('overview', $response['template']);
 
         $this->client->jsonRequest(
             'PUT',

--- a/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
@@ -16,6 +16,7 @@ use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Component\Content\Compat\Structure\LegacyPropertyFactory;
 use Sulu\Component\Content\ContentTypeManagerInterface;
 use Sulu\Component\Content\Document\Behavior\LocalizedStructureBehavior;
+use Sulu\Component\Content\Document\Behavior\ShadowLocaleBehavior;
 use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\Content\Document\LocalizationState;
 use Sulu\Component\Content\Document\Structure\ManagedStructure;
@@ -222,7 +223,11 @@ class StructureSubscriber implements EventSubscriberInterface
         }
 
         $node = $event->getNode();
-        $propertyName = $this->getStructureTypePropertyName($document, $event->getLocale());
+        $locale = $event->getLocale();
+        if ($document instanceof ShadowLocaleBehavior && $document->isShadowLocaleEnabled()) {
+            $locale = $document->getOriginalLocale();
+        }
+        $propertyName = $this->getStructureTypePropertyName($document, $locale);
         $structureType = $node->getPropertyValueWithDefault($propertyName, null);
 
         if (!$structureType && $rehydrate) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

When loading a shadow document and try to change the locale (during reindex in article bundle for example). You get the wrong structure type.
