### PR TITLE
Upgrade document manager cache service definition and http cache return types

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -54,11 +54,54 @@ The `AuthenticationHandler` requires the following changes:
 +public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
 ```
 
+### SuluHttpCache method return types changed
+
+The sulu `SuluHttpCache` requires the following changes:
+
+```diff
+-public function fetch(Request $request, $catch = false)
++public function fetch(Request $request, $catch = false): Response
+-protected function createStore()
++protected function createStore(): StoreInterface
+```
+
+If a method was overwritten it is required to be updated to the new return types.
+
+### DocumentManager cache service definitions changed
+
+The cache services which are activated for `stage` and `prod` environment
+should be upgraded to the new `DoctrineProvider` factory.
+
+Depending on your installation change the `config/packages/sulu_document_manager.yaml`
+or for older skeleton versions `config/packages/prod/sulu_document_manager.yaml` file:
+
+```diff
+services:
+    doctrine_phpcr.meta_cache_provider:
+-        class: Symfony\Component\Cache\DoctrineProvider
++        class: Doctrine\Common\Cache\Psr6\DoctrineProvider
++        factory: ['Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap']
+        public: false
+        arguments:
+            - '@doctrine_phpcr.meta_cache_pool'
+        tags:
+            - { name: 'kernel.reset', method: 'reset' }
+
+    doctrine_phpcr.nodes_cache_provider:
+-        class: Symfony\Component\Cache\DoctrineProvider
++        class: Doctrine\Common\Cache\Psr6\DoctrineProvider
++        factory: ['Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap']
+        public: false
+        arguments:
+            - '@doctrine_phpcr.nodes_cache_pool'
+        tags:
+            - { name: 'kernel.reset', method: 'reset' }
+```
+
 ### WebsiteController methods removed and return types changed
 
 Symfony 6 has deprecated and removed the `get` and `has` methods to access services.
 Instead, the methods from the container should be used:
-
 
 ```diff
 -$this->has('twig');
@@ -83,7 +126,7 @@ The following service changed its definition:
  - `sulu_security.command.create_user`
  - `sulu_security.resetting_controller`
 
- They require now `sulu_security.encoder_factory` instead of `security.encoder_factory`.
+They require now `sulu_security.encoder_factory` instead of `security.encoder_factory`.
 
 ### Kernel Return Types changed
 

--- a/config/packages/sulu_document_manager.yaml
+++ b/config/packages/sulu_document_manager.yaml
@@ -31,7 +31,8 @@ when@prod: &prod
 
     services:
         doctrine_phpcr.meta_cache_provider:
-            class: Symfony\Component\Cache\DoctrineProvider
+            class: Doctrine\Common\Cache\Psr6\DoctrineProvider
+            factory: ['Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap']
             public: false
             arguments:
                 - '@doctrine_phpcr.meta_cache_pool'
@@ -39,7 +40,8 @@ when@prod: &prod
                 - { name: 'kernel.reset', method: 'reset' }
 
         doctrine_phpcr.nodes_cache_provider:
-            class: Symfony\Component\Cache\DoctrineProvider
+            class: Doctrine\Common\Cache\Psr6\DoctrineProvider
+            factory: ['Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap']
             public: false
             arguments:
                 - '@doctrine_phpcr.nodes_cache_pool'

--- a/src/Sulu/Bundle/HttpCacheBundle/Cache/SuluHttpCache.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Cache/SuluHttpCache.php
@@ -24,6 +24,7 @@ use Sulu\Component\HttpKernel\SuluKernel;
 use Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpCache\StoreInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Toflar\Psr6HttpCacheStore\Psr6Store;
@@ -80,15 +81,12 @@ class SuluHttpCache extends HttpCache implements CacheInvalidation
      *
      * {@inheritdoc}
      */
-    public function fetch(Request $request, $catch = false)
+    public function fetch(Request $request, $catch = false): Response
     {
         return parent::fetch($request, $catch);
     }
 
-    /**
-     * @return StoreInterface
-     */
-    protected function createStore()
+    protected function createStore(): StoreInterface
     {
         return new Psr6Store([
             'cache_directory' => $this->cacheDir,

--- a/src/Sulu/Bundle/SecurityBundle/Security/LogoutSuccessHandler.php
+++ b/src/Sulu/Bundle/SecurityBundle/Security/LogoutSuccessHandler.php
@@ -30,6 +30,8 @@ class LogoutSuccessHandler implements LogoutSuccessHandlerInterface
 
     public function __construct(RouterInterface $router)
     {
+        @\trigger_error(__CLASS__ . '() is deprecated since version sulu/sulu 2.5 and will be removed in 3.0. Use LogoutEventSubscriber instead.', \E_USER_DEPRECATED);
+
         $this->router = $router;
     }
 


### PR DESCRIPTION

| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #6556 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Upgrade document manager cache service definition and http cache return types.

#### Why?

For future Symfony 6 support.