### PR TITLE
Catch invalid path exception from phpcr in load by resource-locator

### DIFF
--- a/src/Sulu/Component/Content/Tests/Functional/ResourceLocator/Mapper/PhpcrMapperTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/ResourceLocator/Mapper/PhpcrMapperTest.php
@@ -270,7 +270,7 @@ class PhpcrMapperTest extends SuluTestCase
 
     public function testLoadFailureInvalidPath()
     {
-        $this->expectException('Sulu\Component\Content\Exception\ResourceLocatorNotFoundException');
+        $this->setExpectedException('Sulu\Component\Content\Exception\ResourceLocatorNotFoundException');
         $this->phpcrMapper->loadByResourceLocator('/https://sulu.io/test/test-1', 'sulu_io', 'de');
     }
 

--- a/src/Sulu/Component/Content/Tests/Functional/ResourceLocator/Mapper/PhpcrMapperTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/ResourceLocator/Mapper/PhpcrMapperTest.php
@@ -262,10 +262,16 @@ class PhpcrMapperTest extends SuluTestCase
         $this->assertEquals('/products/news/content1-news', $result);
     }
 
-    public function testLoadFailure()
+    public function testLoadFailureNotFound()
     {
         $this->setExpectedException('Sulu\Component\Content\Exception\ResourceLocatorNotFoundException');
         $this->phpcrMapper->loadByResourceLocator('/test/test-1', 'sulu_io', 'de');
+    }
+
+    public function testLoadFailureInvalidPath()
+    {
+        $this->expectException('Sulu\Component\Content\Exception\ResourceLocatorNotFoundException');
+        $this->phpcrMapper->loadByResourceLocator('/https://sulu.io/test/test-1', 'sulu_io', 'de');
     }
 
     public function testLoad()

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
@@ -15,6 +15,7 @@ use DateTime;
 use PHPCR\ItemExistsException;
 use PHPCR\NodeInterface;
 use PHPCR\PathNotFoundException;
+use PHPCR\RepositoryException;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
 use Sulu\Component\Content\Exception\ResourceLocatorAlreadyExistsException;
@@ -256,6 +257,8 @@ class PhpcrMapper implements ResourceLocatorMapperInterface
                 $route = $this->getWebspaceRouteNode($webspaceKey, $languageCode, $segmentKey);
             }
         } catch (PathNotFoundException $e) {
+            throw new ResourceLocatorNotFoundException(\sprintf('Path "%s" not found', $path), null, $e);
+        } catch (RepositoryException $e) {
             throw new ResourceLocatorNotFoundException(\sprintf('Path "%s" not found', $path), null, $e);
         }
 

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
@@ -16,6 +16,7 @@ use PHPCR\ItemExistsException;
 use PHPCR\NodeInterface;
 use PHPCR\PathNotFoundException;
 use PHPCR\RepositoryException;
+use PHPCR\Util\PathHelper;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
 use Sulu\Component\Content\Exception\ResourceLocatorAlreadyExistsException;
@@ -243,12 +244,17 @@ class PhpcrMapper implements ResourceLocatorMapperInterface
     {
         $resourceLocator = \ltrim($resourceLocator, '/');
 
+        $path = \sprintf(
+            '%s/%s',
+            $this->getWebspaceRouteNodeBasePath($webspaceKey, $languageCode, $segmentKey),
+            $resourceLocator
+        );
+
+        if (!PathHelper::assertValidAbsolutePath($path, false, false)) {
+            throw new ResourceLocatorNotFoundException(\sprintf('Path "%s" not found', $path), null, $e);
+        }
+
         try {
-            $path = \sprintf(
-                '%s/%s',
-                $this->getWebspaceRouteNodeBasePath($webspaceKey, $languageCode, $segmentKey),
-                $resourceLocator
-            );
             if ('' !== $resourceLocator) {
                 // get requested resource locator route node
                 $route = $this->sessionManager->getSession()->getNode($path);
@@ -257,8 +263,6 @@ class PhpcrMapper implements ResourceLocatorMapperInterface
                 $route = $this->getWebspaceRouteNode($webspaceKey, $languageCode, $segmentKey);
             }
         } catch (PathNotFoundException $e) {
-            throw new ResourceLocatorNotFoundException(\sprintf('Path "%s" not found', $path), null, $e);
-        } catch (RepositoryException $e) {
             throw new ResourceLocatorNotFoundException(\sprintf('Path "%s" not found', $path), null, $e);
         }
 

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
@@ -250,7 +250,7 @@ class PhpcrMapper implements ResourceLocatorMapperInterface
         );
 
         if (!PathHelper::assertValidAbsolutePath($path, false, false)) {
-            throw new ResourceLocatorNotFoundException(\sprintf('Path "%s" not found', $path), null, $e);
+            throw new ResourceLocatorNotFoundException(\sprintf('Path "%s" not found', $path));
         }
 
         try {

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
@@ -15,7 +15,6 @@ use DateTime;
 use PHPCR\ItemExistsException;
 use PHPCR\NodeInterface;
 use PHPCR\PathNotFoundException;
-use PHPCR\RepositoryException;
 use PHPCR\Util\PathHelper;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no yes
| New feature? | no yes
| BC breaks? | no yes
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

This PR fixes a Problem when passing an invalid path to the `oadByResourceLocator` function of the `PHPCRMapper`

#### Why?

The exception passes and has to be handled in the follow up classes which should not be needed.
