### PR TITLE
Upgrade RouteProvider and RouteEnhancer compatibility to Symfony 6

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -84,6 +84,22 @@ The Symfony Kernel requires the following return types now:
 
 If a method was overwritten it is required to be updated to the new return types.
 
+### RouteProvider and RouteEnhancer return types changed
+
+The following return types on RouteProviders were added
+which effects `RouteProvider`, `ContentRouteProvider`, `CustomUrlRouteProvider` services:
+
+- `public function getRouteCollectionForRequest(Request $request): RouteCollection`
+- `public function getRouteByName($name): Route`
+- `public function getRoutesByNames($names = null): iterable`
+
+The following return types on the RouteEnhancer were added
+which effects `AbstractEnhancer`, `ExternalLinkEnhancer`, `InternalLinkEnhancer`, `StructureEnhancer` services:
+
+- `public function enhance(array $defaults, Request $request): array`
+
+If a method was overwritten it is required to be updated to the new return types.
+
 ### DoctrineCacheBundle integration removed
 
 All integration of the deprecated DoctrineCacheBundle were removed.

--- a/src/Sulu/Bundle/RouteBundle/Resources/config/routing.xml
+++ b/src/Sulu/Bundle/RouteBundle/Resources/config/routing.xml
@@ -4,7 +4,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="sulu_route.routing.uri_filter_regexp">null</parameter>
+        <parameter key="sulu_route.routing.uri_filter_regexp"></parameter>
     </parameters>
 
     <services>

--- a/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
@@ -91,7 +91,7 @@ class RouteProvider implements RouteProviderInterface
         $this->defaultOptions = $defaultOptions;
     }
 
-    public function getRouteCollectionForRequest(Request $request)
+    public function getRouteCollectionForRequest(Request $request): RouteCollection
     {
         $collection = new RouteCollection();
         $path = $this->decodePathInfo($request->getPathInfo());
@@ -180,7 +180,7 @@ class RouteProvider implements RouteProviderInterface
         return $this->routeCache[$path];
     }
 
-    public function getRouteByName($name)
+    public function getRouteByName($name): Route
     {
         if (0 !== \strpos($name, self::ROUTE_PREFIX)) {
             throw new RouteNotFoundException();
@@ -216,7 +216,7 @@ class RouteProvider implements RouteProviderInterface
         return $this->createRoute($route, $request, $attributes);
     }
 
-    public function getRoutesByNames($names)
+    public function getRoutesByNames($names = null): iterable
     {
         return [];
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
@@ -32,6 +32,7 @@ use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Symfony\Cmf\Component\Routing\RouteProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
@@ -100,7 +101,7 @@ class ContentRouteProvider implements RouteProviderInterface
         $this->defaultOptions = $defaultOptions;
     }
 
-    public function getRouteCollectionForRequest(Request $request)
+    public function getRouteCollectionForRequest(Request $request): RouteCollection
     {
         $collection = new RouteCollection();
 
@@ -259,14 +260,13 @@ class ContentRouteProvider implements RouteProviderInterface
         return $collection;
     }
 
-    public function getRouteByName($name, $parameters = [])
+    public function getRouteByName($name): Route
     {
-        // TODO: Implement getRouteByName() method.
+        throw new RouteNotFoundException();
     }
 
-    public function getRoutesByNames($names, $parameters = [])
+    public function getRoutesByNames($names = null): iterable
     {
-        // TODO
         return [];
     }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RedirectExceptionSubscriberTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RedirectExceptionSubscriberTest.php
@@ -120,9 +120,9 @@ class RedirectExceptionSubscriberTest extends TestCase
         $this->request->getPathInfo()->willReturn('/de/test/');
         $this->request->getRequestFormat()->willReturn('html');
 
-        $this->router->matchRequest(Argument::type(Request::class))->willReturn(
-            $this->prophesize(Route::class)->reveal()
-        );
+        $this->router->matchRequest(Argument::type(Request::class))->willReturn([
+            $this->prophesize(Route::class)->reveal(),
+        ]);
 
         $this->exceptionListener->redirectTrailingSlashOrHtml($this->event);
 
@@ -139,9 +139,9 @@ class RedirectExceptionSubscriberTest extends TestCase
         $this->request->getPathInfo()->willReturn('//');
         $this->request->getRequestFormat()->willReturn('html');
 
-        $this->router->matchRequest(Argument::type(Request::class))->willReturn(
-            $this->prophesize(Route::class)->reveal()
-        );
+        $this->router->matchRequest(Argument::type(Request::class))->willReturn([
+            $this->prophesize(Route::class)->reveal(),
+        ]);
 
         $this->exceptionListener->redirectTrailingSlashOrHtml($this->event);
 
@@ -158,9 +158,9 @@ class RedirectExceptionSubscriberTest extends TestCase
         $this->request->getPathInfo()->willReturn('///');
         $this->request->getRequestFormat()->willReturn('html');
 
-        $this->router->matchRequest(Argument::type(Request::class))->willReturn(
-            $this->prophesize(Route::class)->reveal()
-        );
+        $this->router->matchRequest(Argument::type(Request::class))->willReturn([
+            $this->prophesize(Route::class)->reveal(),
+        ]);
 
         $this->exceptionListener->redirectTrailingSlashOrHtml($this->event);
 
@@ -177,9 +177,9 @@ class RedirectExceptionSubscriberTest extends TestCase
         $this->request->getPathInfo()->willReturn('/de/test.html');
         $this->request->getRequestFormat()->willReturn('html');
 
-        $this->router->matchRequest(Argument::type(Request::class))->willReturn(
-            $this->prophesize(Route::class)->reveal()
-        );
+        $this->router->matchRequest(Argument::type(Request::class))->willReturn([
+            $this->prophesize(Route::class)->reveal(),
+        ]);
 
         $this->exceptionListener->redirectTrailingSlashOrHtml($this->event);
 
@@ -196,9 +196,9 @@ class RedirectExceptionSubscriberTest extends TestCase
         $this->request->getPathInfo()->willReturn('/de/test.json');
         $this->request->getRequestFormat()->willReturn('json');
 
-        $this->router->matchRequest(Argument::type(Request::class))->willReturn(
-            $this->prophesize(Route::class)->reveal()
-        );
+        $this->router->matchRequest(Argument::type(Request::class))->willReturn([
+            $this->prophesize(Route::class)->reveal(),
+        ]);
 
         $this->exceptionListener->redirectTrailingSlashOrHtml($this->event);
 
@@ -241,9 +241,9 @@ class RedirectExceptionSubscriberTest extends TestCase
         $localization->setLanguage('de');
         $this->defaultLocaleProvider->getDefaultLocale()->willReturn($localization);
 
-        $this->router->matchRequest(Argument::type(Request::class))->willReturn(
-            $this->prophesize(Route::class)->reveal()
-        );
+        $this->router->matchRequest(Argument::type(Request::class))->willReturn([
+            $this->prophesize(Route::class)->reveal(),
+        ]);
 
         $this->exceptionListener->redirectPartialMatch($this->event);
 
@@ -273,9 +273,9 @@ class RedirectExceptionSubscriberTest extends TestCase
         $localization->setLanguage('de');
         $this->defaultLocaleProvider->getDefaultLocale()->willReturn($localization);
 
-        $this->router->matchRequest(Argument::type(Request::class))->willReturn(
-            $this->prophesize(Route::class)->reveal()
-        );
+        $this->router->matchRequest(Argument::type(Request::class))->willReturn([
+            $this->prophesize(Route::class)->reveal(),
+        ]);
 
         $this->exceptionListener->redirectPartialMatch($this->event);
 
@@ -309,9 +309,9 @@ class RedirectExceptionSubscriberTest extends TestCase
         $this->urlReplacer->replaceLanguage(Argument::cetera())->shouldBeCalled()->willReturn('sulu.lo/de');
         $this->urlReplacer->replaceLocalization(Argument::cetera())->shouldBeCalled()->willReturn('sulu.lo/de');
 
-        $this->router->matchRequest(Argument::type(Request::class))->willReturn(
-            $this->prophesize(Route::class)->reveal()
-        );
+        $this->router->matchRequest(Argument::type(Request::class))->willReturn([
+            $this->prophesize(Route::class)->reveal(),
+        ]);
 
         $this->exceptionListener->redirectPartialMatch($this->event);
 
@@ -345,9 +345,9 @@ class RedirectExceptionSubscriberTest extends TestCase
         $this->urlReplacer->replaceLanguage(Argument::cetera())->shouldBeCalled()->willReturn('sulu.lo/de');
         $this->urlReplacer->replaceLocalization(Argument::cetera())->shouldBeCalled()->willReturn('sulu.lo/de');
 
-        $this->router->matchRequest(Argument::type(Request::class))->willReturn(
-            $this->prophesize(Route::class)->reveal()
-        );
+        $this->router->matchRequest(Argument::type(Request::class))->willReturn([
+            $this->prophesize(Route::class)->reveal(),
+        ]);
 
         $this->request->getUri()->willReturn('sulu.lo/.json');
 
@@ -394,9 +394,9 @@ class RedirectExceptionSubscriberTest extends TestCase
                     return 'http://sulu.lo/de-at' === $request->getUri();
                 }
             )
-        )->willReturn(
-            $this->prophesize(Route::class)->reveal()
-        );
+        )->willReturn([
+            $this->prophesize(Route::class)->reveal(),
+        ]);
 
         $this->exceptionListener->redirectPartialMatch($this->event);
 
@@ -465,9 +465,9 @@ class RedirectExceptionSubscriberTest extends TestCase
         $this->urlReplacer->replaceLanguage('sulu.lo', 'de')->shouldBeCalled()->willReturn('sulu.lo');
         $this->urlReplacer->replaceLocalization('sulu.lo', 'de-at')->shouldBeCalled()->willReturn('sulu.lo');
 
-        $this->router->matchRequest(Argument::type(Request::class))->willReturn(
-            $this->prophesize(Route::class)->reveal()
-        );
+        $this->router->matchRequest(Argument::type(Request::class))->willReturn([
+            $this->prophesize(Route::class)->reveal(),
+        ]);
 
         $this->exceptionListener->redirectPartialMatch($this->event);
 
@@ -492,9 +492,9 @@ class RedirectExceptionSubscriberTest extends TestCase
         $this->urlReplacer->replaceLanguage(Argument::cetera())->shouldBeCalled()->willReturn('sulu.lo/de-at');
         $this->urlReplacer->replaceLocalization(Argument::cetera())->shouldBeCalled()->willReturn('sulu.lo/de-at');
 
-        $this->router->matchRequest(Argument::type(Request::class))->willReturn(
-            $this->prophesize(Route::class)->reveal()
-        );
+        $this->router->matchRequest(Argument::type(Request::class))->willReturn([
+            $this->prophesize(Route::class)->reveal(),
+        ]);
 
         $this->exceptionListener->redirectPartialMatch($this->event);
 
@@ -573,9 +573,9 @@ class RedirectExceptionSubscriberTest extends TestCase
         $this->urlReplacer->replaceLanguage(Argument::cetera())->shouldBeCalled()->willReturn($redirectUrl);
         $this->urlReplacer->replaceLocalization(Argument::cetera())->shouldBeCalled()->willReturn($redirectUrl);
 
-        $this->router->matchRequest(Argument::type(Request::class))->willReturn(
-            $this->prophesize(Route::class)->reveal()
-        );
+        $this->router->matchRequest(Argument::type(Request::class))->willReturn([
+            $this->prophesize(Route::class)->reveal(),
+        ]);
 
         $this->exceptionListener->redirectPartialMatch($this->event);
 

--- a/src/Sulu/Component/CustomUrl/Routing/CustomUrlRouteProvider.php
+++ b/src/Sulu/Component/CustomUrl/Routing/CustomUrlRouteProvider.php
@@ -18,6 +18,7 @@ use Sulu\Component\DocumentManager\PathBuilder;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Symfony\Cmf\Component\Routing\RouteProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
@@ -58,7 +59,7 @@ class CustomUrlRouteProvider implements RouteProviderInterface
         $this->defaultOptions = $defaultOptions;
     }
 
-    public function getRouteCollectionForRequest(Request $request)
+    public function getRouteCollectionForRequest(Request $request): RouteCollection
     {
         $collection = new RouteCollection();
 
@@ -111,12 +112,12 @@ class CustomUrlRouteProvider implements RouteProviderInterface
         return $collection;
     }
 
-    public function getRouteByName($name)
+    public function getRouteByName($name): Route
     {
-        // TODO: Implement getRouteByName() method.
+        throw new RouteNotFoundException();
     }
 
-    public function getRoutesByNames($names)
+    public function getRoutesByNames($names = null): iterable
     {
         return [];
     }

--- a/src/Sulu/Component/CustomUrl/Routing/Enhancers/AbstractEnhancer.php
+++ b/src/Sulu/Component/CustomUrl/Routing/Enhancers/AbstractEnhancer.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 abstract class AbstractEnhancer implements RouteEnhancerInterface
 {
-    public function enhance(array $defaults, Request $request)
+    public function enhance(array $defaults, Request $request): array
     {
         if ((\array_key_exists('_finalized', $defaults) && true === $defaults['_finalized'])
             || !$this->supports($defaults['_custom_url'])

--- a/src/Sulu/Component/CustomUrl/Routing/Enhancers/ExternalLinkEnhancer.php
+++ b/src/Sulu/Component/CustomUrl/Routing/Enhancers/ExternalLinkEnhancer.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class ExternalLinkEnhancer implements RouteEnhancerInterface
 {
-    public function enhance(array $defaults, Request $request)
+    public function enhance(array $defaults, Request $request): array
     {
         if (!\array_key_exists('_structure', $defaults)
             || Structure::NODE_TYPE_EXTERNAL_LINK !== $defaults['_structure']->getNodeType()

--- a/src/Sulu/Component/CustomUrl/Routing/Enhancers/InternalLinkEnhancer.php
+++ b/src/Sulu/Component/CustomUrl/Routing/Enhancers/InternalLinkEnhancer.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class InternalLinkEnhancer implements RouteEnhancerInterface
 {
-    public function enhance(array $defaults, Request $request)
+    public function enhance(array $defaults, Request $request): array
     {
         if (!\array_key_exists('_structure', $defaults)
             || Structure::NODE_TYPE_INTERNAL_LINK !== $defaults['_structure']->getNodeType()

--- a/src/Sulu/Component/CustomUrl/Routing/Enhancers/StructureEnhancer.php
+++ b/src/Sulu/Component/CustomUrl/Routing/Enhancers/StructureEnhancer.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class StructureEnhancer implements RouteEnhancerInterface
 {
-    public function enhance(array $defaults, Request $request)
+    public function enhance(array $defaults, Request $request): array
     {
         if (!\array_key_exists('_structure', $defaults)) {
             return $defaults;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | yes 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #6556 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Upgrade RouteProvider and RouteEnhancer compatibility to Symfony 6.

#### Why?

For future compatibility with Symfony 6.