### PR TITLE
Add config bridge to symfony 6 security system for tests

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -3,7 +3,7 @@ security:
         strategy: unanimous
         allow_if_all_abstain: true
 
-    encoders:
+    password_hashers:
         Sulu\Bundle\SecurityBundle\Entity\User: bcrypt
 
     providers:
@@ -27,7 +27,6 @@ security:
             security: false
         admin:
             pattern: ^/admin(\/|$)
-            anonymous: true
             lazy: true
             provider: sulu
             entry_point: sulu_security.authentication_entry_point
@@ -37,7 +36,6 @@ security:
                 failure_handler: sulu_security.authentication_handler
             logout:
                 path: sulu_admin.logout
-                success_handler: sulu_security.logout_success_handler
 
 #        website:
 #            pattern: ^/

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/config.php
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/config.php
@@ -9,6 +9,8 @@
  * with this source code in the file LICENSE.
  */
 
+use Symfony\Component\HttpKernel\Kernel;
+
 $filesystem = new \Symfony\Component\Filesystem\Filesystem();
 
 $context = $container->getParameter('sulu.context');
@@ -21,4 +23,18 @@ $loader->import('context_' . $context . '.yml');
 
 if (\class_exists(\Swift_Mailer::class)) {
     $loader->import('swiftmailer.yml');
+}
+
+if ('admin' === $context) {
+    if (\version_compare(Kernel::VERSION, '6.0.0', '>=')) {
+        $loader->import('security-6.yml');
+    } else {
+        $loader->import('security-5-4.yml');
+    }
+}
+
+if (\version_compare(Kernel::VERSION, '6.0.0', '>=')) {
+    $loader->import('symfony-6.yml');
+} else {
+    $loader->import('symfony-5-4.yml');
 }

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/config.php
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/config.php
@@ -9,32 +9,37 @@
  * with this source code in the file LICENSE.
  */
 
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Kernel;
 
-$filesystem = new \Symfony\Component\Filesystem\Filesystem();
+return static function(PhpFileLoader $loader, ContainerBuilder $container) {
+    $filesystem = new Filesystem();
 
-$context = $container->getParameter('sulu.context');
-$path = __DIR__ . \DIRECTORY_SEPARATOR;
-if (!$filesystem->exists($path . 'parameters.yml')) {
-    $filesystem->copy($path . 'parameters.yml.dist', $path . 'parameters.yml');
-}
-$loader->import('parameters.yml');
-$loader->import('context_' . $context . '.yml');
-
-if (\class_exists(\Swift_Mailer::class)) {
-    $loader->import('swiftmailer.yml');
-}
-
-if ('admin' === $context) {
-    if (\version_compare(Kernel::VERSION, '6.0.0', '>=')) {
-        $loader->import('security-6.yml');
-    } else {
-        $loader->import('security-5-4.yml');
+    $context = $container->getParameter('sulu.context');
+    $path = __DIR__ . \DIRECTORY_SEPARATOR;
+    if (!$filesystem->exists($path . 'parameters.yml')) {
+        $filesystem->copy($path . 'parameters.yml.dist', $path . 'parameters.yml');
     }
-}
+    $loader->import('parameters.yml');
+    $loader->import('context_' . $context . '.yml');
 
-if (\version_compare(Kernel::VERSION, '6.0.0', '>=')) {
-    $loader->import('symfony-6.yml');
-} else {
-    $loader->import('symfony-5-4.yml');
-}
+    if (\class_exists(\Swift_Mailer::class)) {
+        $loader->import('swiftmailer.yml');
+    }
+
+    if ('admin' === $context) {
+        if (\version_compare(Kernel::VERSION, '6.0.0', '>=')) {
+            $loader->import('security-6.yml');
+        } else {
+            $loader->import('security-5-4.yml');
+        }
+    }
+
+    if (\version_compare(Kernel::VERSION, '6.0.0', '>=')) {
+        $loader->import('symfony-6.yml');
+    } else {
+        $loader->import('symfony-5-4.yml');
+    }
+};

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/context_admin.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/context_admin.yml
@@ -5,21 +5,6 @@ sulu_admin:
     name: SULU 2.0
     email: installation.email@sulu.test
 
-security:
-    access_decision_manager:
-        strategy: affirmative
-
-    encoders:
-        Sulu\Bundle\SecurityBundle\Entity\User: plaintext
-
-    providers:
-        testprovider:
-            id: test_user_provider
-
-    firewalls:
-        test:
-            http_basic:
-
 sulu_security:
     checker:
         enabled: true

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/security-5-4.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/security-5-4.yml
@@ -1,0 +1,18 @@
+framework:
+    session:
+        storage_id: session.storage.mock_file
+
+security:
+    access_decision_manager:
+        strategy: affirmative
+
+    encoders:
+        Sulu\Bundle\SecurityBundle\Entity\User: plaintext
+
+    providers:
+        testprovider:
+            id: test_user_provider
+
+    firewalls:
+        test:
+            http_basic:

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/security-6.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/security-6.yml
@@ -1,0 +1,18 @@
+framework:
+    session:
+        storage_factory_id: session.storage.factory.mock_file
+
+security:
+    access_decision_manager:
+        strategy: affirmative
+
+    password_hashers:
+        Sulu\Bundle\SecurityBundle\Entity\User: 'plaintext'
+
+    providers:
+        testprovider:
+            id: test_user_provider
+
+    firewalls:
+        test:
+            http_basic: ~

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
@@ -2,8 +2,6 @@ framework:
     secret: secret
     router: { resource: '%kernel.project_dir%/config/routing.yml' }
     test: ~
-    session:
-        storage_id: session.storage.mock_file
     profiler:
         enabled: false
     mailer:

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/symfony-5-4.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/symfony-5-4.yml
@@ -1,0 +1,3 @@
+framework:
+    session:
+        storage_id: session.storage.mock_file

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/symfony-6.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/symfony-6.yml
@@ -1,0 +1,3 @@
+framework:
+    session:
+        storage_factory_id: session.storage.factory.mock_file


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #6556 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add config bridge to symfony 6 security system for tests.

#### Why?

For future Symfony 6 support.
