### PR TITLE
Upgrade JS Routing Bundle to 3.0

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,18 @@
 
 ## 2.5.0
 
+### FOSJSRoutingBundle upgraded
+
+The FOSJSRoutingBundle was upgraded and requires to change the routing include for it:
+
+```diff
+# config/routes/fos_js_routing_admin.yaml
+fos_js_routing:
+    prefix: /admin
+-    resource: "@FOSJsRoutingBundle/Resources/config/routing/routing.xml"
++    resource: "@FOSJsRoutingBundle/Resources/config/routing/routing-sf4.xml"
+```
+
 ### User Provider service definition changed
 
 The user provider service now requires the `SystemStoreInterface` service

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "friendsofphp/proxy-manager-lts": "^1.0",
         "friendsofsymfony/http-cache": "^2.5",
         "friendsofsymfony/http-cache-bundle": "^2.6",
-        "friendsofsymfony/jsrouting-bundle": "^2.3",
+        "friendsofsymfony/jsrouting-bundle": "^2.3 || ^3.0",
         "friendsofsymfony/rest-bundle": "^2.8 || ^3.0",
         "gedmo/doctrine-extensions": "^2.4 || ^3.0",
         "guzzlehttp/promises": "^1.0",

--- a/config/routes/fos_js_routing_admin.yaml
+++ b/config/routes/fos_js_routing_admin.yaml
@@ -1,3 +1,3 @@
 fos_js_routing:
     prefix: /admin
-    resource: "@FOSJsRoutingBundle/Resources/config/routing/routing.xml"
+    resource: "@FOSJsRoutingBundle/Resources/config/routing/routing-sf4.xml"

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
@@ -1,7 +1,7 @@
 # Required vendor routes
 fos_js_routing:
     prefix: /admin
-    resource: "@FOSJsRoutingBundle/Resources/config/routing/routing.xml"
+    resource: "@FOSJsRoutingBundle/Resources/config/routing/routing-sf4.xml"
 
 # Sulu Routes
 sulu_admin:


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? |  yes
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/issues/6513, https://github.com/sulu/skeleton/pull/165
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Upgrade JS Routing Bundle to 3.0

#### Why?

To support Symfony 6 in future.