### PR TITLE
Improving the role querying in user creation

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Command/CreateUserCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/CreateUserCommand.php
@@ -350,25 +350,23 @@ class CreateUserCommand extends Command
     /**
      * Return the names of all the roles.
      *
-     * @return array
+     * @return array<string>
      *
      * @throws \RuntimeException If no roles exist
      */
-    private function getRoleNames()
+    private function getRoleNames(): array
     {
-        $roles = $this->roleRepository->findAllRoles();
+        $roles = $this->roleRepository->findAllRoles(['anonymous' => false]);
         $roleNames = [];
 
         foreach ($roles as $role) {
-            if (!$role->getAnonymous()) {
-                $roleNames[] = $role->getName();
-            }
+            $roleNames[] = $role->getName();
         }
 
         if (empty($roleNames)) {
-            throw new \RuntimeException(\sprintf(
+            throw new \RuntimeException(
                 'The system currently has no roles. Use the "sulu:security:role:create" command to create roles.'
-            ));
+            );
         }
 
         return $roleNames;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Using a more precise query to get a list of non-anonymous roles. Also adding a return type to the function.

#### Why?
Then we don't need to filter the roles with PHP and it technically also reduces the amount of data that needs to be handled.

#### Example Usage
There shouldn't be a change in usage since the method is private it doesn't break any backwards compatibility.

#### To Do

- [x] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md
