### PR TITLE
Remove default value for title sulu-link attributes

### DIFF
--- a/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
@@ -83,7 +83,7 @@ class LinkTag implements TagInterface
 
                 $title = $item->getTitle();
                 $attributes['href'] = $url;
-                $attributes['title'] = $this->getValue($attributes, 'title', $title);
+                $attributes['title'] = $this->getValue($attributes, 'title');
             } elseif ($this->isPreview && self::VALIDATE_UNPUBLISHED === $validationState) {
                 // render anchor without href to keep styling even if target is not published in preview
                 $title = $this->getContent($attributes);

--- a/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
@@ -83,12 +83,10 @@ class LinkTag implements TagInterface
 
                 $title = $item->getTitle();
                 $attributes['href'] = $url;
-                $attributes['title'] = $this->getValue($attributes, 'title');
             } elseif ($this->isPreview && self::VALIDATE_UNPUBLISHED === $validationState) {
                 // render anchor without href to keep styling even if target is not published in preview
                 $title = $this->getContent($attributes);
                 $attributes['href'] = null;
-                $attributes['title'] = $this->getValue($attributes, 'title');
             } else {
                 // only render text instead of anchor to prevent dead links on website
                 $result[$tag] = $this->getContent($attributes);

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
@@ -93,7 +93,7 @@ class LinkTagTest extends TestCase
                 '<sulu-link href="123-123-123" provider="article">Test-Content</sulu-link>',
                 ['href' => '123-123-123', 'content' => 'Test-Content', 'provider' => 'article'],
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
-                '<a href="http://sulu.lo/de/test" title="Page-Title">Test-Content</a>',
+                '<a href="http://sulu.lo/de/test">Test-Content</a>',
             ],
             [
                 '<sulu-link href="123-123-123" title="Test-Title" target="_blank" provider="article">Test-Content</sulu-link>',
@@ -128,7 +128,7 @@ class LinkTagTest extends TestCase
                     'content' => 'Test-Content',
                 ],
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
-                '<a href="http://sulu.lo/de/test" class="test" title="Page-Title">Test-Content</a>',
+                '<a href="http://sulu.lo/de/test" class="test">Test-Content</a>',
             ],
             [
                 '<sulu-link href="123-123-123" title="Test-Title" class="test" provider="article">Test-Content</sulu-link>',
@@ -230,7 +230,7 @@ class LinkTagTest extends TestCase
 
         $this->assertEquals(
             [
-                $tag1 => '<a href="http://sulu.lo/de/test-1" title="Page-Title 1">Test-Content</a>',
+                $tag1 => '<a href="http://sulu.lo/de/test-1">Test-Content</a>',
                 $tag2 => '<a href="http://sulu.lo/de/test-2" title="Test-Title">Page-Title 2</a>',
                 $tag3 => '<a href="http://sulu.lo/de/test-1" title="Test-Title">Test-Content</a>',
                 $tag4 => '<a href="http://sulu.lo/de/test-1" title="Test-Title" target="_blank">Test-Content</a>',
@@ -267,8 +267,8 @@ class LinkTagTest extends TestCase
 
         $this->assertEquals(
             [
-                $tag1 => '<a href="http://sulu.lo/de/test-2" title="Page-Title 2">Page-Title 2</a>',
-                $tag2 => '<a href="http://sulu.lo/de/test-1" title="Page-Title 1">Page-Title 1</a>',
+                $tag1 => '<a href="http://sulu.lo/de/test-2">Page-Title 2</a>',
+                $tag2 => '<a href="http://sulu.lo/de/test-1">Page-Title 1</a>',
             ],
             $result
         );
@@ -302,8 +302,8 @@ class LinkTagTest extends TestCase
 
         $this->assertEquals(
             [
-                $tag1 => '<a href="http://sulu.lo/de/test-2" title="Page-Title 2">Page-Title 2</a>',
-                $tag2 => '<a href="http://sulu.lo/de/test-1" title="Page-Title 1">Page-Title 1</a>',
+                $tag1 => '<a href="http://sulu.lo/de/test-2">Page-Title 2</a>',
+                $tag2 => '<a href="http://sulu.lo/de/test-1">Page-Title 1</a>',
             ],
             $result
         );

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Markup/LinkTagTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Markup/LinkTagTest.php
@@ -130,7 +130,7 @@ class LinkTagTest extends TestCase
             [
                 '<sulu-link href="123-123-123">Test-Content</sulu-link>',
                 ['href' => '123-123-123', 'content' => 'Test-Content'],
-                '<a href="/de/test" title="Pagetitle">Test-Content</a>',
+                '<a href="/de/test">Test-Content</a>',
             ],
             [
                 '<sulu-link href="123-123-123" title="Test-Title" target="_blank">Test-Content</sulu-link>',
@@ -215,7 +215,7 @@ class LinkTagTest extends TestCase
 
         $this->assertEquals(
             [
-                $tag1 => '<a href="/de/test-1" title="1">Test-Content</a>',
+                $tag1 => '<a href="/de/test-1">Test-Content</a>',
                 $tag2 => '<a href="/de/test-2" title="Test-Title">2</a>',
                 $tag3 => '<a href="/de/test-1" title="Test-Title">Test-Content</a>',
                 $tag4 => '<a href="/de/test-1" title="Test-Title" target="_blank">Test-Content</a>',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove default value for title sulu-link attributes.

#### Why?

The `title` attribute hurts the accessibility of pages as screenreaders will output them and should be avoided.