### PR TITLE
Add floating snackbar

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/block.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/block.scss
@@ -61,12 +61,14 @@ $blockSelectedColor: $blueZodiac;
     color: $blockHandleColor;
     background-color: $blockHandleBackgroundColor;
     overflow: hidden;
+    width: fit-content;
 }
 
 .content {
     flex-grow: 1;
     font-size: 12px;
     line-height: 18px;
+    width: 0; /* avoid overflowing text editor - display flex on parent pushes it still to 100% */
 }
 
 .children {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -10,7 +10,7 @@ import Icon from '../Icon';
 import Sticky from '../Sticky';
 import SortableBlockList from './SortableBlockList';
 import blockCollectionStyles from './blockCollection.scss';
-import type {RenderBlockContentCallback, BlockMode} from './types';
+import type {RenderBlockContentCallback, BlockMode, Message} from './types';
 
 type Props<T: string, U: {type: T}> = {|
     addButtonText?: ?string,
@@ -24,6 +24,7 @@ type Props<T: string, U: {type: T}> = {|
     onChange: (value: Array<U>) => void,
     onSettingsClick?: (index: number) => void,
     onSortEnd?: (oldIndex: number, newIndex: number) => void,
+    onTriggerMessage?: (message: Message) => void,
     pasteButtonText?: ?string,
     renderBlockContent: RenderBlockContentCallback<T, U>,
     types?: {[key: T]: string},
@@ -147,37 +148,47 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
     };
 
     @action handlePasteBlocks = (insertionIndex: number) => {
-        const {onChange, value} = this.props;
+        const {onChange, onTriggerMessage, value} = this.props;
 
         if (this.hasMaximumReached) {
             throw new Error('The maximum amount of blocks has already been reached!');
         }
 
-        if (value) {
-            this.expandedBlocks.splice(
-                insertionIndex, 0, ...this.pasteableBlocks.map(() => true)
-            );
-            this.selectedBlocks.splice(
-                insertionIndex, 0, ...this.pasteableBlocks.map(() => false)
-            );
-            this.generatedBlockIds.splice(
-                insertionIndex, 0, ...this.pasteableBlocks.map(() => ++BlockCollection.idCounter)
-            );
+        if (!value) {
+            return;
+        }
 
-            const newElements = this.pasteableBlocks.map((block) => {
-                // paste block with default type if type of block in clipboard is not known
-                if (!this.props.types?.[block.type]) {
-                    return {...block, type: this.props.defaultType};
-                }
+        this.expandedBlocks.splice(
+            insertionIndex, 0, ...this.pasteableBlocks.map(() => true)
+        );
+        this.selectedBlocks.splice(
+            insertionIndex, 0, ...this.pasteableBlocks.map(() => false)
+        );
+        this.generatedBlockIds.splice(
+            insertionIndex, 0, ...this.pasteableBlocks.map(() => ++BlockCollection.idCounter)
+        );
 
-                return block;
+        const newElements = this.pasteableBlocks.map((block) => {
+            // paste block with default type if type of block in clipboard is not known
+            if (!this.props.types?.[block.type]) {
+                return {...block, type: this.props.defaultType};
+            }
+
+            return block;
+        });
+        const elementsBefore = value.slice(0, insertionIndex);
+        const elementsAfter = value.slice(insertionIndex);
+
+        // $FlowFixMe
+        onChange([...elementsBefore, ...newElements, ...elementsAfter]);
+        clipboard.set(BLOCKS_CLIPBOARD_KEY, undefined);
+
+        if (onTriggerMessage) {
+            onTriggerMessage({
+                type: 'info',
+                text: translate('sulu_admin.%count%_blocks_pasted', {count: newElements.length}),
+                icon: 'su-copy',
             });
-            const elementsBefore = value.slice(0, insertionIndex);
-            const elementsAfter = value.slice(insertionIndex);
-
-            // $FlowFixMe
-            onChange([...elementsBefore, ...newElements, ...elementsAfter]);
-            clipboard.set(BLOCKS_CLIPBOARD_KEY, undefined);
         }
     };
 
@@ -189,8 +200,8 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
         this.removeBlocks(this.selectedBlockIndexes);
     };
 
-    @action removeBlocks = (indexes: Array<number>) => {
-        const {onChange, movable, value} = this.props;
+    @action removeBlocks = (indexes: Array<number>, triggerMessage: boolean = true) => {
+        const {onChange, onTriggerMessage, movable, value} = this.props;
 
         if (!value) {
             return;
@@ -214,6 +225,14 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
         }
 
         onChange(value.filter((block, index) => indexes.indexOf(index) === -1));
+
+        if (triggerMessage && onTriggerMessage) {
+            onTriggerMessage({
+                type: 'info',
+                text: translate('sulu_admin.%count%_blocks_removed', {count: indexes.length}),
+                icon: 'su-trash-alt',
+            });
+        }
     };
 
     handleDuplicateSelectedBlocks = () => {
@@ -227,7 +246,7 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
     };
 
     @action duplicateBlocks = (indexes: Array<number>, insertAfterIndex: number) => {
-        const {onChange, value} = this.props;
+        const {onChange, onTriggerMessage, value} = this.props;
 
         if (!value) {
             return;
@@ -254,6 +273,14 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
         });
 
         onChange(newValue);
+
+        if (onTriggerMessage) {
+            onTriggerMessage({
+                type: 'info',
+                text: translate('sulu_admin.%count%_blocks_duplicated', {count: indexes.length}),
+                icon: 'su-duplicate',
+            });
+        }
     };
 
     handleCopySelectedBlocks = () => {
@@ -264,8 +291,8 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
         this.copyBlocks([index]);
     };
 
-    copyBlocks = (indexes: Array<number>) => {
-        const {value} = this.props;
+    copyBlocks = (indexes: Array<number>, triggerMessage: boolean = true) => {
+        const {onTriggerMessage, value} = this.props;
 
         if (!value) {
             return;
@@ -278,6 +305,14 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
         });
 
         clipboard.set(BLOCKS_CLIPBOARD_KEY, blocks);
+
+        if (triggerMessage && onTriggerMessage) {
+            onTriggerMessage({
+                type: 'info',
+                text: translate('sulu_admin.%count%_blocks_copied', {count: indexes.length}),
+                icon: 'su-copy',
+            });
+        }
     };
 
     handleCutSelectedBlocks = () => {
@@ -289,8 +324,18 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
     };
 
     cutBlocks = (indexes: Array<number>) => {
-        this.copyBlocks(indexes);
-        this.removeBlocks(indexes);
+        const {onTriggerMessage} = this.props;
+
+        this.copyBlocks(indexes, false);
+        this.removeBlocks(indexes, false);
+
+        if (onTriggerMessage) {
+            onTriggerMessage({
+                type: 'info',
+                text: translate('sulu_admin.%count%_blocks_cut', {count: indexes.length}),
+                icon: 'su-cut',
+            });
+        }
     };
 
     @action handleSortEnd = ({newIndex, oldIndex}: {newIndex: number, oldIndex: number}) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -22,9 +22,9 @@ type Props<T: string, U: {type: T}> = {|
     minOccurs?: ?number,
     movable: boolean,
     onChange: (value: Array<U>) => void,
+    onDisplaySnackbar?: (message: Message) => void,
     onSettingsClick?: (index: number) => void,
     onSortEnd?: (oldIndex: number, newIndex: number) => void,
-    onTriggerMessage?: (message: Message) => void,
     pasteButtonText?: ?string,
     renderBlockContent: RenderBlockContentCallback<T, U>,
     types?: {[key: T]: string},
@@ -148,7 +148,7 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
     };
 
     @action handlePasteBlocks = (insertionIndex: number) => {
-        const {onChange, onTriggerMessage, value} = this.props;
+        const {onChange, onDisplaySnackbar, value} = this.props;
 
         if (this.hasMaximumReached) {
             throw new Error('The maximum amount of blocks has already been reached!');
@@ -183,8 +183,8 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
         onChange([...elementsBefore, ...newElements, ...elementsAfter]);
         clipboard.set(BLOCKS_CLIPBOARD_KEY, undefined);
 
-        if (onTriggerMessage) {
-            onTriggerMessage({
+        if (onDisplaySnackbar) {
+            onDisplaySnackbar({
                 type: 'info',
                 text: translate('sulu_admin.%count%_blocks_pasted', {count: newElements.length}),
                 icon: 'su-copy',
@@ -200,8 +200,8 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
         this.removeBlocks(this.selectedBlockIndexes);
     };
 
-    @action removeBlocks = (indexes: Array<number>, triggerMessage: boolean = true) => {
-        const {onChange, onTriggerMessage, movable, value} = this.props;
+    @action removeBlocks = (indexes: Array<number>, shouldDisplaySnackbar: boolean = true) => {
+        const {onChange, onDisplaySnackbar, movable, value} = this.props;
 
         if (!value) {
             return;
@@ -226,8 +226,8 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
 
         onChange(value.filter((block, index) => indexes.indexOf(index) === -1));
 
-        if (triggerMessage && onTriggerMessage) {
-            onTriggerMessage({
+        if (shouldDisplaySnackbar && onDisplaySnackbar) {
+            onDisplaySnackbar({
                 type: 'info',
                 text: translate('sulu_admin.%count%_blocks_removed', {count: indexes.length}),
                 icon: 'su-trash-alt',
@@ -246,7 +246,7 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
     };
 
     @action duplicateBlocks = (indexes: Array<number>, insertAfterIndex: number) => {
-        const {onChange, onTriggerMessage, value} = this.props;
+        const {onChange, onDisplaySnackbar, value} = this.props;
 
         if (!value) {
             return;
@@ -274,8 +274,8 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
 
         onChange(newValue);
 
-        if (onTriggerMessage) {
-            onTriggerMessage({
+        if (onDisplaySnackbar) {
+            onDisplaySnackbar({
                 type: 'info',
                 text: translate('sulu_admin.%count%_blocks_duplicated', {count: indexes.length}),
                 icon: 'su-duplicate',
@@ -291,8 +291,8 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
         this.copyBlocks([index]);
     };
 
-    copyBlocks = (indexes: Array<number>, triggerMessage: boolean = true) => {
-        const {onTriggerMessage, value} = this.props;
+    copyBlocks = (indexes: Array<number>, shouldDisplaySnackbar: boolean = true) => {
+        const {onDisplaySnackbar, value} = this.props;
 
         if (!value) {
             return;
@@ -306,8 +306,8 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
 
         clipboard.set(BLOCKS_CLIPBOARD_KEY, blocks);
 
-        if (triggerMessage && onTriggerMessage) {
-            onTriggerMessage({
+        if (shouldDisplaySnackbar && onDisplaySnackbar) {
+            onDisplaySnackbar({
                 type: 'info',
                 text: translate('sulu_admin.%count%_blocks_copied', {count: indexes.length}),
                 icon: 'su-copy',
@@ -324,13 +324,13 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
     };
 
     cutBlocks = (indexes: Array<number>) => {
-        const {onTriggerMessage} = this.props;
+        const {onDisplaySnackbar} = this.props;
 
         this.copyBlocks(indexes, false);
         this.removeBlocks(indexes, false);
 
-        if (onTriggerMessage) {
-            onTriggerMessage({
+        if (onDisplaySnackbar) {
+            onDisplaySnackbar({
                 type: 'info',
                 text: translate('sulu_admin.%count%_blocks_cut', {count: indexes.length}),
                 icon: 'su-cut',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/types.js
@@ -10,3 +10,9 @@ export type RenderBlockContentCallback<T: string, U: {type: T}>
     = (value: U, type: T, index: number, expanded: boolean) => Node;
 
 export type BlockMode = 'static' | 'sortable' | 'selectable';
+
+export type Message = {
+    icon?: string,
+    text: string,
+    type: 'success' | 'error' | 'warning' | 'info',
+};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockToolbar/BlockToolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockToolbar/BlockToolbar.js
@@ -1,12 +1,14 @@
 // @flow
 import React from 'react';
-import classNames from 'classnames';
+import classnames from 'classnames';
 import Checkbox from '../Checkbox';
 import {translate} from '../../utils';
 import Icon from '../Icon';
 import Tooltip from '../Tooltip';
 import blockToolbarStyles from './blockToolbar.scss';
 import type {BlockToolbarMode} from './types';
+import applicationStyles from "../../containers/Application/application.scss";
+import {sidebarStore} from "../../containers";
 
 type Props = {|
     actions: Array<{|
@@ -61,7 +63,7 @@ class BlockToolbar extends React.Component<Props> {
         } = this.props;
 
         return (
-            <section className={classNames(blockToolbarStyles.container, blockToolbarStyles[mode])}>
+            <section className={classnames(blockToolbarStyles.container, blockToolbarStyles[mode])}>
                 <div className={blockToolbarStyles.divide}>
                     <div className={blockToolbarStyles.selected}>
                         {translate('sulu_admin.%count%_selected', {count: selectedCount})}
@@ -84,7 +86,10 @@ class BlockToolbar extends React.Component<Props> {
                             <Tooltip key={action.label} label={action.label}>
                                 <button
                                     aria-label={action.label}
-                                    className={blockToolbarStyles.actionButton}
+                                    className={classnames(blockToolbarStyles.actionButton, {
+                                        [blockToolbarStyles.actionButtonDisabled]: selectedCount === 0,
+                                    })}
+                                    disabled={selectedCount === 0}
                                     onClick={action.handleClick}
                                     type="button"
                                 >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockToolbar/BlockToolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockToolbar/BlockToolbar.js
@@ -7,8 +7,6 @@ import Icon from '../Icon';
 import Tooltip from '../Tooltip';
 import blockToolbarStyles from './blockToolbar.scss';
 import type {BlockToolbarMode} from './types';
-import applicationStyles from "../../containers/Application/application.scss";
-import {sidebarStore} from "../../containers";
 
 type Props = {|
     actions: Array<{|

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockToolbar/BlockToolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockToolbar/BlockToolbar.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import classnames from 'classnames';
+import classNames from 'classnames';
 import Checkbox from '../Checkbox';
 import {translate} from '../../utils';
 import Icon from '../Icon';
@@ -61,7 +61,7 @@ class BlockToolbar extends React.Component<Props> {
         } = this.props;
 
         return (
-            <section className={classnames(blockToolbarStyles.container, blockToolbarStyles[mode])}>
+            <section className={classNames(blockToolbarStyles.container, blockToolbarStyles[mode])}>
                 <div className={blockToolbarStyles.divide}>
                     <div className={blockToolbarStyles.selected}>
                         {translate('sulu_admin.%count%_selected', {count: selectedCount})}
@@ -84,7 +84,7 @@ class BlockToolbar extends React.Component<Props> {
                             <Tooltip key={action.label} label={action.label}>
                                 <button
                                     aria-label={action.label}
-                                    className={classnames(blockToolbarStyles.actionButton, {
+                                    className={classNames(blockToolbarStyles.actionButton, {
                                         [blockToolbarStyles.actionButtonDisabled]: selectedCount === 0,
                                     })}
                                     disabled={selectedCount === 0}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockToolbar/blockToolbar.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockToolbar/blockToolbar.scss
@@ -70,9 +70,16 @@
 
     &:hover,
     &:focus {
-        color: $shakespeare;
-        outline: none;
+        &:not(.actionButtonDisabled) {
+            color: $shakespeare;
+            outline: none;
+        }
     }
+}
+
+.actionButtonDisabled {
+    color: $silver;
+    cursor: default;
 }
 
 .actionButtonIcon {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/README.md
@@ -1,13 +1,47 @@
 The `Snackbar` component is used to display information that is moving in from the top of the screen using an animation.
 
 ```javascript
-<Snackbar message="Something went wrong" type="error" />
+<Snackbar message="Some error is shown here" type="error" />
 ```
 
-Besides errors it can also show warnings:
+Besides errors it can also show `warning`, `success` and `info` messages:
 
 ```javascript
-<Snackbar message="Something not so bad went wrong" type="warning" />
+<div style={{display: 'flex', flexDirection: 'column', gap: '10px'}}>
+    <Snackbar message="Some warning is shown here" type="warning" />
+    
+    <Snackbar message="Some information is shown here" type="info" />
+    
+    <Snackbar message="Some not so bad went wrong" type="success" />
+</div>
+```
+
+There is also a behaviour `floating` option used for floating snackbar:
+
+```javascript
+
+<div style={{height: '130px', position: 'relative'}}>
+    <div style={{position: 'absolute', bottom: '0', left: '0', right: '0', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '10px', marginLeft: 'auto', marginRight: 'auto', width: 'fit-content'}}>
+        <Snackbar behaviour="floating" message="Some error is shown here" type="error" />
+        
+        <Snackbar behaviour="floating" message="Some warning is shown here" type="warning" />
+        
+        <Snackbar behaviour="floating" message="Some information is shown here" type="info" />
+        
+        <Snackbar behaviour="floating" message="Some not so bad went wrong" type="success" />
+    </div>
+</div>
+```
+
+There is also a behaviour `floating` option used for floating snackbar:
+
+```javascript
+
+<div style={{height: '32px', position: 'relative'}}>
+    <div style={{position: 'absolute', bottom: '0', left: '0', right: '0', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '10px', marginLeft: 'auto', marginRight: 'auto', width: 'fit-content'}}>
+        <Snackbar behaviour="floating" icon="su-copy" message="3 blocks copied to clipboard" type="info" />
+    </div>
+</div>
 ```
 
 There are two different callbacks that can be added. One is the `onCloseClick` callback, which makes a close button

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/README.md
@@ -22,24 +22,24 @@ There is also a behaviour `floating` option used for floating snackbar:
 
 <div style={{height: '130px', position: 'relative'}}>
     <div style={{position: 'absolute', bottom: '0', left: '0', right: '0', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '10px', marginLeft: 'auto', marginRight: 'auto', width: 'fit-content'}}>
-        <Snackbar behaviour="floating" message="Some error is shown here" type="error" />
+        <Snackbar skin="floating" message="Some error is shown here" type="error" />
         
-        <Snackbar behaviour="floating" message="Some warning is shown here" type="warning" />
+        <Snackbar skin="floating" message="Some warning is shown here" type="warning" />
         
-        <Snackbar behaviour="floating" message="Some information is shown here" type="info" />
+        <Snackbar skin="floating" message="Some information is shown here" type="info" />
         
-        <Snackbar behaviour="floating" message="Some not so bad went wrong" type="success" />
+        <Snackbar skin="floating" message="Some not so bad went wrong" type="success" />
     </div>
 </div>
 ```
 
-There is also a behaviour `floating` option used for floating snackbar:
+This is used as example for block snackbar messages like the following:
 
 ```javascript
 
 <div style={{height: '32px', position: 'relative'}}>
     <div style={{position: 'absolute', bottom: '0', left: '0', right: '0', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '10px', marginLeft: 'auto', marginRight: 'auto', width: 'fit-content'}}>
-        <Snackbar behaviour="floating" icon="su-copy" message="3 blocks copied to clipboard" type="info" />
+        <Snackbar skin="floating" icon="su-copy" message="3 blocks copied to clipboard" type="info" />
     </div>
 </div>
 ```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/Snackbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/Snackbar.js
@@ -7,9 +7,11 @@ import {translate} from '../../utils/Translator';
 import Icon from '../Icon';
 import snackbarStyles from './snackbar.scss';
 
-export type SnackbarType = 'error' | 'warning';
+export type SnackbarType = 'error' | 'warning' | 'info' | 'success';
 
 type Props = {|
+    behaviour: 'static' | 'floating',
+    icon?: string,
     message: string,
     onClick?: () => void,
     onCloseClick?: () => void,
@@ -20,6 +22,8 @@ type Props = {|
 const ICONS = {
     error: 'su-exclamation-triangle',
     warning: 'su-bell',
+    info: 'su-exclamation-circle',
+    success: 'su-check-circle',
 };
 
 const DEFAULT_SNACKBAR_TYPE: SnackbarType = 'error';
@@ -27,6 +31,7 @@ const DEFAULT_SNACKBAR_TYPE: SnackbarType = 'error';
 @observer
 class Snackbar extends React.Component<Props> {
     static defaultProps = {
+        behaviour: 'static',
         visible: true,
     };
 
@@ -72,22 +77,30 @@ class Snackbar extends React.Component<Props> {
     };
 
     render() {
-        const {onCloseClick, onClick, visible} = this.props;
+        const {icon, behaviour, onCloseClick, onClick, visible} = this.props;
 
         const snackbarClass = classNames(
             snackbarStyles.snackbar,
             snackbarStyles[this.type],
             {
                 [snackbarStyles.clickable]: onClick,
+                [snackbarStyles.floating]: behaviour === 'floating',
                 [snackbarStyles.visible]: visible,
             }
         );
 
         return (
             <div className={snackbarClass} onClick={onClick} onTransitionEnd={this.handleTransitionEnd} role="button">
-                <Icon className={snackbarStyles.icon} name={ICONS[this.type]} />
+                <Icon className={snackbarStyles.icon} name={icon || ICONS[this.type]} />
                 <div className={snackbarStyles.text}>
-                    <strong>{translate('sulu_admin.' + this.type)}</strong> - {this.message}
+                    {
+                        behaviour === 'static'
+                            ? <>
+                                <strong>{translate('sulu_admin.' + this.type)}</strong> -
+                            </>
+                            : null
+                    }
+                    {this.message}
                 </div>
                 {onCloseClick &&
                     <Icon className={snackbarStyles.closeIcon} name="su-times" onClick={onCloseClick} />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/Snackbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/Snackbar.js
@@ -96,7 +96,7 @@ class Snackbar extends React.Component<Props> {
                     {
                         behaviour === 'static'
                             ? <>
-                                <strong>{translate('sulu_admin.' + this.type)}</strong> -
+                                <strong>{translate('sulu_admin.' + this.type)}</strong>{' - '}
                             </>
                             : null
                     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/Snackbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/Snackbar.js
@@ -10,11 +10,11 @@ import snackbarStyles from './snackbar.scss';
 export type SnackbarType = 'error' | 'warning' | 'info' | 'success';
 
 type Props = {|
-    behaviour: 'static' | 'floating',
     icon?: string,
     message: string,
     onClick?: () => void,
     onCloseClick?: () => void,
+    skin: 'static' | 'floating',
     type: SnackbarType,
     visible: boolean,
 |};
@@ -31,7 +31,7 @@ const DEFAULT_SNACKBAR_TYPE: SnackbarType = 'error';
 @observer
 class Snackbar extends React.Component<Props> {
     static defaultProps = {
-        behaviour: 'static',
+        skin: 'static',
         visible: true,
     };
 
@@ -77,14 +77,14 @@ class Snackbar extends React.Component<Props> {
     };
 
     render() {
-        const {icon, behaviour, onCloseClick, onClick, visible} = this.props;
+        const {icon, onCloseClick, onClick, skin, visible} = this.props;
 
         const snackbarClass = classNames(
             snackbarStyles.snackbar,
             snackbarStyles[this.type],
             {
                 [snackbarStyles.clickable]: onClick,
-                [snackbarStyles.floating]: behaviour === 'floating',
+                [snackbarStyles.floating]: skin === 'floating',
                 [snackbarStyles.visible]: visible,
             }
         );
@@ -94,7 +94,7 @@ class Snackbar extends React.Component<Props> {
                 <Icon className={snackbarStyles.icon} name={icon || ICONS[this.type]} />
                 <div className={snackbarStyles.text}>
                     {
-                        behaviour === 'static'
+                        skin === 'static'
                             ? <>
                                 <strong>{translate('sulu_admin.' + this.type)}</strong>{' - '}
                             </>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/snackbar.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/snackbar.scss
@@ -28,7 +28,7 @@ $snackbarSuccessBackgroundColor: $mantis;
 }
 
 .floating {
-    box-shadow: 2px 6px 12px 0 rgba($silver, .5);
+    box-shadow: 2px 6px 12px 0 rgba($black, .5);
     border-radius: 3px;
     padding: 6px 7px;
     height: 32px;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/snackbar.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/snackbar.scss
@@ -6,6 +6,10 @@ $snackbarErrorColor: $white;
 $snackbarErrorBackgroundColor: $persianRed;
 $snackbarWarningColor: $blueZodiac;
 $snackbarWarningBackgroundColor: $gold;
+$snackbarInfoColor: $white;
+$snackbarInfoBackgroundColor: $blueZodiac;
+$snackbarSuccessColor: $white;
+$snackbarSuccessBackgroundColor: $mantis;
 
 .snackbar {
     height: $snackbarHeight;
@@ -20,6 +24,18 @@ $snackbarWarningBackgroundColor: $gold;
         transition: margin-top .15s, visibility 0s .15s;
         visibility: hidden;
         margin-top: -$snackbarHeight;
+    }
+}
+
+.floating {
+    box-shadow: 2px 6px 12px 0 rgba($silver, .5);
+    border-radius: 3px;
+    padding: 6px 7px;
+    height: 32px;
+    width: fit-content;
+
+    .icon {
+        font-size: 17px;
     }
 }
 
@@ -64,5 +80,25 @@ $snackbarWarningBackgroundColor: $gold;
     .close-button {
         background-color: $snackbarWarningColor;
         color: $snackbarWarningColor;
+    }
+}
+
+.info {
+    background-color: $snackbarInfoBackgroundColor;
+    color: $snackbarInfoColor;
+
+    .close-button {
+        background-color: $snackbarInfoColor;
+        color: $snackbarInfoColor;
+    }
+}
+
+.success {
+    background-color: $snackbarSuccessBackgroundColor;
+    color: $snackbarSuccessColor;
+
+    .close-button {
+        background-color: $snackbarSuccessColor;
+        color: $snackbarSuccessColor;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/tests/Snackbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/tests/Snackbar.test.js
@@ -26,6 +26,36 @@ test('Render a warning snackbar', () => {
     expect(snackbar.render()).toMatchSnapshot();
 });
 
+test('Render a info snackbar', () => {
+    const snackbar = mount(
+        <Snackbar message="Something unimportant went wrong" onCloseClick={jest.fn()} type="info" />
+    );
+
+    expect(snackbar.render()).toMatchSnapshot();
+});
+
+test('Render a success snackbar', () => {
+    const snackbar = mount(
+        <Snackbar message="Something unimportant went wrong" onCloseClick={jest.fn()} type="success" />
+    );
+
+    expect(snackbar.render()).toMatchSnapshot();
+});
+
+test('Render a floating snackbar', () => {
+    const snackbar = mount(
+        <Snackbar
+            behaviour="floating"
+            icon="su-copy"
+            message="3 blocks copied to clipboard"
+            onCloseClick={jest.fn()}
+            type="info"
+        />
+    );
+
+    expect(snackbar.render()).toMatchSnapshot();
+});
+
 test('Render an error snackbar without close button', () => {
     const snackbar = mount(<Snackbar message="Something went wrong" type="error" />);
     expect(snackbar.render()).toMatchSnapshot();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/tests/Snackbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/tests/Snackbar.test.js
@@ -45,10 +45,10 @@ test('Render a success snackbar', () => {
 test('Render a floating snackbar', () => {
     const snackbar = mount(
         <Snackbar
-            behaviour="floating"
             icon="su-copy"
             message="3 blocks copied to clipboard"
             onCloseClick={jest.fn()}
+            skin="floating"
             type="info"
         />
     );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/tests/__snapshots__/Snackbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/tests/__snapshots__/Snackbar.test.js.snap
@@ -1,5 +1,80 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Render a floating snackbar 1`] = `
+<div
+  class="snackbar info floating visible"
+  role="button"
+>
+  <span
+    aria-label="su-copy"
+    class="su-copy icon"
+  />
+  <div
+    class="text"
+  >
+    3 blocks copied to clipboard
+  </div>
+  <span
+    aria-label="su-times"
+    class="su-times clickable closeIcon"
+    role="button"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`Render a info snackbar 1`] = `
+<div
+  class="snackbar info visible"
+  role="button"
+>
+  <span
+    aria-label="su-exclamation-circle"
+    class="su-exclamation-circle icon"
+  />
+  <div
+    class="text"
+  >
+    <strong>
+      sulu_admin.info
+    </strong>
+     -Something unimportant went wrong
+  </div>
+  <span
+    aria-label="su-times"
+    class="su-times clickable closeIcon"
+    role="button"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`Render a success snackbar 1`] = `
+<div
+  class="snackbar success visible"
+  role="button"
+>
+  <span
+    aria-label="su-check-circle"
+    class="su-check-circle icon"
+  />
+  <div
+    class="text"
+  >
+    <strong>
+      sulu_admin.success
+    </strong>
+     -Something unimportant went wrong
+  </div>
+  <span
+    aria-label="su-times"
+    class="su-times clickable closeIcon"
+    role="button"
+    tabindex="0"
+  />
+</div>
+`;
+
 exports[`Render a warning snackbar 1`] = `
 <div
   class="snackbar warning visible"
@@ -15,7 +90,7 @@ exports[`Render a warning snackbar 1`] = `
     <strong>
       sulu_admin.warning
     </strong>
-     - Something unimportant went wrong
+     -Something unimportant went wrong
   </div>
   <span
     aria-label="su-times"
@@ -41,7 +116,7 @@ exports[`Render an error snackbar 1`] = `
     <strong>
       sulu_admin.error
     </strong>
-     - Something went wrong
+     -Something went wrong
   </div>
   <span
     aria-label="su-times"
@@ -67,7 +142,7 @@ exports[`Render an error snackbar without close button 1`] = `
     <strong>
       sulu_admin.error
     </strong>
-     - Something went wrong
+     -Something went wrong
   </div>
 </div>
 `;
@@ -87,7 +162,7 @@ exports[`Render an updated error snackbar 1`] = `
     <strong>
       sulu_admin.error
     </strong>
-     - Something went wrong again
+     -Something went wrong again
   </div>
   <span
     aria-label="su-times"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/tests/__snapshots__/Snackbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/tests/__snapshots__/Snackbar.test.js.snap
@@ -38,7 +38,7 @@ exports[`Render a info snackbar 1`] = `
     <strong>
       sulu_admin.info
     </strong>
-     -Something unimportant went wrong
+     - Something unimportant went wrong
   </div>
   <span
     aria-label="su-times"
@@ -64,7 +64,7 @@ exports[`Render a success snackbar 1`] = `
     <strong>
       sulu_admin.success
     </strong>
-     -Something unimportant went wrong
+     - Something unimportant went wrong
   </div>
   <span
     aria-label="su-times"
@@ -90,7 +90,7 @@ exports[`Render a warning snackbar 1`] = `
     <strong>
       sulu_admin.warning
     </strong>
-     -Something unimportant went wrong
+     - Something unimportant went wrong
   </div>
   <span
     aria-label="su-times"
@@ -116,7 +116,7 @@ exports[`Render an error snackbar 1`] = `
     <strong>
       sulu_admin.error
     </strong>
-     -Something went wrong
+     - Something went wrong
   </div>
   <span
     aria-label="su-times"
@@ -142,7 +142,7 @@ exports[`Render an error snackbar without close button 1`] = `
     <strong>
       sulu_admin.error
     </strong>
-     -Something went wrong
+     - Something went wrong
   </div>
 </div>
 `;
@@ -162,7 +162,7 @@ exports[`Render an updated error snackbar 1`] = `
     <strong>
       sulu_admin.error
     </strong>
-     -Something went wrong again
+     - Something went wrong again
   </div>
   <span
     aria-label="su-times"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SnackbarContainer/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SnackbarContainer/README.md
@@ -1,0 +1,2 @@
+The `SnackbarContainer` component is used to display floating snackbar messages.
+It is fixed and uses a React.Portal so the messages are at to top of every other elements.

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SnackbarContainer/SnackbarContainer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SnackbarContainer/SnackbarContainer.js
@@ -1,0 +1,27 @@
+// @flow
+import React from 'react';
+import {observer} from 'mobx-react';
+import {Portal} from 'react-portal';
+import snackbarContainerStyles from './snackbarContainer.scss';
+import type {Node} from 'react';
+
+type Props = {|
+    children: Node,
+|};
+
+@observer
+class SnackbarContainer extends React.Component<Props> {
+    render() {
+        const {children} = this.props;
+
+        return (
+            <Portal>
+                <div className={snackbarContainerStyles.container}>
+                    {children}
+                </div>
+            </Portal>
+        );
+    }
+}
+
+export default SnackbarContainer;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SnackbarContainer/SnackbarContainer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SnackbarContainer/SnackbarContainer.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import classnames from 'classnames';
+import classNames from 'classnames';
 import {observer} from 'mobx-react';
 import {Portal} from 'react-portal';
 import snackbarContainerStyles from './snackbarContainer.scss';
@@ -18,7 +18,7 @@ class SnackbarContainer extends React.Component<Props> {
 
         return (
             <Portal>
-                <div className={classnames(snackbarContainerStyles.container, className)}>
+                <div className={classNames(snackbarContainerStyles.container, className)}>
                     {children}
                 </div>
             </Portal>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SnackbarContainer/SnackbarContainer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SnackbarContainer/SnackbarContainer.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import classnames from 'classnames';
 import {observer} from 'mobx-react';
 import {Portal} from 'react-portal';
 import snackbarContainerStyles from './snackbarContainer.scss';
@@ -7,16 +8,17 @@ import type {Node} from 'react';
 
 type Props = {|
     children: Node,
+    className?: string,
 |};
 
 @observer
 class SnackbarContainer extends React.Component<Props> {
     render() {
-        const {children} = this.props;
+        const {children, className} = this.props;
 
         return (
             <Portal>
-                <div className={snackbarContainerStyles.container}>
+                <div className={classnames(snackbarContainerStyles.container, className)}>
                     {children}
                 </div>
             </Portal>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SnackbarContainer/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SnackbarContainer/index.js
@@ -1,0 +1,4 @@
+// @flow
+import SnackbarContainer from './SnackbarContainer';
+
+export default SnackbarContainer;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SnackbarContainer/snackbarContainer.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SnackbarContainer/snackbarContainer.scss
@@ -1,0 +1,13 @@
+.container {
+    position: absolute;
+    bottom: 30px;
+    left: 0;
+    right: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    margin-left: auto;
+    margin-right: auto;
+    width: fit-content;
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/Application.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/Application.js
@@ -227,10 +227,10 @@ class Application extends React.Component<Props>{
                                     {snackbarStore.messages.map((message, index) => {
                                         return (
                                             <Snackbar
-                                                behaviour="floating"
                                                 icon={message.icon}
                                                 key={index}
                                                 message={message.text}
+                                                skin="floating"
                                                 type={message.type}
                                             />
                                         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/Application.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/Application.js
@@ -16,6 +16,9 @@ import Sidebar, {sidebarStore} from '../Sidebar';
 import Toolbar from '../Toolbar';
 import ViewRenderer from '../ViewRenderer';
 import './global.scss';
+import SnackbarContainer from '../../components/SnackbarContainer';
+import snackbarStore from '../../stores/snackbarStore';
+import Snackbar from '../../components/Snackbar';
 import applicationStyles from './application.scss';
 
 const NAVIGATION_PINNED_SETTING_KEY = 'sulu_admin.application.navigation_pinned';
@@ -115,6 +118,7 @@ class Application extends React.Component<Props>{
             }
         });
     };
+
     handleProfileOverlayClose = () => {
         this.closeProfileFormOverlay();
     };
@@ -208,6 +212,23 @@ class Application extends React.Component<Props>{
                             onClose={this.handleProfileOverlayClose}
                             open={this.openedProfileFormOverlay}
                         />
+                        {
+                            snackbarStore.messages.length
+                                ? <SnackbarContainer>
+                                    {snackbarStore.messages.map((message, index) => {
+                                        return (
+                                            <Snackbar
+                                                behaviour="floating"
+                                                icon={message.icon}
+                                                key={index}
+                                                message={message.text}
+                                                type={message.type}
+                                            />
+                                        );
+                                    })}
+                                </SnackbarContainer>
+                                : null
+                        }
                     </Fragment>
                     : <div className={applicationStyles.loader}>
                         <Loader />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/Application.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/Application.js
@@ -147,6 +147,15 @@ class Application extends React.Component<Props>{
             }
         );
 
+        const snackbarClass = classNames(
+            applicationStyles.snackbar,
+            {
+                [applicationStyles.isNavigationVisible]: this.navigationVisible,
+                [applicationStyles.isNavigationPinned]: this.navigationPinned,
+                [applicationStyles[sidebarStore.size]]: sidebarStore.size,
+            }
+        );
+
         const contentClass = classNames(
             applicationStyles.content,
             {
@@ -214,7 +223,7 @@ class Application extends React.Component<Props>{
                         />
                         {
                             snackbarStore.messages.length
-                                ? <SnackbarContainer>
+                                ? <SnackbarContainer className={snackbarClass}>
                                     {snackbarStore.messages.map((message, index) => {
                                         return (
                                             <Snackbar

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/application.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/application.scss
@@ -77,6 +77,55 @@
     }
 }
 
+.snackbar {
+    max-width: $viewMaxWidth;
+    transition: $navigationMoveAnimationDuration;
+
+    &.small {
+        right: 30%;
+    }
+
+    &.medium {
+        right: 50%;
+    }
+
+    &.large {
+        right: $sidebarMaxWidth;
+    }
+
+    &.isNavigationPinned {
+        left: $navigationWidth;
+
+        &.small {
+            right: calc((100% - $navigationWidth) * 0.3);
+        }
+
+        &.medium {
+            right: calc((100% - $navigationWidth) * 0.5);
+        }
+
+        &.large {
+            right: calc(100% - $navigationWidth - $sidebarMaxWidth);
+        }
+    }
+
+    &.isNavigationVisible {
+        left: $navigationWidth;
+
+        &.small {
+            right: calc(30% - $navigationWidth);
+        }
+
+        &.medium {
+            right: calc(50% - $navigationWidth);
+        }
+
+        &.large {
+            right: calc(100% + $navigationWidth - $sidebarMaxWidth);
+        }
+    }
+}
+
 .navigation {
     overflow-x: hidden;
     overflow-y: auto;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/application.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/application.scss
@@ -97,11 +97,11 @@
         left: $navigationWidth;
 
         &.small {
-            right: calc((100% - $navigationWidth) * 0.3);
+            right: calc((100% - $navigationWidth) * .3);
         }
 
         &.medium {
-            right: calc((100% - $navigationWidth) * 0.5);
+            right: calc((100% - $navigationWidth) * .5);
         }
 
         &.large {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -8,10 +8,12 @@ import BlockCollection from '../../components/BlockCollection';
 import {translate} from '../../utils/Translator';
 import {memoryFormStoreFactory} from '../Form';
 import FormOverlay from '../FormOverlay';
+import snackbarStore from '../../stores/snackbarStore';
 import blockPreviewTransformerRegistry from './registries/blockPreviewTransformerRegistry';
 import FieldRenderer from './FieldRenderer';
 import type {BlockError, FieldTypeProps, FormStoreInterface} from '../Form/types';
 import type {BlockEntry} from './types';
+import type {Message} from '../../components/BlockCollection/types';
 
 const MISSING_BLOCK_ERROR_MESSAGE = 'The "block" field type needs at least one type to be configured!';
 const BLOCK_PREVIEW_TAG = 'sulu.block_preview';
@@ -418,6 +420,10 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
         this.closeSettingsOverlay();
     };
 
+    handleTriggerMessage = (message: Message) => {
+        snackbarStore.add(message, 2500);
+    };
+
     @action closeSettingsOverlay = () => {
         this.openedBlockSettingsIndex = undefined;
     };
@@ -492,6 +498,7 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
                     onChange={this.handleBlocksChange}
                     onSettingsClick={this.settingsFormKey ? this.handleSettingsClick : undefined}
                     onSortEnd={this.handleSortEnd}
+                    onTriggerMessage={this.handleTriggerMessage}
                     pasteButtonText={this.pasteButtonText}
                     renderBlockContent={this.renderBlockContent}
                     types={blockTypes}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -420,7 +420,7 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
         this.closeSettingsOverlay();
     };
 
-    handleTriggerMessage = (message: Message) => {
+    handleDisplaySnackbar = (message: Message) => {
         snackbarStore.add(message, 2500);
     };
 
@@ -496,9 +496,9 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
                     minOccurs={minOccurs}
                     movable={this.movable}
                     onChange={this.handleBlocksChange}
+                    onDisplaySnackbar={this.handleDisplaySnackbar}
                     onSettingsClick={this.settingsFormKey ? this.handleSettingsClick : undefined}
                     onSortEnd={this.handleSortEnd}
-                    onTriggerMessage={this.handleTriggerMessage}
                     pasteButtonText={this.pasteButtonText}
                     renderBlockContent={this.renderBlockContent}
                     types={blockTypes}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/snackbarStore/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/snackbarStore/index.js
@@ -1,0 +1,4 @@
+// @flow
+import snackbarStore from './snackbarStore';
+
+export default snackbarStore;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/snackbarStore/snackbarStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/snackbarStore/snackbarStore.js
@@ -1,13 +1,13 @@
 // @flow
-import {observable} from 'mobx';
+import {action, observable} from 'mobx';
 import type {Message} from './types';
 
 class SnackbarStore {
     @observable.shallow messages: Array<Message> = [];
 
-    timeouts: Array<number> = [];
+    timeouts: Array<TimeoutID | null> = [];
 
-    add(message: Message, milliseconds: number = null) {
+    @action add(message: Message, milliseconds: ?number = null) {
         this.messages.push(message);
         this.timeouts.push(null);
 
@@ -18,7 +18,7 @@ class SnackbarStore {
         }
     }
 
-    remove(message: Message) {
+    @action remove(message: Message) {
         const messageIndex = this.messages.indexOf(message);
 
         if (messageIndex !== -1) {
@@ -31,7 +31,7 @@ class SnackbarStore {
         }
     }
 
-    clear() {
+    @action clear() {
         this.messages = [];
         this.timeouts.forEach((timeoutId) => {
             clearTimeout(timeoutId);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/snackbarStore/snackbarStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/snackbarStore/snackbarStore.js
@@ -1,0 +1,43 @@
+// @flow
+import {observable} from 'mobx';
+import type {Message} from './types';
+
+class SnackbarStore {
+    @observable.shallow messages: Array<Message> = [];
+
+    timeouts: Array<number> = [];
+
+    add(message: Message, milliseconds: number = null) {
+        this.messages.push(message);
+        this.timeouts.push(null);
+
+        if (milliseconds) {
+            this.timeouts[this.messages.length - 1] = setTimeout(() => {
+                this.remove(message);
+            }, milliseconds);
+        }
+    }
+
+    remove(message: Message) {
+        const messageIndex = this.messages.indexOf(message);
+
+        if (messageIndex !== -1) {
+            if (this.timeouts[messageIndex]) {
+                clearTimeout(this.timeouts[messageIndex]);
+            }
+
+            this.timeouts.splice(messageIndex, 1);
+            this.messages.splice(messageIndex, 1);
+        }
+    }
+
+    clear() {
+        this.messages = [];
+        this.timeouts.forEach((timeoutId) => {
+            clearTimeout(timeoutId);
+        });
+        this.timeouts = [];
+    }
+}
+
+export default new SnackbarStore();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/snackbarStore/tests/snackbarStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/snackbarStore/tests/snackbarStore.test.js
@@ -9,7 +9,7 @@ test('Add should increase the messages', () => {
     expect(snackbarStore.messages.length).toBe(0);
 
     snackbarStore.add({
-        message: 'Test message',
+        text: 'Test message',
         type: 'success',
     });
 
@@ -18,7 +18,7 @@ test('Add should increase the messages', () => {
 
 test('Remove should decrease the messages', () => {
     const message = {
-        message: 'Test message',
+        text: 'Test message',
         type: 'success',
     };
 
@@ -30,7 +30,7 @@ test('Remove should decrease the messages', () => {
 
 test('Clear should remove all messages', () => {
     const message = {
-        message: 'Test message',
+        text: 'Test message',
         type: 'success',
     };
 
@@ -41,10 +41,11 @@ test('Clear should remove all messages', () => {
 });
 
 test('Add with message should create a setTimeout', () => {
+    // eslint-disable-next-line no-undef
     const timeoutSpy = jest.spyOn(global, 'setTimeout');
 
     const message = {
-        message: 'Test message',
+        text: 'Test message',
         type: 'success',
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/snackbarStore/tests/snackbarStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/snackbarStore/tests/snackbarStore.test.js
@@ -1,0 +1,54 @@
+// @flow
+import snackbarStore from '../snackbarStore';
+
+beforeEach(() => {
+    snackbarStore.clear();
+});
+
+test('Add should increase the messages', () => {
+    expect(snackbarStore.messages.length).toBe(0);
+
+    snackbarStore.add({
+        message: 'Test message',
+        type: 'success',
+    });
+
+    expect(snackbarStore.messages.length).toBe(1);
+});
+
+test('Remove should decrease the messages', () => {
+    const message = {
+        message: 'Test message',
+        type: 'success',
+    };
+
+    snackbarStore.add(message);
+    snackbarStore.remove(message);
+
+    expect(snackbarStore.messages.length).toBe(0);
+});
+
+test('Clear should remove all messages', () => {
+    const message = {
+        message: 'Test message',
+        type: 'success',
+    };
+
+    snackbarStore.add(message);
+    snackbarStore.clear();
+
+    expect(snackbarStore.messages.length).toBe(0);
+});
+
+test('Add with message should create a setTimeout', () => {
+    const timeoutSpy = jest.spyOn(global, 'setTimeout');
+
+    const message = {
+        message: 'Test message',
+        type: 'success',
+    };
+
+    snackbarStore.add(message, 10);
+
+    expect(timeoutSpy).toBeCalled();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/snackbarStore/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/snackbarStore/types.js
@@ -1,0 +1,6 @@
+// @flow
+export type Message = {
+    icon?: string,
+    text: string,
+    type: 'success' | 'error' | 'warning' | 'info',
+};

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -61,6 +61,8 @@
     "sulu_admin.list_search_placeholder": "Suche…",
     "sulu_admin.error": "Fehler",
     "sulu_admin.warning": "Warnung",
+    "sulu_admin.info": "Info",
+    "sulu_admin.success": "Erfolg",
     "sulu_admin.close": "Schließen",
     "sulu_admin.id": "ID",
     "sulu_admin.key": "Schlüssel",

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -223,9 +223,9 @@
     "sulu_admin.deselect_all": "Alle abwählen",
     "sulu_admin.cancel": "Abbrechen",
     "sulu_admin.select_multiple_blocks": "Mehrere Blöcke auswählen",
-    "sulu_admin.%count%_blocks_copied": "{count, plural, =1 {Ein Block} other {{count} Blöcke}} zur Zwischenablage kopiert.",
-    "sulu_admin.%count%_blocks_duplicated": "{count, plural, =1 {Ein Block} other {{count} Blöcke}} dupliziert.",
-    "sulu_admin.%count%_blocks_removed": "{count, plural, =1 {Ein Block} other {{count} Blöcke}} gelöscht.",
-    "sulu_admin.%count%_blocks_cut": "{count, plural, =1 {Ein Block} other {{count} Blöcke}} zur Zwischenablage ausgeschnitten.",
-    "sulu_admin.%count%_blocks_pasted": "{count, plural, =1 {Ein Block} other {{count} Blöcke}} eingefügt."
+    "sulu_admin.%count%_blocks_copied": "{count} {count, plural, =1 {Block} other {Blöcke}} zur Zwischenablage kopiert.",
+    "sulu_admin.%count%_blocks_duplicated": "{count} {count, plural, =1 {Block} other {Blöcke}} dupliziert.",
+    "sulu_admin.%count%_blocks_removed": "{count} {count, plural, =1 {Block} other {Blöcke}} gelöscht.",
+    "sulu_admin.%count%_blocks_cut": "{count} {count, plural, =1 {Block} other {Blöcke}} zur Zwischenablage ausgeschnitten.",
+    "sulu_admin.%count%_blocks_pasted": "{count} {count, plural, =1 {Block} other {Blöcke}} eingefügt."
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -1,7 +1,7 @@
 {
     "sulu_admin.add": "Hinzufügen",
     "sulu_admin.add_block": "Block hinzufügen",
-    "sulu_admin.paste_blocks": "{count} {count, plural, =1 {Block} other {Blocks}} einfügen",
+    "sulu_admin.paste_blocks": "{count} {count, plural, =1 {Block} other {Blöcke}} einfügen",
     "sulu_admin.delete": "Löschen",
     "sulu_admin.delete_selected": "Ausgewählte löschen",
     "sulu_admin.delete_locale": "Aktuelle Sprache löschen",
@@ -222,5 +222,10 @@
     "sulu_admin.select_all": "Alle auswählen",
     "sulu_admin.deselect_all": "Alle abwählen",
     "sulu_admin.cancel": "Abbrechen",
-    "sulu_admin.select_multiple_blocks": "Mehrere blöcke auswählen"
+    "sulu_admin.select_multiple_blocks": "Mehrere Blöcke auswählen",
+    "sulu_admin.%count%_blocks_copied": "{count, plural, =1 {Ein Block} other {{count} Blöcke}} zur Zwischenablage kopiert.",
+    "sulu_admin.%count%_blocks_duplicated": "{count, plural, =1 {Ein Block} other {{count} Blöcke}} dupliziert.",
+    "sulu_admin.%count%_blocks_removed": "{count, plural, =1 {Ein Block} other {{count} Blöcke}} gelöscht.",
+    "sulu_admin.%count%_blocks_cut": "{count, plural, =1 {Ein Block} other {{count} Blöcke}} zur Zwischenablage ausgeschnitten.",
+    "sulu_admin.%count%_blocks_pasted": "{count, plural, =1 {Ein Block} other {{count} Blöcke}} eingefügt."
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -225,5 +225,10 @@
     "sulu_admin.select_all": "Select all",
     "sulu_admin.deselect_all": "Deselect all",
     "sulu_admin.cancel": "Cancel",
-    "sulu_admin.select_multiple_blocks": "Select multiple blocks"
+    "sulu_admin.select_multiple_blocks": "Select multiple blocks",
+    "sulu_admin.%count%_blocks_copied": "{count, plural, =1 {One block} other {{count} blocks}} copied to clipboard.",
+    "sulu_admin.%count%_blocks_duplicated": "{count, plural, =1 {One block} other {{count} blocks}} duplicated.",
+    "sulu_admin.%count%_blocks_removed": "{count, plural, =1 {One block} other {{count} blocks}} removed.",
+    "sulu_admin.%count%_blocks_cut": "{count, plural, =1 {One block} other {{count} blocks}} cut to clipboard.",
+    "sulu_admin.%count%_blocks_pasted": "{count, plural, =1 {One block} other {{count} blocks}} pasted."
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -61,6 +61,8 @@
     "sulu_admin.list_search_placeholder": "Search…",
     "sulu_admin.error": "Error",
     "sulu_admin.warning": "Warning",
+    "sulu_admin.info": "Info",
+    "sulu_admin.success": "Success",
     "sulu_admin.close": "Close",
     "sulu_admin.id": "ID",
     "sulu_admin.key": "Key",

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -226,9 +226,9 @@
     "sulu_admin.deselect_all": "Deselect all",
     "sulu_admin.cancel": "Cancel",
     "sulu_admin.select_multiple_blocks": "Select multiple blocks",
-    "sulu_admin.%count%_blocks_copied": "{count, plural, =1 {One block} other {{count} blocks}} copied to clipboard.",
-    "sulu_admin.%count%_blocks_duplicated": "{count, plural, =1 {One block} other {{count} blocks}} duplicated.",
-    "sulu_admin.%count%_blocks_removed": "{count, plural, =1 {One block} other {{count} blocks}} removed.",
-    "sulu_admin.%count%_blocks_cut": "{count, plural, =1 {One block} other {{count} blocks}} cut to clipboard.",
-    "sulu_admin.%count%_blocks_pasted": "{count, plural, =1 {One block} other {{count} blocks}} pasted."
+    "sulu_admin.%count%_blocks_copied": "{count} {count, plural, =1 {block} other {blocks}} copied to clipboard.",
+    "sulu_admin.%count%_blocks_duplicated": "{count} {count, plural, =1 {block} other {blocks}} duplicated.",
+    "sulu_admin.%count%_blocks_removed": "{count} {count, plural, =1 {block} other {blocks}} removed.",
+    "sulu_admin.%count%_blocks_cut": "{count} {count, plural, =1 {block} other {blocks}} cut to clipboard.",
+    "sulu_admin.%count%_blocks_pasted": "{count} {count, plural, =1 {block} other {blocks}} pasted."
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? |  yes
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add floating snackbar.

![snackbar](https://user-images.githubusercontent.com/1698337/177960583-3b979781-54be-4cea-8437-1c3998b6b924.gif)

#### Why?

To show snackbar messages for copy and pasting of blocks.

#### To Do

- [x] Implement Snackbar Container
- [x] Implement block messages
