### PR TITLE
Changed height of description-label and error-label to min-height

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/field.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/field.scss
@@ -61,7 +61,7 @@ $errorLabelHeight: 20px;
     color: $labelColor;
     font-size: 10px;
     line-height: $errorLabelHeight;
-    height: $errorLabelHeight;
+    min-height: $errorLabelHeight;
 
     .dark & {
         color: $labelDarkColor;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #6939
| Related issues/PRs | 
| License | MIT
| Documentation PR |

#### What's in this PR?

The height of the `.description-label` and `.error-label` are now defined by a min-height, not by a height.

#### Why?

Previously, longer help texts led to overflow and overlapping content.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
