### PR TITLE
Avoid admin UI crash with false translation

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Translator/Translator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Translator/Translator.js
@@ -8,7 +8,16 @@ let translationMap;
 function setTranslations(translations: TranslationMap, locale: string) {
     translationMap = Object.keys(translations).reduce((messages, translationKey) => {
         // TODO add locale for correct translation of numbers, dates, ...
-        messages[translationKey] = new IntlMessageFormat(translations[translationKey], locale);
+        try {
+            messages[translationKey] = new IntlMessageFormat(translations[translationKey], locale);
+        } catch (e) {
+            log.error(
+                'The translation key ' + translationKey + ' could not be translated. ' +
+                'It is translated to "' + translations[translationKey] + '" which is an invalid IntlMessageFormat: ' +
+                e.toString()
+            );
+        }
+
         return messages;
     }, {});
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? |  no
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Avoid admin UI crash with false translation.

#### Why?

When having a invalid translation format the admin UI crashes with a crypted error in the browser console. This way we catch the error and show only a log of it and the UI keeps running. Example translation which make it crash: `"{{count}} selected"` which is incorrect and crashes currently the UI ({count} selected would be correct).
