### PR TITLE
Fix renaming of babel files in update build command

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php
@@ -130,15 +130,31 @@ class UpdateBuildCommand extends Command
             '.babelrc' => 'babel.config.json',
         ];
 
-        // files which are expected to be changed but requires then a manual build
-        $appFiles = ['app.js'];
+        $deletedFiles = [
+            '.babelrc',
+        ];
+
+        $appFiles = ['app.js']; // files which are expected to be changed but requires then a manual build
 
         foreach ($renamedFiles as $oldFile => $newFile) {
-            if ($filesystem->exists($this->projectDir . $oldFile)) {
+            if (
+                $filesystem->exists($this->projectDir . static::ASSETS_DIR . $oldFile)
+                && !$filesystem->exists($this->projectDir . static::ASSETS_DIR . $newFile)
+            ) {
                 if ('y' === \strtolower(
                     $ui->ask(\sprintf('The "%s" should be renamed to "%s" should wo do this now?', $oldFile, $newFile), 'y')
                 )) {
-                    $filesystem->rename($this->projectDir . $oldFile, $this->projectDir . $newFile);
+                    $filesystem->rename($this->projectDir . static::ASSETS_DIR . $oldFile, $this->projectDir . static::ASSETS_DIR . $newFile);
+                }
+            }
+        }
+
+        foreach ($deletedFiles as $deletedFile) {
+            if ($filesystem->exists($this->projectDir . static::ASSETS_DIR . $deletedFile)) {
+                if ('y' === \strtolower(
+                    $ui->ask(\sprintf('The "%s" should be deleted should wo do this now?', $deletedFile), 'y')
+                )) {
+                    $filesystem->remove($this->projectDir . static::ASSETS_DIR . $deletedFile);
                 }
             }
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Rename the correct files and delete eventually existing old files.

#### Why?

Currently the path to the `renamedFiles` was not correctly.
