### PR TITLE
Upgrade the FlattenExceptionNormalizer for Symfony 6 compatibility

### DIFF
--- a/src/Sulu/Component/Rest/FlattenExceptionNormalizer.php
+++ b/src/Sulu/Component/Rest/FlattenExceptionNormalizer.php
@@ -92,7 +92,7 @@ class FlattenExceptionNormalizer implements ContextAwareNormalizerInterface
         return $data;
     }
 
-    public function supportsNormalization($data, $format = null, array $context = [])
+    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
     {
         return $data instanceof FlattenException && !($context['messenger_serialization'] ?? false);
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #6556 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Upgrade the FlattenExceptionNormalizer for Symfony 6 compatibility.

#### Why?

To be compatible with Symfony 6 in future.
