### PR TITLE
Fix import xliff link problem

### DIFF
--- a/src/Sulu/Component/Content/Tests/Unit/Types/LinkTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Types/LinkTest.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Component\Content\Tests\Unit\Types;
 
+use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -216,5 +217,33 @@ class LinkTest extends TestCase
         $result = $this->link->getContentData($this->property->reveal());
 
         $this->assertNull($result);
+    }
+
+    public function testImportData(): void
+    {
+        $value = [
+            'href' => '123456',
+            'provider' => 'pages',
+            'locale' => 'de',
+            'target' => 'testTarget',
+            'anchor' => 'testAnchor',
+        ];
+
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->setValue($value)->shouldBeCalled();
+        $property->getValue()->willReturn($value);
+        $property->getName()->willReturn('test-link');
+
+        $node = $this->prophesize(NodeInterface::class);
+        $node->setProperty('test-link', \json_encode($value))->shouldBeCalled();
+
+        $this->link->importData(
+            $node->reveal(),
+            $property->reveal(),
+            \json_encode($value),
+            1,
+            'sulu_io',
+            'en'
+        );
     }
 }

--- a/src/Sulu/Component/Content/Types/Link.php
+++ b/src/Sulu/Component/Content/Types/Link.php
@@ -113,7 +113,7 @@ class Link extends SimpleContentType
 
         return $url;
     }
-    
+
     public function importData(
         NodeInterface $node,
         PropertyInterface $property,
@@ -122,9 +122,8 @@ class Link extends SimpleContentType
         $webspaceKey,
         $languageCode,
         $segmentKey = null
-    ) {
+    ): void {
         $property->setValue(\json_decode($value, true));
         $this->write($node, $property, $userId, $webspaceKey, $languageCode, $segmentKey);
     }
-    
 }

--- a/src/Sulu/Component/Content/Types/Link.php
+++ b/src/Sulu/Component/Content/Types/Link.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Component\Content\Types;
 
+use PHPCR\NodeInterface;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderPoolInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\SimpleContentType;
@@ -112,4 +113,18 @@ class Link extends SimpleContentType
 
         return $url;
     }
+    
+    public function importData(
+        NodeInterface $node,
+        PropertyInterface $property,
+        $value,
+        $userId,
+        $webspaceKey,
+        $languageCode,
+        $segmentKey = null
+    ) {
+        $property->setValue(\json_decode($value, true));
+        $this->write($node, $property, $userId, $webspaceKey, $languageCode, $segmentKey);
+    }
+    
 }


### PR DESCRIPTION
Added the importData function so that the link can be imported correctly.

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | slack communication - https://sulu-io.slack.com/archives/C0430GGCV/p1656490331677969

#### What's in this PR? Why?

Fixes a problem while importing xliff files. ImportData function was missing for type link.

#### Example Usage
```sh
bin/console sulu:webspaces:import example.en.xliff main en
```
