### PR TITLE
Allow doctrine/persistence 3.0 and doctrine/collections 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "doctrine/doctrine-fixtures-bundle": "^3.3 || ^4.0",
         "doctrine/inflector": "^1.4.1 || ^2.0.1",
         "doctrine/orm": "^2.13",
-        "doctrine/persistence": "^2.0",
+        "doctrine/persistence": "^2.0 || ^3.0",
         "doctrine/phpcr-bundle": "^2.2",
         "dragonmantank/cron-expression": "^1.1 || ^2.0 || ^3.0",
         "friendsofphp/proxy-manager-lts": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "dantleech/phpcr-migrations-bundle": "^1.3",
         "doctrine/annotations": "^1.2 || ^2.0",
         "doctrine/cache": "^1.0",
-        "doctrine/collections": "^1.0",
+        "doctrine/collections": "^1.0 || ^2.0",
         "doctrine/data-fixtures": "^1.3.3",
         "doctrine/dbal": "^2.13 || ^3.0",
         "doctrine/doctrine-bundle": "^2.4",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -32946,16 +32946,6 @@ parameters:
 			path: src/Sulu/Bundle/WebsiteBundle/DependencyInjection/SuluWebsiteExtension.php
 
 		-
-			message: "#^Parameter \\#1 \\$func of method Doctrine\\\\Common\\\\Collections\\\\ReadableCollection\\<\\(int\\|string\\),mixed\\>\\:\\:map\\(\\) expects Closure\\(mixed\\)\\: string, Closure\\(Sulu\\\\Bundle\\\\WebsiteBundle\\\\Entity\\\\Domain\\)\\: string given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Entity/Analytics.php
-
-		-
-			message: "#^Property Sulu\\\\Bundle\\\\WebsiteBundle\\\\Entity\\\\Analytics\\:\\:\\$domains with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Entity/Analytics.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Entity\\\\AnalyticsRepository\\:\\:findById\\(\\) should return Sulu\\\\Bundle\\\\WebsiteBundle\\\\Entity\\\\AnalyticsInterface but returns mixed\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Entity/AnalyticsRepository.php

--- a/src/Sulu/Bundle/WebsiteBundle/Entity/Analytics.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Entity/Analytics.php
@@ -51,7 +51,7 @@ class Analytics implements AnalyticsInterface
     private $webspaceKey;
 
     /**
-     * @var Collection|Domain[]
+     * @var Collection<int, Domain>
      *
      * @Exclude
      */
@@ -154,6 +154,8 @@ class Analytics implements AnalyticsInterface
 
     /**
      * @VirtualProperty
+     *
+     * @return Collection<int, string>|null
      */
     public function getDomains(): ?Collection
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7134, https://github.com/sulu/sulu/pull/7027, https://github.com/sulu/sulu/issues/7184, https://github.com/sulu/sulu/issues/7198, https://github.com/sulu/sulu/pull/7235
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Allow doctrine/persistence 3.0

#### Why?

Avoid outdated doctrine/persistence dependency.

Current outdated list:

```bash
doctrine/cache                      1.13.0 2.2.0  PHP Doctrine Cache library is a popular cache implementation th...
doctrine/persistence                2.5.3  3.0.2  The Doctrine Persistence project is a set of shared interfaces ...
guzzlehttp/psr7                     1.8.5  2.3.0  PSR-7 message implementation that also provides common utility ...
league/flysystem                    1.1.9  3.0.20 Filesystem abstraction: Many filesystems, one API.
league/flysystem-aws-s3-v3          1.0.29 3.0.13 Flysystem adapter for the AWS S3 SDK v3.x
league/flysystem-azure-blob-storage 1.0.0  3.0.9
monolog/monolog                     2.7.0  3.1.0  Sends your logs to files, sockets, inboxes, databases and vario...
```

#### TODO

 - [x] https://github.com/sulu/sulu/pull/7134
 - [x] https://github.com/sulu/sulu/pull/7027
 - [x] Check usage of `EntityManagerInterface::merge` see phpstan issues
    - [x] https://github.com/sulu/sulu/issues/7184
    - [x] https://github.com/sulu/sulu/issues/7198