### PR TITLE
Add emoji support for url slugger

### DIFF
--- a/src/Sulu/Component/PHPCR/PathCleanup.php
+++ b/src/Sulu/Component/PHPCR/PathCleanup.php
@@ -29,12 +29,7 @@ class PathCleanup implements PathCleanupInterface
     /**
      * @var SluggerInterface
      */
-    private $sluggerWithEmoji;
-
-    /**
-     * @var SluggerInterface
-     */
-    private $sluggerWithoutEmoji;
+    private $slugger;
 
     /**
      * valid pattern for path
@@ -59,13 +54,11 @@ class PathCleanup implements PathCleanupInterface
         }
 
         if (\method_exists($slugger, 'withEmoji')) {
-            $this->sluggerWithEmoji = $slugger->withEmoji();
-        } else {
-            $this->sluggerWithEmoji = $slugger;
+            $slugger = $slugger->withEmoji();
         }
 
         $this->replacers = $replacers;
-        $this->sluggerWithoutEmoji = $slugger;
+        $this->slugger = $slugger;
     }
 
     /**
@@ -85,6 +78,7 @@ class PathCleanup implements PathCleanupInterface
                 $replacers,
                 isset($this->replacers[$languageCode]) ? $this->replacers[$languageCode] : []
             );
+            $languageCode = \str_replace('-', '_', $languageCode);
         }
 
         if (\count($replacers) > 0) {
@@ -113,11 +107,7 @@ class PathCleanup implements PathCleanupInterface
 
         $totalParts = \count($parts);
         foreach ($parts as $i => $part) {
-            try {
-                $slug = $this->sluggerWithEmoji->slug($part, '-', $languageCode);
-            } catch (\IntlException $e) { // handle unknown emoji transliterator id
-                $slug = $this->sluggerWithoutEmoji->slug($part, '-', $languageCode);
-            }
+            $slug = $this->slugger->slug($part, '-', $languageCode);
             $slug = $slug->lower();
             if (0 === $i || $i + 1 === $totalParts || !$slug->isEmpty()) {
                 $newParts[] = $slug->toString();

--- a/src/Sulu/Component/PHPCR/PathCleanup.php
+++ b/src/Sulu/Component/PHPCR/PathCleanup.php
@@ -106,7 +106,16 @@ class PathCleanup implements PathCleanupInterface
 
         $totalParts = \count($parts);
         foreach ($parts as $i => $part) {
-            $slug = $this->slugger->slug($part, '-', $languageCode);
+            try {
+                $slug = $this->slugger->slug($part, '-', $languageCode);
+            } catch (\IntlException $e) { // handle unknown emoji transliterator id
+                if (\method_exists($this->slugger, 'withEmoji')) {
+                    $this->slugger = $this->slugger->withEmoji(false);
+                    $slug = $this->slugger->slug($part, '-', $languageCode);
+                } else {
+                    throw $e;
+                }
+            }
             $slug = $slug->lower();
             if (0 === $i || $i + 1 === $totalParts || !$slug->isEmpty()) {
                 $newParts[] = $slug->toString();

--- a/src/Sulu/Component/PHPCR/PathCleanup.php
+++ b/src/Sulu/Component/PHPCR/PathCleanup.php
@@ -53,6 +53,10 @@ class PathCleanup implements PathCleanupInterface
             $slugger = new AsciiSlugger();
         }
 
+        if (\method_exists($slugger, 'withEmoji')) {
+            $slugger = $slugger->withEmoji();
+        }
+
         $this->replacers = $replacers;
         $this->slugger = $slugger;
     }

--- a/src/Sulu/Component/PHPCR/Tests/Unit/PathCleanupTest.php
+++ b/src/Sulu/Component/PHPCR/Tests/Unit/PathCleanupTest.php
@@ -115,8 +115,8 @@ class PathCleanupTest extends TestCase
 
     public function emojiCleanupProvider(): \Generator
     {
-        yield ['a 😺, and a 🦁 go to 🏞️', 'a-grinning-cat-and-a-lion-go-to-national-park', 'en'];
-        yield ['Menus with 🍕 or 🍝', 'menus-with-pizza-or-spaghetti', 'en'];
-        yield ['Menus with 🍕 or 🍝', 'menus-with-or', 'unknown'];
+        yield 'default' => ['a 😺, and a 🦁 go to 🏞️', 'a-grinning-cat-and-a-lion-go-to-national-park', 'en'];
+        yield 'locale code with dash' => ['Menus with 🍕 or 🍝', 'menus-with-pizza-or-spaghetti', 'en-US'];
+        yield 'unknown locale' => ['Menus with 🍕 or 🍝', 'menus-with-or', 'unknown'];
     }
 }

--- a/src/Sulu/Component/PHPCR/Tests/Unit/PathCleanupTest.php
+++ b/src/Sulu/Component/PHPCR/Tests/Unit/PathCleanupTest.php
@@ -117,5 +117,6 @@ class PathCleanupTest extends TestCase
     {
         yield ['a 😺, and a 🦁 go to 🏞️', 'a-grinning-cat-and-a-lion-go-to-national-park', 'en'];
         yield ['Menus with 🍕 or 🍝', 'menus-with-pizza-or-spaghetti', 'en'];
+        yield ['Menus with 🍕 or 🍝', 'menus-with-or', 'unknown'];
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #6882
| License | MIT

#### What's in this PR?

<!-- Explain the contents of the PR. -->

Add emoji support for url slugger

#### Why?

<!-- Which problem does the PR fix? (add some context and maybe link to an issue here) -->
Currently emojis are just removed and not replaced by the name when slugging a title with emoji for it.
