### PR TITLE
Add a better error message for moved resource locator

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/PageBundle/Resources/translations/admin.de.json
@@ -22,6 +22,7 @@
     "sulu_page.linked_content": "Verlinkter Inhalt",
     "sulu_page.url": "URL",
     "sulu_page.resource_locator_assigned_to_other_page": "Die URL \"{resourceLocator}\" ist bereits einer anderen Seite zugewiesen.",
+    "sulu_page.resource_locator_was_moved": "The URL die du verwendest wurde verschoben nach \"{newResourceLocator}\". Prüfe die URL Historie dieser Seite und entferne die Weiterleitung.",
     "sulu_page.shadow_page": "Shadow Seite",
     "sulu_page.enable_shadow_page": "Shadow Seite aktivieren",
     "sulu_page.enable_shadow_page_info_text": "Diese Funktion ist deaktiviert, wenn die aktuelle Sprache bereits als Shadow Sprache verwendet wird.",

--- a/src/Sulu/Bundle/PageBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/PageBundle/Resources/translations/admin.en.json
@@ -22,6 +22,7 @@
     "sulu_page.linked_content": "Linked Content",
     "sulu_page.url": "URL",
     "sulu_page.resource_locator_assigned_to_other_page": "The URL \"{resourceLocator}\" is already assigned to another page.",
+    "sulu_page.resource_locator_was_moved": "The URL you are trying to use was moved to \"{newResourceLocator}\". Please check the URL history of that page to remove the redirect.",
     "sulu_page.shadow_page": "Shadow Page",
     "sulu_page.enable_shadow_page": "Enable Shadow Page",
     "sulu_page.enable_shadow_page_info_text": "This function is disabled if the current locale is already used as shadow locale.",

--- a/src/Sulu/Component/Content/Exception/ResourceLocatorMovedException.php
+++ b/src/Sulu/Component/Content/Exception/ResourceLocatorMovedException.php
@@ -11,7 +11,9 @@
 
 namespace Sulu\Component\Content\Exception;
 
-class ResourceLocatorMovedException extends \Exception
+use Sulu\Component\Rest\Exception\TranslationErrorMessageExceptionInterface;
+
+class ResourceLocatorMovedException extends \Exception implements TranslationErrorMessageExceptionInterface
 {
     /**
      * new resource locator after move.
@@ -50,5 +52,15 @@ class ResourceLocatorMovedException extends \Exception
     public function getNewResourceLocatorUuid()
     {
         return $this->newResourceLocatorUuid;
+    }
+
+    public function getMessageTranslationKey(): string
+    {
+        return 'sulu_page.resource_locator_was_moved';
+    }
+
+    public function getMessageTranslationParameters(): array
+    {
+        return ['{newResourceLocator}' => $this->newResourceLocator];
     }
 }

--- a/src/Sulu/Component/Rest/Exception/TranslationErrorMessageExceptionInterface.php
+++ b/src/Sulu/Component/Rest/Exception/TranslationErrorMessageExceptionInterface.php
@@ -15,5 +15,8 @@ interface TranslationErrorMessageExceptionInterface
 {
     public function getMessageTranslationKey(): string;
 
+    /**
+     * @return array<string, string|int|float>
+     */
     public function getMessageTranslationParameters(): array;
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Adding a more helpful error message to the page publishing process.

Before:
![image](https://user-images.githubusercontent.com/14860264/162438897-c616ab8c-b386-405b-aded-50a80b926f7f.png)

After:
![image](https://user-images.githubusercontent.com/14860264/162438753-c96575c9-7fa6-41c4-b2f1-34d647edd516.png)


#### Why?
As a user of the Sylius backend it is always very unhelpful to see a generic error message pop up and then having to ask a developer to check the logs and see what the real issue is.

Having more clear error messages in this case would be more helpful so that the user can identify the issue and fix it themselves.

#### Example Usage
Just save the page and see the error message.

#### To Do

- [x] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md
