### PR TITLE
Migrate enzyme AutoCompletePopover tests to React Testing Library 

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/AutoCompletePopover.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/AutoCompletePopover.js
@@ -64,6 +64,13 @@ export default class AutoCompletePopover extends React.Component<Props> {
         }
     };
 
+    componentDidMount() {
+        if (this.props.open === true) {
+            Mousetrap.bind('up', this.handleUp);
+            Mousetrap.bind('down', this.handleDown);
+        }
+    }
+
     componentDidUpdate(prevProps: Props) {
         if (this.props.open === true && prevProps.open === false) {
             Mousetrap.bind('up', this.handleUp);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/tests/AutoCompletePopover.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/tests/AutoCompletePopover.test.js
@@ -1,74 +1,96 @@
 // @flow
 import React from 'react';
-import {mount, render, shallow} from 'enzyme';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import Mousetrap from 'mousetrap';
 import AutoCompletePopover from '../AutoCompletePopover';
-import Popover from '../../Popover';
-
-jest.mock('../../Popover', () => ({children}) => children(jest.fn(), {}));
 
 beforeEach(() => {
     Mousetrap.reset();
 });
 
 test('Popover should be hidden when open is set to false', () => {
-    const autoCompletePopover = shallow(
+    render(
+        <div>Anchor Element</div>
+    );
+
+    const suggestions = [
+        {id: 1, name: 'Test 1 (selector-1)'},
+        {id: 2, name: 'Test 2 (selector-2)'},
+    ];
+    render(
         <AutoCompletePopover
-            anchorElement={jest.fn()}
+            anchorElement={screen.getByText('Anchor Element')}
             onSelect={jest.fn()}
             open={false}
-            query=""
-            searchProperties={[]}
-            suggestions={[]}
+            query="Test"
+            searchProperties={['name']}
+            suggestions={suggestions}
         />
     );
 
-    expect(autoCompletePopover.find(Popover).prop('open')).toEqual(false);
+    expect(screen.queryByText(/selector-1/)).not.toBeInTheDocument();
 });
 
 test('Popover should be shown when open is set to true', () => {
-    const autoCompletePopover = shallow(
-        <AutoCompletePopover
-            anchorElement={jest.fn()}
-            onSelect={jest.fn()}
-            open={true}
-            query=""
-            searchProperties={[]}
-            suggestions={[]}
-        />
+    render(
+        <div>Anchor Element</div>
     );
 
-    expect(autoCompletePopover.find(Popover).prop('open')).toEqual(true);
-});
-
-test('Render with highlighted suggestions', () => {
     const suggestions = [
-        {id: 1, name: 'Test 1'},
-        {id: 2, name: 'Test 2'},
+        {id: 1, name: 'Test 1 (selector-1)'},
+        {id: 2, name: 'Test 2 (selector-2)'},
     ];
-
-    expect(render(
+    render(
         <AutoCompletePopover
-            anchorElement={jest.fn()}
+            anchorElement={screen.getByText('Anchor Element')}
             onSelect={jest.fn()}
             open={true}
             query="Test"
             searchProperties={['name']}
             suggestions={suggestions}
         />
-    )).toMatchSnapshot();
+    );
+
+    expect(screen.getByText(/selector-1/)).toBeInTheDocument();
 });
 
-test('Call onClose when Popover is closed', () => {
-    const suggestions = [
-        {id: 1, name: 'Test 1'},
-        {id: 2, name: 'Test 2'},
-    ];
+test('Render with highlighted suggestions', () => {
+    render(
+        <div>Anchor Element</div>
+    );
 
-    const closeSpy = jest.fn();
-    const autoCompletePopover = shallow(
+    const suggestions = [
+        {id: 1, name: 'Test 1 (selector-1)'},
+        {id: 2, name: 'Test 2 (selector-2)'},
+    ];
+    render(
         <AutoCompletePopover
-            anchorElement={jest.fn()}
+            anchorElement={screen.getByText('Anchor Element')}
+            onSelect={jest.fn()}
+            open={true}
+            query="Test"
+            searchProperties={['name']}
+            suggestions={suggestions}
+        />
+    );
+
+    expect(document.body).toMatchSnapshot();
+});
+
+test('Call onClose when Popover is closed', async() => {
+    render(
+        <div>Anchor Element</div>
+    );
+
+    const suggestions = [
+        {id: 1, name: 'Test 1 (selector-1)'},
+        {id: 2, name: 'Test 2 (selector-2)'},
+    ];
+    const closeSpy = jest.fn();
+    render(
+        <AutoCompletePopover
+            anchorElement={screen.getByText('Anchor Element')}
             onClose={closeSpy()}
             onSelect={jest.fn()}
             open={true}
@@ -78,20 +100,24 @@ test('Call onClose when Popover is closed', () => {
         />
     );
 
-    autoCompletePopover.find(Popover).prop('onClose')();
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('backdrop'));
     expect(closeSpy).toBeCalledWith();
 });
 
-test('Call onSelect with clicked suggestion', () => {
-    const suggestions = [
-        {id: 1, name: 'Test 1'},
-        {id: 2, name: 'Test 2'},
-    ];
+test('Call onSelect with clicked suggestion', async() => {
+    render(
+        <div>Anchor Element</div>
+    );
 
+    const suggestions = [
+        {id: 1, name: 'Test 1 (selector-1)'},
+        {id: 2, name: 'Test 2 (selector-2)'},
+    ];
     const selectSpy = jest.fn();
-    const autoCompletePopover = mount(
+    render(
         <AutoCompletePopover
-            anchorElement={jest.fn()}
+            anchorElement={screen.getByText('Anchor Element')}
             onSelect={selectSpy}
             open={true}
             query="Test"
@@ -100,80 +126,44 @@ test('Call onSelect with clicked suggestion', () => {
         />
     );
 
-    expect(autoCompletePopover.find('Suggestion').at(1).prop('value')).toBe(suggestions[1]);
-    autoCompletePopover.find('Suggestion').at(1).prop('onSelect')(suggestions[1]);
+    const user = userEvent.setup();
+    await user.click(screen.getByText(/selector-2/));
     expect(selectSpy).toBeCalledWith(suggestions[1]);
 });
 
-test('Pressing down should select next item', () => {
-    const suggestions = [
-        {id: 1, name: 'Test 1'},
-        {id: 2, name: 'Test 2'},
-    ];
+test('Should focus suggestions when pressing up and down key', async() => {
+    render(
+        <div>Anchor Element</div>
+    );
 
-    const autoCompletePopover = mount(
+    const suggestions = [
+        {id: 1, name: 'Test 1 (selector-1)'},
+        {id: 2, name: 'Test 2 (selector-2)'},
+    ];
+    render(
         <AutoCompletePopover
-            anchorElement={jest.fn()}
+            anchorElement={screen.getByText('Anchor Element')}
             onSelect={jest.fn()}
-            open={false}
+            open={true}
             query="Test"
             searchProperties={['name']}
             suggestions={suggestions}
         />
     );
+    const suggestionElements = screen.getAllByRole('button').slice(1); // first button is the popover backdrop
 
-    const suggestionElement1 = {focus: jest.fn()};
-    const suggestionElement2 = {focus: jest.fn()};
-
-    autoCompletePopover.instance().suggestionsRef = {
-        getElementsByTagName: jest.fn().mockReturnValue([
-            suggestionElement1,
-            suggestionElement2,
-        ]),
-    };
-    autoCompletePopover.setProps({open: true});
-    autoCompletePopover.update();
+    expect(suggestionElements[0]).not.toHaveFocus();
+    expect(suggestionElements[1]).not.toHaveFocus();
 
     Mousetrap.trigger('down');
-    expect(suggestionElement1.focus).toBeCalledWith();
-    expect(suggestionElement2.focus).not.toBeCalledWith();
-});
+    expect(suggestionElements[0]).toHaveFocus();
+    expect(suggestionElements[1]).not.toHaveFocus();
 
-test('Pressing up should select previous item', () => {
-    const suggestions = [
-        {id: 1, name: 'Test 1'},
-        {id: 2, name: 'Test 2'},
-    ];
-
-    const autoCompletePopover = mount(
-        <AutoCompletePopover
-            anchorElement={jest.fn()}
-            onSelect={jest.fn()}
-            open={false}
-            query="Test"
-            searchProperties={['name']}
-            suggestions={suggestions}
-        />
-    );
-
-    const suggestionElement1 = {focus: jest.fn()};
-    const suggestionElement2 = {focus: jest.fn()};
-
-    Object.defineProperty(document, 'activeElement', {
-        // $FlowFixMe
-        value: suggestionElement2,
-    });
-
-    autoCompletePopover.instance().suggestionsRef = {
-        getElementsByTagName: jest.fn().mockReturnValue([
-            suggestionElement1,
-            suggestionElement2,
-        ]),
-    };
-    autoCompletePopover.setProps({open: true});
-    autoCompletePopover.update();
+    Mousetrap.trigger('down');
+    expect(suggestionElements[0]).not.toHaveFocus();
+    expect(suggestionElements[1]).toHaveFocus();
 
     Mousetrap.trigger('up');
-    expect(suggestionElement1.focus).toBeCalledWith();
-    expect(suggestionElement2.focus).not.toBeCalledWith();
+    expect(suggestionElements[0]).toHaveFocus();
+    expect(suggestionElements[1]).not.toHaveFocus();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/tests/Suggestion.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/tests/Suggestion.test.js
@@ -1,10 +1,11 @@
 // @flow
 import React from 'react';
-import {render, shallow} from 'enzyme';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import Suggestion from '../Suggestion';
 
 test('Suggestion should render', () => {
-    expect(render(
+    const {container} = render(
         <Suggestion
             icon="fa-ticket"
             onSelect={jest.fn()}
@@ -12,11 +13,13 @@ test('Suggestion should render', () => {
         >
             Suggestion 1
         </Suggestion>
-    )).toMatchSnapshot();
+    );
+
+    expect(container).toMatchSnapshot();
 });
 
 test('Suggestion should render strong-tags around found chars', () => {
-    expect(render(
+    const {container} = render(
         <Suggestion
             icon="fa-ticket"
             onSelect={jest.fn()}
@@ -25,11 +28,13 @@ test('Suggestion should render strong-tags around found chars', () => {
         >
             Suggestion 2
         </Suggestion>
-    )).toMatchSnapshot();
+    );
+
+    expect(container).toMatchSnapshot();
 });
 
 test('Suggestion should render if given query is not a valid regular expression', () => {
-    expect(render(
+    const {container} = render(
         <Suggestion
             icon="fa-ticket"
             onSelect={jest.fn()}
@@ -38,12 +43,14 @@ test('Suggestion should render if given query is not a valid regular expression'
         >
             Suggestion 2
         </Suggestion>
-    )).toMatchSnapshot();
+    );
+
+    expect(container).toMatchSnapshot();
 });
 
-test('Clicking on a suggestion should call the onClick handler', () => {
+test('Clicking on a suggestion should call the onClick handler', async() => {
     const selectSpy = jest.fn();
-    const suggestion = shallow(
+    render(
         <Suggestion
             icon="fa-ticket"
             onSelect={selectSpy}
@@ -56,12 +63,14 @@ test('Clicking on a suggestion should call the onClick handler', () => {
         </Suggestion>
     );
 
-    suggestion.find('button').simulate('click');
+    const user = userEvent.setup();
+    await user.click(screen.getByText('Suggestion 3'));
+
     expect(selectSpy).toHaveBeenCalledTimes(1);
 });
 
 test('Should highlight the part of the suggestion text which matches the query prop', () => {
-    const suggestion = shallow(
+    const {container} = render(
         <Suggestion
             icon="fa-ticket"
             onSelect={jest.fn()}
@@ -74,5 +83,5 @@ test('Should highlight the part of the suggestion text which matches the query p
         </Suggestion>
     );
 
-    expect(suggestion.render()).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/tests/__snapshots__/AutoCompletePopover.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/tests/__snapshots__/AutoCompletePopover.test.js.snap
@@ -1,48 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Render with highlighted suggestions 1`] = `
-<ul
-  class="menu"
->
-  <li
-    class="suggestionItem"
-    style="min-width:0px"
-  >
-    <button
-      class="suggestion"
-      type="button"
+<body>
+  <div>
+    <div>
+      Anchor Element
+    </div>
+  </div>
+  <div />
+  <div>
+    <div
+      class="backdrop fixed"
+      data-testid="backdrop"
+      role="button"
+    />
+    <div
+      class="container"
     >
-      <span
-        class="column"
+      <ul
+        class="menu"
+        style="top: 10px; left: 10px; position: fixed; pointer-events: auto;"
       >
-        <span>
-          <strong>
-            Test
-          </strong>
-           1
-        </span>
-      </span>
-    </button>
-  </li>
-  <li
-    class="suggestionItem"
-    style="min-width:0px"
-  >
-    <button
-      class="suggestion"
-      type="button"
-    >
-      <span
-        class="column"
-      >
-        <span>
-          <strong>
-            Test
-          </strong>
-           2
-        </span>
-      </span>
-    </button>
-  </li>
-</ul>
+        <li
+          class="suggestionItem"
+          style="min-width: 0px;"
+        >
+          <button
+            class="suggestion"
+            type="button"
+          >
+            <span
+              class="column"
+            >
+              <span>
+                <strong>
+                  Test
+                </strong>
+                 1 (selector-1)
+              </span>
+            </span>
+          </button>
+        </li>
+        <li
+          class="suggestionItem"
+          style="min-width: 0px;"
+        >
+          <button
+            class="suggestion"
+            type="button"
+          >
+            <span
+              class="column"
+            >
+              <span>
+                <strong>
+                  Test
+                </strong>
+                 2 (selector-2)
+              </span>
+            </span>
+          </button>
+        </li>
+      </ul>
+    </div>
+  </div>
+</body>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/tests/__snapshots__/Suggestion.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/tests/__snapshots__/Suggestion.test.js.snap
@@ -1,87 +1,95 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Should highlight the part of the suggestion text which matches the query prop 1`] = `
-<li
-  class="suggestionItem"
-  style="min-width:0px"
->
-  <button
-    class="suggestion"
-    type="button"
+<div>
+  <li
+    class="suggestionItem"
+    style="min-width: 0px;"
   >
-    <span
-      aria-label="fa-ticket"
-      class="fa fa-ticket icon"
-    />
-    <div>
+    <button
+      class="suggestion"
+      type="button"
+    >
+      <span
+        aria-label="fa-ticket"
+        class="fa fa-ticket icon"
+      />
+      <div>
+        <span>
+          <strong>
+            Sug
+          </strong>
+          gestion 3
+        </span>
+      </div>
+    </button>
+  </li>
+</div>
+`;
+
+exports[`Suggestion should render 1`] = `
+<div>
+  <li
+    class="suggestionItem"
+    style="min-width: 0px;"
+  >
+    <button
+      class="suggestion"
+      type="button"
+    >
+      <span
+        aria-label="fa-ticket"
+        class="fa fa-ticket icon"
+      />
+      Suggestion 1
+    </button>
+  </li>
+</div>
+`;
+
+exports[`Suggestion should render if given query is not a valid regular expression 1`] = `
+<div>
+  <li
+    class="suggestionItem"
+    style="min-width: 0px;"
+  >
+    <button
+      class="suggestion"
+      type="button"
+    >
+      <span
+        aria-label="fa-ticket"
+        class="fa fa-ticket icon"
+      />
+      <span>
+        Suggestion 2
+      </span>
+    </button>
+  </li>
+</div>
+`;
+
+exports[`Suggestion should render strong-tags around found chars 1`] = `
+<div>
+  <li
+    class="suggestionItem"
+    style="min-width: 0px;"
+  >
+    <button
+      class="suggestion"
+      type="button"
+    >
+      <span
+        aria-label="fa-ticket"
+        class="fa fa-ticket icon"
+      />
       <span>
         <strong>
           Sug
         </strong>
-        gestion 3
+        gestion 2
       </span>
-    </div>
-  </button>
-</li>
-`;
-
-exports[`Suggestion should render 1`] = `
-<li
-  class="suggestionItem"
-  style="min-width:0px"
->
-  <button
-    class="suggestion"
-    type="button"
-  >
-    <span
-      aria-label="fa-ticket"
-      class="fa fa-ticket icon"
-    />
-    Suggestion 1
-  </button>
-</li>
-`;
-
-exports[`Suggestion should render if given query is not a valid regular expression 1`] = `
-<li
-  class="suggestionItem"
-  style="min-width:0px"
->
-  <button
-    class="suggestion"
-    type="button"
-  >
-    <span
-      aria-label="fa-ticket"
-      class="fa fa-ticket icon"
-    />
-    <span>
-      Suggestion 2
-    </span>
-  </button>
-</li>
-`;
-
-exports[`Suggestion should render strong-tags around found chars 1`] = `
-<li
-  class="suggestionItem"
-  style="min-width:0px"
->
-  <button
-    class="suggestion"
-    type="button"
-  >
-    <span
-      aria-label="fa-ticket"
-      class="fa fa-ticket icon"
-    />
-    <span>
-      <strong>
-        Sug
-      </strong>
-      gestion 2
-    </span>
-  </button>
-</li>
+    </button>
+  </li>
+</div>
 `;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Related issues/PRs | build upon #6711
| License | MIT

#### What's in this PR?

This PR adjusts the test cases of the `AutoCompletePopover` component to use the `@testing-library/react` package instead of `enzyme`.

#### Why?

Because `enzyme` will not be compatible with `react@18` (see #6711).
