### PR TITLE
Fix getPathsByTag method of FormStore for data that includes unknown block type

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
@@ -58,14 +58,17 @@ function collectTagPathsWithPriority(
         ) {
             for (const childKey of data[key].keys()) {
                 const childData = data[key][childKey];
-                pathsWithPriority.push(
-                    ...collectTagPathsWithPriority(
-                        tagName,
-                        childData,
-                        types[childData.type].form,
-                        parentPath.concat([key, childKey])
-                    )
-                );
+
+                if (childData.type in types) {
+                    pathsWithPriority.push(
+                        ...collectTagPathsWithPriority(
+                            tagName,
+                            childData,
+                            types[childData.type].form,
+                            parentPath.concat([key, childKey])
+                        )
+                    );
+                }
             }
             continue;
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #6610
| License | MIT

#### What's in this PR?

This PR fixes the `getPathsByTag` of the `AbstractFormStore` to not crash if the data contains a block type that is not present in the current template.

#### Why?

The `ResourceLocator` component uses the `getPathsByTag` method to collect the parts of the generated path. This crashes the administration interface when the template of a page is switched before it is saved. 

The problem happens because the `ResourceLocator` calls the `getPathsByTag` method after the template was switched. At this time, the `AbstractFormStore` contains the data from before the template switch and therefore can contain blocks with a type that is not present in the new template. See #6610 for an example.

