### PR TITLE
Fixed missing translations in admin search box dropdown for Sulu 2.4

### DIFF
--- a/src/Sulu/Bundle/SearchBundle/Search/Configuration/IndexConfigurationProvider.php
+++ b/src/Sulu/Bundle/SearchBundle/Search/Configuration/IndexConfigurationProvider.php
@@ -19,22 +19,24 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class IndexConfigurationProvider implements IndexConfigurationProviderInterface
 {
     /**
-     * @var string
+     * @var array|null
      */
-    private $indexConfigurations = [];
+    private $indexConfigurations = null;
 
-    public function __construct(TranslatorInterface $translator, array $indexConfigurations)
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var array
+     */
+    private $searchIndexes;
+
+    public function __construct(TranslatorInterface $translator, array $searchIndexes)
     {
-        foreach ($indexConfigurations as $indexName => $indexConfiguration) {
-            $this->indexConfigurations[$indexName] = new IndexConfiguration(
-                $indexName,
-                $indexConfiguration['icon'],
-                $translator->trans($indexConfiguration['name'], [], 'admin'),
-                new Route($indexConfiguration['view']['name'], $indexConfiguration['view']['result_to_view']),
-                isset($indexConfiguration['security_context']) ? $indexConfiguration['security_context'] : null,
-                isset($indexConfiguration['contexts']) ? $indexConfiguration['contexts'] : []
-            );
-        }
+        $this->translator = $translator;
+        $this->searchIndexes = $searchIndexes;
     }
 
     /**
@@ -44,6 +46,19 @@ class IndexConfigurationProvider implements IndexConfigurationProviderInterface
      */
     public function getIndexConfigurations()
     {
+        if (null === $this->indexConfigurations) {
+            foreach ($this->searchIndexes as $indexName => $indexConfiguration) {
+                $this->indexConfigurations[$indexName] = new IndexConfiguration(
+                    $indexName,
+                    $indexConfiguration['icon'],
+                    $this->translator->trans($indexConfiguration['name'], [], 'admin'),
+                    new Route($indexConfiguration['view']['name'], $indexConfiguration['view']['result_to_view']),
+                    isset($indexConfiguration['security_context']) ? $indexConfiguration['security_context'] : null,
+                    isset($indexConfiguration['contexts']) ? $indexConfiguration['contexts'] : []
+                );
+            }
+        }
+
         return $this->indexConfigurations;
     }
 
@@ -56,6 +71,8 @@ class IndexConfigurationProvider implements IndexConfigurationProviderInterface
      */
     public function getIndexConfiguration($name)
     {
+        $this->indexConfigurations = $this->getIndexConfigurations();
+
         if (!\array_key_exists($name, $this->indexConfigurations)) {
             return;
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #6763
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Transferring index configuration processing logic from the constructor to the getIndexConfiguration() method due to false locale.

#### Why?

Text translations in the admin search box dropdown are not working properly.
