### PR TITLE
Fix prophecy warnings on PHPUnit 9.5

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="./vendor/autoload.php"
          colors="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+         failOnIncomplete="true"
+         failOnWarning="true"
+         failOnRisky="true"
+>
     <coverage>
         <include>
             <directory>./src/Sulu/Component/</directory>

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Listener/SwiftMailerListenerTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Listener/SwiftMailerListenerTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\MarkupBundle\Tests\Unit\Listener;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\MarkupBundle\Listener\SwiftMailerListener;
 use Sulu\Bundle\MarkupBundle\Markup\MarkupParserInterface;
@@ -20,6 +21,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class SwiftMailerListenerTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var MarkupParserInterface
      */

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/PhpWebspaceCollectionDumperTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/PhpWebspaceCollectionDumperTest.php
@@ -14,12 +14,15 @@ declare(strict_types=1);
 namespace Sulu\Component\Webspace\Tests\Unit\Manager;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Component\Webspace\Manager\Dumper\PhpWebspaceCollectionDumper;
 use Sulu\Component\Webspace\Manager\WebspaceCollection;
 
 class PhpWebspaceCollectionDumperTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var ObjectProphecy<WebspaceCollection>
      */


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix prophecy warnings on PHPUnit 9.5.

#### Why?

Avoid warnings so Jackalope 2 pull request can concentrete on its own errors.