### PR TITLE
Add update of locale in previews PageObjectProvider

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Preview/PageObjectProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Preview/PageObjectProvider.php
@@ -70,6 +70,9 @@ class PageObjectProvider implements PreviewObjectProviderInterface
             ->enableMagicCall()
             ->getPropertyAccessor();
 
+        $object->setLocale($locale);
+        $object->setOriginalLocale($locale);
+
         $structure = $object->getStructure();
         foreach ($data as $property => $value) {
             try {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #6831
| Related issues/PRs | replaces #6861 , linked with https://github.com/sulu/SuluArticleBundle/pull/630
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add an update of locale and original locale on the preview document. To allow loading the data (e.g. teaser_selection) in the correct locale.