### PR TITLE
Migrate enzyme GhostIndicator tests to React Testing Library

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/tests/GhostIndicator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/tests/GhostIndicator.test.js
@@ -1,12 +1,14 @@
 // @flow
 import React from 'react';
-import {render} from 'enzyme';
+import {render} from '@testing-library/react';
 import GhostIndicator from '../GhostIndicator';
 
 test('Should render with given locale', () => {
-    expect(render(<GhostIndicator locale="de-at" />)).toMatchSnapshot();
+    const {container} = render(<GhostIndicator locale="de-at" />);
+    expect(container).toMatchSnapshot();
 });
 
 test('Should render with given locale and className', () => {
-    expect(render(<GhostIndicator className="test" locale="de-at" />)).toMatchSnapshot();
+    const {container} = render(<GhostIndicator className="test" locale="de-at" />);
+    expect(container).toMatchSnapshot();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/tests/__snapshots__/GhostIndicator.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/tests/__snapshots__/GhostIndicator.test.js.snap
@@ -1,17 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Should render with given locale 1`] = `
-<span
-  class="ghostIndicator"
->
-  de-at
-</span>
+<div>
+  <span
+    class="ghostIndicator"
+  >
+    de-at
+  </span>
+</div>
 `;
 
 exports[`Should render with given locale and className 1`] = `
-<span
-  class="ghostIndicator test"
->
-  de-at
-</span>
+<div>
+  <span
+    class="ghostIndicator test"
+  >
+    de-at
+  </span>
+</div>
 `;


### PR DESCRIPTION
#### What's in this PR?

GhostIndicator component unit test migrations enzyme --> RTL