### PR TITLE
Add compatiblity of CollaborationControllerTest for Symfony 6

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/config.yml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/config.yml
@@ -5,6 +5,8 @@ security:
         - { path: ^/admin/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/admin, roles: ROLE_USER }
 
+    session_fixation_strategy: none # required for the CollaborationControllerTest
+
     firewalls:
         test:
             pattern: ^/


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #6556 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add compatiblity of CollaborationControllerTest for Symfony 6.

#### Why?

For Future Symfony 6 compatibility.
