### PR TITLE
Add incompatibility for doctrine-extensions 3.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -146,6 +146,7 @@
         "doctrine/orm": "2.10.0",
         "doctrine/doctrine-cache-bundle": "<1.3.1",
         "friendsofphp/php-cs-fixer": "3.9.1",
+        "gedmo/doctrine-extensions" : "3.7.0",
         "jackalope/jackalope": "< 1.3.4",
         "jackalope/jackalope-doctrine-dbal": "< 1.3.0",
         "jackalope/jackalope-jackrabbit": "< 1.3.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #6808 <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #6808  <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | none <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Incompatibility with gedmo/doctrine-extensions 3.7.0 declared.

#### Why?

Sulu doesn't work with this version as described in issue.

