### PR TITLE
Fix TargetGroupSubscriber throw error on BinaryFileResponse

### DIFF
--- a/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/TargetGroupSubscriber.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/TargetGroupSubscriber.php
@@ -16,8 +16,10 @@ use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupRuleInterface;
 use Sulu\Bundle\AudienceTargetingBundle\TargetGroup\TargetGroupEvaluatorInterface;
 use Sulu\Bundle\AudienceTargetingBundle\TargetGroup\TargetGroupStoreInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -238,6 +240,8 @@ class TargetGroupSubscriber implements EventSubscriberInterface
         if ($this->preview
             || 0 !== \strpos($response->headers->get('Content-Type'), 'text/html')
             || Request::METHOD_GET !== $request->getMethod()
+            || $response instanceof BinaryFileResponse
+            || $response instanceof StreamedResponse
         ) {
             return;
         }

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
@@ -21,9 +21,11 @@ use Sulu\Bundle\AudienceTargetingBundle\EventListener\TargetGroupSubscriber;
 use Sulu\Bundle\AudienceTargetingBundle\TargetGroup\TargetGroupEvaluatorInterface;
 use Sulu\Bundle\AudienceTargetingBundle\TargetGroup\TargetGroupStoreInterface;
 use Sulu\Component\Content\Compat\Structure\StructureBridge;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -463,6 +465,68 @@ class TargetGroupSubscriberTest extends TestCase
         $request = new Request();
         $request->setMethod(Request::METHOD_GET);
         $response = new Response();
+        $response->headers->set('Content-Type', 'text/html');
+        $event = $this->createResponseEvent($request, $response);
+
+        $this->twig->render(Argument::cetera())->shouldNotBeCalled();
+
+        $targetGroupSubscriber->addTargetGroupHitScript($event);
+
+        $this->assertEquals('', $response->getContent());
+    }
+
+    public function testAddTargetGroupHitScriptOnBinaryFileResponse(): void
+    {
+        $targetGroupSubscriber = new TargetGroupSubscriber(
+            $this->twig->reveal(),
+            false,
+            $this->targetGroupStore->reveal(),
+            $this->targetGroupEvaluator->reveal(),
+            $this->targetGroupRepository->reveal(),
+            '/_target_group',
+            '/_target_group_hit',
+            'X-Forwarded-Url',
+            'X-Forwarded-Referer',
+            'X-Forwarded-UUID',
+            'X-Sulu-Target-Group',
+            'sulu-visitor-target-group',
+            'visitor-session'
+        );
+
+        $request = new Request();
+        $request->setMethod(Request::METHOD_GET);
+        $response = new BinaryFileResponse(__FILE__);
+        $response->headers->set('Content-Type', 'text/html');
+        $event = $this->createResponseEvent($request, $response);
+
+        $this->twig->render(Argument::cetera())->shouldNotBeCalled();
+
+        $targetGroupSubscriber->addTargetGroupHitScript($event);
+
+        $this->assertEquals('', $response->getContent());
+    }
+
+    public function testAddTargetGroupHitScriptOnStreamedResponse(): void
+    {
+        $targetGroupSubscriber = new TargetGroupSubscriber(
+            $this->twig->reveal(),
+            false,
+            $this->targetGroupStore->reveal(),
+            $this->targetGroupEvaluator->reveal(),
+            $this->targetGroupRepository->reveal(),
+            '/_target_group',
+            '/_target_group_hit',
+            'X-Forwarded-Url',
+            'X-Forwarded-Referer',
+            'X-Forwarded-UUID',
+            'X-Sulu-Target-Group',
+            'sulu-visitor-target-group',
+            'visitor-session'
+        );
+
+        $request = new Request();
+        $request->setMethod(Request::METHOD_GET);
+        $response = new StreamedResponse(function() {});
         $response->headers->set('Content-Type', 'text/html');
         $event = $this->createResponseEvent($request, $response);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/symfony/symfony/pull/47516, https://github.com/symfony/symfony/pull/47746
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix TargetGroupSubscriber throw error on BinaryFileResponse.

#### Why?

Currently an error is now thrown as the response is set to `text/html` this is happening because of a change in Symfony itself here: https://github.com/symfony/symfony/pull/47516, bug is fixed in https://github.com/symfony/symfony/pull/47746. But the subscriber should not be listening to this kind of BinaryFileResponses.
