### PR TITLE
Add excluded types to link field type

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Link.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Link.js
@@ -28,6 +28,9 @@ export default class Link extends React.Component<FieldTypeProps<LinkValue>> {
                 types: {
                     value: unvalidatedTypes,
                 } = {},
+                excluded_types: {
+                    value: unvalidatedExcludedTypes,
+                } = {},
             },
         } = this.props;
 
@@ -56,6 +59,29 @@ export default class Link extends React.Component<FieldTypeProps<LinkValue>> {
             });
         }
 
+        let excludedProviderTypes = [];
+
+        if (unvalidatedExcludedTypes) {
+            if (!isArrayLike(unvalidatedExcludedTypes)) {
+                throw new Error('The "excluded_types" schema option must be an array!');
+            }
+            // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
+            const excludedTypes: Array<any> | IObservableArray<any> = unvalidatedExcludedTypes;
+
+            if (excludedTypes.length === 0) {
+                throw new Error('The "excluded_types" schema option must contain some values!');
+            }
+
+            excludedProviderTypes = excludedTypes.map((type) => {
+                if (typeof type.name !== 'string') {
+                    throw new Error(
+                        'Every type in the "excluded_types" schemaOption must contain a string as name'
+                    );
+                }
+                return type.name;
+            });
+        }
+
         if (enableAnchor !== undefined && enableAnchor !== null && typeof enableAnchor !== 'boolean') {
             throw new Error('The "anchor" schema option must be a boolean if given!');
         }
@@ -74,6 +100,7 @@ export default class Link extends React.Component<FieldTypeProps<LinkValue>> {
                 enableAnchor={enableAnchor}
                 enableTarget={enableTarget}
                 enableTitle={enableTitle}
+                excludedTypes={excludedProviderTypes}
                 locale={locale}
                 onChange={onChange}
                 onFinish={onFinish}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Link.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Link.test.js
@@ -67,6 +67,7 @@ test('Pass props correctly to Link component', () => {
         'enableAnchor': true,
         'enableTarget': true,
         'enableTitle': true,
+        'excludedTypes': [],
         locale,
         'onChange': changeSpy,
         'onFinish': finishSpy,
@@ -139,10 +140,84 @@ test('Pass props correctly to Link component filtered types', () => {
         'enableAnchor': true,
         'enableTarget': true,
         'enableTitle': true,
+        'excludedTypes': [],
         locale,
         'onChange': changeSpy,
         'onFinish': finishSpy,
         'types': ['external', 'page'],
+        'value': {
+            'anchor': 'anchorTest',
+            'href': '123-asdf-123',
+            'locale': 'en',
+            'provider': 'page',
+            'target': '_blank',
+            'title': 'Test',
+        },
+    });
+});
+
+test('Pass props correctly to Link component filtered excluded_types', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+    const changeSpy = jest.fn();
+    const finishSpy = jest.fn();
+
+    const locale = observable.box('en');
+    // $FlowFixMe
+    formInspector.locale = locale;
+
+    const value: LinkValue = {
+        anchor: 'anchorTest',
+        href: '123-asdf-123',
+        locale: 'en',
+        provider: 'page',
+        target: '_blank',
+        title: 'Test',
+    };
+
+    const options = {
+        enable_target: {
+            name: 'target',
+            value: true,
+        },
+        enable_anchor: {
+            name: 'anchor',
+            value: true,
+        },
+        enable_title: {
+            name: 'title',
+            value: true,
+        },
+        excluded_types: {
+            name: 'types',
+            value: [
+                {name: 'external'},
+                {name: 'page'},
+            ],
+        },
+    };
+
+    const link = shallow(
+        <Link
+            {...fieldTypeDefaultProps}
+            disabled={true}
+            formInspector={formInspector}
+            onChange={changeSpy}
+            onFinish={finishSpy}
+            schemaOptions={options}
+            value={value}
+        />
+    );
+
+    expect(link.find('Link').props()).toEqual({
+        'disabled': true,
+        'enableAnchor': true,
+        'enableTarget': true,
+        'enableTitle': true,
+        'excludedTypes': ['external', 'page'],
+        locale,
+        'onChange': changeSpy,
+        'onFinish': finishSpy,
+        'types': [],
         'value': {
             'anchor': 'anchorTest',
             'href': '123-asdf-123',
@@ -199,6 +274,7 @@ test('Pass props correctly to Link component disabled anchor and target', () => 
         'enableAnchor': false,
         'enableTarget': false,
         'enableTitle': false,
+        'excludedTypes': [],
         locale,
         'onChange': changeSpy,
         'onFinish': finishSpy,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/Link.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/Link.js
@@ -204,13 +204,10 @@ class Link extends Component<Props> {
             }
         );
 
-        const allowedTypes = linkTypeRegistry.getKeys().filter((key) => {
-            if (types !== undefined && types.length > 0) {
-                return types.includes(key);
-            }
-
-            return !excludedTypes.includes(key);
-        });
+        let allowedTypes = linkTypeRegistry.getKeys().filter((key) => !excludedTypes.includes(key));
+        if (types !== undefined && types.length > 0) {
+            allowedTypes = allowedTypes.filter((key) => types.length > 0 && types.includes(key));
+        }
 
         return (
             <Fragment>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/Link.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/Link.js
@@ -18,6 +18,7 @@ type Props = {
     enableAnchor?: ?boolean,
     enableTarget?: ?boolean,
     enableTitle?: ?boolean,
+    excludedTypes: string[],
     locale: IObservableValue<string>,
     onChange: (value: LinkValue) => void,
     onFinish: () => void,
@@ -34,6 +35,7 @@ class Link extends Component<Props> {
         enableAnchor: false,
         enableTarget: false,
         enableTitle: false,
+        excludedTypes: [],
         types: [],
     };
 
@@ -189,6 +191,7 @@ class Link extends Component<Props> {
             enableTarget,
             enableTitle,
             types,
+            excludedTypes,
             value,
         } = this.props;
         const {href, provider} = value || {};
@@ -202,11 +205,11 @@ class Link extends Component<Props> {
         );
 
         const allowedTypes = linkTypeRegistry.getKeys().filter((key) => {
-            if (types === undefined || types.length === 0) {
-                return true;
+            if (types !== undefined && types.length > 0) {
+                return types.includes(key);
             }
 
-            return types.includes(key);
+            return !excludedTypes.includes(key);
         });
 
         return (

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/Link.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/Link.test.js
@@ -275,3 +275,61 @@ test('Display providers with "types" property', () => {
 
     expect(link.find('Option').length).toEqual(2);
 });
+
+test('Display providers with "types" property', () => {
+    const changeSpy = jest.fn();
+    const finishSpy = jest.fn();
+
+    linkTypeRegistry.getOverlay.mockReturnValue(LinkTypeOverlay);
+    linkTypeRegistry.getOptions.mockReturnValue({
+        title: 'Pages',
+        overlayTitle: 'Test Overlay',
+        resourceKey: 'pages',
+        displayProperties: ['title'],
+    });
+    linkTypeRegistry.getKeys.mockReturnValue(['page', 'media', 'article']);
+
+    const link = shallow(
+        <Link
+            enableAnchor={true}
+            enableTarget={true}
+            enableTitle={true}
+            locale={observable.box('en')}
+            onChange={changeSpy}
+            onFinish={finishSpy}
+            types={['page', 'article']}
+            value={undefined}
+        />);
+
+    const removeButton = link.find('.removeButton');
+    removeButton.simulate('click');
+    expect(link.find('Option').length).toEqual(2);
+});
+
+test('Display providers with "excluded_types" property', () => {
+    const changeSpy = jest.fn();
+    const finishSpy = jest.fn();
+
+    linkTypeRegistry.getOverlay.mockReturnValue(LinkTypeOverlay);
+    linkTypeRegistry.getOptions.mockReturnValue({
+        title: 'Pages',
+        overlayTitle: 'Test Overlay',
+        resourceKey: 'pages',
+        displayProperties: ['title'],
+    });
+    linkTypeRegistry.getKeys.mockReturnValue(['page', 'media', 'article']);
+
+    const link = shallow(
+        <Link
+            enableAnchor={true}
+            enableTarget={true}
+            enableTitle={true}
+            excludedTypes={['page', 'article']}
+            locale={observable.box('en')}
+            onChange={changeSpy}
+            onFinish={finishSpy}
+            value={undefined}
+        />);
+
+    expect(link.find('Option').length).toEqual(1);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/Link.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/Link.test.js
@@ -273,34 +273,6 @@ test('Display providers with "types" property', () => {
             value={undefined}
         />);
 
-    expect(link.find('Option').length).toEqual(2);
-});
-
-test('Display providers with "types" property', () => {
-    const changeSpy = jest.fn();
-    const finishSpy = jest.fn();
-
-    linkTypeRegistry.getOverlay.mockReturnValue(LinkTypeOverlay);
-    linkTypeRegistry.getOptions.mockReturnValue({
-        title: 'Pages',
-        overlayTitle: 'Test Overlay',
-        resourceKey: 'pages',
-        displayProperties: ['title'],
-    });
-    linkTypeRegistry.getKeys.mockReturnValue(['page', 'media', 'article']);
-
-    const link = shallow(
-        <Link
-            enableAnchor={true}
-            enableTarget={true}
-            enableTitle={true}
-            locale={observable.box('en')}
-            onChange={changeSpy}
-            onFinish={finishSpy}
-            types={['page', 'article']}
-            value={undefined}
-        />);
-
     const removeButton = link.find('.removeButton');
     removeButton.simulate('click');
     expect(link.find('Option').length).toEqual(2);
@@ -332,4 +304,33 @@ test('Display providers with "excluded_types" property', () => {
         />);
 
     expect(link.find('Option').length).toEqual(1);
+});
+
+test('Display providers with "excluded_types" and "types" property', () => {
+    const changeSpy = jest.fn();
+    const finishSpy = jest.fn();
+
+    linkTypeRegistry.getOverlay.mockReturnValue(LinkTypeOverlay);
+    linkTypeRegistry.getOptions.mockReturnValue({
+        title: 'Pages',
+        overlayTitle: 'Test Overlay',
+        resourceKey: 'pages',
+        displayProperties: ['title'],
+    });
+    linkTypeRegistry.getKeys.mockReturnValue(['page', 'media', 'article', 'account']);
+
+    const link = shallow(
+        <Link
+            enableAnchor={true}
+            enableTarget={true}
+            enableTitle={true}
+            excludedTypes={['page', 'article']}
+            locale={observable.box('en')}
+            onChange={changeSpy}
+            onFinish={finishSpy}
+            types={['media', 'account']}
+            value={undefined}
+        />);
+
+    expect(link.find('Option').length).toEqual(2);
 });


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/719

#### What's in this PR?

This PR add the possibility to filter link types by excluded types.

#### Why?

Add possibility to filter types by excluded types.

#### Example Usage

```xml
        <property name="link" type="link">
            <meta>
                <title>app.link</title>
            </meta>
            <params>
                <param name="enable_title" value="true"/>
                <param name="excluded_types" type="collection">
                    <param name="media"/>
                </param>
            </params>
        </property>
```

#### To Do

- [x] Create a documentation PR
