### PR TITLE
Fix path to ckeditor theme in webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -153,7 +153,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                             options: {
                                 postcssOptions: styles.getPostCssConfig({
                                     themeImporter: {
-                                        themePath: require.resolve( '@ckeditor/ckeditor5-theme-lark' ),
+                                        themePath: require.resolve(path.resolve(nodeModulesPath, '@ckeditor/ckeditor5-theme-lark')),
                                     },
                                     minify: true,
                                 }),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/skeleton/pull/175 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?
Fix path to ckeditor theme in webpack config.

#### Why?
Fix build with: https://github.com/sulu/skeleton/pull/175
