### PR TITLE
Implement a static browserlist

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,3 +1,14 @@
-last 2 versions and not dead
-not ie < 12
-not ie_mob < 12
+and_chr >= 107
+and_ff >= 106
+and_qq >= 13.1
+and_uc >= 13.4
+android >= 107
+chrome >= 106
+edge >= 106
+firefox >= 105
+ios_saf >= 16.0
+kaios >= 2.5
+op_mob >= 64
+opera >= 90
+safari >= 16.0
+samsung >= 17.0


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/skeleton/pull/200
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Implement a static browser list: https://www.diffchecker.com/KzP9iLpL

#### Why?

Avoid problems like: https://github.com/sulu/sulu/issues/6917

I used the output of `npx browserlist` and added `>=` to all the browsers. I removed `op_mini all`, which is already ignored by babel or other transpiling tools.

