### PR TITLE
Add cache control max age and immutable header

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -3,7 +3,7 @@
 # mod_rewrite). Additionally, this reduces the matching process for the
 # start page (path "/") because otherwise Apache will apply the rewriting rules
 # to each configured DirectoryIndex file (e.g. index.php, index.html, index.pl).
-DirectoryIndex website.php
+DirectoryIndex index.php
 
 # By default, Apache does not evaluate symbolic links if you did not enable this
 # feature in your server configuration. Uncomment the following line if you
@@ -11,8 +11,8 @@ DirectoryIndex website.php
 # when compiling LESS/Sass/CoffeScript assets.
 # Options FollowSymlinks
 
-# Disabling MultiViews prevents unwanted negotiation, e.g. "/app" should not resolve
-# to the front controller "/app.php" but be rewritten to "/app.php/app".
+# Disabling MultiViews prevents unwanted negotiation, e.g. "/index" should not resolve
+# to the front controller "/index.php" but be rewritten to "/index.php/index".
 <IfModule mod_negotiation.c>
     Options -MultiViews
 </IfModule>
@@ -23,19 +23,19 @@ DirectoryIndex website.php
     # Determine the RewriteBase automatically and set it as environment variable.
     # If you are using Apache aliases to do mass virtual hosting or installed the
     # project in a subdirectory, the base path will be prepended to allow proper
-    # resolution of the website.php file and to redirect to the correct URI. It will
+    # resolution of the index.php file and to redirect to the correct URI. It will
     # work in environments without path prefix as well, providing a safe, one-size
     # fits all solution. But as you do not need it in this case, you can comment
     # the following 2 lines to eliminate the overhead.
     RewriteCond %{REQUEST_URI}::$1 ^(/.+)/(.*)::\2$
     RewriteRule ^(.*) - [E=BASE:%1]
 
-    # Sets the HTTP_AUTHORIZATION header removed by apache
+    # Sets the HTTP_AUTHORIZATION header removed by Apache
     RewriteCond %{HTTP:Authorization} .
-    RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+    RewriteRule ^ - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
     # Redirect to URI without front controller to prevent duplicate content
-    # (with and without `/app.php`). Only do this redirect on the initial
+    # (with and without `/index.php`). Only do this redirect on the initial
     # rewrite by Apache and not on subsequent cycles. Otherwise we would get an
     # endless redirect loop (request -> rewrite to front controller ->
     # redirect -> request -> ...).
@@ -46,19 +46,15 @@ DirectoryIndex website.php
     # - use Apache >= 2.3.9 and replace all L flags by END flags and remove the
     #   following RewriteCond (best solution)
     RewriteCond %{ENV:REDIRECT_STATUS} ^$
-    RewriteRule ^website\.php(/(.*)|$) %{ENV:BASE}/$2 [R=301,L]
+    RewriteRule ^index\.php(?:/(.*)|$) %{ENV:BASE}/$1 [R=301,L]
 
     # If the requested filename exists, simply serve it.
     # We only want to let Apache serve files and not directories.
     RewriteCond %{REQUEST_FILENAME} -f
-    RewriteRule .? - [L]
-
-    # Rewrite rules for Sulu admin
-    RewriteRule ^admin/ %{ENV:BASE}/admin.php [L]
-    RewriteRule ^admin$ %{ENV:BASE}/admin.php [L]
+    RewriteRule ^ - [L]
 
     # Rewrite all other queries to the front controller.
-    RewriteRule .? %{ENV:BASE}/website.php [L]
+    RewriteRule ^ %{ENV:BASE}/index.php [L]
 </IfModule>
 
 <IfModule !mod_rewrite.c>
@@ -66,7 +62,7 @@ DirectoryIndex website.php
         # When mod_rewrite is not available, we instruct a temporary redirect of
         # the start page to the front controller explicitly so that the website
         # and the generated links can still be used.
-        RedirectMatch 302 ^/$ /website.php/
+        RedirectMatch 307 ^/$ /index.php/
         # RedirectTemp cannot be used instead
     </IfModule>
 </IfModule>

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
@@ -93,7 +93,7 @@ class Configuration implements ConfigurationInterface
                         ->prototype('scalar')->end()->defaultValue([
                             'Expires' => '+1 month',
                             'Pragma' => 'public',
-                            'Cache-Control' => 'public',
+                            'Cache-Control' => 'public, immutable, max-age=31536000',
                         ])
                     ->end()
                     ->arrayNode('default_imagine_options')

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/DependencyInjection/SuluMediaExtensionTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/DependencyInjection/SuluMediaExtensionTest.php
@@ -54,7 +54,7 @@ class SuluMediaExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('sulu_media.format_manager.response_headers', [
             'Expires' => '+1 month',
             'Pragma' => 'public',
-            'Cache-Control' => 'public',
+            'Cache-Control' => 'public, immutable, max-age=31536000',
         ]);
         $this->assertContainerBuilderHasParameter('sulu_media.search.default_image_format', 'sulu-100x100');
         $this->assertContainerBuilderHasParameter('sulu_media.media.storage.local.path', '%kernel.project_dir%/var/uploads/media');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add the `max-age` and `immutable` flag for the media image stream action.

#### Why?

Currently image directly responded by php are not cached. If we only set `Cache-Control: public, max-age`, the browser is still doing a request as there was no `last-modified` header or something similar provided, so it waits for 304 request. After some research the way to force the browser to cache the resource is the `immutable` flag: https://developer.mozilla.org/de/docs/Web/HTTP/Headers/Cache-Control

This already is in use on our own website https://sulu.io. As we are versioning all our assets with `?v=1-0` and so have a unique identifier. It make sense to use the immutable cache control header to tell the browser not even do a lookup for a 304 response.