### PR TITLE
Add Tooltip component

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
@@ -22,6 +22,7 @@ type Props = {
         verticalPosition: string,
         horizontalPosition: string,
     ) => Node,
+    horizontalCenter?: boolean,
     horizontalOffset: number,
     onClose?: () => void,
     open: boolean,
@@ -35,6 +36,7 @@ const CLOSE_KEY = 'esc';
 class Popover extends React.Component<Props> {
     static defaultProps = {
         backdrop: true,
+        horizontalCenter: false,
         horizontalOffset: 0,
         open: false,
         verticalOffset: 0,
@@ -103,6 +105,7 @@ class Popover extends React.Component<Props> {
         const {
             anchorElement,
             verticalOffset,
+            horizontalCenter,
             horizontalOffset,
             centerChildElement,
         } = this.props;
@@ -115,6 +118,8 @@ class Popover extends React.Component<Props> {
         const centerChildOffsetTop = (centerChildElement) ? centerChildElement.offsetTop : 0;
         const alignOnVerticalAnchorEdges = !centerChildElement;
 
+        const horizontalCenterValue = horizontalCenter ? (width - this.popoverWidth) / 2 : 0;
+
         return PopoverPositioner.getCroppedDimensions(
             this.popoverWidth,
             this.popoverHeight,
@@ -122,7 +127,7 @@ class Popover extends React.Component<Props> {
             left,
             width,
             height,
-            horizontalOffset,
+            horizontalCenterValue + horizontalOffset,
             verticalOffset,
             centerChildOffsetTop,
             alignOnVerticalAnchorEdges

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
@@ -8,7 +8,7 @@ import {afterElementsRendered} from '../../utils/DOM';
 import Backdrop from '../Backdrop';
 import PopoverPositioner from './PopoverPositioner';
 import popoverStyles from './popover.scss';
-import type {PopoverDimensions} from './types';
+import type {HorizontalAnchorMode, PopoverDimensions} from './types';
 import type {ElementRef, Node} from 'react';
 
 type Props = {
@@ -22,7 +22,7 @@ type Props = {
         verticalPosition: string,
         horizontalPosition: string,
     ) => Node,
-    horizontalCenter?: boolean,
+    horizontalAnchorMode?: HorizontalAnchorMode,
     horizontalOffset: number,
     onClose?: () => void,
     open: boolean,
@@ -36,7 +36,7 @@ const CLOSE_KEY = 'esc';
 class Popover extends React.Component<Props> {
     static defaultProps = {
         backdrop: true,
-        horizontalCenter: false,
+        horizontalAnchorMode: 'left',
         horizontalOffset: 0,
         open: false,
         verticalOffset: 0,
@@ -105,7 +105,7 @@ class Popover extends React.Component<Props> {
         const {
             anchorElement,
             verticalOffset,
-            horizontalCenter,
+            horizontalAnchorMode,
             horizontalOffset,
             centerChildElement,
         } = this.props;
@@ -118,7 +118,7 @@ class Popover extends React.Component<Props> {
         const centerChildOffsetTop = (centerChildElement) ? centerChildElement.offsetTop : 0;
         const alignOnVerticalAnchorEdges = !centerChildElement;
 
-        const horizontalCenterValue = horizontalCenter ? (width - this.popoverWidth) / 2 : 0;
+        const horizontalOffsetValue = horizontalAnchorMode === 'center' ? (width - this.popoverWidth) / 2 : 0;
 
         return PopoverPositioner.getCroppedDimensions(
             this.popoverWidth,
@@ -127,7 +127,7 @@ class Popover extends React.Component<Props> {
             left,
             width,
             height,
-            horizontalCenterValue + horizontalOffset,
+            horizontalOffsetValue + horizontalOffset,
             verticalOffset,
             centerChildOffsetTop,
             alignOnVerticalAnchorEdges

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/types.js
@@ -18,3 +18,5 @@ export type VerticalCrop = {
     touchesBottomBorder: boolean,
     touchesTopBorder: boolean,
 };
+
+export type HorizontalAnchorMode = 'left' | 'center';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tooltip/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tooltip/README.md
@@ -1,0 +1,52 @@
+This component provide the Tooltip:
+
+```javascript
+import Icon from '../Icon';
+
+<Tooltip label="Some hover text" aria-label="Some hover text">
+    Hover to see the tooltip
+</Tooltip>
+```
+
+The tooltip itself is rendered on the root body element to avoid z-index problems, as this means
+it is out of context it is rendered as `aria-hidden`.
+
+For accessibility reasons your button or element should define the `aria-label` attribute.
+
+A button with a tooltip should be wrapped inside the tooltip so focus on the button will also
+show the tooltip:
+
+```javascript
+import Icon from '../Icon';
+const buttonStyle = {
+    background: 'none',
+    border: 'none',
+    cursor: 'pointer',
+};
+
+<div style={{display: 'flex', gap: '20px'}}>
+    <Tooltip label="Copy">
+        <button type="button" onClick={() => {alert("Copy")}} aria-label="Copy" style={buttonStyle}>
+            <Icon name="su-copy" />
+        </button>
+    </Tooltip>
+
+    <Tooltip label="Duplicate">
+        <button type="button" onClick={() => {alert("Duplicate")}} aria-label="Duplicate" style={buttonStyle}>
+            <Icon name="su-duplicate" />
+        </button>
+    </Tooltip>
+
+    <Tooltip label="Cut">
+        <button type="button" onClick={() => {alert("Cut")}} aria-label="Cut" style={buttonStyle}>
+            <Icon name="su-cut" />
+        </button>
+    </Tooltip>
+
+    <Tooltip label="Delete">
+        <button type="button" onClick={() => {alert("Delete")}} aria-label="Delete" style={buttonStyle}>
+            <Icon name="su-trash-alt" />
+        </button>
+    </Tooltip>
+</div>
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tooltip/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tooltip/README.md
@@ -1,4 +1,4 @@
-This component provide the Tooltip:
+This component displays a tooltip if its content is hovered or focused:
 
 ```javascript
 import Icon from '../Icon';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tooltip/Tooltip.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tooltip/Tooltip.js
@@ -1,0 +1,83 @@
+// @flow
+import React from 'react';
+import classNames from 'classnames';
+import {action, observable} from 'mobx';
+import {observer} from 'mobx-react';
+import Popover from '../Popover';
+import tooltipStyles from './tooltip.scss';
+import type {ChildrenArray, Element, ElementRef} from 'react';
+
+type Props = {|
+    children: ChildrenArray<Element<*> | false>,
+    label: string,
+|};
+
+@observer
+class Tooltip extends React.Component<Props> {
+    constructor(props: Props) {
+        super(props);
+    }
+
+    @observable tooltipOpen: boolean = false;
+
+    @observable tooltipRef: ?ElementRef<*>;
+
+    @action setTooltipRef = (ref: ?ElementRef<*>) => {
+        this.tooltipRef = ref;
+    };
+
+    @action handleEnter = () => {
+        this.tooltipOpen = true;
+    };
+
+    @action handleLeave = () => {
+        this.tooltipOpen = false;
+    };
+
+    render() {
+        const {
+            children,
+            label,
+        } = this.props;
+
+        return (
+            // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+            <span
+                className={tooltipStyles.tooltipContainer}
+                onBlur={this.handleLeave}
+                onFocus={this.handleEnter}
+                onMouseEnter={this.handleEnter}
+                onMouseLeave={this.handleLeave}
+                ref={this.setTooltipRef}
+            >
+                {
+                    this.tooltipRef
+                        && <Popover
+                            anchorElement={this.tooltipRef}
+                            backdrop={false}
+                            horizontalCenter={true}
+                            open={this.tooltipOpen}
+                            verticalOffset={10}
+                        >
+                            {
+                                (setPopoverRef, styles, verticalPosition) => (
+                                    <span
+                                        aria-hidden={true}
+                                        className={classNames(tooltipStyles.tooltip, tooltipStyles[verticalPosition])}
+                                        ref={setPopoverRef}
+                                        style={styles}
+                                    >
+                                        {label}
+                                    </span>
+                                )
+                            }
+                        </Popover>
+                }
+
+                {children}
+            </span>
+        );
+    }
+}
+
+export default Tooltip;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tooltip/Tooltip.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tooltip/Tooltip.js
@@ -5,10 +5,10 @@ import {action, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import Popover from '../Popover';
 import tooltipStyles from './tooltip.scss';
-import type {ChildrenArray, Element, ElementRef} from 'react';
+import type {Node, ElementRef} from 'react';
 
 type Props = {|
-    children: ChildrenArray<Element<*> | false>,
+    children: Node,
     label: string,
 |};
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tooltip/Tooltip.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tooltip/Tooltip.js
@@ -5,7 +5,7 @@ import {action, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import Popover from '../Popover';
 import tooltipStyles from './tooltip.scss';
-import type {Node, ElementRef} from 'react';
+import type {ElementRef, Node} from 'react';
 
 type Props = {|
     children: Node,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tooltip/Tooltip.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tooltip/Tooltip.js
@@ -55,7 +55,7 @@ class Tooltip extends React.Component<Props> {
                         && <Popover
                             anchorElement={this.tooltipRef}
                             backdrop={false}
-                            horizontalCenter={true}
+                            horizontalAnchorMode="center"
                             open={this.tooltipOpen}
                             verticalOffset={10}
                         >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tooltip/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tooltip/index.js
@@ -1,0 +1,4 @@
+// @flow
+import Tooltip from './Tooltip';
+
+export default Tooltip;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tooltip/tests/Tooltip.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tooltip/tests/Tooltip.test.js
@@ -1,0 +1,52 @@
+// @flow
+import React from 'react';
+import {mount, render} from 'enzyme';
+import Tooltip from '../Tooltip';
+import Icon from '../../Icon';
+
+test('The component should render in unfocused state', () => {
+    const component = render(
+        <Tooltip label="Copy">
+            <button aria-label="Copy" type="button">
+                <Icon name="su-copy" />
+            </button>
+        </Tooltip>
+    );
+
+    expect(component.find('Popover span').length).toBe(0);
+
+    expect(component).toMatchSnapshot();
+});
+
+test('The component should render in focused state', () => {
+    const component = mount(
+        <Tooltip label="Copy">
+            <button aria-label="Copy" type="button">
+                <Icon name="su-copy" />
+            </button>
+        </Tooltip>
+    );
+
+    component.find('button').simulate('focus');
+
+    expect(component.find('Popover span').text()).toBe('Copy');
+    expect(component).toMatchSnapshot();
+});
+
+test('The component should render in hovered state', () => {
+    const component = mount(
+        <Tooltip label="Copy">
+            <button aria-label="Copy" type="button">
+                <Icon name="su-copy" />
+            </button>
+        </Tooltip>
+    );
+
+    component.find('Tooltip').simulate('mouseenter');
+
+    expect(component.find('Popover span').text()).toBe('Copy');
+    expect(component).toMatchSnapshot();
+
+    component.find('Tooltip').simulate('mouseleave');
+    expect(component.find('Popover span').length).toBe(0);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tooltip/tests/__snapshots__/Tooltip.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tooltip/tests/__snapshots__/Tooltip.test.js.snap
@@ -1,0 +1,197 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The component should render in focused state 1`] = `
+<Tooltip
+  label="Copy"
+>
+  <span
+    className="tooltipContainer"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <Popover
+      anchorElement={
+        <span
+          class="tooltipContainer"
+        >
+          <button
+            aria-label="Copy"
+            type="button"
+          >
+            <span
+              aria-label="su-copy"
+              class="su-copy"
+            />
+          </button>
+        </span>
+      }
+      backdrop={false}
+      horizontalCenter={true}
+      horizontalOffset={0}
+      open={true}
+      verticalOffset={10}
+    >
+      <Portal>
+        <Portal
+          containerInfo={
+            <div>
+              <div
+                class="container"
+              >
+                <span
+                  aria-hidden="true"
+                  class="tooltip bottom"
+                  style="top: 10px; position: fixed; pointer-events: auto; left: 10px;"
+                >
+                  Copy
+                </span>
+              </div>
+            </div>
+          }
+        >
+          <div
+            className="container"
+          >
+            <span
+              aria-hidden={true}
+              className="tooltip bottom"
+              style={
+                Object {
+                  "left": "10px",
+                  "maxHeight": undefined,
+                  "pointerEvents": "auto",
+                  "position": "fixed",
+                  "top": "10px",
+                }
+              }
+            >
+              Copy
+            </span>
+          </div>
+        </Portal>
+      </Portal>
+    </Popover>
+    <button
+      aria-label="Copy"
+      type="button"
+    >
+      <Icon
+        name="su-copy"
+      >
+        <span
+          aria-label="su-copy"
+          className="su-copy"
+        />
+      </Icon>
+    </button>
+  </span>
+</Tooltip>
+`;
+
+exports[`The component should render in hovered state 1`] = `
+<Tooltip
+  label="Copy"
+>
+  <span
+    className="tooltipContainer"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <Popover
+      anchorElement={
+        <span
+          class="tooltipContainer"
+        >
+          <button
+            aria-label="Copy"
+            type="button"
+          >
+            <span
+              aria-label="su-copy"
+              class="su-copy"
+            />
+          </button>
+        </span>
+      }
+      backdrop={false}
+      horizontalCenter={true}
+      horizontalOffset={0}
+      open={true}
+      verticalOffset={10}
+    >
+      <Portal>
+        <Portal
+          containerInfo={
+            <div>
+              <div
+                class="container"
+              >
+                <span
+                  aria-hidden="true"
+                  class="tooltip bottom"
+                  style="top: 10px; position: fixed; pointer-events: auto; left: 10px;"
+                >
+                  Copy
+                </span>
+              </div>
+            </div>
+          }
+        >
+          <div
+            className="container"
+          >
+            <span
+              aria-hidden={true}
+              className="tooltip bottom"
+              style={
+                Object {
+                  "left": "10px",
+                  "maxHeight": undefined,
+                  "pointerEvents": "auto",
+                  "position": "fixed",
+                  "top": "10px",
+                }
+              }
+            >
+              Copy
+            </span>
+          </div>
+        </Portal>
+      </Portal>
+    </Popover>
+    <button
+      aria-label="Copy"
+      type="button"
+    >
+      <Icon
+        name="su-copy"
+      >
+        <span
+          aria-label="su-copy"
+          className="su-copy"
+        />
+      </Icon>
+    </button>
+  </span>
+</Tooltip>
+`;
+
+exports[`The component should render in unfocused state 1`] = `
+<span
+  class="tooltipContainer"
+>
+  <button
+    aria-label="Copy"
+    type="button"
+  >
+    <span
+      aria-label="su-copy"
+      class="su-copy"
+    />
+  </button>
+</span>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tooltip/tests/__snapshots__/Tooltip.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tooltip/tests/__snapshots__/Tooltip.test.js.snap
@@ -28,7 +28,7 @@ exports[`The component should render in focused state 1`] = `
         </span>
       }
       backdrop={false}
-      horizontalCenter={true}
+      horizontalAnchorMode="center"
       horizontalOffset={0}
       open={true}
       verticalOffset={10}
@@ -118,7 +118,7 @@ exports[`The component should render in hovered state 1`] = `
         </span>
       }
       backdrop={false}
-      horizontalCenter={true}
+      horizontalAnchorMode="center"
       horizontalOffset={0}
       open={true}
       verticalOffset={10}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tooltip/tooltip.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Tooltip/tooltip.scss
@@ -1,0 +1,47 @@
+@import '../../containers/Application/colors.scss';
+
+.tooltipContainer {
+    display: inline-block;
+    background: none;
+    border: none;
+}
+
+.tooltip {
+    background: $black;
+    border-radius: 3px;
+    color: $white;
+    font-weight: 600;
+    font-size: 10px;
+    line-height: 14px;
+    padding: 3px 7px 3px;
+}
+
+.top {
+    position: relative;
+
+    &::before {
+        content: '';
+        position: absolute;
+        top: 100%;
+        left: 50%;
+        margin-left: -6px;
+        border-width: 4px 6px 0 6px;
+        border-style: solid;
+        border-color: $black transparent transparent transparent;
+    }
+}
+
+.bottom {
+    position: relative;
+
+    &::before {
+        content: '';
+        position: absolute;
+        top: -4px;
+        left: 50%;
+        margin-left: -6px;
+        border-width: 0 6px 4px 6px;
+        border-style: solid;
+        border-color: transparent transparent $black transparent;
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | yes 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/6669 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add Tooltip component.

#### Why?

For the BlockToolbar we need a Tooltip component.

#### Example Usage

```html
<Tooltip label="Copy">
    <-- Button is inside to bubble focus event to the Tooltip -->
    <button type="button" onClick={() => {}} aria-label="Copy" style={buttonStyle}>
        <Icon name="su-copy" />
    </button>
</Tooltip>
```

![tooltip](https://user-images.githubusercontent.com/1698337/176782176-bf14d82c-c9f7-4d32-b51b-46411eb565ff.gif)


#### To Do

- [x] Create a documentation PR