### PR TITLE
Upgrade toflar/psr6-symfony-http-cache-store to 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -100,7 +100,7 @@
         "symfony/twig-bundle": "^5.4",
         "symfony/validator": "^5.4",
         "symfony/yaml": "^5.4",
-        "toflar/psr6-symfony-http-cache-store": "^3.0",
+        "toflar/psr6-symfony-http-cache-store": "^3.0 || ^4.0",
         "twig/twig": "^2.13 || ^3.0",
         "webmozart/assert": "^1.9"
     },


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | yes 
| BC breaks? | no 
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/issues/6513, https://github.com/Toflar/psr6-symfony-http-cache-store/pull/42
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Upgrade toflar/psr6-symfony-http-cache-store to 4.0

#### Why?

For future symfony 6 support..