### PR TITLE
Fix search mapping prefix with multiple block types

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Search/Metadata/StructureProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Search/Metadata/StructureProvider.php
@@ -318,7 +318,7 @@ EOT;
                     $this->mapProperty(
                         $componentProperty,
                         $propertyMapping,
-                        $componentProperty->getType() . '_',
+                        $component->getName() . '_',
                         'type === \'' . $component->getName() . '\''
                     );
                 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
Related issues/PRs | #6868
| License | MIT

#### What's in this PR?

Changed search mapping prefix.

![SearchIndex)](https://user-images.githubusercontent.com/24388840/199053431-2cf8bc5b-8717-48d3-9fab-f1f301b1405d.png)
