### PR TITLE
 Add default media image quality and markup data provider configuration

### DIFF
--- a/config/packages/sulu_markup.yaml
+++ b/config/packages/sulu_markup.yaml
@@ -1,0 +1,4 @@
+# see also: https://docs.sulu.io/en/2.4/bundles/markup/index.html
+sulu_markup:
+    link_tag:
+        provider_attribute: 'data-provider'

--- a/config/packages/sulu_media.yaml
+++ b/config/packages/sulu_media.yaml
@@ -1,0 +1,7 @@
+sulu_media:
+    format_manager:
+        default_imagine_options:
+            # a value between 95 and 75 is recommended
+            # see also: https://docs.sulu.io/en/2.5/book/image-formats.html
+            jpeg_quality: 90
+            webp_quality: 90


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no yes
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add default media image quality and markup data provider configuration.

#### Why?

Update from skeleton