### PR TITLE
Upgrade PHPUnit to Version 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -126,7 +126,7 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "phpstan/phpstan-symfony": "^1.0",
         "phpstan/phpstan-webmozart-assert": "^1.0",
-        "phpunit/phpunit": "^8.5.21",
+        "phpunit/phpunit": "^8.5.24 || ^9.5.18",
         "psr/event-dispatcher": "^1.0",
         "superbalist/flysystem-google-storage": "^7.1",
         "symfony/browser-kit": "^4.4 || ^5.0",

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
@@ -2277,16 +2277,16 @@ class ContactControllerTest extends SuluTestCase
 
         $this->assertContains(
             [
-                'primaryAddress' => false,
                 'street' => 'Musterstraße',
+                'primaryAddress' => false,
             ],
             $filteredAddresses
         );
 
         $this->assertContains(
             [
-                'primaryAddress' => true,
                 'street' => 'Musterstraße 2',
+                'primaryAddress' => true,
             ],
             $filteredAddresses
         );

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/ContentRepositoryTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/ContentRepositoryTest.php
@@ -1144,17 +1144,24 @@ class ContentRepositoryTest extends SuluTestCase
         );
 
         $homepageUuid = $this->sessionManager->getContentNode('sulu_io')->getIdentifier();
-        $this->assertContains(
-            ['uuid' => $homepageUuid, 'hasChildren' => true, 'children' => [], 'permissions' => []],
-            $items
+
+        $this->assertSame(
+            [
+                'uuid' => $homepageUuid,
+                'hasChildren' => true,
+                'children' => null,
+                'permissions' => []
+            ],
+            $items[0]
         );
-        $this->assertContains(
+
+        $this->assertSame(
             [
                 'uuid' => $page1->getUuid(),
                 'hasChildren' => true,
-                'children' => [],
+                'children' => null,
                 'permissions' => [
-                    $role1->getId() => ['view' => false, 'add' => false, 'delete' => false, 'edit' => true],
+                    $role1->getId() => ['view' => false, 'add' => false, 'edit' => true, 'delete' => false],
                     $role2->getId() => [
                         'view' => true,
                         'add' => false,
@@ -1170,11 +1177,16 @@ class ContentRepositoryTest extends SuluTestCase
                     ],
                 ],
             ],
-            $items
+            $items[1]
         );
-        $this->assertContains(
-            ['uuid' => $page2->getUuid(), 'hasChildren' => false, 'children' => [], 'permissions' => []],
-            $items
+        $this->assertSame(
+            [
+                'uuid' => $page2->getUuid(),
+                'hasChildren' => false,
+                'children' => null,
+                'permissions' => []
+            ],
+            $items[2]
         );
     }
 
@@ -1227,13 +1239,13 @@ class ContentRepositoryTest extends SuluTestCase
             $result
         );
 
-        $this->assertContains(
+        $this->assertSame(
             [
                 'uuid' => $page1->getUuid(),
                 'hasChildren' => true,
-                'children' => [],
+                'children' => null,
                 'permissions' => [
-                    $role1->getId() => ['view' => false, 'add' => false, 'delete' => false, 'edit' => true],
+                    $role1->getId() => ['view' => false, 'add' => false, 'edit' => true, 'delete' => false],
                     $role2->getId() => [
                         'view' => true,
                         'add' => false,
@@ -1249,16 +1261,16 @@ class ContentRepositoryTest extends SuluTestCase
                     ],
                 ],
             ],
-            $items
+            $items[0]
         );
-        $this->assertContains(
+        $this->assertSame(
             [
                 'uuid' => $page2->getUuid(),
                 'hasChildren' => false,
-                'children' => [],
+                'children' => null,
                 'permissions' => [],
             ],
-            $items
+            $items[1]
         );
     }
 
@@ -1319,7 +1331,7 @@ class ContentRepositoryTest extends SuluTestCase
 
         $this->assertContains(
             [
-                $role1->getId() => ['view' => false, 'add' => false, 'delete' => false, 'edit' => true],
+                $role1->getId() => ['view' => false, 'add' => false, 'edit' => true, 'delete' => false],
                 $role2->getId() => [
                     'view' => true,
                     'add' => false,

--- a/src/Sulu/Component/SmartContent/Tests/Unit/ContentTypeTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/ContentTypeTest.php
@@ -399,7 +399,12 @@ class ContentTypeTest extends TestCase
 
         $viewData = $smartContent->getViewData($property);
 
-        $this->assertContains(\array_merge($config, ['page' => 1, 'hasNextPage' => true]), $viewData);
+        $expectedViewData = \array_merge($config, ['page' => 1, 'hasNextPage' => true]);
+
+        foreach ($expectedViewData as $key => $value) {
+            $this->assertArrayHasKey($key, $viewData);
+            $this->assertSame($value, $viewData[$key]);
+        }
     }
 
     public function testGetContentData()

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
@@ -961,16 +961,17 @@ class WebspaceManagerTest extends WebspaceTestCase
             ],
             $localizations
         );
+
         $this->assertContains(
             [
-                'country' => null,
+                'country' => '',
                 'language' => 'de',
             ],
             $localizations
         );
         $this->assertContains(
             [
-                'country' => null,
+                'country' => '',
                 'language' => 'en',
             ],
             $localizations


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Upgrade phpunit to latest version adjust test which build on unstrictness assertContains. The assertContains on PHPUnit 9 is strict and so e.g. `['children' => []]` is not longer the same as `['children' => null]`. Also `assertContains` can not longer be used to search for appereance of elements in the root element.

PHPUnit 9 will output the following warning in all unit tests using `prophesize` method:

> PHPUnit\Framework\TestCase::prophesize() is deprecated and will be removed in PHPUnit 10. 
> Please use the trait provided by phpspec/prophecy-phpunit.

This can not be fixed until we increase the required PHP version. As deprecations are not longer converted to errors test still runs this way.

#### Why?

Keep dependency uptodate.