### PR TITLE
Fix account deletion by setting parent account references to null

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,19 @@
 # Upgrade
 
+## 2.3.12
+
+### Add DELETE SET NULL to account parent relation
+
+There did exist a bug in sulu when trying to remove an account entity
+which was connected to another account entity it was not possible to
+remove it. The `DELETE SET NULL` on the parent connection will solve
+this issue. For this a database change is required:
+
+```sql
+ALTER TABLE co_accounts DROP FOREIGN KEY FK_805CD14AC9171171;
+ALTER TABLE co_accounts ADD CONSTRAINT FK_805CD14AC9171171 FOREIGN KEY (idAccountsParent) REFERENCES co_accounts (id) ON DELETE SET NULL
+```
+
 ## 2.3.7
 
 ### Add missing `kernel.reset` tag for document manager cache services

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/doctrine/Account.orm.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/doctrine/Account.orm.xml
@@ -58,7 +58,7 @@
 
         <many-to-one field="parent" target-entity="Sulu\Bundle\ContactBundle\Entity\AccountInterface" inversed-by="children">
             <join-columns>
-                <join-column name="idAccountsParent" referenced-column-name="id"/>
+                <join-column name="idAccountsParent" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>
             </join-columns>
             <gedmo:tree-parent/>
         </many-to-one>

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Entity/AccountRepositoryTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Entity/AccountRepositoryTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\ContactBundle\Tests\Functional\Entity;
 
 use Doctrine\ORM\EntityManager;
 use Sulu\Bundle\ContactBundle\Entity\Account;
+use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
 use Sulu\Bundle\ContactBundle\Entity\AccountRepository;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
@@ -572,6 +573,21 @@ class AccountRepositoryTest extends SuluTestCase
         $result = $this->accountRepository->findByIds([]);
 
         $this->assertCount(0, $result);
+    }
+
+    public function testRemoveParentAccount(): void
+    {
+        $account1 = $this->createAccount('Sulu');
+        $account2 = $this->createAccount('Sensiolabs');
+        $account2->setParent($account1);
+
+        $this->em->flush();
+        $account1Id = $account1->getId();
+
+        $this->em->remove($account1);
+        $this->em->flush();
+
+        $this->assertNull($this->em->find(AccountInterface::class, $account1Id));
     }
 
     private function createTag($name)


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #6600 (partially)
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

Will set ```on-delete="SET NULL"``` for parent organization references in organizations; Current solution will default to ```on-delete=„PROTECT“```; This will cause failing foreign key constraints when deleting organizations with broken references - the references are protected and will not be deleted/cleaned up properly.

#### Why?

For detailed description see https://github.com/sulu/sulu/issues/6600