### PR TITLE
Add size small prop to checkbox and switch component

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/Checkbox.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/Checkbox.js
@@ -9,6 +9,7 @@ type Props<T> = {|
     ...SwitchProps<T>,
     className?: string,
     onChange?: (checked: boolean, value?: T) => void,
+    size: 'small' | 'default',
     skin: 'dark' | 'light',
     tabIndex?: ?number,
 |};
@@ -19,11 +20,13 @@ export default class Checkbox<T: string | number> extends React.PureComponent<Pr
     static defaultProps = {
         checked: false,
         disabled: false,
+        size: 'default',
         skin: 'dark',
     };
 
     render() {
         const {
+            size,
             skin,
             name,
             value,
@@ -48,6 +51,7 @@ export default class Checkbox<T: string | number> extends React.PureComponent<Pr
                 icon={checked ? CHECKED_ICON : undefined}
                 name={name}
                 onChange={onChange}
+                size={size}
                 tabIndex={tabIndex}
                 value={value}
             >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/README.md
@@ -18,7 +18,7 @@ const [checked, setChecked] = React.useState(false);
 
 const onChange = (checked) => setChecked(checked);
 <div style={{background: 'black', padding: '10px'}}>
-    <Checkbox skin="light" checked={checked} onChange={onChange} />
+    <Checkbox skin="light" checked={checked} onChange={onChange}>Save the world</Checkbox>
 </div>
 ```
 
@@ -27,7 +27,20 @@ const [checked, setChecked] = React.useState(false);
 
 const onChange = (checked) => setChecked(checked);
 <div style={{background: 'black', padding: '10px'}}>
-    <Checkbox active={false} checked={checked} onChange={onChange} />
+    <Checkbox active={false} checked={checked} onChange={onChange}>Buy groceries</Checkbox>
+</div>
+```
+
+There is also a size option to render a smaller variant, effecting the label font size.
+Used when the Checkbox is part of another fields. Example in the TwoFactorForm or BlockToolbar.
+
+```javascript
+const [checked1, setChecked1] = React.useState(false);
+const [checked2, setChecked2] = React.useState(true);
+
+<div>
+    <Checkbox value="1" checked={checked1} onChange={setChecked1} size="small">Save the world</Checkbox>
+    <Checkbox value="2" checked={checked2} onChange={setChecked2} size="small">Buy groceries</Checkbox>
 </div>
 ```
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/checkbox.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/checkbox.scss
@@ -29,6 +29,10 @@ $disabledColor: $silver;
     }
 }
 
+.checkbox.small {
+    font-size: 12px;
+}
+
 .checkbox {
     width: $length;
     height: $length;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/tests/Checkbox.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/tests/Checkbox.test.js
@@ -18,6 +18,11 @@ test('The component should render in disabled state', () => {
     expect(checkbox).toMatchSnapshot();
 });
 
+test('The component should render in size small', () => {
+    const checkbox = render(<Checkbox size="small" />);
+    expect(checkbox).toMatchSnapshot();
+});
+
 test('The component pass the props correctly to the generic checkbox', () => {
     const onChange = jest.fn();
     const checkbox = shallow(

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/tests/__snapshots__/Checkbox.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/tests/__snapshots__/Checkbox.test.js.snap
@@ -48,3 +48,19 @@ exports[`The component should render in light skin 1`] = `
   </span>
 </label>
 `;
+
+exports[`The component should render in size small 1`] = `
+<label
+  class="label small"
+  tabindex="-1"
+>
+  <span
+    class="switch checkbox dark"
+  >
+    <input
+      type="checkbox"
+    />
+    <span />
+  </span>
+</label>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Switch/Switch.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Switch/Switch.js
@@ -10,6 +10,7 @@ type Props<T> = {|
     className?: string,
     icon?: string,
     onChange?: (checked: boolean, value?: T) => void,
+    size: 'small' | 'default',
     tabIndex?: ?number,
     type: string,
 |};
@@ -18,6 +19,7 @@ export default class Switch<T: string | number> extends React.PureComponent<Prop
     static defaultProps = {
         checked: false,
         disabled: false,
+        size: 'default',
         type: 'checkbox',
     };
 
@@ -42,14 +44,17 @@ export default class Switch<T: string | number> extends React.PureComponent<Prop
             children,
             className,
             disabled,
+            size,
             tabIndex,
         } = this.props;
         const labelClass = classNames(
             switchStyles.label,
             {
                 [switchStyles.disabled]: disabled,
-            }
+            },
+            switchStyles[size]
         );
+
         const switchClass = classNames(
             switchStyles.switch,
             {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Switch/Switch.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Switch/Switch.js
@@ -52,7 +52,7 @@ export default class Switch<T: string | number> extends React.PureComponent<Prop
             {
                 [switchStyles.disabled]: disabled,
             },
-            switchStyles[size]
+            size !== 'default' ? switchStyles[size] : null
         );
 
         const switchClass = classNames(

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Switch/switch.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Switch/switch.scss
@@ -21,6 +21,13 @@ $marginBottom: 10px;
     }
 }
 
+.label.small {
+    & > div {
+        font-size: 12px;
+        margin-left: 8px;
+    }
+}
+
 .switch {
     display: inline-block;
     position: relative;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/TwoFactorForm.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/TwoFactorForm.js
@@ -112,10 +112,9 @@ class TwoFactorForm extends React.Component<Props> {
                             <Checkbox
                                 checked={this.trustedDevice}
                                 onChange={this.handleTrustedDeviceChange}
+                                size="small"
                             >
-                                <span className={formStyles.labelSmallText}>
-                                    {translate('sulu_admin.two_factor_trust_device')}
-                                </span>
+                                {translate('sulu_admin.two_factor_trust_device')}
                             </Checkbox>
                         }
                         <div className={formStyles.buttons}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/form.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/form.scss
@@ -38,7 +38,3 @@ $errorColor: $roman;
     line-height: 20px;
     height: 20px;
 }
-
-.label-small-text {
-    font-size: 12px;
-}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/__snapshots__/TwoFactorForm.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/__snapshots__/TwoFactorForm.test.js.snap
@@ -38,7 +38,7 @@ Array [
         </div>
       </label>
       <label
-        class="label"
+        class="label small"
         tabindex="-1"
       >
         <span
@@ -50,11 +50,7 @@ Array [
           <span />
         </span>
         <div>
-          <span
-            class="labelSmallText"
-          >
-            sulu_admin.two_factor_trust_device
-          </span>
+          sulu_admin.two_factor_trust_device
         </div>
       </label>
       <div
@@ -125,7 +121,7 @@ Array [
         </div>
       </label>
       <label
-        class="label"
+        class="label small"
         tabindex="-1"
       >
         <span
@@ -137,11 +133,7 @@ Array [
           <span />
         </span>
         <div>
-          <span
-            class="labelSmallText"
-          >
-            sulu_admin.two_factor_trust_device
-          </span>
+          sulu_admin.two_factor_trust_device
         </div>
       </label>
       <div


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? |  yes
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #6669 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add size small prop to checkbox and switch component.

#### Why?

This is required for BlockToolbar and TwoFactorForm.
