### PR TITLE
Add option to toggle the snippet admin to a list per snippet type

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
@@ -110,6 +110,8 @@ class StructureFormMetadataLoader implements FormMetadataLoaderInterface, CacheW
             foreach ($webspace->getExcludedTemplates() as $excludedTemplate) {
                 $form->removeForm($excludedTemplate);
             }
+        } elseif (isset($metadataOptions['defaultType'])) {
+            $form->setDefaultType($metadataOptions['defaultType']);
         } elseif (isset($this->defaultTypes[$key])) {
             $form->setDefaultType($this->defaultTypes[$key]);
         }

--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -131,7 +131,7 @@ class SnippetAdmin extends Admin
         $parentSnippet = $snippet;
         foreach ($this->getTypes() as $typeConfig) {
             $snippet = new NavigationItem($typeConfig['title']);
-            $snippet->setView(static::LIST_VIEW.'_'.$typeConfig['type']);
+            $snippet->setView(static::LIST_VIEW . '_' . $typeConfig['type']);
             $parentSnippet->addChild($snippet);
         }
     }
@@ -190,11 +190,7 @@ class SnippetAdmin extends Admin
 
         $viewCollection->add(
             $this->viewBuilderFactory
-                ->createViewBuilder(
-                    'sulu_snippet.snippet_areas',
-                    '/snippet-areas',
-                    'sulu_snippet.snippet_areas'
-                )
+                ->createViewBuilder('sulu_snippet.snippet_areas', '/snippet-areas', 'sulu_snippet.snippet_areas')
                 ->setOption('snippetEditView', static::EDIT_FORM_VIEW)
                 ->setOption('tabTitle', 'sulu_snippet.default_snippets')
                 ->setOption('tabOrder', 3072)
@@ -278,8 +274,8 @@ class SnippetAdmin extends Admin
             if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
                 $viewCollection->add(
                     $this->viewBuilderFactory->createListViewBuilder(
-                        static::LIST_VIEW.'_'.$typeKey,
-                        '/:locale/'.$typeKey
+                        static::LIST_VIEW . '_' . $typeKey,
+                        '/:locale/' . $typeKey
                     )
                         ->setResourceKey(SnippetDocument::RESOURCE_KEY)
                         ->setListKey(SnippetDocument::LIST_KEY)
@@ -288,46 +284,46 @@ class SnippetAdmin extends Admin
                         ->addLocales($snippetLocales)
                         ->addRequestParameters(['types' => $typeKey])
                         ->setDefaultLocale($snippetLocales[0])
-                        ->setAddView(static::ADD_FORM_VIEW.'_'.$typeKey)
-                        ->setEditView(static::EDIT_FORM_VIEW.'_'.$typeKey)
+                        ->setAddView(static::ADD_FORM_VIEW . '_' . $typeKey)
+                        ->setEditView(static::EDIT_FORM_VIEW . '_' . $typeKey)
                         ->addToolbarActions($listToolbarActions)
                 );
                 $viewCollection->add(
                     $this->viewBuilderFactory->createResourceTabViewBuilder(
-                        static::ADD_FORM_VIEW.'_'.$typeKey,
-                        '/snippets/:locale/'.$typeKey.'/add'
+                        static::ADD_FORM_VIEW . '_' . $typeKey,
+                        '/snippets/:locale/' . $typeKey . '/add'
                     )
                         ->setResourceKey(SnippetDocument::RESOURCE_KEY)
                         ->addLocales($snippetLocales)
-                        ->setBackView(static::LIST_VIEW.'_'.$typeKey)
+                        ->setBackView(static::LIST_VIEW . '_' . $typeKey)
                 );
                 $viewCollection->add(
                     $this->viewBuilderFactory->createFormViewBuilder(
-                        static::ADD_FORM_VIEW_DETAILS.'_'.$typeKey,
+                        static::ADD_FORM_VIEW_DETAILS . '_' . $typeKey,
                         '/details'
                     )
                         ->setResourceKey(SnippetDocument::RESOURCE_KEY)
                         ->addMetadataRequestParameters(['defaultType' => $typeKey])
                         ->setFormKey('snippet')
                         ->setTabTitle('sulu_admin.details')
-                        ->setEditView(static::EDIT_FORM_VIEW.'_'.$typeKey)
+                        ->setEditView(static::EDIT_FORM_VIEW . '_' . $typeKey)
                         ->addToolbarActions($formToolbarActionsWithType)
-                        ->setParent(static::ADD_FORM_VIEW.'_'.$typeKey)
+                        ->setParent(static::ADD_FORM_VIEW . '_' . $typeKey)
                 );
                 $viewCollection->add(
                     $this->viewBuilderFactory
                         ->createResourceTabViewBuilder(
-                            static::EDIT_FORM_VIEW.'_'.$typeKey,
-                            '/snippets/:locale/'.$typeKey.'/:id'
+                            static::EDIT_FORM_VIEW . '_' . $typeKey,
+                            '/snippets/:locale/' . $typeKey . '/:id'
                         )
                         ->setResourceKey(SnippetDocument::RESOURCE_KEY)
                         ->addLocales($snippetLocales)
-                        ->setBackView(static::LIST_VIEW.'_'.$typeKey)
+                        ->setBackView(static::LIST_VIEW . '_' . $typeKey)
                         ->setTitleProperty('title')
                 );
                 $viewCollection->add(
                     $this->viewBuilderFactory->createFormViewBuilder(
-                        static::EDIT_FORM_VIEW_DETAILS.'_'.$typeKey,
+                        static::EDIT_FORM_VIEW_DETAILS . '_' . $typeKey,
                         '/details'
                     )
                         ->setResourceKey(SnippetDocument::RESOURCE_KEY)
@@ -335,17 +331,17 @@ class SnippetAdmin extends Admin
                         ->setFormKey('snippet')
                         ->setTabTitle('sulu_admin.details')
                         ->addToolbarActions($formToolbarActionsWithType)
-                        ->setParent(static::EDIT_FORM_VIEW.'_'.$typeKey)
+                        ->setParent(static::EDIT_FORM_VIEW . '_' . $typeKey)
                 );
                 $viewCollection->add(
                     $this->viewBuilderFactory
-                        ->createFormViewBuilder(self::EDIT_FORM_VIEW_TAXONOMIES.'_'.$typeKey, '/taxonomies')
+                        ->createFormViewBuilder(self::EDIT_FORM_VIEW_TAXONOMIES . '_' . $typeKey, '/taxonomies')
                         ->setResourceKey(SnippetDocument::RESOURCE_KEY)
                         ->setFormKey('snippet_taxonomies')
                         ->setTabTitle('sulu_snippet.taxonomies')
                         ->addToolbarActions($formToolbarActionsWithoutType)
                         ->setTitleVisible(true)
-                        ->setParent(static::EDIT_FORM_VIEW.'_'.$typeKey)
+                        ->setParent(static::EDIT_FORM_VIEW . '_' . $typeKey)
                 );
             }
         }

--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -17,25 +17,33 @@ use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
 use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
 use Sulu\Bundle\PageBundle\Admin\PageAdmin;
 use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
+use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Webspace;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
  * Admin for snippet.
  */
 class SnippetAdmin extends Admin
 {
+    public const VIEW_SINGLE_LIST = 'single_list';
+    public const VIEW_TYPES_LIST = 'types_list';
+
     public const SECURITY_CONTEXT = 'sulu.global.snippets';
 
     public const LIST_VIEW = 'sulu_snippet.list';
 
     public const ADD_FORM_VIEW = 'sulu_snippet.add_form';
-
+    public const ADD_FORM_VIEW_DETAILS = 'sulu_snippet.add_form.details';
     public const EDIT_FORM_VIEW = 'sulu_snippet.edit_form';
+    public const EDIT_FORM_VIEW_DETAILS = 'sulu_snippet.edit_form.details';
+    public const EDIT_FORM_VIEW_TAXONOMIES = 'sulu_snippet.edit_form.taxonomies';
 
     /**
      * @var ViewBuilderFactoryInterface
@@ -58,6 +66,21 @@ class SnippetAdmin extends Admin
     private $defaultEnabled;
 
     /**
+     * @var string
+     */
+    private $adminView;
+
+    /**
+     * @var MetadataProviderInterface
+     */
+    private $formMetadataProvider;
+
+    /**
+     * @var TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    /**
      * Returns security context for default-snippets in given webspace.
      *
      * @param string $webspaceKey
@@ -73,28 +96,52 @@ class SnippetAdmin extends Admin
         ViewBuilderFactoryInterface $viewBuilderFactory,
         SecurityCheckerInterface $securityChecker,
         WebspaceManagerInterface $webspaceManager,
-        $defaultEnabled
+        $defaultEnabled,
+        $adminView,
+        MetadataProviderInterface $formMetadataProvider = null,
+        TokenStorageInterface $tokenStorage = null
     ) {
         $this->viewBuilderFactory = $viewBuilderFactory;
         $this->securityChecker = $securityChecker;
         $this->webspaceManager = $webspaceManager;
         $this->defaultEnabled = $defaultEnabled;
+        $this->adminView = $adminView;
+        $this->formMetadataProvider = $formMetadataProvider;
+        $this->tokenStorage = $tokenStorage;
     }
 
     public function configureNavigationItems(NavigationItemCollection $navigationItemCollection): void
     {
-        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
-            $snippet = new NavigationItem('sulu_snippet.snippets');
-            $snippet->setPosition(20);
-            $snippet->setIcon('su-snippet');
-            $snippet->setView(static::LIST_VIEW);
+        if (!$this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
+            return;
+        }
 
-            $navigationItemCollection->add($snippet);
+        $snippet = new NavigationItem('sulu_snippet.snippets');
+        $snippet->setPosition(20);
+        $snippet->setIcon('su-snippet');
+        if ($this->adminView === static::VIEW_SINGLE_LIST) {
+            $snippet->setView(static::LIST_VIEW);
+        }
+        $navigationItemCollection->add($snippet);
+
+        if ($this->adminView !== static::VIEW_TYPES_LIST) {
+            return;
+        }
+
+        $parentSnippet = $snippet;
+        foreach ($this->getTypes() as $typeConfig) {
+            $snippet = new NavigationItem($typeConfig['title']);
+            $snippet->setView(static::LIST_VIEW.'_'.$typeConfig['type']);
+            $parentSnippet->addChild($snippet);
         }
     }
 
     public function configureViews(ViewCollection $viewCollection): void
     {
+        if (!$this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
+            return;
+        }
+
         $snippetLocales = $this->webspaceManager->getAllLocales();
 
         $formToolbarActionsWithType = [];
@@ -120,69 +167,187 @@ class SnippetAdmin extends Admin
             $listToolbarActions[] = new ToolbarAction('sulu_admin.export');
         }
 
-        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
-            $viewCollection->add(
-                $this->viewBuilderFactory->createListViewBuilder(static::LIST_VIEW, '/snippets/:locale')
-                    ->setResourceKey(SnippetDocument::RESOURCE_KEY)
-                    ->setListKey(SnippetDocument::LIST_KEY)
-                    ->setTitle('sulu_snippet.snippets')
-                    ->addListAdapters(['table'])
-                    ->addLocales($snippetLocales)
-                    ->setAddView(static::ADD_FORM_VIEW)
-                    ->setEditView(static::EDIT_FORM_VIEW)
-                    ->addToolbarActions($listToolbarActions)
-            );
-            $viewCollection->add(
-                $this->viewBuilderFactory
-                    ->createResourceTabViewBuilder(static::ADD_FORM_VIEW, '/snippets/:locale/add')
-                    ->setResourceKey(SnippetDocument::RESOURCE_KEY)
-                    ->addLocales($snippetLocales)
-                    ->setBackView(static::LIST_VIEW)
-            );
-            $viewCollection->add(
-                $this->viewBuilderFactory->createFormViewBuilder('sulu_snippet.add_form.details', '/details')
-                    ->setResourceKey(SnippetDocument::RESOURCE_KEY)
-                    ->setFormKey('snippet')
-                    ->setTabTitle('sulu_admin.details')
-                    ->setEditView(static::EDIT_FORM_VIEW)
-                    ->addToolbarActions($formToolbarActionsWithType)
-                    ->setParent(static::ADD_FORM_VIEW)
-            );
-            $viewCollection->add(
-                $this->viewBuilderFactory
-                    ->createResourceTabViewBuilder(static::EDIT_FORM_VIEW, '/snippets/:locale/:id')
-                    ->setResourceKey(SnippetDocument::RESOURCE_KEY)
-                    ->addLocales($snippetLocales)
-                    ->setBackView(static::LIST_VIEW)
-                    ->setTitleProperty('title')
-            );
-            $viewCollection->add(
-                $this->viewBuilderFactory->createFormViewBuilder('sulu_snippet.edit_form.details', '/details')
-                    ->setResourceKey(SnippetDocument::RESOURCE_KEY)
-                    ->setFormKey('snippet')
-                    ->setTabTitle('sulu_admin.details')
-                    ->addToolbarActions($formToolbarActionsWithType)
-                    ->setParent(static::EDIT_FORM_VIEW)
-            );
-            $viewCollection->add(
-                $this->viewBuilderFactory
-                    ->createFormViewBuilder('sulu_snippet.edit_form.taxonomies', '/taxonomies')
-                    ->setResourceKey(SnippetDocument::RESOURCE_KEY)
-                    ->setFormKey('snippet_taxonomies')
-                    ->setTabTitle('sulu_snippet.taxonomies')
-                    ->addToolbarActions($formToolbarActionsWithoutType)
-                    ->setTitleVisible(true)
-                    ->setParent(static::EDIT_FORM_VIEW)
-            );
-            $viewCollection->add(
-                $this->viewBuilderFactory
-                    ->createViewBuilder('sulu_snippet.snippet_areas', '/snippet-areas', 'sulu_snippet.snippet_areas')
-                    ->setOption('snippetEditView', static::EDIT_FORM_VIEW)
-                    ->setOption('tabTitle', 'sulu_snippet.default_snippets')
-                    ->setOption('tabOrder', 3072)
-                    ->setParent(PageAdmin::WEBSPACE_TABS_VIEW)
-                    ->addRerenderAttribute('webspace')
-            );
+        switch ($this->adminView) {
+            case static::VIEW_TYPES_LIST:
+                $this->addViewsPerType(
+                    $viewCollection,
+                    $snippetLocales,
+                    $formToolbarActionsWithType,
+                    $formToolbarActionsWithoutType,
+                    $listToolbarActions
+                );
+                break;
+            default:
+                $this->addSingleListView(
+                    $viewCollection,
+                    $snippetLocales,
+                    $formToolbarActionsWithType,
+                    $formToolbarActionsWithoutType,
+                    $listToolbarActions
+                );
+                break;
+        }
+
+        $viewCollection->add(
+            $this->viewBuilderFactory
+                ->createViewBuilder(
+                    'sulu_snippet.snippet_areas',
+                    '/snippet-areas',
+                    'sulu_snippet.snippet_areas'
+                )
+                ->setOption('snippetEditView', static::EDIT_FORM_VIEW)
+                ->setOption('tabTitle', 'sulu_snippet.default_snippets')
+                ->setOption('tabOrder', 3072)
+                ->setParent(PageAdmin::WEBSPACE_TABS_VIEW)
+                ->addRerenderAttribute('webspace')
+        );
+    }
+
+    private function addSingleListView(
+        ViewCollection $viewCollection,
+        array $snippetLocales = [],
+        array $formToolbarActionsWithType = [],
+        array $formToolbarActionsWithoutType = [],
+        array $listToolbarActions = []
+    ) {
+        $viewCollection->add(
+            $this->viewBuilderFactory->createListViewBuilder(static::LIST_VIEW, '/snippets/:locale')
+                ->setResourceKey(SnippetDocument::RESOURCE_KEY)
+                ->setListKey(SnippetDocument::LIST_KEY)
+                ->setTitle('sulu_snippet.snippets')
+                ->addListAdapters(['table'])
+                ->addLocales($snippetLocales)
+                ->setAddView(static::ADD_FORM_VIEW)
+                ->setEditView(static::EDIT_FORM_VIEW)
+                ->addToolbarActions($listToolbarActions)
+        );
+        $viewCollection->add(
+            $this->viewBuilderFactory
+                ->createResourceTabViewBuilder(static::ADD_FORM_VIEW, '/snippets/:locale/add')
+                ->setResourceKey(SnippetDocument::RESOURCE_KEY)
+                ->addLocales($snippetLocales)
+                ->setBackView(static::LIST_VIEW)
+        );
+        $viewCollection->add(
+            $this->viewBuilderFactory->createFormViewBuilder('sulu_snippet.add_form.details', '/details')
+                ->setResourceKey(SnippetDocument::RESOURCE_KEY)
+                ->setFormKey('snippet')
+                ->setTabTitle('sulu_admin.details')
+                ->setEditView(static::EDIT_FORM_VIEW)
+                ->addToolbarActions($formToolbarActionsWithType)
+                ->setParent(static::ADD_FORM_VIEW)
+        );
+        $viewCollection->add(
+            $this->viewBuilderFactory
+                ->createResourceTabViewBuilder(static::EDIT_FORM_VIEW, '/snippets/:locale/:id')
+                ->setResourceKey(SnippetDocument::RESOURCE_KEY)
+                ->addLocales($snippetLocales)
+                ->setBackView(static::LIST_VIEW)
+                ->setTitleProperty('title')
+        );
+        $viewCollection->add(
+            $this->viewBuilderFactory->createFormViewBuilder('sulu_snippet.edit_form.details', '/details')
+                ->setResourceKey(SnippetDocument::RESOURCE_KEY)
+                ->setFormKey('snippet')
+                ->setTabTitle('sulu_admin.details')
+                ->addToolbarActions($formToolbarActionsWithType)
+                ->setParent(static::EDIT_FORM_VIEW)
+        );
+        $viewCollection->add(
+            $this->viewBuilderFactory
+                ->createFormViewBuilder('sulu_snippet.edit_form.taxonomies', '/taxonomies')
+                ->setResourceKey(SnippetDocument::RESOURCE_KEY)
+                ->setFormKey('snippet_taxonomies')
+                ->setTabTitle('sulu_snippet.taxonomies')
+                ->addToolbarActions($formToolbarActionsWithoutType)
+                ->setTitleVisible(true)
+                ->setParent(static::EDIT_FORM_VIEW)
+        );
+    }
+
+    private function addViewsPerType(
+        ViewCollection $viewCollection,
+        array $snippetLocales = [],
+        array $formToolbarActionsWithType = [],
+        array $formToolbarActionsWithoutType = [],
+        array $listToolbarActions = []
+    ) {
+        foreach ($this->getTypes() as $typeConfig) {
+            $typeKey = $typeConfig['type'];
+
+            if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
+                $viewCollection->add(
+                    $this->viewBuilderFactory->createListViewBuilder(
+                        static::LIST_VIEW.'_'.$typeKey,
+                        '/:locale/'.$typeKey
+                    )
+                        ->setResourceKey(SnippetDocument::RESOURCE_KEY)
+                        ->setListKey(SnippetDocument::LIST_KEY)
+                        ->setTitle($typeConfig['title'])
+                        ->addListAdapters(['table'])
+                        ->addLocales($snippetLocales)
+                        ->addRequestParameters(['types' => $typeKey])
+                        ->setDefaultLocale($snippetLocales[0])
+                        ->setAddView(static::ADD_FORM_VIEW.'_'.$typeKey)
+                        ->setEditView(static::EDIT_FORM_VIEW.'_'.$typeKey)
+                        ->addToolbarActions($listToolbarActions)
+                );
+                $viewCollection->add(
+                    $this->viewBuilderFactory->createResourceTabViewBuilder(
+                        static::ADD_FORM_VIEW.'_'.$typeKey,
+                        '/snippets/:locale/'.$typeKey.'/add'
+                    )
+                        ->setResourceKey(SnippetDocument::RESOURCE_KEY)
+                        ->addLocales($snippetLocales)
+                        ->setBackView(static::LIST_VIEW.'_'.$typeKey)
+                );
+                $viewCollection->add(
+                    $this->viewBuilderFactory->createFormViewBuilder(
+                        static::ADD_FORM_VIEW_DETAILS.'_'.$typeKey,
+                        '/details'
+                    )
+                        ->setResourceKey(SnippetDocument::RESOURCE_KEY)
+                        ->addMetadataRequestParameters(['defaultType' => $typeKey])
+                        ->setFormKey('snippet')
+                        ->setTabTitle('sulu_admin.details')
+                        ->setEditView(static::EDIT_FORM_VIEW.'_'.$typeKey)
+                        ->addToolbarActions($formToolbarActionsWithType)
+                        ->setParent(static::ADD_FORM_VIEW.'_'.$typeKey)
+                );
+                $viewCollection->add(
+                    $this->viewBuilderFactory
+                        ->createResourceTabViewBuilder(
+                            static::EDIT_FORM_VIEW.'_'.$typeKey,
+                            '/snippets/:locale/'.$typeKey.'/:id'
+                        )
+                        ->setResourceKey(SnippetDocument::RESOURCE_KEY)
+                        ->addLocales($snippetLocales)
+                        ->setBackView(static::LIST_VIEW.'_'.$typeKey)
+                        ->setTitleProperty('title')
+                );
+                $viewCollection->add(
+                    $this->viewBuilderFactory->createFormViewBuilder(
+                        static::EDIT_FORM_VIEW_DETAILS.'_'.$typeKey,
+                        '/details'
+                    )
+                        ->setResourceKey(SnippetDocument::RESOURCE_KEY)
+                        ->addMetadataRequestParameters(['defaultType' => $typeKey])
+                        ->setFormKey('snippet')
+                        ->setTabTitle('sulu_admin.details')
+                        ->addToolbarActions($formToolbarActionsWithType)
+                        ->setParent(static::EDIT_FORM_VIEW.'_'.$typeKey)
+                );
+                $viewCollection->add(
+                    $this->viewBuilderFactory
+                        ->createFormViewBuilder(self::EDIT_FORM_VIEW_TAXONOMIES.'_'.$typeKey, '/taxonomies')
+                        ->setResourceKey(SnippetDocument::RESOURCE_KEY)
+                        ->setFormKey('snippet_taxonomies')
+                        ->setTabTitle('sulu_snippet.taxonomies')
+                        ->addToolbarActions($formToolbarActionsWithoutType)
+                        ->setTitleVisible(true)
+                        ->setParent(static::EDIT_FORM_VIEW.'_'.$typeKey)
+                );
+            }
         }
     }
 
@@ -236,5 +401,29 @@ class SnippetAdmin extends Admin
                 ],
             ],
         ];
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    private function getTypes(): array
+    {
+        $types = [];
+        if ($this->tokenStorage && null !== $this->tokenStorage->getToken() && $this->formMetadataProvider) {
+            $user = $this->tokenStorage->getToken()->getUser();
+
+            if (!$user instanceof UserInterface) {
+                return $types;
+            }
+
+            /** @var TypedFormMetadata $metadata */
+            $metadata = $this->formMetadataProvider->getMetadata('snippet', $user->getLocale(), []);
+
+            foreach ($metadata->getForms() as $form) {
+                $types[] = ['type' => $form->getName(), 'title' => $form->getTitle()];
+            }
+        }
+
+        return $types;
     }
 }

--- a/src/Sulu/Bundle/SnippetBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/SnippetBundle/DependencyInjection/Configuration.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\SnippetBundle\DependencyInjection;
 
+use Sulu\Bundle\SnippetBundle\Admin\SnippetAdmin;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -43,6 +44,13 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                         ->end()
+                    ->end()
+                ->end()
+                ->scalarNode('admin_view')
+                    ->defaultValue(SnippetAdmin::VIEW_SINGLE_LIST)
+                    ->validate()
+                        ->ifNotInArray(['single_list', 'types_list'])
+                        ->thenInvalid('Invalid snippet admin view "%s"')
                     ->end()
                 ->end()
             ->end();

--- a/src/Sulu/Bundle/SnippetBundle/DependencyInjection/SuluSnippetExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/DependencyInjection/SuluSnippetExtension.php
@@ -197,6 +197,10 @@ class SuluSnippetExtension extends Extension implements PrependExtensionInterfac
             'sulu_snippet.twig.snippet.cache_lifetime',
             $config['twig']['snippet']['cache_lifetime']
         );
+        $container->setParameter(
+            'sulu_snippet.admin_view',
+            $config['admin_view']
+        );
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('content.xml');

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/admin.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/admin.xml
@@ -8,6 +8,9 @@
             <argument type="service" id="sulu_security.security_checker"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument>%sulu_snippet.content-type.default_enabled%</argument>
+            <argument>%sulu_snippet.admin_view%</argument>
+            <argument type="service" id="sulu_admin.form_metadata_provider" on-invalid="null"/>
+            <argument type="service" id="security.token_storage" on-invalid="null"/>
 
             <tag name="sulu.admin"/>
             <tag name="sulu.context" context="admin"/>

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
@@ -15,10 +15,17 @@ use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactory;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataProvider;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\SnippetBundle\Admin\SnippetAdmin;
 use Sulu\Bundle\TestBundle\Testing\ReadObjectAttributeTrait;
 use Sulu\Component\Security\Authorization\SecurityChecker;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface;
 
 class SnippetAdminTest extends TestCase
 {
@@ -39,11 +46,24 @@ class SnippetAdminTest extends TestCase
      */
     private $webspaceManager;
 
+    /**
+     * @var MetadataProviderInterface
+     */
+    private $formMetadataProvider;
+
+    /**
+     * @var TokenStorageInterface
+     */
+    private $tokenStorage;
+
     public function setUp(): void
     {
         $this->viewBuilderFactory = new ViewBuilderFactory();
         $this->securityChecker = $this->prophesize(SecurityChecker::class);
         $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $this->formMetadataProvider = $this->prophesize(FormMetadataProvider::class);
+        $this->tokenStorage = $this->prophesize(TokenStorage::class);
+        $this->token = $this->prophesize(TokenInterface::class);
     }
 
     public function provideConfigureViews()
@@ -57,14 +77,16 @@ class SnippetAdminTest extends TestCase
     /**
      * @dataProvider provideConfigureViews
      */
-    public function testConfigureViews($locales)
+    public function testConfigureSingleListViews($locales)
     {
         $snippetAdmin = new SnippetAdmin(
             $this->viewBuilderFactory,
             $this->securityChecker->reveal(),
             $this->webspaceManager->reveal(),
             false,
-            'Test'
+            SnippetAdmin::VIEW_SINGLE_LIST,
+            $this->formMetadataProvider->reveal(),
+            $this->tokenStorage->reveal()
         );
 
         $this->securityChecker->hasPermission('sulu.global.snippets', 'add')->willReturn(true);
@@ -96,7 +118,7 @@ class SnippetAdminTest extends TestCase
             'adapters' => ['table'],
             'addView' => 'sulu_snippet.add_form',
             'editView' => 'sulu_snippet.edit_form',
-            'locales' => \array_keys($locales),
+            'locales' => \array_keys($locales)
         ], $this->readObjectAttribute($listView, 'options'));
         $this->assertEquals(['locale' => \array_keys($locales)[0]], $this->readObjectAttribute($listView, 'attributeDefaults'));
         $this->assertEquals('sulu_snippet.add_form', $addFormView->getName());
@@ -135,6 +157,108 @@ class SnippetAdminTest extends TestCase
                 new Toolbaraction('sulu_admin.type', ['sort_by' => 'title']),
                 new Toolbaraction('sulu_admin.delete'),
             ],
+        ], $this->readObjectAttribute($editDetailView, 'options'));
+    }
+
+    /**
+     * @dataProvider provideConfigureViews
+     */
+    public function testConfigureTypesListViews($locales)
+    {
+        $snippetAdmin = new SnippetAdmin(
+            $this->viewBuilderFactory,
+            $this->securityChecker->reveal(),
+            $this->webspaceManager->reveal(),
+            false,
+            SnippetAdmin::VIEW_TYPES_LIST,
+            $this->formMetadataProvider->reveal(),
+            $this->tokenStorage->reveal()
+        );
+
+        $this->securityChecker->hasPermission('sulu.global.snippets', 'add')->willReturn(true);
+        $this->securityChecker->hasPermission('sulu.global.snippets', 'edit')->willReturn(true);
+        $this->securityChecker->hasPermission('sulu.global.snippets', 'delete')->willReturn(true);
+        $this->securityChecker->hasPermission('sulu.global.snippets', 'view')->willReturn(true);
+
+        $this->webspaceManager->getAllLocales()->willReturn(\array_values($locales));
+
+        $user = new User();
+        $user->setLocale('en');
+        $this->token->getUser()->willReturn($user);
+        $this->tokenStorage->getToken()->willReturn($this->token);
+
+        $type1 = new FormMetadata();
+        $type1->setKey('type1');
+        $type1->setName('type1');
+        $type1->setTitle('Snippet type 1');
+        $formMetadata = new TypedFormMetadata();
+        $formMetadata->addForm('type1', $type1);
+        $this->formMetadataProvider->getMetadata('snippet', 'en', [])->willReturn($formMetadata);
+
+        $viewCollection = new ViewCollection();
+        $snippetAdmin->configureViews($viewCollection);
+
+        $listView = $viewCollection->get('sulu_snippet.list_type1')->getView();
+        $addFormView = $viewCollection->get('sulu_snippet.add_form_type1')->getView();
+        $addDetailView = $viewCollection->get('sulu_snippet.add_form.details_type1')->getView();
+        $editFormView = $viewCollection->get('sulu_snippet.edit_form_type1')->getView();
+        $editDetailView = $viewCollection->get('sulu_snippet.edit_form.details_type1')->getView();
+
+        $this->assertEquals('sulu_snippet.list_type1', $listView->getName());
+        $this->assertEquals([
+            'title' => 'Snippet type 1',
+            'toolbarActions' => [
+                new ToolbarAction('sulu_admin.add'),
+                new ToolbarAction('sulu_admin.delete'),
+                new ToolbarAction('sulu_admin.export'),
+            ],
+            'resourceKey' => 'snippets',
+            'listKey' => 'snippets',
+            'adapters' => ['table'],
+            'addView' => 'sulu_snippet.add_form_type1',
+            'editView' => 'sulu_snippet.edit_form_type1',
+            'locales' => \array_keys($locales),
+            'requestParameters' => ['types' => 'type1']
+        ], $this->readObjectAttribute($listView, 'options'));
+        $this->assertEquals(['locale' => \array_keys($locales)[0]], $this->readObjectAttribute($listView, 'attributeDefaults'));
+        $this->assertEquals('sulu_snippet.add_form_type1', $addFormView->getName());
+        $this->assertEquals([
+            'resourceKey' => 'snippets',
+            'backView' => 'sulu_snippet.list_type1',
+            'locales' => \array_keys($locales),
+        ], $this->readObjectAttribute($addFormView, 'options'));
+        $this->assertEquals('sulu_snippet.add_form_type1', $addDetailView->getParent());
+        $this->assertEquals([
+            'resourceKey' => 'snippets',
+            'tabTitle' => 'sulu_admin.details',
+            'formKey' => 'snippet',
+            'editView' => 'sulu_snippet.edit_form_type1',
+            'toolbarActions' => [
+                new Toolbaraction('sulu_admin.save'),
+                new Toolbaraction('sulu_admin.type', ['sort_by' => 'title']),
+                new Toolbaraction('sulu_admin.delete'),
+            ],
+            'metadataRequestParameters' => ['defaultType' => 'type1'],
+        ], $this->readObjectAttribute($addDetailView, 'options'));
+        $this->assertEquals('sulu_snippet.edit_form_type1', $editFormView->getName());
+        $this->assertEquals([
+            'resourceKey' => 'snippets',
+            'backView' => 'sulu_snippet.list_type1',
+            'locales' => \array_keys($locales),
+            'titleProperty' => 'title',
+        ], $this->readObjectAttribute($editFormView, 'options'));
+        $this->assertEquals('sulu_snippet.edit_form.details_type1', $editDetailView->getName());
+        $this->assertEquals('sulu_snippet.edit_form_type1', $editDetailView->getParent());
+        $this->assertEquals([
+            'resourceKey' => 'snippets',
+            'tabTitle' => 'sulu_admin.details',
+            'formKey' => 'snippet',
+            'toolbarActions' => [
+                new Toolbaraction('sulu_admin.save'),
+                new Toolbaraction('sulu_admin.type', ['sort_by' => 'title']),
+                new Toolbaraction('sulu_admin.delete'),
+            ],
+            'metadataRequestParameters' => ['defaultType' => 'type1'],
         ], $this->readObjectAttribute($editDetailView, 'options'));
     }
 }

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/DependencyInjection/SuluSnippetExtensionTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/DependencyInjection/SuluSnippetExtensionTest.php
@@ -52,6 +52,7 @@ class SuluSnippetExtensionTest extends AbstractExtensionTestCase
         ]);
 
         $this->assertContainerBuilderHasParameter('sulu_snippet.twig.snippet.cache_lifetime', 20);
+        $this->assertContainerBuilderHasParameter('sulu_snippet.admin_view', 'single_list');
         $this->assertContainerBuilderHasService('sulu_snippet.snippet_trash_subscriber');
     }
 }


### PR DESCRIPTION
Added a config toggle to switch between the single snippet list view (current) and a list view per snippet type (with a navigation entry per snippet type in the admin sidebar).

| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | #4278
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

A config toggle to switch between the single snippet list view (current) and a list view per snippet type (with a navigation entry per snippet type in the admin sidebar) has been added to the Sulu snippet configuration.

#### Why?

The single list of snippets becomes a burden when you have a few snippet types with a lot of content, it's easier to manage the snippet types separately. 

#### Example Usage

The default admin view for the snippets is the current single list view. To toggle to the new view (with subnavigation per snippet type) you should have the following in your configuration :

```
sulu_snippet:
    admin_view: types_list
```

To revert back either remove the admin_view or set it's value to `single_list`.

A screenshot of the admin when the new view is active :
![snippets-nav](https://user-images.githubusercontent.com/777114/182899635-8c3d8c04-ae7b-477c-8d38-48fdedb3c36f.png)

#### To Do

- [ ] Create a documentation PR
