### PR TITLE
Fix uncatched errors when external code writes invalid JSON strings to localStorage

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/clipboard/tests/clipboard.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/clipboard/tests/clipboard.test.js
@@ -69,3 +69,23 @@ test('Observer should be called when observed key is changed n another tab', () 
     window.dispatchEvent(new StorageEvent('storage', {key: 'test-key', newValue: JSON.stringify({key1: 'value4'})}));
     expect(observerSpy).toBeCalledTimes(2);
 });
+
+test('Should not crash if external code writes invalid JSON string to localStorage', () => {
+    window.localStorage.setItem('test-key', 'invalid-json-string-1');
+
+    const observerSpy = jest.fn();
+    clipboard.observe('test-key', observerSpy, true);
+
+    expect(observerSpy).toBeCalledTimes(1);
+    expect(observerSpy).toHaveBeenLastCalledWith(undefined);
+
+    window.dispatchEvent(new StorageEvent('storage', {key: 'test-key', newValue: 'invalid-json-string-2'}));
+
+    expect(observerSpy).toBeCalledTimes(2);
+    expect(observerSpy).toHaveBeenLastCalledWith(undefined);
+
+    window.dispatchEvent(new StorageEvent('storage', {key: 'test-key', newValue: '"valid-json-string"'}));
+
+    expect(observerSpy).toBeCalledTimes(3);
+    expect(observerSpy).toHaveBeenLastCalledWith('valid-json-string');
+});


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #6724
| License | MIT

#### What's in this PR?

This PR adjusts the `clipboard` util to not throw uncatched errors if external code write invalid JSON strings into the localStorage of the browser. I implements to changes to prevent problems in the future:

1. Try to parse the value of `storage` events only if there is an active listener for the key of the event
2. Fallback to `undefined` if the value of the event (or the the value that is present in the localStorage) is not a valid JSON string

#### Why?

At the moment, writing invalid JSON strings into the localStorage will lead to an error in the `cllipboard` util. See write invalid JSON strings into the localStorage
