### PR TITLE
Extract PageInterface::getCacheLifeTime into own interface

### DIFF
--- a/src/Sulu/Bundle/HttpCacheBundle/CacheLifetime/CacheLifetimeEnhancer.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/CacheLifetime/CacheLifetimeEnhancer.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\HttpCacheBundle\CacheLifetime;
 
 use Sulu\Bundle\HttpCacheBundle\Cache\SuluHttpCache;
-use Sulu\Component\Content\Compat\CacheLifetimeStructureInterface;
+use Sulu\Component\Content\Compat\RoutableStructureInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -52,7 +52,7 @@ class CacheLifetimeEnhancer implements CacheLifetimeEnhancerInterface
 
     public function enhance(Response $response, StructureInterface $structure)
     {
-        if (!$structure instanceof CacheLifetimeStructureInterface) {
+        if (!$structure instanceof RoutableStructureInterface) {
             return;
         }
 

--- a/src/Sulu/Bundle/HttpCacheBundle/CacheLifetime/CacheLifetimeEnhancer.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/CacheLifetime/CacheLifetimeEnhancer.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\HttpCacheBundle\CacheLifetime;
 
 use Sulu\Bundle\HttpCacheBundle\Cache\SuluHttpCache;
-use Sulu\Component\Content\Compat\CacheLifetimeBehaviourInterface;
+use Sulu\Component\Content\Compat\CacheLifetimeStructureInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -52,7 +52,7 @@ class CacheLifetimeEnhancer implements CacheLifetimeEnhancerInterface
 
     public function enhance(Response $response, StructureInterface $structure)
     {
-        if (!$structure instanceof CacheLifetimeBehaviourInterface) {
+        if (!$structure instanceof CacheLifetimeStructureInterface) {
             return;
         }
 

--- a/src/Sulu/Bundle/HttpCacheBundle/CacheLifetime/CacheLifetimeEnhancer.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/CacheLifetime/CacheLifetimeEnhancer.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\HttpCacheBundle\CacheLifetime;
 
 use Sulu\Bundle\HttpCacheBundle\Cache\SuluHttpCache;
+use Sulu\Component\Content\Compat\CacheLifetimeBehaviourInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -51,7 +52,7 @@ class CacheLifetimeEnhancer implements CacheLifetimeEnhancerInterface
 
     public function enhance(Response $response, StructureInterface $structure)
     {
-        if (!\method_exists($structure, 'getCacheLifeTime')) {
+        if (!$structure instanceof CacheLifetimeBehaviourInterface) {
             return;
         }
 

--- a/src/Sulu/Component/Content/Compat/CacheLifetimeBehaviourInterface.php
+++ b/src/Sulu/Component/Content/Compat/CacheLifetimeBehaviourInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Compat;
+
+interface CacheLifetimeBehaviourInterface
+{
+    /**
+     * cacheLifeTime of template definition.
+     *
+     * @return array{
+     *     type: string,
+     *     value: string,
+     * }
+     */
+    public function getCacheLifeTime();
+}

--- a/src/Sulu/Component/Content/Compat/CacheLifetimeStructureInterface.php
+++ b/src/Sulu/Component/Content/Compat/CacheLifetimeStructureInterface.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Component\Content\Compat;
 
-interface CacheLifetimeBehaviourInterface
+interface CacheLifetimeStructureInterface
 {
     /**
      * cacheLifeTime of template definition.

--- a/src/Sulu/Component/Content/Compat/PageInterface.php
+++ b/src/Sulu/Component/Content/Compat/PageInterface.php
@@ -14,22 +14,8 @@ namespace Sulu\Component\Content\Compat;
 /**
  * Structure for template.
  */
-interface PageInterface extends StructureInterface, CacheLifetimeStructureInterface
+interface PageInterface extends StructureInterface, RoutableStructureInterface
 {
-    /**
-     * twig template of template definition.
-     *
-     * @return string
-     */
-    public function getView();
-
-    /**
-     * controller which renders the template definition.
-     *
-     * @return string
-     */
-    public function getController();
-
     /**
      * @return string
      */

--- a/src/Sulu/Component/Content/Compat/PageInterface.php
+++ b/src/Sulu/Component/Content/Compat/PageInterface.php
@@ -14,7 +14,7 @@ namespace Sulu\Component\Content\Compat;
 /**
  * Structure for template.
  */
-interface PageInterface extends StructureInterface, CacheLifetimeBehaviourInterface
+interface PageInterface extends StructureInterface, CacheLifetimeStructureInterface
 {
     /**
      * twig template of template definition.

--- a/src/Sulu/Component/Content/Compat/PageInterface.php
+++ b/src/Sulu/Component/Content/Compat/PageInterface.php
@@ -14,7 +14,7 @@ namespace Sulu\Component\Content\Compat;
 /**
  * Structure for template.
  */
-interface PageInterface extends StructureInterface
+interface PageInterface extends StructureInterface, CacheLifetimeBehaviourInterface
 {
     /**
      * twig template of template definition.
@@ -29,13 +29,6 @@ interface PageInterface extends StructureInterface
      * @return string
      */
     public function getController();
-
-    /**
-     * cacheLifeTime of template definition.
-     *
-     * @return array
-     */
-    public function getCacheLifeTime();
 
     /**
      * @return string

--- a/src/Sulu/Component/Content/Compat/RoutableStructureInterface.php
+++ b/src/Sulu/Component/Content/Compat/RoutableStructureInterface.php
@@ -11,8 +11,22 @@
 
 namespace Sulu\Component\Content\Compat;
 
-interface CacheLifetimeStructureInterface
+interface RoutableStructureInterface
 {
+    /**
+     * twig template of template definition.
+     *
+     * @return string
+     */
+    public function getView();
+
+    /**
+     * controller which renders the twig template.
+     *
+     * @return string
+     */
+    public function getController();
+
     /**
      * cacheLifeTime of template definition.
      *

--- a/src/Sulu/Component/Content/Compat/Structure/PageBridge.php
+++ b/src/Sulu/Component/Content/Compat/Structure/PageBridge.php
@@ -46,7 +46,10 @@ class PageBridge extends StructureBridge implements PageInterface
 
     public function getCacheLifeTime()
     {
-        return $this->structure->getCacheLifetime();
+        /** @var array{type: string, value: string} $cacheLifetime */
+        $cacheLifetime = $this->structure->getCacheLifetime();
+
+        return $cacheLifetime;
     }
 
     public function getOriginTemplate()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #6814
| License | MIT
| Documentation PR | -

#### What's in this PR?

Extract `PageInterface::getCacheLifeTime()` into own interface

#### Why?

To allow other structures to implement this method, so the `CacheLifetimeEnhancer` service works with those structures too. This PR is required for the integration of the SuluHeadlessBundle with the SuluArticleBundle
