### PR TITLE
Fixed the meta title of the Sulu admin

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/views/Admin/main.html.twig
+++ b/src/Sulu/Bundle/AdminBundle/Resources/views/Admin/main.html.twig
@@ -4,7 +4,7 @@
     {%- block meta ~%}
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <title>{% block title %}SULU{% endblock %}</title>
+        <title>{% block title %}Sulu{% endblock %}</title>
     {% endblock %}
     {% block style %}
         {#- We do not preload the files because of problems with big files on http push in Chrome -#}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fixed the meta title of the Sulu admin area from "SULU" to "Sulu".

#### Why?

Because this is the correct way to write Sulu. It's just a small change but it seems that some Devs now always write "SULU" instead of "Sulu" in documentations, system landscapes,... because they are used to this spelling.

