### PR TITLE
Add admin resource URLs to FOSJsRouter automatically

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/ExposeResourceRoutesPass.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/ExposeResourceRoutesPass.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * This compiler pass is responsible for adding all configured admin resource
+ * routes to `fos_js_routing.routes_to_expose` extension config automatically.
+ *
+ * @final
+ *
+ * @internal
+ */
+class ExposeResourceRoutesPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $resources = $container->getParameter('sulu_admin.resources');
+
+        $routeNames = [];
+
+        // Collect all resource routes that have to be exposed
+        foreach ($resources as $resource) {
+            if (isset($resource['routes'])) {
+                foreach ($resource['routes'] as $routeName) {
+                    $routeNames[] = $routeName;
+                }
+            }
+        }
+
+        $extractorDefinition = $container->getDefinition('fos_js_routing.extractor');
+        $allRouteNames = \array_unique(\array_merge($extractorDefinition->getArgument(1), $routeNames));
+
+        $extractorDefinition->replaceArgument(1, $allRouteNames);
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/ExposeResourceRoutesPass.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/ExposeResourceRoutesPass.php
@@ -32,7 +32,7 @@ class ExposeResourceRoutesPass implements CompilerPassInterface
 
         // Collect all resource routes that have to be exposed
         foreach ($resources as $resource) {
-            if (isset($resource['routes'])) {
+            if (isset($resource['routes'])) { // @phpstan-ignore-line
                 foreach ($resource['routes'] as $routeName) {
                     $routeNames[] = $routeName;
                 }
@@ -40,8 +40,13 @@ class ExposeResourceRoutesPass implements CompilerPassInterface
         }
 
         $extractorDefinition = $container->getDefinition('fos_js_routing.extractor');
-        $allRouteNames = \array_unique(\array_merge($extractorDefinition->getArgument(1), $routeNames));
+        $alreadyDefinedRouteNames = $extractorDefinition->getArgument(1);
 
+        if (!is_array($alreadyDefinedRouteNames)) {
+            throw new \InvalidArgumentException('Invalid type of the second argument of service "fos_js_routing.extractor". Expected array.');
+        }
+
+        $allRouteNames = \array_unique(\array_merge($alreadyDefinedRouteNames, $routeNames));
         $extractorDefinition->replaceArgument(1, $allRouteNames);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/ExposeResourceRoutesPass.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/ExposeResourceRoutesPass.php
@@ -42,7 +42,7 @@ class ExposeResourceRoutesPass implements CompilerPassInterface
         $extractorDefinition = $container->getDefinition('fos_js_routing.extractor');
         $alreadyDefinedRouteNames = $extractorDefinition->getArgument(1);
 
-        if (!is_array($alreadyDefinedRouteNames)) {
+        if (!\is_array($alreadyDefinedRouteNames)) {
             throw new \InvalidArgumentException('Invalid type of the second argument of service "fos_js_routing.extractor". Expected array.');
         }
 

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
@@ -105,7 +105,6 @@ class SuluAdminExtension extends Extension implements PrependExtensionInterface
                     'routes_to_expose' => [
                         '(.+\.)?c?get_.*',
                         'sulu_admin.metadata',
-                        'sulu_admin.put_collaborations',
                     ],
                 ]
             );

--- a/src/Sulu/Bundle/AdminBundle/SuluAdminBundle.php
+++ b/src/Sulu/Bundle/AdminBundle/SuluAdminBundle.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\AdminBundle;
 
 use Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\AddAdminPass;
 use Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\AddMetadataProviderPass;
+use Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\ExposeResourceRoutesPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -24,5 +25,9 @@ class SuluAdminBundle extends Bundle
 
         $container->addCompilerPass(new AddAdminPass());
         $container->addCompilerPass(new AddMetadataProviderPass());
+
+        if ($container->hasExtension('fos_js_routing')) {
+            $container->addCompilerPass(new ExposeResourceRoutesPass());
+        }
     }
 }

--- a/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
+++ b/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
@@ -250,19 +250,6 @@ class SuluContactExtension extends Extension implements PrependExtensionInterfac
             );
         }
 
-        if ($container->hasExtension('fos_js_routing')) {
-            $container->prependExtensionConfig(
-                'fos_js_routing',
-                [
-                    'routes_to_expose' => [
-                        'sulu_contact.delete_contact_medias',
-                        'sulu_contact.delete_account_medias',
-                        'sulu_contact.delete_account_contacts',
-                    ],
-                ]
-            );
-        }
-
         if ($container->hasExtension('fos_rest')) {
             $container->prependExtensionConfig(
                 'fos_rest',

--- a/src/Sulu/Bundle/LocationBundle/DependencyInjection/SuluLocationExtension.php
+++ b/src/Sulu/Bundle/LocationBundle/DependencyInjection/SuluLocationExtension.php
@@ -35,17 +35,6 @@ class SuluLocationExtension extends Extension implements PrependExtensionInterfa
                 ]
             );
         }
-
-        if ($container->hasExtension('fos_js_routing')) {
-            $container->prependExtensionConfig(
-                'fos_js_routing',
-                [
-                    'routes_to_expose' => [
-                        'sulu_location.geolocator_query',
-                    ],
-                ]
-            );
-        }
     }
 
     public function load(array $configs, ContainerBuilder $container)

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -102,9 +102,6 @@ class SuluMediaExtension extends Extension implements PrependExtensionInterface
                 'fos_js_routing',
                 [
                     'routes_to_expose' => [
-                        'sulu_media.put_media_format',
-                        'sulu_media.delete_media_version',
-                        'sulu_media.post_media_preview',
                         'sulu_media.redirect',
                     ],
                 ]

--- a/src/Sulu/Bundle/PageBundle/DependencyInjection/SuluPageExtension.php
+++ b/src/Sulu/Bundle/PageBundle/DependencyInjection/SuluPageExtension.php
@@ -211,17 +211,6 @@ class SuluPageExtension extends Extension implements PrependExtensionInterface
             );
         }
 
-        if ($container->hasExtension('fos_js_routing')) {
-            $container->prependExtensionConfig(
-                'fos_js_routing',
-                [
-                    'routes_to_expose' => [
-                        'sulu_page.post_page_version_trigger',
-                    ],
-                ]
-            );
-        }
-
         if ($container->hasExtension('sulu_search')) {
             $container->prependExtensionConfig(
                 'sulu_page',

--- a/src/Sulu/Bundle/SearchBundle/DependencyInjection/SuluSearchExtension.php
+++ b/src/Sulu/Bundle/SearchBundle/DependencyInjection/SuluSearchExtension.php
@@ -41,18 +41,6 @@ class SuluSearchExtension extends Extension implements PrependExtensionInterface
             );
         }
 
-        if ($container->hasExtension('fos_js_routing')) {
-            $container->prependExtensionConfig(
-                'fos_js_routing',
-                [
-                    'routes_to_expose' => [
-                        'sulu_search_indexes',
-                        'sulu_search_search',
-                    ],
-                ]
-            );
-        }
-
         $container->prependExtensionConfig('jms_serializer', [
             'metadata' => [
                 'directories' => [

--- a/src/Sulu/Bundle/SnippetBundle/DependencyInjection/SuluSnippetExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/DependencyInjection/SuluSnippetExtension.php
@@ -103,17 +103,6 @@ class SuluSnippetExtension extends Extension implements PrependExtensionInterfac
             );
         }
 
-        if ($container->hasExtension('fos_js_routing')) {
-            $container->prependExtensionConfig(
-                'fos_js_routing',
-                [
-                    'routes_to_expose' => [
-                        'sulu_snippet.put_snippet-area',
-                    ],
-                ]
-            );
-        }
-
         if ($container->hasExtension('sulu_search')) {
             $container->prependExtensionConfig(
                 'sulu_search',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #6886
| License | MIT
| Documentation PR | -

#### What's in this PR?

A new compiler pass collects all configured routes for admin resources and adds them to the argument of the `ExposedRoutesExtractor` service of the FOSJsRouterBundle. This way it is not required to follow a naming convention for those routes or add them to the bundle's config manually anymore.

#### Why?

Improve developer experience.

#### Example Usage

irrelevant

#### To Do

- nothing
