### PR TITLE
Upgrade UsernamePasswordToken and Token accesses

### DIFF
--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Document/Subscriber/SecuritySubscriberTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Document/Subscriber/SecuritySubscriberTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\User\InMemoryUser;
 
 class SecuritySubscriberTest extends TestCase
 {
@@ -77,6 +78,10 @@ class SecuritySubscriberTest extends TestCase
 
     public function testSetDefaultUserWithAnonymousToken()
     {
+        if (!\class_exists(AnonymousToken::class)) {
+            $this->markTestSkipped('The AnonymousToken is only available on Symfony 5.4');
+        }
+
         $event = $this->prophesize(ConfigureOptionsEvent::class);
 
         $optionsResolver = $this->prophesize(OptionsResolver::class);
@@ -100,7 +105,7 @@ class SecuritySubscriberTest extends TestCase
         $token = $this->prophesize(TokenInterface::class);
         $this->tokenStorage->getToken()->willReturn($token->reveal());
 
-        $token->getUser()->willReturn(new \stdClass());
+        $token->getUser()->willReturn(new InMemoryUser('test', 'test'));
 
         $optionsResolver->setDefault('user', null)->shouldBeCalled()->willReturn($optionsResolver->reveal());
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Mapper/ContentMapperTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Mapper/ContentMapperTest.php
@@ -2692,7 +2692,7 @@ class ContentMapperTest extends SuluTestCase
 
     private function createUserToken(): UsernamePasswordToken
     {
-        return new UsernamePasswordToken($this->getTestUser(), 'testpass', 'fake_provider');
+        return new UsernamePasswordToken($this->getTestUser(), 'testpass');
     }
 
     private function getHomeUuid()

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/NodeRepositoryTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/NodeRepositoryTest.php
@@ -106,7 +106,7 @@ class NodeRepositoryTest extends SuluTestCase
         $this->em->flush();
 
         $this->getContainer()->get('sulu_security.system_store')->setSystem('Sulu');
-        $this->getContainer()->get('security.token_storage')->setToken(new UsernamePasswordToken($user, '', 'test'));
+        $this->getContainer()->get('security.token_storage')->setToken(new UsernamePasswordToken($user, 'test'));
     }
 
     private function prepareGetTestData()

--- a/src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
@@ -411,7 +411,7 @@ class ResettingController
      */
     private function loginUser(UserInterface $user, $request)
     {
-        $token = new UsernamePasswordToken($user, null, 'admin', $user->getRoles());
+        $token = new UsernamePasswordToken($user, 'admin', $user->getRoles());
         $this->tokenStorage->setToken($token); //now the user is logged in
 
         //now dispatch the login event

--- a/src/Sulu/Bundle/SecurityBundle/Domain/Event/UserPasswordResettedEvent.php
+++ b/src/Sulu/Bundle/SecurityBundle/Domain/Event/UserPasswordResettedEvent.php
@@ -46,7 +46,7 @@ class UserPasswordResettedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        return $this->resourceUser->getUsername();
+        return $this->resourceUser->getUserIdentifier();
     }
 
     public function getResourceSecurityContext(): ?string

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Domain/Event/UserPasswordResettedEventTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Domain/Event/UserPasswordResettedEventTest.php
@@ -48,7 +48,7 @@ class UserPasswordResettedEventTest extends TestCase
     public function testGetResourceTitle(): void
     {
         $user = $this->prophesize(UserInterface::class);
-        $user->getUsername()->shouldBeCalled()->willReturn('username');
+        $user->getUserIdentifier()->shouldBeCalled()->willReturn('username');
         $event = new UserPasswordResettedEvent($user->reveal());
 
         $this->assertSame('username', $event->getResourceTitle());

--- a/src/Sulu/Bundle/SecurityBundle/User/UserProvider.php
+++ b/src/Sulu/Bundle/SecurityBundle/User/UserProvider.php
@@ -49,7 +49,7 @@ class UserProvider implements UserProviderInterface
         return $this->loadUserByIdentifier($username);
     }
 
-    public function loadUserByIdentifier(string $identifier)
+    public function loadUserByIdentifier(string $identifier): UserInterface
     {
         $exceptionMessage = \sprintf(
             'Unable to find an Sulu\Component\Security\Authentication\UserInterface object identified by %s',

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Twig/SnippetTwigExtensionTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Twig/SnippetTwigExtensionTest.php
@@ -95,7 +95,7 @@ class SnippetTwigExtensionTest extends SuluTestCase
         );
 
         $user = $this->getContainer()->get('test_user_provider')->getUser();
-        $this->getContainer()->get('security.token_storage')->setToken(new UsernamePasswordToken($user, '', 'test'));
+        $this->getContainer()->get('security.token_storage')->setToken(new UsernamePasswordToken($user, 'test'));
     }
 
     public function testLoadSnippetNotExists()

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Navigation/NavigationMapperTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Navigation/NavigationMapperTest.php
@@ -341,7 +341,7 @@ class NavigationMapperTest extends SuluTestCase
         $userRole->setRole($this->grantedRole);
         $this->getEntityManager()->persist($userRole);
         $this->user->addUserRole($userRole);
-        $this->tokenStorage->setToken(new UsernamePasswordToken($this->user, '', 'test'));
+        $this->tokenStorage->setToken(new UsernamePasswordToken($this->user, 'test'));
 
         $main = $this->navigationMapper->getRootNavigation(
             'sulu_io',
@@ -460,7 +460,7 @@ class NavigationMapperTest extends SuluTestCase
         $userRole->setRole($this->grantedRole);
         $this->getEntityManager()->persist($userRole);
         $this->user->addUserRole($userRole);
-        $this->tokenStorage->setToken(new UsernamePasswordToken($this->user, '', 'test'));
+        $this->tokenStorage->setToken(new UsernamePasswordToken($this->user, 'test'));
 
         $document = $this->createPageDocument();
         $document->setStructureType('simple');

--- a/src/Sulu/Component/Security/Tests/Unit/Authorization/SecurityCheckerTest.php
+++ b/src/Sulu/Component/Security/Tests/Unit/Authorization/SecurityCheckerTest.php
@@ -16,6 +16,7 @@ use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Component\Security\Authorization\SecurityChecker;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
@@ -43,7 +44,8 @@ class SecurityCheckerTest extends TestCase
         parent::setUp();
 
         $this->tokenStorage = $this->prophesize(TokenStorageInterface::class);
-        $this->tokenStorage->getToken()->willReturn(true); // stands for a valid token
+        $token = new NullToken(); // stands for a valid token
+        $this->tokenStorage->getToken()->willReturn($token);
 
         $this->authorizationChecker = $this->prophesize(AuthorizationCheckerInterface::class);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #6556 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Upgrade UsernamePasswordToken and Token accesses.

#### Why?

For future symfony 6 compatibility.
