### PR TITLE
Fix permission check when clearing cache without permissions for all webspaces

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Controller/CacheController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/CacheController.php
@@ -84,7 +84,7 @@ class CacheController
     private function checkLivePermissionForAllWebspaces()
     {
         foreach ($this->webspaceManager->getWebspaceCollection() as $webspace) {
-            $context = PageAdmin::SECURITY_CONTEXT_PREFIX . $webspace->getKey();
+            $context = PageAdmin::getPageSecurityContext($webspace->getKey());
             if (!$this->securityChecker->hasPermission($context, PermissionTypes::LIVE)) {
                 return false;
             }
@@ -96,7 +96,7 @@ class CacheController
     private function checkLivePermissionForWebspace(string $webspaceKey): bool
     {
         return $this->securityChecker->hasPermission(
-            PageAdmin::SECURITY_CONTEXT_PREFIX . $webspaceKey,
+            PageAdmin::getPageSecurityContext($webspaceKey),
             PermissionTypes::LIVE
         );
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/CacheController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/CacheController.php
@@ -60,7 +60,8 @@ class CacheController
         $webspaceKey = $request->query->get('webspaceKey');
         if ($webspaceKey && !$this->checkLivePermissionForWebspace($webspaceKey)) {
             return new JsonResponse(null, 403);
-        } elseif (!$this->checkLivePermissionForAllWebspaces()) {
+        }
+        if (!$webspaceKey && !$this->checkLivePermissionForAllWebspaces()) {
             return new JsonResponse(null, 403);
         }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/CacheControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/CacheControllerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Tests\Functional\Controller;
+
+use Sulu\Bundle\AdminBundle\Admin\Admin;
+use Sulu\Bundle\ContactBundle\Entity\Contact;
+use Sulu\Bundle\PageBundle\Admin\PageAdmin;
+use Sulu\Bundle\SecurityBundle\Entity\Permission;
+use Sulu\Bundle\SecurityBundle\Entity\Role;
+use Sulu\Bundle\SecurityBundle\Entity\User;
+use Sulu\Bundle\SecurityBundle\Entity\UserRole;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+class CacheControllerTest extends SuluTestCase
+{
+    /**
+     * @var KernelBrowser
+     */
+    private $client;
+
+    public function setUp(): void
+    {
+        $this->client = static::createAuthenticatedClient([], [
+            'PHP_AUTH_USER' => 'cache-user',
+            'PHP_AUTH_PW' => 'cache-user',
+        ]);
+        static::purgeDatabase();
+        $entityManager = static::getEntityManager();
+
+        $contact = new Contact();
+        $contact->setFirstName('Max');
+        $contact->setLastName('Mustermann');
+        $entityManager->persist($contact);
+
+        $user = new User();
+        $encoder = self::$container->get('security.encoder_factory')->getEncoder($user);
+        $user->setUsername('cache-user');
+        $user->setContact($contact);
+        $user->setLocale('en');
+        $user->setSalt('');
+        $user->setPassword($encoder->encodePassword('cache-user', $user->getSalt()));
+        $entityManager->persist($user);
+
+        $role = new Role();
+        $role->setName('Cache User Role');
+        $role->setSystem(Admin::SULU_ADMIN_SECURITY_SYSTEM);
+        $entityManager->persist($role);
+
+        $suluWebspacePermission = new Permission();
+        $suluWebspacePermission->setContext(PageAdmin::getPageSecurityContext('sulu_io'));
+        $suluWebspacePermission->setPermissions(127);
+        $suluWebspacePermission->setRole($role);
+        $role->addPermission($suluWebspacePermission);
+        $entityManager->persist($suluWebspacePermission);
+
+        $userRole = new UserRole();
+        $userRole->setRole($role);
+        $userRole->setLocale('["en","de"]');
+        $userRole->setUser($user);
+        $user->addUserRole($userRole);
+        $entityManager->persist($userRole);
+
+        $entityManager->flush();
+    }
+
+    public function testClearWebspaceWithPermissions(): void
+    {
+        $this->client->request('DELETE', '/sulu_website/cache?webspaceKey=sulu_io');
+
+        static::assertHttpStatusCode(204, $this->client->getResponse());
+    }
+
+    public function testClearWebspaceWithoutPermissions(): void
+    {
+        $this->client->request('DELETE', '/sulu_website/cache?webspaceKey=test_io');
+
+        static::assertHttpStatusCode(403, $this->client->getResponse());
+    }
+
+    public function testClearAllWebspacseWithoutPermissions(): void
+    {
+        $this->client->request('DELETE', '/sulu_website/cache');
+
+        static::assertHttpStatusCode(403, $this->client->getResponse());
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | 
| License | MIT
| Documentation PR | sulu/sulu-docs

#### What's in this PR?

We have 2 webspaces WSA and WSB. The user has the live permission for WSA, but NOT for WSB. Now the user clicks in sulu admin "clear webspace cache" for the webspace WSA, the request is denied with http code 403. The reason is the guard at CacheController::clearAction. The first guard is fine, the user has access to to webspace WSA. Now the check goes to the elseif, but here it must also be checked if the webspace key is given, only with this combination the check makes sense.

#### Why?

Without this fix a user with which has only access to one webspace, can't clear his webspace cache.





