### PR TITLE
Fix SecurityChecker if no firewall is active and enable_authenticator_manager is set to false

### DIFF
--- a/src/Sulu/Component/Security/Authorization/SecurityChecker.php
+++ b/src/Sulu/Component/Security/Authorization/SecurityChecker.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\Security\Authorization;
 
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 
 /**
  * Implementation of Sulu specific security checks, includes a subject, the type of permission and the localization.
@@ -48,8 +49,12 @@ class SecurityChecker extends AbstractSecurityChecker
             $subject = new SecurityCondition($subject);
         }
 
-        $granted = $this->authorizationChecker->isGranted($permission, $subject);
-
-        return $granted;
+        try {
+            return $this->authorizationChecker->isGranted($permission, $subject);
+        } catch (AuthenticationCredentialsNotFoundException $e) {
+            // the AuthorizationChecker service will throw an exception if enable_authenticator_manager is false and
+            // no firewall is active. we grant access per default if there is no active firewall
+            return true;
+        }
     }
 }

--- a/src/Sulu/Component/Security/Tests/Unit/Authorization/SecurityCheckerTest.php
+++ b/src/Sulu/Component/Security/Tests/Unit/Authorization/SecurityCheckerTest.php
@@ -119,7 +119,7 @@ class SecurityCheckerTest extends TestCase
         $this->assertTrue($this->securityChecker->checkPermission('sulu.media.collection', 'view'));
     }
 
-    public function testIsGrantedWithAuthenticationCredentialsNotFoundException (): void
+    public function testIsGrantedWithAuthenticationCredentialsNotFoundException(): void
     {
         $this->tokenStorage->getToken()->willReturn(null);
         $this->authorizationChecker->isGranted(Argument::any(), Argument::any())->willThrow(new AuthenticationCredentialsNotFoundException());

--- a/src/Sulu/Component/Security/Tests/Unit/Authorization/SecurityCheckerTest.php
+++ b/src/Sulu/Component/Security/Tests/Unit/Authorization/SecurityCheckerTest.php
@@ -19,6 +19,7 @@ use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 
 class SecurityCheckerTest extends TestCase
 {
@@ -114,6 +115,14 @@ class SecurityCheckerTest extends TestCase
     {
         $this->tokenStorage->getToken()->willReturn(null);
         $this->authorizationChecker->isGranted(Argument::any(), Argument::any())->willReturn(true);
+
+        $this->assertTrue($this->securityChecker->checkPermission('sulu.media.collection', 'view'));
+    }
+
+    public function testIsGrantedWithAuthenticationCredentialsNotFoundException (): void
+    {
+        $this->tokenStorage->getToken()->willReturn(null);
+        $this->authorizationChecker->isGranted(Argument::any(), Argument::any())->willThrow(new AuthenticationCredentialsNotFoundException());
 
         $this->assertTrue($this->securityChecker->checkPermission('sulu.media.collection', 'view'));
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Fixed tickets | fixes #6880
| Related issues/PRs | #6837
| License | MIT

#### What's in this PR?

This pull request fixes the behaviour of our `SecurityChecker` service in the case where no firewall is active and `enable_authenticator_manager` is set to false. The problem that is fixed was introduced in #6837.
