### PR TITLE
Fix logout response for symfony 6

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/EventListener/LogoutEventSubscriber.php
+++ b/src/Sulu/Bundle/SecurityBundle/EventListener/LogoutEventSubscriber.php
@@ -36,14 +36,19 @@ final class LogoutEventSubscriber implements EventSubscriberInterface
 
     public function onLogout(LogoutEvent $logoutEvent): void
     {
-        if (null !== $logoutEvent->getResponse()) {
+        $adminUrl = $this->urlGenerator->generate('sulu_admin');
+        $request = $logoutEvent->getRequest();
+
+        if (!\str_starts_with($request->getPathInfo(), $adminUrl)) {
+            // do nothing when not in admin context
+
             return;
         }
 
-        if ($logoutEvent->getRequest()->isXmlHttpRequest()) {
+        if ($request->isXmlHttpRequest()) {
             $response = new JsonResponse(null, Response::HTTP_OK);
         } else {
-            $response = new RedirectResponse($this->urlGenerator->generate('sulu_admin'));
+            $response = new RedirectResponse($adminUrl);
         }
 
         $logoutEvent->setResponse($response);

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/LogoutEventSubscriberTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/LogoutEventSubscriberTest.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\SecurityBundle\Tests\Unit\EventListener;
 
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\SecurityBundle\EventListener\LogoutEventSubscriber;

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/LogoutEventSubscriberTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/LogoutEventSubscriberTest.php
@@ -38,11 +38,13 @@ class LogoutEventSubscriberTest extends TestCase
     protected function setUp(): void
     {
         $this->urlGenerator = $this->prophesize(UrlGeneratorInterface::class);
+        $this->urlGenerator->generate('sulu_admin')
+            ->willReturn('/admin/');
 
         $this->subscriber = new LogoutEventSubscriber($this->urlGenerator->reveal());
     }
 
-    public function testLogoutEventWithResponse(): void
+    public function testLogoutEventWebsiteLogout(): void
     {
         $request = Request::create('/');
         $event = new LogoutEvent($request, new NullToken());
@@ -57,23 +59,19 @@ class LogoutEventSubscriberTest extends TestCase
 
     public function testLogoutEventUrlGenerator(): void
     {
-        $request = Request::create('/');
+        $request = Request::create('/admin/logout');
         $event = new LogoutEvent($request, new NullToken());
-
-        $this->urlGenerator->generate(Argument::any())
-            ->willReturn('/admin')
-            ->shouldBeCalled();
 
         $this->subscriber->onLogout($event);
 
         $response = $event->getResponse();
         $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertSame('/admin', $response->getTargetUrl());
+        $this->assertSame('/admin/', $response->getTargetUrl());
     }
 
     public function testLogoutEventAjax(): void
     {
-        $request = Request::create('/');
+        $request = Request::create('/admin/logout');
         $request->headers->set('X-Requested-With', 'XMLHttpRequest');
         $event = new LogoutEvent($request, new NullToken());
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix logout response for symfony 6.

#### Why?

A response is always set so we need to check if the request url starts with a admin url so we know we are in the admin context.