### PR TITLE
Using LCID syntax for setting request locale

### DIFF
--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Component\Webspace\Analyzer\Attributes;
 
+use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\PortalInformation;
 use Symfony\Component\HttpFoundation\Request;
@@ -52,7 +53,7 @@ class PortalInformationRequestProcessor implements RequestProcessorInterface
         if ($attributes['localization']) {
             $localization = $attributes['localization'];
             $attributes['locale'] = $localization->getLocale();
-            $request->setLocale($localization->getLocale());
+            $request->setLocale($localization->getLocale(Localization::LCID));
         }
 
         list($resourceLocator, $format) = $this->getResourceLocatorFromRequest(

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
@@ -74,7 +74,7 @@ class PortalInformationRequestProcessorTest extends TestCase
             new RequestAttributes(['portalInformation' => $portalInformation, 'path' => $config['path_info']])
         );
 
-        $this->assertEquals($localization->getLocale(), $request->getLocale());
+        $this->assertEquals($localization->getLocale(Localization::LCID), $request->getLocale());
 
         $this->assertEquals('de_at', $attributes->getAttribute('localization'));
         $this->assertEquals('sulu', $attributes->getAttribute('webspace')->getKey());
@@ -129,7 +129,7 @@ class PortalInformationRequestProcessorTest extends TestCase
             new RequestAttributes(['portalInformation' => $portalInformation, 'path' => $config['path_info']])
         );
 
-        $this->assertEquals('it_ch', $request->getLocale());
+        $this->assertEquals('it_CH', $request->getLocale());
 
         $this->assertEquals('it_ch', $attributes->getAttribute('localization'));
         $this->assertEquals('sulu', $attributes->getAttribute('webspace')->getKey());
@@ -181,7 +181,7 @@ class PortalInformationRequestProcessorTest extends TestCase
             new RequestAttributes(['portalInformation' => $portalInformation, 'path' => $config['path_info']])
         );
 
-        $this->assertEquals($localization->getLocale(), $request->getLocale());
+        $this->assertEquals($localization->getLocale(Localization::LCID), $request->getLocale());
         if ($expected['format']) {
             $this->assertEquals($expected['format'], $request->getRequestFormat());
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes?
| New feature? | no
| BC breaks? | yes?
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

In Symfony the standard for locales is the LCID format aka `en_US` or `it_IT`. This is now also the format that Sulu sets the request locale to.

#### Why?

If you want to render another controller inside of twig you can do this like so:
```twig
render(controller('controller_service_name'));
```
This then also starts the request analyser that processes the request. If you then proceed to check the locale after rendering said controller it will not be the same as going in. Something like `de_DE` will turn into `de_de`. This should be acceptable as well. But if you try to render translations with this non-standard locale Symfony might not find it and fall back to the application's default locale being `en_US` in most cases.

#### Example Usage

This processor isn't really used anywhere. If you want to recreate the problems just create a Webspace with a non English default locale render a controller inside twig and see the locale change.

#### To Do

- [x] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md

I don't know if this a breaking change since people might rely that the format is that way now.
