### PR TITLE
Use the reload() method to trigger the reload in the ListStore

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
@@ -391,8 +391,8 @@ export default class ListStore {
         this.structureStrategy = structureStrategy;
 
         if (hadStructureStrategy) {
-            // force a reload with the currently active item to match new structure
-            this.activate(this.active.get());
+            // force a reload to match new structure
+            this.reload();
         }
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
@@ -1792,9 +1792,10 @@ test('Should trigger a mobx autorun if activate is called with the same id', () 
     autorunDisposer();
 });
 
-test('Should activate the current item if structure strategy is changed to trigger a reload', () => {
+test('Should call the reload method if structure strategy is changed', () => {
     const page = observable.box();
     const listStore = new ListStore('snippets', 'snippets', 'list_test', {page});
+    const reloadSpy = jest.spyOn(listStore, 'reload');
     listStore.schema = {};
 
     const loadingStrategy = new LoadingStrategy();
@@ -1808,7 +1809,7 @@ test('Should activate the current item if structure strategy is changed to trigg
 
     const otherStructureStrategy = new StructureStrategy();
     listStore.updateStructureStrategy(otherStructureStrategy);
-    expect(otherStructureStrategy.activate).toBeCalledWith(3);
+    expect(reloadSpy).toBeCalled();
 });
 
 test('Should call the activate method of the structure strategy if an item gets activated', () => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| License | MIT

#### What's in this PR?

<!-- Explain the contents of the PR. -->
Use reload() instead of activate() to trigger the reload in the ListStore after changing the Structure strategy.

#### Why?

<!-- Which problem does the PR fix? (add some context and maybe link to an issue here) -->
The reload was triggered by re setting the active item, but that doesn't work if there never was an active item.

