### PR TITLE
Fix csv export if value contains line break

### DIFF
--- a/src/Sulu/Component/Rest/Csv/CsvHandler.php
+++ b/src/Sulu/Component/Rest/Csv/CsvHandler.php
@@ -133,6 +133,12 @@ class CsvHandler
             }
         }
 
+        foreach ($row as $key => $value) {
+            if (\is_string($value) && false !== \strpos($value, \PHP_EOL)) {
+                $row[$key] = \str_replace(\PHP_EOL, '\n', $value);
+            }
+        }
+
         return $row;
     }
 

--- a/src/Sulu/Component/Rest/Csv/CsvHandler.php
+++ b/src/Sulu/Component/Rest/Csv/CsvHandler.php
@@ -130,11 +130,7 @@ class CsvHandler
                 $row[$key] = true === $value ? 1 : 0;
             } elseif (\is_array($value) || \is_object($value)) {
                 $row[$key] = \json_encode($value);
-            }
-        }
-
-        foreach ($row as $key => $value) {
-            if (\is_string($value) && false !== \strpos($value, \PHP_EOL)) {
+            } elseif (\is_string($value) && false !== \strpos($value, \PHP_EOL)) {
                 $row[$key] = \str_replace(\PHP_EOL, '\n', $value);
             }
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix csv export if value contains line break

#### Why?

The generated csv should not contain additional line breaks
