### PR TITLE
Allow newer version of matomo device detector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "jms/serializer-bundle": "^3.0 || ^4.0",
         "massive/build-bundle": "^0.3 || ^0.4 || ^0.5",
         "massive/search-bundle": "^2.0",
-        "matomo/device-detector": "^3.7 || ^4.0.1",
+        "matomo/device-detector": "^3.7 || ^4.0.1 || ^5.0 || ^6.0",
         "nyholm/psr7": "^1.0",
         "oro/doctrine-extensions": "^1.0.8 || ^2.0",
         "ramsey/uuid": "^3.1 || ^4.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | yes 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Allow newer version of matomo device detector.

#### Why?

Keep dependencies up2date.