### PR TITLE
Render add button when hovering space between blocks

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -87,7 +87,7 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
         }
     };
 
-    @action handleAddBlock = (index: number) => {
+    @action handleAddBlock = (insertionIndex: number) => {
         const {defaultType, onChange, value} = this.props;
 
         if (this.hasMaximumReached()) {
@@ -95,11 +95,11 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
         }
 
         if (value) {
-            this.expandedBlocks.splice(index, 0, true);
-            this.generatedBlockIds.splice(index, 0, ++BlockCollection.idCounter);
+            this.expandedBlocks.splice(insertionIndex, 0, true);
+            this.generatedBlockIds.splice(insertionIndex, 0, ++BlockCollection.idCounter);
 
-            const elementsBefore = value.slice(0, index);
-            const elementsAfter = value.slice(index);
+            const elementsBefore = value.slice(0, insertionIndex);
+            const elementsAfter = value.slice(insertionIndex);
             // $FlowFixMe
             onChange([...elementsBefore, {type: defaultType}, ...elementsAfter]);
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -98,9 +98,9 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
             this.expandedBlocks.splice(index, 0, true);
             this.generatedBlockIds.splice(index, 0, ++BlockCollection.idCounter);
 
-            // $FlowFixMe
             const elementsBefore = value.slice(0, index);
             const elementsAfter = value.slice(index);
+            // $FlowFixMe
             onChange([...elementsBefore, {type: defaultType}, ...elementsAfter]);
         }
     };
@@ -183,8 +183,9 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
                     className={blockCollectionStyles.addButton}
                     disabled={disabled || this.hasMaximumReached()}
                     icon="su-plus"
-                    onClick={() => this.handleAddBlock(aboveBlockIndex + 1)}
+                    onClick={this.handleAddBlock}
                     skin="secondary"
+                    value={aboveBlockIndex + 1}
                 >
                     {addButtonText ? addButtonText : translate('sulu_admin.add_block')}
                 </Button>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import {action, observable, toJS, reaction} from 'mobx';
 import {observer} from 'mobx-react';
+import classNames from 'classnames';
 import {arrayMove} from '../../utils';
 import {translate} from '../../utils/Translator';
 import Button from '../Button';
@@ -86,7 +87,7 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
         }
     };
 
-    @action handleAddBlock = () => {
+    @action handleAddBlock = (index: number) => {
         const {defaultType, onChange, value} = this.props;
 
         if (this.hasMaximumReached()) {
@@ -94,11 +95,13 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
         }
 
         if (value) {
-            this.expandedBlocks.push(true);
-            this.generatedBlockIds.push(++BlockCollection.idCounter);
+            this.expandedBlocks.splice(index, 0, true);
+            this.generatedBlockIds.splice(index, 0, ++BlockCollection.idCounter);
 
             // $FlowFixMe
-            onChange([...value, {type: defaultType}]);
+            const elementsBefore = value.slice(0, index);
+            const elementsAfter = value.slice(index);
+            onChange([...elementsBefore, {type: defaultType}, ...elementsAfter]);
         }
     };
 
@@ -163,9 +166,34 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
         return !!minOccurs && value.length <= minOccurs;
     }
 
+    renderAddButton = (aboveBlockIndex: number) => {
+        const {addButtonText, disabled, value} = this.props;
+        const isDividerButton = aboveBlockIndex < value.length - 1;
+
+        const containerClass = classNames(
+            blockCollectionStyles.addButtonContainer,
+            {
+                [blockCollectionStyles.addButtonDivider]: isDividerButton,
+            }
+        );
+
+        return (
+            <div className={containerClass}>
+                <Button
+                    className={blockCollectionStyles.addButton}
+                    disabled={disabled || this.hasMaximumReached()}
+                    icon="su-plus"
+                    onClick={() => this.handleAddBlock(aboveBlockIndex + 1)}
+                    skin="secondary"
+                >
+                    {addButtonText ? addButtonText : translate('sulu_admin.add_block')}
+                </Button>
+            </div>
+        );
+    };
+
     render() {
         const {
-            addButtonText,
             collapsable,
             disabled,
             icons,
@@ -177,7 +205,7 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
         } = this.props;
 
         return (
-            <section className={blockCollectionStyles.blockCollection}>
+            <section>
                 <SortableBlockList
                     disabled={disabled}
                     expandedBlocks={this.expandedBlocks}
@@ -192,18 +220,12 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
                     onSortEnd={this.handleSortEnd}
                     onTypeChange={this.handleTypeChange}
                     renderBlockContent={renderBlockContent}
+                    renderDivider={this.renderAddButton}
                     types={types}
                     useDragHandle={true}
                     value={value}
                 />
-                <Button
-                    disabled={disabled || this.hasMaximumReached()}
-                    icon="su-plus"
-                    onClick={this.handleAddBlock}
-                    skin="secondary"
-                >
-                    {addButtonText ? addButtonText : translate('sulu_admin.add_block')}
-                </Button>
+                {this.renderAddButton(value.length - 1)}
             </section>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlockList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlockList.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import React, {Fragment, Node} from 'react';
 import {observer} from 'mobx-react';
 import {SortableContainer} from 'react-sortable-hoc';
 import classNames from 'classnames';
@@ -19,6 +19,7 @@ type Props<T: string, U: {type: T}> = {|
     onSettingsClick?: (index: number) => void,
     onTypeChange?: (type: T, index: number) => void,
     renderBlockContent: RenderBlockContentCallback<T, U>,
+    renderDivider?: (aboveBlockIndex: number) => Node,
     types?: {[key: T]: string},
     value: Array<U>,
 |};
@@ -80,6 +81,7 @@ class SortableBlockList<T: string, U: {type: T}> extends React.Component<Props<T
             onRemove,
             onSettingsClick,
             renderBlockContent,
+            renderDivider,
             types,
             value,
         } = this.props;
@@ -94,23 +96,28 @@ class SortableBlockList<T: string, U: {type: T}> extends React.Component<Props<T
         return (
             <div className={sortableBlockListClass}>
                 {value && value.map((block, index) => (
-                    <SortableBlock
-                        activeType={block.type}
-                        expanded={!disabled && expandedBlocks[index]}
-                        icons={icons && icons[index]}
-                        index={index}
-                        key={generatedBlockIds[index]}
-                        movable={movable}
-                        onCollapse={onCollapse ? this.handleCollapse : undefined}
-                        onExpand={onExpand ? this.handleExpand : undefined}
-                        onRemove={onRemove ? this.handleRemove : undefined}
-                        onSettingsClick={onSettingsClick ? this.handleSettingsClick : undefined}
-                        onTypeChange={this.handleTypeChange}
-                        renderBlockContent={renderBlockContent}
-                        sortIndex={index}
-                        types={types}
-                        value={block}
-                    />
+                    <Fragment key={index}>
+                        <SortableBlock
+                            activeType={block.type}
+                            expanded={!disabled && expandedBlocks[index]}
+                            icons={icons && icons[index]}
+                            index={index}
+                            key={generatedBlockIds[index]}
+                            movable={movable}
+                            onCollapse={onCollapse ? this.handleCollapse : undefined}
+                            onExpand={onExpand ? this.handleExpand : undefined}
+                            onRemove={onRemove ? this.handleRemove : undefined}
+                            onSettingsClick={onSettingsClick ? this.handleSettingsClick : undefined}
+                            onTypeChange={this.handleTypeChange}
+                            renderBlockContent={renderBlockContent}
+                            sortIndex={index}
+                            types={types}
+                            value={block}
+                        />
+                        {renderDivider && index < value.length - 1 && (
+                            renderDivider(index)
+                        )}
+                    </Fragment>
                 ))}
             </div>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlockList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlockList.js
@@ -1,11 +1,12 @@
 // @flow
-import React, {Fragment, Node} from 'react';
+import React, {Fragment} from 'react';
 import {observer} from 'mobx-react';
 import {SortableContainer} from 'react-sortable-hoc';
 import classNames from 'classnames';
 import SortableBlock from './SortableBlock';
 import sortableBlockListStyles from './sortableBlockList.scss';
 import type {RenderBlockContentCallback} from './types';
+import type {Node} from 'react';
 
 type Props<T: string, U: {type: T}> = {|
     disabled: boolean,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/blockCollection.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/blockCollection.scss
@@ -1,3 +1,25 @@
-.blockCollection {
+@import './variables.scss';
+
+.addButtonContainer {
     text-align: center;
+}
+
+.addButtonDivider {
+    /* replace margin of block above with container to display button if space between blocks is hovered */
+    margin-top: -$blockMarginBottom;
+    padding-top: $blockMarginBottom;
+    margin-bottom: 0;
+    height: 0;
+
+    .addButton {
+        display: none;
+    }
+
+    /* display button in the middle of the container when container is hovered */
+    &:hover {
+        .addButton {
+            display: unset;
+            transform: translateY(calc(-50% - $blockMarginBottom / 2));
+        }
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/blockCollection.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/blockCollection.scss
@@ -1,4 +1,5 @@
 @import './variables.scss';
+@import '../../containers/Application/colors.scss';
 
 .addButtonContainer {
     text-align: center;
@@ -12,14 +13,17 @@
     height: 0;
 
     .addButton {
-        display: none;
+        transform: translateY(calc(-50% - $blockMarginBottom / 2));
+        box-shadow: 2px 6px 12px 0 rgba($silver, .5);
+        visibility: hidden;
     }
 
     /* display button in the middle of the container when container is hovered */
     &:hover {
         .addButton {
-            display: unset;
-            transform: translateY(calc(-50% - $blockMarginBottom / 2));
+            visibility: unset;
+            transition-property: visibility;
+            transition-delay: .1s;
         }
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/sortableBlockList.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/sortableBlockList.scss
@@ -1,8 +1,10 @@
+@import './variables.scss';
+
 .sortableBlockList {
     text-align: left;
 
     & > * {
-        margin-bottom: 10px;
+        margin-bottom: $blockMarginBottom;
     }
 
     &.disabled {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -284,7 +284,28 @@ test('Should allow to reorder blocks by using drag and drop', () => {
     expect(blockCollection.instance().generatedBlockIds.toJS()).toEqual([2, 3, 1]);
 });
 
-test('Should allow to add a new block', () => {
+test('Should allow to add a new block between existing blocks', () => {
+    const changeSpy = jest.fn();
+    const value = [{content: 'Test 1', type: 'editor'}, {content: 'Test 2', type: 'editor'}];
+    const blockCollection = mount(
+        <BlockCollection
+            defaultType="editor"
+            onChange={changeSpy}
+            renderBlockContent={jest.fn()}
+            value={value}
+        />
+    );
+
+    blockCollection.find('Button[icon="su-plus"]').at(0).simulate('click');
+
+    expect(changeSpy).toBeCalledWith([
+        {content: 'Test 1', type: 'editor'},
+        {type: 'editor'},
+        {content: 'Test 2', type: 'editor'},
+    ]);
+});
+
+test('Should allow to add a new block at the end', () => {
     const changeSpy = jest.fn();
     const value = [{content: 'Test 1', type: 'editor'}, {content: 'Test 2', type: 'editor'}];
     const blockCollection = mount(

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -56,7 +56,7 @@ test('Should render a disabled block list', () => {
     );
 
     expect(blockCollection.find('.sortableBlockList.disabled')).toHaveLength(1);
-    expect(blockCollection.find('Button[icon="su-plus"]').prop('disabled')).toEqual(true);
+    expect(blockCollection.find('Button[icon="su-plus"]').last().prop('disabled')).toEqual(true);
 });
 
 test('Should mark the add button disabled if maxOccurs is reached', () => {
@@ -287,7 +287,7 @@ test('Should allow to reorder blocks by using drag and drop', () => {
 test('Should allow to add a new block', () => {
     const changeSpy = jest.fn();
     const value = [{content: 'Test 1', type: 'editor'}, {content: 'Test 2', type: 'editor'}];
-    const blockCollection = shallow(
+    const blockCollection = mount(
         <BlockCollection
             defaultType="editor"
             onChange={changeSpy}
@@ -296,7 +296,7 @@ test('Should allow to add a new block', () => {
         />
     );
 
-    blockCollection.find('Button').simulate('click');
+    blockCollection.find('Button[icon="su-plus"]').last().simulate('click');
 
     expect(changeSpy).toBeCalledWith([...value, {type: 'editor'}]);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/BlockCollection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/BlockCollection.test.js.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Should render a fully filled block list 1`] = `
-<section
-  class="blockCollection"
->
+<section>
   <div
     class="sortableBlockList"
   >
@@ -38,6 +36,24 @@ exports[`Should render a fully filled block list 1`] = `
         />
       </div>
     </section>
+    <div
+      class="addButtonContainer addButtonDivider"
+    >
+      <button
+        class="button secondary hasText addButton"
+        type="button"
+      >
+        <span
+          aria-label="su-plus"
+          class="su-plus buttonIcon"
+        />
+        <span
+          class="buttonText"
+        >
+          Add block
+        </span>
+      </button>
+    </div>
     <section
       class="block"
       role="switch"
@@ -75,27 +91,29 @@ exports[`Should render a fully filled block list 1`] = `
       </div>
     </section>
   </div>
-  <button
-    class="button secondary hasText"
-    type="button"
+  <div
+    class="addButtonContainer"
   >
-    <span
-      aria-label="su-plus"
-      class="su-plus buttonIcon"
-    />
-    <span
-      class="buttonText"
+    <button
+      class="button secondary hasText addButton"
+      type="button"
     >
-      Add block
-    </span>
-  </button>
+      <span
+        aria-label="su-plus"
+        class="su-plus buttonIcon"
+      />
+      <span
+        class="buttonText"
+      >
+        Add block
+      </span>
+    </button>
+  </div>
 </section>
 `;
 
 exports[`Should render a non-movable block list 1`] = `
-<section
-  class="blockCollection"
->
+<section>
   <div
     class="sortableBlockList"
   >
@@ -125,6 +143,24 @@ exports[`Should render a non-movable block list 1`] = `
         />
       </div>
     </section>
+    <div
+      class="addButtonContainer addButtonDivider"
+    >
+      <button
+        class="button secondary hasText addButton"
+        type="button"
+      >
+        <span
+          aria-label="su-plus"
+          class="su-plus buttonIcon"
+        />
+        <span
+          class="buttonText"
+        >
+          Add block
+        </span>
+      </button>
+    </div>
     <section
       class="block expanded"
       role="switch"
@@ -152,19 +188,23 @@ exports[`Should render a non-movable block list 1`] = `
       </div>
     </section>
   </div>
-  <button
-    class="button secondary hasText"
-    type="button"
+  <div
+    class="addButtonContainer"
   >
-    <span
-      aria-label="su-plus"
-      class="su-plus buttonIcon"
-    />
-    <span
-      class="buttonText"
+    <button
+      class="button secondary hasText addButton"
+      type="button"
     >
-      Add block
-    </span>
-  </button>
+      <span
+        aria-label="su-plus"
+        class="su-plus buttonIcon"
+      />
+      <span
+        class="buttonText"
+      >
+        Add block
+      </span>
+    </button>
+  </div>
 </section>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/variables.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/variables.scss
@@ -1,0 +1,1 @@
+$blockMarginBottom: 10px;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Render block with schema 1`] = `
-<section
-  class="blockCollection"
->
+<section>
   <div
     class="sortableBlockList"
   >
@@ -113,6 +111,24 @@ exports[`Render block with schema 1`] = `
         </article>
       </div>
     </section>
+    <div
+      class="addButtonContainer addButtonDivider"
+    >
+      <button
+        class="button secondary hasText addButton"
+        type="button"
+      >
+        <span
+          aria-label="su-plus"
+          class="su-plus buttonIcon"
+        />
+        <span
+          class="buttonText"
+        >
+          sulu_admin.add_block
+        </span>
+      </button>
+    </div>
     <section
       class="block expanded"
       role="switch"
@@ -220,27 +236,29 @@ exports[`Render block with schema 1`] = `
       </div>
     </section>
   </div>
-  <button
-    class="button secondary hasText"
-    type="button"
+  <div
+    class="addButtonContainer"
   >
-    <span
-      aria-label="su-plus"
-      class="su-plus buttonIcon"
-    />
-    <span
-      class="buttonText"
+    <button
+      class="button secondary hasText addButton"
+      type="button"
     >
-      sulu_admin.add_block
-    </span>
-  </button>
+      <span
+        aria-label="su-plus"
+        class="su-plus buttonIcon"
+      />
+      <span
+        class="buttonText"
+      >
+        sulu_admin.add_block
+      </span>
+    </button>
+  </div>
 </section>
 `;
 
 exports[`Render block with schema and error on fields already being modified 1`] = `
-<section
-  class="blockCollection"
->
+<section>
   <div
     class="sortableBlockList"
   >
@@ -321,6 +339,24 @@ exports[`Render block with schema and error on fields already being modified 1`]
         </article>
       </div>
     </section>
+    <div
+      class="addButtonContainer addButtonDivider"
+    >
+      <button
+        class="button secondary hasText addButton"
+        type="button"
+      >
+        <span
+          aria-label="su-plus"
+          class="su-plus buttonIcon"
+        />
+        <span
+          class="buttonText"
+        >
+          sulu_admin.add_block
+        </span>
+      </button>
+    </div>
     <section
       class="block expanded"
       role="switch"
@@ -401,6 +437,24 @@ exports[`Render block with schema and error on fields already being modified 1`]
         </article>
       </div>
     </section>
+    <div
+      class="addButtonContainer addButtonDivider"
+    >
+      <button
+        class="button secondary hasText addButton"
+        type="button"
+      >
+        <span
+          aria-label="su-plus"
+          class="su-plus buttonIcon"
+        />
+        <span
+          class="buttonText"
+        >
+          sulu_admin.add_block
+        </span>
+      </button>
+    </div>
     <section
       class="block expanded"
       role="switch"
@@ -479,27 +533,29 @@ exports[`Render block with schema and error on fields already being modified 1`]
       </div>
     </section>
   </div>
-  <button
-    class="button secondary hasText"
-    type="button"
+  <div
+    class="addButtonContainer"
   >
-    <span
-      aria-label="su-plus"
-      class="su-plus buttonIcon"
-    />
-    <span
-      class="buttonText"
+    <button
+      class="button secondary hasText addButton"
+      type="button"
     >
-      sulu_admin.add_block
-    </span>
-  </button>
+      <span
+        aria-label="su-plus"
+        class="su-plus buttonIcon"
+      />
+      <span
+        class="buttonText"
+      >
+        sulu_admin.add_block
+      </span>
+    </button>
+  </div>
 </section>
 `;
 
 exports[`Render block with schema and error on fields already being modified 2`] = `
-<section
-  class="blockCollection"
->
+<section>
   <div
     class="sortableBlockList"
   >
@@ -580,6 +636,24 @@ exports[`Render block with schema and error on fields already being modified 2`]
         </article>
       </div>
     </section>
+    <div
+      class="addButtonContainer addButtonDivider"
+    >
+      <button
+        class="button secondary hasText addButton"
+        type="button"
+      >
+        <span
+          aria-label="su-plus"
+          class="su-plus buttonIcon"
+        />
+        <span
+          class="buttonText"
+        >
+          sulu_admin.add_block
+        </span>
+      </button>
+    </div>
     <section
       class="block expanded"
       role="switch"
@@ -660,6 +734,24 @@ exports[`Render block with schema and error on fields already being modified 2`]
         </article>
       </div>
     </section>
+    <div
+      class="addButtonContainer addButtonDivider"
+    >
+      <button
+        class="button secondary hasText addButton"
+        type="button"
+      >
+        <span
+          aria-label="su-plus"
+          class="su-plus buttonIcon"
+        />
+        <span
+          class="buttonText"
+        >
+          sulu_admin.add_block
+        </span>
+      </button>
+    </div>
     <section
       class="block expanded"
       role="switch"
@@ -741,27 +833,29 @@ exports[`Render block with schema and error on fields already being modified 2`]
       </div>
     </section>
   </div>
-  <button
-    class="button secondary hasText"
-    type="button"
+  <div
+    class="addButtonContainer"
   >
-    <span
-      aria-label="su-plus"
-      class="su-plus buttonIcon"
-    />
-    <span
-      class="buttonText"
+    <button
+      class="button secondary hasText addButton"
+      type="button"
     >
-      sulu_admin.add_block
-    </span>
-  </button>
+      <span
+        aria-label="su-plus"
+        class="su-plus buttonIcon"
+      />
+      <span
+        class="buttonText"
+      >
+        sulu_admin.add_block
+      </span>
+    </button>
+  </div>
 </section>
 `;
 
 exports[`Render collapsed blocks with block previews 1`] = `
-<section
-  class="blockCollection"
->
+<section>
   <div
     class="sortableBlockList"
   >
@@ -810,6 +904,24 @@ exports[`Render collapsed blocks with block previews 1`] = `
         </article>
       </div>
     </section>
+    <div
+      class="addButtonContainer addButtonDivider"
+    >
+      <button
+        class="button secondary hasText addButton"
+        type="button"
+      >
+        <span
+          aria-label="su-plus"
+          class="su-plus buttonIcon"
+        />
+        <span
+          class="buttonText"
+        >
+          sulu_admin.add_block
+        </span>
+      </button>
+    </div>
     <section
       class="block"
       role="switch"
@@ -856,27 +968,29 @@ exports[`Render collapsed blocks with block previews 1`] = `
       </div>
     </section>
   </div>
-  <button
-    class="button secondary hasText"
-    type="button"
+  <div
+    class="addButtonContainer"
   >
-    <span
-      aria-label="su-plus"
-      class="su-plus buttonIcon"
-    />
-    <span
-      class="buttonText"
+    <button
+      class="button secondary hasText addButton"
+      type="button"
     >
-      sulu_admin.add_block
-    </span>
-  </button>
+      <span
+        aria-label="su-plus"
+        class="su-plus buttonIcon"
+      />
+      <span
+        class="buttonText"
+      >
+        sulu_admin.add_block
+      </span>
+    </button>
+  </div>
 </section>
 `;
 
 exports[`Render collapsed blocks with block previews 2`] = `
-<section
-  class="blockCollection"
->
+<section>
   <div
     class="sortableBlockList"
   >
@@ -926,6 +1040,24 @@ exports[`Render collapsed blocks with block previews 2`] = `
         </article>
       </div>
     </section>
+    <div
+      class="addButtonContainer addButtonDivider"
+    >
+      <button
+        class="button secondary hasText addButton"
+        type="button"
+      >
+        <span
+          aria-label="su-plus"
+          class="su-plus buttonIcon"
+        />
+        <span
+          class="buttonText"
+        >
+          sulu_admin.add_block
+        </span>
+      </button>
+    </div>
     <section
       class="block"
       role="switch"
@@ -973,27 +1105,29 @@ exports[`Render collapsed blocks with block previews 2`] = `
       </div>
     </section>
   </div>
-  <button
-    class="button secondary hasText"
-    type="button"
+  <div
+    class="addButtonContainer"
   >
-    <span
-      aria-label="su-plus"
-      class="su-plus buttonIcon"
-    />
-    <span
-      class="buttonText"
+    <button
+      class="button secondary hasText addButton"
+      type="button"
     >
-      sulu_admin.add_block
-    </span>
-  </button>
+      <span
+        aria-label="su-plus"
+        class="su-plus buttonIcon"
+      />
+      <span
+        class="buttonText"
+      >
+        sulu_admin.add_block
+      </span>
+    </button>
+  </div>
 </section>
 `;
 
 exports[`Render collapsed blocks with block previews and sections 1`] = `
-<section
-  class="blockCollection"
->
+<section>
   <div
     class="sortableBlockList"
   >
@@ -1040,6 +1174,24 @@ exports[`Render collapsed blocks with block previews and sections 1`] = `
         </article>
       </div>
     </section>
+    <div
+      class="addButtonContainer addButtonDivider"
+    >
+      <button
+        class="button secondary hasText addButton"
+        type="button"
+      >
+        <span
+          aria-label="su-plus"
+          class="su-plus buttonIcon"
+        />
+        <span
+          class="buttonText"
+        >
+          sulu_admin.add_block
+        </span>
+      </button>
+    </div>
     <section
       class="block"
       role="switch"
@@ -1084,27 +1236,29 @@ exports[`Render collapsed blocks with block previews and sections 1`] = `
       </div>
     </section>
   </div>
-  <button
-    class="button secondary hasText"
-    type="button"
+  <div
+    class="addButtonContainer"
   >
-    <span
-      aria-label="su-plus"
-      class="su-plus buttonIcon"
-    />
-    <span
-      class="buttonText"
+    <button
+      class="button secondary hasText addButton"
+      type="button"
     >
-      sulu_admin.add_block
-    </span>
-  </button>
+      <span
+        aria-label="su-plus"
+        class="su-plus buttonIcon"
+      />
+      <span
+        class="buttonText"
+      >
+        sulu_admin.add_block
+      </span>
+    </button>
+  </div>
 </section>
 `;
 
 exports[`Render collapsed blocks with block previews without tags 1`] = `
-<section
-  class="blockCollection"
->
+<section>
   <div
     class="sortableBlockList"
   >
@@ -1154,6 +1308,24 @@ exports[`Render collapsed blocks with block previews without tags 1`] = `
         </article>
       </div>
     </section>
+    <div
+      class="addButtonContainer addButtonDivider"
+    >
+      <button
+        class="button secondary hasText addButton"
+        type="button"
+      >
+        <span
+          aria-label="su-plus"
+          class="su-plus buttonIcon"
+        />
+        <span
+          class="buttonText"
+        >
+          sulu_admin.add_block
+        </span>
+      </button>
+    </div>
     <section
       class="block"
       role="switch"
@@ -1201,27 +1373,29 @@ exports[`Render collapsed blocks with block previews without tags 1`] = `
       </div>
     </section>
   </div>
-  <button
-    class="button secondary hasText"
-    type="button"
+  <div
+    class="addButtonContainer"
   >
-    <span
-      aria-label="su-plus"
-      class="su-plus buttonIcon"
-    />
-    <span
-      class="buttonText"
+    <button
+      class="button secondary hasText addButton"
+      type="button"
     >
-      sulu_admin.add_block
-    </span>
-  </button>
+      <span
+        aria-label="su-plus"
+        class="su-plus buttonIcon"
+      />
+      <span
+        class="buttonText"
+      >
+        sulu_admin.add_block
+      </span>
+    </button>
+  </div>
 </section>
 `;
 
 exports[`Render collapsed blocks with block previews without tags and with sections 1`] = `
-<section
-  class="blockCollection"
->
+<section>
   <div
     class="sortableBlockList"
   >
@@ -1271,6 +1445,24 @@ exports[`Render collapsed blocks with block previews without tags and with secti
         </article>
       </div>
     </section>
+    <div
+      class="addButtonContainer addButtonDivider"
+    >
+      <button
+        class="button secondary hasText addButton"
+        type="button"
+      >
+        <span
+          aria-label="su-plus"
+          class="su-plus buttonIcon"
+        />
+        <span
+          class="buttonText"
+        >
+          sulu_admin.add_block
+        </span>
+      </button>
+    </div>
     <section
       class="block"
       role="switch"
@@ -1318,19 +1510,23 @@ exports[`Render collapsed blocks with block previews without tags and with secti
       </div>
     </section>
   </div>
-  <button
-    class="button secondary hasText"
-    type="button"
+  <div
+    class="addButtonContainer"
   >
-    <span
-      aria-label="su-plus"
-      class="su-plus buttonIcon"
-    />
-    <span
-      class="buttonText"
+    <button
+      class="button secondary hasText addButton"
+      type="button"
     >
-      sulu_admin.add_block
-    </span>
-  </button>
+      <span
+        aria-label="su-plus"
+        class="su-plus buttonIcon"
+      />
+      <span
+        class="buttonText"
+      >
+        sulu_admin.add_block
+      </span>
+    </button>
+  </div>
 </section>
 `;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Fixed tickets | fixes https://github.com/sulu/sulu/issues/6103
| License | MIT

#### What's in this PR?

This PR adjusts the `BlockCollection` component to render a button for adding a new block if the space between two blocks is hovered.

#### Why?

See https://github.com/sulu/sulu/issues/6103
