### PR TITLE
Dispatch PageTranslationRestoredEvent when restoring single translation only

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Domain/Event/PageTranslationRestoredEvent.php
+++ b/src/Sulu/Bundle/PageBundle/Domain/Event/PageTranslationRestoredEvent.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PageBundle\Domain\Event;
+
+use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
+use Sulu\Bundle\PageBundle\Admin\PageAdmin;
+use Sulu\Bundle\PageBundle\Document\BasePageDocument;
+use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
+
+class PageTranslationRestoredEvent extends DomainEvent
+{
+    /**
+     * @var BasePageDocument
+     */
+    private $pageDocument;
+
+    /**
+     * @var string
+     */
+    private $locale;
+
+    /**
+     * @var mixed[]
+     */
+    private $payload;
+
+    /**
+     * @param mixed[] $payload
+     */
+    public function __construct(
+        BasePageDocument $pageDocument,
+        string $locale,
+        array $payload
+    ) {
+        parent::__construct();
+
+        $this->pageDocument = $pageDocument;
+        $this->locale = $locale;
+        $this->payload = $payload;
+    }
+
+    public function getPageDocument(): BasePageDocument
+    {
+        return $this->pageDocument;
+    }
+
+    public function getEventType(): string
+    {
+        return 'translation_restored';
+    }
+
+    public function getEventPayload(): ?array
+    {
+        return $this->payload;
+    }
+
+    public function getResourceKey(): string
+    {
+        return BasePageDocument::RESOURCE_KEY;
+    }
+
+    public function getResourceId(): string
+    {
+        return (string) $this->pageDocument->getUuid();
+    }
+
+    public function getResourceLocale(): ?string
+    {
+        return $this->locale;
+    }
+
+    public function getResourceWebspaceKey(): string
+    {
+        return $this->pageDocument->getWebspaceName();
+    }
+
+    public function getResourceTitle(): ?string
+    {
+        return $this->pageDocument->getTitle();
+    }
+
+    public function getResourceTitleLocale(): ?string
+    {
+        return $this->pageDocument->getLocale();
+    }
+
+    public function getResourceSecurityContext(): ?string
+    {
+        return PageAdmin::getPageSecurityContext(static::getResourceWebspaceKey());
+    }
+
+    public function getResourceSecurityObjectType(): ?string
+    {
+        return SecurityBehavior::class;
+    }
+}

--- a/src/Sulu/Bundle/PageBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/PageBundle/Resources/translations/admin.de.json
@@ -80,6 +80,7 @@
     "sulu_activity.description.pages.translation_added": "{userFullName} hat eine neue Sprachvariante für \"{resourceLocale}\" zur Seite \"{resourceTitle}\" hinzugefügt",
     "sulu_activity.description.pages.translation_copied": "{userFullName} hat die Sprachvariante für \"{context_sourceLocale}\" der Seite \"{resourceTitle}\" nach \"{resourceLocale}\" kopiert",
     "sulu_activity.description.pages.translation_removed": "{userFullName} hat die Sprachvariante für \"{resourceLocale}\" der Seite \"{resourceTitle}\" gelöscht",
+    "sulu_activity.description.pages.translation_restored": "{userFullName} hat die Sprachvariante für \"{resourceLocale}\" der Seite \"{resourceTitle}\" wiederhergestellt",
     "sulu_activity.description.pages.version_restored": "{userFullName} hat die Version \"{context_version}\" der Seite \"{resourceTitle}\" wiederhergestellt",
     "sulu_activity.description.pages.preview_link_generated": "{userFullName} hat den öffentlichen Vorschaulink \"{resourceTitle}\" erstellt",
     "sulu_activity.description.pages.preview_link_revoked": "{userFullName} hat den öffentlichen Vorschaulink \"{resourceTitle}\" widerrufen"

--- a/src/Sulu/Bundle/PageBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/PageBundle/Resources/translations/admin.en.json
@@ -80,6 +80,7 @@
     "sulu_activity.description.pages.translation_added": "{userFullName} has added a new translation \"{resourceLocale}\" to the page \"{resourceTitle}\"",
     "sulu_activity.description.pages.translation_copied": "{userFullName} has copied the \"{context_sourceLocale}\" translation of the page \"{resourceTitle}\" into \"{resourceLocale}\"",
     "sulu_activity.description.pages.translation_removed": "{userFullName} has removed the \"{resourceLocale}\" translation of the page \"{resourceTitle}\"",
+    "sulu_activity.description.pages.translation_restored": "{userFullName} has restored the \"{resourceLocale}\" translation of the page \"{resourceTitle}\"",
     "sulu_activity.description.pages.version_restored": "{userFullName} has restored the version \"{context_version}\" of the page \"{resourceTitle}\"",
     "sulu_activity.description.pages.preview_link_generated": "{userFullName} has generated a public preview link \"{resourceTitle}\"",
     "sulu_activity.description.pages.preview_link_revoked": "{userFullName} has revoked the public preview link \"{resourceTitle}\""

--- a/src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
+++ b/src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
@@ -19,6 +19,7 @@ use Sulu\Bundle\PageBundle\Admin\PageAdmin;
 use Sulu\Bundle\PageBundle\Document\BasePageDocument;
 use Sulu\Bundle\PageBundle\Document\PageDocument;
 use Sulu\Bundle\PageBundle\Domain\Event\PageRestoredEvent;
+use Sulu\Bundle\PageBundle\Domain\Event\PageTranslationRestoredEvent;
 use Sulu\Bundle\TrashBundle\Application\RestoreConfigurationProvider\RestoreConfiguration;
 use Sulu\Bundle\TrashBundle\Application\RestoreConfigurationProvider\RestoreConfigurationProviderInterface;
 use Sulu\Bundle\TrashBundle\Application\TrashItemHandler\RestoreTrashItemHandlerInterface;
@@ -197,7 +198,10 @@ final class PageTrashItemHandler implements
         }
 
         Assert::isInstanceOf($localizedPage, PageDocument::class);
-        $this->documentDomainEventCollector->collect(new PageRestoredEvent($localizedPage, $data));
+        $event = 'translation' === $trashItem->getRestoreType()
+            ? new PageTranslationRestoredEvent($localizedPage, $trashItem->getRestoreOptions()['locale'], $data)
+            : new PageRestoredEvent($localizedPage, $data);
+        $this->documentDomainEventCollector->collect($event);
         $this->documentManager->flush();
 
         return $localizedPage;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Related issues/PRs | #6337
| License | MIT

#### What's in this PR?

This PR adjusts the `PageTrashItemHandler` service to dispatch a `PageTranslationRestoredEvent` instead of a `PageRestoredEvent` if a single translation is restored.

#### Why?

This allows us to display a more intuitive message in the activity log. Also, we already dispatch specific events when managing translations in other places (eg. `PageTranslationCopiedEvent` and `PageTranslationRemovedEvent`).
