### PR TITLE
Prevent infinite loading of contact_account_selection

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Resources/js/containers/ContactAccountSelection/ContactAccountSelection.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/containers/ContactAccountSelection/ContactAccountSelection.js
@@ -35,15 +35,13 @@ class ContactAccountSelection extends React.Component<Props> {
         this.store.loadItems(value);
     }
 
-    componentDidUpdate() {
+    componentDidUpdate(prevProps: Props) {
         const {value} = this.props;
 
+        const oldIds = toJS(prevProps.value);
         const newIds = toJS(value);
-        const loadedIds = this.loadedIds;
 
-        newIds.sort();
-        loadedIds.sort();
-        if (!equals(newIds, loadedIds) && !this.store.loading) {
+        if (!equals(oldIds, newIds) && !this.store.loading) {
             this.store.loadItems(value);
         }
     }

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/containers/ContactAccountSelection/tests/ContactAccountSelection.test.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/containers/ContactAccountSelection/tests/ContactAccountSelection.test.js
@@ -87,6 +87,30 @@ test('Load items when being updated', () => {
     expect(contactAccountSelection.instance().store.loadItems).toBeCalledWith(['a1', 'c2']);
 });
 
+test('Load items when being updated without infinite loop', () => {
+    // $FlowFixMe
+    ContactAccountSelectionStore.mockImplementation(function() {
+        this.loadItems = jest.fn(() => {
+            this.items = [
+                {id: 'a1', fullName: 'Acme GmbH'},
+                {id: 'c2', fullName: 'Erika Mustermann'},
+            ];
+        });
+        this.items = [];
+    });
+
+    const contactAccountSelection = mount(
+        <ContactAccountSelection onChange={jest.fn()} value={['a1', 'c1', 'c2']} />
+    );
+
+    expect(contactAccountSelection.instance().store.loadItems).toHaveBeenCalledWith(['a1', 'c1', 'c2']);
+    expect(contactAccountSelection.instance().store.loadItems).toHaveBeenCalledTimes(1);
+
+    contactAccountSelection.setProps({value: ['a1', 'c1', 'c2']});
+
+    expect(contactAccountSelection.instance().store.loadItems).toHaveBeenCalledTimes(1);
+});
+
 test('Close contact overlay if close button is clicked', () => {
     const contactAccountSelection = mount(
         <ContactAccountSelection onChange={jest.fn()} value={undefined} />


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #6512
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Prevent infinite loading of contact_account_selection
