### PR TITLE
Implement CopyToolbarAction for Form view

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -98,6 +98,7 @@ import {
 import {textEditorRegistry} from './containers/TextEditor';
 import Form, {
     formToolbarActionRegistry,
+    CopyToolbarAction as FormCopyToolbarAction,
     CopyLocaleToolbarAction as FormCopyLocaleToolbarAction,
     DeleteDraftToolbarAction as FormDeleteDraftToolbarAction,
     DeleteToolbarAction as FormDeleteToolbarAction,
@@ -314,6 +315,7 @@ function registerInternalLinkTypes(internalLinkTypes) {
 }
 
 function registerFormToolbarActions() {
+    formToolbarActionRegistry.add('sulu_admin.copy', FormCopyToolbarAction);
     formToolbarActionRegistry.add('sulu_admin.copy_locale', FormCopyLocaleToolbarAction);
     formToolbarActionRegistry.add('sulu_admin.delete', FormDeleteToolbarAction);
     formToolbarActionRegistry.add('sulu_admin.delete_draft', FormDeleteDraftToolbarAction);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/index.js
@@ -2,6 +2,7 @@
 import Form from './Form';
 import formToolbarActionRegistry from './registries/formToolbarActionRegistry';
 import AbstractFormToolbarAction from './toolbarActions/AbstractFormToolbarAction';
+import CopyToolbarAction from './toolbarActions/CopyToolbarAction';
 import CopyLocaleToolbarAction from './toolbarActions/CopyLocaleToolbarAction';
 import DeleteDraftToolbarAction from './toolbarActions/DeleteDraftToolbarAction';
 import DeleteToolbarAction from './toolbarActions/DeleteToolbarAction';
@@ -19,6 +20,7 @@ export default Form;
 export {
     formToolbarActionRegistry,
     AbstractFormToolbarAction,
+    CopyToolbarAction,
     CopyLocaleToolbarAction,
     DeleteDraftToolbarAction,
     DeleteToolbarAction,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/CopyToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/CopyToolbarAction.test.js
@@ -1,0 +1,237 @@
+// @flow
+import {mount} from 'enzyme';
+import {ResourceFormStore} from '../../../../containers/Form';
+import ResourceRequester from '../../../../services/ResourceRequester';
+import ResourceStore from '../../../../stores/ResourceStore';
+import Router from '../../../../services/Router';
+import Form from '../../../../views/Form';
+import CopyToolbarAction from '../../toolbarActions/CopyToolbarAction';
+import conditionDataProviderRegistry from '../../../../containers/Form/registries/conditionDataProviderRegistry';
+
+jest.mock('../../../../utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
+
+jest.mock('../../../../stores/ResourceStore', () => jest.fn(function(resourceKey, id, observableOptions) {
+    this.id = id;
+    this.data = {};
+    this.observableOptions = observableOptions;
+    this.locale = {
+        get: jest.fn(),
+    };
+}));
+
+jest.mock('../../../../services/ResourceRequester', () => ({
+    post: jest.fn(),
+}));
+
+jest.mock('../../../../containers/Form/stores/ResourceFormStore', () => (
+    class {
+        resourceStore;
+        options = {};
+
+        constructor(resourceStore) {
+            this.resourceStore = resourceStore;
+        }
+
+        get id() {
+            return this.resourceStore.id;
+        }
+
+        get locale() {
+            return this.resourceStore.locale;
+        }
+
+        get data() {
+            return this.resourceStore.data;
+        }
+
+        delete = jest.fn();
+        changeMultiple = jest.fn();
+    })
+);
+
+jest.mock('../../../../services/Router', () => jest.fn(function() {
+    this.navigate = jest.fn();
+    this.route = {
+        name: 'current_route_name',
+        options: {},
+    };
+}));
+
+jest.mock('../../../../views/Form', () => jest.fn(function() {
+    this.showSuccessSnackbar = jest.fn();
+}));
+
+function createCopyToolbarAction(options = {}) {
+    const resourceStore = new ResourceStore('test');
+    const formStore = new ResourceFormStore(resourceStore, 'test');
+    const router = new Router({});
+    const form = new Form({
+        locales: [],
+        resourceStore,
+        route: router.route,
+        router,
+    });
+
+    return new CopyToolbarAction(formStore, form, router, [], options, resourceStore);
+}
+
+test('Return item config with correct disabled, type and label', () => {
+    const copyToolbarAction = createCopyToolbarAction();
+
+    expect(copyToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        disabled: true,
+        label: 'sulu_admin.create_copy',
+        type: 'button',
+    }));
+});
+
+test('Return  item config with enabled button if form store contains an id', () => {
+    const copyToolbarAction = createCopyToolbarAction();
+    copyToolbarAction.resourceFormStore.resourceStore.id = 123;
+
+    expect(copyToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        disabled: false,
+    }));
+});
+
+test('Return item config if passed visible_condition is met', () => {
+    const copyToolbarAction = createCopyToolbarAction({visible_condition: '_permission.edit'});
+    copyToolbarAction.resourceFormStore.resourceStore.data._permission = {edit: true};
+
+    expect(copyToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        label: 'sulu_admin.create_copy',
+    }));
+});
+
+test('Return empty item config if passed visible_condition is not met', () => {
+    const copyToolbarAction = createCopyToolbarAction({visible_condition: '_permission.edit'});
+    copyToolbarAction.resourceFormStore.resourceStore.data._permission = {edit: false};
+
+    expect(copyToolbarAction.getToolbarItemConfig()).toEqual(undefined);
+});
+
+test('Include data of conditionDataProviderRegistry when evaluating passed visible_condition', () => {
+    const copyToolbarAction = createCopyToolbarAction({visible_condition: '__conditionDataProviderValue'});
+    expect(copyToolbarAction.getToolbarItemConfig()).toBeUndefined();
+
+    conditionDataProviderRegistry.add(() => ({__conditionDataProviderValue: true}));
+    expect(copyToolbarAction.getToolbarItemConfig()).toBeDefined();
+
+    conditionDataProviderRegistry.clear();
+    conditionDataProviderRegistry.add(() => ({__conditionDataProviderValue: false}));
+    expect(copyToolbarAction.getToolbarItemConfig()).toBeUndefined();
+});
+
+test('Display confirmation dialog when button is clicked', () => {
+    const copyToolbarAction = createCopyToolbarAction();
+    copyToolbarAction.resourceFormStore.resourceStore.id = 3;
+    // $FlowFixMe
+    copyToolbarAction.resourceFormStore.resourceStore.locale.get.mockReturnValue('en');
+    copyToolbarAction.resourceFormStore.options.webspace = 'sulu_io';
+
+    const toolbarItemConfig = copyToolbarAction.getToolbarItemConfig();
+    if (!toolbarItemConfig) {
+        throw new Error('The toolbarItemConfig should be a value!');
+    }
+
+    const onClickCallback = toolbarItemConfig.onClick;
+    if (!onClickCallback) {
+        throw new Error('A onClick callback should be registered on the unpublish option');
+    }
+
+    let element = mount(copyToolbarAction.getNode());
+    expect(element.instance().props).toEqual(expect.objectContaining({
+        open: false,
+    }));
+
+    onClickCallback();
+    element = mount(copyToolbarAction.getNode());
+    expect(element.instance().props).toEqual(expect.objectContaining({
+        open: true,
+    }));
+
+    expect(element.render()).toMatchSnapshot();
+});
+
+test('Close confirmation dialog when onCancel callback is fired', () => {
+    const copyToolbarAction = createCopyToolbarAction();
+    copyToolbarAction.resourceFormStore.resourceStore.id = 3;
+    // $FlowFixMe
+    copyToolbarAction.resourceFormStore.resourceStore.locale.get.mockReturnValue('en');
+    copyToolbarAction.resourceFormStore.options.webspace = 'sulu_io';
+
+    const toolbarItemConfig = copyToolbarAction.getToolbarItemConfig();
+    if (!toolbarItemConfig) {
+        throw new Error('The toolbarItemConfig should be a value!');
+    }
+
+    const onClickCallback = toolbarItemConfig.onClick;
+    if (!onClickCallback) {
+        throw new Error('A onClick callback should be registered on the unpublish option');
+    }
+
+    let element = mount(copyToolbarAction.getNode());
+    expect(element.instance().props).toEqual(expect.objectContaining({
+        open: false,
+    }));
+
+    onClickCallback();
+    element = mount(copyToolbarAction.getNode());
+    expect(element.instance().props).toEqual(expect.objectContaining({
+        open: true,
+    }));
+
+    element.prop('onCancel')();
+    element = mount(copyToolbarAction.getNode());
+    expect(element.instance().props).toEqual(expect.objectContaining({
+        open: false,
+    }));
+});
+
+test('Copy resource when confirmation dialog is confirmed', () => {
+    const copyPromise = Promise.resolve({id: 'copied-id', webspace: 'copied-webspace'});
+    ResourceRequester.post.mockReturnValue(copyPromise);
+
+    const copyToolbarAction = createCopyToolbarAction();
+    copyToolbarAction.resourceFormStore.resourceStore.id = 3;
+    // $FlowFixMe
+    copyToolbarAction.resourceFormStore.resourceKey = 'pages';
+    // $FlowFixMe
+    copyToolbarAction.resourceFormStore.resourceStore.locale.get.mockReturnValue('en');
+    copyToolbarAction.resourceFormStore.options.webspace = 'sulu_io';
+
+    const toolbarItemConfig = copyToolbarAction.getToolbarItemConfig();
+    if (!toolbarItemConfig) {
+        throw new Error('The toolbarItemConfig should be a value!');
+    }
+
+    const clickHandler = toolbarItemConfig.onClick;
+    if (!clickHandler) {
+        throw new Error('A onClick callback should be registered on the unpublish option');
+    }
+
+    let element = mount(copyToolbarAction.getNode());
+    clickHandler();
+
+    expect(element.prop('confirmLoading')).toEqual(false);
+    element.prop('onConfirm')();
+    element = mount(copyToolbarAction.getNode());
+    expect(element.prop('confirmLoading')).toEqual(true);
+    expect(ResourceRequester.post).toBeCalledWith(
+        'pages',
+        undefined,
+        {action: 'copy', id: 3, webspace: 'sulu_io'}
+    );
+
+    return copyPromise.then(() => {
+        element = mount(copyToolbarAction.getNode());
+        expect(copyToolbarAction.form.showSuccessSnackbar).toBeCalledWith();
+        expect(element.prop('confirmLoading')).toEqual(false);
+        expect(copyToolbarAction.router.navigate).toBeCalledWith(
+            'current_route_name',
+            {id: 'copied-id', webspace: 'copied-webspace'}
+        );
+    });
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/__snapshots__/CopyToolbarAction.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/__snapshots__/CopyToolbarAction.test.js.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Display confirmation dialog when button is clicked 1`] = `
+Array [
+  <div
+    class="backdrop visible fixed"
+    role="button"
+  />,
+  <div
+    class="dialogContainer open"
+  >
+    <div
+      class="dialog"
+    >
+      <section
+        class="content"
+      >
+        <div
+          class="snackbar"
+        >
+          <div
+            class="snackbar error"
+            role="button"
+          >
+            <span
+              aria-label="su-exclamation-triangle"
+              class="su-exclamation-triangle icon"
+            />
+            <div
+              class="text"
+            >
+              <strong>
+                sulu_admin.error
+              </strong>
+               - 
+            </div>
+          </div>
+        </div>
+        <header
+          class="header"
+        >
+          <span
+            class="headerItem"
+          >
+            sulu_admin.create_copy
+          </span>
+        </header>
+        <article
+          class="article center"
+        >
+          sulu_admin.copy_dialog_description
+        </article>
+        <footer
+          class="footer"
+        >
+          <button
+            class="button primary hasText"
+            type="button"
+          >
+            <span
+              class="buttonText"
+            >
+              sulu_admin.ok
+            </span>
+          </button>
+          <button
+            class="button secondary hasText"
+            type="button"
+          >
+            <span
+              class="buttonText"
+            >
+              sulu_admin.cancel
+            </span>
+          </button>
+        </footer>
+      </section>
+    </div>
+  </div>,
+]
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/CopyToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/CopyToolbarAction.js
@@ -1,0 +1,89 @@
+// @flow
+import React from 'react';
+import {action, observable} from 'mobx';
+import jexl from 'jexl';
+import log from 'loglevel';
+import Dialog from '../../../components/Dialog';
+import ResourceRequester from '../../../services/ResourceRequester';
+import ResourceStore from '../../../stores/ResourceStore';
+import {translate} from '../../../utils/Translator';
+import {ResourceFormStore} from '../../../containers/Form';
+import Form from '../Form';
+import Router from '../../../services/Router';
+import AbstractFormToolbarAction from './AbstractFormToolbarAction';
+
+export default class CopyToolbarAction extends AbstractFormToolbarAction {
+    @observable showCopyDialog = false;
+    @observable copying = false;
+
+    getNode() {
+        return (
+            <Dialog
+                cancelText={translate('sulu_admin.cancel')}
+                confirmLoading={this.copying}
+                confirmText={translate('sulu_admin.ok')}
+                key="sulu_admin.copy"
+                onCancel={this.handleCopyDialogClose}
+                onConfirm={this.handleCopyDialogConfirm}
+                open={this.showCopyDialog}
+                title={translate('sulu_admin.create_copy')}
+            >
+                {translate('sulu_admin.copy_dialog_description')}
+            </Dialog>
+        );
+    }
+
+    getToolbarItemConfig() {
+        const {
+            visible_condition: visibleCondition,
+        } = this.options;
+
+        const {id} = this.resourceFormStore;
+        const visibleConditionFulfilled = !visibleCondition || jexl.evalSync(visibleCondition, this.conditionData);
+
+        if (visibleConditionFulfilled) {
+            return {
+                disabled: !id,
+                label: translate('sulu_admin.create_copy'),
+                onClick: action(() => {
+                    this.showCopyDialog = true;
+                }),
+                type: 'button',
+            };
+        }
+    }
+
+    @action handleCopyDialogConfirm = () => {
+        const {
+            id,
+            locale,
+            options: {
+                webspace,
+            },
+            resourceKey,
+        } = this.resourceFormStore;
+
+        this.copying = true;
+
+        ResourceRequester.post(
+            resourceKey,
+            undefined,
+            {
+                action: 'copy',
+                id,
+                webspace,
+            }
+        ).then(action((response) => {
+            this.copying = false;
+            this.showCopyDialog = false;
+            this.form.showSuccessSnackbar();
+
+            const {id, webspace} = response;
+            this.router.navigate(this.router.route.name, {id, webspace});
+        }));
+    };
+
+    @action handleCopyDialogClose = () => {
+        this.showCopyDialog = false;
+    };
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/CopyToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/CopyToolbarAction.js
@@ -2,14 +2,9 @@
 import React from 'react';
 import {action, observable} from 'mobx';
 import jexl from 'jexl';
-import log from 'loglevel';
 import Dialog from '../../../components/Dialog';
 import ResourceRequester from '../../../services/ResourceRequester';
-import ResourceStore from '../../../stores/ResourceStore';
 import {translate} from '../../../utils/Translator';
-import {ResourceFormStore} from '../../../containers/Form';
-import Form from '../Form';
-import Router from '../../../services/Router';
 import AbstractFormToolbarAction from './AbstractFormToolbarAction';
 
 export default class CopyToolbarAction extends AbstractFormToolbarAction {
@@ -56,7 +51,6 @@ export default class CopyToolbarAction extends AbstractFormToolbarAction {
     @action handleCopyDialogConfirm = () => {
         const {
             id,
-            locale,
             options: {
                 webspace,
             },

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -88,6 +88,8 @@
     "sulu_admin.choose_language": "Sprache wählen",
     "sulu_admin.characters_left": "Zeichen übrig",
     "sulu_admin.segments_left": "Segmente übrig",
+    "sulu_admin.create_copy": "Kopie erstellen",
+    "sulu_admin.copy_dialog_description": "Diese Operation erstellt eine Kopie des aktuellen Elements. Wollen Sie fortfahren?",
     "sulu_admin.copy_locale": "Sprachvariante kopieren",
     "sulu_admin.choose_target_locale": "Wähle Zielsprachen",
     "sulu_admin.copy_locale_dialog_description": "* Neue Sprachvariante wird erstellt",

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -89,6 +89,8 @@
     "sulu_admin.choose_language": "Choose language",
     "sulu_admin.characters_left": "characters left",
     "sulu_admin.segments_left": "segments left",
+    "sulu_admin.create_copy": "Create copy",
+    "sulu_admin.copy_dialog_description": "This operation creates a copy of the current item. Do you wish to proceed?",
     "sulu_admin.copy_locale": "Copy locale",
     "sulu_admin.choose_target_locale": "Choose target locales",
     "sulu_admin.copy_locale_dialog_description": "* New locale will be created",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adds a `CopyToolbarAction` for the `Form` view.

#### Why?

Because we want to implement a `Copy form` functionality for the [SuluFormBundle](https://github.com/sulu/SuluFormBundle).

#### Example Usage

```php
new ToolbarAction(
    'sulu_admin.copy',
    [
        'visible_condition' => '(!_permissions || _permissions.edit)',
    ]
);
```
