### PR TITLE
Fix uncatched exception in SnippetResolver if snippet has been deleted

### DIFF
--- a/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetResolver.php
+++ b/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetResolver.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\SnippetBundle\Snippet;
 
 use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
+use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 
 /**
  * Resolves snippets by UUIDs.
@@ -47,7 +48,11 @@ class SnippetResolver implements SnippetResolverInterface
         $snippets = [];
         foreach ($uuids as $uuid) {
             if (!\array_key_exists($uuid, $this->snippetCache)) {
-                $snippet = $this->contentMapper->load($uuid, $webspaceKey, $locale);
+                try {
+                    $snippet = $this->contentMapper->load($uuid, $webspaceKey, $locale);
+                } catch (DocumentNotFoundException $e) {
+                    continue;
+                }
 
                 if (!$snippet->getHasTranslation() && null !== $shadowLocale) {
                     $snippet = $this->contentMapper->load($uuid, $webspaceKey, $shadowLocale);

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/BaseFunctionalTestCase.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/BaseFunctionalTestCase.php
@@ -39,7 +39,7 @@ abstract class BaseFunctionalTestCase extends SuluTestCase
      */
     private $manager;
 
-    private function createSnippet($type, array $localizedData)
+    protected function createSnippet($type, array $localizedData)
     {
         $snippet = new SnippetDocument();
         $snippet->setStructureType($type);

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/SnippetContentTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/SnippetContentTest.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\SnippetBundle\Tests\Functional\Content;
 use PHPCR\SessionInterface;
 use PHPCR\Util\UUIDHelper;
 use Prophecy\Argument;
+use Sulu\Bundle\PageBundle\Document\PageDocument;
 use Sulu\Bundle\SnippetBundle\Content\SnippetContent;
 use Sulu\Bundle\SnippetBundle\Snippet\DefaultSnippetManagerInterface;
 use Sulu\Bundle\SnippetBundle\Snippet\WrongSnippetTypeException;
@@ -139,6 +140,31 @@ class SnippetContentTest extends BaseFunctionalTestCase
         $this->assertEquals('Le grande budapest', $hotel1['title']);
         $hotel2 = \next($data);
         $this->assertEquals('L\'Hôtel New Hampshire', $hotel2['title']);
+    }
+
+    public function testGetContentDataNotExistingValue(): void
+    {
+        $page = new PageDocument();
+        $page->setTitle('Other hotels page');
+        $page->setStructureType('hotel_page');
+        $page->setResourceSegment('/other-hotels');
+        $page->getStructure()->bind([
+            'hotels' => [
+                '0526b49b-be4c-45a0-9fe0-b55b3a3bd596', // Not existing snippet
+            ],
+        ]);
+
+        $this->getContainer()->get('sulu_document_manager.document_manager')->persist($page, 'de', [
+            'path' => '/cmf/sulu_io/contents/other-hotels',
+        ]);
+        $this->getContainer()->get('sulu_document_manager.document_manager')->flush();
+        $this->getContainer()->get('sulu_document_manager.document_manager')->clear();
+
+        $pageNode = $this->session->getNode('/cmf/sulu_io/contents/other-hotels');
+        $pageStructure = $this->contentMapper->loadByNode($pageNode, 'de');
+        $property = $pageStructure->getProperty('hotels');
+        $data = $this->contentType->getContentData($property);
+        $this->assertCount(0, $data);
     }
 
     public function testGetContentDataShadow()

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/SnippetContentTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/SnippetContentTest.php
@@ -144,19 +144,29 @@ class SnippetContentTest extends BaseFunctionalTestCase
 
     public function testGetContentDataNotExistingValue(): void
     {
+        $snippet = $this->createSnippet(
+            'hotel',
+            [
+                'de' => [
+                    'title' => 'Hotel to be removed',
+                ],
+            ]
+        );
+
         $page = new PageDocument();
         $page->setTitle('Other hotels page');
         $page->setStructureType('hotel_page');
         $page->setResourceSegment('/other-hotels');
         $page->getStructure()->bind([
             'hotels' => [
-                '0526b49b-be4c-45a0-9fe0-b55b3a3bd596', // Not existing snippet
+                $snippet->getUuid(),
             ],
         ]);
-
         $this->getContainer()->get('sulu_document_manager.document_manager')->persist($page, 'de', [
             'path' => '/cmf/sulu_io/contents/other-hotels',
         ]);
+        $this->getContainer()->get('sulu_document_manager.document_manager')->flush();
+        $this->getContainer()->get('sulu_document_manager.document_manager')->remove($snippet);
         $this->getContainer()->get('sulu_document_manager.document_manager')->flush();
         $this->getContainer()->get('sulu_document_manager.document_manager')->clear();
 

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
@@ -17,6 +17,7 @@ use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;
 use Sulu\Component\Content\Compat\Structure\SnippetBridge;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
+use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 
 class SnippetResolverTest extends TestCase
 {
@@ -97,6 +98,22 @@ class SnippetResolverTest extends TestCase
                 $item
             );
         }
+    }
+
+    public function testResolveNotExistingUuid(): void
+    {
+        $contentMapper = $this->prophesize(ContentMapperInterface::class);
+        $structureResolver = $this->prophesize(StructureResolverInterface::class);
+        $resolver = new SnippetResolver($contentMapper->reveal(), $structureResolver->reveal());
+
+        $contentMapper->load('123-123-123', 'test_io', 'en')
+            ->shouldBeCalledTimes(1)
+            ->willThrow(new DocumentNotFoundException());
+
+        $this->assertSame(
+            [],
+            $resolver->resolve(['123-123-123'], 'test_io', 'en')
+        );
     }
 
     public function testResolveWithShadowLocale()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #6541
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Catch error in SnippetResolver if snippet has been deleted
