### PR TITLE
Fix sulu-link tag for internal link pages 

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/ContentRepositoryTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/ContentRepositoryTest.php
@@ -696,11 +696,12 @@ class ContentRepositoryTest extends SuluTestCase
             $page->getUuid(),
             'de',
             'sulu_io',
-            MappingBuilder::create()->addProperties(['title'])->getMapping()
+            MappingBuilder::create()->addProperties(['title'])->setResolveUrl(true)->getMapping()
         );
 
         $this->assertEquals($page->getUuid(), $result->getId());
         $this->assertEquals('/test-2', $result->getPath());
+        $this->assertEquals('/test-1', $result->getUrl());
         $this->assertEquals('test-2', $result['title']);
     }
 

--- a/src/Sulu/Component/Content/Repository/ContentRepository.php
+++ b/src/Sulu/Component/Content/Repository/ContentRepository.php
@@ -819,6 +819,8 @@ class ContentRepository implements ContentRepositoryInterface, DescendantProvide
             $permissions,
             $type
         );
+        $content->setUrl($linkedContent->getUrl());
+        $content->setUrls($linkedContent->getUrls());
 
         if (!$content->getTemplate() || !$this->structureManager->getStructure($content->getTemplate())) {
             $content->setBrokenTemplate();

--- a/src/Sulu/Component/Content/Repository/ContentRepository.php
+++ b/src/Sulu/Component/Content/Repository/ContentRepository.php
@@ -819,8 +819,11 @@ class ContentRepository implements ContentRepositoryInterface, DescendantProvide
             $permissions,
             $type
         );
-        $content->setUrl($linkedContent->getUrl());
-        $content->setUrls($linkedContent->getUrls());
+
+        if ($mapping->resolveUrl()) {
+            $content->setUrl($linkedContent->getUrl());
+            $content->setUrls($linkedContent->getUrls());
+        }
 
         if (!$content->getTemplate() || !$this->structureManager->getStructure($content->getTemplate())) {
             $content->setBrokenTemplate();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #6369
| License | MIT

#### What's in this PR?

This pull request adjusts the `ContentRepository` to set include the url of internal link pages in the returned data. 

#### Why?

At the moment, the `url` property is not set for internal link pages. Because of this, the `<sulu-link>` tag does not work for internal link pages (see #6369).
