### PR TITLE
show tag names and category names in contact list

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -423,6 +423,7 @@ class AccountController extends AbstractRestController implements ClassResourceI
         if ('true' == $request->get('flat')) {
             $fieldDescriptors = $this->getFieldDescriptors();
             $listBuilder = $this->generateFlatListBuilder();
+            $listBuilder->addGroupBy($fieldDescriptors['id']);
             $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
             $this->applyRequestParameters($request, $listBuilder);
 

--- a/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
@@ -305,6 +305,7 @@ class ContactController extends AbstractRestController implements ClassResourceI
     {
         $fieldDescriptors = $this->getFieldDescriptors();
         $listBuilder = $this->listBuilderFactory->create($this->contactClass);
+        $listBuilder->addGroupBy($fieldDescriptors['id']);
         $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
 
         $account = $request->get('accountId');

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/lists/accounts.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/lists/accounts.xml
@@ -248,6 +248,19 @@
             <joins ref="tags"/>
         </group-concat-property>
 
+        <group-concat-property
+            name="tagNames"
+            visibility="no"
+            translation="sulu_tag.tags"
+            glue=","
+            distinct="true"
+        >
+            <field-name>name</field-name>
+            <entity-name>SuluTagBundle:Tag</entity-name>
+
+            <joins ref="tags"/>
+        </group-concat-property>
+
         <!-- tagId property is only used for filtering and should never be included as column in a list -->
         <!-- when used as column, the property will lead to duplicated rows for entities with multiple tags -->
         <property
@@ -292,5 +305,28 @@
                 </params>
             </filter>
         </property>
+
+        <group-concat-property
+            name="categoryNames"
+            visibility="no"
+            translation="sulu_category.categories"
+            glue=","
+            distinct="true"
+        >
+            <field-name>translation</field-name>
+            <entity-name>SuluCategoryBundle:CategoryTranslation</entity-name>
+
+            <joins>
+                <join>
+                    <entity-name>SuluCategoryBundle:Category</entity-name>
+                    <field-name>%sulu.model.account.class%.categories</field-name>
+                </join>
+                <join>
+                    <entity-name>SuluCategoryBundle:CategoryTranslation</entity-name>
+                    <field-name>SuluCategoryBundle:Category.translations</field-name>
+                    <condition>SuluCategoryBundle:CategoryTranslation.locale = '%default_locale%'</condition>
+                </join>
+            </joins>
+        </group-concat-property>
     </properties>
 </list>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/lists/accounts.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/lists/accounts.xml
@@ -324,7 +324,7 @@
                 <join>
                     <entity-name>SuluCategoryBundle:CategoryTranslation</entity-name>
                     <field-name>SuluCategoryBundle:Category.translations</field-name>
-                    <condition>SuluCategoryBundle:CategoryTranslation.locale = '%default_locale%'</condition>
+                    <condition>SuluCategoryBundle:CategoryTranslation.locale = SuluCategoryBundle:Category.defaultLocale</condition>
                 </join>
             </joins>
         </group-concat-property>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
@@ -296,8 +296,8 @@
         </property>
 
         <group-concat-property
-            name="tagIds"
-            visibility="never"
+            name="tagNames"
+            visibility="yes"
             translation="sulu_tag.tags"
             glue=","
         >
@@ -351,6 +351,29 @@
                 </params>
             </filter>
         </property>
+
+        <group-concat-property
+            name="categoryNames"
+            visibility="yes"
+            translation="sulu_category.categories"
+            glue=","
+            distinct="true"
+        >
+            <field-name>translation</field-name>
+            <entity-name>SuluCategoryBundle:CategoryTranslation</entity-name>
+
+            <joins>
+                <join>
+                    <entity-name>SuluCategoryBundle:Category</entity-name>
+                    <field-name>%sulu.model.contact.class%.categories</field-name>
+                </join>
+                <join>
+                    <entity-name>SuluCategoryBundle:CategoryTranslation</entity-name>
+                    <field-name>SuluCategoryBundle:Category.translations</field-name>
+                    <condition>SuluCategoryBundle:CategoryTranslation.locale = '%default_locale%'</condition>
+                </join>
+            </joins>
+        </group-concat-property>
 
         <property name="user" visibility="no" searchability="yes" translation="sulu_security.user_name">
             <field-name>username</field-name>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
@@ -300,8 +300,9 @@
             visibility="yes"
             translation="sulu_tag.tags"
             glue=","
+            distinct="true"
         >
-            <field-name>id</field-name>
+            <field-name>name</field-name>
             <entity-name>SuluTagBundle:Tag</entity-name>
 
             <joins ref="tags"/>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
@@ -296,8 +296,20 @@
         </property>
 
         <group-concat-property
+            name="tagIds"
+            visibility="never"
+            translation="sulu_tag.tags"
+            glue=","
+        >
+            <field-name>id</field-name>
+            <entity-name>SuluTagBundle:Tag</entity-name>
+
+            <joins ref="tags"/>
+        </group-concat-property>
+
+        <group-concat-property
             name="tagNames"
-            visibility="yes"
+            visibility="no"
             translation="sulu_tag.tags"
             glue=","
             distinct="true"
@@ -355,7 +367,7 @@
 
         <group-concat-property
             name="categoryNames"
-            visibility="yes"
+            visibility="no"
             translation="sulu_category.categories"
             glue=","
             distinct="true"

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
@@ -383,7 +383,7 @@
                 <join>
                     <entity-name>SuluCategoryBundle:CategoryTranslation</entity-name>
                     <field-name>SuluCategoryBundle:Category.translations</field-name>
-                    <condition>SuluCategoryBundle:CategoryTranslation.locale = '%default_locale%'</condition>
+                    <condition>SuluCategoryBundle:CategoryTranslation.locale = SuluCategoryBundle:Category.defaultLocale</condition>
                 </join>
             </joins>
         </group-concat-property>

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/parameters.yml.dist
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/parameters.yml.dist
@@ -9,7 +9,6 @@ parameters:
     phpcr.password: '%env(PHPCR_PASSWORD)%'
     phpcr.workspace: '%env(PHPCR_WORKSPACE)%'
 
-    default_locale: en
 
     # Fallback values (used if environmental variables are not set)
 

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/parameters.yml.dist
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/parameters.yml.dist
@@ -9,6 +9,7 @@ parameters:
     phpcr.password: '%env(PHPCR_PASSWORD)%'
     phpcr.workspace: '%env(PHPCR_WORKSPACE)%'
 
+    default_locale: en
 
     # Fallback values (used if environmental variables are not set)
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | 
| License | MIT
| Documentation PR | sulu/sulu-docs

#### What's in this PR?

It's possible to filter tags or categories in the contact list, but the admin doesn't see which contact has which tags or categories. As admin it's faster to see assigned categories in the list and find where categories are missing.

#### Why?

If the admin wants to see e.g. which categories are assigned to contact he must open the detail view of the contact. With this PR the admin can display the column "Categories" and sees the assigned categories directly in the list.

These changes can also be done for the accounts list.

#### To Do

- [ ] Add changes to UPGRADE.md
