### PR TITLE
Replace user provider system logic with SystemStore

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,7 +5,7 @@
 ### User Provider service definition changed
 
 The user provider service now requires the `SystemStoreInterface` service
-to read correct set **security system**.
+instead of the `RequestStack` to read correct set **security system**.
 
 ## 2.4.1
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,12 @@
 # Upgrade
 
+## 2.5.0
+
+### User Provider service definition changed
+
+The user provider service now requires the `SystemStoreInterface` service
+to read correct set **security system**.
+
 ## 2.4.1
 
 ### Change PreviewLinkInterface

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -134,6 +134,8 @@
             <tag name="kernel.reset" method="reset" />
         </service>
 
+        <service id="Sulu\Bundle\SecurityBundle\System\SystemStoreInterface" alias="sulu_security.system_store"/>
+
         <service id="sulu_security.phpcr_access_control_provider" class="%sulu_security.phpcr_access_control_provider.class%">
             <argument type="service" id="sulu_document_manager.document_manager"/>
             <argument type="service" id="sulu.repository.role"/>
@@ -260,7 +262,7 @@
         <service id="sulu_security.user_provider" class="Sulu\Bundle\SecurityBundle\User\UserProvider">
             <argument type="service" id="sulu_security.user_repository"/>
             <argument type="service" id="request_stack"/>
-            <argument>%sulu_security.system%</argument>
+            <argument type="service" id="sulu_security.system_store"/>
         </service>
 
         <service id="sulu_security.build.user" class="%sulu_security.build.user.class%">

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -261,7 +261,6 @@
 
         <service id="sulu_security.user_provider" class="Sulu\Bundle\SecurityBundle\User\UserProvider">
             <argument type="service" id="sulu_security.user_repository"/>
-            <argument type="service" id="request_stack"/>
             <argument type="service" id="sulu_security.system_store"/>
         </service>
 

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/User/UserProviderTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/User/UserProviderTest.php
@@ -19,7 +19,6 @@ use Sulu\Bundle\SecurityBundle\Entity\UserRole;
 use Sulu\Bundle\SecurityBundle\System\SystemStoreInterface;
 use Sulu\Bundle\SecurityBundle\User\UserProvider;
 use Sulu\Component\Security\Authentication\UserRepositoryInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Exception\DisabledException;
 use Symfony\Component\Security\Core\Exception\LockedException;
 
@@ -29,11 +28,6 @@ class UserProviderTest extends TestCase
      * @var ObjectProphecy<UserRepositoryInterface>
      */
     private $userRepository;
-
-    /**
-     * @var ObjectProphecy<RequestStack>
-     */
-    private $requestStack;
 
     /**
      * @var ObjectProphecy<SystemStoreInterface>
@@ -53,9 +47,8 @@ class UserProviderTest extends TestCase
     public function setUp(): void
     {
         $this->userRepository = $this->prophesize(UserRepositoryInterface::class);
-        $this->requestStack = $this->prophesize(RequestStack::class);
         $this->systemStore = $this->prophesize(SystemStoreInterface::class);
-        $this->userProvider = new UserProvider($this->userRepository->reveal(), $this->requestStack->reveal(), $this->systemStore->reveal());
+        $this->userProvider = new UserProvider($this->userRepository->reveal(), $this->systemStore->reveal());
 
         $this->user = new User();
         $this->user->setUsername('sulu');

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/User/UserProviderTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/User/UserProviderTest.php
@@ -12,9 +12,11 @@
 namespace Sulu\Bundle\SecurityBundle\Tests\Unit\User;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\SecurityBundle\Entity\Role;
 use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\SecurityBundle\Entity\UserRole;
+use Sulu\Bundle\SecurityBundle\System\SystemStoreInterface;
 use Sulu\Bundle\SecurityBundle\User\UserProvider;
 use Sulu\Component\Security\Authentication\UserRepositoryInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -24,14 +26,19 @@ use Symfony\Component\Security\Core\Exception\LockedException;
 class UserProviderTest extends TestCase
 {
     /**
-     * @var UserRepositoryInterface
+     * @var ObjectProphecy<UserRepositoryInterface>
      */
     private $userRepository;
 
     /**
-     * @var RequestStack
+     * @var ObjectProphecy<RequestStack>
      */
     private $requestStack;
+
+    /**
+     * @var ObjectProphecy<SystemStoreInterface>
+     */
+    private $systemStore;
 
     /**
      * @var UserProvider
@@ -47,7 +54,8 @@ class UserProviderTest extends TestCase
     {
         $this->userRepository = $this->prophesize(UserRepositoryInterface::class);
         $this->requestStack = $this->prophesize(RequestStack::class);
-        $this->userProvider = new UserProvider($this->userRepository->reveal(), $this->requestStack->reveal(), 'Sulu');
+        $this->systemStore = $this->prophesize(SystemStoreInterface::class);
+        $this->userProvider = new UserProvider($this->userRepository->reveal(), $this->requestStack->reveal(), $this->systemStore->reveal());
 
         $this->user = new User();
         $this->user->setUsername('sulu');
@@ -57,45 +65,48 @@ class UserProviderTest extends TestCase
         $this->userRepository->findUserByIdentifier('sulu')->willReturn($this->user);
     }
 
-    public function testLoginFailDisabledUser()
+    public function testLoginFailDisabledUser(): void
     {
         $this->expectException(DisabledException::class);
         $this->user->setEnabled(false);
         $this->userProvider->loadUserByUsername('sulu');
     }
 
-    public function testLoginFailLockedUser()
+    public function testLoginFailLockedUser(): void
     {
         $this->expectException(LockedException::class);
         $this->user->setLocked(true);
         $this->userProvider->loadUserByUsername('sulu');
     }
 
-    public function testLoadUserByUsername()
+    public function testLoadUserByUsername(): void
     {
         $role = new Role();
         $role->setSystem('Sulu');
         $userRole = new UserRole();
         $userRole->setRole($role);
         $this->user->addUserRole($userRole);
+        $this->systemStore->getSystem()
+            ->willReturn('Sulu')
+            ->shouldBeCalled();
         $user = $this->userProvider->loadUserByUsername('sulu');
 
         $this->assertEquals('test@sulu.io', $user->getEmail());
     }
 
-    public function testRefreshUser()
+    public function testRefreshUser(): void
     {
         $this->assertEquals($this->user->getUsername(), $this->userProvider->refreshUser($this->user)->getUsername());
     }
 
-    public function testRefreshUserWithLockedUser()
+    public function testRefreshUserWithLockedUser(): void
     {
         $this->expectException(LockedException::class);
         $this->user->setLocked(true);
         $this->userProvider->refreshUser($this->user);
     }
 
-    public function testRefreshUserWithDisabledUser()
+    public function testRefreshUserWithDisabledUser(): void
     {
         $this->expectException(DisabledException::class);
         $this->user->setEnabled(false);

--- a/src/Sulu/Bundle/SecurityBundle/User/UserProvider.php
+++ b/src/Sulu/Bundle/SecurityBundle/User/UserProvider.php
@@ -15,7 +15,6 @@ use Doctrine\ORM\NoResultException;
 use Sulu\Bundle\SecurityBundle\System\SystemStoreInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authentication\UserRepositoryInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Exception\DisabledException;
 use Symfony\Component\Security\Core\Exception\LockedException;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
@@ -35,19 +34,13 @@ class UserProvider implements UserProviderInterface
     private $userRepository;
 
     /**
-     * @var RequestStack
-     */
-    private $requestStack;
-
-    /**
      * @var SystemStoreInterface
      */
     private $systemStore;
 
-    public function __construct(UserRepositoryInterface $userRepository, RequestStack $requestStack, SystemStoreInterface $systemStore)
+    public function __construct(UserRepositoryInterface $userRepository, SystemStoreInterface $systemStore)
     {
         $this->userRepository = $userRepository;
-        $this->requestStack = $requestStack;
         $this->systemStore = $systemStore;
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | yes
| BC breaks? | no
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| License | MIT

#### What's in this PR?

Replace user provider system logic with SystemStore.

#### Why?

This way create a custom listener to set a custom system for another user provider:

```php
$this->systemStore->setSystem(YourAdmin::SYSTEM);
```
