### PR TITLE
Add php-cs-fixer global import rule for classes

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -25,6 +25,7 @@ $config->setRiskyAllowed(true)
         'native_constant_invocation' => true,
         'native_function_casing' => true,
         'native_function_invocation' => ['include' => ['@internal']],
+        'global_namespace_import' => ['import_classes' => false, 'import_constants' => false, 'import_functions' => false],
         'no_superfluous_phpdoc_tags' => ['allow_mixed' => true, 'remove_inheritdoc' => true],
         'ordered_imports' => true,
         'phpdoc_align' => ['align' => 'left'],

--- a/src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\ContactBundle\Contact;
 
-use DateTime;
 use Doctrine\Persistence\ObjectManager;
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
 use Sulu\Bundle\ContactBundle\Api\Contact as ContactApi;
@@ -380,7 +379,7 @@ class ContactManager extends AbstractContactManager implements DataProviderRepos
         if (!$patch || $this->getProperty($data, 'birthday')) {
             $birthday = $this->getProperty($data, 'birthday');
             if (!empty($birthday)) {
-                $birthday = new DateTime($birthday);
+                $birthday = new \DateTime($birthday);
             } else {
                 $birthday = null;
             }

--- a/src/Sulu/Bundle/ContactBundle/Entity/ContactTitle.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/ContactTitle.php
@@ -12,12 +12,11 @@
 namespace Sulu\Bundle\ContactBundle\Entity;
 
 use JMS\Serializer\Annotation\Groups;
-use JsonSerializable;
 
 /**
  * ContactTitle.
  */
-class ContactTitle implements JsonSerializable
+class ContactTitle implements \JsonSerializable
 {
     public const RESOURCE_KEY = 'contact_titles';
 

--- a/src/Sulu/Bundle/ContactBundle/Entity/Position.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/Position.php
@@ -12,12 +12,11 @@
 namespace Sulu\Bundle\ContactBundle\Entity;
 
 use JMS\Serializer\Annotation\Groups;
-use JsonSerializable;
 
 /**
  * Position.
  */
-class Position implements JsonSerializable
+class Position implements \JsonSerializable
 {
     public const RESOURCE_KEY = 'contact_positions';
 

--- a/src/Sulu/Bundle/MarkupBundle/Listener/SwiftMailerListener.php
+++ b/src/Sulu/Bundle/MarkupBundle/Listener/SwiftMailerListener.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\MarkupBundle\Listener;
 
 use Sulu\Bundle\MarkupBundle\Markup\MarkupParserInterface;
-use Swift_Events_SendEvent;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 class SwiftMailerListener implements \Swift_Events_SendListener
@@ -39,7 +38,7 @@ class SwiftMailerListener implements \Swift_Events_SendListener
         $this->defaultLocale = $defaultLocale;
     }
 
-    public function beforeSendPerformed(Swift_Events_SendEvent $event)
+    public function beforeSendPerformed(\Swift_Events_SendEvent $event)
     {
         $message = $event->getMessage();
 
@@ -66,7 +65,7 @@ class SwiftMailerListener implements \Swift_Events_SendListener
         );
     }
 
-    public function sendPerformed(Swift_Events_SendEvent $evt)
+    public function sendPerformed(\Swift_Events_SendEvent $evt)
     {
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Media/Exception/MediaException.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Exception/MediaException.php
@@ -11,12 +11,10 @@
 
 namespace Sulu\Bundle\MediaBundle\Media\Exception;
 
-use Exception;
-
 /**
  * This Exception is thrown when a Uploaded File is not valid.
  */
-class MediaException extends Exception
+class MediaException extends \Exception
 {
     /**
      * Used when $_FILES['error'] > 0.

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaWebsiteControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaWebsiteControllerTest.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\MediaBundle\Tests\Functional\Controller;
 
-use DateTime;
 use Doctrine\ORM\EntityManager;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\MediaBundle\Entity\Collection;
@@ -230,7 +229,7 @@ class MediaWebsiteControllerTest extends WebsiteTestCase
     public function testResponseHeader()
     {
         $media = $this->createMedia('photo');
-        $date = new DateTime();
+        $date = new \DateTime();
         $date->modify('+1 month');
 
         $this->client->request(

--- a/src/Sulu/Bundle/SecurityBundle/Exception/AssignAnonymousRoleException.php
+++ b/src/Sulu/Bundle/SecurityBundle/Exception/AssignAnonymousRoleException.php
@@ -12,11 +12,10 @@
 namespace Sulu\Bundle\SecurityBundle\Exception;
 
 use Sulu\Component\Security\Authentication\RoleInterface;
-use Throwable;
 
 class AssignAnonymousRoleException extends \LogicException
 {
-    public function __construct(RoleInterface $role, $code = 0, Throwable $previous = null)
+    public function __construct(RoleInterface $role, $code = 0, \Throwable $previous = null)
     {
         parent::__construct(
             \sprintf(

--- a/src/Sulu/Bundle/SecurityBundle/Security/Exception/SecurityException.php
+++ b/src/Sulu/Bundle/SecurityBundle/Security/Exception/SecurityException.php
@@ -11,13 +11,11 @@
 
 namespace Sulu\Bundle\SecurityBundle\Security\Exception;
 
-use Exception;
-
 /**
  * This exception is a general security exception.
  * Exceptions related with the security bundle should inherit form this exception and use it's exception codes.
  */
-class SecurityException extends Exception
+class SecurityException extends \Exception
 {
     public function toArray()
     {

--- a/src/Sulu/Bundle/TagBundle/Tag/Exception/TagAlreadyExistsException.php
+++ b/src/Sulu/Bundle/TagBundle/Tag/Exception/TagAlreadyExistsException.php
@@ -11,12 +11,10 @@
 
 namespace Sulu\Bundle\TagBundle\Tag\Exception;
 
-use Exception;
-
 /**
  * This Exception is thrown when a Tag already exists.
  */
-class TagAlreadyExistsException extends Exception
+class TagAlreadyExistsException extends \Exception
 {
     /**
      * The id of the tag, which was not found.

--- a/src/Sulu/Bundle/TagBundle/Tag/Exception/TagNotFoundException.php
+++ b/src/Sulu/Bundle/TagBundle/Tag/Exception/TagNotFoundException.php
@@ -11,12 +11,10 @@
 
 namespace Sulu\Bundle\TagBundle\Tag\Exception;
 
-use Exception;
-
 /**
  * This Exception is thrown when a Tag is not found.
  */
-class TagNotFoundException extends Exception
+class TagNotFoundException extends \Exception
 {
     /**
      * The id of the tag, which was not found.

--- a/src/Sulu/Component/Content/Compat/Structure.php
+++ b/src/Sulu/Component/Content/Compat/Structure.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Component\Content\Compat;
 
-use DateTime;
 use JMS\Serializer\Annotation\Exclude;
 use JMS\Serializer\Annotation\Type;
 use Sulu\Component\Content\Compat\Section\SectionPropertyInterface;
@@ -125,7 +124,7 @@ abstract class Structure implements StructureInterface
     /**
      * datetime of creation.
      *
-     * @var DateTime
+     * @var \DateTime
      * @Type("DateTime")
      */
     private $created;
@@ -133,7 +132,7 @@ abstract class Structure implements StructureInterface
     /**
      * datetime of last changed.
      *
-     * @var DateTime
+     * @var \DateTime
      * @Type("DateTime")
      */
     private $changed;
@@ -141,7 +140,7 @@ abstract class Structure implements StructureInterface
     /**
      * first published.
      *
-     * @var DateTime
+     * @var \DateTime
      * @Type("DateTime")
      */
     private $published;
@@ -404,7 +403,7 @@ abstract class Structure implements StructureInterface
     /**
      * return created datetime.
      *
-     * @return DateTime
+     * @return \DateTime
      */
     public function getCreated()
     {
@@ -416,7 +415,7 @@ abstract class Structure implements StructureInterface
      *
      * @return \DateTime
      */
-    public function setCreated(DateTime $created)
+    public function setCreated(\DateTime $created)
     {
         return $this->created = $created;
     }
@@ -424,7 +423,7 @@ abstract class Structure implements StructureInterface
     /**
      * returns changed DateTime.
      *
-     * @return DateTime
+     * @return \DateTime
      */
     public function getChanged()
     {
@@ -434,7 +433,7 @@ abstract class Structure implements StructureInterface
     /**
      * sets changed datetime.
      */
-    public function setChanged(DateTime $changed)
+    public function setChanged(\DateTime $changed)
     {
         $this->changed = $changed;
     }

--- a/src/Sulu/Component/Content/Compat/StructureInterface.php
+++ b/src/Sulu/Component/Content/Compat/StructureInterface.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Component\Content\Compat;
 
-use DateTime;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 
 /**
@@ -92,26 +91,26 @@ interface StructureInterface extends \JsonSerializable
     /**
      * return created datetime.
      *
-     * @return DateTime
+     * @return \DateTime
      */
     public function getCreated();
 
     /**
      * sets created datetime.
      */
-    public function setCreated(DateTime $created);
+    public function setCreated(\DateTime $created);
 
     /**
      * returns changed DateTime.
      *
-     * @return DateTime
+     * @return \DateTime
      */
     public function getChanged();
 
     /**
      * sets changed datetime.
      */
-    public function setChanged(DateTime $changed);
+    public function setChanged(\DateTime $changed);
 
     /**
      * key of template definition.

--- a/src/Sulu/Component/Content/Exception/ResourceLocatorGeneratorException.php
+++ b/src/Sulu/Component/Content/Exception/ResourceLocatorGeneratorException.php
@@ -11,9 +11,7 @@
 
 namespace Sulu\Component\Content\Exception;
 
-use Exception;
-
-class ResourceLocatorGeneratorException extends Exception
+class ResourceLocatorGeneratorException extends \Exception
 {
     /**
      * @var string

--- a/src/Sulu/Component/Content/Exception/ResourceLocatorMovedException.php
+++ b/src/Sulu/Component/Content/Exception/ResourceLocatorMovedException.php
@@ -11,9 +11,7 @@
 
 namespace Sulu\Component\Content\Exception;
 
-use Exception;
-
-class ResourceLocatorMovedException extends Exception
+class ResourceLocatorMovedException extends \Exception
 {
     /**
      * new resource locator after move.

--- a/src/Sulu/Component/Content/Exception/ResourceLocatorNotFoundException.php
+++ b/src/Sulu/Component/Content/Exception/ResourceLocatorNotFoundException.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Component\Content\Exception;
 
-use Exception;
-
-class ResourceLocatorNotFoundException extends Exception
+class ResourceLocatorNotFoundException extends \Exception
 {
 }

--- a/src/Sulu/Component/Content/Exception/ResourceLocatorNotValidException.php
+++ b/src/Sulu/Component/Content/Exception/ResourceLocatorNotValidException.php
@@ -11,12 +11,10 @@
 
 namespace Sulu\Component\Content\Exception;
 
-use Exception;
-
 /**
  * Exception indicates not valid resourcelocator.
  */
-class ResourceLocatorNotValidException extends Exception
+class ResourceLocatorNotValidException extends \Exception
 {
     /**
      * @var string

--- a/src/Sulu/Component/Content/Metadata/Loader/Exception/TemplateException.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/Exception/TemplateException.php
@@ -11,12 +11,10 @@
 
 namespace Sulu\Component\Content\Metadata\Loader\Exception;
 
-use Exception;
-
 /**
  * Thrown when there is an error concerning a template.
  */
-class TemplateException extends Exception
+class TemplateException extends \Exception
 {
     /**
      * The template causing the error.

--- a/src/Sulu/Component/Content/Metadata/Loader/Exception/TemplateNotFoundException.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/Exception/TemplateNotFoundException.php
@@ -11,12 +11,10 @@
 
 namespace Sulu\Component\Content\Metadata\Loader\Exception;
 
-use Exception;
-
 /**
  * indicates an exception in template loading.
  */
-class TemplateNotFoundException extends Exception
+class TemplateNotFoundException extends \Exception
 {
     /**
      * @var string

--- a/src/Sulu/Component/Content/Template/Exception/TemplateException.php
+++ b/src/Sulu/Component/Content/Template/Exception/TemplateException.php
@@ -11,12 +11,10 @@
 
 namespace Sulu\Component\Content\Template\Exception;
 
-use Exception;
-
 /**
  * Thrown when there is an error concerning a template.
  */
-class TemplateException extends Exception
+class TemplateException extends \Exception
 {
     /**
      * The template causing the error.

--- a/src/Sulu/Component/Content/Template/Exception/TemplateNotFoundException.php
+++ b/src/Sulu/Component/Content/Template/Exception/TemplateNotFoundException.php
@@ -11,12 +11,10 @@
 
 namespace Sulu\Component\Content\Template\Exception;
 
-use Exception;
-
 /**
  * indicates an exception in template loading.
  */
-class TemplateNotFoundException extends Exception
+class TemplateNotFoundException extends \Exception
 {
     /**
      * @var string

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Component\Content\Types\ResourceLocator\Mapper;
 
-use DateTime;
 use PHPCR\ItemExistsException;
 use PHPCR\NodeInterface;
 use PHPCR\PathNotFoundException;
@@ -216,7 +215,7 @@ class PhpcrMapper implements ResourceLocatorMapperInterface
                     $result[] = new ResourceLocatorInformation(
                     //backward compability
                         $resourceLocator,
-                        $node->getPropertyValueWithDefault('sulu:created', new DateTime()),
+                        $node->getPropertyValueWithDefault('sulu:created', new \DateTime()),
                         $node->getIdentifier()
                     );
                 }

--- a/src/Sulu/Component/Content/Types/ResourceLocator/ResourceLocatorInformation.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/ResourceLocatorInformation.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Component\Content\Types\ResourceLocator;
 
-use DateTime;
-
 /**
  * holds information for one Resourcelocator and his history.
  */
@@ -24,7 +22,7 @@ class ResourceLocatorInformation
     private $resourceLocator;
 
     /**
-     * @var DateTime
+     * @var \DateTime
      */
     private $created;
 

--- a/src/Sulu/Component/Doctrine/ReferencesOption.php
+++ b/src/Sulu/Component/Doctrine/ReferencesOption.php
@@ -19,7 +19,6 @@ use Doctrine\ORM\Tools\Event\GenerateSchemaTableEventArgs;
 use Doctrine\ORM\Tools\ToolEvents;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
-use RuntimeException;
 
 /**
  * Adds a "references" option to the Doctrine schema.
@@ -124,7 +123,7 @@ class ReferencesOption implements EventSubscriber
             $unknownOptions = \array_diff_key($referencesOptions, \array_flip(self::$knownOptions));
 
             if (\count($unknownOptions) > 0) {
-                throw new RuntimeException(
+                throw new \RuntimeException(
                     \sprintf(
                         'Unknown options "%s" in the "references" option in the Doctrine schema of %s::%s.',
                         \implode('", "', \array_keys($unknownOptions)),
@@ -135,7 +134,7 @@ class ReferencesOption implements EventSubscriber
             }
 
             if (!isset($referencesOptions['entity'])) {
-                throw new RuntimeException(
+                throw new \RuntimeException(
                     \sprintf(
                         'Missing option "entity" in the "references" option in the Doctrine schema of %s::%s.',
                         $classMetadata->getReflectionClass()->getName(),
@@ -145,7 +144,7 @@ class ReferencesOption implements EventSubscriber
             }
 
             if (!isset($referencesOptions['field'])) {
-                throw new RuntimeException(
+                throw new \RuntimeException(
                     \sprintf(
                         'Missing option "field" in the "references" option in the Doctrine schema of %s::%s.',
                         $classMetadata->getReflectionClass()->getName(),

--- a/src/Sulu/Component/Persistence/RelationTrait.php
+++ b/src/Sulu/Component/Persistence/RelationTrait.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Component\Persistence;
 
-use Traversable;
-
 /**
  * Offers methods for easier handling of relations.
  */
@@ -22,7 +20,7 @@ trait RelationTrait
      * This method processes a put request (delete non-existing entities, update existing entities, add new
      * entries), and let the single actions be modified by callbacks.
      *
-     * @param Traversable $entities The list of entities to work on
+     * @param \Traversable $entities The list of entities to work on
      * @param array $requestEntities The entities as retrieved from the request
      * @param callable $get Return id of entity
      * @param callable $add
@@ -54,7 +52,7 @@ trait RelationTrait
     /**
      * Compares entities with data array and calls the given callbacks.
      *
-     * @param Traversable $entities The list of entities to work on
+     * @param \Traversable $entities The list of entities to work on
      * @param array $requestEntities The entities as retrieved from the request
      * @param callable $compare return true if data matches entity
      * @param callable $add
@@ -83,7 +81,7 @@ trait RelationTrait
      * Applies a given compare function to a given set of data entries. Returns the entity itself and its key with the
      * $matchedEntry and $matchKey parameters.
      *
-     * @param Traversable $entity The entity to compare
+     * @param \Traversable $entity The entity to compare
      * @param array $requestEntities The set of entities to search in
      * @param callable $compare Compare function, which defines if data matches the entity
      * @param array $matchedEntry
@@ -107,7 +105,7 @@ trait RelationTrait
     /**
      * function compares entities with data of array and makes callback.
      *
-     * @param Traversable $entities
+     * @param \Traversable $entities
      * @param callable $compare
      * @param callable $add
      * @param callable $update

--- a/src/Sulu/Component/Rest/Exception/RestException.php
+++ b/src/Sulu/Component/Rest/Exception/RestException.php
@@ -11,9 +11,7 @@
 
 namespace Sulu\Component\Rest\Exception;
 
-use Exception;
-
-class RestException extends Exception
+class RestException extends \Exception
 {
     public function toArray()
     {

--- a/src/Sulu/Component/Rest/RestHelperInterface.php
+++ b/src/Sulu/Component/Rest/RestHelperInterface.php
@@ -13,7 +13,6 @@ namespace Sulu\Component\Rest;
 
 use Sulu\Component\Rest\ListBuilder\FieldDescriptorInterface;
 use Sulu\Component\Rest\ListBuilder\ListBuilderInterface;
-use Traversable;
 
 interface RestHelperInterface
 {
@@ -29,7 +28,7 @@ interface RestHelperInterface
      * This method processes a put request (delete non-existing entities, update existing entities, add new
      * entries), and let the single actions be modified by callbacks.
      *
-     * @param Traversable $entities The list of entities to work on
+     * @param \Traversable $entities The list of entities to work on
      * @param array $requestEntities The entities as retrieved from the request
      * @param callable $get The
      * @param callable $add

--- a/src/Sulu/Component/Security/Authorization/AccessControl/DoctrineAccessControlProvider.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/DoctrineAccessControlProvider.php
@@ -12,8 +12,6 @@
 namespace Sulu\Component\Security\Authorization\AccessControl;
 
 use Doctrine\Persistence\ObjectManager;
-use ReflectionClass;
-use ReflectionException;
 use Sulu\Bundle\SecurityBundle\Entity\AccessControl;
 use Sulu\Component\Security\Authentication\RoleInterface;
 use Sulu\Component\Security\Authentication\RoleRepositoryInterface;
@@ -139,8 +137,8 @@ class DoctrineAccessControlProvider implements AccessControlProviderInterface
     public function supports($type)
     {
         try {
-            $class = new ReflectionClass($type);
-        } catch (ReflectionException $e) {
+            $class = new \ReflectionClass($type);
+        } catch (\ReflectionException $e) {
             // in case the class does not exist there is no support
             return false;
         }

--- a/src/Sulu/Component/Security/Authorization/AccessControl/PhpcrAccessControlProvider.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/PhpcrAccessControlProvider.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Component\Security\Authorization\AccessControl;
 
-use ReflectionClass;
-use ReflectionException;
 use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
@@ -97,8 +95,8 @@ class PhpcrAccessControlProvider implements AccessControlProviderInterface
     public function supports($type)
     {
         try {
-            $class = new ReflectionClass($type);
-        } catch (ReflectionException $e) {
+            $class = new \ReflectionClass($type);
+        } catch (\ReflectionException $e) {
             // in case the class does not exist there is no support
             return false;
         }

--- a/src/Sulu/Exception/FeatureNotImplementedException.php
+++ b/src/Sulu/Exception/FeatureNotImplementedException.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Exception;
 
-use Exception;
-
-class FeatureNotImplementedException extends Exception
+class FeatureNotImplementedException extends \Exception
 {
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add php-cs-fixer global import rule for classes.

#### Why?

It was defined once that we use `\Exception` instead of `use Exception`, it seems currently this was not covered by the php cs fixer correctly. 



```
\nuse [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789]+;
# or
\nuse [a-zA-Z0-9]+;
```
