### PR TITLE
Add LogoutSuccessHandler bridge between Symfony 5.4 and 6.0

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Security/LogoutSuccessHandler.php
+++ b/src/Sulu/Bundle/SecurityBundle/Security/LogoutSuccessHandler.php
@@ -16,7 +16,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Security\Http\Logout\LogoutSuccessHandlerInterface;
 
 /**
  * @deprecated Can be removed when Symfony 5.4 support is canceled. Is replaced by LogoutEventSubscriber.

--- a/src/Sulu/Bundle/SecurityBundle/Security/LogoutSuccessHandlerInterface.php
+++ b/src/Sulu/Bundle/SecurityBundle/Security/LogoutSuccessHandlerInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\Security;
+
+use Symfony\Component\Security\Http\Logout\LogoutSuccessHandlerInterface as SymfonyLogoutSuccessHandlerInterface;
+
+if (\interface_exists(SymfonyLogoutSuccessHandlerInterface::class)) {
+    /**
+     * @internal Just a internal bridge to be compatible with Symfony 5.4.
+     */
+    interface LogoutSuccessHandlerInterface extends SymfonyLogoutSuccessHandlerInterface
+    {
+    }
+} else {
+    /**
+     * @internal Just a internal bridge to be compatible with Symfony 5.4.
+     */
+    interface LogoutSuccessHandlerInterface
+    {
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/issues/6556
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add LogoutSuccessHandler bridge between Symfony 5.4 and 6.0.

#### Why?

The interface does not longer exist so we need a bridge between Symfony 5.4 and 6.0.
