### PR TITLE
Fix admin build with webpack 4

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -8,7 +8,8 @@
         "@babel/plugin-transform-flow-strip-types",
         "@babel/plugin-proposal-nullish-coalescing-operator",
         "@babel/plugin-proposal-class-properties",
-        "@babel/plugin-proposal-optional-chaining"
+        "@babel/plugin-proposal-optional-chaining",
+        "@babel/plugin-proposal-export-namespace-from"
     ],
     "assumptions": {
         "setPublicClassFields": true

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "@babel/core": "^7.5.5",
         "@babel/plugin-proposal-class-properties": "^7.16.5",
         "@babel/plugin-proposal-decorators": "^7.4.4",
+        "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.2",
         "@babel/plugin-proposal-optional-chaining": "^7.18.9",
         "@babel/plugin-transform-flow-strip-types": "^7.4.4",

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/HtmlFieldTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/HtmlFieldTransformer.js
@@ -10,7 +10,7 @@ export default class HtmlFieldTransformer implements FieldTransformer {
             return null;
         }
 
-        const sanitizedHtml = sanitizeHtml(value, {
+        const sanitizedHtml = sanitizeHtml(value.toString(), {
             allowedTags: ['b', 'em', 'i', 's', 'small', 'strong', 'sub', 'sup', 'time', 'u'],
             allowedAttributes: {},
             disallowedTagsMode: 'recursiveEscape',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,7 +85,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                 {
                     test: /\.js$/,
                     // eslint-disable-next-line max-len
-                    exclude: /node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5|array-move|lodash-es|@react-leaflet|react-leaflet)[/\\])/,
+                    exclude: /node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5|array-move|htmlparser2|lodash-es|@react-leaflet|react-leaflet)[/\\])/,
                     use: {
                         loader: 'babel-loader',
                         options: {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #6917 <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/skeleton/pull/203 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix admin build with webpack 4. Also the HtmlFieldTransformer is required to work like before.

#### Why?

Currently the admin build is failing, because of sanitze-html 2.8 version which also changed behaviour for numbers which need to be adjusted:

 - https://github.com/apostrophecms/sanitize-html/issues/592
 
**Update** other related issues:

 - https://github.com/fb55/htmlparser2/issues/1369
 - https://github.com/fb55/htmlparser2/issues/1237#issuecomment-1182522861
