### PR TITLE
Register list builder services in website context

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -317,8 +317,7 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
             $this->initFields($config['fields_defaults'], $container);
         }
 
-        $this->initListBuilder($container, $loader);
-
+        $loader->load('list_builder.xml');
         $loader->load('expression_language.xml');
         $loader->load('phpcr.xml');
         $loader->load('rest.xml');
@@ -407,15 +406,5 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
         $container->setParameter('sulu_core.cache.memoize.default_lifetime', $cache['memoize']['default_lifetime']);
 
         $loader->load('cache.xml');
-    }
-
-    /**
-     * Initializes list builder.
-     */
-    private function initListBuilder(ContainerBuilder $container, XmlFileLoader $loader)
-    {
-        if (SuluKernel::CONTEXT_ADMIN === $container->getParameter('sulu.context')) {
-            $loader->load('list_builder.xml');
-        }
     }
 }

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -317,7 +317,8 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
             $this->initFields($config['fields_defaults'], $container);
         }
 
-        $loader->load('list_builder.xml');
+        $this->initListBuilder($container, $loader);
+
         $loader->load('expression_language.xml');
         $loader->load('phpcr.xml');
         $loader->load('rest.xml');
@@ -406,5 +407,16 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
         $container->setParameter('sulu_core.cache.memoize.default_lifetime', $cache['memoize']['default_lifetime']);
 
         $loader->load('cache.xml');
+    }
+
+    /**
+     * Initializes list builder.
+     */
+    private function initListBuilder(ContainerBuilder $container, XmlFileLoader $loader)
+    {
+        $bundles = $container->getParameter('kernel.bundles');
+        if (\array_key_exists('SuluAdminBundle', $bundles)) {
+            $loader->load('list_builder.xml');
+        }
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes https://github.com/sulu/sulu/issues/4946
| Related issues/PRs | https://github.com/sulu/sulu/pull/5942
| License | MIT

#### What's in this PR?

This pull request adjusts the `SuluCoreExtension` to register our list builder services in the website context too.

#### Why?

Because it makes things cumbersome if these services are not available in the website context (you need to register dependant services only in the admin context too). Also, we already closed an issue about this (https://github.com/sulu/sulu/issues/4946) after merging https://github.com/sulu/sulu/pull/5942.
