### PR TITLE
Remove deprecated urls variable from sulu_content_load result

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,32 @@
 # Upgrade
 
+## 2.6.0
+
+### Deprecated urls variable in return value of sulu_content_load
+
+The `urls` variable in the return value of the `sulu_content_load` function was deprecated.
+This makes the data consistent with the data that is available inside of page templates.
+Instead of using the `urls` variable, you should pass `url` in the `properties` parameter of
+the function:
+
+```twig
+{% set page = sulu_content_load('1234-1234-1234-1234', {
+    'title': 'title',
+    'url': 'url',
+}) %}
+```
+
+If you need to use the `urls` variable, you can enable it in your configuration. Be aware that
+this configuration option will be removed in the next major version.
+
+```yaml
+# config/packages/sulu_website.yaml
+sulu_website:
+    twig:
+        attributes:
+            urls: true
+```
+
 ## 2.5.2
 
 ### Add indexes to route table

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -159,6 +159,7 @@
             <argument type="service" id="sulu_security.security_checker" on-invalid="null"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="request_stack"/>
+            <argument>%sulu_website.enabled_twig_attributes%</argument>
         </service>
         <service id="sulu_website.twig.content.memoized" class="%sulu_website.twig.content.memoized.class%">
             <argument type="service" id="sulu_website.twig.content"/>

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
@@ -77,12 +77,12 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
     private $requestStack;
 
     /**
-     * @var array
+     * @var array{urls?: boolean}
      */
     private $enabledTwigAttributes;
 
     /**
-     * Constructor.
+     * @param array{urls?: boolean} $enabledTwigAttributes
      */
     public function __construct(
         ContentMapperInterface $contentMapper,

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
@@ -77,6 +77,11 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
     private $requestStack;
 
     /**
+     * @var array
+     */
+    private $enabledTwigAttributes;
+
+    /**
      * Constructor.
      */
     public function __construct(
@@ -87,7 +92,10 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
         LoggerInterface $logger = null,
         $securityChecker = null,
         WebspaceManagerInterface $webspaceManager = null,
-        RequestStack $requestStack = null
+        RequestStack $requestStack = null,
+        array $enabledTwigAttributes = [
+            'urls' => true,
+        ]
     ) {
         $this->contentMapper = $contentMapper;
         $this->structureResolver = $structureResolver;
@@ -115,6 +123,8 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
                 \E_USER_DEPRECATED
             );
         }
+
+        $this->enabledTwigAttributes = $enabledTwigAttributes;
     }
 
     public function getFunctions()
@@ -199,20 +209,28 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
         array $includedProperties = null
     ) {
         if (null === $this->requestStack) {
-            return $this->structureResolver->resolve($structure, $loadExcerpt, $includedProperties);
+            $structureData = $this->structureResolver->resolve($structure, $loadExcerpt, $includedProperties);
+        } else {
+            $currentRequest = $this->requestStack->getCurrentRequest();
+
+            // This sets query parameters, request parameters and files to an empty array
+            $subRequest = $currentRequest->duplicate([], [], null, null, []);
+            $this->requestStack->push($subRequest);
+
+            try {
+                $structureData = $this->structureResolver->resolve($structure, $loadExcerpt, $includedProperties);
+            } finally {
+                $this->requestStack->pop();
+            }
         }
 
-        $currentRequest = $this->requestStack->getCurrentRequest();
-
-        // This sets query parameters, request parameters and files to an empty array
-        $subRequest = $currentRequest->duplicate([], [], null, null, []);
-        $this->requestStack->push($subRequest);
-
-        try {
-            return $this->structureResolver->resolve($structure, $loadExcerpt, $includedProperties);
-        } finally {
-            $this->requestStack->pop();
+        if ($this->enabledTwigAttributes['urls'] ?? true) {
+            @\trigger_error('Enabling the "urls" parameter is deprecated since Sulu 2.2', \E_USER_DEPRECATED);
+        } else {
+            unset($structureData['urls']);
         }
+
+        return $structureData;
     }
 
     private function resolveProperties(StructureInterface $contentStructure, array $properties): array


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| Deprecations? | yes
| Related issues/PRs | this was forgotten in https://github.com/sulu/sulu/pull/5361
| License | MIT
| Documentation PR | related to https://github.com/sulu/sulu-docs/pull/742

#### What's in this PR?

This pull request removes the `urls` variable from the return value of the `sulu_content_load` function.
Removing the variable was forgotten in https://github.com/sulu/sulu/pull/5361.