### PR TITLE
Remove constructor declaration from PreviewLinkInterface

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,15 @@
 # Upgrade
 
+## 2.4.x
+
+### Change PreviewLinkInterface
+
+Added the following method to the `PreviewLinkInterface`:
+
+```php
+public static function create(string $token, string $resourceKey, string $resourceId, string $locale, array $options): self;
+```
+
 ## 2.4.0
 
 ### Added PreviewLink resource to PreviewBundle

--- a/src/Sulu/Bundle/PreviewBundle/Domain/Model/PreviewLink.php
+++ b/src/Sulu/Bundle/PreviewBundle/Domain/Model/PreviewLink.php
@@ -53,6 +53,15 @@ class PreviewLink implements PreviewLinkInterface
      */
     private $lastVisit;
 
+    public function __construct(string $token, string $resourceKey, string $resourceId, string $locale, array $options)
+    {
+        $this->token = $token;
+        $this->resourceKey = $resourceKey;
+        $this->resourceId = $resourceId;
+        $this->locale = $locale;
+        $this->options = $options;
+    }
+
     public function getId(): int
     {
         return $this->id;
@@ -106,14 +115,12 @@ class PreviewLink implements PreviewLinkInterface
      */
     public static function create(string $token, string $resourceKey, string $resourceId, string $locale, array $options): PreviewLinkInterface
     {
-        $previewLink = new self();
-
-        $previewLink->token = $token;
-        $previewLink->resourceKey = $resourceKey;
-        $previewLink->resourceId = $resourceId;
-        $previewLink->locale = $locale;
-        $previewLink->options = $options;
-
-        return $previewLink;
+        return new self(
+            $token,
+            $resourceKey,
+            $resourceId,
+            $locale,
+            $options
+        );
     }
 }

--- a/src/Sulu/Bundle/PreviewBundle/Domain/Model/PreviewLink.php
+++ b/src/Sulu/Bundle/PreviewBundle/Domain/Model/PreviewLink.php
@@ -53,15 +53,6 @@ class PreviewLink implements PreviewLinkInterface
      */
     private $lastVisit;
 
-    public function __construct(string $token, string $resourceKey, string $resourceId, string $locale, array $options)
-    {
-        $this->token = $token;
-        $this->resourceKey = $resourceKey;
-        $this->resourceId = $resourceId;
-        $this->locale = $locale;
-        $this->options = $options;
-    }
-
     public function getId(): int
     {
         return $this->id;
@@ -108,5 +99,21 @@ class PreviewLink implements PreviewLinkInterface
     public function getLastVisit(): ?\DateTimeImmutable
     {
         return $this->lastVisit;
+    }
+
+    /**
+     * @param mixed[] $options
+     */
+    public static function create(string $token, string $resourceKey, string $resourceId, string $locale, array $options): self
+    {
+        $previewLink = new self();
+
+        $previewLink->token = $token;
+        $previewLink->resourceKey = $resourceKey;
+        $previewLink->resourceId = $resourceId;
+        $previewLink->locale = $locale;
+        $previewLink->options = $options;
+
+        return $previewLink;
     }
 }

--- a/src/Sulu/Bundle/PreviewBundle/Domain/Model/PreviewLink.php
+++ b/src/Sulu/Bundle/PreviewBundle/Domain/Model/PreviewLink.php
@@ -104,7 +104,7 @@ class PreviewLink implements PreviewLinkInterface
     /**
      * @param mixed[] $options
      */
-    public static function create(string $token, string $resourceKey, string $resourceId, string $locale, array $options): self
+    public static function create(string $token, string $resourceKey, string $resourceId, string $locale, array $options): PreviewLinkInterface
     {
         $previewLink = new self();
 

--- a/src/Sulu/Bundle/PreviewBundle/Domain/Model/PreviewLinkInterface.php
+++ b/src/Sulu/Bundle/PreviewBundle/Domain/Model/PreviewLinkInterface.php
@@ -18,7 +18,7 @@ interface PreviewLinkInterface
     /**
      * @param mixed[] $options
      */
-    public function __construct(string $token, string $resourceKey, string $resourceId, string $locale, array $options);
+    public static function create(string $token, string $resourceKey, string $resourceId, string $locale, array $options): self;
 
     public function getId(): int;
 

--- a/src/Sulu/Bundle/PreviewBundle/Infrastructure/Doctrine/Repository/PreviewLinkRepository.php
+++ b/src/Sulu/Bundle/PreviewBundle/Infrastructure/Doctrine/Repository/PreviewLinkRepository.php
@@ -39,7 +39,7 @@ class PreviewLinkRepository implements PreviewLinkRepositoryInterface
     {
         $token = $this->generateToken();
 
-        /** @var class-string<PreviewLinkInterface>|PreviewLinkInterface $className */
+        /** @var class-string<PreviewLinkInterface>$className */
         $className = $this->entityRepository->getClassName();
 
         return $className::create($token, $resourceKey, $resourceId, $locale, $options);

--- a/src/Sulu/Bundle/PreviewBundle/Infrastructure/Doctrine/Repository/PreviewLinkRepository.php
+++ b/src/Sulu/Bundle/PreviewBundle/Infrastructure/Doctrine/Repository/PreviewLinkRepository.php
@@ -39,10 +39,10 @@ class PreviewLinkRepository implements PreviewLinkRepositoryInterface
     {
         $token = $this->generateToken();
 
-        /** @var class-string<PreviewLinkInterface> $className */
+        /** @var class-string<PreviewLinkInterface>|PreviewLinkInterface $className */
         $className = $this->entityRepository->getClassName();
 
-        return new $className($token, $resourceKey, $resourceId, $locale, $options);
+        return $className::create($token, $resourceKey, $resourceId, $locale, $options);
     }
 
     public function findByResource(string $resourceKey, string $resourceId, string $locale): ?PreviewLinkInterface

--- a/src/Sulu/Bundle/PreviewBundle/Infrastructure/Doctrine/Repository/PreviewLinkRepository.php
+++ b/src/Sulu/Bundle/PreviewBundle/Infrastructure/Doctrine/Repository/PreviewLinkRepository.php
@@ -39,7 +39,7 @@ class PreviewLinkRepository implements PreviewLinkRepositoryInterface
     {
         $token = $this->generateToken();
 
-        /** @var class-string<PreviewLinkInterface>$className */
+        /** @var class-string<PreviewLinkInterface> $className */
         $className = $this->entityRepository->getClassName();
 
         return $className::create($token, $resourceKey, $resourceId, $locale, $options);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Remove constructor declaration from PreviewLinkInterface

#### Why?

Because otherwise this leads to a `Declaration incompatible` error with doctrine proxies
