### PR TITLE
Fix missing icons for copy toolbar actions

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/CopyLocaleToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/CopyLocaleToolbarAction.js
@@ -109,6 +109,7 @@ export default class CopyLocaleToolbarAction extends AbstractFormToolbarAction {
         if (visibleConditionFulfilled) {
             return {
                 disabled: !id,
+                icon: 'su-copy',
                 label: translate('sulu_admin.copy_locale'),
                 onClick: action(() => {
                     this.showCopyLocaleDialog = true;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/CopyToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/CopyToolbarAction.js
@@ -39,6 +39,7 @@ export default class CopyToolbarAction extends AbstractFormToolbarAction {
         if (visibleConditionFulfilled) {
             return {
                 disabled: !id,
+                icon: 'su-copy',
                 label: translate('sulu_admin.create_copy'),
                 onClick: action(() => {
                     this.showCopyDialog = true;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

Adding missing icons for copy toolbar actions.

<img width="481" alt="Capture d’écran 2022-10-05 à 16 04 12" src="https://user-images.githubusercontent.com/16030067/194080345-1e8d327c-3cf1-4ea9-ad4a-3e44db700085.png">