### PR TITLE
display the target page's title even if enableTitle is false

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/Link.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/Link.js
@@ -115,7 +115,7 @@ class Link extends Component<Props> {
                 target: enableTarget ? target : undefined,
                 anchor: enableAnchor ? anchor : undefined,
                 href,
-                title: enableTitle || title.length ? title : undefined,
+                title: enableTitle || (title != undefined && title.length) ? title : undefined,
                 locale: toJS(locale),
             }
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/Link.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/Link.js
@@ -115,7 +115,7 @@ class Link extends Component<Props> {
                 target: enableTarget ? target : undefined,
                 anchor: enableAnchor ? anchor : undefined,
                 href,
-                title: enableTitle ? title : undefined,
+                title: enableTitle || title.length ? title : undefined,
                 locale: toJS(locale),
             }
         );


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #6525 
| License | MIT

#### What's in this PR?

This PR makes sure that a content element of type "link" always displays the target's title in its admin preview even if the parameter "enableTitle" (which is only used to set a custom title) is false or undefined.

#### Why?
see #6525 
