### PR TITLE
Fix PHPdoc types for name in media API class

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -14861,11 +14861,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Api/Media.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Api\\\\Media\\:\\:getName\\(\\) should return int but returns string\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Api/Media.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Api\\\\Media\\:\\:getProperties\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Api/Media.php
@@ -14948,11 +14943,6 @@ parameters:
 		-
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 6
-			path: src/Sulu/Bundle/MediaBundle/Api/Media.php
-
-		-
-			message: "#^Parameter \\#1 \\$name of method Sulu\\\\Bundle\\\\MediaBundle\\\\Entity\\\\FileVersion\\:\\:setName\\(\\) expects string, int given\\.$#"
-			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Api/Media.php
 
 		-
@@ -18033,11 +18023,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$userId of method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Manager\\\\MediaManager\\:\\:getUser\\(\\) expects int, int\\|null given\\.$#"
 			count: 2
-			path: src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
-
-		-
-			message: "#^Parameter \\#2 \\$fileName of method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\FormatManager\\\\FormatManagerInterface\\:\\:getFormats\\(\\) expects string, int given\\.$#"
-			count: 3
 			path: src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
 
 		-

--- a/src/Sulu/Bundle/MediaBundle/Api/Media.php
+++ b/src/Sulu/Bundle/MediaBundle/Api/Media.php
@@ -433,7 +433,7 @@ class Media extends ApiWrapper
     }
 
     /**
-     * @param int $name
+     * @param string $name
      *
      * @return $this
      */
@@ -448,7 +448,7 @@ class Media extends ApiWrapper
      * @VirtualProperty
      * @SerializedName("name")
      *
-     * @return int
+     * @return string
      */
     public function getName()
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

It fixes the return type for the name property mentioned in the PHPDoc for the media API class.

#### Why?

It fixes the return type for the name property mentioned in the PHPDoc for the media API class.
