### PR TITLE
Remove not longer existing Kernel Root Dir

### DIFF
--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Application/AppCache.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Application/AppCache.php
@@ -87,11 +87,6 @@ class AppCache extends SuluHttpCache implements KernelInterface
         return $this->kernel->isDebug();
     }
 
-    public function getRootDir()
-    {
-        return $this->kernel->getRootDir();
-    }
-
     public function getProjectDir(): string
     {
         return $this->kernel->getProjectDir();

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
@@ -64,11 +64,11 @@ class PreviewKernel extends Kernel
             $dir = $r->getFileName();
 
             if (!\is_file($dir)) {
-                throw new \LogicException(sprintf('Cannot auto-detect project dir for kernel of class "%s".', $r->name));
+                throw new \LogicException(\sprintf('Cannot auto-detect project dir for kernel of class "%s".', $r->name));
             }
 
             $dir = $rootDir = \dirname($dir);
-            while (!\is_file($dir.'/composer.json')) {
+            while (!\is_file($dir . '/composer.json')) {
                 if ($dir === \dirname($dir)) {
                     return $this->projectDir = $rootDir;
                 }

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
@@ -58,9 +58,17 @@ class PreviewKernel extends Kernel
     public function getProjectDir(): string
     {
         if (null === $this->projectDir) {
-            $reflectionClass = new \ReflectionClass(Kernel::class);
-            $dir = $rootDir = \dirname($reflectionClass->getFileName());
-            while (!\file_exists($dir . '/composer.json')) {
+            $r = new \ReflectionClass(Kernel::class); // uses App\Kernel to set dirs correctly
+
+            /** @var string $dir */
+            $dir = $r->getFileName();
+
+            if (!\is_file($dir)) {
+                throw new \LogicException(sprintf('Cannot auto-detect project dir for kernel of class "%s".', $r->name));
+            }
+
+            $dir = $rootDir = \dirname($dir);
+            while (!\is_file($dir.'/composer.json')) {
                 if ($dir === \dirname($dir)) {
                     return $this->projectDir = $rootDir;
                 }

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
@@ -58,7 +58,7 @@ class PreviewKernel extends Kernel
     public function getProjectDir(): string
     {
         if (null === $this->projectDir) {
-            $r = new \ReflectionClass(Kernel::class); // uses App\Kernel to set dirs correctly
+            $r = new \ReflectionClass(Kernel::class); // uses App\Kernel to cache dirs and co. correctly
 
             /** @var string $dir */
             $dir = $r->getFileName();

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
@@ -25,11 +25,6 @@ class PreviewKernel extends Kernel
     /**
      * @var string
      */
-    protected $rootDir;
-
-    /**
-     * @var string
-     */
     private $projectDir;
 
     public function registerContainerConfiguration(LoaderInterface $loader)
@@ -58,20 +53,6 @@ class PreviewKernel extends Kernel
     {
         // use parent class to normalize the generated container class.
         return $this->generateContainerClass(\get_parent_class());
-    }
-
-    public function getRootDir(/* $triggerDeprecation = true */)
-    {
-        if (0 === \func_num_args() || \func_get_arg(0)) {
-            @\trigger_error(\sprintf('The "%s()" method is deprecated since Symfony 4.2, use getProjectDir() instead.', __METHOD__), \E_USER_DEPRECATED);
-        }
-
-        if (null === $this->rootDir) {
-            $reflectionClass = new \ReflectionClass(Kernel::class);
-            $this->rootDir = \dirname($reflectionClass->getFileName());
-        }
-
-        return $this->rootDir;
     }
 
     public function getProjectDir(): string

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/AppCache.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/AppCache.php
@@ -84,11 +84,6 @@ class AppCache extends SuluHttpCache implements KernelInterface
         return $this->kernel->isDebug();
     }
 
-    public function getRootDir()
-    {
-        return $this->kernel->getRootDir();
-    }
-
     public function getProjectDir(): string
     {
         return $this->kernel->getProjectDir();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #6556 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove not longer existing Kernel Root Dir

#### Why?

Deprecated since symfony 4 and removed in symfony 5 the kernel root dir should now be possible to be removed safely from our methods.