### PR TITLE
Add support for position sticky inside tabs container

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/View/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/View/README.md
@@ -1,0 +1,11 @@
+This view component provides the basic spaces for every view.
+
+```javascript
+<div style={{background: '#cc00ff'}}>
+    <View>
+        <div style={{background: '#00ccff'}}>
+            Basic View Component with space around it.
+        </div>
+    </View>
+</div>
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/View/View.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/View/View.js
@@ -1,0 +1,24 @@
+// @flow
+import React from 'react';
+import viewStyles from './view.scss';
+import type {Node} from 'react';
+
+type Props = {
+    children: Node,
+};
+
+class View extends React.Component<Props> {
+    render() {
+        const {
+            children,
+        } = this.props;
+
+        return (
+            <div className={viewStyles.view}>
+                {children}
+            </div>
+        );
+    }
+}
+
+export default View;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/View/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/View/index.js
@@ -1,0 +1,4 @@
+// @flow
+import View from './View';
+
+export default View;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/View/variables.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/View/variables.scss
@@ -1,0 +1,4 @@
+$viewPaddingHorizontal: 60px;
+$viewPaddingVertical: 40px;
+$viewMinWidth: 420px;
+$viewMaxWidth: 1140px;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/View/view.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/View/view.scss
@@ -1,0 +1,6 @@
+@import './variables.scss';
+
+.view {
+    height: calc(100% - $viewPaddingVertical);
+    padding: $viewPaddingVertical $viewPaddingHorizontal;
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/application.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/application.scss
@@ -45,7 +45,6 @@
     width: 100%;
     height: 100%;
     overflow-y: auto;
-    padding: $viewPaddingVertical $viewPaddingHorizontal 0;
 }
 
 .main {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/ViewRenderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/ViewRenderer.js
@@ -4,9 +4,9 @@ import {observer} from 'mobx-react';
 import {observable, reaction} from 'mobx';
 import Router, {getViewKeyFromRoute, Route} from '../../services/Router';
 import userStore from '../../stores/userStore';
+import View from '../../components/View';
 import viewRegistry from './registries/viewRegistry';
 import type {Element} from 'react';
-import type {View} from './types';
 
 type Props = {
     router: Router,
@@ -48,37 +48,36 @@ class ViewRenderer extends React.Component<Props> {
         }
     }
 
-    getView = (route: Route): View => {
-        const View = viewRegistry.get(route.type);
-
-        if (!View) {
-            throw new Error('View "' + route.type + '" has not been found');
-        }
-
-        return View;
-    };
-
     renderView(route: Route, child: Element<*> | null = null) {
         const {router} = this.props;
-        const View = this.getView(route);
+        const CurrentView = viewRegistry.get(route.type);
+        const viewConfig = viewRegistry.getConfig(route.type);
 
         let viewKey = getViewKeyFromRoute(route, router.attributes) || '';
-        if (View.remountViewOnLogin) {
+        if (CurrentView.remountViewOnLogin) {
             viewKey = viewKey + '__' + this.loginCount;
         }
 
         const element = (
-            <View
+            <CurrentView
                 isRootView={!route.parent}
                 key={viewKey}
                 route={route}
                 router={router}
             >
                 {(props) => child ? React.cloneElement(child, props) : null}
-            </View>
+            </CurrentView>
         );
 
         if (!route.parent) {
+            if (!viewConfig.rootSpaceless) {
+                return (
+                    <View>
+                        {element}
+                    </View>
+                );
+            }
+
             return element;
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/ViewRenderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/ViewRenderer.js
@@ -70,7 +70,7 @@ class ViewRenderer extends React.Component<Props> {
         );
 
         if (!route.parent) {
-            if (!viewConfig.rootSpaceless) {
+            if (!viewConfig.disableDefaultSpacing) {
                 return (
                     <View>
                         {element}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/registries/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/registries/README.md
@@ -1,0 +1,19 @@
+The view registry allows to configure different views.
+
+```js
+const CustomView = <div>Custom View </div>;
+
+viewRegistry.set('customView', CustomView);
+```
+
+An optional ViewConfig parameters allow to define behaviour of the view:
+
+```js
+const CustomView = <div>Custom View </div>;
+
+viewRegistry.set('customView', CustomView, { rootSpaceless: true });
+```
+
+| Name          | Type    | DefaultValue |
+|---------------|---------|--------------|
+| rootSpaceless | boolean | false        |

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/registries/viewRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/registries/viewRegistry.js
@@ -1,8 +1,9 @@
 // @flow
-import type {View} from '../types';
+import type {View, ViewConfig} from '../types';
 
 class ViewRegistry {
     views: {[string]: View};
+    viewConfigs: {[string]: ViewConfig};
 
     constructor() {
         this.clear();
@@ -10,14 +11,16 @@ class ViewRegistry {
 
     clear() {
         this.views = {};
+        this.viewConfigs = {};
     }
 
-    add(name: string, view: View) {
+    add(name: string, view: View, viewConfig?: ViewConfig) {
         if (name in this.views) {
             throw new Error('The key "' + name + '" has already been used for another view');
         }
 
         this.views[name] = view;
+        this.viewConfigs[name] = viewConfig ? viewConfig : {};
     }
 
     get(name: string): View {
@@ -26,6 +29,14 @@ class ViewRegistry {
         }
 
         throw new Error('There is not view for the key "' + name + '" registered');
+    }
+
+    getConfig(name: string): ViewConfig {
+        if (name in this.viewConfigs) {
+            return this.viewConfigs[name];
+        }
+
+        throw new Error('There is not view config for the key "' + name + '" registered');
     }
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/ViewRenderer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/ViewRenderer.test.js
@@ -21,13 +21,13 @@ test('Render view returned from ViewRegistry', () => {
     expect(viewRegistry.get).toBeCalledWith('test');
 });
 
-test('Render view returned from ViewRegistry with rootSpaceless true', () => {
+test('Render view returned from ViewRegistry with disableDefaultSpacing true', () => {
     const router = {
         addUpdateRouteHook: jest.fn(),
         route: {type: 'test'},
     };
     viewRegistry.get.mockReturnValue(() => (<h1>Test</h1>));
-    viewRegistry.getConfig.mockReturnValue({rootSpaceless: true});
+    viewRegistry.getConfig.mockReturnValue({disableDefaultSpacing: true});
     const view = mount(<ViewRenderer router={router} />);
     expect(render(view)).toMatchSnapshot();
     expect(viewRegistry.get).toBeCalledWith('test');
@@ -155,7 +155,7 @@ test('Render view with parents should nest rendered views and correctly pass chi
                 };
         }
     });
-    viewRegistry.getConfig.mockReturnValue({rootSpaceless: true});
+    viewRegistry.getConfig.mockReturnValue({disableDefaultSpacing: true});
 
     expect(render(<ViewRenderer router={router} />)).toMatchSnapshot();
 });
@@ -184,7 +184,7 @@ test('Render view with route that has no rerenderAttributes', () => {
                 };
         }
     });
-    viewRegistry.getConfig.mockReturnValue({rootSpaceless: true});
+    viewRegistry.getConfig.mockReturnValue({disableDefaultSpacing: true});
 
     const viewRenderer = shallow(<ViewRenderer router={router} />);
     expect(viewRenderer.key()).toBe('route');
@@ -217,7 +217,7 @@ test('Render view with route that has rerenderAttributes', () => {
                 };
         }
     });
-    viewRegistry.getConfig.mockReturnValue({rootSpaceless: true});
+    viewRegistry.getConfig.mockReturnValue({disableDefaultSpacing: true});
 
     const viewRenderer = shallow(<ViewRenderer router={router} />);
     expect(viewRenderer.key()).toBe('route-test');
@@ -252,7 +252,7 @@ test('Render view with route that has more than one rerenderAttributes', () => {
                 };
         }
     });
-    viewRegistry.getConfig.mockReturnValue({rootSpaceless: true});
+    viewRegistry.getConfig.mockReturnValue({disableDefaultSpacing: true});
 
     const viewRenderer = shallow(<ViewRenderer router={router} />);
     expect(viewRenderer.key()).toBe('route-test__de');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/ViewRenderer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/ViewRenderer.test.js
@@ -6,6 +6,7 @@ import viewRegistry from '../registries/viewRegistry';
 
 jest.mock('../registries/viewRegistry', () => ({
     get: jest.fn(),
+    getConfig: jest.fn(),
 }));
 
 test('Render view returned from ViewRegistry', () => {
@@ -14,6 +15,19 @@ test('Render view returned from ViewRegistry', () => {
         route: {type: 'test'},
     };
     viewRegistry.get.mockReturnValue(() => (<h1>Test</h1>));
+    viewRegistry.getConfig.mockReturnValue({});
+    const view = mount(<ViewRenderer router={router} />);
+    expect(render(view)).toMatchSnapshot();
+    expect(viewRegistry.get).toBeCalledWith('test');
+});
+
+test('Render view returned from ViewRegistry with rootSpaceless true', () => {
+    const router = {
+        addUpdateRouteHook: jest.fn(),
+        route: {type: 'test'},
+    };
+    viewRegistry.get.mockReturnValue(() => (<h1>Test</h1>));
+    viewRegistry.getConfig.mockReturnValue({rootSpaceless: true});
     const view = mount(<ViewRenderer router={router} />);
     expect(render(view)).toMatchSnapshot();
     expect(viewRegistry.get).toBeCalledWith('test');
@@ -30,14 +44,10 @@ test('Render view returned from ViewRegistry with passed router', () => {
     };
 
     viewRegistry.get.mockReturnValue((props) => (<h1>{props.router.attributes.value}</h1>));
+    viewRegistry.getConfig.mockReturnValue({});
     const view = render(<ViewRenderer router={router} />);
     expect(view).toMatchSnapshot();
     expect(viewRegistry.get).toBeCalledWith('test');
-});
-
-test('Render view should throw if view does not exist', () => {
-    viewRegistry.get.mockReturnValue(undefined);
-    expect(() => render(<ViewRenderer router={{route: {type: 'not_existing'}}} />)).toThrow(/not_existing/);
 });
 
 test('Render view with parents should nest rendered views', () => {
@@ -89,6 +99,7 @@ test('Render view with parents should nest rendered views', () => {
                 };
         }
     });
+    viewRegistry.getConfig.mockReturnValue({});
 
     expect(render(<ViewRenderer router={router} />)).toMatchSnapshot();
 });
@@ -144,46 +155,9 @@ test('Render view with parents should nest rendered views and correctly pass chi
                 };
         }
     });
+    viewRegistry.getConfig.mockReturnValue({rootSpaceless: true});
 
     expect(render(<ViewRenderer router={router} />)).toMatchSnapshot();
-});
-
-test('Render view with not existing parent should throw', () => {
-    const router = {
-        route: {
-            type: 'form_tab',
-            parent: {
-                type: 'form',
-                parent: {
-                    type: 'app',
-                },
-            },
-        },
-    };
-
-    viewRegistry.get.mockImplementation((view) => {
-        switch (view) {
-            case 'form_tab':
-                return function FormTab() {
-                    return (
-                        <div>
-                            <h3>Form Tab</h3>
-                        </div>
-                    );
-                };
-            case 'form':
-                return function Form(props) {
-                    return (
-                        <div>
-                            <h2>Form</h2>
-                            {props.children}
-                        </div>
-                    );
-                };
-        }
-    });
-
-    expect(() => render(<ViewRenderer router={router} />)).toThrow(/app/);
 });
 
 test('Render view with route that has no rerenderAttributes', () => {
@@ -210,6 +184,7 @@ test('Render view with route that has no rerenderAttributes', () => {
                 };
         }
     });
+    viewRegistry.getConfig.mockReturnValue({rootSpaceless: true});
 
     const viewRenderer = shallow(<ViewRenderer router={router} />);
     expect(viewRenderer.key()).toBe('route');
@@ -242,6 +217,7 @@ test('Render view with route that has rerenderAttributes', () => {
                 };
         }
     });
+    viewRegistry.getConfig.mockReturnValue({rootSpaceless: true});
 
     const viewRenderer = shallow(<ViewRenderer router={router} />);
     expect(viewRenderer.key()).toBe('route-test');
@@ -276,6 +252,7 @@ test('Render view with route that has more than one rerenderAttributes', () => {
                 };
         }
     });
+    viewRegistry.getConfig.mockReturnValue({rootSpaceless: true});
 
     const viewRenderer = shallow(<ViewRenderer router={router} />);
     expect(viewRenderer.key()).toBe('route-test__de');
@@ -283,6 +260,7 @@ test('Render view with route that has more than one rerenderAttributes', () => {
 
 test('Clear bindings of router everytime a new view is rendered', () => {
     viewRegistry.get.mockReturnValue(() => (<h1>Test</h1>));
+    viewRegistry.getConfig.mockReturnValue({});
 
     const route1 = {
         name: 'test1',
@@ -314,6 +292,7 @@ test('Clear bindings of router everytime a new view is rendered', () => {
 
 test('Clear bindings of router when same view with a different rerender attribute is rendered', () => {
     viewRegistry.get.mockReturnValue(() => (<h1>Test</h1>));
+    viewRegistry.getConfig.mockReturnValue({});
 
     const route = {
         name: 'test1',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/__snapshots__/ViewRenderer.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/__snapshots__/ViewRenderer.test.js.snap
@@ -1,33 +1,51 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Render view returned from ViewRegistry 1`] = `
+<div
+  class="view"
+>
+  <h1>
+    Test
+  </h1>
+</div>
+`;
+
+exports[`Render view returned from ViewRegistry with passed router 1`] = `
+<div
+  class="view"
+>
+  <h1>
+    Test attribute
+  </h1>
+</div>
+`;
+
+exports[`Render view returned from ViewRegistry with rootSpaceless true 1`] = `
 <h1>
   Test
 </h1>
 `;
 
-exports[`Render view returned from ViewRegistry with passed router 1`] = `
-<h1>
-  Test attribute
-</h1>
-`;
-
 exports[`Render view with parents should nest rendered views 1`] = `
-<div>
-  <h1>
-    App
-  </h1>
-  sulu_admin.app
+<div
+  class="view"
+>
   <div>
-    <h2>
-      Form
-    </h2>
-    sulu_admin.form
+    <h1>
+      App
+    </h1>
+    sulu_admin.app
     <div>
-      <h3>
-        Form Tab
-      </h3>
-      sulu_admin.form_tab
+      <h2>
+        Form
+      </h2>
+      sulu_admin.form
+      <div>
+        <h3>
+          Form Tab
+        </h3>
+        sulu_admin.form_tab
+      </div>
     </div>
   </div>
 </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/__snapshots__/ViewRenderer.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/__snapshots__/ViewRenderer.test.js.snap
@@ -10,6 +10,12 @@ exports[`Render view returned from ViewRegistry 1`] = `
 </div>
 `;
 
+exports[`Render view returned from ViewRegistry with disableDefaultSpacing true 1`] = `
+<h1>
+  Test
+</h1>
+`;
+
 exports[`Render view returned from ViewRegistry with passed router 1`] = `
 <div
   class="view"
@@ -18,12 +24,6 @@ exports[`Render view returned from ViewRegistry with passed router 1`] = `
     Test attribute
   </h1>
 </div>
-`;
-
-exports[`Render view returned from ViewRegistry with rootSpaceless true 1`] = `
-<h1>
-  Test
-</h1>
 `;
 
 exports[`Render view with parents should nest rendered views 1`] = `

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/registries/ViewRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/registries/ViewRegistry.test.js
@@ -34,3 +34,11 @@ test('Add view with existing key should throw', () => {
     viewRegistry.add('test1', component1);
     expect(() => viewRegistry.add('test1', 'test1 react component')).toThrow(/test1/);
 });
+
+test('Add view to ViewRegistry with Config', () => {
+    viewRegistry.add('test1', <h1>Test1</h1>, {rootSpaceless: false});
+    viewRegistry.add('test2', <h1>Test2</h1>, {rootSpaceless: true});
+
+    expect(viewRegistry.getConfig('test1')?.rootSpaceless).toBe(false);
+    expect(viewRegistry.getConfig('test2')?.rootSpaceless).toBe(true);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/registries/ViewRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/registries/ViewRegistry.test.js
@@ -36,9 +36,9 @@ test('Add view with existing key should throw', () => {
 });
 
 test('Add view to ViewRegistry with Config', () => {
-    viewRegistry.add('test1', <h1>Test1</h1>, {rootSpaceless: false});
-    viewRegistry.add('test2', <h1>Test2</h1>, {rootSpaceless: true});
+    viewRegistry.add('test1', <h1>Test1</h1>, {disableDefaultSpacing: false});
+    viewRegistry.add('test2', <h1>Test2</h1>, {disableDefaultSpacing: true});
 
-    expect(viewRegistry.getConfig('test1')?.rootSpaceless).toBe(false);
-    expect(viewRegistry.getConfig('test2')?.rootSpaceless).toBe(true);
+    expect(viewRegistry.getConfig('test1')?.disableDefaultSpacing).toBe(false);
+    expect(viewRegistry.getConfig('test2')?.disableDefaultSpacing).toBe(true);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/types.js
@@ -21,5 +21,5 @@ interface RemountViewOnLoginInterface {
 export type View = Class<Component<ViewProps & *>> & GetDerivedRouteAttributesInterface & RemountViewOnLoginInterface;
 
 export type ViewConfig = {
-    rootSpaceless?: boolean,
+    disableDefaultSpacing?: boolean,
 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/types.js
@@ -19,3 +19,7 @@ interface RemountViewOnLoginInterface {
 }
 
 export type View = Class<Component<ViewProps & *>> & GetDerivedRouteAttributesInterface & RemountViewOnLoginInterface;
+
+export type ViewConfig = {
+    rootSpaceless?: boolean,
+};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -187,8 +187,8 @@ function registerViews() {
     viewRegistry.add('sulu_admin.preview_form', PreviewForm);
     viewRegistry.add('sulu_admin.list', List);
     viewRegistry.add('sulu_admin.form_overlay_list', FormOverlayList);
-    viewRegistry.add('sulu_admin.resource_tabs', ResourceTabs);
-    viewRegistry.add('sulu_admin.tabs', Tabs);
+    viewRegistry.add('sulu_admin.resource_tabs', ResourceTabs, {rootSpaceless: true});
+    viewRegistry.add('sulu_admin.tabs', Tabs, {rootSpaceless: true});
 }
 
 function registerListAdapters() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -187,8 +187,8 @@ function registerViews() {
     viewRegistry.add('sulu_admin.preview_form', PreviewForm);
     viewRegistry.add('sulu_admin.list', List);
     viewRegistry.add('sulu_admin.form_overlay_list', FormOverlayList);
-    viewRegistry.add('sulu_admin.resource_tabs', ResourceTabs, {rootSpaceless: true});
-    viewRegistry.add('sulu_admin.tabs', Tabs, {rootSpaceless: true});
+    viewRegistry.add('sulu_admin.resource_tabs', ResourceTabs, {disableDefaultSpacing: true});
+    viewRegistry.add('sulu_admin.tabs', Tabs, {disableDefaultSpacing: true});
 }
 
 function registerListAdapters() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/Tabs.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/Tabs.js
@@ -7,6 +7,7 @@ import TabsComponent from '../../components/Tabs';
 import {translate} from '../../utils/Translator';
 import {Route} from '../../services/Router';
 import Badge, {type BadgeOptions} from '../../containers/Badge';
+import View from '../../components/View';
 import tabsStyles from './tabs.scss';
 import type {ViewProps} from '../../containers/ViewRenderer';
 import type {Element, Node} from 'react';
@@ -192,8 +193,19 @@ class Tabs<T> extends React.Component<Props<T>> {
                         </TabsComponent>
                     }
                 </div>
-                {header}
-                {childComponent}
+
+                {
+                    isRootView
+                        ? <View>
+                            {header}
+                            {childComponent}
+                        </View>
+                        : <>
+                            {header}
+                            {childComponent}
+                        </>
+                }
+
             </Fragment>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/tabs.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/tabs.scss
@@ -1,7 +1,7 @@
 @import '../../containers/Application/variables.scss';
 
 .tabs-container {
-    margin: -$viewPaddingVertical -$viewPaddingHorizontal $viewPaddingVertical;
+    margin: 0;
 
     &.nested {
         margin: 0 0 $viewPaddingVertical;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/tests/__snapshots__/Tabs.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/tests/__snapshots__/Tabs.test.js.snap
@@ -83,9 +83,13 @@ Array [
       </div>
     </div>
   </div>,
-  <h1>
-    Child
-  </h1>,
+  <div
+    class="view"
+  >
+    <h1>
+      Child
+    </h1>
+  </div>,
 ]
 `;
 
@@ -117,9 +121,13 @@ Array [
       </div>
     </div>
   </div>,
-  <h2>
-    Value
-  </h2>,
+  <div
+    class="view"
+  >
+    <h2>
+      Value
+    </h2>
+  </div>,
 ]
 `;
 
@@ -151,11 +159,15 @@ Array [
       </div>
     </div>
   </div>,
-  <h1>
-    Header
-  </h1>,
-  <h2>
-    Child
-  </h2>,
+  <div
+    class="view"
+  >
+    <h1>
+      Header
+    </h1>
+    <h2>
+      Child
+    </h2>
+  </div>,
 ]
 `;

--- a/src/Sulu/Bundle/PageBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/index.js
@@ -30,9 +30,9 @@ initializer.addUpdateConfigHook('sulu_page', (config: Object, initialized: boole
         return;
     }
 
-    viewRegistry.add('sulu_page.page_tabs', PageTabs, {rootSpaceless: true});
+    viewRegistry.add('sulu_page.page_tabs', PageTabs, {disableDefaultSpacing: true});
     viewRegistry.add('sulu_page.page_list', PageList);
-    viewRegistry.add('sulu_page.webspace_tabs', WebspaceTabs, {rootSpaceless: true});
+    viewRegistry.add('sulu_page.webspace_tabs', WebspaceTabs, {disableDefaultSpacing: true});
 
     fieldRegistry.add('page_settings_navigation_select', PageSettingsNavigationSelect);
     fieldRegistry.add('page_settings_shadow_locale_select', PageSettingsShadowLocaleSelect);

--- a/src/Sulu/Bundle/PageBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/index.js
@@ -30,9 +30,9 @@ initializer.addUpdateConfigHook('sulu_page', (config: Object, initialized: boole
         return;
     }
 
-    viewRegistry.add('sulu_page.page_tabs', PageTabs);
+    viewRegistry.add('sulu_page.page_tabs', PageTabs, {rootSpaceless: true});
     viewRegistry.add('sulu_page.page_list', PageList);
-    viewRegistry.add('sulu_page.webspace_tabs', WebspaceTabs);
+    viewRegistry.add('sulu_page.webspace_tabs', WebspaceTabs, {rootSpaceless: true});
 
     fieldRegistry.add('page_settings_navigation_select', PageSettingsNavigationSelect);
     fieldRegistry.add('page_settings_shadow_locale_select', PageSettingsShadowLocaleSelect);

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/pageList.scss
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/pageList.scss
@@ -7,7 +7,7 @@
     flex-grow: 1;
 
     /* +12px to aggravate the bottom space to 40px */
-    height: calc(100% - $webspaceTabsWebspaceSelectMargin - $tabMenuHeight + 12px);
+    height: calc(100% - $webspaceTabsWebspaceSelectMargin + 12px);
 
     /* +2px to center the toolbaractions with the webspace selection */
     margin-top: calc(0 - $webspaceTabsWebspaceSelectMargin - $tabMenuHeight + 2px);

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/WebspaceTabs/tests/__snapshots__/WebspaceTabs.test.js.snap
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/WebspaceTabs/tests/__snapshots__/WebspaceTabs.test.js.snap
@@ -18,31 +18,35 @@ Array [
     </div>
   </div>,
   <div
-    class="webspaceSelect"
+    class="view"
   >
     <div
       class="webspaceSelect"
     >
-      <button
-        class="button"
-        type="button"
+      <div
+        class="webspaceSelect"
       >
-        <span
-          aria-label="su-webspace"
-          class="su-webspace buttonIcon"
-        />
-        <span
-          class="buttonValue"
-        />
-        <span
-          aria-label="su-angle-down"
-          class="su-angle-down buttonIcon"
-        />
-      </button>
+        <button
+          class="button"
+          type="button"
+        >
+          <span
+            aria-label="su-webspace"
+            class="su-webspace buttonIcon"
+          />
+          <span
+            class="buttonValue"
+          />
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down buttonIcon"
+          />
+        </button>
+      </div>
     </div>
+    <h1>
+      sulu_blog
+    </h1>
   </div>,
-  <h1>
-    sulu_blog
-  </h1>,
 ]
 `;

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/WebspaceTabs/variables.scss
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/WebspaceTabs/variables.scss
@@ -1,1 +1,1 @@
-$webspaceTabsWebspaceSelectMargin: 60px;
+$webspaceTabsWebspaceSelectMargin: 20px;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | yes
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add support for position sticky inside tabs container.

#### Why?

The current negative margin on the `tabs-container` does break the whole position sticky things.

Why it would be possible to use a top: - the same value. The field does not know if its inside a tabs-container or not even the tabs-container is not a parent class. And as fields are also used outside of tabs-container example in form overlay it is required that get ride of the minus margins in the views.

By moving the padding from the application to the `ViewRenderer` we can based on new added `ViewConfig` and the new `rootSpaceless` option there if the padding should be added or not on its rootelement.

