### PR TITLE
Remove self closing slash from seo tags

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Extension/seo.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Extension/seo.html.twig
@@ -54,19 +54,19 @@
 
 {%- block description -%}
     {%- if seoDescription -%}
-        <meta name="description" content="{{ seoDescription }}"/>
+        <meta name="description" content="{{ seoDescription }}">
     {%- endif -%}
 {%- endblock -%}
 
 {%- block keywords -%}
     {%- if seoKeywords -%}
-        <meta name="keywords" content="{{ seoKeywords }}"/>
+        <meta name="keywords" content="{{ seoKeywords }}">
     {%- endif -%}
 {%- endblock -%}
 
 {%- block robots -%}
     {%- if seoRobots -%}
-        <meta name="robots" content="{{ seoRobots }}"/>
+        <meta name="robots" content="{{ seoRobots }}">
     {%- endif -%}
 {%- endblock -%}
 
@@ -75,7 +75,7 @@
     {%- if localizations|length > 1 -%}
         {%- for localization in localizations -%}
             {%- if localization.alternate is not defined or localization.alternate -%}
-                <link rel="alternate" href="{{ localization.url }}" hreflang="{{ localization.locale|replace({'_': '-'}) }}"/>
+                <link rel="alternate" href="{{ localization.url }}" hreflang="{{ localization.locale|replace({'_': '-'}) }}">
             {%- endif -%}
         {%- endfor -%}
     {%- endif -%}
@@ -83,5 +83,5 @@
 
 {%- block canonical -%}
     {#- Set canonical to itself if a bot clone the page -#}
-    <link rel="canonical" href="{{ seoCanonical|default(app.request.uri) }}"/>
+    <link rel="canonical" href="{{ seoCanonical|default(app.request.uri) }}">
 {%- endblock -%}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove the closing slash from `<meta />` and `<link />`.

#### Why?

<img width="1534" alt="grafik" src="https://user-images.githubusercontent.com/1698337/195860517-1b17a700-8dca-4cd5-9ffa-d38b6f8da692.png">