### PR TITLE
Migrate missing enzyme Block tests to React Testing Library

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/tests/Block.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/tests/Block.test.js
@@ -132,7 +132,7 @@ test('Clicking the close icon in an expanded block should collapse it', async() 
     expect(collapseSpy).toHaveBeenCalledTimes(1);
 });
 
-test('Clicking the action icon should open a popover that displays the given actions', () => {
+test('Clicking the action icon should open a popover that displays the given actions', async() => {
     const actions = [
         {
             type: 'button',
@@ -156,18 +156,21 @@ test('Clicking the action icon should open a popover that displays the given act
             onClick: jest.fn(),
         },
     ];
-    render(
+    const {container} = render(
         <Block actions={actions} expanded={true} onCollapse={jest.fn()} onExpand={jest.fn()}>Block content</Block>
     );
-    expect(block.find('ActionPopover').prop('open')).toEqual(false);
-    expect(block.find('Icon[name="su-more-circle"]')).toHaveLength(1);
-    block.find('Icon[name="su-more-circle"]').simulate('click');
+    const icon = screen.queryByLabelText('su-more-circle');
 
-    expect(block.find('ActionPopover').prop('open')).toEqual(true);
-    expect(block.find('ActionPopover Popover').render()).toMatchSnapshot();
+    expect(screen.queryByText(/Test Action 1/)).not.toBeInTheDocument();
+    expect(icon).toBeInTheDocument();
+
+    await userEvent.click(icon);
+
+    expect(screen.getByText(/Test Action 1/)).toBeInTheDocument();
+    expect(container).toMatchSnapshot();
 });
 
-test('Clicking an action in the action popover should fire the respective callback', () => {
+test('Clicking an action in the action popover should fire the respective callback', async() => {
     const onActionClickSpy = jest.fn();
     const actions = [
         {
@@ -180,10 +183,13 @@ test('Clicking an action in the action popover should fire the respective callba
     render(
         <Block actions={actions} expanded={true} onCollapse={jest.fn()} onExpand={jest.fn()}>Block content</Block>
     );
-    block.find('Icon[name="su-more-circle"]').simulate('click');
 
+    const icon = screen.queryByLabelText('su-more-circle');
+
+    await userEvent.click(icon);
     expect(onActionClickSpy).not.toBeCalled();
-    block.find('ActionPopover Popover button').at(0).simulate('click');
+
+    await userEvent.click(screen.queryByText('Test Action 1'));
     expect(onActionClickSpy).toBeCalledWith();
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/tests/__snapshots__/Block.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/tests/__snapshots__/Block.test.js.snap
@@ -1,60 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Clicking the action icon should open a popover that displays the given actions 1`] = `
-Array [
-  <div
-    class="backdrop fixed"
-    role="button"
-  />,
-  <div
-    class="container"
+<div>
+  <section
+    class="block expanded"
+    role="switch"
   >
-    <ul
-      class="menu"
-      style="top: 10px; left: 10px; position: fixed; pointer-events: auto;"
+    <div
+      class="content"
     >
-      <li>
-        <button
-          class="action"
-          type="button"
+      <header
+        class="header"
+      >
+        <div
+          class="iconButtons"
         >
-          <span
-            aria-label="su-test-1"
-            class="su-test-1 icon"
-          />
-          Test Action 1
-        </button>
-      </li>
-      <li
-        class="divider"
-      />
-      <li>
-        <button
-          class="action"
-          type="button"
-        >
-          <span
-            aria-label="su-test-2"
-            class="su-test-2 icon"
-          />
-          Test Action 2
-        </button>
-      </li>
-      <li>
-        <button
-          class="action"
-          type="button"
-        >
-          <span
-            aria-label="su-test-3"
-            class="su-test-3 icon"
-          />
-          Test Action 3
-        </button>
-      </li>
-    </ul>
-  </div>,
-]
+          <button
+            type="button"
+          >
+            <span
+              aria-label="su-more-circle"
+              class="su-more-circle"
+            />
+          </button>
+          <button
+            type="button"
+          >
+            <span
+              aria-label="su-collapse-vertical"
+              class="su-collapse-vertical"
+            />
+          </button>
+        </div>
+      </header>
+      <article
+        class="children"
+      >
+        Block content
+      </article>
+    </div>
+  </section>
+</div>
 `;
 
 exports[`Render a collapsed block 1`] = `


### PR DESCRIPTION
Related: https://github.com/sulu/sulu/pull/6784

#### What's in this PR?

Migrated missing `Block.test.js` component unit tests from enzyme to React Testing Library