### PR TITLE
Migrate enzyme PermissionHint tests to React Testing Library

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PermissionHint/tests/PermissionHint.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PermissionHint/tests/PermissionHint.test.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {render} from 'enzyme';
+import {render} from '@testing-library/react';
 import PermissionHint from '../PermissionHint';
 
 jest.mock('../../../utils/Translator', () => ({
@@ -8,5 +8,6 @@ jest.mock('../../../utils/Translator', () => ({
 }));
 
 test('Render PermissionHint', () => {
-    expect(render(<PermissionHint />)).toMatchSnapshot();
+    const {container} = render(<PermissionHint />);
+    expect(container).toMatchSnapshot();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PermissionHint/tests/__snapshots__/PermissionHint.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PermissionHint/tests/__snapshots__/PermissionHint.test.js.snap
@@ -1,17 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Render PermissionHint 1`] = `
-<div
-  class="permissionHint"
->
+<div>
   <div
-    class="permissionIcon"
+    class="permissionHint"
   >
-    <span
-      aria-label="su-lock"
-      class="su-lock"
-    />
+    <div
+      class="permissionIcon"
+    >
+      <span
+        aria-label="su-lock"
+        class="su-lock"
+      />
+    </div>
+    sulu_admin.no_permissions
   </div>
-  sulu_admin.no_permissions
 </div>
 `;


### PR DESCRIPTION
#### What's in this PR?

PermissionHint component unit test migration enzyme --> RTL