### PR TITLE
Add Sticky component

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Sticky/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Sticky/README.md
@@ -1,0 +1,44 @@
+This component provides Sticky functionality to a postion relative parent container.
+
+This component is only required when the sticky container need different styling
+between stuck or unstuck mode. For all other cases the component is not required
+and a simple `position: sticky` CSS should be used.
+
+A related CSS issue can be found in [w3c/csswg-drafts](https://github.com/w3c/csswg-drafts/issues/5979).
+
+The component implementation is inspired by a post on the [Chrome Developers Blog](https://developer.chrome.com/blog/sticky-headers/)
+and was simplified for our use case.
+
+```javascript
+<div style={{position: 'relative'}}>
+    <Sticky>
+        {
+            (isSticky) => <div style={{background: (isSticky ? '#cc00ff' : '#00ccff'), color: (isSticky ? 'white' : 'black'), padding: '20px'}}>
+                {isSticky ? 'Container is sticky!' : 'Container is unsticky!'}
+            </div>
+        }
+    </Sticky>
+    
+    <div style={{height: '150px', marginTop: '10px', background: '#ffcc00'}}>
+        
+    </div>
+</div>
+```
+
+Via the "top" property it can be controlled the position to the sticked container.
+
+```javascript
+<div style={{position: 'relative'}}>
+    <Sticky top={20}>
+        {
+            (isSticky) => <div style={{background: (isSticky ? '#cc00ff' : '#00ccff'), color: (isSticky ? 'white' : 'black'), padding: '20px'}}>
+                {isSticky ? 'Container is sticky!' : 'Container is unsticky!'}
+            </div>
+        }
+    </Sticky>
+    
+    <div style={{height: '150px', marginTop: '10px', background: '#ffcc00'}}>
+        
+    </div>
+</div>
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Sticky/Sticky.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Sticky/Sticky.js
@@ -1,0 +1,79 @@
+// @flow
+import React from 'react';
+import {observer} from 'mobx-react';
+import {action, observable} from 'mobx';
+import stickyStyles from './sticky.scss';
+import type {ElementRef, Node} from 'react';
+
+type Props = {|
+    children: (
+        isSticky: boolean,
+    ) => Node,
+    top: number,
+|};
+
+@observer
+class Sticky extends React.Component<Props> {
+    static defaultProps = {
+        top: 0,
+    };
+
+    intersectionObserver: ?IntersectionObserver;
+
+    constructor(props: Props) {
+        super(props);
+
+        if (typeof IntersectionObserver !== 'undefined') {
+            this.intersectionObserver = new IntersectionObserver((records) => {
+                for (const record of records) {
+                    action(() => {
+                        this.isSticky = !record.isIntersecting;
+                    })();
+                }
+            }, {});
+        }
+    }
+
+    componentWillUnmount() {
+        if (this.intersectionObserver) {
+            this.intersectionObserver.disconnect();
+        }
+    }
+
+    @observable isSticky: boolean = false;
+
+    @observable stickySentinelRef: ElementRef<*>;
+
+    setStickySentinelRef = (ref: ElementRef<*>) => {
+        this.stickySentinelRef = ref;
+
+        if (!this.stickySentinelRef || !this.intersectionObserver) {
+            return;
+        }
+
+        this.intersectionObserver.observe(this.stickySentinelRef);
+    };
+
+    render() {
+        const {
+            children,
+            top,
+        } = this.props;
+
+        return (
+            <>
+                <div
+                    className={stickyStyles.stickySentinel}
+                    ref={this.setStickySentinelRef}
+                    style={{top: (0 - top - 1)}}
+                />
+
+                <div className={stickyStyles.sticky} style={{top}}>
+                    {children(this.isSticky)}
+                </div>
+            </>
+        );
+    }
+}
+
+export default Sticky;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Sticky/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Sticky/index.js
@@ -1,0 +1,4 @@
+// @flow
+import Sticky from './Sticky';
+
+export default Sticky;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Sticky/sticky.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Sticky/sticky.scss
@@ -1,0 +1,14 @@
+.sticky {
+    position: sticky;
+    top: 0;
+    z-index: 1; /* push element in front of position: relative elements */
+}
+
+.stickySentinel {
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 1px;
+    visibility: hidden;
+    pointer-events: none;
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Sticky/tests/Sticky.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Sticky/tests/Sticky.test.js
@@ -1,0 +1,14 @@
+// @flow
+import {render} from 'enzyme';
+import React from 'react';
+import Sticky from '../Sticky.js';
+
+test('The component should render', () => {
+    const component = render(
+        <Sticky>{
+            (isSticky) => <span>{isSticky ? 'Stick' : 'Unsticky'}</span>
+        }</Sticky>
+    );
+
+    expect(component).toMatchSnapshot();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Sticky/tests/__snapshots__/Sticky.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Sticky/tests/__snapshots__/Sticky.test.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The component should render 1`] = `
+Array [
+  <div
+    class="stickySentinel"
+    style="top:-1px"
+  />,
+  <div
+    class="sticky"
+    style="top:0"
+  >
+    <span>
+      Unsticky
+    </span>
+  </div>,
+]
+`;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | yes
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/6676, https://github.com/sulu/sulu/pull/6669 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add a sticky component which childs allow to behave different between stick state.

#### Why?

This will be required for the BlockToolbar. 

#### Example Usage

```js
<Sticky>{
    (isSticky) => <span>{isSticky ? 'Stick' : 'Unsticky'}</span>
}</Sticky>
```

![sticky](https://user-images.githubusercontent.com/1698337/176781611-e3f1d0e8-92eb-40e5-be25-f1a9c313d95a.gif)

#### To Do

- [x] Create a documentation PR
