### PR TITLE
Upgrade Symfony calls to MAIN_REQUEST, LogoutEvent, TestUserProvider, Kernel RoutingConfigurator

### DIFF
--- a/src/Sulu/Bundle/ActivityBundle/Application/Subscriber/DispatchSpecificDomainEventSubscriber.php
+++ b/src/Sulu/Bundle/ActivityBundle/Application/Subscriber/DispatchSpecificDomainEventSubscriber.php
@@ -41,6 +41,6 @@ class DispatchSpecificDomainEventSubscriber implements EventSubscriberInterface
         // allows to register listeners that listen to all domain events.
         // this subscriber additionally dispatches the event with a specific event-name such as TagRemovedEvent::class
         // to allow for registering listeners for a specific type of event.
-        $this->eventDispatcher->dispatch($event, \get_class($event));
+        $this->eventDispatcher->dispatch($event);
     }
 }

--- a/src/Sulu/Bundle/ActivityBundle/Tests/Unit/Application/Subscriber/DispatchSpecificDomainEventSubscriberTest.php
+++ b/src/Sulu/Bundle/ActivityBundle/Tests/Unit/Application/Subscriber/DispatchSpecificDomainEventSubscriberTest.php
@@ -37,7 +37,7 @@ class DispatchSpecificDomainEventSubscriberTest extends TestCase
         $subscriber = $this->createDispatchSpecificDomainEventSubscriber();
 
         $event = new TestDomainEvent();
-        $this->eventDispatcher->dispatch($event, TestDomainEvent::class)
+        $this->eventDispatcher->dispatch($event)
             ->shouldBeCalled()
             ->willReturn($event);
 

--- a/src/Sulu/Bundle/AdminBundle/Command/InfoCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/InfoCommand.php
@@ -31,7 +31,7 @@ class InfoCommand extends Command
         $this->suluVersion = $suluVersion;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $docsVersion = 'latest';
         if (false !== \strpos($this->suluVersion, '.')) {

--- a/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/AudienceTargetingCacheListener.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/AudienceTargetingCacheListener.php
@@ -128,7 +128,7 @@ class AudienceTargetingCacheListener implements EventSubscriberInterface
         $targetGroupRequest->headers->set(static::USER_CONTEXT_URL_HEADER, $request->getUri());
 
         try {
-            $targetGroupResponse = $kernel->handle($targetGroupRequest, HttpKernelInterface::MASTER_REQUEST, false);
+            $targetGroupResponse = $kernel->handle($targetGroupRequest, HttpKernelInterface::MAIN_REQUEST, false);
         } catch (NotFoundHttpException $e) {
             // happens on command execution in the admin context because there is no target-group-url route registered
             return null;

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/AudienceTargetingCacheListenerTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/AudienceTargetingCacheListenerTest.php
@@ -148,7 +148,7 @@ class AudienceTargetingCacheListenerTest extends TestCase
         $httpCache = $this->prophesize(SuluHttpCache::class);
         $httpCache->handle(
             Argument::any(),
-            HttpKernelInterface::MASTER_REQUEST,
+            HttpKernelInterface::MAIN_REQUEST,
             false
         )->willReturn($targetGroupResponse->reveal());
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
@@ -573,7 +573,7 @@ class TargetGroupSubscriberTest extends TestCase
         return new ResponseEvent(
             $this->kernel->reveal(),
             $request,
-            HttpKernelInterface::MASTER_REQUEST,
+            HttpKernelInterface::MAIN_REQUEST,
             $response
         );
     }
@@ -583,7 +583,7 @@ class TargetGroupSubscriberTest extends TestCase
         return new RequestEvent(
             $this->kernel->reveal(),
             $request,
-            HttpKernelInterface::MASTER_REQUEST
+            HttpKernelInterface::MAIN_REQUEST
         );
     }
 }

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Listener/MarkupListenerTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Listener/MarkupListenerTest.php
@@ -76,7 +76,7 @@ class MarkupListenerTest extends TestCase
         $this->event = new ResponseEvent(
             $this->kernel->reveal(),
             $this->request->reveal(),
-            HttpKernelInterface::MASTER_REQUEST,
+            HttpKernelInterface::MAIN_REQUEST,
             $this->response->reveal()
         );
 

--- a/src/Sulu/Bundle/PageBundle/Command/ValidateWebspacesCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/ValidateWebspacesCommand.php
@@ -96,7 +96,7 @@ class ValidateWebspacesCommand extends Command
         $this->setDescription('Dumps webspaces and will show an error when template could not be loaded');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->output = $output;
 

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
@@ -196,7 +196,7 @@ class PreviewRendererTest extends TestCase
                         && $request->getScheme() === $expectedScheme;
                 }
             ),
-            HttpKernelInterface::MASTER_REQUEST,
+            HttpKernelInterface::MAIN_REQUEST,
             false
         )->shouldBeCalled()->willReturn(new Response('<title>Hallo</title>'));
 
@@ -242,7 +242,7 @@ class PreviewRendererTest extends TestCase
             Argument::that(function(Request $request) {
                 return 2 == $request->headers->get('X-Sulu-Target-Group');
             }),
-            HttpKernelInterface::MASTER_REQUEST,
+            HttpKernelInterface::MAIN_REQUEST,
             false
         )->shouldBeCalled()->willReturn(new Response('<title>Hallo</title>'));
 
@@ -288,7 +288,7 @@ class PreviewRendererTest extends TestCase
             Argument::that(function(Request $request) use ($segment) {
                 return $request->attributes->get('_sulu')->getAttribute('segment') === $segment;
             }),
-            HttpKernelInterface::MASTER_REQUEST,
+            HttpKernelInterface::MAIN_REQUEST,
             false
         )->shouldBeCalled()->willReturn(new Response('<title>Hallo</title>'));
 
@@ -335,7 +335,7 @@ class PreviewRendererTest extends TestCase
 
                 return $dateTime->getTimestamp() === (new \DateTime($dateTimeString))->getTimestamp();
             }),
-            HttpKernelInterface::MASTER_REQUEST,
+            HttpKernelInterface::MAIN_REQUEST,
             false
         )->shouldBeCalled()->willReturn(new Response('<title>Hallo</title>'));
 
@@ -367,7 +367,7 @@ class PreviewRendererTest extends TestCase
         $this->eventDispatcher->dispatch(Argument::type(PreRenderEvent::class), Events::PRE_RENDER)
             ->shouldBeCalled();
 
-        $this->httpKernel->handle(Argument::type(Request::class), HttpKernelInterface::MASTER_REQUEST, false)
+        $this->httpKernel->handle(Argument::type(Request::class), HttpKernelInterface::MAIN_REQUEST, false)
             ->willReturn(new Response('<title>Hallo</title>'));
 
         $request = new Request();
@@ -440,7 +440,7 @@ class PreviewRendererTest extends TestCase
         $this->eventDispatcher->dispatch(Argument::type(PreRenderEvent::class), Events::PRE_RENDER)
             ->shouldNotBeCalled();
 
-        $this->httpKernel->handle(Argument::type(Request::class), HttpKernelInterface::MASTER_REQUEST, false)
+        $this->httpKernel->handle(Argument::type(Request::class), HttpKernelInterface::MAIN_REQUEST, false)
             ->shouldNotBeCalled();
 
         $request = new Request();
@@ -474,7 +474,7 @@ class PreviewRendererTest extends TestCase
         $this->eventDispatcher->dispatch(Argument::type(PreRenderEvent::class), Events::PRE_RENDER)
             ->shouldBeCalled();
 
-        $this->httpKernel->handle(Argument::type(Request::class), HttpKernelInterface::MASTER_REQUEST, false)
+        $this->httpKernel->handle(Argument::type(Request::class), HttpKernelInterface::MAIN_REQUEST, false)
             ->shouldBeCalled()->willThrow(new RuntimeError('Test error'));
 
         $request = new Request();
@@ -508,7 +508,7 @@ class PreviewRendererTest extends TestCase
         $this->eventDispatcher->dispatch(Argument::type(PreRenderEvent::class), Events::PRE_RENDER)
             ->shouldBeCalled();
 
-        $this->httpKernel->handle(Argument::type(Request::class), HttpKernelInterface::MASTER_REQUEST, false)
+        $this->httpKernel->handle(Argument::type(Request::class), HttpKernelInterface::MAIN_REQUEST, false)
             ->shouldBeCalled()->willThrow(new \InvalidArgumentException());
 
         $request = new Request();
@@ -542,7 +542,7 @@ class PreviewRendererTest extends TestCase
         $this->eventDispatcher->dispatch(Argument::type(PreRenderEvent::class), Events::PRE_RENDER)
             ->shouldBeCalled();
 
-        $this->httpKernel->handle(Argument::type(Request::class), HttpKernelInterface::MASTER_REQUEST, false)
+        $this->httpKernel->handle(Argument::type(Request::class), HttpKernelInterface::MAIN_REQUEST, false)
             ->shouldBeCalled()->willThrow(
                 new HttpException(406, 'Error encountered when rendering content', new \InvalidArgumentException())
             );
@@ -578,7 +578,7 @@ class PreviewRendererTest extends TestCase
         $this->eventDispatcher->dispatch(Argument::type(PreRenderEvent::class), Events::PRE_RENDER)
             ->shouldBeCalled();
 
-        $this->httpKernel->handle(Argument::type(Request::class), HttpKernelInterface::MASTER_REQUEST, false)
+        $this->httpKernel->handle(Argument::type(Request::class), HttpKernelInterface::MAIN_REQUEST, false)
             ->shouldBeCalled()->willThrow(
                 new HttpException(406, 'Error encountered when rendering content')
             );
@@ -659,7 +659,7 @@ class PreviewRendererTest extends TestCase
                     return true;
                 }
             ),
-            HttpKernelInterface::MASTER_REQUEST,
+            HttpKernelInterface::MAIN_REQUEST,
             false
         )->shouldBeCalled()->willReturn(new Response('<title>Hallo</title>'));
 

--- a/src/Sulu/Bundle/RouteBundle/Generator/TranslatorWrapper.php
+++ b/src/Sulu/Bundle/RouteBundle/Generator/TranslatorWrapper.php
@@ -35,12 +35,12 @@ class TranslatorWrapper implements TranslatorInterface, LocaleAwareInterface
     /**
      * @param mixed[] $parameters
      */
-    public function trans($id, array $parameters = [], $domain = null, $locale = null): string
+    public function trans(string $id, array $parameters = [], string $domain = null, string $locale = null): string
     {
         return $this->translator->trans($id, $parameters, $domain, $locale);
     }
 
-    public function setLocale($locale): void
+    public function setLocale(string $locale): void
     {
         throw new \LogicException('Not supported.');
     }

--- a/src/Sulu/Bundle/SecurityBundle/Controller/GroupController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/GroupController.php
@@ -28,6 +28,7 @@ use Sulu\Component\Security\Authentication\RoleInterface;
 use Sulu\Component\Security\Authentication\RoleRepositoryInterface;
 use Sulu\Component\Security\SecuredControllerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Makes the groups accessible through a REST-API.
@@ -94,7 +95,7 @@ class GroupController extends AbstractRestController implements ClassResourceInt
     /**
      * returns all groups.
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function cgetAction(Request $request)
     {
@@ -128,7 +129,7 @@ class GroupController extends AbstractRestController implements ClassResourceInt
      *
      * @param $id
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function getAction($id)
     {
@@ -147,9 +148,9 @@ class GroupController extends AbstractRestController implements ClassResourceInt
     /**
      * Creates a new group with the given data.
      *
-     * @throws \Sulu\Component\Rest\Exception\EntityNotFoundException
+     * @throws EntityNotFoundException
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function postAction(Request $request)
     {
@@ -184,7 +185,7 @@ class GroupController extends AbstractRestController implements ClassResourceInt
      *
      * @param $id
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function putAction(Request $request, $id)
     {
@@ -252,7 +253,7 @@ class GroupController extends AbstractRestController implements ClassResourceInt
      *
      * @param $id
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function deleteAction($id)
     {
@@ -279,7 +280,7 @@ class GroupController extends AbstractRestController implements ClassResourceInt
      *
      * @return bool
      *
-     * @throws \Sulu\Component\Rest\Exception\EntityNotFoundException
+     * @throws EntityNotFoundException
      */
     private function addRole(Group $group, $roleData)
     {

--- a/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
@@ -23,6 +23,7 @@ use Sulu\Bundle\SecurityBundle\Entity\Permission;
 use Sulu\Bundle\SecurityBundle\Exception\RoleKeyAlreadyExistsException;
 use Sulu\Bundle\SecurityBundle\Exception\RoleNameAlreadyExistsException;
 use Sulu\Component\Rest\AbstractRestController;
+use Sulu\Component\Rest\Exception\EntityIdAlreadySetException;
 use Sulu\Component\Rest\Exception\EntityNotFoundException;
 use Sulu\Component\Rest\Exception\InvalidArgumentException;
 use Sulu\Component\Rest\Exception\RestException;
@@ -36,6 +37,7 @@ use Sulu\Component\Security\Authentication\RoleRepositoryInterface;
 use Sulu\Component\Security\Authorization\MaskConverterInterface;
 use Sulu\Component\Security\SecuredControllerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Makes the roles accessible through a REST-API.
@@ -137,7 +139,7 @@ class RoleController extends AbstractRestController implements ClassResourceInte
     /**
      * returns all roles.
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function cgetAction(Request $request)
     {
@@ -184,7 +186,7 @@ class RoleController extends AbstractRestController implements ClassResourceInte
      *
      * @param $id
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function getAction($id)
     {
@@ -203,10 +205,10 @@ class RoleController extends AbstractRestController implements ClassResourceInte
     /**
      * Creates a new role with the given data.
      *
-     * @throws \Sulu\Component\Rest\Exception\EntityIdAlreadySetException
-     * @throws \Sulu\Component\Rest\Exception\EntityNotFoundException
+     * @throws EntityIdAlreadySetException
+     * @throws EntityNotFoundException
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function postAction(Request $request)
     {
@@ -248,9 +250,9 @@ class RoleController extends AbstractRestController implements ClassResourceInte
                 $view = $this->view($this->convertRole($role), 200);
             } catch (UniqueConstraintViolationException $e) {
                 if (\strpos($e->getMessage(), 'Duplicate entry \'' . $role->getName())) {
-                    throw new RoleNameAlreadyExistsException($name);
+                    throw new RoleNameAlreadyExistsException($name, $e);
                 } else {
-                    throw new RoleKeyAlreadyExistsException($key);
+                    throw new RoleKeyAlreadyExistsException($key, $e);
                 }
             }
         } catch (RestException $e) {
@@ -265,7 +267,7 @@ class RoleController extends AbstractRestController implements ClassResourceInte
      *
      * @param $id
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function putAction(Request $request, $id)
     {
@@ -302,9 +304,9 @@ class RoleController extends AbstractRestController implements ClassResourceInte
             $view = $this->view($enfe->toArray(), 404);
         } catch (UniqueConstraintViolationException $e) {
             if (\strpos($e->getMessage(), 'Duplicate entry \'' . $role->getName())) {
-                throw new RoleNameAlreadyExistsException($name);
+                throw new RoleNameAlreadyExistsException($name, $e);
             } else {
-                throw new RoleKeyAlreadyExistsException($key);
+                throw new RoleKeyAlreadyExistsException($key, $e);
             }
         } catch (RestException $re) {
             $view = $this->view($re->toArray(), 400);
@@ -318,7 +320,7 @@ class RoleController extends AbstractRestController implements ClassResourceInte
      *
      * @param $id
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function deleteAction($id)
     {
@@ -487,7 +489,7 @@ class RoleController extends AbstractRestController implements ClassResourceInte
      * @param RoleInterface $role
      * @param $securityTypeData
      *
-     * @throws \Sulu\Component\Rest\Exception\EntityNotFoundException
+     * @throws EntityNotFoundException
      */
     private function setSecurityType($role, $securityTypeData)
     {

--- a/src/Sulu/Bundle/SecurityBundle/Controller/UserController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/UserController.php
@@ -31,6 +31,7 @@ use Sulu\Component\Rest\RestHelperInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\SecuredControllerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Makes the users accessible through a rest api.
@@ -138,7 +139,7 @@ class UserController extends AbstractRestController implements ClassResourceInte
      *
      * @param int $id
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function getAction($id)
     {
@@ -156,7 +157,7 @@ class UserController extends AbstractRestController implements ClassResourceInte
     /**
      * Creates a new user in the system.
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function postAction(Request $request)
     {
@@ -181,7 +182,7 @@ class UserController extends AbstractRestController implements ClassResourceInte
     /**
      * @param int $id
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function postTriggerAction($id, Request $request)
     {
@@ -218,7 +219,7 @@ class UserController extends AbstractRestController implements ClassResourceInte
      *
      * @param int $id
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function putAction(Request $request, $id)
     {
@@ -243,7 +244,7 @@ class UserController extends AbstractRestController implements ClassResourceInte
      *
      * @param int $id
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function patchAction(Request $request, $id)
     {
@@ -267,7 +268,7 @@ class UserController extends AbstractRestController implements ClassResourceInte
      *
      * @param int $id
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function deleteAction($id)
     {
@@ -280,12 +281,10 @@ class UserController extends AbstractRestController implements ClassResourceInte
     /**
      * Checks if all the arguments are given, and throws an exception if one is missing.
      *
-     * @throws \Sulu\Component\Rest\Exception\MissingArgumentException
+     * @throws MissingArgumentException
      */
-
     // TODO: Use schema validation see:
     // https://github.com/sulu-io/sulu/issues/1136
-
     private function checkArguments(Request $request)
     {
         if (null == $request->get('username')) {
@@ -306,7 +305,7 @@ class UserController extends AbstractRestController implements ClassResourceInte
      * Returns a user with a specific contact id or all users
      * optional parameter 'flat' calls listAction.
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function cgetAction(Request $request)
     {

--- a/src/Sulu/Bundle/SecurityBundle/DependencyInjection/SuluSecurityExtension.php
+++ b/src/Sulu/Bundle/SecurityBundle/DependencyInjection/SuluSecurityExtension.php
@@ -25,7 +25,7 @@ use Sulu\Component\Security\Authorization\AccessControl\DescendantProviderInterf
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
-use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
@@ -50,7 +50,7 @@ class SuluSecurityExtension extends Extension implements PrependExtensionInterfa
         $container->registerForAutoconfiguration(DescendantProviderInterface::class)
             ->addTag('sulu_security.access_control_descendant_provider');
 
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
         $loader->load('command.xml');
 

--- a/src/Sulu/Bundle/SecurityBundle/Entity/UserRepository.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/UserRepository.php
@@ -12,11 +12,11 @@
 namespace Sulu\Bundle\SecurityBundle\Entity;
 
 use Doctrine\ORM\NoResultException;
+use Doctrine\ORM\QueryBuilder;
 use Sulu\Component\Persistence\Repository\ORM\EntityRepository;
 use Sulu\Component\Persistence\Repository\ORM\OrderByTrait;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authentication\UserRepositoryInterface;
-use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 
 /**
  * Repository for the User, implementing some additional functions
@@ -287,7 +287,7 @@ class UserRepository extends EntityRepository implements UserRepositoryInterface
      * Returns the query for the user with the joins for retrieving the permissions. Especially useful for security
      * related queries.
      *
-     * @return \Doctrine\ORM\QueryBuilder
+     * @return QueryBuilder
      */
     private function getUserWithPermissionsQuery()
     {

--- a/src/Sulu/Bundle/SecurityBundle/Exception/RoleKeyAlreadyExistsException.php
+++ b/src/Sulu/Bundle/SecurityBundle/Exception/RoleKeyAlreadyExistsException.php
@@ -26,10 +26,10 @@ class RoleKeyAlreadyExistsException extends \Exception implements TranslationErr
     /**
      * @param string $key
      */
-    public function __construct($key)
+    public function __construct($key, \Throwable $previous = null)
     {
         $this->key = $key;
-        parent::__construct(\sprintf('Role with key "%s" already exists', $key), 1101);
+        parent::__construct(\sprintf('Role with key "%s" already exists', $key), 1101, $previous);
     }
 
     /**

--- a/src/Sulu/Bundle/SecurityBundle/Exception/RoleNameAlreadyExistsException.php
+++ b/src/Sulu/Bundle/SecurityBundle/Exception/RoleNameAlreadyExistsException.php
@@ -26,10 +26,10 @@ class RoleNameAlreadyExistsException extends \Exception implements TranslationEr
     /**
      * @param string $name
      */
-    public function __construct($name)
+    public function __construct($name, \Throwable $previous = null)
     {
         $this->name = $name;
-        parent::__construct(\sprintf('Role "%s" already exists', $name), 1101);
+        parent::__construct(\sprintf('Role "%s" already exists', $name), 1101, $previous);
     }
 
     /**

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Application/Kernel.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Application/Kernel.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\SecurityBundle\Tests\Application;
 
 use Sulu\Bundle\TestBundle\Kernel\SuluTestKernel;
+use Symfony\Bundle\DebugBundle\DebugBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 
 class Kernel extends SuluTestKernel
@@ -21,7 +22,7 @@ class Kernel extends SuluTestKernel
         return \array_merge(
             parent::registerBundles(),
             [
-                new \Symfony\Bundle\DebugBundle\DebugBundle(),
+                new DebugBundle(),
             ]
         );
     }

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/LegacyResettingControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/LegacyResettingControllerTest.php
@@ -20,6 +20,7 @@ use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\SecurityBundle\Entity\UserRole;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\Routing\Router;
 
 class LegacyResettingControllerTest extends SuluTestCase
 {
@@ -405,7 +406,7 @@ class LegacyResettingControllerTest extends SuluTestCase
         $resetUrl = $this->getContainer()->get('router')->generate(
             'sulu_admin',
             [],
-            \Symfony\Component\Routing\Router::ABSOLUTE_URL
+            Router::ABSOLUTE_URL
         );
         $body = $this->getContainer()->get('twig')->render($template, [
             'user' => $user,

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ResettingControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ResettingControllerTest.php
@@ -22,6 +22,7 @@ use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\Mailer\DataCollector\MessageDataCollector;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Routing\Router;
 
 class ResettingControllerTest extends SuluTestCase
 {
@@ -436,7 +437,7 @@ class ResettingControllerTest extends SuluTestCase
         $resetUrl = $this->getContainer()->get('router')->generate(
             'sulu_admin',
             [],
-            \Symfony\Component\Routing\Router::ABSOLUTE_URL
+            Router::ABSOLUTE_URL
         );
         $body = $this->getContainer()->get('twig')->render($template, [
             'user' => $user,

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/SuluSecurityListenerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/SuluSecurityListenerTest.php
@@ -19,7 +19,7 @@ use Sulu\Component\Security\Authorization\AccessControl\SecuredObjectControllerI
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Sulu\Component\Security\Authorization\SecurityCondition;
 use Sulu\Component\Security\SecuredControllerInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
@@ -149,7 +149,7 @@ class SuluSecurityListenerTest extends TestCase
     {
         $this->securityChecker->checkPermission(Argument::cetera())->shouldNotHaveBeenCalled();
 
-        $controller = $this->prophesize(Controller::class);
+        $controller = $this->prophesize(AbstractController::class);
 
         $request = $this->prophesize(Request::class);
 
@@ -291,7 +291,7 @@ class SuluSecurityListenerTest extends TestCase
             $this->kernel->reveal(),
             $controller,
             $request,
-            HttpKernelInterface::MASTER_REQUEST
+            HttpKernelInterface::MAIN_REQUEST
         );
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/UserLocaleListenerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/UserLocaleListenerTest.php
@@ -70,7 +70,7 @@ class UserLocaleListenerTest extends TestCase
         $this->event = new RequestEvent(
             $this->kernel->reveal(),
             $this->request->reveal(),
-            HttpKernelInterface::MASTER_REQUEST
+            HttpKernelInterface::MAIN_REQUEST
         );
 
         $this->token = $this->prophesize(TokenInterface::class);

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/User/UserProviderTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/User/UserProviderTest.php
@@ -65,14 +65,14 @@ class UserProviderTest extends TestCase
     {
         $this->expectException(DisabledException::class);
         $this->user->setEnabled(false);
-        $this->userProvider->loadUserByUsername('sulu');
+        $this->userProvider->loadUserByIdentifier('sulu');
     }
 
     public function testLoginFailLockedUser(): void
     {
         $this->expectException(LockedException::class);
         $this->user->setLocked(true);
-        $this->userProvider->loadUserByUsername('sulu');
+        $this->userProvider->loadUserByIdentifier('sulu');
     }
 
     public function testLoadUserByUsername(): void
@@ -85,7 +85,7 @@ class UserProviderTest extends TestCase
         $this->systemStore->getSystem()
             ->willReturn('Sulu')
             ->shouldBeCalled();
-        $user = $this->userProvider->loadUserByUsername('sulu');
+        $user = $this->userProvider->loadUserByIdentifier('sulu');
 
         $this->assertEquals('test@sulu.io', $user->getEmail());
     }

--- a/src/Sulu/Bundle/SecurityBundle/User/UserProvider.php
+++ b/src/Sulu/Bundle/SecurityBundle/User/UserProvider.php
@@ -18,7 +18,7 @@ use Sulu\Component\Security\Authentication\UserRepositoryInterface;
 use Symfony\Component\Security\Core\Exception\DisabledException;
 use Symfony\Component\Security\Core\Exception\LockedException;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
-use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface as BaseUserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
@@ -75,10 +75,10 @@ class UserProvider implements UserProviderInterface
                 }
             }
         } catch (NoResultException $e) {
-            throw new UsernameNotFoundException($exceptionMessage, 0, $e);
+            throw new UserNotFoundException($exceptionMessage, 0, $e);
         }
 
-        throw new UsernameNotFoundException($exceptionMessage, 0);
+        throw new UserNotFoundException($exceptionMessage, 0);
     }
 
     public function refreshUser(BaseUserInterface $user)

--- a/src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
+++ b/src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
@@ -509,7 +509,7 @@ class UserManager implements UserManagerInterface
      *
      * @param $userRoleData
      *
-     * @throws \Sulu\Component\Rest\Exception\EntityNotFoundException
+     * @throws EntityNotFoundException
      *
      * @return bool
      */
@@ -536,7 +536,7 @@ class UserManager implements UserManagerInterface
      *
      * @param $userRoleData
      *
-     * @throws \Sulu\Component\Rest\Exception\EntityNotFoundException
+     * @throws EntityNotFoundException
      *
      * @return bool
      */
@@ -576,7 +576,7 @@ class UserManager implements UserManagerInterface
      *
      * @param $userGroupData
      *
-     * @throws \Sulu\Component\Rest\Exception\EntityNotFoundException
+     * @throws EntityNotFoundException
      *
      * @return bool
      */
@@ -604,7 +604,7 @@ class UserManager implements UserManagerInterface
      *
      * @param $userGroupData
      *
-     * @throws \Sulu\Component\Rest\Exception\EntityNotFoundException
+     * @throws EntityNotFoundException
      *
      * @return bool
      */
@@ -631,7 +631,7 @@ class UserManager implements UserManagerInterface
      *
      * @param int $id
      *
-     * @throws \Sulu\Component\Rest\Exception\EntityNotFoundException
+     * @throws EntityNotFoundException
      *
      * @return Contact
      */

--- a/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
@@ -146,7 +146,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
     /**
      * Returns list of snippets.
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function cgetAction(Request $request)
     {
@@ -212,7 +212,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
      *
      * @param string $id
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function getAction(Request $request, $id = null)
     {
@@ -227,7 +227,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
     /**
      * Saves a new snippet.
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function postAction(Request $request)
     {
@@ -242,7 +242,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
      *
      * @param string $id
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function putAction(Request $request, $id)
     {
@@ -298,7 +298,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
      *
      * @param string $id
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function postTriggerAction($id, Request $request)
     {

--- a/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetRepository.php
+++ b/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetRepository.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\SnippetBundle\Snippet;
 
 use Jackalope\Query\Query;
+use PHPCR\NodeInterface;
 use PHPCR\Query\QOM\QueryObjectModelConstantsInterface;
 use PHPCR\Util\QOM\QueryBuilder;
 use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
@@ -61,7 +62,7 @@ class SnippetRepository
      *
      * @param string $uuid
      *
-     * @return \PHPCR\NodeInterface[]
+     * @return NodeInterface[]
      */
     public function getReferences($uuid)
     {

--- a/src/Sulu/Bundle/TagBundle/Controller/TagController.php
+++ b/src/Sulu/Bundle/TagBundle/Controller/TagController.php
@@ -172,7 +172,7 @@ class TagController extends AbstractRestController implements ClassResourceInter
     /**
      * Inserts a new tag.
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      *
      * @throws \Exception
      */
@@ -209,7 +209,7 @@ class TagController extends AbstractRestController implements ClassResourceInter
      *
      * @param $id
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      *
      * @throws \Exception
      */

--- a/src/Sulu/Bundle/TagBundle/DependencyInjection/SuluTagExtension.php
+++ b/src/Sulu/Bundle/TagBundle/DependencyInjection/SuluTagExtension.php
@@ -17,7 +17,7 @@ use Sulu\Bundle\TagBundle\Tag\TagRepositoryInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
-use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
@@ -87,7 +87,7 @@ class SuluTagExtension extends Extension implements PrependExtensionInterface
             ]
         );
 
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
 
         if (\array_key_exists('SuluTrashBundle', $bundles)) {

--- a/src/Sulu/Bundle/TestBundle/DependencyInjection/SuluTestExtension.php
+++ b/src/Sulu/Bundle/TestBundle/DependencyInjection/SuluTestExtension.php
@@ -13,7 +13,7 @@ namespace Sulu\Bundle\TestBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class SuluTestExtension extends Extension
@@ -23,7 +23,7 @@ class SuluTestExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
 
         if (isset($config['enable_test_user_provider']) && $config['enable_test_user_provider']) {
             $loader->load('test_user_provider.xml');

--- a/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
@@ -17,7 +17,7 @@ use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Component\Security\Authentication\UserRepositoryInterface;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
-use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Contracts\Service\ResetInterface;
@@ -118,15 +118,20 @@ class TestUserProvider implements UserProviderInterface, ResetInterface
      *
      * @see UsernameNotFoundException
      *
-     * @throws UsernameNotFoundException if the user is not found
+     * @throws UserNotFoundException if the user is not found
      */
     public function loadUserByUsername($username)
     {
-        if (self::TEST_USER_USERNAME === $username) {
+        return $this->loadUserByIdentifier($username);
+    }
+
+    public function loadUserByIdentifier(string $identifier): UserInterface
+    {
+        if (self::TEST_USER_USERNAME === $identifier) {
             return $this->getUser();
         }
 
-        return $this->userProvider->loadUserByUsername($username);
+        return $this->userProvider->loadUserByIdentifier($identifier);
     }
 
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/SitemapController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/SitemapController.php
@@ -85,7 +85,7 @@ class SitemapController
      * Render sitemap-index of all available sitemap.xml files.
      * If only one provider exists this provider will be rendered directly.
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function indexAction(Request $request)
     {

--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/SuluWebsiteExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/SuluWebsiteExtension.php
@@ -19,7 +19,7 @@ use Sulu\Component\HttpKernel\SuluKernel;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
-use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
@@ -123,7 +123,7 @@ class SuluWebsiteExtension extends Extension implements PrependExtensionInterfac
         $container->registerForAutoconfiguration(SitemapProviderInterface::class)
             ->addTag('sulu.sitemap.provider');
 
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
         $loader->load('sitemap.xml');
         $loader->load('command.xml');

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
@@ -88,7 +88,7 @@ class AppendAnalyticsListener
      */
     public function onResponse(ResponseEvent $event)
     {
-        if (!$event->isMasterRequest()
+        if (!$event->isMainRequest()
             || $this->preview
         ) {
             return;

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/AppendAnalyticsListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/AppendAnalyticsListenerTest.php
@@ -460,7 +460,7 @@ class AppendAnalyticsListenerTest extends TestCase
         return new ResponseEvent(
             $kernel->reveal(),
             $request,
-            HttpKernelInterface::MASTER_REQUEST,
+            HttpKernelInterface::MAIN_REQUEST,
             $response
         );
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/RouterListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/RouterListenerTest.php
@@ -101,7 +101,7 @@ class RouterListenerTest extends TestCase
         return new RequestEvent(
             $this->kernel->reveal(),
             $request,
-            HttpKernelInterface::MASTER_REQUEST
+            HttpKernelInterface::MAIN_REQUEST
         );
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/SegmentSubscriberTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/SegmentSubscriberTest.php
@@ -118,7 +118,7 @@ class SegmentSubscriberTest extends TestCase
         return new ResponseEvent(
             $kernel->reveal(),
             $request,
-            HttpKernelInterface::MASTER_REQUEST,
+            HttpKernelInterface::MAIN_REQUEST,
             $response
         );
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/TranslatorListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/TranslatorListenerTest.php
@@ -59,7 +59,7 @@ class TranslatorListenerTest extends TestCase
         return new RequestEvent(
             $this->kernel->reveal(),
             $request,
-            HttpKernelInterface::MASTER_REQUEST
+            HttpKernelInterface::MAIN_REQUEST
         );
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RedirectExceptionSubscriberTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RedirectExceptionSubscriberTest.php
@@ -107,7 +107,7 @@ class RedirectExceptionSubscriberTest extends TestCase
         $this->event = new ExceptionEvent(
             $this->kernel->reveal(),
             $this->request->reveal(),
-            HttpKernelInterface::MASTER_REQUEST,
+            HttpKernelInterface::MAIN_REQUEST,
             new NotFoundHttpException()
         );
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RequestListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RequestListenerTest.php
@@ -87,7 +87,7 @@ class RequestListenerTest extends TestCase
         return new RequestEvent(
             $this->kernel->reveal(),
             $request,
-            HttpKernelInterface::MASTER_REQUEST
+            HttpKernelInterface::MAIN_REQUEST
         );
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtensionInterface.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtensionInterface.php
@@ -50,7 +50,7 @@ interface NavigationTwigExtensionInterface extends ExtensionInterface
      * @param bool $loadExcerpt
      * @param int $level
      *
-     * @return \Sulu\Bundle\WebsiteBundle\Navigation\NavigationItem[]
+     * @return NavigationItem[]
      */
     public function treeNavigationFunction($uuid, $context = null, $depth = 1, $loadExcerpt = false, $level = null);
 
@@ -63,7 +63,7 @@ interface NavigationTwigExtensionInterface extends ExtensionInterface
      * @param bool $loadExcerpt
      * @param int $level
      *
-     * @return \Sulu\Bundle\WebsiteBundle\Navigation\NavigationItem[]
+     * @return NavigationItem[]
      */
     public function flatNavigationFunction($uuid, $context = null, $depth = 1, $loadExcerpt = false, $level = null);
 
@@ -72,7 +72,7 @@ interface NavigationTwigExtensionInterface extends ExtensionInterface
      *
      * @param string $uuid
      *
-     * @return \Sulu\Bundle\WebsiteBundle\Navigation\NavigationItem[]
+     * @return NavigationItem[]
      */
     public function breadcrumbFunction($uuid);
 
@@ -82,7 +82,7 @@ interface NavigationTwigExtensionInterface extends ExtensionInterface
      * @param string $requestUrl
      * @param string $itemUrl
      *
-     * @return \Sulu\Bundle\WebsiteBundle\Navigation\NavigationItem[]
+     * @return NavigationItem[]
      */
     public function navigationIsActiveFunction($requestUrl, $itemUrl);
 }

--- a/src/Sulu/Component/Content/Compat/Block/BlockPropertyWrapper.php
+++ b/src/Sulu/Component/Content/Compat/Block/BlockPropertyWrapper.php
@@ -130,7 +130,7 @@ class BlockPropertyWrapper implements PropertyInterface
     }
 
     /**
-     * @param \Sulu\Component\Content\Compat\Block\BlockPropertyInterface $block
+     * @param BlockPropertyInterface $block
      */
     public function setBlock($block)
     {
@@ -138,7 +138,7 @@ class BlockPropertyWrapper implements PropertyInterface
     }
 
     /**
-     * @return \Sulu\Component\Content\Compat\Block\BlockPropertyInterface
+     * @return BlockPropertyInterface
      */
     public function getBlock()
     {
@@ -146,7 +146,7 @@ class BlockPropertyWrapper implements PropertyInterface
     }
 
     /**
-     * @param \Sulu\Component\Content\Compat\PropertyInterface $property
+     * @param PropertyInterface $property
      */
     public function setProperty($property)
     {
@@ -154,7 +154,7 @@ class BlockPropertyWrapper implements PropertyInterface
     }
 
     /**
-     * @return \Sulu\Component\Content\Compat\PropertyInterface
+     * @return PropertyInterface
      */
     public function getProperty()
     {

--- a/src/Sulu/Component/Content/Compat/Property.php
+++ b/src/Sulu/Component/Content/Compat/Property.php
@@ -227,7 +227,7 @@ class Property implements PropertyInterface, \JsonSerializable
     /**
      * returns tags defined in xml.
      *
-     * @return \Sulu\Component\Content\Compat\PropertyTag[]
+     * @return PropertyTag[]
      */
     public function getTags()
     {

--- a/src/Sulu/Component/Content/Compat/Structure.php
+++ b/src/Sulu/Component/Content/Compat/Structure.php
@@ -701,7 +701,7 @@ abstract class Structure implements StructureInterface
     }
 
     /**
-     * @param \Sulu\Component\Content\Compat\StructureType $type
+     * @param StructureType $type
      */
     public function setType($type)
     {
@@ -709,7 +709,7 @@ abstract class Structure implements StructureInterface
     }
 
     /**
-     * @return \Sulu\Component\Content\Compat\StructureType
+     * @return StructureType
      */
     public function getType()
     {

--- a/src/Sulu/Component/Content/Compat/StructureInterface.php
+++ b/src/Sulu/Component/Content/Compat/StructureInterface.php
@@ -206,14 +206,14 @@ interface StructureInterface extends \JsonSerializable
     public function getPropertyNames();
 
     /**
-     * @param \Sulu\Component\Content\Compat\StructureType $type
+     * @param StructureType $type
      */
     public function setType($type);
 
     /**
      * Return type of structure.
      *
-     * @return \Sulu\Component\Content\Compat\StructureType
+     * @return StructureType
      */
     public function getType();
 
@@ -267,7 +267,7 @@ interface StructureInterface extends \JsonSerializable
      *
      * @param string $tagName
      *
-     * @throws \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
+     * @throws NoSuchPropertyException
      *
      * @return PropertyInterface[]
      */

--- a/src/Sulu/Component/Content/Document/Subscriber/WorkflowStageSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/WorkflowStageSubscriber.php
@@ -25,6 +25,7 @@ use Sulu\Component\DocumentManager\Event\PublishEvent;
 use Sulu\Component\DocumentManager\Event\RestoreEvent;
 use Sulu\Component\DocumentManager\Event\UnpublishEvent;
 use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
 use Sulu\Component\DocumentManager\PropertyEncoder;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -81,7 +82,7 @@ class WorkflowStageSubscriber implements EventSubscriberInterface
     /**
      * Sets the workflow properties from the node on the document.
      *
-     * @throws \Sulu\Component\DocumentManager\Exception\DocumentManagerException
+     * @throws DocumentManagerException
      */
     public function setWorkflowStageOnDocument(HydrateEvent $event)
     {
@@ -224,7 +225,7 @@ class WorkflowStageSubscriber implements EventSubscriberInterface
      * @param string $locale
      * @param string $live
      *
-     * @throws \Sulu\Component\DocumentManager\Exception\DocumentManagerException
+     * @throws DocumentManagerException
      */
     private function setWorkflowStage(
         WorkflowStageBehavior $document,

--- a/src/Sulu/Component/Content/Export/WebspaceExport.php
+++ b/src/Sulu/Component/Content/Export/WebspaceExport.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\Content\Export;
 
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
+use Sulu\Bundle\PageBundle\Content\Structure\ExcerptStructureExtension;
 use Sulu\Bundle\PageBundle\Document\BasePageDocument;
 use Sulu\Bundle\PageBundle\Document\PageDocument;
 use Sulu\Component\Content\Compat\StructureManagerInterface;
@@ -147,7 +148,7 @@ class WebspaceExport extends Export implements WebspaceExportInterface
 
         $extensionData = [];
         foreach ($data as $extensionName => $extensionProperties) {
-            /** @var \Sulu\Bundle\PageBundle\Content\Structure\ExcerptStructureExtension $extension */
+            /** @var ExcerptStructureExtension $extension */
             $extension = $this->extensionManager->getExtension($document->getStructureType(), $extensionName);
 
             if ($extension instanceof ExportExtensionInterface) {

--- a/src/Sulu/Component/Content/Mapper/ContentMapperInterface.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapperInterface.php
@@ -16,6 +16,7 @@ use PHPCR\Query\QueryInterface;
 use PHPCR\Query\QueryResultInterface;
 use Sulu\Component\Content\BreadcrumbItemInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
+use Sulu\Component\Content\Exception\InvalidOrderPositionException;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\Localization\Localization;
 
@@ -196,8 +197,8 @@ interface ContentMapperInterface
      * @param string $webspaceKey
      * @param string $languageCode
      *
-     * @throws \Sulu\Component\Content\Exception\InvalidOrderPositionException
-     *                                                                         thrown if position is out of range
+     * @throws InvalidOrderPositionException
+     *                                       thrown if position is out of range
      *
      * @return StructureInterface
      */

--- a/src/Sulu/Component/Content/Mapper/Translation/MultipleTranslatedProperties.php
+++ b/src/Sulu/Component/Content/Mapper/Translation/MultipleTranslatedProperties.php
@@ -76,7 +76,7 @@ class MultipleTranslatedProperties
      *
      * @param string $key
      *
-     * @throws \Sulu\Component\Content\Exception\NoSuchPropertyException
+     * @throws NoSuchPropertyException
      *
      * @return string
      */

--- a/src/Sulu/Component/Content/Metadata/Factory/StructureMetadataFactory.php
+++ b/src/Sulu/Component/Content/Metadata/Factory/StructureMetadataFactory.php
@@ -13,6 +13,8 @@ namespace Sulu\Component\Content\Metadata\Factory;
 
 use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
+use Sulu\Component\Content\Metadata\Factory\Exception\DocumentTypeNotFoundException;
+use Sulu\Component\Content\Metadata\Factory\Exception\StructureTypeNotFoundException;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -110,7 +112,7 @@ class StructureMetadataFactory implements StructureMetadataFactoryInterface
             try {
                 $filePath = $fileLocator->locate(\sprintf('%s.xml', $structureType));
             } catch (\InvalidArgumentException $e) {
-                throw new Exception\StructureTypeNotFoundException(
+                throw new StructureTypeNotFoundException(
                     \sprintf(
                         'Could not load structure type "%s" for document type "%s", looked in "%s"',
                         $structureType,
@@ -203,7 +205,7 @@ class StructureMetadataFactory implements StructureMetadataFactoryInterface
     private function assertExists($type)
     {
         if (!isset($this->typePaths[$type])) {
-            throw new Exception\DocumentTypeNotFoundException(
+            throw new DocumentTypeNotFoundException(
                 \sprintf(
                     'Structure path for document type "%s" is not mapped. Mapped structure types: "%s"',
                     $type,

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
@@ -14,6 +14,7 @@ namespace Sulu\Component\Content\Types\ResourceLocator\Mapper;
 use PHPCR\ItemExistsException;
 use PHPCR\NodeInterface;
 use PHPCR\PathNotFoundException;
+use PHPCR\PropertyInterface;
 use PHPCR\Util\PathHelper;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
@@ -131,7 +132,7 @@ class PhpcrMapper implements ResourceLocatorMapperInterface
      * @param string $languageCode
      * @param string $segmentKey
      *
-     * @return \PHPCR\NodeInterface
+     * @return NodeInterface
      */
     private function iterateRouteNodes(
         NodeInterface $node,
@@ -148,7 +149,7 @@ class PhpcrMapper implements ResourceLocatorMapperInterface
 
         // search for references with name 'content'
         foreach ($node->getReferences('sulu:content') as $ref) {
-            if ($ref instanceof \PHPCR\PropertyInterface) {
+            if ($ref instanceof PropertyInterface) {
                 $routeNode = $ref->getParent();
                 if (0 !== \strpos($routeNode->getPath(), $routePath)) {
                     continue;
@@ -376,7 +377,7 @@ class PhpcrMapper implements ResourceLocatorMapperInterface
      * @param string $languageCode
      * @param string $segmentKey
      *
-     * @return \PHPCR\NodeInterface base node of routes
+     * @return NodeInterface base node of routes
      */
     private function getWebspaceRouteNode($webspaceKey, $languageCode, $segmentKey)
     {

--- a/src/Sulu/Component/DocumentManager/ProxyFactory.php
+++ b/src/Sulu/Component/DocumentManager/ProxyFactory.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\DocumentManager;
 
 use PHPCR\NodeInterface;
 use ProxyManager\Factory\LazyLoadingGhostFactory;
+use ProxyManager\Proxy\GhostObjectInterface;
 use ProxyManager\Proxy\LazyLoadingInterface;
 use Sulu\Component\DocumentManager\Collection\ChildrenCollection;
 use Sulu\Component\DocumentManager\Collection\ReferrerCollection;
@@ -66,7 +67,7 @@ class ProxyFactory
      * @param object $fromDocument
      * @param array $options
      *
-     * @return \ProxyManager\Proxy\GhostObjectInterface
+     * @return GhostObjectInterface
      */
     public function createProxyForNode($fromDocument, NodeInterface $targetNode, $options = [])
     {

--- a/src/Sulu/Component/DocumentManager/Query/Query.php
+++ b/src/Sulu/Component/DocumentManager/Query/Query.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\DocumentManager\Query;
 
 use PHPCR\Query\QueryInterface;
+use PHPCR\Query\QueryResultInterface;
 use Sulu\Component\DocumentManager\Event\QueryExecuteEvent;
 use Sulu\Component\DocumentManager\Events;
 use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
@@ -87,7 +88,7 @@ class Query
     /**
      * @param string $hydrationMode
      *
-     * @return mixed|\PHPCR\Query\QueryResultInterface
+     * @return mixed|QueryResultInterface
      *
      * @throws DocumentManagerException
      */

--- a/src/Sulu/Component/Export/Export.php
+++ b/src/Sulu/Component/Export/Export.php
@@ -17,6 +17,7 @@ use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\Content\Document\Structure\PropertyValue;
 use Sulu\Component\Content\Metadata\BlockMetadata;
 use Sulu\Component\Content\Metadata\PropertyMetadata;
+use Sulu\Component\Content\Metadata\StructureMetadata;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
 use Sulu\Component\Export\Manager\ExportManagerInterface;
@@ -208,7 +209,7 @@ class Export
         /** @var BasePageDocument $loadedDocument */
         $loadedDocument = $this->documentManager->find($document->getUuid(), $locale);
 
-        /** @var \Sulu\Component\Content\Metadata\StructureMetadata $metaData */
+        /** @var StructureMetadata $metaData */
         $metaData = $this->documentInspector->getStructureMetadata($document);
 
         $propertyValues = $loadedDocument->getStructure()->toArray();

--- a/src/Sulu/Component/HttpKernel/SuluKernel.php
+++ b/src/Sulu/Component/HttpKernel/SuluKernel.php
@@ -18,7 +18,6 @@ use Symfony\Component\Config\Resource\GlobResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
-use Symfony\Component\Routing\RouteCollectionBuilder;
 
 /**
  * Base class for all Sulu kernels.
@@ -146,10 +145,7 @@ abstract class SuluKernel extends Kernel
         return $class;
     }
 
-    /**
-     * @param RouteCollectionBuilder|RoutingConfigurator $routes Is a RouteCollectionBuilder for Symfony <= 4.4
-     */
-    protected function configureRoutes($routes)
+    protected function configureRoutes(RoutingConfigurator $routes)
     {
         $confDir = $this->getProjectDir() . '/config';
 
@@ -177,10 +173,7 @@ abstract class SuluKernel extends Kernel
         }
     }
 
-    /**
-     * @param RouteCollectionBuilder|RoutingConfigurator $routes Is a RouteCollectionBuilder for Symfony <= 4.4
-     */
-    protected function import($routes, $confDir, $pattern)
+    protected function import(RoutingConfigurator $routes, $confDir, $pattern)
     {
         $configExtensions = $this->getConfigExtensions();
         $reversedConfigExtensions = $this->getReversedConfigExtensions();

--- a/src/Sulu/Component/PHPCR/NodeTypes/Path/ContentPropertyDefinition.php
+++ b/src/Sulu/Component/PHPCR/NodeTypes/Path/ContentPropertyDefinition.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Component\PHPCR\NodeTypes\Path;
 
+use PHPCR\NodeType\NodeTypeInterface;
 use PHPCR\NodeType\PropertyDefinitionInterface;
 use PHPCR\PropertyType;
 use PHPCR\Version\OnParentVersionAction;
@@ -25,7 +26,7 @@ class ContentPropertyDefinition implements PropertyDefinitionInterface
      * PropertyDefinitionTemplate) that is not attached to a live NodeType. In
      * such cases this method returns null.
      *
-     * @return \PHPCR\NodeType\NodeTypeInterface A NodeType object
+     * @return NodeTypeInterface A NodeType object
      *
      * @api
      */

--- a/src/Sulu/Component/PHPCR/NodeTypes/Path/HistoryPropertyDefinition.php
+++ b/src/Sulu/Component/PHPCR/NodeTypes/Path/HistoryPropertyDefinition.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Component\PHPCR\NodeTypes\Path;
 
+use PHPCR\NodeType\NodeTypeInterface;
 use PHPCR\NodeType\PropertyDefinitionInterface;
 use PHPCR\PropertyType;
 use PHPCR\Version\OnParentVersionAction;
@@ -25,7 +26,7 @@ class HistoryPropertyDefinition implements PropertyDefinitionInterface
      * PropertyDefinitionTemplate) that is not attached to a live NodeType. In
      * such cases this method returns null.
      *
-     * @return \PHPCR\NodeType\NodeTypeInterface A NodeType object
+     * @return NodeTypeInterface A NodeType object
      *
      * @api
      */

--- a/src/Sulu/Component/PHPCR/SessionManager/SessionManager.php
+++ b/src/Sulu/Component/PHPCR/SessionManager/SessionManager.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Component\PHPCR\SessionManager;
 
+use PHPCR\PathNotFoundException;
 use PHPCR\SessionInterface;
 
 class SessionManager implements SessionManagerInterface
@@ -97,7 +98,7 @@ class SessionManager implements SessionManagerInterface
 
         try {
             $node = $this->getSession()->getNode($nodePath);
-        } catch (\PHPCR\PathNotFoundException $e) {
+        } catch (PathNotFoundException $e) {
             $node = $this->getSession()->getNode($snippetPath)->addNode($templateKey);
         }
 

--- a/src/Sulu/Component/PHPCR/SessionManager/SessionManagerInterface.php
+++ b/src/Sulu/Component/PHPCR/SessionManager/SessionManagerInterface.php
@@ -98,7 +98,7 @@ interface SessionManagerInterface
     /**
      * returns the snippet node.
      *
-     * @return \PHPCR\NodeInterface
+     * @return NodeInterface
      *
      * @deprecated Do not use anymore, because the node is always returned from the default session, although multiple
      *             sessions can exist

--- a/src/Sulu/Component/Rest/DQL/Cast.php
+++ b/src/Sulu/Component/Rest/DQL/Cast.php
@@ -13,6 +13,8 @@ namespace Sulu\Component\Rest\DQL;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
 
 /**
  * @deprecated
@@ -24,7 +26,7 @@ class Cast extends FunctionNode
 
     public $unit = null;
 
-    public function parse(\Doctrine\ORM\Query\Parser $parser)
+    public function parse(Parser $parser)
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
@@ -39,7 +41,7 @@ class Cast extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(\Doctrine\ORM\Query\SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker)
     {
         return \sprintf('CAST(%s AS %s)', $this->firstDateExpression->dispatch($sqlWalker), $this->unit);
     }

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -575,7 +575,7 @@ class DoctrineListBuilder extends AbstractListBuilder
      *
      * @param DoctrineJoinDescriptor[]|null $joins Define which joins should be made
      *
-     * @return \Doctrine\ORM\QueryBuilder
+     * @return QueryBuilder
      */
     protected function createQueryBuilder($joins = null)
     {

--- a/src/Sulu/Component/Rest/RestControllerTrait.php
+++ b/src/Sulu/Component/Rest/RestControllerTrait.php
@@ -138,7 +138,7 @@ trait RestControllerTrait
      * @param string $id
      * @param callable $deleteCallback
      *
-     * @return \FOS\RestBundle\View\View
+     * @return View
      */
     public function responseDelete($id, $deleteCallback)
     {

--- a/src/Sulu/Component/Route/RouteDefaultOptionsCompilerPass.php
+++ b/src/Sulu/Component/Route/RouteDefaultOptionsCompilerPass.php
@@ -50,12 +50,6 @@ class RouteDefaultOptionsCompilerPass implements CompilerPassInterface
         // https://github.com/symfony/symfony/pull/31900
         $routeDefaultOptions = $container->getDefinition('routing.loader')->getArgument(1);
 
-        // symfony 4.4 passes the default options on index 2 instead of index 1
-        $deprecatedRouteDefaultOptions = $container->getDefinition('routing.loader')->getArgument(2);
-        if (\is_array($deprecatedRouteDefaultOptions) && isset($deprecatedRouteDefaultOptions['utf8'])) {
-            $routeDefaultOptions = $deprecatedRouteDefaultOptions;
-        }
-
         $container->getDefinition($this->targetService)->replaceArgument(
             $this->targetDefaultOptionsArgument,
             $routeDefaultOptions

--- a/src/Sulu/Component/Security/Authentication/UserRepositoryInterface.php
+++ b/src/Sulu/Component/Security/Authentication/UserRepositoryInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Component\Security\Authentication;
 
+use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
 use Sulu\Component\Persistence\Repository\RepositoryInterface;
 
@@ -45,7 +46,7 @@ interface UserRepositoryInterface extends RepositoryInterface
      * @return UserInterface
      *
      * @throws NoResultException
-     * @throws \Doctrine\ORM\NonUniqueResultException
+     * @throws NonUniqueResultException
      */
     public function findUserWithSecurityById($id);
 

--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
@@ -172,7 +172,7 @@ class WebspaceCollection implements \IteratorAggregate
     }
 
     /**
-     * @param \Sulu\Component\Webspace\Webspace[] $webspaces
+     * @param Webspace[] $webspaces
      */
     public function setWebspaces($webspaces)
     {
@@ -180,7 +180,7 @@ class WebspaceCollection implements \IteratorAggregate
     }
 
     /**
-     * @return \Sulu\Component\Webspace\Webspace[]
+     * @return Webspace[]
      */
     public function getWebspaces()
     {

--- a/src/Sulu/Component/Webspace/Portal.php
+++ b/src/Sulu/Component/Webspace/Portal.php
@@ -209,7 +209,7 @@ class Portal
     /**
      * Sets the environments for this portal.
      *
-     * @param \Sulu\Component\Webspace\Environment[] $environments
+     * @param Environment[] $environments
      */
     public function setEnvironments(array $environments)
     {
@@ -223,7 +223,7 @@ class Portal
     /**
      * Returns the environment for this portal.
      *
-     * @return \Sulu\Component\Webspace\Environment[]
+     * @return Environment[]
      */
     public function getEnvironments()
     {
@@ -237,7 +237,7 @@ class Portal
      *
      * @throws Exception\EnvironmentNotFoundException
      *
-     * @return \Sulu\Component\Webspace\Environment
+     * @return Environment
      */
     public function getEnvironment($type)
     {
@@ -248,16 +248,13 @@ class Portal
         return $this->environments[$type];
     }
 
-    /**
-     * @param \Sulu\Component\Webspace\Webspace $webspace
-     */
     public function setWebspace(Webspace $webspace)
     {
         $this->webspace = $webspace;
     }
 
     /**
-     * @return \Sulu\Component\Webspace\Webspace
+     * @return Webspace
      */
     public function getWebspace()
     {

--- a/src/Sulu/Component/Webspace/PortalInformation.php
+++ b/src/Sulu/Component/Webspace/PortalInformation.php
@@ -147,7 +147,7 @@ class PortalInformation implements ArrayableInterface
     /**
      * Sets the portal for this PortalInformation.
      *
-     * @param \Sulu\Component\Webspace\Portal $portal
+     * @param Portal $portal
      */
     public function setPortal($portal)
     {
@@ -157,7 +157,7 @@ class PortalInformation implements ArrayableInterface
     /**
      * Returns the portal for this PortalInformation.
      *
-     * @return \Sulu\Component\Webspace\Portal
+     * @return Portal
      */
     public function getPortal()
     {
@@ -201,7 +201,7 @@ class PortalInformation implements ArrayableInterface
      *
      * @deprecated Is not set anymore since https://github.com/sulu/sulu/pull/5277
      *
-     * @param \Sulu\Component\Webspace\Segment $segment
+     * @param Segment $segment
      */
     public function setSegment($segment)
     {
@@ -217,7 +217,7 @@ class PortalInformation implements ArrayableInterface
      *
      * @deprecated Is not set anymore since https://github.com/sulu/sulu/pull/5277
      *
-     * @return \Sulu\Component\Webspace\Segment
+     * @return Segment
      */
     public function getSegment()
     {
@@ -307,7 +307,7 @@ class PortalInformation implements ArrayableInterface
     /**
      * Sets the webspace for this PortalInformation.
      *
-     * @param \Sulu\Component\Webspace\Webspace $webspace
+     * @param Webspace $webspace
      */
     public function setWebspace($webspace)
     {
@@ -317,7 +317,7 @@ class PortalInformation implements ArrayableInterface
     /**
      * Returns the webspace for this PortalInformation.
      *
-     * @return \Sulu\Component\Webspace\Webspace
+     * @return Webspace
      */
     public function getWebspace()
     {

--- a/src/Sulu/Component/Webspace/Tests/Unit/Url/WebspaceUrlProviderTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Url/WebspaceUrlProviderTest.php
@@ -16,6 +16,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Component\Webspace\Environment;
 use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\Url;
+use Sulu\Component\Webspace\Url\WebspaceUrlProvider;
 use Sulu\Component\Webspace\Webspace;
 
 class WebspaceUrlProviderTest extends TestCase
@@ -49,7 +50,7 @@ class WebspaceUrlProviderTest extends TestCase
             )
         );
 
-        $provider = new Url\WebspaceUrlProvider();
+        $provider = new WebspaceUrlProvider();
         $this->assertEquals($urls, $provider->getUrls($webspace->reveal(), 'prod'));
     }
 }

--- a/src/Sulu/Component/Webspace/Webspace.php
+++ b/src/Sulu/Component/Webspace/Webspace.php
@@ -290,7 +290,7 @@ class Webspace implements ArrayableInterface
     /**
      * Sets the portals of this webspace.
      *
-     * @param \Sulu\Component\Webspace\Portal[] $portals
+     * @param Portal[] $portals
      */
     public function setPortals($portals)
     {
@@ -300,7 +300,7 @@ class Webspace implements ArrayableInterface
     /**
      * Returns the portals of this webspace.
      *
-     * @return \Sulu\Component\Webspace\Portal[]
+     * @return Portal[]
      */
     public function getPortals()
     {
@@ -322,7 +322,7 @@ class Webspace implements ArrayableInterface
     /**
      * Sets the segments of this webspace.
      *
-     * @param \Sulu\Component\Webspace\Segment[] $segments
+     * @param Segment[] $segments
      */
     public function setSegments($segments)
     {
@@ -332,7 +332,7 @@ class Webspace implements ArrayableInterface
     /**
      * Returns the segments of this webspace.
      *
-     * @return \Sulu\Component\Webspace\Segment[]
+     * @return Segment[]
      */
     public function getSegments()
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | 
| Related issues/PRs | #6556 
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Upgrade deprecated symfony method calls.

#### Why?

To make sulu compatible with symfony 6 in future.
