### PR TITLE
Rerender form fields when type changes to prevent stale components

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
@@ -200,6 +200,7 @@ class Field extends React.Component<Props> {
                 <div className={fieldStyles.fieldContainer}>
                     <div className={fieldStyles.field}>
                         <FieldType
+                            key={name + '_' + type}
                             data={data}
                             dataPath={dataPath}
                             defaultType={defaultType}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
@@ -200,7 +200,6 @@ class Field extends React.Component<Props> {
                 <div className={fieldStyles.fieldContainer}>
                     <div className={fieldStyles.field}>
                         <FieldType
-                            key={name + '_' + type}
                             data={data}
                             dataPath={dataPath}
                             defaultType={defaultType}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
@@ -67,7 +67,7 @@ class Renderer extends React.Component<Props> {
                 dataPath={itemDataPath}
                 error={error}
                 formInspector={formInspector}
-                key={schemaKey}
+                key={schemaKey + '_' + schemaField.type}
                 name={schemaKey}
                 onChange={onChange}
                 onFinish={this.handleFieldFinish}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
@@ -134,9 +134,7 @@ jest.mock('../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 
-jest.mock('../../SingleListOverlay', () => function() {
-    return null;
-});
+jest.mock('../../../containers/SingleListOverlay', () => jest.fn(() => null));
 
 class LoadingStrategy {
     destroy = jest.fn();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes https://github.com/sulu/sulu/issues/6613
| Related issues/PRs | replaces https://github.com/sulu/sulu/pull/6615
| License | MIT

#### What's in this PR?

The PR adjusts the `Rerender` component to rerender a form field if its type is changed.

#### Why?

Because we might end up with stale components if we do not do this. For example, at the moment, when switching between block types with selection properties, the selection property is not rerendered and therefore the type of the selection overlay does not match the new block typy (see #6613).
