### PR TITLE
Remove `send` for compatibility with phppm kernel

### DIFF
--- a/src/Sulu/Component/Rest/Csv/CsvHandler.php
+++ b/src/Sulu/Component/Rest/Csv/CsvHandler.php
@@ -104,7 +104,6 @@ class CsvHandler
                 $exporter->export('php://output', $data);
             }
         );
-        $response->send();
 
         return $response;
     }

--- a/src/Sulu/Component/Rest/Tests/Unit/Csv/CsvHandlerTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/Csv/CsvHandlerTest.php
@@ -65,6 +65,7 @@ class CsvHandlerTest extends TestCase
 
         \ob_start();
         $response = $handler->createResponse($viewHandler->reveal(), $view, $request->reveal(), $format);
+        $response->send();
         $content = \ob_get_contents();
         \ob_end_clean();
 
@@ -107,6 +108,7 @@ class CsvHandlerTest extends TestCase
 
         \ob_start();
         $response = $handler->createResponse($viewHandler->reveal(), $view, $request->reveal(), $format);
+        $response->send();
         $content = \ob_get_contents();
         \ob_end_clean();
 
@@ -149,6 +151,7 @@ class CsvHandlerTest extends TestCase
 
         \ob_start();
         $response = $handler->createResponse($viewHandler->reveal(), $view, $request->reveal(), $format);
+        $response->send();
         $content = \ob_get_contents();
         \ob_end_clean();
 
@@ -191,6 +194,7 @@ class CsvHandlerTest extends TestCase
 
         \ob_start();
         $response = $handler->createResponse($viewHandler->reveal(), $view, $request->reveal(), $format);
+        $response->send();
         $content = \ob_get_contents();
         \ob_end_clean();
 
@@ -228,6 +232,7 @@ class CsvHandlerTest extends TestCase
 
         \ob_start();
         $response = $handler->createResponse($viewHandler->reveal(), $view, $request->reveal(), $format);
+        $response->send();
         $content = \ob_get_contents();
         \ob_end_clean();
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

Calling `send` is directly writing to stdout at a point in request/response flow execution where the outside component (e.g. the currently used kernel) is not expecting something to write to stdout.

If you run sulu using phppm or wrap the kernels `$app->handle()` into another application, it expects to get a response object returned, and have nothing written to stdout yet. Doing this might break the calling application as it does currently with phppm.

I also don't see the need to call `send` here, as it is called by the kernel later anyways.