### PR TITLE
Add link provider as a data attribute to rendered <sulu-link>

### DIFF
--- a/src/Sulu/Bundle/MarkupBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/MarkupBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MarkupBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder('sulu_markup');
+
+        $treeBuilder->getRootNode()
+            ->children()
+                ->arrayNode('link_tag')
+                ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('provider_attribute')->defaultNull()->end()
+                    ->end()
+                ->end()
+            ->end();
+
+        return $treeBuilder;
+    }
+}

--- a/src/Sulu/Bundle/MarkupBundle/DependencyInjection/SuluMarkupExtension.php
+++ b/src/Sulu/Bundle/MarkupBundle/DependencyInjection/SuluMarkupExtension.php
@@ -23,6 +23,10 @@ class SuluMarkupExtension extends Extension
 {
     public function load(array $configs, ContainerBuilder $container)
     {
+        $config = $this->processConfiguration(new Configuration(), $configs);
+
+        $container->setParameter('sulu_markup.link_tag.provider_attribute', $config['link_tag']['provider_attribute']);
+
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
 

--- a/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
@@ -103,8 +103,12 @@ class LinkTag implements TagInterface
 
             $htmlAttributes = \array_map(
                 function($value, $name) {
-                    if (\in_array($name, ['provider', 'content', 'sulu-validation-state']) || empty($value)) {
+                    if (\in_array($name, ['content', 'sulu-validation-state']) || empty($value)) {
                         return null;
+                    }
+                    
+                    if ('provider' === $name) {
+                        return \sprintf('data-%s="%s"', $name, $value);
                     }
 
                     return \sprintf('%s="%s"', $name, $value);

--- a/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
@@ -39,14 +39,21 @@ class LinkTag implements TagInterface
      */
     private $urlHelper;
 
+    /**
+     * @var ?string
+     */
+    private $providerAttribute;
+
     public function __construct(
         LinkProviderPoolInterface $linkProviderPool,
         bool $isPreview = false,
-        UrlHelper $urlHelper = null
+        UrlHelper $urlHelper = null,
+        ?string $providerAttribute = null
     ) {
         $this->linkProviderPool = $linkProviderPool;
         $this->isPreview = $isPreview;
         $this->urlHelper = $urlHelper;
+        $this->providerAttribute = $providerAttribute;
 
         if (null === $this->urlHelper) {
             @\trigger_error(
@@ -103,12 +110,16 @@ class LinkTag implements TagInterface
 
             $htmlAttributes = \array_map(
                 function($value, $name) use ($attributes) {
-                    if (\in_array($name, ['content', 'sulu-validation-state']) || empty($value)) {
+                    if (empty($value) || \in_array($name, ['content', 'sulu-validation-state'])) {
                         return null;
                     }
 
                     if ('provider' === $name) {
-                        return !\array_key_exists('data-provider', $attributes) ? \sprintf('data-%s="%s"', $name, $value) : null;
+                        if (null === $this->providerAttribute || \array_key_exists($this->providerAttribute, $attributes)) {
+                            return null;
+                        }
+
+                        return \sprintf('%s="%s"', $this->providerAttribute, $value);
                     }
 
                     return \sprintf('%s="%s"', $name, $value);

--- a/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
@@ -102,13 +102,13 @@ class LinkTag implements TagInterface
             }
 
             $htmlAttributes = \array_map(
-                function($value, $name) {
+                function($value, $name) use ($attributes) {
                     if (\in_array($name, ['content', 'sulu-validation-state']) || empty($value)) {
                         return null;
                     }
-                    
+
                     if ('provider' === $name) {
-                        return \sprintf('data-%s="%s"', $name, $value);
+                        return !\array_key_exists('data-provider', $attributes) ? \sprintf('data-%s="%s"', $name, $value) : null;
                     }
 
                     return \sprintf('%s="%s"', $name, $value);

--- a/src/Sulu/Bundle/MarkupBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MarkupBundle/Resources/config/services.xml
@@ -47,6 +47,7 @@
             <argument type="service" id="sulu_markup.link_tag.provider_pool"/>
             <argument type="expression">container.hasParameter('sulu.preview') ? parameter('sulu.preview') : false</argument>
             <argument type="service" id="url_helper"/>
+            <argument>%sulu_markup.link_tag.provider_attribute%</argument>
 
             <tag name="sulu_markup.tag" tag="link" type="html"/>
         </service>

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
@@ -77,25 +77,25 @@ class LinkTagTest extends TestCase
                     'provider' => 'article',
                 ],
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
-                '<a href="http://sulu.lo/de/test" title="Test-Title">Test-Content</a>',
+                '<a href="http://sulu.lo/de/test" title="Test-Title" data-provider="article">Test-Content</a>',
             ],
             [
                 '<sulu-link href="123-123-123" title="Test-Title" provider="article"/>',
                 ['href' => '123-123-123', 'title' => 'Test-Title', 'provider' => 'article'],
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
-                '<a href="http://sulu.lo/de/test" title="Test-Title">Page-Title</a>',
+                '<a href="http://sulu.lo/de/test" title="Test-Title" data-provider="article">Page-Title</a>',
             ],
             [
                 '<sulu-link href="123-123-123" title="Test-Title" provider="article"></sulu-link>',
                 ['href' => '123-123-123', 'title' => 'Test-Title', 'provider' => 'article'],
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
-                '<a href="http://sulu.lo/de/test" title="Test-Title">Page-Title</a>',
+                '<a href="http://sulu.lo/de/test" title="Test-Title" data-provider="article">Page-Title</a>',
             ],
             [
                 '<sulu-link href="123-123-123" provider="article">Test-Content</sulu-link>',
                 ['href' => '123-123-123', 'content' => 'Test-Content', 'provider' => 'article'],
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
-                '<a href="http://sulu.lo/de/test" title="Page-Title">Test-Content</a>',
+                '<a href="http://sulu.lo/de/test" data-provider="article" title="Page-Title">Test-Content</a>',
             ],
             [
                 '<sulu-link href="123-123-123" title="Test-Title" target="_blank" provider="article">Test-Content</sulu-link>',
@@ -107,7 +107,7 @@ class LinkTagTest extends TestCase
                     'provider' => 'article',
                 ],
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
-                '<a href="http://sulu.lo/de/test" title="Test-Title" target="_blank">Test-Content</a>',
+                '<a href="http://sulu.lo/de/test" title="Test-Title" target="_blank" data-provider="article">Test-Content</a>',
             ],
             [
                 '<sulu-link href="123-123-123" title="Test-Title" target="_self" provider="article">Test-Content</sulu-link>',
@@ -119,7 +119,7 @@ class LinkTagTest extends TestCase
                     'provider' => 'article',
                 ],
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
-                '<a href="http://sulu.lo/de/test" title="Test-Title" target="_self">Test-Content</a>',
+                '<a href="http://sulu.lo/de/test" title="Test-Title" target="_self" data-provider="article">Test-Content</a>',
             ],
             [
                 '<sulu-link href="123-123-123" provider="article" class="test">Test-Content</sulu-link>',
@@ -130,7 +130,7 @@ class LinkTagTest extends TestCase
                     'content' => 'Test-Content',
                 ],
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
-                '<a href="http://sulu.lo/de/test" class="test" title="Page-Title">Test-Content</a>',
+                '<a href="http://sulu.lo/de/test" data-provider="article" class="test" title="Page-Title">Test-Content</a>',
             ],
             [
                 '<sulu-link href="123-123-123" title="Test-Title" class="test" provider="article">Test-Content</sulu-link>',
@@ -142,7 +142,7 @@ class LinkTagTest extends TestCase
                     'content' => 'Test-Content',
                 ],
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
-                '<a href="http://sulu.lo/de/test" title="Test-Title" class="test">Test-Content</a>',
+                '<a href="http://sulu.lo/de/test" title="Test-Title" class="test" data-provider="article">Test-Content</a>',
             ],
             [
                 '<sulu-link href="123-123-123#anchor" provider="article" title="Test-Title">Test-Content</sulu-link>',
@@ -153,7 +153,7 @@ class LinkTagTest extends TestCase
                     'content' => 'Test-Content',
                 ],
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
-                '<a href="http://sulu.lo/de/test#anchor" title="Test-Title">Test-Content</a>',
+                '<a href="http://sulu.lo/de/test#anchor" title="Test-Title" data-provider="article">Test-Content</a>',
             ],
             [
                 '<sulu-link href="123-123-123?query=parameter" provider="article" title="Test-Title">Test-Content</sulu-link>',
@@ -164,7 +164,7 @@ class LinkTagTest extends TestCase
                     'content' => 'Test-Content',
                 ],
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
-                '<a href="http://sulu.lo/de/test?query=parameter" title="Test-Title">Test-Content</a>',
+                '<a href="http://sulu.lo/de/test?query=parameter" title="Test-Title" data-provider="article">Test-Content</a>',
             ],
             [
                 '<sulu-link href="123-123-123?query=parameter#anchor" provider="article" title="Test-Title">Test-Content</sulu-link>',
@@ -175,7 +175,7 @@ class LinkTagTest extends TestCase
                     'content' => 'Test-Content',
                 ],
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
-                '<a href="http://sulu.lo/de/test?query=parameter#anchor" title="Test-Title">Test-Content</a>',
+                '<a href="http://sulu.lo/de/test?query=parameter#anchor" title="Test-Title" data-provider="article">Test-Content</a>',
             ],
             [
                 '<sulu-link href="123-123-123#anchor?not=query" provider="article" title="Test-Title">Test-Content</sulu-link>',
@@ -186,7 +186,19 @@ class LinkTagTest extends TestCase
                   'content' => 'Test-Content',
                 ],
                 [new LinkItem('123-123-123', 'Page-Title', 'de/test', true)],
-                '<a href="http://sulu.lo/de/test#anchor?not=query" title="Test-Title">Test-Content</a>',
+                '<a href="http://sulu.lo/de/test#anchor?not=query" title="Test-Title" data-provider="article">Test-Content</a>',
+            ],
+            [
+                '<sulu-link href="123-123-123" title="Test-Title" provider="article" data-provider="dummy">Test-Content</sulu-link>',
+                [
+                    'href' => '123-123-123',
+                    'title' => 'Test-Title',
+                    'content' => 'Test-Content',
+                    'provider' => 'article',
+                    'data-provider' => 'dummy',
+                ],
+                [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
+                '<a href="http://sulu.lo/de/test" title="Test-Title" data-provider="dummy">Test-Content</a>',
             ],
         ];
     }
@@ -223,7 +235,7 @@ class LinkTagTest extends TestCase
         );
 
         $this->assertEquals(
-            [$tag => '<a href="/de/test" title="Test-Title">Page-Title</a>'],
+            [$tag => '<a href="/de/test" title="Test-Title" data-provider="article">Page-Title</a>'],
             $result
         );
     }
@@ -266,10 +278,10 @@ class LinkTagTest extends TestCase
 
         $this->assertEquals(
             [
-                $tag1 => '<a href="http://sulu.lo/de/test-1" title="Page-Title 1">Test-Content</a>',
-                $tag2 => '<a href="http://sulu.lo/de/test-2" title="Test-Title">Page-Title 2</a>',
-                $tag3 => '<a href="http://sulu.lo/de/test-1" title="Test-Title">Test-Content</a>',
-                $tag4 => '<a href="http://sulu.lo/de/test-1" title="Test-Title" target="_blank">Test-Content</a>',
+                $tag1 => '<a href="http://sulu.lo/de/test-1" data-provider="article" title="Page-Title 1">Test-Content</a>',
+                $tag2 => '<a href="http://sulu.lo/de/test-2" title="Test-Title" data-provider="article">Page-Title 2</a>',
+                $tag3 => '<a href="http://sulu.lo/de/test-1" title="Test-Title" data-provider="article">Test-Content</a>',
+                $tag4 => '<a href="http://sulu.lo/de/test-1" title="Test-Title" target="_blank" data-provider="article">Test-Content</a>',
             ],
             $result
         );
@@ -303,8 +315,8 @@ class LinkTagTest extends TestCase
 
         $this->assertEquals(
             [
-                $tag1 => '<a href="http://sulu.lo/de/test-2" title="Page-Title 2">Page-Title 2</a>',
-                $tag2 => '<a href="http://sulu.lo/de/test-1" title="Page-Title 1">Page-Title 1</a>',
+                $tag1 => '<a href="http://sulu.lo/de/test-2" data-provider="article" title="Page-Title 2">Page-Title 2</a>',
+                $tag2 => '<a href="http://sulu.lo/de/test-1" data-provider="page" title="Page-Title 1">Page-Title 1</a>',
             ],
             $result
         );
@@ -338,8 +350,8 @@ class LinkTagTest extends TestCase
 
         $this->assertEquals(
             [
-                $tag1 => '<a href="http://sulu.lo/de/test-2" title="Page-Title 2">Page-Title 2</a>',
-                $tag2 => '<a href="http://sulu.lo/de/test-1" title="Page-Title 1">Page-Title 1</a>',
+                $tag1 => '<a href="http://sulu.lo/de/test-2" data-provider="article" title="Page-Title 2">Page-Title 2</a>',
+                $tag2 => '<a href="http://sulu.lo/de/test-1" data-provider="page" title="Page-Title 1">Page-Title 1</a>',
             ],
             $result
         );
@@ -431,7 +443,7 @@ class LinkTagTest extends TestCase
 
         $this->assertEquals(
             [
-                $tag1 => '<a href="http://sulu.lo/de/test-1" title="Test-Title" target="_blank">Test-Content</a>',
+                $tag1 => '<a href="http://sulu.lo/de/test-1" title="Test-Title" target="_blank" data-provider="article">Test-Content</a>',
                 $tag2 => 'Test-Content',
                 $tag3 => 'Test-Content',
                 $tag4 => 'Test-Content',
@@ -493,8 +505,8 @@ class LinkTagTest extends TestCase
 
         $this->assertEquals(
             [
-                $tag1 => '<a href="http://sulu.lo/de/test-1" title="Test-Title" target="_blank">Test-Content</a>',
-                $tag2 => '<a title="Test-Title" target="_blank">Test-Content</a>',
+                $tag1 => '<a href="http://sulu.lo/de/test-1" title="Test-Title" target="_blank" data-provider="article">Test-Content</a>',
+                $tag2 => '<a title="Test-Title" target="_blank" data-provider="article">Test-Content</a>',
                 $tag3 => 'Test-Content',
                 $tag4 => 'Test-Content',
             ],

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
@@ -77,25 +77,25 @@ class LinkTagTest extends TestCase
                     'provider' => 'article',
                 ],
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
-                '<a href="http://sulu.lo/de/test" title="Test-Title" data-provider="article">Test-Content</a>',
+                '<a href="http://sulu.lo/de/test" title="Test-Title">Test-Content</a>',
             ],
             [
                 '<sulu-link href="123-123-123" title="Test-Title" provider="article"/>',
                 ['href' => '123-123-123', 'title' => 'Test-Title', 'provider' => 'article'],
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
-                '<a href="http://sulu.lo/de/test" title="Test-Title" data-provider="article">Page-Title</a>',
+                '<a href="http://sulu.lo/de/test" title="Test-Title">Page-Title</a>',
             ],
             [
                 '<sulu-link href="123-123-123" title="Test-Title" provider="article"></sulu-link>',
                 ['href' => '123-123-123', 'title' => 'Test-Title', 'provider' => 'article'],
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
-                '<a href="http://sulu.lo/de/test" title="Test-Title" data-provider="article">Page-Title</a>',
+                '<a href="http://sulu.lo/de/test" title="Test-Title">Page-Title</a>',
             ],
             [
                 '<sulu-link href="123-123-123" provider="article">Test-Content</sulu-link>',
                 ['href' => '123-123-123', 'content' => 'Test-Content', 'provider' => 'article'],
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
-                '<a href="http://sulu.lo/de/test" data-provider="article" title="Page-Title">Test-Content</a>',
+                '<a href="http://sulu.lo/de/test" title="Page-Title">Test-Content</a>',
             ],
             [
                 '<sulu-link href="123-123-123" title="Test-Title" target="_blank" provider="article">Test-Content</sulu-link>',
@@ -107,7 +107,7 @@ class LinkTagTest extends TestCase
                     'provider' => 'article',
                 ],
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
-                '<a href="http://sulu.lo/de/test" title="Test-Title" target="_blank" data-provider="article">Test-Content</a>',
+                '<a href="http://sulu.lo/de/test" title="Test-Title" target="_blank">Test-Content</a>',
             ],
             [
                 '<sulu-link href="123-123-123" title="Test-Title" target="_self" provider="article">Test-Content</sulu-link>',
@@ -119,7 +119,7 @@ class LinkTagTest extends TestCase
                     'provider' => 'article',
                 ],
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
-                '<a href="http://sulu.lo/de/test" title="Test-Title" target="_self" data-provider="article">Test-Content</a>',
+                '<a href="http://sulu.lo/de/test" title="Test-Title" target="_self">Test-Content</a>',
             ],
             [
                 '<sulu-link href="123-123-123" provider="article" class="test">Test-Content</sulu-link>',
@@ -130,7 +130,7 @@ class LinkTagTest extends TestCase
                     'content' => 'Test-Content',
                 ],
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
-                '<a href="http://sulu.lo/de/test" data-provider="article" class="test" title="Page-Title">Test-Content</a>',
+                '<a href="http://sulu.lo/de/test" class="test" title="Page-Title">Test-Content</a>',
             ],
             [
                 '<sulu-link href="123-123-123" title="Test-Title" class="test" provider="article">Test-Content</sulu-link>',
@@ -142,7 +142,7 @@ class LinkTagTest extends TestCase
                     'content' => 'Test-Content',
                 ],
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
-                '<a href="http://sulu.lo/de/test" title="Test-Title" class="test" data-provider="article">Test-Content</a>',
+                '<a href="http://sulu.lo/de/test" title="Test-Title" class="test">Test-Content</a>',
             ],
             [
                 '<sulu-link href="123-123-123#anchor" provider="article" title="Test-Title">Test-Content</sulu-link>',
@@ -153,7 +153,7 @@ class LinkTagTest extends TestCase
                     'content' => 'Test-Content',
                 ],
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
-                '<a href="http://sulu.lo/de/test#anchor" title="Test-Title" data-provider="article">Test-Content</a>',
+                '<a href="http://sulu.lo/de/test#anchor" title="Test-Title">Test-Content</a>',
             ],
             [
                 '<sulu-link href="123-123-123?query=parameter" provider="article" title="Test-Title">Test-Content</sulu-link>',
@@ -164,7 +164,7 @@ class LinkTagTest extends TestCase
                     'content' => 'Test-Content',
                 ],
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
-                '<a href="http://sulu.lo/de/test?query=parameter" title="Test-Title" data-provider="article">Test-Content</a>',
+                '<a href="http://sulu.lo/de/test?query=parameter" title="Test-Title">Test-Content</a>',
             ],
             [
                 '<sulu-link href="123-123-123?query=parameter#anchor" provider="article" title="Test-Title">Test-Content</sulu-link>',
@@ -175,7 +175,7 @@ class LinkTagTest extends TestCase
                     'content' => 'Test-Content',
                 ],
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
-                '<a href="http://sulu.lo/de/test?query=parameter#anchor" title="Test-Title" data-provider="article">Test-Content</a>',
+                '<a href="http://sulu.lo/de/test?query=parameter#anchor" title="Test-Title">Test-Content</a>',
             ],
             [
                 '<sulu-link href="123-123-123#anchor?not=query" provider="article" title="Test-Title">Test-Content</sulu-link>',
@@ -186,7 +186,7 @@ class LinkTagTest extends TestCase
                   'content' => 'Test-Content',
                 ],
                 [new LinkItem('123-123-123', 'Page-Title', 'de/test', true)],
-                '<a href="http://sulu.lo/de/test#anchor?not=query" title="Test-Title" data-provider="article">Test-Content</a>',
+                '<a href="http://sulu.lo/de/test#anchor?not=query" title="Test-Title">Test-Content</a>',
             ],
             [
                 '<sulu-link href="123-123-123" title="Test-Title" provider="article" data-provider="dummy">Test-Content</sulu-link>',
@@ -235,7 +235,7 @@ class LinkTagTest extends TestCase
         );
 
         $this->assertEquals(
-            [$tag => '<a href="/de/test" title="Test-Title" data-provider="article">Page-Title</a>'],
+            [$tag => '<a href="/de/test" title="Test-Title">Page-Title</a>'],
             $result
         );
     }
@@ -278,10 +278,10 @@ class LinkTagTest extends TestCase
 
         $this->assertEquals(
             [
-                $tag1 => '<a href="http://sulu.lo/de/test-1" data-provider="article" title="Page-Title 1">Test-Content</a>',
-                $tag2 => '<a href="http://sulu.lo/de/test-2" title="Test-Title" data-provider="article">Page-Title 2</a>',
-                $tag3 => '<a href="http://sulu.lo/de/test-1" title="Test-Title" data-provider="article">Test-Content</a>',
-                $tag4 => '<a href="http://sulu.lo/de/test-1" title="Test-Title" target="_blank" data-provider="article">Test-Content</a>',
+                $tag1 => '<a href="http://sulu.lo/de/test-1" title="Page-Title 1">Test-Content</a>',
+                $tag2 => '<a href="http://sulu.lo/de/test-2" title="Test-Title">Page-Title 2</a>',
+                $tag3 => '<a href="http://sulu.lo/de/test-1" title="Test-Title">Test-Content</a>',
+                $tag4 => '<a href="http://sulu.lo/de/test-1" title="Test-Title" target="_blank">Test-Content</a>',
             ],
             $result
         );
@@ -315,8 +315,8 @@ class LinkTagTest extends TestCase
 
         $this->assertEquals(
             [
-                $tag1 => '<a href="http://sulu.lo/de/test-2" data-provider="article" title="Page-Title 2">Page-Title 2</a>',
-                $tag2 => '<a href="http://sulu.lo/de/test-1" data-provider="page" title="Page-Title 1">Page-Title 1</a>',
+                $tag1 => '<a href="http://sulu.lo/de/test-2" title="Page-Title 2">Page-Title 2</a>',
+                $tag2 => '<a href="http://sulu.lo/de/test-1" title="Page-Title 1">Page-Title 1</a>',
             ],
             $result
         );
@@ -350,8 +350,8 @@ class LinkTagTest extends TestCase
 
         $this->assertEquals(
             [
-                $tag1 => '<a href="http://sulu.lo/de/test-2" data-provider="article" title="Page-Title 2">Page-Title 2</a>',
-                $tag2 => '<a href="http://sulu.lo/de/test-1" data-provider="page" title="Page-Title 1">Page-Title 1</a>',
+                $tag1 => '<a href="http://sulu.lo/de/test-2" title="Page-Title 2">Page-Title 2</a>',
+                $tag2 => '<a href="http://sulu.lo/de/test-1" title="Page-Title 1">Page-Title 1</a>',
             ],
             $result
         );
@@ -443,7 +443,7 @@ class LinkTagTest extends TestCase
 
         $this->assertEquals(
             [
-                $tag1 => '<a href="http://sulu.lo/de/test-1" title="Test-Title" target="_blank" data-provider="article">Test-Content</a>',
+                $tag1 => '<a href="http://sulu.lo/de/test-1" title="Test-Title" target="_blank">Test-Content</a>',
                 $tag2 => 'Test-Content',
                 $tag3 => 'Test-Content',
                 $tag4 => 'Test-Content',
@@ -505,11 +505,36 @@ class LinkTagTest extends TestCase
 
         $this->assertEquals(
             [
-                $tag1 => '<a href="http://sulu.lo/de/test-1" title="Test-Title" target="_blank" data-provider="article">Test-Content</a>',
-                $tag2 => '<a title="Test-Title" target="_blank" data-provider="article">Test-Content</a>',
+                $tag1 => '<a href="http://sulu.lo/de/test-1" title="Test-Title" target="_blank">Test-Content</a>',
+                $tag2 => '<a title="Test-Title" target="_blank">Test-Content</a>',
                 $tag3 => 'Test-Content',
                 $tag4 => 'Test-Content',
             ],
+            $result
+        );
+    }
+
+    public function testParseAllWithProviderAttribute()
+    {
+        $this->linkTag = new LinkTag($this->providerPool->reveal(), true, $this->urlHelper, 'data-provider');
+
+        $tag = '<sulu-link href="123-123-123" title="Test-Title" provider="article"/>';
+
+        $this->providers['article']->preload(['123-123-123'], 'de', true)
+            ->willReturn([new LinkItem('123-123-123', 'Page-Title', '/de/test', true)]);
+
+        $result = $this->linkTag->parseAll(
+            [$tag => [
+                'href' => '123-123-123',
+                'title' => 'Test-Title',
+                'provider' => 'article',
+                ],
+            ],
+            'de'
+        );
+
+        $this->assertEquals(
+            [$tag => '<a href="http://sulu.lo/de/test" title="Test-Title" data-provider="article">Page-Title</a>'],
             $result
         );
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#724

#### What's in this PR?

When adding internal links in CKEditor there are several link providers available ("page", "media", "article").
Right now the information which provider has been selected will be removed when converting the `<sulu-link>` tag to a real HTML `a` tag.
This simple change will forward the selected provider as an HTML data attribute.

#### Why?

Adding the selected provider as a data attribute allows targeting the links in CSS and in Javascript.

Examples:
- Add an icon to download (media) links
- Format internal links ("page", "article") differently
- Add custom analytics tracking by link type

#### Example Usage

```css
a[data-provider="media"] {
  font-color: green;
}
```

#### To Do

- [ ] Create a documentation PR
