### PR TITLE
Upgrade $request->get('key') calls on array to $request->all('key');

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
@@ -230,14 +230,15 @@ class RoleController extends AbstractRestController implements ClassResourceInte
             $role->setKey($key);
             $role->setSystem($system);
 
-            $permissions = $request->request->get('permissions');
+            $permissions = $request->request->all('permissions');
+
             if (!empty($permissions)) {
                 foreach ($permissions as $permissionData) {
                     $this->addPermission($role, $permissionData);
                 }
             }
 
-            $securityTypeData = $request->request->get('securityType');
+            $securityTypeData = $request->request->all('securityType');
             if ($this->checkSecurityTypeData($securityTypeData)) {
                 $this->setSecurityType($role, $securityTypeData);
             }
@@ -285,11 +286,11 @@ class RoleController extends AbstractRestController implements ClassResourceInte
                 $role->setKey($key);
                 $role->setSystem($system);
 
-                if (!$this->processPermissions($role, $request->request->get('permissions', []))) {
+                if (!$this->processPermissions($role, $request->request->all('permissions'))) {
                     throw new RestException('Could not update dependencies!');
                 }
 
-                $securityTypeData = $request->request->get('securityType');
+                $securityTypeData = $request->request->all('securityType');
                 if ($this->checkSecurityTypeData($securityTypeData)) {
                     $this->setSecurityType($role, $securityTypeData);
                 } else {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #6556 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Upgrade $request->get('key') calls on array to $request->all('key');

#### Why?

Symfony does not longer allow to fetch an array from InputBag with `get('key')` instead `all('key')` in Symfony 6 need to be used.

All discussions about it see:

 - https://github.com/symfony/symfony/pull/34363
 - https://github.com/symfony/symfony/pull/40315
 - https://github.com/symfony/symfony/pull/41766
