### PR TITLE
Fix code style after php-cs-fixer update

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php
@@ -194,7 +194,7 @@ class UpdateBuildCommand extends Command
                                 \sprintf('Merge "%s" together like above?', $file),
                                 'y'
                             )
-                            )
+                        )
                         ) {
                             $ui->writeln(\sprintf('Write new "%s" version.', $file));
                             $this->writeFile($filePath, $mergedJson . "\n");

--- a/src/Sulu/Bundle/TagBundle/Tests/Unit/Tag/TagManagerTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Unit/Tag/TagManagerTest.php
@@ -118,7 +118,7 @@ class TagManagerTest extends TestCase
                 ['Tag2', (new Tag())->setId(2)],
                 ['Tag3', (new Tag())->setId(3)],
             ]
-            )
+        )
         );
 
         $this->tagRepository->expects($this->any())->method('findTagById')->will($this->returnValueMap(
@@ -127,7 +127,7 @@ class TagManagerTest extends TestCase
                 [2, (new Tag())->setName('Tag2')],
                 [3, (new Tag())->setName('Tag3')],
             ]
-            )
+        )
         );
 
         $this->tagManager = new TagManager(

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -855,7 +855,7 @@ class ContentMapper implements ContentMapperInterface
                 $templateKey,
                 $webspaceKey,
                 $locale
-                ))
+            ))
             ) {
                 $target[$field['name']] = $data;
             }

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/PhpWebspaceCollectionDumperTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/PhpWebspaceCollectionDumperTest.php
@@ -2,12 +2,21 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Sulu\Component\Webspace\Tests\Unit\Manager;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Component\Webspace\Manager\Dumper\PhpWebspaceCollectionDumper;
 use Sulu\Component\Webspace\Manager\WebspaceCollection;
-use Prophecy\Prophecy\ObjectProphecy;
 
 class PhpWebspaceCollectionDumperTest extends TestCase
 {
@@ -29,7 +38,7 @@ class PhpWebspaceCollectionDumperTest extends TestCase
 
     public function testGenerate(): void
     {
-        $this->webspaceCollection ->toArray() ->shouldBeCalled() ->willReturn([]);
+        $this->webspaceCollection->toArray()->shouldBeCalled()->willReturn([]);
 
         $string = $this->webspaceDumper->dump(['cache_class' => 'CacheClass', 'base_class' => 'BaseClass']);
 
@@ -82,7 +91,7 @@ class CacheClass extends BaseClass
                ->toArray()
                ->shouldBeCalled()
                ->willReturn(['webspaces' => [['key' => 'some_webspace', 'name' => 'Somewebspace']]])
-           ;
+        ;
         $string = $this->webspaceDumper->dump(['cache_class' => 'CacheClass', 'base_class' => 'BaseClass']);
 
         $expected = '<?php
@@ -151,7 +160,7 @@ class CacheClass extends BaseClass
                ->toArray()
                ->shouldBeCalled()
                ->willReturn(['webspaces' => [['key' => 'some_webspace', 'name' => 'Joe\'s webspace']]])
-           ;
+        ;
         $string = $this->webspaceDumper->dump(['cache_class' => 'CacheClass', 'base_class' => 'BaseClass']);
 
         $expected = '<?php


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix code style of PhpWebspaceCollectionDumperTest.

#### Why?

Makes currently the CI failing.
