### PR TITLE
Allows CategoryConverter to convert documents without a locale

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4651,11 +4651,6 @@ parameters:
 			path: src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
 
 		-
-			message: "#^Parameter \\#1 \\$locale of method Sulu\\\\Bundle\\\\CategoryBundle\\\\Entity\\\\CategoryInterface\\:\\:findTranslationByLocale\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
-
-		-
 			message: "#^Parameter \\#1 \\$locale of method Sulu\\\\Bundle\\\\CategoryBundle\\\\Entity\\\\KeywordInterface\\:\\:setLocale\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
@@ -4682,11 +4677,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$value of method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\AbstractListBuilder\\:\\:where\\(\\) expects string, Sulu\\\\Bundle\\\\CategoryBundle\\\\Entity\\\\CategoryTranslationInterface given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\AbstractListBuilder\\:\\:where\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
 

--- a/src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
@@ -127,13 +127,15 @@ class KeywordController extends AbstractRestController implements ClassResourceI
         $listBuilder = $this->listBuilderFactory->create($this->keywordClass);
         $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptor);
 
-        $categoryTranslation = $category->findTranslationByLocale($request->get('locale'));
+        /** @var string $locale */
+        $locale = $request->get('locale');
+        $categoryTranslation = $category->findTranslationByLocale($locale);
 
         if (false == $categoryTranslation) {
             return $this->handleView($this->view(null, 404));
         }
 
-        $listBuilder->where($fieldDescriptor['locale'], $request->get('locale'));
+        $listBuilder->where($fieldDescriptor['locale'], $locale);
         $listBuilder->where(
             $fieldDescriptor['categoryTranslationIds'],
             $categoryTranslation

--- a/src/Sulu/Bundle/CategoryBundle/Entity/CategoryInterface.php
+++ b/src/Sulu/Bundle/CategoryBundle/Entity/CategoryInterface.php
@@ -163,7 +163,7 @@ interface CategoryInterface extends AuditableInterface
     /**
      * Get single meta by locale or false if does not exists.
      *
-     * @param string $locale
+     * @param ?string $locale
      *
      * @return CategoryTranslationInterface|false
      */

--- a/src/Sulu/Bundle/CategoryBundle/Search/Converter/CategoryConverter.php
+++ b/src/Sulu/Bundle/CategoryBundle/Search/Converter/CategoryConverter.php
@@ -102,7 +102,7 @@ class CategoryConverter implements ConverterInterface
     /**
      * @return Field[]
      */
-    private function getFieldsById(int $id, string $locale): array
+    private function getFieldsById(int $id, ?string $locale): array
     {
         try {
             $category = $this->categoryManager->findById($id);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | yes
| BC breaks? | no
| Fixed tickets | fixes #6900 
| License | MIT

#### What's in this PR?

Adds nullable datatype to `getFieldsById` method, the method was already able to handle categories without a locale with a fallback to the default category locale, but the method parameter `string $locale` was blocking it.

#### Why?

Fixes #6900 