### PR TITLE
Fix resolving of internal links if target is unpublished

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/ContentRepositoryTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/ContentRepositoryTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\PageBundle\Tests\Functional\Repository;
 
 use Doctrine\ORM\EntityManagerInterface;
+use PHPCR\ItemNotFoundException;
 use PHPCR\SessionInterface;
 use Sulu\Bundle\PageBundle\Document\HomeDocument;
 use Sulu\Bundle\PageBundle\Document\PageDocument;
@@ -27,6 +28,7 @@ use Sulu\Component\Content\Repository\ContentRepository;
 use Sulu\Component\Content\Repository\Mapping\MappingBuilder;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\PropertyEncoder;
+use Sulu\Component\HttpKernel\SuluKernel;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
 use Sulu\Component\Security\Authentication\RoleInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
@@ -126,7 +128,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->homeDocument = $this->documentManager->find($this->sessionManager->getContentPath('sulu_io'), 'de');
     }
 
-    public function testFindByParent()
+    public function testFindByParent(): void
     {
         $role1 = $this->createRole('Role 1', 'Sulu');
         $role2 = $this->createRole('Role 2', 'Sulu');
@@ -195,7 +197,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals([], $result[2]->getPermissions());
     }
 
-    public function testFindDescendantIdsById()
+    public function testFindDescendantIdsById(): void
     {
         $page1 = $this->createPage('test-1', 'de');
         $page2 = $this->createPage('test-2', 'de', [], $page1);
@@ -212,7 +214,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals($page3->getUuid(), $result[2]);
     }
 
-    public function testFindByParentMapping()
+    public function testFindByParentMapping(): void
     {
         $this->createPage('test-1', 'de');
         $this->createPage('test-2', 'de');
@@ -234,7 +236,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('test-3', $result[2]['title']);
     }
 
-    public function testFindByParentWithShadow()
+    public function testFindByParentWithShadow(): void
     {
         $this->createShadowPage('test-1', 'de', 'en');
         $this->createPage('test-2', 'en');
@@ -256,7 +258,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('test-3', $result[2]['title']);
     }
 
-    public function testFindByParentWithShadowNoHydrate()
+    public function testFindByParentWithShadowNoHydrate(): void
     {
         $this->createShadowPage('test-1', 'en_us', 'en');
         $this->createPage('test-2', 'en');
@@ -277,7 +279,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('test-3', $result[1]['title']);
     }
 
-    public function testFindByParentWithGhost()
+    public function testFindByParentWithGhost(): void
     {
         $this->createPage('test-1', 'en');
         $this->createPage('test-2', 'de');
@@ -306,7 +308,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('test-3', $result[2]['title']);
     }
 
-    public function testFindByParentWithGhostNoHydrate()
+    public function testFindByParentWithGhostNoHydrate(): void
     {
         $this->createPage('test-1', 'en');
         $this->createPage('test-2', 'de');
@@ -327,7 +329,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('test-3', $result[1]['title']);
     }
 
-    public function testFindByParentWithInternalLink()
+    public function testFindByParentWithInternalLink(): void
     {
         $link = $this->createPage('test-1', 'de');
         $this->createInternalLinkPage('test-2', 'de', $link);
@@ -350,7 +352,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('test-3', $result[2]['title']);
     }
 
-    public function testFindByParentWithDraftInternalLink()
+    public function testFindByParentWithDraftInternalLink(): void
     {
         $link = $this->createPage('test-1', 'de');
         $this->createInternalLinkPage('test-2', 'de', $link, false);
@@ -374,7 +376,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('test-3', $result[2]['title']);
     }
 
-    public function testFindByParentWithInternalLinkNotFollow()
+    public function testFindByParentWithInternalLinkNotFollow(): void
     {
         $link = $this->createPage('test-1', 'de');
         $this->createInternalLinkPage('test-2', 'de', $link);
@@ -396,7 +398,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('test-3', $result[2]['title']);
     }
 
-    public function testFindByParentWithInternalLinkAndShadow()
+    public function testFindByParentWithInternalLinkAndShadow(): void
     {
         $link = $this->createShadowPage('test-1', 'de', 'en');
         $this->createInternalLinkPage('test-2', 'en', $link);
@@ -419,7 +421,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('test-3', $result[2]['title']);
     }
 
-    public function testFindByParentOneLayer()
+    public function testFindByParentOneLayer(): void
     {
         $page1 = $this->createPage('test-1', 'de');
         $this->createPage('test-1-1', 'de', [], $page1);
@@ -444,7 +446,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('/test-3', $result[2]->getPath());
     }
 
-    public function testFindByWebspaceRoot()
+    public function testFindByWebspaceRoot(): void
     {
         $this->createPage('test-1', 'de');
         $this->createPage('test-2', 'de');
@@ -463,7 +465,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('/test-3', $result[2]->getPath());
     }
 
-    public function testFindByWebspaceRootWithPermissions()
+    public function testFindByWebspaceRootWithPermissions(): void
     {
         $role1 = $this->createRole('Role 1', 'Website');
         $role2 = $this->createRole('Role 2', 'Website');
@@ -522,7 +524,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals([], $result[2]->getPermissions());
     }
 
-    public function testFindByWebspaceRootNonExistingLocale()
+    public function testFindByWebspaceRootNonExistingLocale(): void
     {
         $this->createPage('test-1', 'de');
 
@@ -537,7 +539,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('fr', $result[0]->getLocale());
     }
 
-    public function testFindByWebspaceRootMapping()
+    public function testFindByWebspaceRootMapping(): void
     {
         $this->createPage('test-1', 'de');
         $this->createPage('test-2', 'de');
@@ -556,7 +558,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('test-3', $result[2]['title']);
     }
 
-    public function testFindByWebspaceRootWithShadow()
+    public function testFindByWebspaceRootWithShadow(): void
     {
         $this->createShadowPage('test-1', 'de', 'en');
         $this->createPage('test-2', 'en');
@@ -575,7 +577,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('test-3', $result[2]['title']);
     }
 
-    public function testFindByWebspaceRootWithInternalLink()
+    public function testFindByWebspaceRootWithInternalLink(): void
     {
         $link = $this->createPage('test-1', 'de');
         $this->createInternalLinkPage('test-2', 'de', $link);
@@ -594,7 +596,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('test-3', $result[2]['title']);
     }
 
-    public function testFindByWebspaceRootWithInternalLinkAndShadow()
+    public function testFindByWebspaceRootWithInternalLinkAndShadow(): void
     {
         $link = $this->createShadowPage('test-1', 'de', 'en');
         $this->createInternalLinkPage('test-2', 'en', $link);
@@ -613,7 +615,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('test-3', $result[2]['title']);
     }
 
-    public function testFindByWebspaceRootOneLayer()
+    public function testFindByWebspaceRootOneLayer(): void
     {
         $page1 = $this->createPage('test-1', 'de');
         $this->createPage('test-1-1', 'de', [], $page1);
@@ -635,7 +637,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('/test-3', $result[2]->getPath());
     }
 
-    public function testFind()
+    public function testFind(): void
     {
         $page = $this->createPage('test-1', 'de');
 
@@ -653,7 +655,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('test-1', $result['title']);
     }
 
-    public function testFindWithGhost()
+    public function testFindWithGhost(): void
     {
         $page = $this->createPage('test-1', 'en');
 
@@ -670,7 +672,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('test-1', $result['title']);
     }
 
-    public function testFindWithShadow()
+    public function testFindWithShadow(): void
     {
         $page = $this->createShadowPage('test-1', 'de', 'en');
 
@@ -687,7 +689,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('test-1', $result['title']);
     }
 
-    public function testFindWithInternalLink()
+    public function testFindWithInternalLink(): void
     {
         $link = $this->createPage('test-1', 'de');
         $page = $this->createInternalLinkPage('test-2', 'de', $link);
@@ -705,7 +707,39 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('test-2', $result['title']);
     }
 
-    public function testFindWithEmptyInternalLink()
+    public function testFindWithUnpublishedInternalLink(): void
+    {
+        $link = $this->createPage('test-1', 'de', [], null, [], false);
+        $page = $this->createInternalLinkPage('test-2', 'de', $link);
+
+        // should load content with requested node and not try to follow internal link
+
+        $result = $this->contentRepository->find(
+            $page->getUuid(),
+            'de',
+            'sulu_io',
+            MappingBuilder::create()->addProperties(['title'])->getMapping()
+        );
+
+        $this->assertEquals($page->getUuid(), $result->getId());
+        $this->assertEquals('/test-2', $result->getPath());
+        $this->assertEquals('test-2', $result['title']);
+
+        static::bootKernel([
+            'sulu.context' => SuluKernel::CONTEXT_WEBSITE,
+        ]);
+        $this->setUp();
+
+        $this->expectException(ItemNotFoundException::class);
+        $result = $this->contentRepository->find(
+            $page->getUuid(),
+            'de',
+            'sulu_io',
+            MappingBuilder::create()->addProperties(['title'])->getMapping()
+        );
+    }
+
+    public function testFindWithEmptyInternalLink(): void
     {
         $link = $this->createPage('test-1', 'de');
         $page = $this->createInternalLinkPage('test-2', 'de', $link);
@@ -726,9 +760,22 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals($page->getUuid(), $result->getId());
         $this->assertEquals('/test-2', $result->getPath());
         $this->assertEquals('test-2', $result['title']);
+
+        static::bootKernel([
+            'sulu.context' => SuluKernel::CONTEXT_WEBSITE,
+        ]);
+        $this->setUp();
+
+        $this->expectException(ItemNotFoundException::class);
+        $result = $this->contentRepository->find(
+            $page->getUuid(),
+            'de',
+            'sulu_io',
+            MappingBuilder::create()->addProperties(['title'])->getMapping()
+        );
     }
 
-    public function testFindWithInternalLinkToItself()
+    public function testFindWithInternalLinkToItself(): void
     {
         $link = $this->createPage('test-1', 'de');
         $page = $this->createInternalLinkPage('test-2', 'de', $link);
@@ -751,7 +798,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('test-2', $result['title']);
     }
 
-    public function testFindWithInternalLinkAndShadow()
+    public function testFindWithInternalLinkAndShadow(): void
     {
         $link = $this->createShadowPage('test-1', 'de', 'en');
         $page = $this->createInternalLinkPage('test-2', 'de', $link);
@@ -768,7 +815,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('test-2', $result['title']);
     }
 
-    public function testFindWithNonFallbackProperties()
+    public function testFindWithNonFallbackProperties(): void
     {
         $link = $this->createPage('test-1', 'de');
         \sleep(1); // create a difference between link and page (created / changed)
@@ -827,7 +874,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('test-2', $result['title']);
     }
 
-    public function testFindPermissions()
+    public function testFindPermissions(): void
     {
         $role1 = $this->createRole('Role 1', 'Sulu');
         $role2 = $this->createRole('Role 2', 'Sulu');
@@ -881,7 +928,7 @@ class ContentRepositoryTest extends SuluTestCase
         );
     }
 
-    public function testFindWithoutPermissions()
+    public function testFindWithoutPermissions(): void
     {
         $role1 = $this->prophesize(RoleInterface::class);
         $role1->getId()->willReturn(1);
@@ -914,7 +961,7 @@ class ContentRepositoryTest extends SuluTestCase
         );
     }
 
-    public function testFindWithPermissionsNotGranted()
+    public function testFindWithPermissionsNotGranted(): void
     {
         $role1 = $this->createRole('Role 1', 'Sulu');
         $role2 = $this->createRole('Role 2', 'Sulu');
@@ -970,7 +1017,7 @@ class ContentRepositoryTest extends SuluTestCase
     /**
      * @dataProvider provideWebspaceKeys
      */
-    public function testFindParentsWithSiblingsByUuid($webspaceKey)
+    public function testFindParentsWithSiblingsByUuid($webspaceKey): void
     {
         $role1 = $this->createRole('Role 1', 'Sulu');
         $role2 = $this->createRole('Role 2', 'Sulu');
@@ -1078,7 +1125,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals([], $layer[1]->getPermissions());
     }
 
-    public function testFindParentsWithSiblingsByUuidWithoutWebspaceKey()
+    public function testFindParentsWithSiblingsByUuidWithoutWebspaceKey(): void
     {
         $page = $this->createPage('test-1', 'de');
 
@@ -1094,7 +1141,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals($page->getWebspaceName(), $result[0]->getWebspaceKey());
     }
 
-    public function testFindByPaths()
+    public function testFindByPaths(): void
     {
         $role1 = $this->createRole('Role 1', 'Sulu');
         $role2 = $this->createRole('Role 2', 'Sulu');
@@ -1178,7 +1225,7 @@ class ContentRepositoryTest extends SuluTestCase
         );
     }
 
-    public function testFindByUuids()
+    public function testFindByUuids(): void
     {
         $role1 = $this->createRole('Role 1', 'Sulu');
         $role2 = $this->createRole('Role 2', 'Sulu');
@@ -1262,7 +1309,7 @@ class ContentRepositoryTest extends SuluTestCase
         );
     }
 
-    public function testFindAll()
+    public function testFindAll(): void
     {
         $role1 = $this->createRole('Role 1', 'Sulu');
         $role2 = $this->createRole('Role 2', 'Sulu');
@@ -1338,7 +1385,7 @@ class ContentRepositoryTest extends SuluTestCase
         );
     }
 
-    public function testFindAllNoPage()
+    public function testFindAllNoPage(): void
     {
         $result = $this->contentRepository->findAll(
             'de',
@@ -1358,7 +1405,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertContains('/', $paths);
     }
 
-    public function testFindAllByPortal()
+    public function testFindAllByPortal(): void
     {
         $role1 = $this->createRole('Role 1', 'Sulu');
         $role2 = $this->createRole('Role 2', 'Sulu');
@@ -1425,7 +1472,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('/', $urls['en_us']);
     }
 
-    public function testFindUrl()
+    public function testFindUrl(): void
     {
         $page1 = $this->createPage('test-1', 'de');
 
@@ -1449,7 +1496,7 @@ class ContentRepositoryTest extends SuluTestCase
         );
     }
 
-    public function testFindUrls()
+    public function testFindUrls(): void
     {
         $page1 = $this->createShadowPage('test-1', 'de', 'en');
 
@@ -1472,7 +1519,7 @@ class ContentRepositoryTest extends SuluTestCase
         );
     }
 
-    public function testFindByWebspaceRootPublished()
+    public function testFindByWebspaceRootPublished(): void
     {
         $page1 = $this->createPage('test-1', 'de');
         $page2 = $this->createPage('test-2', 'de');
@@ -1496,7 +1543,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('/test-1', $result[0]->getPath());
     }
 
-    public function testFindContentLocales()
+    public function testFindContentLocales(): void
     {
         $page = $this->createShadowPage('test', 'de', 'en');
 
@@ -1510,7 +1557,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals(['de'], $result->getContentLocales());
     }
 
-    public function testFindNonExistingProperty()
+    public function testFindNonExistingProperty(): void
     {
         $page = $this->createShadowPage('test', 'de', 'en');
 
@@ -1531,7 +1578,7 @@ class ContentRepositoryTest extends SuluTestCase
      *
      * @return PageDocument
      */
-    private function createPage($title, $locale, $data = [], $parentDocument = null, array $permissions = [])
+    private function createPage($title, $locale, $data = [], $parentDocument = null, array $permissions = [], bool $publish = true)
     {
         /** @var PageDocument $document */
         $document = $this->documentManager->create('page');
@@ -1561,7 +1608,11 @@ class ContentRepositoryTest extends SuluTestCase
                 'auto_create' => true,
             ]
         );
-        $this->documentManager->publish($document, $locale);
+
+        if ($publish) {
+            $this->documentManager->publish($document, $locale);
+        }
+
         $this->documentManager->flush();
 
         return $document;

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
@@ -17,6 +17,8 @@ use Sulu\Bundle\PageBundle\Document\PageDocument;
 use Sulu\Component\Content\Compat\Structure\PageBridge;
 use Sulu\Component\Content\Compat\StructureManagerInterface;
 use Sulu\Component\Content\Document\Behavior\ExtensionBehavior;
+use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
+use Sulu\Component\Content\Document\Behavior\WebspaceBehavior;
 use Sulu\Component\Content\Document\RedirectType;
 use Sulu\Component\Content\Exception\ResourceLocatorMovedException;
 use Sulu\Component\Content\Exception\ResourceLocatorNotFoundException;
@@ -184,11 +186,17 @@ class ContentRouteProvider implements RouteProviderInterface
                 }
                 $collection->add('redirect_' . \uniqid(), $this->getRedirectRoute($request, $url));
             } elseif (RedirectType::INTERNAL === $document->getRedirectType()) {
+                $redirectTarget = $document->getRedirectTarget();
+
+                if (!$redirectTarget instanceof ResourceSegmentBehavior || !$redirectTarget instanceof WebspaceBehavior) {
+                    return $collection;
+                }
+
                 $redirectUrl = $this->webspaceManager->findUrlByResourceLocator(
-                    $document->getRedirectTarget()->getResourceSegment(),
+                    $redirectTarget->getResourceSegment(),
                     null,
                     $document->getLocale(),
-                    $document->getRedirectTarget()->getWebspaceName()
+                    $redirectTarget->getWebspaceName()
                 );
 
                 if ($request->getQueryString()) {

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Routing/ContentRouteProviderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Routing/ContentRouteProviderTest.php
@@ -9,14 +9,14 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\RouteBundle\Tests\Functional\Controller;
+namespace Sulu\Bundle\WebsiteBundle\Tests\Functional\Routing;
 
 use Sulu\Bundle\TestBundle\Testing\WebsiteTestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 class ContentRouteProviderTest extends WebsiteTestCase
 {
-    public function testRouteIncludesUtf8Option()
+    public function testRouteIncludesUtf8Option(): void
     {
         static::initPhpcr();
 

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -734,15 +734,15 @@ class ContentMapper implements ContentMapperInterface
             if (RedirectType::INTERNAL === $redirectType) {
                 $target = $document->getRedirectTarget();
 
-                if ($target) {
-                    $url = $target->getResourceSegment();
-
-                    $document = $target;
-                    $node = $this->inspector->getNode($document);
+                if (!$target instanceof ResourceSegmentBehavior) {
+                    return false;
                 }
-            }
 
-            if (RedirectType::EXTERNAL === $redirectType) {
+                $url = $target->getResourceSegment();
+
+                $document = $target;
+                $node = $this->inspector->getNode($document);
+            } elseif (RedirectType::EXTERNAL === $redirectType) {
                 $url = $document->getRedirectExternal();
             }
         }

--- a/src/Sulu/Component/Content/Repository/ContentRepository.php
+++ b/src/Sulu/Component/Content/Repository/ContentRepository.php
@@ -128,6 +128,17 @@ class ContentRepository implements ContentRepositoryInterface, DescendantProvide
         $this->qomFactory = $this->session->getWorkspace()->getQueryManager()->getQOMFactory();
     }
 
+    /**
+     * Find content by uuid.
+     *
+     * @param string $uuid
+     * @param string $locale
+     * @param string $webspaceKey
+     * @param MappingInterface $mapping Includes array of property names
+     * @param UserInterface $user
+     *
+     * @return Content|null
+     */
     public function find($uuid, $locale, $webspaceKey, MappingInterface $mapping, UserInterface $user = null)
     {
         $locales = $this->getLocalesByWebspaceKey($webspaceKey);
@@ -656,7 +667,7 @@ class ContentRepository implements ContentRepositoryInterface, DescendantProvide
      * @param string $locale
      * @param string $locales
      *
-     * @return Content
+     * @return Content|null
      */
     private function resolveContent(
         Row $row,
@@ -682,12 +693,12 @@ class ContentRepository implements ContentRepositoryInterface, DescendantProvide
         $type = null;
         if ($row->getValue('shadowOn')) {
             if (!$mapping->shouldHydrateShadow()) {
-                return;
+                return null;
             }
             $type = StructureType::getShadow($row->getValue('shadowBase'));
         } elseif (null !== $ghostLocale && $ghostLocale !== $originalLocale) {
             if (!$mapping->shouldHydrateGhost()) {
-                return;
+                return null;
             }
             $locale = $ghostLocale;
             $type = StructureType::getGhost($locale);
@@ -783,7 +794,7 @@ class ContentRepository implements ContentRepositoryInterface, DescendantProvide
      * @param StructureType $type
      * @param UserInterface $user
      *
-     * @return Content
+     * @return Content|null
      */
     public function resolveInternalLinkContent(
         Row $row,
@@ -794,6 +805,10 @@ class ContentRepository implements ContentRepositoryInterface, DescendantProvide
         UserInterface $user = null
     ) {
         $linkedContent = $this->find($row->getValue('internalLink'), $locale, $webspaceKey, $mapping);
+        if (null === $linkedContent) {
+            return null;
+        }
+
         $data = $linkedContent->getData();
 
         // return value of source node instead of link destination for title and non-fallback-properties

--- a/src/Sulu/Component/Content/Tests/Unit/Repository/ContentRepositoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Repository/ContentRepositoryTest.php
@@ -207,6 +207,7 @@ class ContentRepositoryTest extends TestCase
 
         $result = $this->contentRepository->find('123-123-123', 'de', 'sulu_io', $mapping);
 
+        $this->assertNotNull($result);
         $this->assertTrue($result->isBrokenTemplate());
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix resolving of internal links

#### Why?

If an internal link target is unpublished, SmartContent and PageSelection throw errors, if their result contains that internal link
