### PR TITLE
 Add possibility for query parameters in link field type and ckeditor link overlay

### DIFF
--- a/config/templates/pages/example.xml
+++ b/config/templates/pages/example.xml
@@ -277,7 +277,7 @@
             </meta>
         </property>
 
-        <property name="url" type="url">
+        <property name="external_url" type="url">
             <meta>
                 <title lang="en">URL</title>
                 <title lang="de">URL</title>
@@ -292,6 +292,7 @@
 
             <params>
                 <param name="enable_anchor" value="true"/>
+                <param name="enable_query" value="true"/>
                 <param name="enable_attributes" value="true"/>
             </params>
         </property>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/InternalLinkPlugin/InternalLinkPlugin.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/InternalLinkPlugin/InternalLinkPlugin.js
@@ -52,21 +52,20 @@ export default class InternalLinkPlugin extends Plugin {
 
     @computed get href(): ?string | number {
         const {id, query, anchor} = this;
-        let append = '';
 
         if (!id) {
             return null;
         }
 
+        let suffix = '';
         if (query) {
-            append += '?' + query.replace(/^\?+/g, '');
+            suffix += '?' + query.replace(/^\?+/g, '');
         }
-
         if (anchor) {
-            append += '#' + anchor.replace(/^#+/g, '');
+            suffix += '#' + anchor.replace(/^#+/g, '');
         }
 
-        return id + append;
+        return id + suffix;
     }
 
     init() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Link.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Link.js
@@ -142,7 +142,7 @@ export default class Link extends React.Component<FieldTypeProps<LinkValue>> {
             <LinkContainer
                 disabled={!!disabled}
                 enableAnchor={enableAnchor}
-                enableQuery={enableAnchor}
+                enableQuery={enableQuery}
                 enableRel={enableRel}
                 enableTarget={enableTarget}
                 enableTitle={enableTitle}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Link.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Link.js
@@ -20,6 +20,9 @@ export default class Link extends React.Component<FieldTypeProps<LinkValue>> {
                 enable_anchor: {
                     value: enableAnchor,
                 } = {},
+                enable_query: {
+                    value: enableQuery,
+                } = {},
                 enable_target: {
                     value: deprecatedEnableTarget,
                 } = {},
@@ -40,6 +43,10 @@ export default class Link extends React.Component<FieldTypeProps<LinkValue>> {
 
         if (enableAnchor !== undefined && enableAnchor !== null && typeof enableAnchor !== 'boolean') {
             throw new Error('The "enable_anchor" schema option must be a boolean if given!');
+        }
+
+        if (enableQuery !== undefined && enableQuery !== null && typeof enableQuery !== 'boolean') {
+            throw new Error('The "enable_query" schema option must be a boolean if given!');
         }
 
         let enableTarget = false,
@@ -135,6 +142,7 @@ export default class Link extends React.Component<FieldTypeProps<LinkValue>> {
             <LinkContainer
                 disabled={!!disabled}
                 enableAnchor={enableAnchor}
+                enableQuery={enableAnchor}
                 enableRel={enableRel}
                 enableTarget={enableTarget}
                 enableTitle={enableTitle}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Link.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Link.test.js
@@ -29,6 +29,7 @@ test('Pass props correctly to Link component', () => {
 
     const value = {
         anchor: 'anchorTest',
+        query: 'queryTest',
         href: '123-asdf-123',
         locale: 'en',
         provider: 'page',
@@ -44,6 +45,10 @@ test('Pass props correctly to Link component', () => {
         },
         enable_anchor: {
             name: 'enable_anchor',
+            value: true,
+        },
+        enable_query: {
+            name: 'enable_query',
             value: true,
         },
     };
@@ -63,6 +68,7 @@ test('Pass props correctly to Link component', () => {
     expect(link.find('Link').props()).toEqual({
         'disabled': true,
         'enableAnchor': true,
+        'enableQuery': true,
         'enableTarget': true,
         'enableTitle': true,
         'enableRel': true,
@@ -73,6 +79,7 @@ test('Pass props correctly to Link component', () => {
         'types': [],
         'value': {
             'anchor': 'anchorTest',
+            'query': 'queryTest',
             'href': '123-asdf-123',
             'locale': 'en',
             'provider': 'page',
@@ -135,6 +142,7 @@ test('Pass props correctly to Link component with deprecated options', () => {
     expect(link.find('Link').props()).toEqual({
         'disabled': true,
         'enableAnchor': true,
+        'enableQuery': false,
         'enableTarget': true,
         'enableTitle': true,
         'enableRel': false,
@@ -207,6 +215,7 @@ test('Pass props correctly to Link component filtered types', () => {
     expect(link.find('Link').props()).toEqual({
         'disabled': true,
         'enableAnchor': true,
+        'enableQuery': false,
         'enableTarget': true,
         'enableTitle': true,
         'enableRel': true,
@@ -279,6 +288,7 @@ test('Pass props correctly to Link component filtered excluded_types', () => {
     expect(link.find('Link').props()).toEqual({
         'disabled': true,
         'enableAnchor': true,
+        'enableQuery': false,
         'enableTarget': true,
         'enableTitle': true,
         'enableRel': true,
@@ -299,7 +309,7 @@ test('Pass props correctly to Link component filtered excluded_types', () => {
     });
 });
 
-test('Pass props correctly to Link component disabled anchor, target and rel', () => {
+test('Pass props correctly to Link component disabled anchor, query, target and rel', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
     const changeSpy = jest.fn();
     const finishSpy = jest.fn();
@@ -310,6 +320,7 @@ test('Pass props correctly to Link component disabled anchor, target and rel', (
 
     const value: LinkValue = {
         anchor: 'anchorTest',
+        query: 'queryTest',
         href: '123-asdf-123',
         locale: 'en',
         provider: 'page',
@@ -343,6 +354,7 @@ test('Pass props correctly to Link component disabled anchor, target and rel', (
     expect(link.find('Link').props()).toEqual({
         'disabled': true,
         'enableAnchor': false,
+        'enableQuery': false,
         'enableTarget': false,
         'enableTitle': false,
         'enableRel': false,
@@ -353,6 +365,7 @@ test('Pass props correctly to Link component disabled anchor, target and rel', (
         'types': ['external', 'page'],
         'value': {
             'anchor': 'anchorTest',
+            'query': 'queryTest',
             'href': '123-asdf-123',
             'locale': 'en',
             'provider': 'page',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/Link.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/Link.js
@@ -16,6 +16,7 @@ import type {IObservableValue} from 'mobx/lib/mobx';
 type Props = {
     disabled?: boolean,
     enableAnchor?: ?boolean,
+    enableQuery?: ?boolean,
     enableRel?: ?boolean,
     enableTarget?: ?boolean,
     enableTitle?: ?boolean,
@@ -34,6 +35,7 @@ class Link extends Component<Props> {
     static defaultProps = {
         disabled: false,
         enableAnchor: false,
+        enableQuery: false,
         enableRel: false,
         enableTarget: false,
         enableTitle: false,
@@ -47,6 +49,7 @@ class Link extends Component<Props> {
     @observable overlayRel: ?string;
     @observable overlayTarget: ?string = DEFAULT_TARGET;
     @observable overlayAnchor: ?string;
+    @observable overlayQuery: ?string;
     @observable titleParts: Array<string | number> = [];
     @observable titleLoading: boolean = false;
 
@@ -113,7 +116,7 @@ class Link extends Component<Props> {
     };
 
     @action handleRemoveClick = () => {
-        this.changeValue(undefined, undefined, undefined, undefined, undefined);
+        this.changeValue(undefined, undefined, undefined, undefined, undefined, undefined, undefined);
     };
 
     @action handleTitleClick = () => {
@@ -137,6 +140,7 @@ class Link extends Component<Props> {
             this.overlayTitle,
             this.overlayTarget,
             this.overlayAnchor,
+            this.overlayQuery,
             this.overlayRel
         );
         this.closeOverlay();
@@ -152,6 +156,10 @@ class Link extends Component<Props> {
 
     @action handleOverlayAnchorChange = (anchor: ?string) => {
         this.overlayAnchor = anchor;
+    };
+
+    @action handleOverlayQueryChange = (query: ?string) => {
+        this.overlayQuery = query;
     };
 
     @action handleOverlayTargetChange = (target: ?string) => {
@@ -179,23 +187,30 @@ class Link extends Component<Props> {
             value,
         } = this.props;
         const {
-            provider: currentProvider, title, href, target = DEFAULT_TARGET, anchor, rel,
+            provider: currentProvider, title, href, target = DEFAULT_TARGET, anchor, query, rel,
         } = value || {};
 
         this.overlayHref = currentProvider === provider ? href : undefined;
         this.overlayTarget = target;
         this.overlayTitle = title;
         this.overlayAnchor = anchor;
+        this.overlayQuery = query;
         this.overlayRel = rel;
 
         this.openedOverlayProvider = provider;
     };
 
     changeValue = (
-        provider: ?string, href: ?string | number, title: ?string, target: ?string, anchor: ?string, rel: ?string
+        provider: ?string,
+        href: ?string | number,
+        title: ?string,
+        target: ?string,
+        anchor: ?string,
+        query: ?string,
+        rel: ?string
     ) => {
         const {
-            onChange, onFinish, enableTarget, enableTitle, enableAnchor, enableRel, locale,
+            onChange, onFinish, enableTarget, enableTitle, enableAnchor, enableQuery, enableRel, locale,
         } = this.props;
 
         onChange(
@@ -203,6 +218,7 @@ class Link extends Component<Props> {
                 provider,
                 target: enableTarget ? target : undefined,
                 anchor: enableAnchor ? anchor : undefined,
+                query: enableQuery ? query : undefined,
                 href,
                 title: enableTitle ? title : undefined,
                 rel: enableRel ? rel : undefined,
@@ -217,6 +233,7 @@ class Link extends Component<Props> {
             disabled,
             locale,
             enableAnchor,
+            enableQuery,
             enableTarget,
             enableTitle,
             enableRel,
@@ -304,11 +321,13 @@ class Link extends Component<Props> {
                             onCancel={this.handleOverlayClose}
                             onConfirm={this.handleOverlayConfirm}
                             onHrefChange={this.handleOverlayHrefChange}
+                            onQueryChange={enableQuery ? this.handleOverlayQueryChange : undefined}
                             onRelChange={enableRel ? this.handleOverlayRelChange : undefined}
                             onTargetChange={enableTarget ? this.handleOverlayTargetChange : undefined}
                             onTitleChange={enableTitle ? this.handleOverlayTitleChange : undefined}
                             open={this.openedOverlayProvider === key}
                             options={linkTypeRegistry.getOptions(key)}
+                            query={this.overlayQuery}
                             rel={this.overlayRel}
                             target={this.overlayTarget}
                             title={this.overlayTitle}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/overlays/LinkTypeOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/overlays/LinkTypeOverlay.js
@@ -11,9 +11,11 @@ import type {LinkTypeOverlayProps} from '../types';
 export default class LinkTypeOverlay extends React.Component<LinkTypeOverlayProps> {
     render() {
         const {
+            query,
             anchor,
             href,
             locale,
+            onQueryChange,
             onAnchorChange,
             onCancel,
             onConfirm,
@@ -63,6 +65,12 @@ export default class LinkTypeOverlay extends React.Component<LinkTypeOverlayProp
                             value={href}
                         />
                     </Form.Field>
+
+                    {onQueryChange &&
+                        <Form.Field label={translate('sulu_admin.link_query')}>
+                            <Input onChange={onQueryChange} value={query} />
+                        </Form.Field>
+                    }
 
                     {onAnchorChange &&
                         <Form.Field label={translate('sulu_admin.link_anchor')}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/Link.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/Link.test.js
@@ -160,6 +160,7 @@ test('Update values on overlay confirm', () => {
         href: '123-asdf-123',
         provider: 'page',
         locale: 'en',
+        query: 'TestQuery',
         anchor: 'TestAnchor',
         target: 'TestTarget',
     };
@@ -167,6 +168,7 @@ test('Update values on overlay confirm', () => {
     const link = shallow(
         <Link
             enableAnchor={true}
+            enableQuery={true}
             enableRel={true}
             enableTarget={true}
             enableTitle={true}
@@ -180,6 +182,7 @@ test('Update values on overlay confirm', () => {
 
     const overlayProps = link.find('LinkTypeOverlay').at(1).props();
     overlayProps.onHrefChange('10');
+    overlayProps.onQueryChange('newQuery');
     overlayProps.onAnchorChange('newAnchor');
     overlayProps.onTargetChange('newTarget');
     overlayProps.onTitleChange('newTitle');
@@ -192,6 +195,7 @@ test('Update values on overlay confirm', () => {
             href: '10',
             provider: 'media',
             locale: 'en',
+            query: 'newQuery',
             anchor: 'newAnchor',
             target: 'newTarget',
         }
@@ -211,13 +215,11 @@ test('Update values on overlay confirm with ExternalLinkTypeOverlay', () => {
         href: '10',
         provider: 'media',
         locale: 'en',
-        anchor: 'TestAnchor',
         target: 'TestTarget',
     };
 
     const link = shallow(
         <Link
-            enableAnchor={true}
             enableRel={true}
             enableTarget={true}
             enableTitle={true}
@@ -243,7 +245,6 @@ test('Update values on overlay confirm with ExternalLinkTypeOverlay', () => {
             href: 'https://example.org',
             provider: 'external',
             locale: 'en',
-            anchor: 'TestAnchor',
             target: 'newTarget',
             rel: 'newRel',
         }
@@ -298,6 +299,7 @@ test('Invalidate values on RemoveButton click', async(resolve) => {
                     href: undefined,
                     provider: undefined,
                     locale: 'en',
+                    query: undefined,
                     anchor: undefined,
                     target: undefined,
                     rel: undefined,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/LinkTypeOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/LinkTypeOverlay.test.js
@@ -48,6 +48,31 @@ test('Render overlay without options', () => {
     )).toThrow('The LinkTypeOverlay needs some options in order to work!');
 });
 
+test('Render overlay with query enabled', () => {
+    const linkOverlay = mount(
+        <LinkTypeOverlay
+            href={undefined}
+            onCancel={jest.fn()}
+            onConfirm={jest.fn()}
+            onHrefChange={jest.fn()}
+            onQueryChange={jest.fn()}
+            open={true}
+            options={
+                {
+                    displayProperties: ['title'],
+                    emptyText: 'No page selected',
+                    icon: 'su-document',
+                    listAdapter: 'column_list',
+                    overlayTitle: 'Choose page',
+                    resourceKey: 'pages',
+                }
+            }
+        />
+    );
+
+    expect(linkOverlay.find('Form').render()).toMatchSnapshot();
+});
+
 test('Render overlay with anchor enabled', () => {
     const linkOverlay = mount(
         <LinkTypeOverlay

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/__snapshots__/LinkTypeOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/__snapshots__/LinkTypeOverlay.test.js.snap
@@ -130,6 +130,83 @@ exports[`Render overlay with minimal config 1`] = `
 </div>
 `;
 
+exports[`Render overlay with query enabled 1`] = `
+<div
+  class="grid grid"
+>
+  <div
+    class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
+  >
+    <div
+      class="field"
+    >
+      <label
+        class="label"
+      >
+        sulu_admin.link_url *
+      </label>
+      <div
+        class="singleItemSelection"
+      >
+        <button
+          class="button left"
+          type="button"
+        >
+          <span
+            aria-label="su-document"
+            class="su-document icon"
+          />
+        </button>
+        <div
+          class="itemContainer"
+        >
+          <div
+            class="item"
+            role="button"
+          >
+            <div
+              class="empty"
+            >
+              No page selected
+            </div>
+          </div>
+        </div>
+      </div>
+      <div>
+        single list overlay
+      </div>
+      <label
+        class="errorLabel"
+      />
+    </div>
+  </div>
+  <div
+    class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
+  >
+    <div
+      class="field"
+    >
+      <label
+        class="label"
+      >
+        sulu_admin.link_query
+      </label>
+      <div
+        class="input default left"
+      >
+        <input
+          type="text"
+          value=""
+        />
+      </div>
+      <label
+        class="errorLabel"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Render overlay with target enabled 1`] = `
 <div
   class="grid grid"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/types.js
@@ -35,6 +35,7 @@ export type LinkValue = {|
     href: ?string | ?number,
     locale: string,
     provider: ?string,
+    query?: ?string,
     rel?: ?string,
     target?: ?string,
     title: ?string,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/types.js
@@ -2,10 +2,12 @@
 import type {IObservableValue} from 'mobx/lib/mobx';
 
 export type LinkTypeOverlayProps = {|
+    query?: ?string,
     anchor?: ?string,
     href: ?string | number,
     locale?: ?IObservableValue<string>,
     onAnchorChange?: ?(anchor: ?string) => void,
+    onQueryChange?: ?(query: ?string) => void,
     onCancel: () => void,
     onConfirm: () => void,
     onHrefChange: (id: ?string | number, item: ?Object) => void,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/types.js
@@ -2,20 +2,20 @@
 import type {IObservableValue} from 'mobx/lib/mobx';
 
 export type LinkTypeOverlayProps = {|
-    query?: ?string,
     anchor?: ?string,
     href: ?string | number,
     locale?: ?IObservableValue<string>,
     onAnchorChange?: ?(anchor: ?string) => void,
-    onQueryChange?: ?(query: ?string) => void,
     onCancel: () => void,
     onConfirm: () => void,
     onHrefChange: (id: ?string | number, item: ?Object) => void,
+    onQueryChange?: ?(query: ?string) => void,
     onRelChange?: ?(rel: ?string) => void,
     onTargetChange?: ?(target: string) => void,
     onTitleChange?: ?(title: ?string) => void,
     open: boolean,
     options?: ?LinkTypeOptions,
+    query?: ?string,
     rel?: ?string,
     target?: ?string,
     title?: ?string,

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -164,6 +164,7 @@
     "sulu_admin.link_title": "Alternativer Titel",
     "sulu_admin.link_target": "Link Ziel",
     "sulu_admin.link_url": "Link URL",
+    "sulu_admin.link_query": "Query-String",
     "sulu_admin.link_anchor": "Link Anker",
     "sulu_admin.mail_subject": "E-Mail Betreff",
     "sulu_admin.mail_body": "E-Mail Text",

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -164,7 +164,7 @@
     "sulu_admin.link_title": "Alternativer Titel",
     "sulu_admin.link_target": "Link Ziel",
     "sulu_admin.link_url": "Link URL",
-    "sulu_admin.link_query": "Query-String",
+    "sulu_admin.link_query": "Query String",
     "sulu_admin.link_anchor": "Link Anker",
     "sulu_admin.mail_subject": "E-Mail Betreff",
     "sulu_admin.mail_body": "E-Mail Text",

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -165,7 +165,7 @@
     "sulu_admin.link_title": "Alternative title",
     "sulu_admin.link_target": "Link Target",
     "sulu_admin.link_url": "Link URL",
-    "sulu_admin.link_query": "Query string",
+    "sulu_admin.link_query": "Query String",
     "sulu_admin.link_anchor": "Link Anchor",
     "sulu_admin.mail_subject": "E-Mail Subject",
     "sulu_admin.mail_body": "E-Mail Text",

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -165,6 +165,7 @@
     "sulu_admin.link_title": "Alternative title",
     "sulu_admin.link_target": "Link Target",
     "sulu_admin.link_url": "Link URL",
+    "sulu_admin.link_query": "Query string",
     "sulu_admin.link_anchor": "Link Anchor",
     "sulu_admin.mail_subject": "E-Mail Subject",
     "sulu_admin.mail_body": "E-Mail Text",

--- a/src/Sulu/Component/Content/Tests/Unit/Types/LinkTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Types/LinkTest.php
@@ -108,7 +108,37 @@ class LinkTest extends TestCase
         $this->assertSame([], $result);
     }
 
-    public function testGetContentData(): void
+    public function testGetContentDataWithQuery(): void
+    {
+        $this->property->getValue()
+            ->shouldBeCalled()
+            ->willReturn([
+                'href' => '123456',
+                'provider' => 'pages',
+                'locale' => 'de',
+                'target' => 'testTarget',
+                'query' => 'testQuery',
+            ]);
+
+        $this->providerPool->getProvider(Argument::type('string'))
+            ->shouldBeCalled()
+            ->willReturn($this->provider->reveal());
+
+        $linkItem = $this->prophesize(LinkItem::class);
+        $linkItem->getUrl()
+            ->shouldBeCalled()
+            ->willReturn('/test');
+
+        $this->provider->preload(['123456'], 'de', true)
+            ->shouldBeCalled()
+            ->willReturn([$linkItem]);
+
+        $result = $this->link->getContentData($this->property->reveal());
+
+        $this->assertSame('/test?testQuery', $result);
+    }
+
+    public function testGetContentDataWithAnchor(): void
     {
         $this->property->getValue()
             ->shouldBeCalled()
@@ -138,7 +168,38 @@ class LinkTest extends TestCase
         $this->assertSame('/test#testAnchor', $result);
     }
 
-    public function testGetContentDataWithoutAnchor(): void
+    public function testGetContentDataWithQueryAndAnchor(): void
+    {
+        $this->property->getValue()
+            ->shouldBeCalled()
+            ->willReturn([
+                'href' => '123456',
+                'provider' => 'pages',
+                'locale' => 'de',
+                'target' => 'testTarget',
+                'query' => 'testQuery',
+                'anchor' => 'testAnchor',
+            ]);
+
+        $this->providerPool->getProvider(Argument::type('string'))
+            ->shouldBeCalled()
+            ->willReturn($this->provider->reveal());
+
+        $linkItem = $this->prophesize(LinkItem::class);
+        $linkItem->getUrl()
+            ->shouldBeCalled()
+            ->willReturn('/test');
+
+        $this->provider->preload(['123456'], 'de', true)
+            ->shouldBeCalled()
+            ->willReturn([$linkItem]);
+
+        $result = $this->link->getContentData($this->property->reveal());
+
+        $this->assertSame('/test?testQuery#testAnchor', $result);
+    }
+
+    public function testGetContentData(): void
     {
         $this->property->getValue()
             ->shouldBeCalled()

--- a/src/Sulu/Component/Content/Types/Link.php
+++ b/src/Sulu/Component/Content/Types/Link.php
@@ -111,6 +111,9 @@ class Link extends SimpleContentType
         }
 
         $url = \reset($linkItems)->getUrl();
+        if (isset($value['query'])) {
+            $url = \sprintf('%s?%s', $url, $value['query']);
+        }
         if (isset($value['anchor'])) {
             $url = \sprintf('%s#%s', $url, $value['anchor']);
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | #6440 #6418 
| License | MIT

#### What's in this PR?

This PR adds the possibility to add a query parameter to link in the editor link overlay.

#### Why?

In #6440 the possibility to add query parameters to Internal Links was added for the `<sulu-link>` tag but it was not added to the editor overlay.
