### PR TITLE
Disable collections without add permissions in overlay

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
@@ -178,7 +178,7 @@ class MultiMediaDropzone extends React.Component<Props> {
                 <SingleListOverlay
                     adapter="column_list"
                     clearSelectionOnClose={true}
-                    itemDisabledCondition="!!locked"
+                    itemDisabledCondition="!!locked || (_permissions && !_permissions.add)"
                     listKey={COLLECTIONS_RESOURCE_KEY}
                     locale={locale}
                     onClose={this.handleSelectCollectionOverlayClose}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #6662
| License | MIT

#### What's in this PR?

Disable collections without add permissions in overlay that is displayed when uploading media in root collection.

#### Why?

See https://github.com/sulu/sulu/issues/6662