### PR TITLE
fix import xliff link problem

### DIFF
--- a/src/Sulu/Component/Content/Types/Link.php
+++ b/src/Sulu/Component/Content/Types/Link.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Component\Content\Types;
 
+use PHPCR\NodeInterface;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderPoolInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\SimpleContentType;
@@ -112,4 +113,18 @@ class Link extends SimpleContentType
 
         return $url;
     }
+    
+    public function importData(
+        NodeInterface $node,
+        PropertyInterface $property,
+        $value,
+        $userId,
+        $webspaceKey,
+        $languageCode,
+        $segmentKey = null
+    ) {
+        $property->setValue(\json_decode($value, true));
+        $this->write($node, $property, $userId, $webspaceKey, $languageCode, $segmentKey);
+    }
+    
 }


### PR DESCRIPTION
Added the importData function so that the link can be imported correctly.

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | slack communication - https://sulu-io.slack.com/archives/C0430GGCV/p1656490331677969
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR? Why?

Fixes a problem while importing xliff files. ImportData function was missing for type link.

#### Example Usage

Run the command:
```sh
bin/console sulu:webspaces:import example.en.xliff main en
```
