### PR TITLE
Fix relogin after logout

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/initializer/initializer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/initializer/initializer.js
@@ -107,7 +107,7 @@ class Initializer {
         const routePromise = this.initializeSymfonyRouting();
 
         return Promise.all([configPromise, routePromise])
-            .then(([config]) => {
+            .then(action(([config]) => {
                 this.config = config;
 
                 if (!this.initialized) {
@@ -122,7 +122,7 @@ class Initializer {
 
                 this.setInitialized();
                 return this.initializeTranslations();
-            })
+            }))
             .catch((error) => {
                 if (error.status !== 401) {
                     return Promise.reject(error);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix relogin after logout.

#### Why?

Mobx does not allow to change observable (config) without an action and the relogin does not work.

#### Example Usage

1. Go to [https://sulu.rocks/admin/#/webspaces/demo/pages/en/0abaf383-2193-495e-bec0-3e290a0968f6/details](https://sulu.rocks/admin/#/webspaces/demo/pages/en/0abaf383-2193-495e-bec0-3e290a0968f6/details)
2. Login
3. Logout
4. Login again (no refresh between)

Sulu crashes here with a mobx error.
