### PR TITLE
Upgrade webpack to version 5

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,7 +16,7 @@ Sulu requires now new versions of the following JS packages:
 - `is-email` was removed and replaced by `sulu-admin-bundle/utils/Email/validateEmail` method 
 
 If you created custom admin components you need to upgrade also
-upgrade your components. The core js will automatically be update
+that components. The core js will automatically be update
 via the [update build](https://docs.sulu.io/en/latest/upgrades/upgrade-2.x.html) command.
 
 ### Deprecated urls variable in return value of sulu_content_load

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,23 @@
 
 ## 2.6.0
 
+### Webpack 5 upgrade
+
+Sulu requires now new versions of the following JS packages:
+
+- `webpack`: `^5.75.0`
+- `webpack-cli`: `^5.0`
+- `webpack-manifest-plugin`: `^5.0.0`
+- `mini-css-extract-plugin`: `^2.7.1`
+- `optimize-css-assets-webpack-plugin` was removed replaced by `css-minimizer-webpack-plugin`: `^4.2.2`
+- `clean-webpack-plugin` was removed and replaced by `clean: true` webpack output option
+- `webpack-clean-obsolete-chunks` was removed and replaced by `clean: true` webpack output option
+- `is-email` was removed and replaced by `sulu-admin-bundle/utils/Email/validateEmail` method 
+
+If you created custom admin components you need to upgrade also
+upgrade your components. The core js will automatically be update
+via the [update build](https://docs.sulu.io/en/latest/upgrades/upgrade-2.x.html) command.
+
 ### Deprecated urls variable in return value of sulu_content_load
 
 The `urls` variable in the return value of the `sulu_content_load` function was deprecated.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,7 +4,7 @@
 
 ### Webpack 5 upgrade
 
-Sulu requires now new versions of the following JS packages:
+Sulu now uses Webpack 5 to build the administration interface application. To enable this, the following JavaScript dependencies were updated/changed:
 
 - `webpack`: `^5.75.0`
 - `webpack-cli`: `^5.0`
@@ -15,9 +15,10 @@ Sulu requires now new versions of the following JS packages:
 - `webpack-clean-obsolete-chunks` was removed and replaced by `clean: true` webpack output option
 - `is-email` was removed and replaced by `sulu-admin-bundle/utils/Email/validateEmail` method 
 
-If you created custom admin components you need to upgrade also
-that components. The core js will automatically be update
-via the [update build](https://docs.sulu.io/en/latest/upgrades/upgrade-2.x.html) command.
+If you have integrated custom JavaScript components into the administration interface,
+you might need to adjust your components to be compatible with the updated dependencies.
+If you have not integrated custom JavaScript code, you project is adjusted automatically by the
+[update build](https://docs.sulu.io/en/latest/upgrades/upgrade-2.x.html) command.
 
 ### Deprecated urls variable in return value of sulu_content_load
 

--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
         "autoprefixer": "^10.4.7",
         "babel-jest": "^26.3.0",
         "babel-loader": "^8.0.6",
-        "clean-webpack-plugin": "^4.0.0",
         "core-js": "^3.18.0",
         "css-loader": "^5.2.4",
+        "css-minimizer-webpack-plugin": "^4.2.2",
         "dependency-cruiser": "^11.12.0",
         "empty": "^0.10.1",
         "enzyme": "^3.3.0",
@@ -71,11 +71,10 @@
         "identity-obj-proxy": "^3.0.0",
         "jest": "^26.4.2",
         "jest-canvas-mock": "^2.1.1",
-        "mini-css-extract-plugin": "^1.5.0",
+        "mini-css-extract-plugin": "^2.7.1",
         "mobx": "^4.0.0",
         "mobx-react": "^5.0.0",
         "moment-timezone": "^0.5.14",
-        "optimize-css-assets-webpack-plugin": "^6.0.1",
         "postcss": "^8.4.14",
         "postcss-calc": "^8.2.4",
         "postcss-hexrgba": "^2.1.0",
@@ -93,10 +92,9 @@
         "stylelint": "^14.9.1",
         "stylelint-config-standard-scss": "^5.0.0",
         "url-search-params-polyfill": "^8.0.0",
-        "webpack": "^4.27.0",
-        "webpack-clean-obsolete-chunks": "^0.4.0",
-        "webpack-cli": "^4.7.0",
-        "webpack-manifest-plugin": "^4.0.2"
+        "webpack": "^5.75.0",
+        "webpack-cli": "^5.0.0",
+        "webpack-manifest-plugin": "^5.0.0"
     },
     "jest": {
         "moduleNameMapper": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
         "react-styleguidist": "^11.0.5",
         "react-test-renderer": "^17.0.0",
         "regenerator-runtime": "^0.13.3",
-        "style-loader": "^2.0.0",
         "stylelint": "^14.9.1",
         "stylelint-config-standard-scss": "^5.0.0",
         "url-search-params-polyfill": "^8.0.0",

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/blockCollection.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/blockCollection.scss
@@ -42,7 +42,7 @@
 
 .selectMultipleButtonContainer {
     display: flex;
-    justify-content: end;
+    justify-content: flex-end;
 }
 
 .selectMultipleButton {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/Url.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/Url.js
@@ -4,8 +4,8 @@ import {observer} from 'mobx-react';
 import {action, computed, observable} from 'mobx';
 import classNames from 'classnames';
 import log from 'loglevel';
-import IsEmail from 'isemail';
 import SingleSelect from '../SingleSelect';
+import validateEmail from '../../utils/Email/validateEmail';
 import urlStyles from './url.scss';
 
 type Props = {|
@@ -58,7 +58,7 @@ class Url extends React.Component<Props> {
         }
 
         if (this.selectedProtocol === 'mailto:') {
-            return IsEmail.validate(url.substring(7));
+            return validateEmail(url.substring(7));
         }
 
         return true;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
@@ -25,7 +25,6 @@
         "history": "^5.0.0",
         "imagesloaded": "^4.1.3",
         "intl-messageformat": "^9.3.9",
-        "isemail": "^3.1.2",
         "jexl": "^2.1.0",
         "json-pointer": "^0.6.0",
         "loglevel": "^1.4.1",

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Ajv/formats/idnEmailValidator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Ajv/formats/idnEmailValidator.js
@@ -1,9 +1,9 @@
 // @flow
-import IsEmail from 'isemail';
 import {FormatValidator} from 'ajv';
+import validateEmail from '../../Email/validateEmail';
 
 const idnEmailValidator: typeof FormatValidator = (data: string): boolean => {
-    return IsEmail.validate(data);
+    return validateEmail(data);
 };
 
 export default idnEmailValidator;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Ajv/formats/tests/idnEmailValidator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Ajv/formats/tests/idnEmailValidator.test.js
@@ -5,10 +5,6 @@ test('Normal email address should pass validation', () => {
     expect(idnEmailValidator('hello@example.com')).toBe(true);
 });
 
-test('Email address with emojis should pass validation', () => {
-    expect(idnEmailValidator('🤌@😎')).toBe(true);
-});
-
 test('Invalid email address must not pass validation', () => {
     expect(idnEmailValidator('invalid')).toBe(false);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Email/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Email/index.js
@@ -1,0 +1,4 @@
+// @flow
+import validateEmail from './validateEmail';
+
+export {validateEmail};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Email/tests/validateEmail.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Email/tests/validateEmail.test.js
@@ -11,6 +11,7 @@ test('The valid email addresses', () => {
 });
 
 test('The invalid email addresses', () => {
+    expect(validateEmail(null)).toBe(false);
     expect(validateEmail('example')).toBe(false);
     expect(validateEmail('example@')).toBe(false);
     expect(validateEmail('example@localhost@')).toBe(false);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Email/tests/validateEmail.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Email/tests/validateEmail.test.js
@@ -1,0 +1,17 @@
+// @flow
+import validateEmail from '../validateEmail';
+
+test('The valid email addresses', () => {
+    expect(validateEmail('example@sulu.io')).toBe(true);
+    expect(validateEmail('example@example.org')).toBe(true);
+    expect(validateEmail('example@localhost')).toBe(true);
+    expect(validateEmail('0123@domain123.localhost')).toBe(true);
+    expect(validateEmail('some.name_more-symbols123+postfix@localhost')).toBe(true);
+    expect(validateEmail('some-ip@127.0.0.1')).toBe(true);
+});
+
+test('The invalid email addresses', () => {
+    expect(validateEmail('example')).toBe(false);
+    expect(validateEmail('example@')).toBe(false);
+    expect(validateEmail('example@localhost@')).toBe(false);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Email/validateEmail.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Email/validateEmail.js
@@ -4,5 +4,7 @@ export default function(value: ?string): boolean {
         return false;
     }
 
-    return /^(.+)@(.+)$/.test(value);
+    // used by webkit: https://github.com/WebKit/WebKit/blob/e205a844146bab749642d1b88974b706fe4d9e7e/Source/WebCore/html/EmailInputType.cpp#L38-L39
+    // and recommend by the WHATWG: https://html.spec.whatwg.org/#valid-e-mail-address
+    return /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(value);
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Email/validateEmail.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Email/validateEmail.js
@@ -1,10 +1,14 @@
 // @flow
+
 export default function(value: ?string): boolean {
     if (!value) {
         return false;
     }
 
-    // used by webkit: https://github.com/WebKit/WebKit/blob/e205a844146bab749642d1b88974b706fe4d9e7e/Source/WebCore/html/EmailInputType.cpp#L38-L39
-    // and recommend by the WHATWG: https://html.spec.whatwg.org/#valid-e-mail-address
-    return /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(value);
+    // used by webkit and recommend by the WHATWG:
+    //  - https://html.spec.whatwg.org/#valid-e-mail-address
+    //  - https://github.com/WebKit/WebKit/blob/WebKit-7615.1.12.130.1/Source/WebCore/html/EmailInputType.cpp#L38-L39
+
+    // eslint-disable-next-line max-len
+    return /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(value);
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Email/validateEmail.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Email/validateEmail.js
@@ -1,0 +1,8 @@
+// @flow
+export default function(value: ?string): boolean {
+    if (!value) {
+        return false;
+    }
+
+    return /^(.+)@(.+)$/.test(value);
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,9 +65,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
         ],
         optimization: {
             minimizer: [
-                // For webpack@5 you can use the `...` syntax to extend existing minimizers
-                //      see: https://webpack.js.org/plugins/css-minimizer-webpack-plugin/
-                `...`, // eslint-disable-line quotes
+                '...', // extend existing minimizers: https://webpack.js.org/plugins/css-minimizer-webpack-plugin/
                 new CssMinimizerPlugin(),
             ],
         },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -104,6 +104,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                         {
                             loader: MiniCssExtractPlugin.loader,
                         },
+                        // style loader not required in our setup
                         'css-loader',
                     ],
                 },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,6 +46,10 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
         performance: {
             hints: false,
         },
+        snapshot: {
+            // detect changes in "node_modules/@sulu": https://github.com/webpack/webpack/issues/11612
+            managedPaths: [],
+        },
         devtool: argv.mode === 'development' ? 'eval-source-map' : 'source-map',
         plugins: [
             new MiniCssExtractPlugin({


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? |  yes
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | parts of #6343 <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | ~~requires #6688~~, https://github.com/sulu/skeleton/pull/201 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Upgrade webpack to version 5.

#### Why?

Support latest version of webpack. 

#### TODO

 - [x] Remove dependencies to `util`, `process` packages via `isemail` package.
 - [x] Remove dependency to `Buffer` package see own js
 - [x] Undo changes of https://github.com/sulu/sulu/pull/6690/commits/822516faa66cff14abd75c1fec9a3b79c0b12b06
 - [x] Fix Build with skeleton
 - [x] Replace Email Validator
 
