### PR TITLE
Ignore php.ini and .php-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,11 @@ phpunit.xml
 jackrabbit-standalone*
 jackrabbit/*
 
+# Symfony CLI
+# https://symfony.com/doc/current/setup/symfony_server.html#different-php-settings-per-project
+/php.ini
+/.php-version
+
 ###> symfony/framework-bundle ###
 /.env.local
 /.env.local.php


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets |
| Related issues/PRs |
| License | MIT
| Documentation PR |

#### What's in this PR?

Ignore php.ini and .php-version which are used when working with Symfony CLI.
