### PR TITLE
Fix return type of SecuredControllerInterface getLocale

### DIFF
--- a/src/Sulu/Bundle/CustomUrlBundle/Controller/CustomUrlController.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Controller/CustomUrlController.php
@@ -195,6 +195,6 @@ class CustomUrlController extends AbstractRestController implements SecuredContr
 
     public function getLocale(Request $request)
     {
-        return;
+        return null;
     }
 }

--- a/src/Sulu/Bundle/CustomUrlBundle/Controller/CustomUrlRouteController.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Controller/CustomUrlRouteController.php
@@ -98,6 +98,6 @@ class CustomUrlRouteController extends AbstractRestController implements Secured
 
     public function getLocale(Request $request)
     {
-        return;
+        return null;
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Controller/VersionController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/VersionController.php
@@ -182,6 +182,9 @@ class VersionController extends AbstractRestController implements
         }
     }
 
+    /**
+     * @return string
+     */
     public function getLocale(Request $request)
     {
         return $this->getRequestParameter($request, 'locale', true);

--- a/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
@@ -384,6 +384,9 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
         );
     }
 
+    /**
+     * @return string
+     */
     public function getLocale(Request $request)
     {
         if ($request->query->has('locale')) {

--- a/src/Sulu/Component/Security/SecuredControllerInterface.php
+++ b/src/Sulu/Component/Security/SecuredControllerInterface.php
@@ -28,7 +28,7 @@ interface SecuredControllerInterface
     /**
      * Returns the locale for the given request.
      *
-     * @return string
+     * @return string|null
      */
     public function getLocale(Request $request);
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix return type of SecuredControllerInterface getLocale.

#### Why?

The implementation can return string or null.

https://github.com/sulu/sulu/blob/b45f91ff36b468d200b254f894368cb0c3380671/src/Sulu/Component/Rest/RestControllerTrait.php#L63

Example Contact/Account apis do not have a locale.