### PR TITLE
Use PHP_BINARY in bin/runtests scripts

### DIFF
--- a/bin/runtests
+++ b/bin/runtests
@@ -117,7 +117,7 @@ function exec_sf_cmd($cmd, $echo = true, $checkForError = true)
     }
 
     return exec_cmd(
-        'php ' . get_test_console_path() . ' ' . $cmd,
+        PHP_BINARY . ' ' . get_test_console_path() . ' ' . $cmd,
         $echo,
         $checkForError
     );
@@ -254,7 +254,7 @@ function run_bundle_tests(\SplFileInfo $phpunitFile)
     $flags = $input->getOption('flags');
 
     $process = exec_cmd(sprintf(
-        '%s --configuration %s %s',
+        PHP_BINARY . ' %s --configuration %s %s',
         get_phpunit_path(),
         $phpunitFile->getPathname(),
         $flags
@@ -286,7 +286,7 @@ function init_bundle()
     }
 
     $process = exec_cmd(sprintf(
-        'php %s %s',
+        PHP_BINARY . ' %s %s',
         $console,
         'debug:container doctrine.orm.entity_manager'
     ), false, false);
@@ -299,13 +299,13 @@ function init_bundle()
     write_info('Doctrine ORM detected, updating the schema for the bundle.');
 
     exec_cmd(sprintf(
-        'php %s %s',
+        PHP_BINARY . ' %s %s',
         $console,
         ' doctrine:schema:update --force'
     ));
 
     exec_cmd(sprintf(
-        'php %s %s',
+        PHP_BINARY . ' %s %s',
         $console,
         ' sulu:document:initialize --purge --force --ansi'
     ));


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Use PHP_BINARY in bin/runtests scripts.

#### Why?

When running the script via `php@8.1 bin/runtests` it should also use for all subprocesses `php@8.1` and not fallback to `php` script. This avoids that a PHP version need explicit to be switched globally.
