### PR TITLE
Add better error handling to the block property for non array values

### DIFF
--- a/src/Sulu/Component/Content/Compat/Block/BlockProperty.php
+++ b/src/Sulu/Component/Content/Compat/Block/BlockProperty.php
@@ -73,6 +73,8 @@ class BlockProperty extends Property implements BlockPropertyInterface
      * that the "real" property is updated.
      *
      * TODO: This is very tedious code. It is important to factor this out.
+     *
+     * @param array|PropertyValue|null $value
      */
     public function doSetValue($value)
     {
@@ -83,6 +85,17 @@ class BlockProperty extends Property implements BlockPropertyInterface
 
         if (null == $items) {
             return;
+        }
+
+        if (!is_array($items)) {
+            if (is_object($items)) {
+                $itemsString = 'object of class ' . get_class($items);
+            } else {
+                $itemsString = sprintf('"%s"', var_export($items, true));
+            }
+            throw new \InvalidArgumentException(
+                sprintf('Expected block configuration but got %s at property: %s', $itemsString, $this->getName())
+            );
         }
 
         // check value for single value

--- a/src/Sulu/Component/Content/Compat/Block/BlockProperty.php
+++ b/src/Sulu/Component/Content/Compat/Block/BlockProperty.php
@@ -87,14 +87,9 @@ class BlockProperty extends Property implements BlockPropertyInterface
             return;
         }
 
-        if (!is_array($items)) {
-            if (is_object($items)) {
-                $itemsString = 'object of class ' . get_class($items);
-            } else {
-                $itemsString = sprintf('"%s"', var_export($items, true));
-            }
+        if (!\is_array($items)) {
             throw new \InvalidArgumentException(
-                sprintf('Expected block configuration but got %s at property: %s', $itemsString, $this->getName())
+                \sprintf('Expected block configuration but got "%s" at property: "%s"', \get_debug_type($items), $this->getName())
             );
         }
 

--- a/src/Sulu/Component/Content/Tests/Unit/Block/BlockPropertyTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Block/BlockPropertyTest.php
@@ -11,12 +11,14 @@
 
 namespace Sulu\Component\Content\Tests\Unit\Block;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Component\Content\Compat\Block\BlockProperty;
 use Sulu\Component\Content\Compat\Block\BlockPropertyType;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Document\Structure\PropertyValue;
+use Sulu\Component\Webspace\Webspace;
 
 class BlockPropertyTest extends TestCase
 {
@@ -67,4 +69,25 @@ class BlockPropertyTest extends TestCase
 
         $this->assertEquals($result, $blockProperty->getIsMultiple());
     }
+
+    /**
+     * @dataProvider provideSetInvalidValue
+     */
+    public function testSetInvalidValue($value, string $message): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($message);
+
+        $blockProperty = new BlockProperty('block', [], 'test');
+        $blockProperty->doSetValue($value);
+    }
+
+    public function provideSetInvalidValue(): array {
+        return [
+            'invalid int' => [10, 'Expected block configuration but got "10" at property: block'],
+            'invalid object' => [new Webspace(), 'Expected block configuration but got object of class Sulu\Component\Webspace\Webspace at property: block']
+        ];
+    }
+
+
 }

--- a/src/Sulu/Component/Content/Tests/Unit/Block/BlockPropertyTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Block/BlockPropertyTest.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Component\Content\Tests\Unit\Block;
 
-use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Component\Content\Compat\Block\BlockProperty;
@@ -75,19 +74,18 @@ class BlockPropertyTest extends TestCase
      */
     public function testSetInvalidValue($value, string $message): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage($message);
 
         $blockProperty = new BlockProperty('block', [], 'test');
         $blockProperty->doSetValue($value);
     }
 
-    public function provideSetInvalidValue(): array {
+    public function provideSetInvalidValue(): array
+    {
         return [
-            'invalid int' => [10, 'Expected block configuration but got "10" at property: block'],
-            'invalid object' => [new Webspace(), 'Expected block configuration but got object of class Sulu\Component\Webspace\Webspace at property: block']
+            'invalid int' => [10, 'Expected block configuration but got "int" at property: "block"'],
+            'invalid object' => [new Webspace(), 'Expected block configuration but got "Sulu\Component\Webspace\Webspace" at property: "block"'],
         ];
     }
-
-
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#729

#### What's in this PR?

It contains a better error message for handling setting the value for `BlockProperty`s. This also adds type hints to the function.

#### Why?

Let's say you have a document where the property abc contains a block with a custom type `button`. If you want to bind data to the page your array with the fixture data would look something like this.
```php
$document->bind([
   'abc' => ['type' => 'button', 'value' => 10], 
   // ...more properties
]);
```

But if you put a non-array value in there like this:
```php
$document->bind([
   'abc' => 10
   // ...more properties
]);
```
the following error message will occur:
```text
First argument to the array_keys function must be an array int given.
```
Which at first glance tells you nothing, just by inspecting the stack trace of the error you see that it is inside the block property's `doSetValue` Function trying to set a value.

The new error message reads something like this:
```text
Expected array containing a block configuration but got "10" at property: abc
```

#### To Do

- [x] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md
