### PR TITLE
Fix AccessControlQueryEnhancer to include entities with restricted permissions in unrelated system

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
@@ -243,11 +243,11 @@ class MediaRepositoryTest extends SuluTestCase
         return $user;
     }
 
-    private function createRole()
+    private function createRole(string $system = 'Sulu')
     {
         $role = new Role();
         $role->setName('Role');
-        $role->setSystem('Sulu');
+        $role->setSystem($system);
 
         $this->em->persist($role);
 
@@ -608,6 +608,39 @@ class MediaRepositoryTest extends SuluTestCase
         $this->assertCount(2, $result);
         $this->assertEquals($media2->getId(), $result[0]->getId());
         $this->assertEquals($media4->getId(), $result[1]->getId());
+    }
+
+    public function testFindMediaWithRestricedViewPermissionsInOtherSystem()
+    {
+        // regression test for https://github.com/sulu/sulu/discussions/6804
+
+        $this->systemStore->setSystem('Sulu');
+        $role = $this->createRole('Other');
+        $user = $this->createUser();
+
+        $collection1 = $this->createCollection('default');
+        $collection2 = $this->createCollection('default');
+
+        $this->em->flush();
+
+        $this->createAccessControl($collection1, $role, 0);
+
+        $media1 = $this->createMedia('test-1', 'test-1', $collection1, 'video');
+        $media2 = $this->createMedia('test-2', 'test-2', $collection2, 'image');
+
+        $this->em->flush();
+
+        $result = $this->mediaRepository->findMedia(
+            ['ids' => [$media1->getId(), $media2->getId()]],
+            null,
+            null,
+            $user,
+            64
+        );
+
+        $this->assertCount(2, $result);
+        $this->assertEquals($media1->getId(), $result[0]->getId());
+        $this->assertEquals($media2->getId(), $result[1]->getId());
     }
 
     public function testFindMediaDisplayInfo()

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
@@ -610,7 +610,7 @@ class MediaRepositoryTest extends SuluTestCase
         $this->assertEquals($media4->getId(), $result[1]->getId());
     }
 
-    public function testFindMediaWithRestricedViewPermissionsInOtherSystem()
+    public function testFindMediaWithRestrictedViewPermissionsInOtherSystem(): void
     {
         // regression test for https://github.com/sulu/sulu/discussions/6804
 

--- a/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
+++ b/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
@@ -16,7 +16,6 @@ use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\Mapping\MappingException;
 use Sulu\Bundle\SecurityBundle\Entity\AccessControl;
 use Sulu\Bundle\SecurityBundle\System\SystemStoreInterface;
-use Sulu\Component\Security\Authentication\RoleInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 
 class AccessControlQueryEnhancer
@@ -159,9 +158,15 @@ class AccessControlQueryEnhancer
     private function getUserRoleIds(?UserInterface $user): array
     {
         if ($user) {
-            return \array_map(function(RoleInterface $role) {
-                return $role->getId();
-            }, $user->getRoleObjects());
+            $roleIds = [];
+
+            foreach ($user->getRoleObjects() as $role) {
+                if ($role->getSystem() === $this->systemStore->getSystem()) {
+                    $roleIds[] = $role->getId();
+                }
+            }
+
+            return $roleIds;
         }
 
         $anonymousRole = $this->systemStore->getAnonymousRole();

--- a/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
+++ b/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
@@ -122,7 +122,6 @@ class AccessControlQueryEnhancer
         $subQueryBuilder->andWhere('role.id IN(:roleIds)');
 
         $subQueryBuilder->setParameter('roleIds', $this->getUserRoleIds($user));
-        $subQueryBuilder->setParameter('system', $this->systemStore->getSystem());
         $subQueryBuilder->setParameter('permission', $permission);
 
         $result = $subQueryBuilder->getQuery()->getScalarResult();

--- a/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
+++ b/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
@@ -108,13 +108,13 @@ class AccessControlQueryEnhancer
             $subQueryBuilder->setParameter('entityClass', $entityClass);
         }
 
-        $subQueryBuilder->leftJoin(
+        $subQueryBuilder->innerJoin(
             AccessControl::class,
             'accessControl',
             'WITH',
             $accessClassCondition . ' AND ' . $this->getEntityIdCondition($entityClass, 'entity', $entityIdField)
         );
-        $subQueryBuilder->leftJoin('accessControl.role', 'role');
+        $subQueryBuilder->innerJoin('accessControl.role', 'role');
         $subQueryBuilder->andWhere(
             'BIT_AND(accessControl.permissions, :permission) <> :permission AND accessControl.permissions IS NOT NULL'
         );

--- a/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
+++ b/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
@@ -115,12 +115,12 @@ class AccessControlQueryEnhancer
             'WITH',
             $accessClassCondition . ' AND ' . $this->getEntityIdCondition($entityClass, 'entity', $entityIdField)
         );
-        $subQueryBuilder->leftJoin('accessControl.role', 'role', 'WITH', 'role.system = :system');
+        $subQueryBuilder->leftJoin('accessControl.role', 'role');
         $subQueryBuilder->andWhere(
             'BIT_AND(accessControl.permissions, :permission) <> :permission AND accessControl.permissions IS NOT NULL'
         );
 
-        $subQueryBuilder->andWhere('role.id IN(:roleIds) OR role.id IS NULL');
+        $subQueryBuilder->andWhere('role.id IN(:roleIds) AND role.system = :system');
 
         $subQueryBuilder->setParameter('roleIds', $this->getUserRoleIds($user));
         $subQueryBuilder->setParameter('system', $this->systemStore->getSystem());

--- a/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
+++ b/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
@@ -119,7 +119,7 @@ class AccessControlQueryEnhancer
             'BIT_AND(accessControl.permissions, :permission) <> :permission AND accessControl.permissions IS NOT NULL'
         );
 
-        $subQueryBuilder->andWhere('role.id IN(:roleIds) AND role.system = :system');
+        $subQueryBuilder->andWhere('role.id IN(:roleIds)');
 
         $subQueryBuilder->setParameter('roleIds', $this->getUserRoleIds($user));
         $subQueryBuilder->setParameter('system', $this->systemStore->getSystem());

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -1204,7 +1204,6 @@ class DoctrineListBuilderTest extends TestCase
         $accessQueryBuilder->andWhere('role.id IN(:roleIds)')->shouldBeCalled();
 
         $accessQueryBuilder->setParameter('roleIds', [1])->shouldBeCalled();
-        $accessQueryBuilder->setParameter('system', 'Sulu')->shouldBeCalled();
         $accessQueryBuilder->setParameter('permission', 64)->shouldBeCalled();
 
         $accessQuery = $this->prophesize(AbstractQuery::class);
@@ -1266,7 +1265,6 @@ class DoctrineListBuilderTest extends TestCase
         $accessQueryBuilder->andWhere('role.id IN(:roleIds)')->shouldBeCalled();
 
         $accessQueryBuilder->setParameter('roleIds', [1])->shouldBeCalled();
-        $accessQueryBuilder->setParameter('system', 'Sulu')->shouldBeCalled();
         $accessQueryBuilder->setParameter('permission', 64)->shouldBeCalled();
 
         $accessQuery = $this->prophesize(AbstractQuery::class);
@@ -1335,7 +1333,6 @@ class DoctrineListBuilderTest extends TestCase
         $accessQueryBuilder->andWhere('role.id IN(:roleIds)')->shouldBeCalled();
 
         $accessQueryBuilder->setParameter('roleIds', [1])->shouldBeCalled();
-        $accessQueryBuilder->setParameter('system', 'Sulu')->shouldBeCalled();
         $accessQueryBuilder->setParameter('permission', 64)->shouldBeCalled();
 
         $accessQuery = $this->prophesize(AbstractQuery::class);
@@ -1405,7 +1402,6 @@ class DoctrineListBuilderTest extends TestCase
         $accessQueryBuilder->andWhere('role.id IN(:roleIds)')->shouldBeCalled();
 
         $accessQueryBuilder->setParameter('roleIds', [1])->shouldBeCalled();
-        $accessQueryBuilder->setParameter('system', 'Sulu')->shouldBeCalled();
         $accessQueryBuilder->setParameter('permission', 64)->shouldBeCalled();
 
         $accessQuery = $this->prophesize(AbstractQuery::class);

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -1166,6 +1166,7 @@ class DoctrineListBuilderTest extends TestCase
         $user = $this->prophesize(User::class);
         $role = $this->prophesize(Role::class);
         $role->getId()->willReturn(1);
+        $role->getSystem()->willReturn('Sulu');
         $user->getRoleObjects()->willReturn([$role->reveal()]);
 
         $this->doctrineListBuilder->setPermissionCheck($user->reveal(), PermissionTypes::VIEW);
@@ -1194,13 +1195,13 @@ class DoctrineListBuilderTest extends TestCase
             'accessControl.entityClass = :entityClass AND accessControl.entityId = entity.id'
         )->shouldBeCalled();
 
-        $accessQueryBuilder->leftJoin('accessControl.role', 'role', 'WITH', 'role.system = :system')->shouldBeCalled();
+        $accessQueryBuilder->leftJoin('accessControl.role', 'role')->shouldBeCalled();
 
         $accessQueryBuilder->andWhere(
             'BIT_AND(accessControl.permissions, :permission) <> :permission AND accessControl.permissions IS NOT NULL'
         )->shouldBeCalled();
 
-        $accessQueryBuilder->andWhere('role.id IN(:roleIds) OR role.id IS NULL')->shouldBeCalled();
+        $accessQueryBuilder->andWhere('role.id IN(:roleIds)')->shouldBeCalled();
 
         $accessQueryBuilder->setParameter('roleIds', [1])->shouldBeCalled();
         $accessQueryBuilder->setParameter('system', 'Sulu')->shouldBeCalled();
@@ -1223,6 +1224,7 @@ class DoctrineListBuilderTest extends TestCase
         $user = $this->prophesize(User::class);
         $role = $this->prophesize(Role::class);
         $role->getId()->willReturn(1);
+        $role->getSystem()->willReturn('Sulu');
         $user->getRoleObjects()->willReturn([$role->reveal()]);
 
         $this->doctrineListBuilder->setPermissionCheck($user->reveal(), PermissionTypes::VIEW);
@@ -1255,13 +1257,13 @@ class DoctrineListBuilderTest extends TestCase
             'accessControl.entityClass = :entityClass AND accessControl.entityIdInteger = entity.id'
         )->shouldBeCalled();
 
-        $accessQueryBuilder->leftJoin('accessControl.role', 'role', 'WITH', 'role.system = :system')->shouldBeCalled();
+        $accessQueryBuilder->leftJoin('accessControl.role', 'role')->shouldBeCalled();
 
         $accessQueryBuilder->andWhere(
             'BIT_AND(accessControl.permissions, :permission) <> :permission AND accessControl.permissions IS NOT NULL'
         )->shouldBeCalled();
 
-        $accessQueryBuilder->andWhere('role.id IN(:roleIds) OR role.id IS NULL')->shouldBeCalled();
+        $accessQueryBuilder->andWhere('role.id IN(:roleIds)')->shouldBeCalled();
 
         $accessQueryBuilder->setParameter('roleIds', [1])->shouldBeCalled();
         $accessQueryBuilder->setParameter('system', 'Sulu')->shouldBeCalled();
@@ -1295,6 +1297,7 @@ class DoctrineListBuilderTest extends TestCase
         $user = $this->prophesize(User::class);
         $role = $this->prophesize(Role::class);
         $role->getId()->willReturn(1);
+        $role->getSystem()->willReturn('Sulu');
         $user->getRoleObjects()->willReturn([$role->reveal()]);
 
         $this->doctrineListBuilder->setPermissionCheck($user->reveal(), PermissionTypes::VIEW, \stdClass::class);
@@ -1323,13 +1326,13 @@ class DoctrineListBuilderTest extends TestCase
             'accessControl.entityClass = :entityClass AND accessControl.entityId = entity.id'
         )->shouldBeCalled();
 
-        $accessQueryBuilder->leftJoin('accessControl.role', 'role', 'WITH', 'role.system = :system')->shouldBeCalled();
+        $accessQueryBuilder->leftJoin('accessControl.role', 'role')->shouldBeCalled();
 
         $accessQueryBuilder->andWhere(
             'BIT_AND(accessControl.permissions, :permission) <> :permission AND accessControl.permissions IS NOT NULL'
         )->shouldBeCalled();
 
-        $accessQueryBuilder->andWhere('role.id IN(:roleIds) OR role.id IS NULL')->shouldBeCalled();
+        $accessQueryBuilder->andWhere('role.id IN(:roleIds)')->shouldBeCalled();
 
         $accessQueryBuilder->setParameter('roleIds', [1])->shouldBeCalled();
         $accessQueryBuilder->setParameter('system', 'Sulu')->shouldBeCalled();
@@ -1352,6 +1355,7 @@ class DoctrineListBuilderTest extends TestCase
         $user = $this->prophesize(User::class);
         $role = $this->prophesize(Role::class);
         $role->getId()->willReturn(1);
+        $role->getSystem()->willReturn('Sulu');
         $user->getRoleObjects()->willReturn([$role->reveal()]);
 
         $joinFieldDescriptor = $this->prophesize(DoctrineJoinDescriptor::class);
@@ -1392,13 +1396,13 @@ class DoctrineListBuilderTest extends TestCase
             'accessControl.entityClass = :entityClass AND accessControl.entityId = entity.id'
         )->shouldBeCalled();
 
-        $accessQueryBuilder->leftJoin('accessControl.role', 'role', 'WITH', 'role.system = :system')->shouldBeCalled();
+        $accessQueryBuilder->leftJoin('accessControl.role', 'role')->shouldBeCalled();
 
         $accessQueryBuilder->andWhere(
             'BIT_AND(accessControl.permissions, :permission) <> :permission AND accessControl.permissions IS NOT NULL'
         )->shouldBeCalled();
 
-        $accessQueryBuilder->andWhere('role.id IN(:roleIds) OR role.id IS NULL')->shouldBeCalled();
+        $accessQueryBuilder->andWhere('role.id IN(:roleIds)')->shouldBeCalled();
 
         $accessQueryBuilder->setParameter('roleIds', [1])->shouldBeCalled();
         $accessQueryBuilder->setParameter('system', 'Sulu')->shouldBeCalled();

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -1188,14 +1188,14 @@ class DoctrineListBuilderTest extends TestCase
 
         $accessQueryBuilder->setParameter('entityClass', self::$entityName)->shouldBeCalled();
 
-        $accessQueryBuilder->leftJoin(
+        $accessQueryBuilder->innerJoin(
             AccessControl::class,
             'accessControl',
             'WITH',
             'accessControl.entityClass = :entityClass AND accessControl.entityId = entity.id'
         )->shouldBeCalled();
 
-        $accessQueryBuilder->leftJoin('accessControl.role', 'role')->shouldBeCalled();
+        $accessQueryBuilder->innerJoin('accessControl.role', 'role')->shouldBeCalled();
 
         $accessQueryBuilder->andWhere(
             'BIT_AND(accessControl.permissions, :permission) <> :permission AND accessControl.permissions IS NOT NULL'
@@ -1249,14 +1249,14 @@ class DoctrineListBuilderTest extends TestCase
 
         $accessQueryBuilder->setParameter('entityClass', self::$entityName)->shouldBeCalled();
 
-        $accessQueryBuilder->leftJoin(
+        $accessQueryBuilder->innerJoin(
             AccessControl::class,
             'accessControl',
             'WITH',
             'accessControl.entityClass = :entityClass AND accessControl.entityIdInteger = entity.id'
         )->shouldBeCalled();
 
-        $accessQueryBuilder->leftJoin('accessControl.role', 'role')->shouldBeCalled();
+        $accessQueryBuilder->innerJoin('accessControl.role', 'role')->shouldBeCalled();
 
         $accessQueryBuilder->andWhere(
             'BIT_AND(accessControl.permissions, :permission) <> :permission AND accessControl.permissions IS NOT NULL'
@@ -1317,14 +1317,14 @@ class DoctrineListBuilderTest extends TestCase
 
         $accessQueryBuilder->setParameter('entityClass', \stdClass::class)->shouldBeCalled();
 
-        $accessQueryBuilder->leftJoin(
+        $accessQueryBuilder->innerJoin(
             AccessControl::class,
             'accessControl',
             'WITH',
             'accessControl.entityClass = :entityClass AND accessControl.entityId = entity.id'
         )->shouldBeCalled();
 
-        $accessQueryBuilder->leftJoin('accessControl.role', 'role')->shouldBeCalled();
+        $accessQueryBuilder->innerJoin('accessControl.role', 'role')->shouldBeCalled();
 
         $accessQueryBuilder->andWhere(
             'BIT_AND(accessControl.permissions, :permission) <> :permission AND accessControl.permissions IS NOT NULL'
@@ -1386,14 +1386,14 @@ class DoctrineListBuilderTest extends TestCase
 
         $accessQueryBuilder->setParameter('entityClass', \stdClass::class)->shouldBeCalled();
 
-        $accessQueryBuilder->leftJoin(
+        $accessQueryBuilder->innerJoin(
             AccessControl::class,
             'accessControl',
             'WITH',
             'accessControl.entityClass = :entityClass AND accessControl.entityId = entity.id'
         )->shouldBeCalled();
 
-        $accessQueryBuilder->leftJoin('accessControl.role', 'role')->shouldBeCalled();
+        $accessQueryBuilder->innerJoin('accessControl.role', 'role')->shouldBeCalled();
 
         $accessQueryBuilder->andWhere(
             'BIT_AND(accessControl.permissions, :permission) <> :permission AND accessControl.permissions IS NOT NULL'


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Related issues/PRs | https://github.com/sulu/sulu/discussions/6804
| License | MIT

#### What's in this PR?

This pull requests fixes a bug in the `AccessControlQueryEnhancer` that excluded entities with restricted permissions in an unrelated system from the result set.