### PR TITLE
Remove unused eslint-disable directives

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -234,5 +234,6 @@
         "flowtype/sort-keys": "error",
         "babel/semi": "error",
         "jsx-a11y/no-static-element-interactions": "error"
-    }
+    },
+    "reportUnusedDisableDirectives": true
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/AbstractFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/AbstractFieldFilterType.js
@@ -30,7 +30,6 @@ export default class AbstractFieldFilterType<T> {
 
     };
 
-    // eslint-disable-next-line no-unused-vars
     getFormNode(): Node {
         return null;
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
@@ -134,9 +134,7 @@ jest.mock('../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 
-jest.mock('../../SingleListOverlay', () => function() {
-    return null;
-});
+jest.mock('../../SingleListOverlay', () => jest.fn(() => null));
 
 class LoadingStrategy {
     destroy = jest.fn();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
@@ -941,7 +941,6 @@ test('Click on itemAction should execute its callback', () => {
         <TableAdapter
             {...listAdapterDefaultProps}
             data={data}
-            /* eslint-disable-next-line react/jsx-no-bind */
             itemActionsProvider={actionsProvider}
             onItemClick={jest.fn()}
             page={1}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js
@@ -957,7 +957,6 @@ test('Click on itemAction should execute its callback', () => {
         <TreeTableAdapter
             {...listAdapterDefaultProps}
             data={data}
-            /* eslint-disable-next-line react/jsx-no-bind */
             itemActionsProvider={actionsProvider}
             onItemAdd={jest.fn()}
             schema={schema}


### PR DESCRIPTION
#### What's in this PR?

This PR enables the `reportUnusedDisableDirectives` configuration option of eslint. This will print a warning like shown below if a `eslint-disable` is not needed.

```
/.../sulu-skeleton/vendor/sulu/sulu/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/AbstractFieldFilterType.js
  33:5  warning  Unused eslint-disable directive (no problems were reported from 'no-unused-vars')

/.../sulu-skeleton/vendor/sulu/sulu/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js
  944:13  warning  Unused eslint-disable directive (no problems were reported from 'react/jsx-no-bind')
```

#### Why?

I stumbled upon the configuration option yesterday and think its a nice thing to enable 🙂 
