### PR TITLE
Add possibility to use translation keys in template meta information

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Resources/config/structure.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/structure.xml
@@ -11,8 +11,10 @@
             <argument type="service" id="sulu_page.structure.properties_xml_parser"/>
             <argument type="service" id="sulu_page.structure.schema_xml_parser"/>
             <argument type="service" id="sulu.content.type_manager" />
+            <argument type="service" id="translator" />
             <argument>%sulu.content.structure.required_properties%</argument>
             <argument>%sulu.content.structure.required_tags%</argument>
+            <argument>%sulu_core.translated_locales%</argument>
         </service>
 
         <service id="sulu_page.structure.properties_xml_parser"

--- a/src/Sulu/Bundle/PageBundle/Resources/config/structure.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/structure.xml
@@ -11,10 +11,10 @@
             <argument type="service" id="sulu_page.structure.properties_xml_parser"/>
             <argument type="service" id="sulu_page.structure.schema_xml_parser"/>
             <argument type="service" id="sulu.content.type_manager" />
-            <argument type="service" id="translator" />
             <argument>%sulu.content.structure.required_properties%</argument>
             <argument>%sulu.content.structure.required_tags%</argument>
             <argument>%sulu_core.translated_locales%</argument>
+            <argument type="service" id="translator" />
         </service>
 
         <service id="sulu_page.structure.properties_xml_parser"

--- a/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
@@ -389,6 +389,7 @@ class StructureXmlLoader extends AbstractLoader
 
     /**
      * @param array<string, string> $metaValues
+     *
      * @return array<string, string>
      */
     private function loadMetaValues(array $metaValues): array

--- a/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
@@ -114,19 +114,19 @@ class StructureXmlLoader extends AbstractLoader
         PropertiesXmlParser $propertiesXmlParser,
         SchemaXmlParser $schemaXmlParser,
         ContentTypeManagerInterface $contentTypeManager,
-        TranslatorInterface $translator,
         array $requiredPropertyNames,
         array $requiredTagNames,
-        array $locales
+        array $locales,
+        ?TranslatorInterface $translator = null
     ) {
         $this->cacheLifetimeResolver = $cacheLifetimeResolver;
         $this->propertiesXmlParser = $propertiesXmlParser;
         $this->schemaXmlParser = $schemaXmlParser;
         $this->contentTypeManager = $contentTypeManager;
-        $this->translator = $translator;
         $this->requiredPropertyNames = $requiredPropertyNames;
         $this->requiredTagNames = $requiredTagNames;
         $this->locales = \array_keys($locales);
+        $this->translator = $translator;
 
         parent::__construct(
             self::SCHEME_PATH,
@@ -394,6 +394,10 @@ class StructureXmlLoader extends AbstractLoader
      */
     private function loadMetaValues(array $metaValues): array
     {
+        if (!$this->translator) {
+            return $metaValues;
+        }
+
         $result = [];
 
         $translationKey = null;

--- a/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
@@ -116,7 +116,7 @@ class StructureXmlLoader extends AbstractLoader
         ContentTypeManagerInterface $contentTypeManager,
         array $requiredPropertyNames,
         array $requiredTagNames,
-        array $locales,
+        array $locales = [],
         ?TranslatorInterface $translator = null
     ) {
         $this->cacheLifetimeResolver = $cacheLifetimeResolver;

--- a/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
@@ -77,7 +77,7 @@ class StructureXmlLoader extends AbstractLoader
     private $requiredPropertyNames = [];
 
     /**
-     * @var string[]
+     * @var array<int, string>
      */
     private $locales;
 
@@ -106,6 +106,9 @@ class StructureXmlLoader extends AbstractLoader
      */
     private $translator;
 
+    /**
+     * @param array<string, string> $locales
+     */
     public function __construct(
         CacheLifetimeResolverInterface $cacheLifetimeResolver,
         PropertiesXmlParser $propertiesXmlParser,
@@ -384,6 +387,10 @@ class StructureXmlLoader extends AbstractLoader
         );
     }
 
+    /**
+     * @param array<string, string> $metaValues
+     * @return array<string, string>
+     */
     private function loadMetaValues(array $metaValues): array
     {
         $result = [];

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Factory/StructureMetadataFactoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Factory/StructureMetadataFactoryTest.php
@@ -190,6 +190,8 @@ class StructureMetadataFactoryTest extends TestCase
             $propertiesXmlLoader,
             $schemaXmlLoader,
             $contentTypeManager->reveal(),
+            $this->translator->reveal(),
+            [],
             [],
             []
         );

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Factory/StructureMetadataFactoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Factory/StructureMetadataFactoryTest.php
@@ -179,8 +179,10 @@ class StructureMetadataFactoryTest extends TestCase
         $cacheLifeTimeResolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, Argument::any())
             ->willReturn(true);
 
+        $translatorDouble = $this->translator->reveal();
+
         $propertiesXmlLoader = new PropertiesXmlParser(
-            $this->translator->reveal(),
+            $translatorDouble,
             []
         );
         $schemaXmlLoader = new SchemaXmlParser();
@@ -190,7 +192,7 @@ class StructureMetadataFactoryTest extends TestCase
             $propertiesXmlLoader,
             $schemaXmlLoader,
             $contentTypeManager->reveal(),
-            $this->translator->reveal(),
+            $translatorDouble,
             [],
             [],
             []

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Factory/StructureMetadataFactoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Factory/StructureMetadataFactoryTest.php
@@ -179,10 +179,8 @@ class StructureMetadataFactoryTest extends TestCase
         $cacheLifeTimeResolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, Argument::any())
             ->willReturn(true);
 
-        $translatorDouble = $this->translator->reveal();
-
         $propertiesXmlLoader = new PropertiesXmlParser(
-            $translatorDouble,
+            $this->translator->reveal(),
             []
         );
         $schemaXmlLoader = new SchemaXmlParser();
@@ -192,10 +190,10 @@ class StructureMetadataFactoryTest extends TestCase
             $propertiesXmlLoader,
             $schemaXmlLoader,
             $contentTypeManager->reveal(),
-            $translatorDouble,
             [],
             [],
-            []
+            [],
+            $this->translator->reveal(),
         );
 
         $loadResult = $xmlLoader->load($this->apostropheMappingFile, 'page');

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
@@ -45,7 +45,7 @@ class StructureXmlLoaderTest extends TestCase
         'en' => 'en',
         'de' => 'de',
         'fr' => 'fr',
-        'nl' => 'nl'
+        'nl' => 'nl',
     ];
 
     /**

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
@@ -41,6 +41,9 @@ class StructureXmlLoaderTest extends TestCase
         'snippet' => ['title'],
     ];
 
+    /**
+     * @var string[]
+     */
     private $locales = [
         'en' => 'en',
         'de' => 'de',
@@ -109,7 +112,7 @@ class StructureXmlLoaderTest extends TestCase
         $this->assertNull($result->getSchema());
     }
 
-    public function testLoadTemplateWithLocalization()
+    public function testLoadTemplateWithLocalization(): void
     {
         $this->contentTypeManager->has('text_line')->willReturn(true);
         $this->contentTypeManager->has('resource_locator')->willReturn(true);

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
@@ -88,10 +88,10 @@ class StructureXmlLoaderTest extends TestCase
             $propertiesXmlParser,
             $schemaXmlParser,
             $this->contentTypeManager->reveal(),
-            $this->translator->reveal(),
             $this->requiredPropertyNames,
             $this->requiredTagNames,
-            $this->locales
+            $this->locales,
+            $this->translator->reveal()
         );
     }
 

--- a/tests/Resources/DataFixtures/Page/template_with_localizations.xml
+++ b/tests/Resources/DataFixtures/Page/template_with_localizations.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>template_with_localizations</key>
+
+    <view>page.html.twig</view>
+    <controller>SuluPageBundle:Default:index</controller>
+    <cacheLifetime>2400</cacheLifetime>
+    <index name="foo_index" />
+
+    <meta>
+        <title>template_title</title>
+        <title lang="de">Template Titel</title>
+    </meta>
+
+    <tag name="some.random.structure.tag" foo="bar" bar="foo"/>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title>property_title</title>
+            </meta>
+
+            <indexField />
+
+            <tag name="sulu.node.title" priority="10"/>
+
+            <tag name="some.random.tag" one="1" two="2" three="three" />
+        </property>
+
+        <property name="url" type="resource_locator" mandatory="true">
+            <tag name="sulu.rlp" priority="1"/>
+        </property>
+    </properties>
+</template>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #6661 <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | - <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT

#### What's in this PR?

This PR adds support to define translation keys as meta information in template meta tags.

#### Why?

This streamlines the behaviour between the meta tags of the template itself and its properties as they already have this behaviour.

See #6661 for further details.
