### PR TITLE
Add bindValueToOnChange helper for testing controlled form components with @testing-library/react

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/Input.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/Input.test.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Input from '../Input';
+import bindValueToOnChange from '../../../utils/TestHelper/bindValueToOnChange';
 
 jest.mock('../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
@@ -98,12 +99,12 @@ test('Input should render with a segment counter', () => {
 
 test('Input should call the callback when the input changes', async() => {
     const onChange = jest.fn();
-    render(<Input onBlur={jest.fn()} onChange={onChange} value="My value" />);
+    render(bindValueToOnChange(<Input onBlur={jest.fn()} onChange={onChange} value="My value" />));
 
     const input = screen.queryByDisplayValue('My value');
-    await userEvent.type(input, '!');
+    await userEvent.type(input, ' - changed');
 
-    expect(onChange).toHaveBeenCalledWith('My value!', expect.anything());
+    expect(onChange).toHaveBeenLastCalledWith('My value - changed', expect.anything());
 });
 
 test('Input should call the callback with undefined if the input value is removed', async() => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Number/tests/Number.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Number/tests/Number.test.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Number from '../Number';
+import bindValueToOnChange from '../../../utils/TestHelper/bindValueToOnChange';
 
 test('Number should render', () => {
     const {container} = render(<Number onChange={jest.fn()} value={undefined} />);
@@ -16,13 +17,12 @@ test('Number should render when disabled', () => {
 
 test('Number should call onChange with parsed value', async() => {
     const onChange = jest.fn();
-    render(<Number onChange={onChange} value={2} />);
+    render(bindValueToOnChange(<Number onChange={onChange} value={2} />));
 
     const input = screen.queryByDisplayValue(2);
-    await userEvent.click(input);
-    await userEvent.paste('1.25');
+    await userEvent.type(input, '1.25');
 
-    expect(onChange).toHaveBeenCalledWith(21.25, expect.anything());
+    expect(onChange).toHaveBeenLastCalledWith(21.25, expect.anything());
 });
 
 test('Number should call onChange with undefined when value isn`t a float', async() => {
@@ -32,7 +32,7 @@ test('Number should call onChange with undefined when value isn`t a float', asyn
     const input = screen.queryByDisplayValue(2);
     await userEvent.type(input, 'text');
 
-    expect(onChange).toHaveBeenCalledWith(undefined, expect.anything());
+    expect(onChange).toHaveBeenLastCalledWith(undefined, expect.anything());
 });
 
 test('Number should call onChange with undefined when value is undefined', async() => {
@@ -42,5 +42,5 @@ test('Number should call onChange with undefined when value is undefined', async
     const input = screen.queryByDisplayValue(0.5);
     await userEvent.clear(input);
 
-    expect(onChange).toBeCalledWith(undefined, expect.anything());
+    expect(onChange).toHaveBeenLastCalledWith(undefined, expect.anything());
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/tests/PasswordConfirmation.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/tests/PasswordConfirmation.test.js
@@ -49,7 +49,6 @@ test('Should mark the input fields as invalid if they do not match', async() => 
     await userEvent.type(inputs[0], 'asdf');
     await userEvent.type(inputs[1], 'jklö');
     await userEvent.tab(); // tab away from input
-    //await userEvent.blur(inputs[1]);
 
     // eslint-disable-next-line testing-library/no-container
     expect(container.querySelector('.error')).toBeInTheDocument();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Phone/tests/Phone.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Phone/tests/Phone.test.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Phone from '../Phone';
+import bindValueToOnChange from '../../../utils/TestHelper/bindValueToOnChange';
 
 test('Phone should render', () => {
     const onChange = jest.fn();
@@ -44,13 +45,12 @@ test('Phone should render when disabled', () => {
 test('Phone should trigger callbacks correctly', async() => {
     const onChange = jest.fn();
     const onBlur = jest.fn();
-    render(<Phone onBlur={onBlur} onChange={onChange} value={null} />);
+    render(bindValueToOnChange(<Phone onBlur={onBlur} onChange={onChange} value={null} />));
 
     const input = screen.queryByRole('textbox');
 
-    await userEvent.type(input, '1');
-    expect(onChange).toBeCalledWith('1', expect.anything());
-    expect(onChange).toHaveBeenCalledTimes(1);
+    await userEvent.type(input, '+123');
+    expect(onChange).toHaveBeenLastCalledWith('+123', expect.anything());
 
     await userEvent.tab();
     expect(onBlur).toBeCalled();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/TextArea/tests/TextArea.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/TextArea/tests/TextArea.test.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import TextArea from '../TextArea';
+import bindValueToOnChange from '../../../utils/TestHelper/bindValueToOnChange';
 
 jest.mock('../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
@@ -58,12 +59,12 @@ test('TextArea should call onBlur when it loses focus', async() => {
 
 test('TextArea should call onChange when the TextArea changes', async() => {
     const changeSpy = jest.fn();
-    render(<TextArea onChange={changeSpy} value="My value" />);
+    render(bindValueToOnChange(<TextArea onChange={changeSpy} value="My value" />));
 
     const textarea = screen.queryByDisplayValue('My value');
-    await userEvent.type(textarea, '!');
+    await userEvent.type(textarea, ' - changed');
 
-    expect(changeSpy).toHaveBeenCalledWith('My value!');
+    expect(changeSpy).toHaveBeenLastCalledWith('My value - changed');
 });
 
 test('TextArea should call onChange with undefined when the TextArea changes to empty', async() => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Popover.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Popover.test.js
@@ -20,7 +20,7 @@ test('Disable the Button if the Popover is disabled', () => {
 test('Show a loader if the Popover is loading', () => {
     const {container} = render(<Popover icon="su-calendar" label="Set time" loading={true}>{() => 'Child'}</Popover>);
 
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    // eslint-disable-next-line testing-library/no-container
     expect(container.querySelector('.loader')).toBeInTheDocument();
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/TestHelper/bindValueToOnChange.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/TestHelper/bindValueToOnChange.js
@@ -22,4 +22,5 @@ const bindValueToOnChange = (element: Element<*>) => {
 // need to update the "value" that is passed to the controlled component when its "onChange" callback is fired.
 // if we dont do this, the component will read the old "value" when multiple events are triggered. for example,
 // "userEvent.type()" will trigger an event for each keystroke.
+// https://github.com/testing-library/user-event/issues/549
 export default bindValueToOnChange;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/TestHelper/bindValueToOnChange.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/TestHelper/bindValueToOnChange.js
@@ -1,0 +1,25 @@
+// @flow
+import React from 'react';
+import type {Element} from 'react';
+
+const WrapperComponent = (props: {children: Element<*>}) => {
+    const component = React.Children.only(props.children);
+    const [boundValue, setBoundValue] = React.useState(component.props.value);
+
+    const wrappedOnChange = (newValue, ...remainingParameters) => {
+        setBoundValue(newValue);
+        component.props.onChange(newValue, ...remainingParameters);
+    };
+
+    return React.cloneElement(component, {value: boundValue, onChange: wrappedOnChange});
+};
+
+const bindValueToOnChange = (element: Element<*>) => {
+    return <WrapperComponent>{element}</WrapperComponent>;
+};
+
+// our form components are implemented as controlled components. to test them with @testing-library/react, we
+// need to update the "value" that is passed to the controlled component when its "onChange" callback is fired.
+// if we dont do this, the component will read the old "value" when multiple events are triggered. for example,
+// "userEvent.type()" will trigger an event for each keystroke.
+export default bindValueToOnChange;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Related issues/PRs | #6767, #6783
| License | MIT

#### What's in this PR?

Our form components are implemented as controlled components. To test them with `@testing-library/react`, we
need to update the `value` prop that is passed to the controlled component when its `onChange` callback is fired.
If we dont do this, the component will read the old value when multiple events are triggered. For example, this happens when using the `userEvent.type()` method.

This simplify this process, this PR adds a `bindValueToOnChange` function that wraps the `onChange` prop of the given React element.

