### PR TITLE
Adding static methods for creating standard ToolbarActions

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ToolbarAction.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ToolbarAction.php
@@ -42,4 +42,34 @@ class ToolbarAction
     {
         return $this->options;
     }
+
+    public static function ADD(array $options = []): self
+    {
+        return new self('sulu_admin.add', $options);
+    }
+
+    public static function SAVE(array $options = []): self
+    {
+        return new self('sulu_admin.save', $options);
+    }
+
+    public static function DELETE(array $options = []): self
+    {
+        return new self('sulu_admin.delete', $options);
+    }
+
+    public static function EXPORT(array $options = []): self
+    {
+        return new self('sulu_admin.export', $options);
+    }
+
+    public static function TYPES(array $options = []): self
+    {
+        return new self('sulu_admin.types', $options);
+    }
+
+    public static function DOWNLOAD(array $options = []): self
+    {
+        return new self('sulu_admin.download', $options);
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormOverlayListViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormOverlayListViewBuilderTest.php
@@ -454,9 +454,9 @@ class FormOverlayListViewBuilderTest extends TestCase
 
     public function testBuildAddToolbarActions()
     {
-        $saveToolbarAction = new ToolbarAction('sulu_admin.save');
-        $typesToolbarAction = new ToolbarAction('sulu_admin.types');
-        $deleteToolbarAction = new ToolbarAction('sulu_admin.delete');
+        $saveToolbarAction = ToolbarAction::SAVE();
+        $typesToolbarAction = ToolbarAction::TYPES();
+        $deleteToolbarAction = ToolbarAction::DELETE();
 
         $route = (new FormOverlayListViewBuilder('sulu_role.list', '/roles'))
             ->setResourceKey(RoleInterface::RESOURCE_KEY)
@@ -476,8 +476,8 @@ class FormOverlayListViewBuilderTest extends TestCase
     public function testBuildAddItemActions()
     {
         $linkItemAction = new ToolbarAction('sulu_admin.link');
-        $exportItemAction = new ToolbarAction('sulu_admin.export');
-        $downloadItemAction = new ToolbarAction('sulu_admin.download');
+        $exportItemAction = ToolbarAction::EXPORT();
+        $downloadItemAction = ToolbarAction::DOWNLOAD();
 
         $route = (new FormOverlayListViewBuilder('sulu_role.list', '/roles'))
             ->setResourceKey(RoleInterface::RESOURCE_KEY)

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormViewBuilderTest.php
@@ -192,9 +192,9 @@ class FormViewBuilderTest extends TestCase
 
     public function testBuildFormWithToolbarActions()
     {
-        $saveToolbarAction = new ToolbarAction('sulu_admin.save');
-        $typesToolbarAction = new ToolbarAction('sulu_admin.types');
-        $deleteToolbarAction = new ToolbarAction('sulu_admin.delete');
+        $saveToolbarAction = ToolbarAction::SAVE();
+        $typesToolbarAction = ToolbarAction::TYPES();
+        $deleteToolbarAction = ToolbarAction::DELETE();
 
         $view = (new FormViewBuilder('sulu_role.add_form', '/roles'))
             ->setResourceKey(RoleInterface::RESOURCE_KEY)

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ListViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ListViewBuilderTest.php
@@ -420,9 +420,9 @@ class ListViewBuilderTest extends TestCase
 
     public function testBuildAddToolbarActions()
     {
-        $saveToolbarAction = new ToolbarAction('sulu_admin.save');
-        $typesToolbarAction = new ToolbarAction('sulu_admin.types');
-        $deleteToolbarAction = new ToolbarAction('sulu_admin.delete');
+        $saveToolbarAction = ToolbarAction::SAVE();
+        $typesToolbarAction = ToolbarAction::TYPES();
+        $deleteToolbarAction = ToolbarAction::DELETE();
 
         $view = (new ListViewBuilder('sulu_role.list', '/roles'))
             ->setResourceKey(RoleInterface::RESOURCE_KEY)
@@ -441,8 +441,8 @@ class ListViewBuilderTest extends TestCase
     public function testBuildAddItemActions()
     {
         $linkItemAction = new ToolbarAction('sulu_admin.link');
-        $exportItemAction = new ToolbarAction('sulu_admin.export');
-        $downloadItemAction = new ToolbarAction('sulu_admin.download');
+        $exportItemAction = ToolbarAction::EXPORT();
+        $downloadItemAction = ToolbarAction::DOWNLOAD();
 
         $view = (new ListViewBuilder('sulu_role.list', '/roles'))
             ->setResourceKey(RoleInterface::RESOURCE_KEY)

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/PreviewFormViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/PreviewFormViewBuilderTest.php
@@ -173,9 +173,9 @@ class PreviewFormViewBuilderTest extends TestCase
 
     public function testBuildFormWithToolbarActions()
     {
-        $saveToolbarAction = new ToolbarAction('sulu_admin.save');
-        $typesToolbarAction = new ToolbarAction('sulu_admin.types');
-        $deleteToolbarAction = new ToolbarAction('sulu_admin.delete');
+        $saveToolbarAction = ToolbarAction::SAVE();
+        $typesToolbarAction = ToolbarAction::TYPES();
+        $deleteToolbarAction = ToolbarAction::DELETE();
 
         $view = (new PreviewFormViewBuilder('sulu_role.add_form', '/roles'))
             ->setResourceKey(RoleInterface::RESOURCE_KEY)

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ToolbarActionTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ToolbarActionTest.php
@@ -18,14 +18,14 @@ class ToolbarActionTest extends TestCase
 {
     public function testGetType()
     {
-        $toolbarAction = new ToolbarAction('sulu_admin.delete', ['allow_conflict_deletion' => false]);
+        $toolbarAction = ToolbarAction::DELETE(['allow_conflict_deletion' => false]);
 
         $this->assertSame('sulu_admin.delete', $toolbarAction->getType());
     }
 
     public function testGetOptions()
     {
-        $toolbarAction = new ToolbarAction('sulu_admin.delete', ['allow_conflict_deletion' => false]);
+        $toolbarAction = ToolbarAction::DELETE(['allow_conflict_deletion' => false]);
 
         $this->assertSame(['allow_conflict_deletion' => false], $toolbarAction->getOptions());
     }

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Admin/AudienceTargetingAdmin.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Admin/AudienceTargetingAdmin.php
@@ -77,20 +77,20 @@ class AudienceTargetingAdmin extends Admin
         $formToolbarActions = [];
 
         if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::ADD)) {
-            $listToolbarActions[] = new ToolbarAction('sulu_admin.add');
+            $listToolbarActions[] = ToolbarAction::ADD();
         }
 
         if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
-            $formToolbarActions[] = new ToolbarAction('sulu_admin.save');
+            $formToolbarActions[] = ToolbarAction::SAVE();
         }
 
         if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::DELETE)) {
-            $listToolbarActions[] = new ToolbarAction('sulu_admin.delete');
-            $formToolbarActions[] = new ToolbarAction('sulu_admin.delete');
+            $listToolbarActions[] = ToolbarAction::DELETE();
+            $formToolbarActions[] = ToolbarAction::DELETE();
         }
 
         if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::VIEW)) {
-            $listToolbarActions[] = new ToolbarAction('sulu_admin.export');
+            $listToolbarActions[] = ToolbarAction::EXPORT();
         }
 
         if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::EDIT)) {

--- a/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
+++ b/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
@@ -76,21 +76,21 @@ class CategoryAdmin extends Admin
         $listToolbarActions = [];
 
         if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::ADD)) {
-            $listToolbarActions[] = new ToolbarAction('sulu_admin.add');
+            $listToolbarActions[] = ToolbarAction::ADD();
         }
 
         if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
-            $formToolbarActions[] = new ToolbarAction('sulu_admin.save');
+            $formToolbarActions[] = ToolbarAction::SAVE();
             $listToolbarActions[] = new ToolbarAction('sulu_admin.move');
         }
 
         if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::DELETE)) {
-            $formToolbarActions[] = new ToolbarAction('sulu_admin.delete');
-            $listToolbarActions[] = new ToolbarAction('sulu_admin.delete');
+            $formToolbarActions[] = ToolbarAction::DELETE();
+            $listToolbarActions[] = ToolbarAction::DELETE();
         }
 
         if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::VIEW)) {
-            $listToolbarActions[] = new ToolbarAction('sulu_admin.export');
+            $listToolbarActions[] = ToolbarAction::EXPORT();
         }
 
         if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
@@ -157,7 +157,7 @@ class CategoryAdmin extends Admin
                     ->setFormKey('category_keywords')
                     ->addRouterAttributesToFormRequest(['id' => 'categoryId'])
                     ->setTabTitle('sulu_category.keywords')
-                    ->addToolbarActions([new ToolbarAction('sulu_admin.add'), new ToolbarAction('sulu_admin.delete')])
+                    ->addToolbarActions([ToolbarAction::ADD(), ToolbarAction::DELETE()])
                     ->setParent(static::EDIT_FORM_VIEW)
             );
         }

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -103,22 +103,22 @@ class ContactAdmin extends Admin
             $contactDocumentsItemActions = [];
 
             if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::ADD)) {
-                $contactListToolbarActions[] = new ToolbarAction('sulu_admin.add');
+                $contactListToolbarActions[] = ToolbarAction::ADD();
             }
 
             if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::EDIT)) {
-                $contactFormToolbarActions[] = new ToolbarAction('sulu_admin.save');
+                $contactFormToolbarActions[] = ToolbarAction::SAVE();
                 $contactDocumentsToolbarActions[] = new ToolbarAction('sulu_contact.add_media');
                 $contactDocumentsToolbarActions[] = new ToolbarAction('sulu_contact.delete_media');
             }
 
             if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::DELETE)) {
-                $contactFormToolbarActions[] = new ToolbarAction('sulu_admin.delete');
-                $contactListToolbarActions[] = new ToolbarAction('sulu_admin.delete');
+                $contactFormToolbarActions[] = ToolbarAction::DELETE();
+                $contactListToolbarActions[] = ToolbarAction::DELETE();
             }
 
             if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::VIEW)) {
-                $contactListToolbarActions[] = new ToolbarAction('sulu_admin.export');
+                $contactListToolbarActions[] = ToolbarAction::EXPORT();
                 $contactDocumentsItemActions[] = new ListItemAction(
                     'link',
                     ['icon' => 'su-download', 'link_property' => 'url']
@@ -191,28 +191,22 @@ class ContactAdmin extends Admin
             $accountDocumentsItemActions = [];
 
             if ($this->securityChecker->hasPermission(static::ACCOUNT_SECURITY_CONTEXT, PermissionTypes::ADD)) {
-                $accountListToolbarActions[] = new ToolbarAction('sulu_admin.add');
+                $accountListToolbarActions[] = ToolbarAction::ADD();
             }
 
             if ($this->securityChecker->hasPermission(static::ACCOUNT_SECURITY_CONTEXT, PermissionTypes::EDIT)) {
-                $accountFormToolbarActions[] = new ToolbarAction('sulu_admin.save');
+                $accountFormToolbarActions[] = ToolbarAction::SAVE();
                 $accountDocumentsToolbarActions[] = new ToolbarAction('sulu_contact.add_media');
                 $accountDocumentsToolbarActions[] = new ToolbarAction('sulu_contact.delete_media');
             }
 
             if ($this->securityChecker->hasPermission(static::ACCOUNT_SECURITY_CONTEXT, PermissionTypes::DELETE)) {
-                $accountFormToolbarActions[] = new ToolbarAction(
-                    'sulu_admin.delete',
-                    ['allow_conflict_deletion' => false]
-                );
-                $accountListToolbarActions[] = new ToolbarAction(
-                    'sulu_admin.delete',
-                    ['allow_conflict_deletion' => false]
-                );
+                $accountFormToolbarActions[] = ToolbarAction::DELETE(['allow_conflict_deletion' => false]);
+                $accountListToolbarActions[] = ToolbarAction::DELETE(['allow_conflict_deletion' => false]);
             }
 
             if ($this->securityChecker->hasPermission(static::ACCOUNT_SECURITY_CONTEXT, PermissionTypes::VIEW)) {
-                $accountListToolbarActions[] = new ToolbarAction('sulu_admin.export');
+                $accountListToolbarActions[] = ToolbarAction::EXPORT();
                 $accountDocumentsItemActions[] = new ListItemAction(
                     'link',
                     ['icon' => 'su-download', 'link_property' => 'url']
@@ -274,7 +268,7 @@ class ContactAdmin extends Admin
                     ->addRouterAttributesToListRequest(['id'])
                     ->addToolbarActions([
                         new ToolbarAction('sulu_contact.add_contact'),
-                        new ToolbarAction('sulu_admin.delete'),
+                        ToolbarAction::DELETE(),
                     ])
                     ->addRouterAttributesToListRequest(['id' => 'accountId'])
                     ->setTabOrder(2048)

--- a/src/Sulu/Bundle/CustomUrlBundle/Admin/CustomUrlAdmin.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Admin/CustomUrlAdmin.php
@@ -71,8 +71,8 @@ class CustomUrlAdmin extends Admin
     public function configureViews(ViewCollection $viewCollection): void
     {
         $listToolbarActions = [
-            new ToolbarAction('sulu_admin.add'),
-            new ToolbarAction('sulu_admin.delete'),
+            ToolbarAction::ADD(),
+            ToolbarAction::DELETE(),
         ];
 
         if ($this->hasSomeWebspaceCustomUrlPermission()) {

--- a/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
+++ b/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
@@ -108,10 +108,10 @@ class MediaAdmin extends Admin
         $mediaLocales = $this->localizationManager->getLocales();
 
         $toolbarActions = [
-            new ToolbarAction('sulu_admin.save', [
+            ToolbarAction::SAVE([
                 'visible_condition' => '(_permissions && _permissions.edit)',
             ]),
-            new ToolbarAction('sulu_admin.delete', [
+            ToolbarAction::DELETE([
                 'visible_condition' => '(!_permissions || _permissions.delete)',
             ]),
         ];

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -131,22 +131,16 @@ class PageAdmin extends Admin
             'sulu_admin.save',
             'su-save',
             [
-                new ToolbarAction(
-                    'sulu_admin.save',
-                    [
-                        'label' => 'sulu_admin.save_draft',
-                        'options' => ['action' => 'draft'],
-                        'visible_condition' => $saveVisibleCondition,
-                    ]
-                ),
-                new ToolbarAction(
-                    'sulu_admin.save',
-                    [
-                        'label' => 'sulu_admin.save_publish',
-                        'options' => ['action' => 'publish'],
-                        'visible_condition' => '(' . $saveVisibleCondition . ') && (' . $publishVisibleCondition . ')',
-                    ]
-                ),
+                ToolbarAction::SAVE([
+                    'label' => 'sulu_admin.save_draft',
+                    'options' => ['action' => 'draft'],
+                    'visible_condition' => $saveVisibleCondition,
+                ]),
+                ToolbarAction::SAVE([
+                    'label' => 'sulu_admin.save_publish',
+                    'options' => ['action' => 'publish'],
+                    'visible_condition' => '(' . $saveVisibleCondition . ') && (' . $publishVisibleCondition . ')',
+                ]),
                 new ToolbarAction(
                     'sulu_admin.publish',
                     [
@@ -169,21 +163,15 @@ class PageAdmin extends Admin
                 'sulu_admin.delete',
                 'su-trash-alt',
                 [
-                    new ToolbarAction(
-                        'sulu_admin.delete',
-                        [
-                            'visible_condition' => '(!_permissions || _permissions.delete) && url != "/"',
-                            'router_attributes_to_back_view' => ['webspace'],
-                        ]
-                    ),
-                    new ToolbarAction(
-                        'sulu_admin.delete',
-                        [
-                            'visible_condition' => '(!_permissions || _permissions.delete) && url != "/"',
-                            'router_attributes_to_back_view' => ['webspace'],
-                            'delete_locale' => true,
-                        ]
-                    ),
+                    ToolbarAction::DELETE([
+                        'visible_condition' => '(!_permissions || _permissions.delete) && url != "/"',
+                        'router_attributes_to_back_view' => ['webspace'],
+                    ]),
+                    ToolbarAction::DELETE([
+                        'visible_condition' => '(!_permissions || _permissions.delete) && url != "/"',
+                        'router_attributes_to_back_view' => ['webspace'],
+                        'delete_locale' => true,
+                    ]),
                 ]
             ),
             new DropdownToolbarAction(

--- a/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
+++ b/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
@@ -138,20 +138,20 @@ class SecurityAdmin extends Admin
         $listToolbarActions = [];
 
         if ($this->securityChecker->hasPermission(static::ROLE_SECURITY_CONTEXT, PermissionTypes::ADD)) {
-            $listToolbarActions[] = new ToolbarAction('sulu_admin.add');
+            $listToolbarActions[] = ToolbarAction::ADD();
         }
 
         if ($this->securityChecker->hasPermission(static::ROLE_SECURITY_CONTEXT, PermissionTypes::EDIT)) {
-            $formToolbarActions[] = new ToolbarAction('sulu_admin.save');
+            $formToolbarActions[] = ToolbarAction::SAVE();
         }
 
         if ($this->securityChecker->hasPermission(static::ROLE_SECURITY_CONTEXT, PermissionTypes::DELETE)) {
-            $formToolbarActions[] = new ToolbarAction('sulu_admin.delete');
-            $listToolbarActions[] = new ToolbarAction('sulu_admin.delete');
+            $formToolbarActions[] = ToolbarAction::DELETE();
+            $listToolbarActions[] = ToolbarAction::DELETE();
         }
 
         if ($this->securityChecker->hasPermission(static::ROLE_SECURITY_CONTEXT, PermissionTypes::VIEW)) {
-            $listToolbarActions[] = new ToolbarAction('sulu_admin.export');
+            $listToolbarActions[] = ToolbarAction::EXPORT();
         }
 
         if ($this->securityChecker->hasPermission(static::ROLE_SECURITY_CONTEXT, PermissionTypes::EDIT)) {
@@ -207,7 +207,7 @@ class SecurityAdmin extends Admin
                     ->setFormKey('user_details')
                     ->setTabTitle('sulu_security.permissions')
                     ->addToolbarActions([
-                        new ToolbarAction('sulu_admin.save'),
+                        ToolbarAction::SAVE(),
                         new ToolbarAction('sulu_security.enable_user'),
                         new TogglerToolbarAction(
                             'sulu_security.user_locked',

--- a/src/Sulu/Bundle/SecurityBundle/EventListener/LogoutEventSubscriber.php
+++ b/src/Sulu/Bundle/SecurityBundle/EventListener/LogoutEventSubscriber.php
@@ -39,7 +39,7 @@ final class LogoutEventSubscriber implements EventSubscriberInterface
         $adminUrl = $this->urlGenerator->generate('sulu_admin');
         $request = $logoutEvent->getRequest();
 
-        if (!\str_starts_with($request->getPathInfo(), $adminUrl)) {
+        if (!str_starts_with($request->getPathInfo(), $adminUrl)) {
             // do nothing when not in admin context
 
             return;

--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -102,22 +102,22 @@ class SnippetAdmin extends Admin
         $listToolbarActions = [];
 
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::ADD)) {
-            $listToolbarActions[] = new ToolbarAction('sulu_admin.add');
+            $listToolbarActions[] = ToolbarAction::ADD();
         }
 
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
-            $formToolbarActionsWithoutType[] = new ToolbarAction('sulu_admin.save');
-            $formToolbarActionsWithType[] = new ToolbarAction('sulu_admin.save');
+            $formToolbarActionsWithoutType[] = ToolbarAction::SAVE();
+            $formToolbarActionsWithType[] = ToolbarAction::SAVE();
             $formToolbarActionsWithType[] = new ToolbarAction('sulu_admin.type', ['sort_by' => 'title']);
         }
 
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::DELETE)) {
-            $formToolbarActionsWithType[] = new ToolbarAction('sulu_admin.delete');
-            $listToolbarActions[] = new ToolbarAction('sulu_admin.delete');
+            $formToolbarActionsWithType[] = ToolbarAction::DELETE();
+            $listToolbarActions[] = ToolbarAction::DELETE();
         }
 
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::VIEW)) {
-            $listToolbarActions[] = new ToolbarAction('sulu_admin.export');
+            $listToolbarActions[] = ToolbarAction::EXPORT();
         }
 
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
@@ -89,9 +89,9 @@ class SnippetAdminTest extends TestCase
         $this->assertEquals([
             'title' => 'sulu_snippet.snippets',
             'toolbarActions' => [
-                new ToolbarAction('sulu_admin.add'),
-                new ToolbarAction('sulu_admin.delete'),
-                new ToolbarAction('sulu_admin.export'),
+                ToolbarAction::ADD(),
+                ToolbarAction::DELETE(),
+                ToolbarAction::EXPORT(),
             ],
             'resourceKey' => 'snippets',
             'listKey' => 'snippets',

--- a/src/Sulu/Bundle/TagBundle/Admin/TagAdmin.php
+++ b/src/Sulu/Bundle/TagBundle/Admin/TagAdmin.php
@@ -66,20 +66,20 @@ class TagAdmin extends Admin
         $listToolbarActions = [];
 
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::ADD)) {
-            $listToolbarActions[] = new ToolbarAction('sulu_admin.add');
+            $listToolbarActions[] = ToolbarAction::ADD();
         }
 
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
-            $formToolbarActions[] = new ToolbarAction('sulu_admin.save');
+            $formToolbarActions[] = ToolbarAction::SAVE();
         }
 
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::DELETE)) {
-            $formToolbarActions[] = new ToolbarAction('sulu_admin.delete');
-            $listToolbarActions[] = new ToolbarAction('sulu_admin.delete');
+            $formToolbarActions[] = ToolbarAction::DELETE();
+            $listToolbarActions[] = ToolbarAction::DELETE();
         }
 
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::VIEW)) {
-            $listToolbarActions[] = new ToolbarAction('sulu_admin.export');
+            $listToolbarActions[] = ToolbarAction::EXPORT();
         }
 
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {

--- a/src/Sulu/Bundle/TrashBundle/Infrastructure/Sulu/Admin/TrashAdmin.php
+++ b/src/Sulu/Bundle/TrashBundle/Infrastructure/Sulu/Admin/TrashAdmin.php
@@ -86,7 +86,7 @@ final class TrashAdmin extends Admin
             $toolbarActions = [];
 
             if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::DELETE)) {
-                $toolbarActions[] = new ToolbarAction('sulu_admin.delete');
+                $toolbarActions[] = ToolbarAction::DELETE();
             }
 
             $listViewBuilder = $this->viewBuilderFactory->createListViewBuilder(static::LIST_VIEW, '/trash/:locale')

--- a/src/Sulu/Bundle/WebsiteBundle/Admin/WebsiteAdmin.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Admin/WebsiteAdmin.php
@@ -62,8 +62,8 @@ class WebsiteAdmin extends Admin
     public function configureViews(ViewCollection $viewCollection): void
     {
         $listToolbarActions = [
-            new ToolbarAction('sulu_admin.add'),
-            new ToolbarAction('sulu_admin.delete'),
+            ToolbarAction::ADD(),
+            ToolbarAction::DELETE(),
         ];
 
         if ($this->hasSomeWebspaceAnalyticsPermission()) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes (at least for Devs)
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | TBA

#### What's in this PR?

In this pull requests I created static methods on the `ToolbarAction` class to easily create `ToolbarAction` objects.

#### Why?

There are a few reasons why. It's shorter and more concise to read. But the main reason is that you don't have to rely on magic strings anymore. So the user doesn't have to know that the delete button is the `sulu_admin.delete` button string.

And since the old feature isn't touched at all, it does not break any backwards compatibility.

#### Example Usage
```php

// Before
$viewBuilder
    ->addToolbarActions([new ToolbarAction('sulu_admin.add'), new ToolbarAction('sulu_admin.delete')])
;

// After
$viewBuilder
    ->addToolbarActions([ToolbarAction::ADD(), ToolbarAction::DELETE()])
;
```

#### To Do

- [ ] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md
