### PR TITLE
Add restart of preview when locale of form is changed

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
@@ -46,6 +46,7 @@ class Preview extends React.Component<Props> {
 
     schemaDisposer: () => mixed;
     dataDisposer: () => mixed;
+    localeDisposer: () => mixed;
 
     @computed get webspaceKey() {
         const {
@@ -88,7 +89,6 @@ class Preview extends React.Component<Props> {
         }));
 
         this.createPreviewStore();
-
         if (Preview.mode === 'auto') {
             this.startPreview();
         }
@@ -182,6 +182,13 @@ class Preview extends React.Component<Props> {
                 }
             }
         );
+
+        this.localeDisposer = reaction(
+            () => toJS(formStore.locale),
+            () => {
+                this.previewStore.restart();
+            }
+        );
     };
 
     updatePreview = debounce((data: Object) => {
@@ -221,6 +228,10 @@ class Preview extends React.Component<Props> {
 
         if (this.dataDisposer) {
             this.dataDisposer();
+        }
+
+        if (this.localeDisposer) {
+            this.localeDisposer();
         }
     }
 

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/stores/PreviewStore.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/stores/PreviewStore.js
@@ -89,6 +89,10 @@ export default class PreviewStore {
         });
     }
 
+    restart(): Promise<string> {
+        return this.stop().then(this.start);
+    }
+
     update(data: Object): Promise<string> {
         const route = generateRoute('update', {
             locale: this.locale,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #6831
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add a restart of preview if the locale of the form has changed.
