### PR TITLE
Add missing return types to mocked test instances

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Entity/CollaborationRepository.php
+++ b/src/Sulu/Bundle/AdminBundle/Entity/CollaborationRepository.php
@@ -35,10 +35,6 @@ class CollaborationRepository
     {
         $cacheItem = $this->cache->getItem($this->getCacheId($resourceKey, $id));
 
-        if (!$cacheItem) {
-            return null;
-        }
-
         $collaborations = $cacheItem->get();
 
         if (!$collaborations) {

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Navigation/NavigationRegistryTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Navigation/NavigationRegistryTest.php
@@ -182,6 +182,9 @@ class NavigationRegistryTest extends TestCase
         $this->viewRegistry->findViewByName('view1')->shouldBeCalled()
             ->willReturn($view1->reveal())->shouldBeCalledTimes(1);
 
+        $this->translator->trans(Argument::cetera())
+            ->willReturnArgument(0);
+
         $this->navigationRegistry->getNavigationItems();
     }
 
@@ -208,6 +211,9 @@ class NavigationRegistryTest extends TestCase
 
         $this->viewRegistry->getViews()->willReturn([$view1, $view11, $view21]);
         $this->viewRegistry->findViewByName('view1')->willReturn($view1);
+
+        $this->translator->trans(Argument::cetera())
+            ->willReturnArgument(0);
 
         $navigation = $this->navigationRegistry->getNavigationItems();
 
@@ -239,6 +245,9 @@ class NavigationRegistryTest extends TestCase
         $this->viewRegistry->getViews()->willReturn([$view1, $view2]);
         $this->viewRegistry->findViewByName('view1')->willReturn($view1);
         $this->viewRegistry->findViewByName('view2')->willReturn($view2);
+
+        $this->translator->trans(Argument::cetera())
+            ->willReturnArgument(0);
 
         $navigationItems = $this->navigationRegistry->getNavigationItems();
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Navigation/NavigationRegistryTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Navigation/NavigationRegistryTest.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\AdminBundle\Tests\Unit\Admin\Navigation;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\AdminBundle\Admin\Admin;
 use Sulu\Bundle\AdminBundle\Admin\AdminPool;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItem;
@@ -32,27 +33,27 @@ class NavigationRegistryTest extends TestCase
     protected $navigationRegistry;
 
     /**
-     * @var ViewRegistry
+     * @var ObjectProphecy<ViewRegistry>
      */
     protected $viewRegistry;
 
     /**
-     * @var AdminPool
+     * @var ObjectProphecy<AdminPool>
      */
     protected $adminPool;
 
     /**
-     * @var Admin
+     * @var ObjectProphecy<Admin>
      */
     protected $admin1;
 
     /**
-     * @var Admin
+     * @var ObjectProphecy<Admin>
      */
     protected $admin2;
 
     /**
-     * @var TranslatorInterface
+     * @var ObjectProphecy<TranslatorInterface>
      */
     protected $translator;
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/DependencyInjection/Compiler/AddAdminPassTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/DependencyInjection/Compiler/AddAdminPassTest.php
@@ -76,14 +76,18 @@ class AddAdminPassTest extends TestCase
         $admins = [];
 
         $poolDefinition->addMethodCall('addAdmin', [$adminDefinition1->reveal()])->will(
-            function() use (&$admins, $adminDefinition1) {
+            function() use (&$admins, $adminDefinition1, $poolDefinition) {
                 $admins[] = $adminDefinition1;
+
+                return $poolDefinition->reveal();
             }
         )->shouldBeCalled();
 
         $poolDefinition->addMethodCall('addAdmin', [$adminDefinition2->reveal()])->will(
-            function() use (&$admins, $adminDefinition2) {
+            function() use (&$admins, $adminDefinition2, $poolDefinition) {
                 $admins[] = $adminDefinition2;
+
+                return $poolDefinition->reveal();
             }
         )->shouldBeCalled();
 
@@ -131,8 +135,10 @@ class AddAdminPassTest extends TestCase
         $admins = [];
 
         $poolDefinition->addMethodCall('addAdmin', [$adminDefinition1->reveal()])->will(
-            function() use (&$admins, $adminDefinition1) {
+            function() use (&$admins, $adminDefinition1, $poolDefinition) {
                 $admins[] = $adminDefinition1;
+
+                return $poolDefinition->reveal();
             }
         )->shouldBeCalled();
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Entity/CollaborationRepositoryTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Entity/CollaborationRepositoryTest.php
@@ -91,6 +91,9 @@ class CollaborationRepositoryTest extends TestCase
     {
         $collaborationRepository = new CollaborationRepository($this->cache->reveal(), 20);
 
+        $cacheItem = new CacheItem();
+        $this->cache->getItem('page_8')->willReturn($cacheItem);
+
         $result = $collaborationRepository->find('page', 8, 'collaboration2');
         $this->assertNull($result);
     }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Entity/CollaborationRepositoryTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Entity/CollaborationRepositoryTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\AdminBundle\Tests\Unit\Entity;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Cache\CacheItemPoolInterface;
 use Sulu\Bundle\AdminBundle\Entity\Collaboration;
 use Sulu\Bundle\AdminBundle\Entity\CollaborationRepository;
@@ -24,7 +25,7 @@ class CollaborationRepositoryTest extends TestCase
     use ProphecyTrait;
 
     /**
-     * @var CacheItemPoolInterface
+     * @var ObjectProphecy<CacheItemPoolInterface>
      */
     private $cache;
 

--- a/src/Sulu/Bundle/CoreBundle/Tests/Unit/DependencyInjection/Compiler/ListBuilderMetadataProviderCompilerPassTest.php
+++ b/src/Sulu/Bundle/CoreBundle/Tests/Unit/DependencyInjection/Compiler/ListBuilderMetadataProviderCompilerPassTest.php
@@ -70,7 +70,7 @@ class ListBuilderMetadataProviderCompilerPassTest extends TestCase
                         return true;
                     }
                 )
-            )->shouldBeCalled();
+            )->shouldBeCalled()->willReturn($definition->reveal());
         } else {
             $container->getDefinition(ListBuilderMetadataProviderCompilerPass::CHAIN_PROVIDER_ID)
                 ->shouldNotBeCalled();

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Document/Subscriber/SecuritySubscriberTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Document/Subscriber/SecuritySubscriberTest.php
@@ -55,8 +55,8 @@ class SecuritySubscriberTest extends TestCase
         $user->getId()->willReturn(2);
         $token->getUser()->willReturn($user->reveal());
 
-        $optionsResolver->setDefault('user', null)->shouldBeCalled();
-        $optionsResolver->setDefault('user', 2)->shouldBeCalled();
+        $optionsResolver->setDefault('user', null)->shouldBeCalled()->willReturn($optionsResolver->reveal());
+        $optionsResolver->setDefault('user', 2)->shouldBeCalled()->willReturn($optionsResolver->reveal());
 
         $this->securitySubscriber->setDefaultUser($event->reveal());
     }
@@ -70,7 +70,7 @@ class SecuritySubscriberTest extends TestCase
 
         $this->tokenStorage->getToken()->willReturn(null);
 
-        $optionsResolver->setDefault('user', null)->shouldBeCalled();
+        $optionsResolver->setDefault('user', null)->shouldBeCalled()->willReturn($optionsResolver->reveal());
 
         $this->securitySubscriber->setDefaultUser($event->reveal());
     }
@@ -85,7 +85,7 @@ class SecuritySubscriberTest extends TestCase
         $anonymousToken = $this->prophesize(AnonymousToken::class);
         $this->tokenStorage->getToken()->willReturn($anonymousToken->reveal());
 
-        $optionsResolver->setDefault('user', null)->shouldBeCalled();
+        $optionsResolver->setDefault('user', null)->shouldBeCalled()->willReturn($optionsResolver->reveal());
 
         $this->securitySubscriber->setDefaultUser($event->reveal());
     }
@@ -102,7 +102,7 @@ class SecuritySubscriberTest extends TestCase
 
         $token->getUser()->willReturn(new \stdClass());
 
-        $optionsResolver->setDefault('user', null)->shouldBeCalled();
+        $optionsResolver->setDefault('user', null)->shouldBeCalled()->willReturn($optionsResolver->reveal());
 
         $this->securitySubscriber->setDefaultUser($event->reveal());
     }

--- a/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/CacheLifetime/CacheLifetimeEnhancerTest.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/CacheLifetime/CacheLifetimeEnhancerTest.php
@@ -119,14 +119,14 @@ class CacheLifetimeEnhancerTest extends TestCase
                 ->set(SuluHttpCache::HEADER_REVERSE_PROXY_TTL, $expectedCacheLifetime)
                 ->shouldBeCalled();
 
-            $this->response->setPublic()->shouldBeCalled();
-            $this->response->setMaxAge($this->maxAge)->shouldBeCalled();
-            $this->response->setSharedMaxAge($this->sharedMaxAge)->shouldBeCalled();
+            $this->response->setPublic()->shouldBeCalled()->willReturn($this->response->reveal());
+            $this->response->setMaxAge($this->maxAge)->shouldBeCalled()->willReturn($this->response->reveal());
+            $this->response->setSharedMaxAge($this->sharedMaxAge)->shouldBeCalled()->willReturn($this->response->reveal());
         } else {
-            $this->responseHeaderBag->set(Argument::cetera())->shouldNotBeCalled();
-            $this->response->setPublic()->shouldNotBeCalled();
-            $this->response->setMaxAge(Argument::any())->shouldNotBeCalled();
-            $this->response->setSharedMaxAge(Argument::any())->shouldNotBeCalled();
+            $this->responseHeaderBag->set(Argument::cetera())->shouldNotBeCalled()->willReturn($this->response->reveal());
+            $this->response->setPublic()->shouldNotBeCalled()->willReturn($this->response->reveal());
+            $this->response->setMaxAge(Argument::any())->shouldNotBeCalled()->willReturn($this->response->reveal());
+            $this->response->setSharedMaxAge(Argument::any())->shouldNotBeCalled()->willReturn($this->response->reveal());
         }
 
         if ($requestCacheLifetime) {

--- a/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/CacheLifetime/CacheLifetimeEnhancerTest.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/CacheLifetime/CacheLifetimeEnhancerTest.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\HttpCacheBundle\Tests\Unit\CacheLifetime;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\HttpCacheBundle\Cache\SuluHttpCache;
 use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeEnhancer;
 use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeRequestStore;
@@ -34,32 +35,32 @@ class CacheLifetimeEnhancerTest extends TestCase
     private $cacheLifetimeEnhancer;
 
     /**
-     * @var CacheLifetimeRequestStore
+     * @var ObjectProphecy<CacheLifetimeRequestStore>
      */
     private $cacheLifetimeRequestStore;
 
     /**
-     * @var CacheLifetimeResolver
+     * @var ObjectProphecy<CacheLifetimeResolver>
      */
     private $cacheLifetimeResolver;
 
     /**
-     * @var PageBridge
+     * @var ObjectProphecy<PageBridge>
      */
     private $page;
 
     /**
-     * @var SnippetBridge
+     * @var ObjectProphecy<SnippetBridge>
      */
     private $snippet;
 
     /**
-     * @var Response
+     * @var ObjectProphecy<Response>
      */
     private $response;
 
     /**
-     * @var ResponseHeaderBag
+     * @var ObjectProphecy<ResponseHeaderBag>
      */
     private $responseHeaderBag;
 

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Listener/MarkupListenerTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Listener/MarkupListenerTest.php
@@ -92,7 +92,9 @@ class MarkupListenerTest extends TestCase
         $this->markupParser->parse('<html><sulu-link href="123-123-123"/></html>', 'de')
             ->willReturn('<html><a href="/test">Page-Title</a></html>')->shouldBeCalled();
 
-        $this->response->setContent('<html><a href="/test">Page-Title</a></html>')->shouldBeCalled();
+        $this->response->setContent('<html><a href="/test">Page-Title</a></html>')
+            ->willReturn($this->response->reveal())
+            ->shouldBeCalled();
 
         $this->listener->replaceMarkup($this->event);
     }

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Listener/MarkupListenerTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Listener/MarkupListenerTest.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\MarkupBundle\Tests\Unit\Listener;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\MarkupBundle\Listener\MarkupListener;
 use Sulu\Bundle\MarkupBundle\Markup\MarkupParserInterface;
 use Symfony\Component\HttpFoundation\HeaderBag;
@@ -27,7 +28,7 @@ class MarkupListenerTest extends TestCase
     use ProphecyTrait;
 
     /**
-     * @var MarkupParserInterface
+     * @var ObjectProphecy<MarkupParserInterface>
      */
     private $markupParser;
 
@@ -37,17 +38,17 @@ class MarkupListenerTest extends TestCase
     private $event;
 
     /**
-     * @var Response
+     * @var ObjectProphecy<Response>
      */
     private $response;
 
     /**
-     * @var HeaderBag
+     * @var ObjectProphecy<HeaderBag>
      */
     private $responseHeaders;
 
     /**
-     * @var Request
+     * @var ObjectProphecy<Request>
      */
     private $request;
 
@@ -57,7 +58,7 @@ class MarkupListenerTest extends TestCase
     private $listener;
 
     /**
-     * @var HttpKernelInterface
+     * @var ObjectProphecy<HttpKernelInterface>
      */
     private $kernel;
 

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/DependencyInjection/RouteGeneratorCompilerPassTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/DependencyInjection/RouteGeneratorCompilerPassTest.php
@@ -64,7 +64,7 @@ class RouteGeneratorCompilerPassTest extends TestCase
                     return 1 === \count($argument) && $argument[$generatorAlias]->__toString() === $serviceId;
                 }
             )
-        )->shouldBeCalled();
+        )->shouldBeCalled()->willReturn($definition->reveal());
 
         $container->getDefinition(RouteGeneratorCompilerPass::SERVICE_ID)->willReturn($definition->reveal());
 
@@ -122,7 +122,7 @@ class RouteGeneratorCompilerPassTest extends TestCase
                     return 0 === \count($argument);
                 }
             )
-        )->shouldBeCalled();
+        )->shouldBeCalled()->willReturn($definition->reveal());
 
         $container->getDefinition(RouteGeneratorCompilerPass::SERVICE_ID)->willReturn($definition->reveal());
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/AppendAnalyticsListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/AppendAnalyticsListenerTest.php
@@ -65,7 +65,8 @@ class AppendAnalyticsListenerTest extends TestCase
         $listener->onResponse($event);
 
         $engine->render(Argument::any(), Argument::any())->shouldNotBeCalled();
-        $response->setContent(Argument::any())->shouldNotBeCalled();
+        $response->setContent(Argument::any())->shouldNotBeCalled()
+            ->willReturn($response->reveal());
     }
 
     public function testBinaryFileResponse()
@@ -91,7 +92,8 @@ class AppendAnalyticsListenerTest extends TestCase
         $listener->onResponse($event);
 
         $engine->render(Argument::any(), Argument::any())->shouldNotBeCalled();
-        $response->setContent(Argument::any())->shouldNotBeCalled();
+        $response->setContent(Argument::any())->shouldNotBeCalled()
+            ->willReturn($response->reveal());
     }
 
     public function testAppendFormat()
@@ -148,7 +150,7 @@ class AppendAnalyticsListenerTest extends TestCase
         $response->getContent()->willReturn('<html><head><title>Test</title></head><body><h1>Title</h1></body></html>');
         $response->setContent(
             '<html><head><title>Test</title><script>var i = 0;</script></head><body><h1>Title</h1></body></html>'
-        )->shouldBeCalled();
+        )->shouldBeCalled()->willReturn($response->reveal());
         $listener->onResponse($event);
     }
 
@@ -206,7 +208,7 @@ class AppendAnalyticsListenerTest extends TestCase
         $response->getContent()->willReturn('<html><head><title>Test</title></head><body><h1>Title</h1></body></html>');
         $response->setContent(
             '<html><head><title>Test</title><script>var i = 0;</script></head><body><h1>Title</h1></body></html>'
-        )->shouldBeCalled();
+        )->shouldBeCalled()->willReturn($response->reveal());
 
         $listener->onResponse($event);
     }
@@ -306,7 +308,7 @@ class AppendAnalyticsListenerTest extends TestCase
             ->willReturn('<html><head><title>Test</title></head><body class="test"><h1>Title</h1></body></html>');
         $response->setContent(
             '<html><head><script>var i = 0;</script><title>Test</title></head><body class="test"><noscript><div>Blabla</div></noscript><h1>Title</h1></body></html>'
-        )->shouldBeCalled();
+        )->shouldBeCalled()->willReturn($response->reveal());
         $listener->onResponse($event);
     }
 
@@ -365,7 +367,7 @@ class AppendAnalyticsListenerTest extends TestCase
             ->willReturn('<html><head><title>Test</title></head><body class="test"><h1>Title</h1></body></html>');
         $response->setContent(
             '<html><head><title>Test</title><script>var i = 0;</script></head><body class="test"><noscript><div>Blabla</div></noscript><h1>Title</h1></body></html>'
-        )->shouldBeCalled();
+        )->shouldBeCalled()->willReturn($response->reveal());
         $listener->onResponse($event);
     }
 
@@ -424,7 +426,7 @@ class AppendAnalyticsListenerTest extends TestCase
             ->willReturn('<html><head maybe-a-attribute-here="true"><title>Test</title></head><body><header><h1>Title</h1></header></body></html>');
         $response->setContent(
             '<html><head maybe-a-attribute-here="true"><script>var nice_var = false;</script><title>Test</title></head><body><header><h1>Title</h1></header></body></html>'
-        )->shouldBeCalled();
+        )->shouldBeCalled()->willReturn($response->reveal());
         $listener->onResponse($event);
     }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Resolver/ParameterResolverTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Resolver/ParameterResolverTest.php
@@ -235,6 +235,7 @@ class ParameterResolverTest extends TestCase
             ->willReturn(['webspaceKey' => 'sulu']);
         $this->webspaceManager->findUrlByResourceLocator('/test', null, 'en')->willReturn('/en/test');
         $this->webspaceManager->findUrlByResourceLocator('/test', null, 'de')->willReturn('/de/test');
+        $this->request->getUri()->willReturn('/');
         $this->requestAnalyzer->getPortal()->willReturn($this->portal->reveal())->shouldBeCalledTimes(1);
         $this->portal->getLocalizations()
             ->willReturn([$localization1->reveal(), $localization2->reveal()])->shouldBeCalledTimes(1);
@@ -313,6 +314,7 @@ class ParameterResolverTest extends TestCase
             ->willReturn(['webspaceKey' => 'sulu']);
         $this->webspaceManager->findUrlByResourceLocator('/test', null, 'en_gb')->willReturn('/en/test');
         $this->webspaceManager->findUrlByResourceLocator('/test', null, 'de_at')->willReturn('/de/test');
+        $this->request->getUri()->willReturn('/');
         $this->requestAnalyzer->getPortal()->willReturn($this->portal->reveal())->shouldBeCalledTimes(1);
         $this->portal->getLocalizations()
             ->willReturn([$localization1->reveal(), $localization2->reveal()])->shouldBeCalledTimes(1);
@@ -395,6 +397,7 @@ class ParameterResolverTest extends TestCase
             ->shouldBeCalled()
             ->willReturn('/de');
         $this->requestAnalyzer->getPortal()->willReturn($this->portal->reveal())->shouldBeCalledTimes(1);
+        $this->request->getUri()->willReturn('/');
         $this->portal->getLocalizations()
             ->willReturn([$localization1->reveal(), $localization2->reveal()])->shouldBeCalledTimes(1);
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RequestListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RequestListenerTest.php
@@ -71,8 +71,10 @@ class RequestListenerTest extends TestCase
         $this->requestContext->hasParameter('prefix')->willReturn(false);
         $this->requestContext->hasParameter('host')->willReturn(false);
 
-        $this->requestContext->setParameter('prefix', 'test/')->shouldBeCalled();
-        $this->requestContext->setParameter('host', 'sulu.io')->shouldBeCalled();
+        $this->requestContext->setParameter('prefix', 'test/')->shouldBeCalled()
+            ->willReturn($this->requestContext->reveal());
+        $this->requestContext->setParameter('host', 'sulu.io')->shouldBeCalled()
+            ->willReturn($this->requestContext->reveal());
 
         $this->router->getContext()->willReturn($this->requestContext);
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RequestListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RequestListenerTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\WebsiteBundle\Tests\Unit\Routing;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\WebsiteBundle\Routing\RequestListener;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\PortalInformation;
@@ -27,34 +28,32 @@ class RequestListenerTest extends TestCase
     use ProphecyTrait;
 
     /**
-     * @var RequestAnalyzerInterface
+     * @var ObjectProphecy<RequestAnalyzerInterface>
      */
     private $requestAnalyzer;
 
     /**
-     * @var RouterInterface
+     * @var ObjectProphecy<RouterInterface>
      */
     private $router;
 
     /**
-     * @var PortalInformation
+     * @var ObjectProphecy<PortalInformation>
      */
     private $portalInformation;
 
     /**
-     * @var RequestContext
+     * @var ObjectProphecy<RequestContext>
      */
     private $requestContext;
 
     /**
-     * @var HttpKernelInterface
+     * @var ObjectProphecy<HttpKernelInterface>
      */
     private $kernel;
 
     public function setUp(): void
     {
-        parent::setUp();
-
         $this->kernel = $this->prophesize(HttpKernelInterface::class);
         $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
         $this->router = $this->prophesize(RouterInterface::class);

--- a/src/Sulu/Component/Rest/Tests/Unit/FlattenExceptionNormalizerTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/FlattenExceptionNormalizerTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\Rest\Tests\Unit\ListBuilder\Filter;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Component\Rest\Exception\ReferencingResourcesFoundException;
 use Sulu\Component\Rest\Exception\RemoveDependantResourcesFoundException;
@@ -165,6 +166,10 @@ class FlattenExceptionNormalizerTest extends TestCase
     {
         $decoratedNormalizer = $this->prophesize(NormalizerInterface::class);
         $translator = $this->prophesize(TranslatorInterface::class);
+        $translator->trans(Argument::cetera())
+            ->will(function($args) {
+                return $args[0];
+            });
 
         $normalizer = new FlattenExceptionNormalizer(
             $decoratedNormalizer->reveal(),
@@ -219,6 +224,10 @@ class FlattenExceptionNormalizerTest extends TestCase
     {
         $decoratedNormalizer = $this->prophesize(NormalizerInterface::class);
         $translator = $this->prophesize(TranslatorInterface::class);
+        $translator->trans(Argument::cetera())
+            ->will(function($args) {
+                return $args[0];
+            });
 
         $normalizer = new FlattenExceptionNormalizer(
             $decoratedNormalizer->reveal(),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #6556 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add missing return types to mocked test instances.

#### Why?

For future Symfony 6 support.
