### PR TITLE
Restrict versions of postcss-hexrgba and friendsofphp/php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -145,6 +145,7 @@
         "doctrine/lexer": "1.0.0",
         "doctrine/orm": "2.10.0",
         "doctrine/doctrine-cache-bundle": "<1.3.1",
+        "friendsofphp/php-cs-fixer": "3.9.1",
         "jackalope/jackalope": "< 1.3.4",
         "jackalope/jackalope-doctrine-dbal": "< 1.3.0",
         "jackalope/jackalope-jackrabbit": "< 1.3.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "optimize-css-assets-webpack-plugin": "^5.0.3",
         "postcss": "^7.0.35",
         "postcss-calc": "^7.0.5",
-        "postcss-hexrgba": "^2.0.0",
+        "postcss-hexrgba": "^2.0.0 <2.1.0",
         "postcss-import": "^12.0.1",
         "postcss-loader": "^3.0.0",
         "postcss-nested": "^4.2.3",


### PR DESCRIPTION
It looks like version 3.9.1 of the `friendsofphp/php-cs-fixer` package breaks the code indentation in some cases:
- https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/6470
- https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/6471

Furthermore, version 2.1.0 of the `postcss-hexrgba` package is only compatible with PostCSS 8:
- https://github.com/madeleineostoja/postcss-hexrgba/pull/33