### PR TITLE
Relay deletion errors to snackbar

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -134,6 +134,7 @@ class MediaCollection extends React.Component<Props> {
                     actions={listActions}
                     adapters={mediaListAdapters}
                     onItemClick={onMediaNavigate}
+                    onDeleteError={onDeleteError}
                     ref={mediaListRef}
                     store={mediaListStore}
                 />

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -133,8 +133,8 @@ class MediaCollection extends React.Component<Props> {
                 <List
                     actions={listActions}
                     adapters={mediaListAdapters}
-                    onItemClick={onMediaNavigate}
                     onDeleteError={onDeleteError}
+                    onItemClick={onMediaNavigate}
                     ref={mediaListRef}
                     store={mediaListStore}
                 />


### PR DESCRIPTION
Error messages as a result of deletion failure are not relayed to the snackbar in the media overview. This additional prop definition ensures that.

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

Adds the error handler callback to the List rendering definition of the MediaCollection container.

#### Why?

When delete operations in the Media overview fail, no error message can be relayed to the snackbar.

#### Example Usage

Media controllers can now supply error messages as usual:

```php
return $this->handleView($this->view(['detail' => 'Media cannot be deleted'], Response::HTTP_INTERNAL_SERVER_ERROR));
```
