### PR TITLE
Add FOSJSRouting endpoint regression test

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
@@ -4,6 +4,11 @@ fos_js_routing:
     resource: "@FOSJsRoutingBundle/Resources/config/routing/routing.xml"
 
 # Sulu Routes
+sulu_tag_api:
+    type: rest
+    resource: "@SuluTagBundle/Resources/config/routing_api.yml"
+    prefix:   /admin/api
+
 sulu_admin:
     resource: "@SuluAdminBundle/Resources/config/routing.yml"
     prefix: /admin
@@ -11,6 +16,11 @@ sulu_admin:
 sulu_admin_api:
     resource: "@SuluAdminBundle/Resources/config/routing_api.yml"
     type: rest
+    prefix: /admin/api
+
+sulu_contact_api:
+    type: rest
+    resource: "@SuluContactBundle/Resources/config/routing_api.yml"
     prefix: /admin/api
 
 sulu_security:
@@ -31,9 +41,51 @@ sulu_media:
     resource: "@SuluMediaBundle/Resources/config/routing.yml"
     prefix: /admin/media
 
+sulu_media_website:
+    resource: "@SuluMediaBundle/Resources/config/routing_website.yml"
+
+sulu_media_api:
+    type: rest
+    resource: "@SuluMediaBundle/Resources/config/routing_api.yml"
+    prefix: /admin/api
+
+sulu_category_api:
+    type: rest
+    resource: "@SuluCategoryBundle/Resources/config/routing_api.yml"
+    prefix: /admin/api
+
+sulu_snippet_api:
+    resource: "@SuluSnippetBundle/Resources/config/routing_api.yml"
+    type: rest
+    prefix: /admin/api
+
+sulu_location:
+    resource: "@SuluLocationBundle/Resources/config/routing.yml"
+    prefix: /admin/location
+
 sulu_website:
     resource: "@SuluWebsiteBundle/Resources/config/routing.yml"
     prefix: /admin/website
+
+sulu_website_api:
+    resource: "@SuluWebsiteBundle/Resources/config/routing_api.yml"
+    type: rest
+    prefix: /admin/api
+
+sulu_core:
+    type: rest
+    resource: "@SuluCoreBundle/Resources/config/routing_api.yml"
+    prefix: /admin/api
+
+sulu_custom_urls_api:
+    type: rest
+    resource: "@SuluCustomUrlBundle/Resources/config/routing_api.yml"
+    prefix: /admin/api
+
+sulu_route_api:
+    type: rest
+    resource: "@SuluRouteBundle/Resources/config/routing_api.yml"
+    prefix: /admin/api
 
 sulu_preview:
     resource: "@SuluPreviewBundle/Resources/config/routing.yml"
@@ -47,3 +99,22 @@ sulu_preview_api:
 sulu_preview_public:
     resource: "@SuluPreviewBundle/Resources/config/routing_public.yml"
     prefix: /admin/p
+
+sulu_search:
+    resource: "@SuluSearchBundle/Resources/config/routing.yml"
+    prefix: /admin/search
+
+sulu_audience_targeting_api:
+    type: rest
+    resource: "@SuluAudienceTargetingBundle/Resources/config/routing_api.yml"
+    prefix: /admin/api
+
+sulu_activity_api:
+    resource: "@SuluActivityBundle/Resources/config/routing_api.yml"
+    type: rest
+    prefix: /admin/api
+
+sulu_trash_api:
+    resource: "@SuluTrashBundle/Resources/config/routing_api.yml"
+    type: rest
+    prefix: /admin/api

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/FOSJSRoutingControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/FOSJSRoutingControllerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Functional\Controller;
+
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+class FOSJSRoutingControllerTest extends SuluTestCase
+{
+    /**
+     * @var KernelBrowser
+     */
+    private $client;
+
+    public function setUp(): void
+    {
+        $this->client = $this->createAuthenticatedClient();
+    }
+
+    public function testExposedRoutes(): void
+    {
+        $this->client->jsonRequest('GET', '/admin/js/routing.json');
+        $response = $this->client->getResponse();
+
+        $this->assertHttpStatusCode(200, $response);
+        $content = $response->getContent();
+        $this->assertIsString($content);
+
+        $json = \json_decode($content, true);
+        $this->assertIsArray($json);
+        $this->assertArrayHasKey('routes', $json);
+
+        $routes = \array_keys($json['routes']);
+        \sort($routes);
+
+        $this->assertSame([
+            'sulu_activity.get_activities',
+            'sulu_admin.metadata',
+            'sulu_admin.put_collaborations',
+            'sulu_audience_targeting.get_target-group',
+            'sulu_audience_targeting.get_target-groups',
+            'sulu_category.get_categories',
+            'sulu_category.get_category',
+            'sulu_category.get_category_keyword',
+            'sulu_category.get_category_keywords',
+            'sulu_contact.cget_account_medias',
+            'sulu_contact.cget_contact_medias',
+            'sulu_contact.delete_account_contacts',
+            'sulu_contact.delete_account_medias',
+            'sulu_contact.delete_contact_medias',
+            'sulu_contact.get_account',
+            'sulu_contact.get_account_addresses',
+            'sulu_contact.get_account_contacts',
+            'sulu_contact.get_account_deleteinfo',
+            'sulu_contact.get_account_medias',
+            'sulu_contact.get_accounts',
+            'sulu_contact.get_contact',
+            'sulu_contact.get_contact-position',
+            'sulu_contact.get_contact-positions',
+            'sulu_contact.get_contact-title',
+            'sulu_contact.get_contact-titles',
+            'sulu_contact.get_contact_medias',
+            'sulu_contact.get_contacts',
+            'sulu_core.get_localizations',
+            'sulu_custom_url.cget_webspace_custom-urls',
+            'sulu_custom_url.get_webspace_custom-urls',
+            'sulu_custom_url.get_webspace_custom-urls_routes',
+            'sulu_location.geolocator_query',
+            'sulu_media.cget_media',
+            'sulu_media.delete_media_version',
+            'sulu_media.get_collection',
+            'sulu_media.get_collections',
+            'sulu_media.get_formats',
+            'sulu_media.get_media',
+            'sulu_media.get_media_formats',
+            'sulu_media.post_media_preview',
+            'sulu_media.put_media_format',
+            'sulu_media.redirect',
+            'sulu_page.get_items',
+            'sulu_page.get_page',
+            'sulu_page.get_page_resourcelocators',
+            'sulu_page.get_pages',
+            'sulu_page.get_teasers',
+            'sulu_page.get_webspace',
+            'sulu_page.get_webspace_localizations',
+            'sulu_page.get_webspaces',
+            'sulu_preview.get_preview-link',
+            'sulu_routes.get_routes',
+            'sulu_search_indexes',
+            'sulu_search_search',
+            'sulu_security.cget_security-contexts',
+            'sulu_security.get_group',
+            'sulu_security.get_groups',
+            'sulu_security.get_permissions',
+            'sulu_security.get_profile',
+            'sulu_security.get_role',
+            'sulu_security.get_role_setting',
+            'sulu_security.get_roles',
+            'sulu_security.get_security-contexts',
+            'sulu_security.get_user',
+            'sulu_security.get_users',
+            'sulu_snippet.get_languages',
+            'sulu_snippet.get_snippet',
+            'sulu_snippet.get_snippet-areas',
+            'sulu_snippet.get_snippets',
+            'sulu_snippet.put_snippet-area',
+            'sulu_tag.get_tag',
+            'sulu_tag.get_tags',
+            'sulu_trash.get_trash-item',
+            'sulu_trash.get_trash-items',
+            'sulu_website.cget_webspace_analytics',
+            'sulu_website.get_webspace_analytics',
+        ], $routes);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add FOSJSRouting endpoint regression test.

#### Why?

A regression test to avoid that some changes like in #6886 / #6893 will accidently remove a route or add unnecessary routes.
