### PR TITLE
Update phpstan baseline

### DIFF
--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/BrowserRuleTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/BrowserRuleTest.php
@@ -13,18 +13,19 @@ namespace Sulu\Bundle\AudienceTargetingBundle\Tests\Unit\Rule;
 
 use DeviceDetector\DeviceDetector;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\AudienceTargetingBundle\Rule\BrowserRule;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class BrowserRuleTest extends TestCase
 {
     /**
-     * @var DeviceDetector
+     * @var ObjectProphecy<DeviceDetector>
      */
     private $deviceDetector;
 
     /**
-     * @var TranslatorInterface
+     * @var ObjectProphecy<TranslatorInterface>
      */
     private $translator;
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/DeviceTypeRuleTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/DeviceTypeRuleTest.php
@@ -13,18 +13,19 @@ namespace Sulu\Bundle\AudienceTargetingBundle\Tests\Unit\Rule;
 
 use DeviceDetector\DeviceDetector;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\AudienceTargetingBundle\Rule\DeviceTypeRule;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DeviceTypeRuleTest extends TestCase
 {
     /**
-     * @var DeviceDetector
+     * @var ObjectProphecy<DeviceDetector>
      */
     private $deviceDetector;
 
     /**
-     * @var TranslatorInterface
+     * @var ObjectProphecy<TranslatorInterface>
      */
     private $translator;
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/LocaleRuleTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/LocaleRuleTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\AudienceTargetingBundle\Tests\Unit\Rule;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\AudienceTargetingBundle\Rule\LocaleRule;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -20,17 +21,17 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class LocaleRuleTest extends TestCase
 {
     /**
-     * @var Request
+     * @var ObjectProphecy<Request>
      */
     private $request;
 
     /**
-     * @var RequestStack
+     * @var ObjectProphecy<RequestStack>
      */
     private $requestStack;
 
     /**
-     * @var TranslatorInterface
+     * @var ObjectProphecy<TranslatorInterface>
      */
     private $translator;
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/OperatingSystemRuleTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/OperatingSystemRuleTest.php
@@ -13,18 +13,19 @@ namespace Sulu\Bundle\AudienceTargetingBundle\Tests\Unit\Rule;
 
 use DeviceDetector\DeviceDetector;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\AudienceTargetingBundle\Rule\OperatingSystemRule;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class OperatingSystemRuleTest extends TestCase
 {
     /**
-     * @var DeviceDetector
+     * @var ObjectProphecy<DeviceDetector>
      */
     private $deviceDetector;
 
     /**
-     * @var TranslatorInterface
+     * @var ObjectProphecy<TranslatorInterface>
      */
     private $translator;
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/QueryStringRuleTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/QueryStringRuleTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\AudienceTargetingBundle\Tests\Unit\Rule;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\AudienceTargetingBundle\Rule\QueryStringRule;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -20,12 +21,12 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class QueryStringRuleTest extends TestCase
 {
     /**
-     * @var RequestStack
+     * @var ObjectProphecy<RequestStack>
      */
     private $requestStack;
 
     /**
-     * @var TranslatorInterface
+     * @var ObjectProphecy<TranslatorInterface>
      */
     private $translator;
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/ReferrerRuleTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/ReferrerRuleTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\AudienceTargetingBundle\Tests\Unit\Rule;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\AudienceTargetingBundle\Rule\ReferrerRule;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -20,12 +21,12 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class ReferrerRuleTest extends TestCase
 {
     /**
-     * @var RequestStack
+     * @var ObjectProphecy<RequestStack>
      */
     private $requestStack;
 
     /**
-     * @var TranslatorInterface
+     * @var ObjectProphecy<TranslatorInterface>
      */
     private $translator;
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/TargetGroupEvaluatorTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/TargetGroupEvaluatorTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\AudienceTargetingBundle\Tests\Unit\Rule;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroup;
 use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupCondition;
 use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupRepositoryInterface;
@@ -27,17 +28,17 @@ use Sulu\Component\Webspace\Webspace;
 class TargetGroupEvaluatorTest extends TestCase
 {
     /**
-     * @var RuleCollectionInterface
+     * @var ObjectProphecy<RuleCollectionInterface>
      */
     private $ruleCollection;
 
     /**
-     * @var TargetGroupRepositoryInterface
+     * @var ObjectProphecy<TargetGroupRepositoryInterface>
      */
     private $targetGroupRepository;
 
     /**
-     * @var RequestAnalyzerInterface
+     * @var ObjectProphecy<RequestAnalyzerInterface>
      */
     private $requestAnalyzer;
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Update phpstan baseline

#### Why?

New version of phpstan. Looks like it makes the baseline smaller. Found one issues with prophecy which I did update then the other test cases in the same namespace.