### PR TITLE
Make matrix items keyboard operable

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Item.js
@@ -52,9 +52,14 @@ export default class Item extends React.PureComponent<Props> {
         const itemTitle = title ? title : name.charAt(0).toUpperCase() + name.slice(1);
 
         return (
-            <div className={itemClass} onClick={!disabled ? this.handleClick : undefined} title={itemTitle}>
+            <button
+                className={itemClass}
+                onClick={!disabled ? this.handleClick : undefined}
+                title={itemTitle}
+                type="button"
+            >
                 <Icon name={icon} />
-            </div>
+            </button>
         );
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/tests/__snapshots__/Matrix.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/tests/__snapshots__/Matrix.test.js.snap
@@ -17,33 +17,36 @@ exports[`Render the Matrix component 1`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item"
             title="View"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item"
             title="Edit"
+            type="button"
           >
             <span
               aria-label="su-plus"
               class="su-plus"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item"
             title="Delete"
+            type="button"
           >
             <span
               aria-label="su-trash-alt"
               class="su-trash-alt"
             />
-          </div>
+          </button>
           <button
             class="rowButton"
             type="button"
@@ -63,15 +66,16 @@ exports[`Render the Matrix component 1`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item"
             title="View"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
+          </button>
           <button
             class="rowButton"
             type="button"
@@ -91,24 +95,26 @@ exports[`Render the Matrix component 1`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item"
             title="View"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item"
             title="Edit"
+            type="button"
           >
             <span
               aria-label="su-plus"
               class="su-plus"
             />
-          </div>
+          </button>
           <button
             class="rowButton"
             type="button"
@@ -139,33 +145,36 @@ exports[`Render the Matrix component with values 1`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item selected"
             title="View"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="Edit"
+            type="button"
           >
             <span
               aria-label="su-plus"
               class="su-plus"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item"
             title="Delete"
+            type="button"
           >
             <span
               aria-label="su-trash-alt"
               class="su-trash-alt"
             />
-          </div>
+          </button>
           <button
             class="rowButton"
             type="button"
@@ -185,15 +194,16 @@ exports[`Render the Matrix component with values 1`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item selected"
             title="View"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
+          </button>
           <button
             class="rowButton"
             type="button"
@@ -213,24 +223,26 @@ exports[`Render the Matrix component with values 1`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item selected"
             title="View"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item"
             title="Edit"
+            type="button"
           >
             <span
               aria-label="su-plus"
               class="su-plus"
             />
-          </div>
+          </button>
           <button
             class="rowButton"
             type="button"
@@ -261,33 +273,36 @@ exports[`Render the Matrix component with values in disabled state 1`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item selected disabled"
             title="View"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected disabled"
             title="Edit"
+            type="button"
           >
             <span
               aria-label="su-plus"
               class="su-plus"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item disabled"
             title="Delete"
+            type="button"
           >
             <span
               aria-label="su-trash-alt"
               class="su-trash-alt"
             />
-          </div>
+          </button>
         </td>
       </tr>
       <tr
@@ -301,15 +316,16 @@ exports[`Render the Matrix component with values in disabled state 1`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item selected disabled"
             title="View"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
+          </button>
         </td>
       </tr>
       <tr
@@ -323,24 +339,26 @@ exports[`Render the Matrix component with values in disabled state 1`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item selected disabled"
             title="View"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item disabled"
             title="Edit"
+            type="button"
           >
             <span
               aria-label="su-plus"
               class="su-plus"
             />
-          </div>
+          </button>
         </td>
       </tr>
     </tbody>

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/__snapshots__/PermissionMatrix.test.js.snap
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/__snapshots__/PermissionMatrix.test.js.snap
@@ -19,42 +19,46 @@ exports[`Render in disabled state 1`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item selected disabled"
             title="sulu_security.view"
+            type="button"
           >
             <span
               aria-label="su-eye"
               class="su-eye"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected disabled"
             title="sulu_security.add"
+            type="button"
           >
             <span
               aria-label="su-plus-circle"
               class="su-plus-circle"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected disabled"
             title="sulu_security.edit"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected disabled"
             title="sulu_security.delete"
+            type="button"
           >
             <span
               aria-label="su-trash-alt"
               class="su-trash-alt"
             />
-          </div>
+          </button>
         </td>
       </tr>
       <tr
@@ -68,42 +72,46 @@ exports[`Render in disabled state 1`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item selected disabled"
             title="sulu_security.view"
+            type="button"
           >
             <span
               aria-label="su-eye"
               class="su-eye"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected disabled"
             title="sulu_security.add"
+            type="button"
           >
             <span
               aria-label="su-plus-circle"
               class="su-plus-circle"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected disabled"
             title="sulu_security.edit"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected disabled"
             title="sulu_security.delete"
+            type="button"
           >
             <span
               aria-label="su-trash-alt"
               class="su-trash-alt"
             />
-          </div>
+          </button>
         </td>
       </tr>
     </tbody>
@@ -130,42 +138,46 @@ exports[`Render with minimal 1`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item selected"
             title="sulu_security.view"
+            type="button"
           >
             <span
               aria-label="su-eye"
               class="su-eye"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.add"
+            type="button"
           >
             <span
               aria-label="su-plus-circle"
               class="su-plus-circle"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.edit"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.delete"
+            type="button"
           >
             <span
               aria-label="su-trash-alt"
               class="su-trash-alt"
             />
-          </div>
+          </button>
           <button
             class="rowButton"
             type="button"
@@ -185,42 +197,46 @@ exports[`Render with minimal 1`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item selected"
             title="sulu_security.view"
+            type="button"
           >
             <span
               aria-label="su-eye"
               class="su-eye"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.add"
+            type="button"
           >
             <span
               aria-label="su-plus-circle"
               class="su-plus-circle"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.edit"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.delete"
+            type="button"
           >
             <span
               aria-label="su-trash-alt"
               class="su-trash-alt"
             />
-          </div>
+          </button>
           <button
             class="rowButton"
             type="button"
@@ -256,42 +272,46 @@ exports[`Render with subTitle 1`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item selected"
             title="sulu_security.view"
+            type="button"
           >
             <span
               aria-label="su-eye"
               class="su-eye"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.add"
+            type="button"
           >
             <span
               aria-label="su-plus-circle"
               class="su-plus-circle"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.edit"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.delete"
+            type="button"
           >
             <span
               aria-label="su-trash-alt"
               class="su-trash-alt"
             />
-          </div>
+          </button>
           <button
             class="rowButton"
             type="button"
@@ -311,42 +331,46 @@ exports[`Render with subTitle 1`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item selected"
             title="sulu_security.view"
+            type="button"
           >
             <span
               aria-label="su-eye"
               class="su-eye"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.add"
+            type="button"
           >
             <span
               aria-label="su-plus-circle"
               class="su-plus-circle"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.edit"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.delete"
+            type="button"
           >
             <span
               aria-label="su-trash-alt"
               class="su-trash-alt"
             />
-          </div>
+          </button>
           <button
             class="rowButton"
             type="button"
@@ -382,42 +406,46 @@ exports[`Render with title 1`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item selected"
             title="sulu_security.view"
+            type="button"
           >
             <span
               aria-label="su-eye"
               class="su-eye"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.add"
+            type="button"
           >
             <span
               aria-label="su-plus-circle"
               class="su-plus-circle"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.edit"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.delete"
+            type="button"
           >
             <span
               aria-label="su-trash-alt"
               class="su-trash-alt"
             />
-          </div>
+          </button>
           <button
             class="rowButton"
             type="button"
@@ -437,42 +465,46 @@ exports[`Render with title 1`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item selected"
             title="sulu_security.view"
+            type="button"
           >
             <span
               aria-label="su-eye"
               class="su-eye"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.add"
+            type="button"
           >
             <span
               aria-label="su-plus-circle"
               class="su-plus-circle"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.edit"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.delete"
+            type="button"
           >
             <span
               aria-label="su-trash-alt"
               class="su-trash-alt"
             />
-          </div>
+          </button>
           <button
             class="rowButton"
             type="button"

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/__snapshots__/Permissions.test.js.snap
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/__snapshots__/Permissions.test.js.snap
@@ -22,42 +22,46 @@ exports[`Render in disabled state 1`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item selected disabled"
             title="sulu_security.view"
+            type="button"
           >
             <span
               aria-label="su-eye"
               class="su-eye"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected disabled"
             title="sulu_security.add"
+            type="button"
           >
             <span
               aria-label="su-plus-circle"
               class="su-plus-circle"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected disabled"
             title="sulu_security.edit"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected disabled"
             title="sulu_security.delete"
+            type="button"
           >
             <span
               aria-label="su-trash-alt"
               class="su-trash-alt"
             />
-          </div>
+          </button>
         </td>
       </tr>
       <tr
@@ -71,42 +75,46 @@ exports[`Render in disabled state 1`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item selected disabled"
             title="sulu_security.view"
+            type="button"
           >
             <span
               aria-label="su-eye"
               class="su-eye"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected disabled"
             title="sulu_security.add"
+            type="button"
           >
             <span
               aria-label="su-plus-circle"
               class="su-plus-circle"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected disabled"
             title="sulu_security.edit"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected disabled"
             title="sulu_security.delete"
+            type="button"
           >
             <span
               aria-label="su-trash-alt"
               class="su-trash-alt"
             />
-          </div>
+          </button>
         </td>
       </tr>
     </tbody>
@@ -194,42 +202,46 @@ exports[`Render with empty webspace section 4`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item selected"
             title="sulu_security.view"
+            type="button"
           >
             <span
               aria-label="su-eye"
               class="su-eye"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.add"
+            type="button"
           >
             <span
               aria-label="su-plus-circle"
               class="su-plus-circle"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.edit"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.delete"
+            type="button"
           >
             <span
               aria-label="su-trash-alt"
               class="su-trash-alt"
             />
-          </div>
+          </button>
           <button
             class="rowButton"
             type="button"
@@ -249,42 +261,46 @@ exports[`Render with empty webspace section 4`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item selected"
             title="sulu_security.view"
+            type="button"
           >
             <span
               aria-label="su-eye"
               class="su-eye"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.add"
+            type="button"
           >
             <span
               aria-label="su-plus-circle"
               class="su-plus-circle"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.edit"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.delete"
+            type="button"
           >
             <span
               aria-label="su-trash-alt"
               class="su-trash-alt"
             />
-          </div>
+          </button>
           <button
             class="rowButton"
             type="button"
@@ -320,42 +336,46 @@ exports[`Render with minimal 1`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item selected"
             title="sulu_security.view"
+            type="button"
           >
             <span
               aria-label="su-eye"
               class="su-eye"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.add"
+            type="button"
           >
             <span
               aria-label="su-plus-circle"
               class="su-plus-circle"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.edit"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.delete"
+            type="button"
           >
             <span
               aria-label="su-trash-alt"
               class="su-trash-alt"
             />
-          </div>
+          </button>
           <button
             class="rowButton"
             type="button"
@@ -375,42 +395,46 @@ exports[`Render with minimal 1`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item selected"
             title="sulu_security.view"
+            type="button"
           >
             <span
               aria-label="su-eye"
               class="su-eye"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.add"
+            type="button"
           >
             <span
               aria-label="su-plus-circle"
               class="su-plus-circle"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.edit"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.delete"
+            type="button"
           >
             <span
               aria-label="su-trash-alt"
               class="su-trash-alt"
             />
-          </div>
+          </button>
           <button
             class="rowButton"
             type="button"
@@ -501,60 +525,66 @@ exports[`Render with webspace section 3`] = `
           <td
             class="items"
           >
-            <div
+            <button
               class="item selected"
               title="sulu_security.view"
+              type="button"
             >
               <span
                 aria-label="su-eye"
                 class="su-eye"
               />
-            </div>
-            <div
+            </button>
+            <button
               class="item selected"
               title="sulu_security.add"
+              type="button"
             >
               <span
                 aria-label="su-plus-circle"
                 class="su-plus-circle"
               />
-            </div>
-            <div
+            </button>
+            <button
               class="item selected"
               title="sulu_security.edit"
+              type="button"
             >
               <span
                 aria-label="su-pen"
                 class="su-pen"
               />
-            </div>
-            <div
+            </button>
+            <button
               class="item selected"
               title="sulu_security.delete"
+              type="button"
             >
               <span
                 aria-label="su-trash-alt"
                 class="su-trash-alt"
               />
-            </div>
-            <div
+            </button>
+            <button
               class="item"
               title="sulu_security.live"
+              type="button"
             >
               <span
                 aria-label="su-publish"
                 class="su-publish"
               />
-            </div>
-            <div
+            </button>
+            <button
               class="item"
               title="sulu_security.security"
+              type="button"
             >
               <span
                 aria-label="su-lock"
                 class="su-lock"
               />
-            </div>
+            </button>
             <button
               class="rowButton"
               type="button"
@@ -574,42 +604,46 @@ exports[`Render with webspace section 3`] = `
           <td
             class="items"
           >
-            <div
+            <button
               class="item"
               title="sulu_security.view"
+              type="button"
             >
               <span
                 aria-label="su-eye"
                 class="su-eye"
               />
-            </div>
-            <div
+            </button>
+            <button
               class="item"
               title="sulu_security.add"
+              type="button"
             >
               <span
                 aria-label="su-plus-circle"
                 class="su-plus-circle"
               />
-            </div>
-            <div
+            </button>
+            <button
               class="item"
               title="sulu_security.edit"
+              type="button"
             >
               <span
                 aria-label="su-pen"
                 class="su-pen"
               />
-            </div>
-            <div
+            </button>
+            <button
               class="item"
               title="sulu_security.delete"
+              type="button"
             >
               <span
                 aria-label="su-trash-alt"
                 class="su-trash-alt"
               />
-            </div>
+            </button>
             <button
               class="rowButton"
               type="button"
@@ -629,42 +663,46 @@ exports[`Render with webspace section 3`] = `
           <td
             class="items"
           >
-            <div
+            <button
               class="item"
               title="sulu_security.view"
+              type="button"
             >
               <span
                 aria-label="su-eye"
                 class="su-eye"
               />
-            </div>
-            <div
+            </button>
+            <button
               class="item"
               title="sulu_security.add"
+              type="button"
             >
               <span
                 aria-label="su-plus-circle"
                 class="su-plus-circle"
               />
-            </div>
-            <div
+            </button>
+            <button
               class="item"
               title="sulu_security.edit"
+              type="button"
             >
               <span
                 aria-label="su-pen"
                 class="su-pen"
               />
-            </div>
-            <div
+            </button>
+            <button
               class="item"
               title="sulu_security.delete"
+              type="button"
             >
               <span
                 aria-label="su-trash-alt"
                 class="su-trash-alt"
               />
-            </div>
+            </button>
             <button
               class="rowButton"
               type="button"
@@ -701,42 +739,46 @@ exports[`Render with webspace section 4`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item selected"
             title="sulu_security.view"
+            type="button"
           >
             <span
               aria-label="su-eye"
               class="su-eye"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.add"
+            type="button"
           >
             <span
               aria-label="su-plus-circle"
               class="su-plus-circle"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.edit"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.delete"
+            type="button"
           >
             <span
               aria-label="su-trash-alt"
               class="su-trash-alt"
             />
-          </div>
+          </button>
           <button
             class="rowButton"
             type="button"
@@ -756,42 +798,46 @@ exports[`Render with webspace section 4`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item selected"
             title="sulu_security.view"
+            type="button"
           >
             <span
               aria-label="su-eye"
               class="su-eye"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.add"
+            type="button"
           >
             <span
               aria-label="su-plus-circle"
               class="su-plus-circle"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.edit"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="sulu_security.delete"
+            type="button"
           >
             <span
               aria-label="su-trash-alt"
               class="su-trash-alt"
             />
-          </div>
+          </button>
           <button
             class="rowButton"
             type="button"

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/tests/RolePermissions.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/tests/RolePermissions.test.js
@@ -320,7 +320,7 @@ test('Call onChange callback when new matrix for system is added', () => {
         rolePermissions.update();
         expect(rolePermissions.find('Matrix')).toHaveLength(2);
 
-        rolePermissions.find('Matrix').find('Row[name="2"] Item[icon="su-eye"] > div').simulate('click');
+        rolePermissions.find('Matrix').find('Row[name="2"] Item[icon="su-eye"] > button').simulate('click');
 
         expect(changeSpy).toHaveBeenLastCalledWith({
             '1': {

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/tests/__snapshots__/RolePermissions.test.js.snap
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/tests/__snapshots__/RolePermissions.test.js.snap
@@ -56,51 +56,56 @@ exports[`Render matrix with correct given values 2`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item selected"
             title="View"
+            type="button"
           >
             <span
               aria-label="su-eye"
               class="su-eye"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item"
             title="Add"
+            type="button"
           >
             <span
               aria-label="su-plus-circle"
               class="su-plus-circle"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="Edit"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="Delete"
+            type="button"
           >
             <span
               aria-label="su-trash-alt"
               class="su-trash-alt"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item"
             title="Security"
+            type="button"
           >
             <span
               aria-label="su-lock"
               class="su-lock"
             />
-          </div>
+          </button>
           <button
             class="rowButton"
             type="button"
@@ -120,51 +125,56 @@ exports[`Render matrix with correct given values 2`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item selected"
             title="View"
+            type="button"
           >
             <span
               aria-label="su-eye"
               class="su-eye"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="Add"
+            type="button"
           >
             <span
               aria-label="su-plus-circle"
               class="su-plus-circle"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="Edit"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item"
             title="Delete"
+            type="button"
           >
             <span
               aria-label="su-trash-alt"
               class="su-trash-alt"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item"
             title="Security"
+            type="button"
           >
             <span
               aria-label="su-lock"
               class="su-lock"
             />
-          </div>
+          </button>
           <button
             class="rowButton"
             type="button"

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/tests/__snapshots__/SystemRolePermissions.test.js.snap
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/tests/__snapshots__/SystemRolePermissions.test.js.snap
@@ -42,33 +42,36 @@ exports[`Render permissions for a single system 1`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item selected"
             title="View"
+            type="button"
           >
             <span
               aria-label="su-eye"
               class="su-eye"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item"
             title="Add"
+            type="button"
           >
             <span
               aria-label="su-plus-circle"
               class="su-plus-circle"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="Edit"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
+          </button>
           <button
             class="rowButton"
             type="button"
@@ -88,33 +91,36 @@ exports[`Render permissions for a single system 1`] = `
         <td
           class="items"
         >
-          <div
+          <button
             class="item"
             title="View"
+            type="button"
           >
             <span
               aria-label="su-eye"
               class="su-eye"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item selected"
             title="Add"
+            type="button"
           >
             <span
               aria-label="su-plus-circle"
               class="su-plus-circle"
             />
-          </div>
-          <div
+          </button>
+          <button
             class="item"
             title="Edit"
+            type="button"
           >
             <span
               aria-label="su-pen"
               class="su-pen"
             />
-          </div>
+          </button>
           <button
             class="rowButton"
             type="button"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? |
| Deprecations? |
| Fixed tickets |  
| Related issues/PRs | #6444
| License | MIT
| Documentation PR |

#### What's in this PR?

Render the matrix item with a button instead of a div

#### Why?

The matrix item cannot currently be focused and operated with the keyboard.

#### Example Usage

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
