### PR TITLE
Fix cache clear when cache tags are disabled

### DIFF
--- a/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/SuluHttpCacheExtension.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/SuluHttpCacheExtension.php
@@ -85,6 +85,7 @@ class SuluHttpCacheExtension extends Extension implements PrependExtensionInterf
 
         $container->setParameter('sulu_http_cache.cache.max_age', $config['cache']['max_age']);
         $container->setParameter('sulu_http_cache.cache.shared_max_age', $config['cache']['shared_max_age']);
+        $container->setParameter('sulu_http_cache.tags.enabled', $config['tags']['enabled']);
 
         $proxyClientAvailable = false;
         if (\array_key_exists('proxy_client', $config)) {

--- a/src/Sulu/Bundle/WebsiteBundle/Cache/CacheClearer.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Cache/CacheClearer.php
@@ -65,7 +65,7 @@ class CacheClearer implements CacheClearerInterface
         EventDispatcherInterface $eventDispatcher,
         string $varDir,
         ?CacheManager $cacheManager,
-        bool $tagsEnabled
+        bool $tagsEnabled = true
     ) {
         $this->kernelEnvironment = $kernelEnvironment;
         $this->filesystem = $filesystem;
@@ -87,7 +87,7 @@ class CacheClearer implements CacheClearerInterface
 
         $tags = \func_num_args() >= 1 ? \func_get_arg(0) : null;
 
-        if (null !== $tags && $this->cacheManager && $this->cacheManager->supportsTags() && $this->tagsEnabled) {
+        if (null !== $tags && $this->tagsEnabled && $this->cacheManager && $this->cacheManager->supportsTags()) {
             foreach ($tags as $tag) {
                 $this->cacheManager->invalidateTag($tag);
             }

--- a/src/Sulu/Bundle/WebsiteBundle/Cache/CacheClearer.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Cache/CacheClearer.php
@@ -53,13 +53,19 @@ class CacheClearer implements CacheClearerInterface
      */
     private $eventDispatcher;
 
+    /**
+     * @var bool
+     */
+    private $tagsEnabled;
+
     public function __construct(
         Filesystem $filesystem,
         $kernelEnvironment,
         RequestStack $requestStack,
         EventDispatcherInterface $eventDispatcher,
         string $varDir,
-        ?CacheManager $cacheManager
+        ?CacheManager $cacheManager,
+        bool $tagsEnabled
     ) {
         $this->kernelEnvironment = $kernelEnvironment;
         $this->filesystem = $filesystem;
@@ -67,6 +73,7 @@ class CacheClearer implements CacheClearerInterface
         $this->cacheManager = $cacheManager;
         $this->requestStack = $requestStack;
         $this->eventDispatcher = $eventDispatcher;
+        $this->tagsEnabled = $tagsEnabled;
     }
 
     public function clear(/*?array $tags = null*/)
@@ -80,15 +87,9 @@ class CacheClearer implements CacheClearerInterface
 
         $tags = \func_num_args() >= 1 ? \func_get_arg(0) : null;
 
-        if ($this->cacheManager && $this->cacheManager->supportsInvalidate()) {
-            if (null !== $tags && $this->cacheManager->supportsTags()) {
-                foreach ($tags as $tag) {
-                    $this->cacheManager->invalidateTag($tag);
-                }
-
-                $this->eventDispatcher->dispatch(new CacheClearEvent($tags), Events::CACHE_CLEAR);
-
-                return;
+        if (null !== $tags && $this->cacheManager && $this->cacheManager->supportsTags() && $this->tagsEnabled) {
+            foreach ($tags as $tag) {
+                $this->cacheManager->invalidateTag($tag);
             }
 
             $request = $this->requestStack->getCurrentRequest();

--- a/src/Sulu/Bundle/WebsiteBundle/Cache/CacheClearer.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Cache/CacheClearer.php
@@ -87,9 +87,15 @@ class CacheClearer implements CacheClearerInterface
 
         $tags = \func_num_args() >= 1 ? \func_get_arg(0) : null;
 
-        if (null !== $tags && $this->tagsEnabled && $this->cacheManager && $this->cacheManager->supportsTags()) {
-            foreach ($tags as $tag) {
-                $this->cacheManager->invalidateTag($tag);
+        if ($this->cacheManager && $this->cacheManager->supportsInvalidate()) {
+            if (null !== $tags && $this->tagsEnabled && $this->cacheManager->supportsTags()) {
+                foreach ($tags as $tag) {
+                    $this->cacheManager->invalidateTag($tag);
+                }
+
+                $this->eventDispatcher->dispatch(new CacheClearEvent($tags), Events::CACHE_CLEAR);
+
+                return;
             }
 
             $request = $this->requestStack->getCurrentRequest();

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -272,6 +272,7 @@
             <argument type="service" id="event_dispatcher"/>
             <argument>%kernel.project_dir%/var</argument>
             <argument type="service" id="sulu_http_cache.cache_manager" on-invalid="null"/>
+            <argument>%sulu_http_cache.tags.enabled%</argument>
         </service>
 
         <service id="sulu_website.router_listener"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Now the CacheClearer also check if tags are enabled not only if they are supported.

#### Why?

The user was not able to clear the cache in the admin UI.

