### PR TITLE
Fix AbstractFormToolbarAction::conditionData()

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/AbstractFormToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/AbstractFormToolbarAction.js
@@ -1,5 +1,5 @@
 // @flow
-import {computed} from 'mobx';
+import {computed, toJS} from 'mobx';
 import ResourceStore from '../../../stores/ResourceStore';
 import {ResourceFormStore, FormInspector, conditionDataProviderRegistry} from '../../../containers/Form';
 import Router from '../../../services/Router';
@@ -24,7 +24,7 @@ export default class AbstractFormToolbarAction {
             function(data, conditionDataProvider) {
                 return {...data, ...conditionDataProvider(data, undefined, formInspector)};
             },
-            {...data}
+            {...toJS(data)}
         );
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix `AbstractFormToolbarAction::conditionData()` by adding `toJS()`, because `{...observableObject}` returns an empty object
