### PR TITLE
Fix symfony type warning message

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/SuluPreviewBundle.php
+++ b/src/Sulu/Bundle/PreviewBundle/SuluPreviewBundle.php
@@ -16,6 +16,7 @@ use Sulu\Bundle\PreviewBundle\Domain\Model\PreviewLinkInterface;
 use Sulu\Bundle\PreviewBundle\Infrastructure\Symfony\DependencyInjection\SuluPreviewExtension;
 use Sulu\Component\Symfony\CompilerPass\TaggedServiceCollectorCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -46,7 +47,7 @@ class SuluPreviewBundle extends Bundle
         );
     }
 
-    public function getContainerExtension()
+    public function getContainerExtension(): ExtensionInterface
     {
         return new SuluPreviewExtension();
     }

--- a/src/Sulu/Bundle/TrashBundle/SuluTrashBundle.php
+++ b/src/Sulu/Bundle/TrashBundle/SuluTrashBundle.php
@@ -17,6 +17,7 @@ use Sulu\Bundle\PersistenceBundle\PersistenceBundleTrait;
 use Sulu\Bundle\TrashBundle\Domain\Model\TrashItemInterface;
 use Sulu\Bundle\TrashBundle\Infrastructure\Symfony\DependencyInjection\SuluTrashExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class SuluTrashBundle extends Bundle
@@ -33,7 +34,7 @@ class SuluTrashBundle extends Bundle
         );
     }
 
-    public function getContainerExtension()
+    public function getContainerExtension(): ExtensionInterface
     {
         return new SuluTrashExtension();
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix symfony type warning message.

#### Why?

Symfony throws a type warning in the console for this method.