### PR TITLE
Remove space between toolbar and text area in text editor

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
@@ -78,10 +78,7 @@ $textEditorUnpublishedLinkColor: $gold;
     }
 
     .ck.ck-editor__top {
-        margin-bottom: 10px;
-
         .ck.ck-toolbar {
-            border-radius: $textEditorBorderRadius !important;
             padding: 5px 10px;
 
             &.ck-toolbar_vertical > .ck-toolbar__items > .ck {
@@ -174,7 +171,6 @@ $textEditorUnpublishedLinkColor: $gold;
         }
 
         .ck.ck-content {
-            border-radius: $textEditorBorderRadius !important;
             border-color: $textEditorBackgroundColor !important;
             line-height: 20px;
             min-height: 100px;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

This PR removes the space between the toolbar and the textarea of our text editor.

Before:
<img width="448" alt="Screenshot 2022-05-09 at 12 51 35" src="https://user-images.githubusercontent.com/13310795/167395793-2488b53b-4e4c-4d53-97ac-000c03000486.png">

After:
<img width="448" alt="Screenshot 2022-05-09 at 12 51 58" src="https://user-images.githubusercontent.com/13310795/167395812-ea7ad41f-502e-427f-9524-b1955547d2ff.png">

#### Why?

Because our designer said so 😇 