### PR TITLE
Fix page permissions when there is no array

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Document/BasePageDocument.php
+++ b/src/Sulu/Bundle/PageBundle/Document/BasePageDocument.php
@@ -240,7 +240,7 @@ class BasePageDocument implements
      *
      * @var array
      */
-    protected $permissions;
+    protected $permissions = [];
 
     /**
      * List of versions.

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
@@ -880,7 +880,6 @@ class PageControllerTest extends SuluTestCase
             ],
         ])[0];
 
-        $this->client->disableReboot();
         $this->client->jsonRequest('DELETE', '/api/pages/' . $page1['id'] . '?webspace=sulu_io&language=en');
 
         $response = $this->client->getResponse();

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
@@ -69,6 +69,7 @@ class PageControllerTest extends SuluTestCase
     public function setUp(): void
     {
         $this->client = $this->createAuthenticatedClient();
+        $this->client->disableReboot(); // see https://github.com/symfony/symfony/issues/45580
         $this->purgeDatabase();
         $this->initPhpcr();
         $this->session = $this->getContainer()->get('sulu_document_manager.default_session');

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
@@ -880,6 +880,7 @@ class PageControllerTest extends SuluTestCase
             ],
         ])[0];
 
+        $this->client->disableReboot();
         $this->client->jsonRequest('DELETE', '/api/pages/' . $page1['id'] . '?webspace=sulu_io&language=en');
 
         $response = $this->client->getResponse();

--- a/src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
+++ b/src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
@@ -183,7 +183,7 @@ final class PageTrashItemHandler implements
             $localizedPage->setStructureType($localeData['structureType']);
             $localizedPage->getStructure()->bind($localeData['structureData']);
             $localizedPage->setExtensionsData($localeData['extensionsData']);
-            $localizedPage->setPermissions($localeData['permissions']);
+            $localizedPage->setPermissions($localeData['permissions'] ?: []);
             $localizedPage->setNavigationContexts($localeData['navigationContexts']);
             $localizedPage->setShadowLocaleEnabled($localeData['shadowLocaleEnabled']);
             $localizedPage->setShadowLocale($localeData['shadowLocale']);

--- a/src/Sulu/Bundle/TestBundle/Resources/config/test_user_provider.xml
+++ b/src/Sulu/Bundle/TestBundle/Resources/config/test_user_provider.xml
@@ -12,6 +12,7 @@
             <argument type="service" id="sulu.repository.user"/>
             <argument type="service" id="security.encoder_factory"/>
             <argument type="service" id="sulu_security.user_provider"/>
+            <tag name="kernel.reset" method="reset"/>
         </service>
         <service id="test_voter" class="%sulu.test_voter.class%" public="false">
             <tag name="security.voter"/>

--- a/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
@@ -20,18 +20,19 @@ use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * An UserProvider which returns always the same user for testing purposes.
  */
-class TestUserProvider implements UserProviderInterface
+class TestUserProvider implements UserProviderInterface, ResetInterface
 {
     public const TEST_USER_USERNAME = 'test';
 
     /**
-     * @var UserInterface
+     * @var UserInterface|null
      */
-    private $user;
+    private $user = null;
 
     /**
      * @var EntityManager
@@ -159,5 +160,10 @@ class TestUserProvider implements UserProviderInterface
     public function supportsClass($class)
     {
         return $this->userProvider->supportsClass($class);
+    }
+
+    public function reset(): void
+    {
+        $this->user = null;
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? |  no
| BC breaks? | no 
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #6482 <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix page permissions when there is no array

#### Why?

There was a report here #6482 and also in the slack channel that this happens. That permission is null instead of an array. This change will initialize the BasePageDocument permissions always with an array to avoid that problem and will in restore avoid problem when permissions are there already null as it would be to hard to create a migration there.
