### PR TITLE
Add condition to StructureProvider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "jms/serializer": "^3.0",
         "jms/serializer-bundle": "^3.0 || ^4.0",
         "massive/build-bundle": "^0.3 || ^0.4 || ^0.5",
-        "massive/search-bundle": "^2.7",
+        "massive/search-bundle": "^2.0",
         "matomo/device-detector": "^3.7 || ^4.0.1",
         "nyholm/psr7": "^1.0",
         "oro/doctrine-extensions": "^1.0.8 || ^2.0",

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "jms/serializer": "^3.0",
         "jms/serializer-bundle": "^3.0 || ^4.0",
         "massive/build-bundle": "^0.3 || ^0.4 || ^0.5",
-        "massive/search-bundle": "^2.0",
+        "massive/search-bundle": "^2.7",
         "matomo/device-detector": "^3.7 || ^4.0.1",
         "nyholm/psr7": "^1.0",
         "oro/doctrine-extensions": "^1.0.8 || ^2.0",

--- a/src/Sulu/Bundle/PageBundle/Search/Metadata/StructureProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Search/Metadata/StructureProvider.php
@@ -317,7 +317,7 @@ EOT;
                     $this->mapProperty(
                         $componentProperty,
                         $propertyMapping,
-                        $component->getName() . '_',
+                        $componentProperty->getType() . '_',
                         'type === \'' . $component->getName() . '\''
                     );
                 }

--- a/src/Sulu/Bundle/PageBundle/Search/Metadata/StructureProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Search/Metadata/StructureProvider.php
@@ -288,8 +288,9 @@ EOT;
 
     /**
      * @param IndexMetadata|ComplexMetadata $metadata
+     * @param string|null $condition
      */
-    private function mapProperty(ItemMetadata $property, $metadata, string $prefix = '')
+    private function mapProperty(ItemMetadata $property, $metadata, string $prefix = '', $condition = null)
     {
         $propertyName = $prefix . $property->getName();
 
@@ -298,11 +299,13 @@ EOT;
                 \sprintf(
                     'object.getStructure().%s.getValue()',
                     $property->getName()
-                )
+                ),
+                $condition
             );
         } else {
             $field = $this->factory->createMetadataProperty(
-                '[' . $property->getName() . ']'
+                '[' . $property->getName() . ']',
+                $condition
             );
         }
 
@@ -314,7 +317,8 @@ EOT;
                     $this->mapProperty(
                         $componentProperty,
                         $propertyMapping,
-                        $component->getName() . '_'
+                        $component->getName() . '_',
+                        'type === \'' . $component->getName() . '\''
                     );
                 }
             }


### PR DESCRIPTION
Necessary for the MassiveSearchBundle so that too many fields are no longer generated for blocks.

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | yes - The search index has lesser fields now as only the necessary ones are created (and grouped).
| Deprecations? | no
| Fixed tickets | #6501 
| Related issues/PRs | https://github.com/massiveart/MassiveSearchBundle/pull/168/files
| License | MIT
| Documentation PR | -

#### What's in this PR?

This PR adds the `$condition` to the `mapProperty` method. This is necessary for the MassiveSearchBundle to validate if the field should be indexed or not (when using the same property names across multiple block types).

#### Why?

To fix the ElasticSearch error:

```
Limit of total fields [1000] has been exceeded
```