### PR TITLE
Fix priority of 'RemoveForeignContextServicesPass' compiler pass

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/SuluCoreBundle.php
+++ b/src/Sulu/Bundle/CoreBundle/SuluCoreBundle.php
@@ -31,7 +31,7 @@ class SuluCoreBundle extends Bundle
 
         $container->addCompilerPass(new RegisterContentTypesCompilerPass());
         $container->addCompilerPass(new RegisterLocalizationProvidersPass());
-        $container->addCompilerPass(new RemoveForeignContextServicesPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1024);
+        $container->addCompilerPass(new RemoveForeignContextServicesPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 99);
         $container->addCompilerPass(new ReplacersCompilerPass(__DIR__ . '/DataFixtures/replacers.xml'));
         $container->addCompilerPass(new ListBuilderMetadataProviderCompilerPass());
         $container->addCompilerPass(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no 
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the priority of the "RemoveForeignContextServicesPass" compiler pass to be called after the ResolveInstanceofConditionalsPass" compiler pass (has the priority 100 see https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php#L43)

#### Why?

The admin classes which has dependencies to other admin services crashes when using the _instanceof or auto-configuration feature of dependency-injection.
