### PR TITLE
Fix handling of homepage for invalid path check

### DIFF
--- a/src/Sulu/Component/Content/Tests/Functional/ResourceLocator/Mapper/PhpcrMapperTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/ResourceLocator/Mapper/PhpcrMapperTest.php
@@ -274,6 +274,12 @@ class PhpcrMapperTest extends SuluTestCase
         $this->phpcrMapper->loadByResourceLocator('/https://sulu.io/test/test-1', 'sulu_io', 'de');
     }
 
+    public function testLoadHomepage()
+    {
+        $uuid = $this->phpcrMapper->loadByResourceLocator('', 'sulu_io', 'de');
+        $this->assertSame($this->homeDocument->getUuid(), $uuid);
+    }
+
     public function testLoad()
     {
         // create route for content

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
@@ -249,12 +249,12 @@ class PhpcrMapper implements ResourceLocatorMapperInterface
             $resourceLocator
         );
 
-        if (!PathHelper::assertValidAbsolutePath($path, false, false)) {
-            throw new ResourceLocatorNotFoundException(\sprintf('Path "%s" not found', $path));
-        }
-
         try {
             if ('' !== $resourceLocator) {
+                if (!PathHelper::assertValidAbsolutePath($path, false, false)) {
+                    throw new ResourceLocatorNotFoundException(\sprintf('Path "%s" not found', $path));
+                }
+
                 // get requested resource locator route node
                 $route = $this->sessionManager->getSession()->getNode($path);
             } else {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Valid path only when no homepage is requested.

#### Why?

Was introduced in https://github.com/sulu/sulu/pull/6526 that an exception is thrown when resourceLocator is empty = homepage.