### PR TITLE
Fix passconfig type for document manager event registerlistenerpass

### DIFF
--- a/src/Sulu/Bundle/DocumentManagerBundle/SuluDocumentManagerBundle.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/SuluDocumentManagerBundle.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\DocumentManagerBundle;
 
 use Sulu\Bundle\DocumentManagerBundle\DependencyInjection\Compiler\DocumentFixturePass;
 use Sulu\Bundle\DocumentManagerBundle\DependencyInjection\Compiler\InitializerPass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -27,7 +28,7 @@ class SuluDocumentManagerBundle extends Bundle
             'sulu_document_manager.event_dispatcher',
             'sulu_document_manager.event_listener',
             'sulu_document_manager.event_subscriber'
-        ));
+        ), PassConfig::TYPE_BEFORE_REMOVING);
         $container->addCompilerPass(new DocumentFixturePass());
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #6556 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix passconfig type for document maanger event registerlistenerpass.

#### Why?

For Symfony 6 support. Else the following error happens:

>  Class "" used for service "security.listener.session.test" cannot be found.

This is the same type as symfony framework bundle uses for the same compilerpass: https://github.com/symfony/symfony/blob/fe63f83daab08ecd1d44c33cb7e007014777cd78/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php#L133.