### PR TITLE
Add load user by identifier method to sulu user provider

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/User/UserProvider.php
+++ b/src/Sulu/Bundle/SecurityBundle/User/UserProvider.php
@@ -52,13 +52,18 @@ class UserProvider implements UserProviderInterface
 
     public function loadUserByUsername($username)
     {
+        return $this->loadUserByIdentifier($username);
+    }
+
+    public function loadUserByIdentifier(string $identifier)
+    {
         $exceptionMessage = \sprintf(
             'Unable to find an Sulu\Component\Security\Authentication\UserInterface object identified by %s',
-            $username
+            $identifier
         );
 
         try {
-            $user = $this->userRepository->findUserByIdentifier($username);
+            $user = $this->userRepository->findUserByIdentifier($identifier);
 
             if (!$user->getEnabled()) {
                 throw new DisabledException('User is not enabled yet.');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | yes
| BC breaks? | no
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add load user by identifier method to sulu user provider

#### Why?

The `loadUserByUsername` method is deprecated and will be replaced by `loadUserByIdentifier`.