### PR TITLE
Add CI tests for PHP 8.2

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -154,6 +154,20 @@ jobs:
                           DATABASE_CHARSET: utf8mb4
                           DATABASE_COLLATE: utf8mb4_unicode_ci
 
+                    - php-version: '8.2'
+                      database: mysql
+                      phpcr-transport: doctrinedbal
+                      dependency-versions: 'highest'
+                      php-extensions: 'ctype, iconv, mysql, imagick'
+                      tools: 'composer:v2'
+                      composer-stability: dev
+                      composer-options: '--ignore-platform-req="php"'
+                      env:
+                          SYMFONY_DEPRECATIONS_HELPER: weak
+                          DATABASE_URL: mysql://root:root@127.0.0.1:3306/sulu_test?serverVersion=5.7
+                          DATABASE_CHARSET: utf8mb4
+                          DATABASE_COLLATE: utf8mb4_unicode_ci
+
         services:
             mysql:
                 image: mysql:5.7
@@ -202,8 +216,9 @@ jobs:
               run: composer config minimum-stability ${{ matrix.composer-stability }}
 
             - name: Install composer dependencies
-              uses: ramsey/composer-install@v1
+              uses: ramsey/composer-install@v2
               with:
+                  composer-options: ${{matrix.composer-options}}
                   dependency-versions: ${{matrix.dependency-versions}}
 
             - name: Bootstrap test environment
@@ -238,7 +253,7 @@ jobs:
                   coverage: none
 
             - name: Install composer dependencies
-              uses: ramsey/composer-install@v1
+              uses: ramsey/composer-install@v2
               with:
                   dependency-versions: highest
 

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -158,7 +158,7 @@ jobs:
                       database: postgres
                       phpcr-transport: jackrabbit
                       dependency-versions: 'highest'
-                      php-extensions: 'ctype, iconv, mysql, imagick'
+                      php-extensions: 'ctype, iconv, mysql, gd'
                       tools: 'composer:v2'
                       composer-stability: dev
                       composer-options: '--ignore-platform-req="php"'

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -158,7 +158,7 @@ jobs:
                       database: postgres
                       phpcr-transport: doctrinedbal
                       dependency-versions: 'highest'
-                      php-extensions: 'ctype, iconv, mysql, gd'
+                      php-extensions: 'ctype, iconv, pdo_pgsql, pgsql, gd'
                       tools: 'composer:v2'
                       composer-stability: dev
                       composer-options: '--ignore-platform-req="php"'

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -155,8 +155,8 @@ jobs:
                           DATABASE_COLLATE: utf8mb4_unicode_ci
 
                     - php-version: '8.2'
-                      database: mysql
-                      phpcr-transport: doctrinedbal
+                      database: postgres
+                      phpcr-transport: jackrabbit
                       dependency-versions: 'highest'
                       php-extensions: 'ctype, iconv, mysql, imagick'
                       tools: 'composer:v2'
@@ -164,9 +164,9 @@ jobs:
                       composer-options: '--ignore-platform-req="php"'
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: weak
-                          DATABASE_URL: mysql://root:root@127.0.0.1:3306/sulu_test?serverVersion=5.7
-                          DATABASE_CHARSET: utf8mb4
-                          DATABASE_COLLATE: utf8mb4_unicode_ci
+                          DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/sulu_test?serverVersion=12.5
+                          DATABASE_CHARSET: UTF8
+                          DATABASE_COLLATE:
 
         services:
             mysql:

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -156,7 +156,7 @@ jobs:
 
                     - php-version: '8.2'
                       database: postgres
-                      phpcr-transport: jackrabbit
+                      phpcr-transport: doctrinedbal
                       dependency-versions: 'highest'
                       php-extensions: 'ctype, iconv, mysql, gd'
                       tools: 'composer:v2'


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | yes 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add CI tests for PHP 8.2.

#### Why?

PHP 8.2 will be released soon and sulu should be run on it. 