### PR TITLE
Add helpfully links to browser dev console in Sulu Admin

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -354,15 +354,17 @@ function processConfig(config: Object) {
 function startAdmin() {
     // eslint-disable-next-line no-console
     console.log(
-        '%cWelcome to Sulu CMS 👋' + "\n" +
-        "%c\n" +
-        'The Symfony based content management platform.' + "\n" +
-        "\n" +
-        '📖 Developer documentation: %chttps://docs.sulu.io/%c, %chttps://jsdocs.sulu.io/%c and %chttps://symfony.com/doc%c' + "\n" +
-        '🤝 Contribute to Sulu: %chttps://github.com/sulu/sulu%c' + "\n" +
-        '🔎 Create a new issue: %chttps://github.com/sulu/sulu/issues%c' + "\n" +
-        '🪜 Examples: %chttps://github.com/sulu/sulu-demo%c and %chttps://github.com/sulu/sulu-workshop%c' + "\n" +
-        "\n" +
+        '%cWelcome to Sulu CMS 👋' + '\n' +
+        '%c\n' +
+        'The Symfony based content management platform.' + '\n' +
+        '\n' +
+        '📖 Developer documentation: %chttps://docs.sulu.io/%c,' +
+        ' %chttps://jsdocs.sulu.io/%c and %chttps://symfony.com/doc%c' + '\n' +
+        '🤝 Contribute to Sulu: %chttps://github.com/sulu/sulu%c' + '\n' +
+        '🔎 Create a new issue: %chttps://github.com/sulu/sulu/issues%c' + '\n' +
+        '🪜 Implementation examples: %chttps://github.com/sulu/sulu-demo%c' +
+        ' and %chttps://github.com/sulu/sulu-workshop%c' + '\n' +
+        '\n' +
         'If you like Sulu – give it a ⭐ on Github: %chttps://github.com/sulu/sulu%c',
         'font-family: monospace; font-size: 24px; font-weight: bold;',
         'font-family: monospace; font-size: 10px;',
@@ -381,7 +383,7 @@ function startAdmin() {
         'font-family: monospace; font-size: 10px; text-decoration: underline;',
         'font-family: monospace; font-size: 10px; text-decoration: none;',
         'font-family: monospace; font-size: 10px; text-decoration: underline;',
-        'font-family: monospace; font-size: 10px; text-decoration: none;',
+        'font-family: monospace; font-size: 10px; text-decoration: none;'
     );
 
     if (Config.suluVersion !== SULU_ADMIN_BUILD_VERSION) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -352,6 +352,38 @@ function processConfig(config: Object) {
 }
 
 function startAdmin() {
+    // eslint-disable-next-line no-console
+    console.log(
+        '%cWelcome to Sulu CMS 👋' + "\n" +
+        "%c\n" +
+        'The Symfony based content management platform.' + "\n" +
+        "\n" +
+        '📖 Developer documentation: %chttps://docs.sulu.io/%c, %chttps://jsdocs.sulu.io/%c and %chttps://symfony.com/doc%c' + "\n" +
+        '🤝 Contribute to Sulu: %chttps://github.com/sulu/sulu%c' + "\n" +
+        '🔎 Create a new issue: %chttps://github.com/sulu/sulu/issues%c' + "\n" +
+        '🪜 Examples: %chttps://github.com/sulu/sulu-demo%c and %chttps://github.com/sulu/sulu-workshop%c' + "\n" +
+        "\n" +
+        'If you like Sulu – give it a ⭐ on Github: %chttps://github.com/sulu/sulu%c',
+        'font-family: monospace; font-size: 24px; font-weight: bold;',
+        'font-family: monospace; font-size: 10px;',
+        'font-family: monospace; font-size: 10px; text-decoration: underline;',
+        'font-family: monospace; font-size: 10px; text-decoration: none;',
+        'font-family: monospace; font-size: 10px; text-decoration: underline;',
+        'font-family: monospace; font-size: 10px; text-decoration: none;',
+        'font-family: monospace; font-size: 10px; text-decoration: underline;',
+        'font-family: monospace; font-size: 10px; text-decoration: none;',
+        'font-family: monospace; font-size: 10px; text-decoration: underline;',
+        'font-family: monospace; font-size: 10px; text-decoration: none;',
+        'font-family: monospace; font-size: 10px; text-decoration: underline;',
+        'font-family: monospace; font-size: 10px; text-decoration: none;',
+        'font-family: monospace; font-size: 10px; text-decoration: underline;',
+        'font-family: monospace; font-size: 10px; text-decoration: none;',
+        'font-family: monospace; font-size: 10px; text-decoration: underline;',
+        'font-family: monospace; font-size: 10px; text-decoration: none;',
+        'font-family: monospace; font-size: 10px; text-decoration: underline;',
+        'font-family: monospace; font-size: 10px; text-decoration: none;',
+    );
+
     if (Config.suluVersion !== SULU_ADMIN_BUILD_VERSION) {
         log.error(
             'Sulu administration interface: JavaScript build version mismatch' +


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add helpfully links to browser dev console in Sulu Admin.

#### Why?

Inspired by Gitlab Dev Tools message.

#### Example Usage

<img width="1402" alt="Bildschirmfoto 2022-11-04 um 01 15 01" src="https://user-images.githubusercontent.com/1698337/199858582-56f2ae95-5b73-438e-b237-e7f1b6e3390e.png">
