### PR TITLE
Use userEvent instead of fireEvent for simulating user interactions in javascript tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -238,7 +238,9 @@
         "babel/semi": "error",
         "jsx-a11y/no-static-element-interactions": "error",
         "react/button-has-type": "error",
-        "testing-library/no-node-access": "off"
+        "testing-library/no-node-access": "off",
+        "testing-library/prefer-explicit-assert": "error",
+        "testing-library/prefer-user-event": "error"
     },
     "reportUnusedDisableDirectives": true
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Backdrop/tests/Backdrop.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Backdrop/tests/Backdrop.test.js
@@ -1,5 +1,6 @@
 // @flow
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import Backdrop from '../Backdrop';
 
@@ -8,12 +9,12 @@ test('The component should render', () => {
     expect(container).toMatchSnapshot();
 });
 
-test('The component should call a function when clicked', () => {
+test('The component should call a function when clicked', async() => {
     const onClickSpy = jest.fn();
     render(<Backdrop onClick={onClickSpy} />);
     const backdrop = screen.queryByTestId('backdrop');
 
     expect(onClickSpy).toHaveBeenCalledTimes(0);
-    fireEvent.click(backdrop);
+    await userEvent.click(backdrop);
     expect(onClickSpy).toHaveBeenCalledTimes(1);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/tests/Block.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/tests/Block.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import Block from '../Block';
 
 jest.mock('../../../utils/Translator', () => ({
@@ -76,37 +77,37 @@ test('Do not show settings icon if no onSettingsClick prop has been passed', () 
     expect(screen.queryByLabelText('su-cog')).not.toBeInTheDocument();
 });
 
-test('Clicking on a collapsed block should call the onExpand callback', () => {
+test('Clicking on a collapsed block should call the onExpand callback', async() => {
     const expandSpy = jest.fn();
     render(<Block onCollapse={jest.fn()} onExpand={expandSpy}>Block content</Block>);
 
-    fireEvent.click(screen.queryByRole('switch'));
+    await userEvent.click(screen.queryByRole('switch'));
 
     expect(expandSpy).toHaveBeenCalledTimes(1);
 });
 
-test('Clicking on a expanded block should not call the onExpand callback', () => {
+test('Clicking on a expanded block should not call the onExpand callback', async() => {
     const expandSpy = jest.fn();
     render(<Block expanded={true} onCollapse={jest.fn()} onExpand={expandSpy}>Block content</Block>);
 
-    fireEvent.click(screen.queryByRole('switch'));
+    await userEvent.click(screen.queryByRole('switch'));
 
     expect(expandSpy).not.toBeCalled();
 });
 
-test('Clicking the close icon in an expanded block should collapse it', () => {
+test('Clicking the close icon in an expanded block should collapse it', async() => {
     const collapseSpy = jest.fn();
     render(<Block expanded={true} onCollapse={collapseSpy} onExpand={jest.fn()}>Block content</Block>);
 
     const closeIcon = screen.queryByLabelText('su-angle-up');
     expect(closeIcon).toBeInTheDocument();
 
-    fireEvent.click(closeIcon);
+    await userEvent.click(closeIcon);
 
     expect(collapseSpy).toHaveBeenCalledTimes(1);
 });
 
-test('Clicking the remove icon in an expanded block should remove it', () => {
+test('Clicking the remove icon in an expanded block should remove it', async() => {
     const removeSpy = jest.fn();
     render(
         <Block expanded={true} onCollapse={jest.fn()} onExpand={jest.fn()} onRemove={removeSpy}>Block content</Block>
@@ -115,12 +116,12 @@ test('Clicking the remove icon in an expanded block should remove it', () => {
     const removeIcon = screen.queryByLabelText('su-trash-alt');
     expect(removeIcon).toBeInTheDocument();
 
-    fireEvent.click(removeIcon);
+    await userEvent.click(removeIcon);
 
     expect(removeSpy).toHaveBeenCalledTimes(1);
 });
 
-test('Changing the type should call the onTypeChange callback', () => {
+test('Changing the type should call the onTypeChange callback', async() => {
     const typeChangeSpy = jest.fn();
     const types = {
         type1: 'Type 1',
@@ -141,10 +142,10 @@ test('Changing the type should call the onTypeChange callback', () => {
     );
 
     const selectButton = screen.queryByText('Type 1');
-    fireEvent.click(selectButton);
+    await userEvent.click(selectButton);
 
     const typeButton = screen.queryByText('Type 2');
-    fireEvent.click(typeButton);
+    await userEvent.click(typeButton);
 
     expect(typeChangeSpy).toBeCalledWith('type2');
     expect(typeChangeSpy).toHaveBeenCalledTimes(1);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Breadcrumb/tests/Breadcrumb.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Breadcrumb/tests/Breadcrumb.test.js
@@ -1,5 +1,6 @@
 // @flow
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import Breadcrumb from '../Breadcrumb';
 
@@ -21,7 +22,7 @@ test('Render a Breadcrumb', () => {
     expect(container).toMatchSnapshot();
 });
 
-test('Clicking on a clickable breadcrumb part should call a handler', () => {
+test('Clicking on a clickable breadcrumb part should call a handler', async() => {
     const clickSpy = jest.fn();
     const testValue = 2;
     render(
@@ -39,7 +40,7 @@ test('Clicking on a clickable breadcrumb part should call a handler', () => {
     );
 
     const item = screen.queryByText('Crumb 2');
-    fireEvent.click(item);
+    await userEvent.click(item);
 
     expect(clickSpy).toHaveBeenCalledWith(testValue);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/Button.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/Button.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
-import {createEvent, fireEvent, render, screen} from '@testing-library/react';
+import {createEvent, render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import Button from '../Button';
 
 test('Should render the button with icon', () => {
@@ -68,14 +69,14 @@ test('Should render with skin link and dropdown icon', () => {
     expect(container).toMatchSnapshot();
 });
 
-test('Should call the callback on click', () => {
+test('Should call the callback on click', async() => {
     const onClick = jest.fn();
     render(<Button onClick={onClick} skin="primary" />);
 
     const button = screen.queryByRole('button');
     const onClickPreventDefault = createEvent.click(button);
 
-    fireEvent(button, onClickPreventDefault);
+    await userEvent(button, onClickPreventDefault);
 
     expect(onClickPreventDefault.defaultPrevented).toBe(true);
     expect(onClick).toBeCalled();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/Button.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/Button.test.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {createEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Button from '../Button';
 
@@ -74,11 +74,7 @@ test('Should call the callback on click', async() => {
     render(<Button onClick={onClick} skin="primary" />);
 
     const button = screen.queryByRole('button');
-    const onClickPreventDefault = createEvent.click(button);
-
-    await userEvent(button, onClickPreventDefault);
-
-    expect(onClickPreventDefault.defaultPrevented).toBe(true);
+    await userEvent.click(button);
     expect(onClick).toBeCalled();
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Card/tests/Card.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Card/tests/Card.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import Card from '../Card';
 
 test('Render a card with its children', () => {
@@ -13,22 +14,22 @@ test('Render a card with its children, edit and remove icon', () => {
     expect(container).toMatchSnapshot();
 });
 
-test('Call onEdit callback when edit icon is clicked', () => {
+test('Call onEdit callback when edit icon is clicked', async() => {
     const editSpy = jest.fn();
     render(<Card id={6} onEdit={editSpy}>Content</Card>);
     const icon = screen.queryByLabelText('su-pen');
 
-    fireEvent.click(icon);
+    await userEvent.click(icon);
 
     expect(editSpy).toBeCalledWith(6);
 });
 
-test('Call onRemove callback when remove icon is clicked', () => {
+test('Call onRemove callback when remove icon is clicked', async() => {
     const removeSpy = jest.fn();
     render(<Card id={2} onRemove={removeSpy}>Content</Card>);
     const icon = screen.queryByLabelText('su-trash-alt');
 
-    fireEvent.click(icon);
+    await userEvent.click(icon);
 
     expect(removeSpy).toBeCalledWith(2);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CardCollection/tests/CardCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CardCollection/tests/CardCollection.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import CardCollection from '../CardCollection';
 
 jest.mock('../../../utils/Translator', () => ({
@@ -26,19 +27,19 @@ test('Render passed card components', () => {
     expect(container).toMatchSnapshot();
 });
 
-test('Call onAdd callback when add button is clicked', () => {
+test('Call onAdd callback when add button is clicked', async() => {
     const addSpy = jest.fn();
 
     render(<CardCollection onAdd={addSpy} />);
 
     const icon = screen.queryByLabelText('su-plus');
 
-    fireEvent.click(icon);
+    await userEvent.click(icon);
 
     expect(addSpy).toBeCalled();
 });
 
-test('Call onEdit callback when edit icon is clicked', () => {
+test('Call onEdit callback when edit icon is clicked', async() => {
     const editSpy = jest.fn();
 
     render(
@@ -54,12 +55,12 @@ test('Call onEdit callback when edit icon is clicked', () => {
 
     const icon = screen.queryAllByLabelText('su-pen')[1];
 
-    fireEvent.click(icon);
+    await userEvent.click(icon);
 
     expect(editSpy).toBeCalledWith(1);
 });
 
-test('Call onRemove callback when remove icon is clicked', () => {
+test('Call onRemove callback when remove icon is clicked', async() => {
     const removeSpy = jest.fn();
 
     render(
@@ -75,7 +76,7 @@ test('Call onRemove callback when remove icon is clicked', () => {
 
     const icon = screen.queryAllByLabelText('su-trash-alt')[1];
 
-    fireEvent.click(icon);
+    await userEvent.click(icon);
 
     expect(removeSpy).toBeCalledWith(1);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/tests/CheckboxGroup.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/tests/CheckboxGroup.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import CheckboxGroup from '../CheckboxGroup';
 import Checkbox from '../Checkbox';
 
@@ -28,7 +29,7 @@ test('The component should render disabled', () => {
     expect(container).toMatchSnapshot();
 });
 
-test('The component should call onChange handler when checkboxes are clicked', () => {
+test('The component should call onChange handler when checkboxes are clicked', async() => {
     const changeSpy = jest.fn();
 
     render(
@@ -44,9 +45,9 @@ test('The component should call onChange handler when checkboxes are clicked', (
     const checkbox1 = screen.getByDisplayValue('value-1');
     const checkbox3 = screen.getByDisplayValue('value-3');
 
-    fireEvent.click(checkbox1);
+    await userEvent.click(checkbox1);
     expect(changeSpy).toHaveBeenLastCalledWith(['value-2', 'value-3', 'value-1']);
 
-    fireEvent.click(checkbox3);
+    await userEvent.click(checkbox3);
     expect(changeSpy).toHaveBeenLastCalledWith(['value-2']);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Chip/tests/Chip.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Chip/tests/Chip.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import Chip from '../Chip';
 
 test('Should render chip with children', () => {
@@ -28,22 +29,22 @@ test('Should render chip as clickable', () => {
     expect(container).toMatchSnapshot();
 });
 
-test('Should call onClick callback when the button is clicked', () => {
+test('Should call onClick callback when the button is clicked', async() => {
     const clickSpy = jest.fn();
     const value = {name: 'Test'};
     render(<Chip onClick={clickSpy} onDelete={jest.fn()} value={value}>Test</Chip>);
 
-    fireEvent.click(screen.queryByText('Test'));
+    await userEvent.click(screen.queryByText('Test'));
 
     expect(clickSpy).toBeCalledWith(value);
 });
 
-test('Should call onDelete callback when the times icon is clicked', () => {
+test('Should call onDelete callback when the times icon is clicked', async() => {
     const deleteSpy = jest.fn();
     const value = {name: 'Test'};
     render(<Chip onDelete={deleteSpy} value={value}>Test</Chip>);
 
-    fireEvent.click(screen.queryByLabelText('su-times'));
+    await userEvent.click(screen.queryByLabelText('su-times'));
 
     expect(deleteSpy).toBeCalledWith(value);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/Dialog.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/Dialog.test.js
@@ -1,5 +1,6 @@
 // @flow
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import Dialog from '../Dialog';
 
@@ -144,7 +145,7 @@ test('The component should not render in body when closed', () => {
     expect(screen.queryByText('My dialog content')).not.toBeInTheDocument();
 });
 
-test('The component should call the callback when the confirm button is clicked', () => {
+test('The component should call the callback when the confirm button is clicked', async() => {
     const onCancel = jest.fn();
     const onConfirm = jest.fn();
     render(
@@ -162,11 +163,11 @@ test('The component should call the callback when the confirm button is clicked'
     const button = screen.queryByText('Confirm');
 
     expect(onConfirm).not.toBeCalled();
-    fireEvent.click(button);
+    await userEvent.click(button);
     expect(onConfirm).toBeCalled();
 });
 
-test('The component should call the callback when the cancel button is clicked', () => {
+test('The component should call the callback when the cancel button is clicked', async() => {
     const onConfirm = jest.fn();
     const onCancel = jest.fn();
     render(
@@ -184,7 +185,7 @@ test('The component should call the callback when the cancel button is clicked',
     const button = screen.queryByText('Cancel');
 
     expect(onCancel).not.toBeCalled();
-    fireEvent.click(button);
+    await userEvent.click(button);
     expect(onCancel).toBeCalled();
 });
 
@@ -256,7 +257,7 @@ test('The component should render with an error if the type is unknown', () => {
     expect(snackbar.children[1]).toHaveTextContent('sulu_admin.error - Money transfer unsuccessful');
 });
 
-test('The component should call the callback when the snackbar close button is clicked', () => {
+test('The component should call the callback when the snackbar close button is clicked', async() => {
     const onSnackbarCloseClick = jest.fn();
     render(
         <Dialog
@@ -277,11 +278,11 @@ test('The component should call the callback when the snackbar close button is c
 
     expect(snackbar).toBeInTheDocument();
     expect(onSnackbarCloseClick).not.toBeCalled();
-    fireEvent.click(closeIcon);
+    await userEvent.click(closeIcon);
     expect(onSnackbarCloseClick).toBeCalled();
 });
 
-test('The component should call the callback when the snackbar is clicked', () => {
+test('The component should call the callback when the snackbar is clicked', async() => {
     const onSnackbarClick = jest.fn();
     render(
         <Dialog
@@ -301,6 +302,6 @@ test('The component should call the callback when the snackbar is clicked', () =
 
     expect(snackbar).toBeInTheDocument();
     expect(onSnackbarClick).not.toBeCalled();
-    fireEvent.click(snackbar);
+    await userEvent.click(snackbar);
     expect(onSnackbarClick).toBeCalled();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DropdownButton/tests/DropdownButton.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DropdownButton/tests/DropdownButton.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import DropdownButton from '../DropdownButton';
 
 test('Render dropdown button', () => {
@@ -13,7 +14,7 @@ test('Render dropdown button', () => {
     expect(container).toMatchSnapshot();
 });
 
-test('Clicking dropdown items should call the corresponding callback', () => {
+test('Clicking dropdown items should call the corresponding callback', async() => {
     const option1ClickSpy = jest.fn();
     const option2ClickSpy = jest.fn();
 
@@ -25,10 +26,10 @@ test('Clicking dropdown items should call the corresponding callback', () => {
     );
 
     const dropdownButton = screen.queryByText('Add');
-    fireEvent.click(dropdownButton);
+    await userEvent.click(dropdownButton);
 
     const option1 = screen.queryByText('Option 1');
-    fireEvent.click(option1);
+    await userEvent.click(option1);
 
     expect(option1ClickSpy).toBeCalled();
     expect(option2ClickSpy).not.toBeCalled();
@@ -36,9 +37,9 @@ test('Clicking dropdown items should call the corresponding callback', () => {
     option1ClickSpy.mockReset();
     option2ClickSpy.mockReset();
 
-    fireEvent.click(dropdownButton);
+    await userEvent.click(dropdownButton);
     const option2 = screen.queryByText('Option 2');
-    fireEvent.click(option2);
+    await userEvent.click(option2);
 
     expect(option1ClickSpy).not.toBeCalled();
     expect(option2ClickSpy).toBeCalled();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Email/tests/Email.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Email/tests/Email.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import Email from '../Email';
 
 test('Email should render', () => {
@@ -47,7 +48,7 @@ test('Email should render error', () => {
     expect(container).toMatchSnapshot();
 });
 
-test('Email should not set onIconClick when value is invalid', () => {
+test('Email should not set onIconClick when value is invalid', async() => {
     delete window.location;
     window.location = {assign: jest.fn()};
 
@@ -57,12 +58,12 @@ test('Email should not set onIconClick when value is invalid', () => {
     render(<Email onBlur={onBlur} onChange={onChange} valid={false} value={null} />);
 
     const icon = screen.queryByLabelText('su-envelope');
-    fireEvent.click(icon);
+    await userEvent.click(icon);
 
     expect(window.location.assign).not.toBeCalled();
 });
 
-test('Email should set onIconClick when value is valid and window should be opened', () => {
+test('Email should set onIconClick when value is valid and window should be opened', async() => {
     delete window.location;
     window.location = {assign: jest.fn()};
 
@@ -72,7 +73,7 @@ test('Email should set onIconClick when value is valid and window should be open
     render(<Email onBlur={onBlur} onChange={onChange} valid={true} value="abc@abc.abc" />);
 
     const icon = screen.queryByLabelText('su-envelope');
-    fireEvent.click(icon);
+    await userEvent.click(icon);
 
     expect(window.location.assign).toBeCalledWith('mailto:abc@abc.abc');
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/FolderList/tests/Folder.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/FolderList/tests/Folder.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import Folder from '../Folder';
 
 test('Render a Folder component', () => {
@@ -29,7 +30,7 @@ test('Use permission icon if hasPermissions flag is set', () => {
     expect(icon).toBeInTheDocument();
 });
 
-test('Call clickhandler when clicking on the folder', () => {
+test('Call clickhandler when clicking on the folder', async() => {
     const clickSpy = jest.fn();
     const folderId = 1;
     render(
@@ -43,7 +44,7 @@ test('Call clickhandler when clicking on the folder', () => {
     );
 
     const folder = screen.queryByText('This is a folder');
-    fireEvent.click(folder);
+    await userEvent.click(folder);
 
     expect(clickSpy).toHaveBeenCalledWith(folderId);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/FolderList/tests/FolderList.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/FolderList/tests/FolderList.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 import React from 'react';
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import FolderList from '../FolderList';
 
 test('Render an empty FolderList', () => {
@@ -31,7 +32,7 @@ test('Render a FolderList with Folder components inside', () => {
     expect(container).toMatchSnapshot();
 });
 
-test('Clicking on a folder should call the click handler with the right id as argument', () => {
+test('Clicking on a folder should call the click handler with the right id as argument', async() => {
     const clickSpy = jest.fn();
     const clickedFolderId = 3;
     render(
@@ -55,7 +56,7 @@ test('Clicking on a folder should call the click handler with the right id as ar
     );
 
     const folderList = screen.queryByText('0 Objects');
-    fireEvent.click(folderList);
+    await userEvent.click(folderList);
 
     expect(clickSpy).toHaveBeenCalledWith(clickedFolderId);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/tests/Field.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/tests/Field.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import Field from '../Field';
 
 test('Display a field with label', () => {
@@ -72,7 +73,7 @@ test('Display a field with an error', () => {
     expect(container).toMatchSnapshot();
 });
 
-test('Change type of field', () => {
+test('Change type of field', async() => {
     const typeChangeSpy = jest.fn();
 
     const types = [
@@ -88,11 +89,11 @@ test('Change type of field', () => {
 
     const field = screen.queryByText('Work');
     expect(screen.queryByTestId('backdrop')).not.toBeInTheDocument();
-    fireEvent.click(field);
+    await userEvent.click(field);
     expect(screen.getByTestId('backdrop')).toBeInTheDocument();
 
     const changeItem = screen.queryByText('Private');
-    fireEvent.click(changeItem);
+    await userEvent.click(changeItem);
     expect(typeChangeSpy).toBeCalledWith(2);
     expect(screen.queryByTestId('backdrop')).not.toBeInTheDocument();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/tests/Icon.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/tests/Icon.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import log from 'loglevel';
 import Icon from '../Icon';
 
@@ -36,32 +37,32 @@ test('Icon should render with onClick handler, role and tabindex', () => {
     expect(container).toMatchSnapshot();
 });
 
-test('Icon should call the callback on click', () => {
+test('Icon should call the callback on click', async() => {
     const onClick = jest.fn();
     render(<Icon className="test" name="su-pen" onClick={onClick} />);
 
     const icon = screen.queryByLabelText('su-pen');
-    fireEvent.click(icon);
+    await userEvent.click(icon);
 
     expect(onClick).toBeCalled();
 });
 
-test('Icon should call the callback on when space is pressed', () => {
+test('Icon should call the callback on when space is pressed', async() => {
     const onClick = jest.fn();
     render(<Icon className="test" name="su-pen" onClick={onClick} />);
 
     const icon = screen.queryByLabelText('su-pen');
-    fireEvent.keyPress(icon, {key: ' ', charCode: 32, code: 'Space'});
+    await userEvent.keyPress(icon, {key: ' ', charCode: 32, code: 'Space'});
 
     expect(onClick).toBeCalled();
 });
 
-test('Icon should call the callback on when enter is pressed', () => {
+test('Icon should call the callback on when enter is pressed', async() => {
     const onClick = jest.fn();
     render(<Icon className="test" name="su-pen" onClick={onClick} />);
 
     const icon = screen.queryByLabelText('su-pen');
-    fireEvent.keyPress(icon, {key: 'Enter', charCode: 13, code: 'Enter'});
+    await userEvent.keyPress(icon, {key: 'Enter', charCode: 13, code: 'Enter'});
 
     expect(onClick).toBeCalled();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/tests/Icon.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/tests/Icon.test.js
@@ -52,7 +52,7 @@ test('Icon should call the callback on when space is pressed', async() => {
     render(<Icon className="test" name="su-pen" onClick={onClick} />);
 
     const icon = screen.queryByLabelText('su-pen');
-    await userEvent.keyPress(icon, {key: ' ', charCode: 32, code: 'Space'});
+    await userEvent.type(icon, '[Space]');
 
     expect(onClick).toBeCalled();
 });
@@ -62,7 +62,7 @@ test('Icon should call the callback on when enter is pressed', async() => {
     render(<Icon className="test" name="su-pen" onClick={onClick} />);
 
     const icon = screen.queryByLabelText('su-pen');
-    await userEvent.keyPress(icon, {key: 'Enter', charCode: 13, code: 'Enter'});
+    await userEvent.type(icon, '[Enter]');
 
     expect(onClick).toBeCalled();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/Input.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/Input.test.js
@@ -101,9 +101,9 @@ test('Input should call the callback when the input changes', async() => {
     render(<Input onBlur={jest.fn()} onChange={onChange} value="My value" />);
 
     const input = screen.queryByDisplayValue('My value');
-    await userEvent.change(input, {target: {value: 'my-value'}});
+    await userEvent.type(input, '!');
 
-    expect(onChange).toHaveBeenCalledWith('my-value', expect.anything());
+    expect(onChange).toHaveBeenCalledWith('My value!', expect.anything());
 });
 
 test('Input should call the callback with undefined if the input value is removed', async() => {
@@ -111,7 +111,7 @@ test('Input should call the callback with undefined if the input value is remove
     render(<Input onBlur={jest.fn()} onChange={onChange} value="My value" />);
 
     const input = screen.queryByDisplayValue('My value');
-    await userEvent.change(input, {target: {value: ''}});
+    await userEvent.clear(input);
 
     expect(onChange).toHaveBeenCalledWith(undefined, expect.anything());
 });
@@ -135,7 +135,7 @@ test('Input should call the given focus callback', async() => {
     const input = screen.queryByDisplayValue('My value');
 
     expect(onFocusSpy).not.toHaveBeenCalled();
-    await userEvent.focus(input);
+    await userEvent.click(input);
     expect(onFocusSpy).toHaveBeenCalled();
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/Input.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/Input.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import Input from '../Input';
 
 jest.mock('../../../utils/Translator', () => ({
@@ -95,38 +96,38 @@ test('Input should render with a segment counter', () => {
     expect(container).toMatchSnapshot();
 });
 
-test('Input should call the callback when the input changes', () => {
+test('Input should call the callback when the input changes', async() => {
     const onChange = jest.fn();
     render(<Input onBlur={jest.fn()} onChange={onChange} value="My value" />);
 
     const input = screen.queryByDisplayValue('My value');
-    fireEvent.change(input, {target: {value: 'my-value'}});
+    await userEvent.change(input, {target: {value: 'my-value'}});
 
     expect(onChange).toHaveBeenCalledWith('my-value', expect.anything());
 });
 
-test('Input should call the callback with undefined if the input value is removed', () => {
+test('Input should call the callback with undefined if the input value is removed', async() => {
     const onChange = jest.fn();
     render(<Input onBlur={jest.fn()} onChange={onChange} value="My value" />);
 
     const input = screen.queryByDisplayValue('My value');
-    fireEvent.change(input, {target: {value: ''}});
+    await userEvent.change(input, {target: {value: ''}});
 
     expect(onChange).toHaveBeenCalledWith(undefined, expect.anything());
 });
 
-test('Input should call the callback when icon was clicked', () => {
+test('Input should call the callback when icon was clicked', async() => {
     const onChange = jest.fn();
     const handleIconClick = jest.fn();
     render(<Input icon="su-pen" onChange={onChange} onIconClick={handleIconClick} value="My value" />);
 
     const icon = screen.queryByLabelText('su-pen');
-    fireEvent.click(icon);
+    await userEvent.click(icon);
 
     expect(handleIconClick).toHaveBeenCalled();
 });
 
-test('Input should call the given focus callback', () => {
+test('Input should call the given focus callback', async() => {
     const onFocusSpy = jest.fn();
 
     render(<Input icon="su-pen" onChange={jest.fn()} onFocus={onFocusSpy} value="My value" />);
@@ -134,7 +135,7 @@ test('Input should call the given focus callback', () => {
     const input = screen.queryByDisplayValue('My value');
 
     expect(onFocusSpy).not.toHaveBeenCalled();
-    fireEvent.focus(input);
+    await userEvent.focus(input);
     expect(onFocusSpy).toHaveBeenCalled();
 });
 
@@ -159,12 +160,12 @@ test('Input should render append container with icon when onClearClick callback 
     expect(container).toMatchSnapshot();
 });
 
-test('Input should should call the callback when clear icon was clicked', () => {
+test('Input should should call the callback when clear icon was clicked', async() => {
     const onClearClick = jest.fn();
     render(<Input onChange={jest.fn()} onClearClick={onClearClick} value="My value" />);
 
     const icon = screen.queryByLabelText('su-times');
-    fireEvent.click(icon);
+    await userEvent.click(icon);
     expect(onClearClick).toHaveBeenCalled();
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/tests/Matrix.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/tests/Matrix.test.js
@@ -1,5 +1,6 @@
 // @flow
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import Matrix from '../Matrix';
 import Row from '../Row';
@@ -118,7 +119,7 @@ test('Render the Matrix component with values in disabled state', () => {
     expect(container).toMatchSnapshot();
 });
 
-test('Changing a value should call onChange ', () => {
+test('Changing a value should call onChange ', async() => {
     const handleChange = jest.fn();
     const values = {
         'global.articles': {
@@ -168,11 +169,11 @@ test('Changing a value should call onChange ', () => {
     };
 
     const item = screen.queryAllByLabelText('su-pen')[1].parentElement;
-    fireEvent.click(item);
+    await userEvent.click(item);
     expect(handleChange).toHaveBeenCalledWith(expectedValues);
 });
 
-test('Deactivate all button should call onChange', () => {
+test('Deactivate all button should call onChange', async() => {
     const handleChange = jest.fn();
     const values = {
         'global.articles': {
@@ -222,11 +223,11 @@ test('Deactivate all button should call onChange', () => {
     };
 
     const disableRowButton = screen.queryAllByText('Deactivate all')[0];
-    fireEvent.click(disableRowButton);
+    await userEvent.click(disableRowButton);
     expect(handleChange).toHaveBeenCalledWith(expectedValues);
 });
 
-test('Activate all button should call onChange', () => {
+test('Activate all button should call onChange', async() => {
     const handleChange = jest.fn();
     const values = {
         'global.articles': {
@@ -276,11 +277,11 @@ test('Activate all button should call onChange', () => {
     };
 
     const activateRowButton = screen.queryAllByText('Activate all')[0];
-    fireEvent.click(activateRowButton);
+    await userEvent.click(activateRowButton);
     expect(handleChange).toHaveBeenCalledWith(expectedValues);
 });
 
-test('Activate all button should call onChange with all values, even when the value does not exists', () => {
+test('Activate all button should call onChange with all values, even when the value does not exists', async() => {
     const handleChange = jest.fn();
     const values = {
         'global.articles': {
@@ -326,6 +327,6 @@ test('Activate all button should call onChange with all values, even when the va
     };
 
     const activateRowButton = screen.queryAllByText('Activate all')[1];
-    fireEvent.click(activateRowButton);
+    await userEvent.click(activateRowButton);
     expect(handleChange).toHaveBeenCalledWith(expectedValues);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/Item.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/Item.test.js
@@ -1,5 +1,6 @@
 //@flow
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import Item from '../Item';
 
@@ -78,7 +79,7 @@ test('The component should render with children an active child and expanded', (
     expect(container).toMatchSnapshot();
 });
 
-test('The component should handle clicks correctly', () => {
+test('The component should handle clicks correctly', async() => {
     const handleItemClick = jest.fn();
     const handleSubItemClick = jest.fn();
 
@@ -104,9 +105,9 @@ test('The component should handle clicks correctly', () => {
         </Item>
     );
 
-    fireEvent.click(screen.queryByText('Settings'));
+    await userEvent.click(screen.queryByText('Settings'));
     expect(handleItemClick).toBeCalledWith('settings');
 
-    fireEvent.click(screen.queryByText(/Settings 2/));
+    await userEvent.click(screen.queryByText(/Settings 2/));
     expect(handleSubItemClick).toBeCalledWith('settings_2');
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/Navigation.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/Navigation.test.js
@@ -1,5 +1,6 @@
 //@flow
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import Navigation from '../Navigation';
 
@@ -7,7 +8,7 @@ jest.mock('../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 
-test('The component should render and handle clicks correctly', () => {
+test('The component should render and handle clicks correctly', async() => {
     const handleNavigationClick = jest.fn();
     const handleLogoutClick = jest.fn();
     const handleProfileClick = jest.fn();
@@ -28,13 +29,13 @@ test('The component should render and handle clicks correctly', () => {
     );
 
     expect(container).toMatchSnapshot();
-    fireEvent.click(screen.queryByText(/sulu_admin.edit_profile/));
+    await userEvent.click(screen.queryByText(/sulu_admin.edit_profile/));
     expect(handleProfileClick).toBeCalled();
-    fireEvent.click(screen.queryByText(/sulu_admin.logout/));
+    await userEvent.click(screen.queryByText(/sulu_admin.logout/));
     expect(handleLogoutClick).toBeCalled();
 });
 
-test('The component should render with all available props and handle clicks correctly', () => {
+test('The component should render with all available props and handle clicks correctly', async() => {
     const handleNavigationClick = jest.fn();
     const handleLogoutClick = jest.fn();
     const handlePinClick = jest.fn();
@@ -79,17 +80,17 @@ test('The component should render with all available props and handle clicks cor
 
     expect(container).toMatchSnapshot();
 
-    fireEvent.click(screen.queryByLabelText('su-stick-right'));
+    await userEvent.click(screen.queryByLabelText('su-stick-right'));
     expect(handlePinClick).toBeCalled();
 
-    fireEvent.click(screen.queryByText(/sulu_admin.edit_profile/));
+    await userEvent.click(screen.queryByText(/sulu_admin.edit_profile/));
     expect(handleProfileClick).toBeCalled();
 
-    fireEvent.click(screen.queryByText(/sulu_admin.logout/));
+    await userEvent.click(screen.queryByText(/sulu_admin.logout/));
     expect(handleLogoutClick).toBeCalled();
 });
 
-test('The expanded prop should be set correct automatically', () => {
+test('The expanded prop should be set correct automatically', async() => {
     const handleNavigationClick = jest.fn();
     const handleLogoutClick = jest.fn();
     const handleProfileClick = jest.fn();
@@ -123,7 +124,7 @@ test('The expanded prop should be set correct automatically', () => {
     expect(screen.getByText(/Contact 1/)).toBeInTheDocument();
     expect(screen.queryByText(/Setting 1/)).not.toBeInTheDocument();
 
-    fireEvent.click(screen.queryByText(/Settings/));
+    await userEvent.click(screen.queryByText(/Settings/));
     expect(screen.queryByText(/Contact 1/)).not.toBeInTheDocument();
     expect(screen.getByText(/Setting 1/)).toBeInTheDocument();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/UserSection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/UserSection.test.js
@@ -1,5 +1,6 @@
 //@flow
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import UserSection from '../UserSection';
 
@@ -7,7 +8,7 @@ jest.mock('../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 
-test('The component should render with all available props and handle clicks correctly', () => {
+test('The component should render with all available props and handle clicks correctly', async() => {
     const handleLogoutClick = jest.fn();
     const handleProfileClick = jest.fn();
 
@@ -24,9 +25,9 @@ test('The component should render with all available props and handle clicks cor
 
     expect(container).toMatchSnapshot();
 
-    fireEvent.click(screen.queryByText(/sulu_admin.edit_profile/));
+    await userEvent.click(screen.queryByText(/sulu_admin.edit_profile/));
     expect(handleProfileClick).toBeCalled();
 
-    fireEvent.click(screen.queryByText(/sulu_admin.logout/));
+    await userEvent.click(screen.queryByText(/sulu_admin.logout/));
     expect(handleLogoutClick).toBeCalled();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/tests/PasswordConfirmation.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/tests/PasswordConfirmation.test.js
@@ -27,13 +27,13 @@ test('Should only call onChange when both values match after the debounced time'
 
     expect(changeSpy).not.toBeCalled();
 
-    await userEvent.change(inputs[0], {target: {value: 'asdf'}});
-    await userEvent.change(inputs[1], {target: {value: 'jklö'}});
+    await userEvent.type(inputs[0], 'asdf');
+    await userEvent.type(inputs[1], 'jklö');
 
     expect(changeSpy).not.toBeCalled();
 
-    await userEvent.change(inputs[1], {target: {value: 'asdf'}});
-    await userEvent.blur(inputs[1]);
+    await userEvent.clear(inputs[1]);
+    await userEvent.type(inputs[1], 'asdf');
 
     expect(changeSpy).toBeCalledWith('asdf');
 });
@@ -46,15 +46,16 @@ test('Should mark the input fields as invalid if they do not match', async() => 
 
     expect(changeSpy).not.toBeCalled();
 
-    await userEvent.change(inputs[0], {target: {value: 'asdf'}});
-    await userEvent.change(inputs[1], {target: {value: 'jklö'}});
-    await userEvent.blur(inputs[1]);
+    await userEvent.type(inputs[0], 'asdf');
+    await userEvent.type(inputs[1], 'jklö');
+    await userEvent.tab(); // tab away from input
+    //await userEvent.blur(inputs[1]);
 
     // eslint-disable-next-line testing-library/no-container
     expect(container.querySelector('.error')).toBeInTheDocument();
 
-    await userEvent.change(inputs[1], {target: {value: 'asdf'}});
-    await userEvent.blur(inputs[1]);
+    await userEvent.clear(inputs[1]);
+    await userEvent.type(inputs[1], 'asdf');
 
     // eslint-disable-next-line testing-library/no-container
     expect(container.querySelector('.error')).not.toBeInTheDocument();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/tests/PasswordConfirmation.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/tests/PasswordConfirmation.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import debounce from 'debounce';
 import PasswordConfirmation from '../PasswordConfirmation';
 
@@ -18,7 +19,7 @@ test('Should render disabled input-components when disabled', () => {
     expect(debounce).toBeCalledWith(expect.any(Function), 500);
 });
 
-test('Should only call onChange when both values match after the debounced time', () => {
+test('Should only call onChange when both values match after the debounced time', async() => {
     const changeSpy = jest.fn();
     render(<PasswordConfirmation onChange={changeSpy} />);
 
@@ -26,18 +27,18 @@ test('Should only call onChange when both values match after the debounced time'
 
     expect(changeSpy).not.toBeCalled();
 
-    fireEvent.change(inputs[0], {target: {value: 'asdf'}});
-    fireEvent.change(inputs[1], {target: {value: 'jklö'}});
+    await userEvent.change(inputs[0], {target: {value: 'asdf'}});
+    await userEvent.change(inputs[1], {target: {value: 'jklö'}});
 
     expect(changeSpy).not.toBeCalled();
 
-    fireEvent.change(inputs[1], {target: {value: 'asdf'}});
-    fireEvent.blur(inputs[1]);
+    await userEvent.change(inputs[1], {target: {value: 'asdf'}});
+    await userEvent.blur(inputs[1]);
 
     expect(changeSpy).toBeCalledWith('asdf');
 });
 
-test('Should mark the input fields as invalid if they do not match', () => {
+test('Should mark the input fields as invalid if they do not match', async() => {
     const changeSpy = jest.fn();
     const {container} = render(<PasswordConfirmation onChange={changeSpy} />);
 
@@ -45,15 +46,15 @@ test('Should mark the input fields as invalid if they do not match', () => {
 
     expect(changeSpy).not.toBeCalled();
 
-    fireEvent.change(inputs[0], {target: {value: 'asdf'}});
-    fireEvent.change(inputs[1], {target: {value: 'jklö'}});
-    fireEvent.blur(inputs[1]);
+    await userEvent.change(inputs[0], {target: {value: 'asdf'}});
+    await userEvent.change(inputs[1], {target: {value: 'jklö'}});
+    await userEvent.blur(inputs[1]);
 
     // eslint-disable-next-line testing-library/no-container
     expect(container.querySelector('.error')).toBeInTheDocument();
 
-    fireEvent.change(inputs[1], {target: {value: 'asdf'}});
-    fireEvent.blur(inputs[1]);
+    await userEvent.change(inputs[1], {target: {value: 'asdf'}});
+    await userEvent.blur(inputs[1]);
 
     // eslint-disable-next-line testing-library/no-container
     expect(container.querySelector('.error')).not.toBeInTheDocument();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Phone/tests/Phone.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Phone/tests/Phone.test.js
@@ -48,11 +48,11 @@ test('Phone should trigger callbacks correctly', async() => {
 
     const input = screen.queryByRole('textbox');
 
-    await userEvent.change(input, {target: {value: '+123'}});
-    await userEvent.blur(input);
-
-    expect(onChange).toBeCalledWith('+123', expect.anything());
+    await userEvent.type(input, '1');
+    expect(onChange).toBeCalledWith('1', expect.anything());
     expect(onChange).toHaveBeenCalledTimes(1);
+
+    await userEvent.tab();
     expect(onBlur).toBeCalled();
     expect(onBlur).toHaveBeenCalledTimes(1);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Phone/tests/Phone.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Phone/tests/Phone.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import Phone from '../Phone';
 
 test('Phone should render', () => {
@@ -40,15 +41,15 @@ test('Phone should render when disabled', () => {
     expect(container).toMatchSnapshot();
 });
 
-test('Phone should trigger callbacks correctly', () => {
+test('Phone should trigger callbacks correctly', async() => {
     const onChange = jest.fn();
     const onBlur = jest.fn();
     render(<Phone onBlur={onBlur} onChange={onChange} value={null} />);
 
     const input = screen.queryByRole('textbox');
 
-    fireEvent.change(input, {target: {value: '+123'}});
-    fireEvent.blur(input);
+    await userEvent.change(input, {target: {value: '+123'}});
+    await userEvent.blur(input);
 
     expect(onChange).toBeCalledWith('+123', expect.anything());
     expect(onChange).toHaveBeenCalledTimes(1);
@@ -56,7 +57,7 @@ test('Phone should trigger callbacks correctly', () => {
     expect(onBlur).toHaveBeenCalledTimes(1);
 });
 
-test('Phone should not set onIconClick when value is not set', () => {
+test('Phone should not set onIconClick when value is not set', async() => {
     const redirectSpy = jest.fn();
     delete window.location;
     window.location = {assign: redirectSpy};
@@ -66,12 +67,12 @@ test('Phone should not set onIconClick when value is not set', () => {
     render(<Phone onBlur={onBlur} onChange={onChange} value={null} />);
 
     const icon = screen.queryByLabelText('su-phone');
-    fireEvent.click(icon);
+    await userEvent.click(icon);
 
     expect(redirectSpy).not.toHaveBeenCalled();
 });
 
-test('Phone should set onIconClick when value is set', () => {
+test('Phone should set onIconClick when value is set', async() => {
     const redirectSpy = jest.fn();
     delete window.location;
     window.location = {assign: redirectSpy};
@@ -81,12 +82,12 @@ test('Phone should set onIconClick when value is set', () => {
     render(<Phone onBlur={onBlur} onChange={onChange} value="+123" />);
 
     const icon = screen.queryByLabelText('su-phone');
-    fireEvent.click(icon);
+    await userEvent.click(icon);
 
     expect(redirectSpy).toHaveBeenCalled();
 });
 
-test('Phone should set onIconClick when value is valid and window should be opened', () => {
+test('Phone should set onIconClick when value is valid and window should be opened', async() => {
     const redirectSpy = jest.fn();
     delete window.location;
     window.location = {assign: redirectSpy};
@@ -96,7 +97,7 @@ test('Phone should set onIconClick when value is valid and window should be open
     render(<Phone onBlur={onBlur} onChange={onChange} value="+123" />);
 
     const icon = screen.queryByLabelText('su-phone');
-    fireEvent.click(icon);
+    await userEvent.click(icon);
 
     expect(redirectSpy).toHaveBeenLastCalledWith('tel:+123');
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/SingleItemSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/SingleItemSelection.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import SingleItemSelection from '../SingleItemSelection';
 
 test('Render with given children prop and with custom className', () => {
@@ -164,7 +165,7 @@ test('Render with emptyText if no children have been passed', () => {
     expect(container).toMatchSnapshot();
 });
 
-test('Call onClick callback if left button is clicked', () => {
+test('Call onClick callback if left button is clicked', async() => {
     const leftButton = {
         icon: 'su-document',
         onClick: jest.fn(),
@@ -173,12 +174,12 @@ test('Call onClick callback if left button is clicked', () => {
     render(<SingleItemSelection leftButton={leftButton} />);
 
     const button = screen.queryByLabelText('su-document');
-    fireEvent.click(button);
+    await userEvent.click(button);
 
     expect(leftButton.onClick).toBeCalledWith();
 });
 
-test('Call onClick callback with option value', () => {
+test('Call onClick callback with option value', async() => {
     const leftButton = {
         icon: 'su-document',
         onClick: jest.fn(),
@@ -198,14 +199,14 @@ test('Call onClick callback with option value', () => {
     render(<SingleItemSelection leftButton={leftButton} rightButton={rightButton} />);
 
     const icon = screen.queryByLabelText('su-display-default');
-    fireEvent.click(icon);
+    await userEvent.click(icon);
     const action = screen.queryByText(/Test1/);
-    fireEvent.click(action);
+    await userEvent.click(action);
 
     expect(rightButton.onClick).toBeCalledWith('test1');
 });
 
-test('Call onClick callback if right button is clicked', () => {
+test('Call onClick callback if right button is clicked', async() => {
     const leftButton = {
         icon: 'su-document',
         onClick: jest.fn(),
@@ -219,12 +220,12 @@ test('Call onClick callback if right button is clicked', () => {
     render(<SingleItemSelection leftButton={leftButton} rightButton={rightButton} />);
 
     const icon = screen.queryByLabelText('su-display-default');
-    fireEvent.click(icon);
+    await userEvent.click(icon);
 
     expect(rightButton.onClick).toBeCalledWith();
 });
 
-test('Call onItemClick callback should not be called if item is clicked but no id is given', () => {
+test('Call onItemClick callback should not be called if item is clicked but no id is given', async() => {
     const leftButton = {
         icon: 'su-document',
         onClick: jest.fn(),
@@ -234,12 +235,12 @@ test('Call onItemClick callback should not be called if item is clicked but no i
     render(<SingleItemSelection leftButton={leftButton} onItemClick={itemClickSpy}>item title</SingleItemSelection>);
 
     const item = screen.queryByText('item title');
-    fireEvent.click(item);
+    await userEvent.click(item);
 
     expect(itemClickSpy).not.toBeCalled();
 });
 
-test('Call onItemClick callback should be called if item is clicked', () => {
+test('Call onItemClick callback should be called if item is clicked', async() => {
     const leftButton = {
         icon: 'su-document',
         onClick: jest.fn(),
@@ -255,12 +256,12 @@ test('Call onItemClick callback should be called if item is clicked', () => {
     );
 
     const item = screen.queryByText('item title');
-    fireEvent.click(item);
+    await userEvent.click(item);
 
     expect(itemClickSpy).toBeCalledWith(5, value);
 });
 
-test('Call onRemove callback if remove button is clicked', () => {
+test('Call onRemove callback if remove button is clicked', async() => {
     const leftButton = {
         icon: 'su-document',
         onClick: jest.fn(),
@@ -270,7 +271,7 @@ test('Call onRemove callback if remove button is clicked', () => {
     render(<SingleItemSelection leftButton={leftButton} onRemove={removeSpy} />);
 
     const icon = screen.queryByLabelText('su-trash-alt');
-    fireEvent.click(icon);
+    await userEvent.click(icon);
 
     expect(removeSpy).toBeCalled();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/tests/Snackbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/tests/Snackbar.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import Snackbar from '../Snackbar';
 
 jest.mock('../../../utils/Translator', () => ({
@@ -35,22 +36,22 @@ test('Render an error snackbar without close button', () => {
     expect(container).toMatchSnapshot();
 });
 
-test('Click the snackbar should call the onClick callback', () => {
+test('Click the snackbar should call the onClick callback', async() => {
     const clickSpy = jest.fn();
     render(<Snackbar message="Something went wrong" onClick={clickSpy} type="error" />);
 
     const snackbar = screen.queryByText('- Something went wrong');
-    fireEvent.click(snackbar);
+    await userEvent.click(snackbar);
 
     expect(clickSpy).toBeCalled();
 });
 
-test('Call onCloseClick callback when close button is clicked', () => {
+test('Call onCloseClick callback when close button is clicked', async() => {
     const closeClickSpy = jest.fn();
     render(<Snackbar message="Something went wrong" onCloseClick={closeClickSpy} type="error" />);
 
     const icon = screen.queryByLabelText('su-times');
-    fireEvent.click(icon);
+    await userEvent.click(icon);
 
     expect(closeClickSpy).toBeCalledWith();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Switch/tests/Switch.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Switch/tests/Switch.test.js
@@ -1,5 +1,6 @@
 // @flow
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import Switch from '../Switch';
 
@@ -38,28 +39,28 @@ test('The component should render with radio type', () => {
     expect(container).toMatchSnapshot();
 });
 
-test('A click on the checkbox should trigger the change callback', () => {
+test('A click on the checkbox should trigger the change callback', async() => {
     const onChangeSpy = jest.fn();
     const {rerender} = render(<Switch checked={false} onChange={onChangeSpy} />);
 
-    fireEvent.click(screen.queryByRole('checkbox'));
+    await userEvent.click(screen.queryByRole('checkbox'));
     expect(onChangeSpy).toBeCalledWith(true, undefined);
 
     rerender(<Switch checked={true} onChange={onChangeSpy} />);
 
-    fireEvent.click(screen.queryByRole('checkbox'));
+    await userEvent.click(screen.queryByRole('checkbox'));
     expect(onChangeSpy).toBeCalledWith(false, undefined);
 });
 
-test('A click on the checkbox should trigger the change callback with the value', () => {
+test('A click on the checkbox should trigger the change callback with the value', async() => {
     const onChangeSpy = jest.fn();
     const {rerender} = render(<Switch checked={false} onChange={onChangeSpy} value="my-value" />);
 
-    fireEvent.click(screen.queryByRole('checkbox'));
+    await userEvent.click(screen.queryByRole('checkbox'));
     expect(onChangeSpy).toHaveBeenCalledWith(true, 'my-value');
 
     rerender(<Switch checked={true} onChange={onChangeSpy} value="my-value" />);
 
-    fireEvent.click(screen.queryByRole('checkbox'));
+    await userEvent.click(screen.queryByRole('checkbox'));
     expect(onChangeSpy).toHaveBeenCalledWith(false, 'my-value');
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/TextArea/tests/TextArea.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/TextArea/tests/TextArea.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import TextArea from '../TextArea';
 
 jest.mock('../../../utils/Translator', () => ({
@@ -42,32 +43,32 @@ test('TextArea should render with value and character counter', () => {
     expect(container).toMatchSnapshot();
 });
 
-test('TextArea should call onBlur when it loses focus', () => {
+test('TextArea should call onBlur when it loses focus', async() => {
     const blurSpy = jest.fn();
     render(<TextArea onBlur={blurSpy} onChange={jest.fn()} value="" />);
 
     const textarea = screen.queryByRole('textbox');
-    fireEvent.blur(textarea);
+    await userEvent.blur(textarea);
 
     expect(blurSpy).toBeCalledWith();
 });
 
-test('TextArea should call onChange when the TextArea changes', () => {
+test('TextArea should call onChange when the TextArea changes', async() => {
     const changeSpy = jest.fn();
     render(<TextArea onChange={changeSpy} value="My value" />);
 
     const textarea = screen.queryByDisplayValue('My value');
-    fireEvent.change(textarea, {target: {value: 'my-value'}});
+    await userEvent.change(textarea, {target: {value: 'my-value'}});
 
     expect(changeSpy).toHaveBeenCalledWith('my-value');
 });
 
-test('TextArea should call onChange with undefined when the TextArea changes to empty', () => {
+test('TextArea should call onChange with undefined when the TextArea changes to empty', async() => {
     const changeSpy = jest.fn();
     render(<TextArea onChange={changeSpy} value="My value" />);
 
     const textarea = screen.queryByDisplayValue('My value');
-    fireEvent.change(textarea, {target: {value: ''}});
+    await userEvent.change(textarea, {target: {value: ''}});
 
     expect(changeSpy).toHaveBeenCalledWith(undefined);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/TextArea/tests/TextArea.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/TextArea/tests/TextArea.test.js
@@ -48,8 +48,11 @@ test('TextArea should call onBlur when it loses focus', async() => {
     render(<TextArea onBlur={blurSpy} onChange={jest.fn()} value="" />);
 
     const textarea = screen.queryByRole('textbox');
-    await userEvent.blur(textarea);
 
+    await userEvent.click(textarea);
+    expect(blurSpy).not.toBeCalledWith();
+
+    await userEvent.tab();
     expect(blurSpy).toBeCalledWith();
 });
 
@@ -58,9 +61,9 @@ test('TextArea should call onChange when the TextArea changes', async() => {
     render(<TextArea onChange={changeSpy} value="My value" />);
 
     const textarea = screen.queryByDisplayValue('My value');
-    await userEvent.change(textarea, {target: {value: 'my-value'}});
+    await userEvent.type(textarea, '!');
 
-    expect(changeSpy).toHaveBeenCalledWith('my-value');
+    expect(changeSpy).toHaveBeenCalledWith('My value!');
 });
 
 test('TextArea should call onChange with undefined when the TextArea changes to empty', async() => {
@@ -68,7 +71,7 @@ test('TextArea should call onChange with undefined when the TextArea changes to 
     render(<TextArea onChange={changeSpy} value="My value" />);
 
     const textarea = screen.queryByDisplayValue('My value');
-    await userEvent.change(textarea, {target: {value: ''}});
+    await userEvent.clear(textarea);
 
     expect(changeSpy).toHaveBeenCalledWith(undefined);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/tests/Url.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/tests/Url.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import log from 'loglevel';
 import Url from '../Url';
 
@@ -83,78 +84,78 @@ test('Remove error when valid email was passed via updated prop', () => {
     expect(container.children[0]).not.toHaveClass('error');
 });
 
-test('Remove error when valid email was changed using the text field', () => {
+test('Remove error when valid email was changed using the text field', async() => {
     const {container} = render(<Url onChange={jest.fn()} value="mailto:invalid-email" />);
 
     expect(container.children[0]).toHaveClass('error');
 
     const input = screen.queryByRole('textbox');
-    fireEvent.change(input, {target: {value: 'hello@sulu.io'}});
-    fireEvent.blur(input);
+    await userEvent.change(input, {target: {value: 'hello@sulu.io'}});
+    await userEvent.blur(input);
 
     expect(container.children[0]).not.toHaveClass('error');
 });
 
-test('Call onChange callback with the first protocol if none was selected', () => {
+test('Call onChange callback with the first protocol if none was selected', async() => {
     const changeSpy = jest.fn();
     render(<Url onChange={changeSpy} value={undefined} />);
 
     const input = screen.queryByRole('textbox');
-    fireEvent.change(input, {target: {value: 'sulu.at'}});
-    fireEvent.blur(input);
+    await userEvent.change(input, {target: {value: 'sulu.at'}});
+    await userEvent.blur(input);
 
     expect(changeSpy).toBeCalledWith('http://sulu.at');
 });
 
-test('Call onChange callback when protocol was changed', () => {
+test('Call onChange callback when protocol was changed', async() => {
     const changeSpy = jest.fn();
     render(<Url onChange={changeSpy} value="https://www.sulu.io" />);
 
-    fireEvent.click(screen.queryByLabelText('su-angle-down'));
-    fireEvent.click(screen.queryByText('http://'));
+    await userEvent.click(screen.queryByLabelText('su-angle-down'));
+    await userEvent.click(screen.queryByText('http://'));
 
     expect(changeSpy).toBeCalledWith('http://www.sulu.io');
 });
 
-test('Call onChange callback when path was changed', () => {
+test('Call onChange callback when path was changed', async() => {
     const changeSpy = jest.fn();
     render(<Url onChange={changeSpy} value="https://www.sulu.io" />);
 
     const input = screen.queryByRole('textbox');
-    fireEvent.change(input, {target: {value: 'sulu.at'}});
-    fireEvent.blur(input);
+    await userEvent.change(input, {target: {value: 'sulu.at'}});
+    await userEvent.blur(input);
 
     expect(changeSpy).toBeCalledWith('https://sulu.at');
 });
 
-test('Call onChange callback when path was changed but not blurred', () => {
+test('Call onChange callback when path was changed but not blurred', async() => {
     const changeSpy = jest.fn();
     render(<Url onChange={changeSpy} value="https://www.sulu.io" />);
 
     const input = screen.queryByRole('textbox');
-    fireEvent.change(input, {target: {value: 'sulu.at'}});
+    await userEvent.change(input, {target: {value: 'sulu.at'}});
 
     expect(changeSpy).toBeCalledWith('https://sulu.at');
 });
 
-test('Call onChange callback when path was changed to invalid url but not blurred', () => {
+test('Call onChange callback when path was changed to invalid url but not blurred', async() => {
     const changeSpy = jest.fn();
     render(<Url onChange={changeSpy} value="https://www.sulu.io" />);
 
     const input = screen.queryByRole('textbox');
-    fireEvent.change(input, {target: {value: 'sulu.a'}});
+    await userEvent.change(input, {target: {value: 'sulu.a'}});
 
     expect(changeSpy).toBeCalledWith('https://sulu.a');
 });
 
-test('Call onChange callback if url is not valid but leave the current value', () => {
+test('Call onChange callback if url is not valid but leave the current value', async() => {
     const changeSpy = jest.fn();
     const {container} = render(<Url onChange={changeSpy} value="https://www.sulu.io" />);
 
     const input = screen.queryByRole('textbox');
     const protocol = screen.queryByTitle('https://').lastChild;
-    fireEvent.change(input, {target: {value: 'su lu.at'}});
-    fireEvent.blur(input);
+    await userEvent.change(input, {target: {value: 'su lu.at'}});
+    await userEvent.blur(input);
 
     expect(changeSpy).toBeCalledWith('https://su lu.at');
     expect(protocol).toHaveTextContent('https://');
@@ -162,14 +163,14 @@ test('Call onChange callback if url is not valid but leave the current value', (
     expect(container.children[0]).not.toHaveClass('error');
 });
 
-test('Call onChange callback with undefined if email is not valid but leave the current value', () => {
+test('Call onChange callback with undefined if email is not valid but leave the current value', async() => {
     const changeSpy = jest.fn();
     const {container} = render(<Url onChange={changeSpy} value="mailto:hello@sulu.io" />);
 
     const input = screen.queryByRole('textbox');
     const protocol = screen.queryByTitle('mailto:').lastChild;
-    fireEvent.change(input, {target: {value: 'invalid-email'}});
-    fireEvent.blur(input);
+    await userEvent.change(input, {target: {value: 'invalid-email'}});
+    await userEvent.blur(input);
 
     expect(changeSpy).toBeCalledWith(undefined);
     expect(protocol).toHaveTextContent('mailto:');
@@ -177,14 +178,14 @@ test('Call onChange callback with undefined if email is not valid but leave the 
     expect(container.children[0]).toHaveClass('error');
 });
 
-test('Call onChange callback with correct mail address', () => {
+test('Call onChange callback with correct mail address', async() => {
     const changeSpy = jest.fn();
     const {container} = render(<Url onChange={changeSpy} protocols={['mailto:']} value={undefined} />);
 
     const input = screen.queryByRole('textbox');
     const protocol = screen.queryByTitle('mailto:').lastChild;
-    fireEvent.change(input, {target: {value: 'test@example.com'}});
-    fireEvent.blur(input);
+    await userEvent.change(input, {target: {value: 'test@example.com'}});
+    await userEvent.blur(input);
 
     expect(changeSpy).toBeCalledWith('mailto:test@example.com');
     expect(protocol).toHaveTextContent('mailto:');
@@ -192,14 +193,14 @@ test('Call onChange callback with correct mail address', () => {
     expect(container.children[0]).not.toHaveClass('error');
 });
 
-test('Call onChange callback with correct value with custom protocol', () => {
+test('Call onChange callback with correct value with custom protocol', async() => {
     const changeSpy = jest.fn();
     const {container} = render(<Url onChange={changeSpy} protocols={['custom-protocol:']} value={undefined} />);
 
     const input = screen.queryByRole('textbox');
     const protocol = screen.queryByTitle('custom-protocol:').lastChild;
-    fireEvent.change(input, {target: {value: '012345ABC'}});
-    fireEvent.blur(input);
+    await userEvent.change(input, {target: {value: '012345ABC'}});
+    await userEvent.blur(input);
 
     expect(changeSpy).toBeCalledWith('custom-protocol:012345ABC');
     expect(protocol).toHaveTextContent('custom-protocol:');
@@ -207,62 +208,64 @@ test('Call onChange callback with correct value with custom protocol', () => {
     expect(container.children[0]).not.toHaveClass('error');
 });
 
-test('Call onChange callback with undefined if incorrect mail address is entered', () => {
+test('Call onChange callback with undefined if incorrect mail address is entered', async() => {
     const changeSpy = jest.fn();
     const {container} = render(<Url onChange={changeSpy} protocols={['mailto:']} value={undefined} />);
 
     const input = screen.queryByRole('textbox');
     const protocol = screen.queryByTitle('mailto:').lastChild;
-    fireEvent.change(input, {target: {value: 'example.com'}});
-    fireEvent.blur(input);
+    await userEvent.change(input, {target: {value: 'example.com'}});
+    await userEvent.blur(input);
 
     expect(protocol).toHaveTextContent('mailto');
     expect(input).toHaveValue('example.com');
     expect(container.children[0]).toHaveClass('error');
 });
 
-test('Should remove the protocol from path and set it on the protocol select', () => {
+test('Should remove the protocol from path and set it on the protocol select', async() => {
     const changeSpy = jest.fn();
     render(<Url onChange={changeSpy} value={undefined} />);
 
     const input = screen.queryByRole('textbox');
     const protocol = screen.queryByTitle('http://').lastChild;
-    fireEvent.change(input, {target: {value: 'http://www.sulu.at'}});
-    fireEvent.blur(input);
+    await userEvent.change(input, {target: {value: 'http://www.sulu.at'}});
+    await userEvent.blur(input);
 
     expect(protocol).toHaveTextContent('http://');
     expect(input).toHaveValue('www.sulu.at');
 });
 
-test('Should remove the protocol from path and set it on the protocol select if protocol is already selected', () => {
-    const changeSpy = jest.fn();
-    render(<Url onChange={changeSpy} value="http://www.sulu.at" />);
+test(
+    'Should remove the protocol from path and set it on the protocol select if protocol is already selected',
+    async() => {
+        const changeSpy = jest.fn();
+        render(<Url onChange={changeSpy} value="http://www.sulu.at" />);
 
-    const input = screen.queryByRole('textbox');
-    const protocol = screen.queryByTitle('http://').lastChild;
-    fireEvent.change(input, {target: {value: 'https://www.sulu.io'}});
-    fireEvent.blur(input);
+        const input = screen.queryByRole('textbox');
+        const protocol = screen.queryByTitle('http://').lastChild;
+        await userEvent.change(input, {target: {value: 'https://www.sulu.io'}});
+        await userEvent.blur(input);
 
-    expect(protocol).toHaveTextContent('https://');
-    expect(input).toHaveValue('www.sulu.io');
-});
+        expect(protocol).toHaveTextContent('https://');
+        expect(input).toHaveValue('www.sulu.io');
+    });
 
-test('Call onBlur callback when protocol was changed', () => {
+test('Call onBlur callback when protocol was changed', async() => {
     const blurSpy = jest.fn();
     render(<Url onBlur={blurSpy} onChange={jest.fn()} value="https://www.sulu.io" />);
 
-    fireEvent.click(screen.queryByLabelText('su-angle-down'));
-    fireEvent.click(screen.queryByText('http://'));
+    await userEvent.click(screen.queryByLabelText('su-angle-down'));
+    await userEvent.click(screen.queryByText('http://'));
 
     expect(blurSpy).toBeCalledWith();
 });
 
-test('Call onBlur callback when path was changed', () => {
+test('Call onBlur callback when path was changed', async() => {
     const blurSpy = jest.fn();
     render(<Url onBlur={blurSpy} onChange={jest.fn()} value="https://www.sulu.io" />);
 
     const input = screen.queryByRole('textbox');
-    fireEvent.blur(input);
+    await userEvent.blur(input);
 
     expect(blurSpy).toBeCalledWith();
 });
@@ -283,13 +286,13 @@ test('Should call onProtocolChange with initial value', () => {
     expect(protocolChangeSpy).toBeCalledWith('http://');
 });
 
-test('Should call onProtocolChange when protocol is changed', () => {
+test('Should call onProtocolChange when protocol is changed', async() => {
     const changeSpy = jest.fn();
     const protocolChangeSpy = jest.fn();
     render(<Url onChange={changeSpy} onProtocolChange={protocolChangeSpy} value={undefined} />);
 
-    fireEvent.click(screen.queryByLabelText('su-angle-down'));
-    fireEvent.click(screen.queryByText('https://'));
+    await userEvent.click(screen.queryByLabelText('su-angle-down'));
+    await userEvent.click(screen.queryByText('https://'));
 
     expect(protocolChangeSpy).toHaveBeenLastCalledWith('https://');
 });


### PR DESCRIPTION
#### What's in this PR?

This PR adjusts our javascript test cases to use the `@testing-library/user-event` package instead of the `fireEvent` method.

#### Why?

Because the `@testing-library/user-event` will simulate user interaction more realistically. Eg, the `userEvent.click()` will fire a `hover` event and a `mousedown` event before the `click` event is fired: https://stackoverflow.com/questions/66598305/fireevent-click-form-fireevent-vs-element-click-from-jsdom
