### PR TITLE
Test against node 14 and 16

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -23,6 +23,7 @@ jobs:
                 include:
                     - node-version: '14'
                     - node-version: '16'
+                      npm-version: '6'
 
         env:
             COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -35,6 +36,10 @@ jobs:
               uses: actions/setup-node@v2-beta
               with:
                   node-version: ${{ matrix.node-version }}
+
+            - name: Install npm
+              if: ${{ matrix.npm-version }}
+              run: npm install -g npm@${{ matrix.npm-version }}
 
             - name: Assert error when using yarn
               run: tests/js/check-yarn-warning.sh

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -39,7 +39,7 @@ jobs:
 
             - name: Install npm
               if: ${{ matrix.npm-version }}
-              run: npm install -g npm@${{ matrix.npm-version }}
+              run: npm install --global npm@${{ matrix.npm-version }}
 
             - name: Assert error when using yarn
               run: tests/js/check-yarn-warning.sh

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -21,8 +21,8 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - node-version: '12'
                     - node-version: '14'
+                    - node-version: '16'
 
         env:
             COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/Login.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/Login.js
@@ -70,7 +70,7 @@ class Login extends React.Component<Props> {
 
     handleLoginFormSubmit = (data: LoginFormData) => {
         userStore.login(data).then(() => {
-            if (userStore.twoFactorMethods.length > 0) {
+            if (userStore.twoFactorMethods && userStore.twoFactorMethods.length > 0) {
                 action(() => {
                     this.visibleForm = 'two-factor';
                 })();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -153,7 +153,9 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                             options: {
                                 postcssOptions: styles.getPostCssConfig({
                                     themeImporter: {
-                                        themePath: require.resolve(path.resolve(nodeModulesPath, '@ckeditor/ckeditor5-theme-lark')),
+                                        themePath: require.resolve(
+                                            path.resolve(nodeModulesPath, '@ckeditor/ckeditor5-theme-lark')
+                                        ),
                                     },
                                     minify: true,
                                 }),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Test against node 14 and 16.

#### Why?

Node 12 is not longer supported when using strict engines config like in the skeleton: https://github.com/sulu/skeleton/pull/175