### PR TITLE
Change help and error messages from <label> to <div>

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/Field.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/Field.js
@@ -141,13 +141,13 @@ class Field<T: string | number> extends React.Component<Props<T>> {
                     }
                     {children}
                     {description &&
-                        <label className={fieldStyles.descriptionLabel}>
+                        <div className={fieldStyles.descriptionLabel}>
                             {description}
-                        </label>
+                        </div>
                     }
-                    <label className={fieldStyles.errorLabel}>
+                    <div className={fieldStyles.errorLabel}>
                         {error}
-                    </label>
+                    </div>
                 </div>
             </Grid.Item>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/tests/__snapshots__/Field.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/tests/__snapshots__/Field.test.js.snap
@@ -17,7 +17,7 @@ exports[`Display a field with a required label 1`] = `
       <div>
         Test
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -41,11 +41,11 @@ exports[`Display a field with an error 1`] = `
       <div>
         Test
       </div>
-      <label
+      <div
         class="errorLabel"
       >
         Error! Help!
-      </label>
+      </div>
     </div>
   </div>
 </div>
@@ -62,7 +62,7 @@ exports[`Display a field with colSpan and after space 1`] = `
       <div>
         Test
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -81,12 +81,12 @@ exports[`Display a field with description 1`] = `
       <div>
         Test
       </div>
-      <label
+      <div
         class="descriptionLabel"
       >
         Testdescription
-      </label>
-      <label
+      </div>
+      <div
         class="errorLabel"
       />
     </div>
@@ -110,7 +110,7 @@ exports[`Display a field with label 1`] = `
       <p>
         Test
       </p>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -149,7 +149,7 @@ exports[`Display a field with label and type 1`] = `
       <p>
         Test
       </p>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -168,7 +168,7 @@ exports[`Display a field without label 1`] = `
       <p>
         Test
       </p>
-      <label
+      <div
         class="errorLabel"
       />
     </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/tests/__snapshots__/Form.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/tests/__snapshots__/Form.test.js.snap
@@ -17,7 +17,7 @@ exports[`Render a form 1`] = `
           Test1
         </label>
         Test 1
-        <label
+        <div
           class="errorLabel"
         />
       </div>
@@ -34,7 +34,7 @@ exports[`Render a form 1`] = `
           Test1
         </label>
         Test 2
-        <label
+        <div
           class="errorLabel"
         />
       </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
@@ -100,7 +100,7 @@ exports[`Render block with schema 1`] = `
                     />
                   </div>
                 </div>
-                <label
+                <div
                   class="errorLabel"
                 />
               </div>
@@ -129,7 +129,7 @@ exports[`Render block with schema 1`] = `
                     />
                   </div>
                 </div>
-                <label
+                <div
                   class="errorLabel"
                 />
               </div>
@@ -228,7 +228,7 @@ exports[`Render block with schema 1`] = `
                     />
                   </div>
                 </div>
-                <label
+                <div
                   class="errorLabel"
                 />
               </div>
@@ -257,7 +257,7 @@ exports[`Render block with schema 1`] = `
                     />
                   </div>
                 </div>
-                <label
+                <div
                   class="errorLabel"
                 />
               </div>
@@ -388,7 +388,7 @@ exports[`Render block with schema and error on fields already being modified 1`]
                     />
                   </div>
                 </div>
-                <label
+                <div
                   class="errorLabel"
                 />
               </div>
@@ -488,11 +488,11 @@ exports[`Render block with schema and error on fields already being modified 1`]
                     />
                   </div>
                 </div>
-                <label
+                <div
                   class="errorLabel"
                 >
                   sulu_admin.error_minlength
-                </label>
+                </div>
               </div>
             </div>
           </div>
@@ -589,7 +589,7 @@ exports[`Render block with schema and error on fields already being modified 1`]
                     />
                   </div>
                 </div>
-                <label
+                <div
                   class="errorLabel"
                 />
               </div>
@@ -720,7 +720,7 @@ exports[`Render block with schema and error on fields already being modified 2`]
                     />
                   </div>
                 </div>
-                <label
+                <div
                   class="errorLabel"
                 />
               </div>
@@ -820,11 +820,11 @@ exports[`Render block with schema and error on fields already being modified 2`]
                     />
                   </div>
                 </div>
-                <label
+                <div
                   class="errorLabel"
                 >
                   sulu_admin.error_minlength
-                </label>
+                </div>
               </div>
             </div>
           </div>
@@ -922,11 +922,11 @@ exports[`Render block with schema and error on fields already being modified 2`]
                     />
                   </div>
                 </div>
-                <label
+                <div
                   class="errorLabel"
                 >
                   sulu_admin.error_minlength
-                </label>
+                </div>
               </div>
             </div>
           </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Field.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Field.test.js.snap
@@ -24,12 +24,12 @@ exports[`Render a field with a description 1`] = `
         />
       </div>
     </div>
-    <label
+    <div
       class="descriptionLabel"
     >
       Small description describing the field
-    </label>
-    <label
+    </div>
+    <div
       class="errorLabel"
     />
   </div>
@@ -60,11 +60,11 @@ exports[`Render a field with a error collection 1`] = `
         />
       </div>
     </div>
-    <label
+    <div
       class="errorLabel"
     >
       sulu_admin.error_minitems
-    </label>
+    </div>
   </div>
 </div>
 `;
@@ -93,11 +93,11 @@ exports[`Render a field with an error 1`] = `
         />
       </div>
     </div>
-    <label
+    <div
       class="errorLabel"
     >
       sulu_admin.error_minlength
-    </label>
+    </div>
   </div>
 </div>
 `;
@@ -126,7 +126,7 @@ exports[`Render a field without a const error 1`] = `
         />
       </div>
     </div>
-    <label
+    <div
       class="errorLabel"
     />
   </div>
@@ -151,7 +151,7 @@ exports[`Render a field without a label 1`] = `
         />
       </div>
     </div>
-    <label
+    <div
       class="errorLabel"
     />
   </div>
@@ -182,7 +182,7 @@ exports[`Render a required field with correct field type 1`] = `
         />
       </div>
     </div>
-    <label
+    <div
       class="errorLabel"
     />
   </div>
@@ -213,7 +213,7 @@ exports[`Render correct label with correct field type 1`] = `
         />
       </div>
     </div>
-    <label
+    <div
       class="errorLabel"
     />
   </div>
@@ -244,7 +244,7 @@ exports[`Render correct label with correct field type 2`] = `
         />
       </div>
     </div>
-    <label
+    <div
       class="errorLabel"
     />
   </div>
@@ -275,7 +275,7 @@ exports[`Render field with correct values for grid 1`] = `
         />
       </div>
     </div>
-    <label
+    <div
       class="errorLabel"
     />
   </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/GhostDialog.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/GhostDialog.test.js.snap
@@ -105,7 +105,7 @@ Array [
                     />
                   </button>
                 </div>
-                <label
+                <div
                   class="errorLabel"
                 />
               </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/MissingTypeDialog.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/MissingTypeDialog.test.js.snap
@@ -100,7 +100,7 @@ Array [
                     />
                   </button>
                 </div>
-                <label
+                <div
                   class="errorLabel"
                 />
               </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Renderer.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Renderer.test.js.snap
@@ -31,7 +31,7 @@ exports[`Should not render fields when the schema contains a visibleCondition ev
             />
           </div>
         </div>
-        <label
+        <div
           class="errorLabel"
         />
       </div>
@@ -60,7 +60,7 @@ exports[`Should not render fields when the schema contains a visibleCondition ev
           />
         </div>
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -95,7 +95,7 @@ exports[`Should render field types based on schema 1`] = `
           />
         </div>
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -123,7 +123,7 @@ exports[`Should render field types based on schema 1`] = `
           />
         </div>
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -159,7 +159,7 @@ exports[`Should render nested field types with based on schema 1`] = `
           />
         </div>
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -188,7 +188,7 @@ exports[`Should render nested field types with based on schema 1`] = `
           />
         </div>
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -235,7 +235,7 @@ exports[`Should render nested sections 1`] = `
             />
           </div>
         </div>
-        <label
+        <div
           class="errorLabel"
         />
       </div>
@@ -289,7 +289,7 @@ exports[`Should render nested sections 1`] = `
             />
           </div>
         </div>
-        <label
+        <div
           class="errorLabel"
         />
       </div>
@@ -337,7 +337,7 @@ exports[`Should render sections with colSpan 1`] = `
             />
           </div>
         </div>
-        <label
+        <div
           class="errorLabel"
         />
       </div>
@@ -378,7 +378,7 @@ exports[`Should render sections with colSpan 1`] = `
             />
           </div>
         </div>
-        <label
+        <div
           class="errorLabel"
         />
       </div>
@@ -417,7 +417,7 @@ exports[`Should render sections without label 1`] = `
             />
           </div>
         </div>
-        <label
+        <div
           class="errorLabel"
         />
       </div>
@@ -458,7 +458,7 @@ exports[`Should render sections without label 1`] = `
             />
           </div>
         </div>
-        <label
+        <div
           class="errorLabel"
         />
       </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Section.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Section.test.js.snap
@@ -36,7 +36,7 @@ exports[`Render section with children 1`] = `
           />
         </div>
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/__snapshots__/ExternalLinkTypeOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/__snapshots__/ExternalLinkTypeOverlay.test.js.snap
@@ -66,7 +66,7 @@ exports[`Render overlay with a URL 1`] = `
           value="www.sulu.io"
         />
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -121,7 +121,7 @@ exports[`Render overlay with a URL 1`] = `
           />
         </button>
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -145,7 +145,7 @@ exports[`Render overlay with a URL 1`] = `
           value=""
         />
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -173,7 +173,7 @@ exports[`Render overlay with a URL 1`] = `
           sulu_admin.no_follow
         </div>
       </label>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -247,7 +247,7 @@ exports[`Render overlay with an undefined URL 1`] = `
           value=""
         />
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -302,7 +302,7 @@ exports[`Render overlay with an undefined URL 1`] = `
           />
         </button>
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -326,7 +326,7 @@ exports[`Render overlay with an undefined URL 1`] = `
           value=""
         />
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -354,7 +354,7 @@ exports[`Render overlay with an undefined URL 1`] = `
           sulu_admin.no_follow
         </div>
       </label>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -428,7 +428,7 @@ exports[`Render overlay with mailto URL 1`] = `
           value="test@example.org"
         />
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -452,7 +452,7 @@ exports[`Render overlay with mailto URL 1`] = `
           value="Subject"
         />
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -473,7 +473,7 @@ exports[`Render overlay with mailto URL 1`] = `
       >
         Body
       </textarea>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -497,7 +497,7 @@ exports[`Render overlay with mailto URL 1`] = `
           value=""
         />
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -525,7 +525,7 @@ exports[`Render overlay with mailto URL 1`] = `
           sulu_admin.no_follow
         </div>
       </label>
-      <label
+      <div
         class="errorLabel"
       />
     </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/__snapshots__/LinkTypeOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/__snapshots__/LinkTypeOverlay.test.js.snap
@@ -45,7 +45,7 @@ exports[`Render overlay with anchor enabled 1`] = `
       <div>
         single list overlay
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -69,7 +69,7 @@ exports[`Render overlay with anchor enabled 1`] = `
           value=""
         />
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -122,7 +122,7 @@ exports[`Render overlay with minimal config 1`] = `
       <div>
         single list overlay
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -175,7 +175,7 @@ exports[`Render overlay with query enabled 1`] = `
       <div>
         single list overlay
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -199,7 +199,7 @@ exports[`Render overlay with query enabled 1`] = `
           value=""
         />
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -252,7 +252,7 @@ exports[`Render overlay with target enabled 1`] = `
       <div>
         single list overlay
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -307,7 +307,7 @@ exports[`Render overlay with target enabled 1`] = `
           />
         </button>
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -360,7 +360,7 @@ exports[`Render overlay with title enabled 1`] = `
       <div>
         single list overlay
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -384,7 +384,7 @@ exports[`Render overlay with title enabled 1`] = `
           value=""
         />
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
@@ -82,7 +82,7 @@ Array [
                         />
                       </button>
                     </div>
-                    <label
+                    <div
                       class="errorLabel"
                     />
                   </div>
@@ -130,7 +130,7 @@ Array [
                         />
                       </button>
                     </div>
-                    <label
+                    <div
                       class="errorLabel"
                     />
                   </div>
@@ -182,7 +182,7 @@ Array [
                         />
                       </button>
                     </div>
-                    <label
+                    <div
                       class="errorLabel"
                     />
                   </div>
@@ -232,7 +232,7 @@ Array [
                         />
                       </button>
                     </div>
-                    <label
+                    <div
                       class="errorLabel"
                     />
                   </div>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/__snapshots__/RuleOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/__snapshots__/RuleOverlay.test.js.snap
@@ -57,7 +57,7 @@ Array [
                       value=""
                     />
                   </div>
-                  <label
+                  <div
                     class="errorLabel"
                   />
                 </div>
@@ -112,7 +112,7 @@ Array [
                       />
                     </button>
                   </div>
-                  <label
+                  <div
                     class="errorLabel"
                   />
                 </div>
@@ -142,12 +142,12 @@ Array [
                       sulu_audience_targeting.add_condition
                     </span>
                   </button>
-                  <label
+                  <div
                     class="descriptionLabel"
                   >
                     sulu_audience_targeting.conditions_info_text
-                  </label>
-                  <label
+                  </div>
+                  <div
                     class="errorLabel"
                   />
                 </div>

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/components/ContactDetails/tests/__snapshots__/ContactDetails.test.js.snap
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/components/ContactDetails/tests/__snapshots__/ContactDetails.test.js.snap
@@ -58,7 +58,7 @@ exports[`Render ContactDetails with data 1`] = `
           tabindex="0"
         />
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -117,7 +117,7 @@ exports[`Render ContactDetails with data 1`] = `
           tabindex="0"
         />
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -176,7 +176,7 @@ exports[`Render ContactDetails with data 1`] = `
           tabindex="0"
         />
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -268,7 +268,7 @@ exports[`Render ContactDetails with data 1`] = `
           tabindex="0"
         />
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -325,7 +325,7 @@ exports[`Render ContactDetails with data 1`] = `
           tabindex="0"
         />
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -359,7 +359,7 @@ exports[`Render ContactDetails with data 1`] = `
           class="su-angle-down dropdownIcon"
         />
       </button>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -423,7 +423,7 @@ exports[`Render empty ContactDetails 1`] = `
           tabindex="0"
         />
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -480,7 +480,7 @@ exports[`Render empty ContactDetails 1`] = `
           tabindex="0"
         />
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -514,7 +514,7 @@ exports[`Render empty ContactDetails 1`] = `
           class="su-angle-down dropdownIcon"
         />
       </button>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -578,7 +578,7 @@ exports[`Render empty phone and email fields even if other values are set 1`] = 
           tabindex="0"
         />
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -635,7 +635,7 @@ exports[`Render empty phone and email fields even if other values are set 1`] = 
           tabindex="0"
         />
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -694,7 +694,7 @@ exports[`Render empty phone and email fields even if other values are set 1`] = 
           tabindex="0"
         />
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -786,7 +786,7 @@ exports[`Render empty phone and email fields even if other values are set 1`] = 
           tabindex="0"
         />
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -843,7 +843,7 @@ exports[`Render empty phone and email fields even if other values are set 1`] = 
           tabindex="0"
         />
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -877,7 +877,7 @@ exports[`Render empty phone and email fields even if other values are set 1`] = 
           class="su-angle-down dropdownIcon"
         />
       </button>
-      <label
+      <div
         class="errorLabel"
       />
     </div>

--- a/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/__snapshots__/LocationOverlay.test.js.snap
+++ b/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/__snapshots__/LocationOverlay.test.js.snap
@@ -66,7 +66,7 @@ Array [
                       />
                     </div>
                   </div>
-                  <label
+                  <div
                     class="errorLabel"
                   />
                 </div>
@@ -188,7 +188,7 @@ Array [
                       />
                     </div>
                   </div>
-                  <label
+                  <div
                     class="errorLabel"
                   />
                 </div>
@@ -213,7 +213,7 @@ Array [
                       value="22"
                     />
                   </div>
-                  <label
+                  <div
                     class="errorLabel"
                   />
                 </div>
@@ -238,7 +238,7 @@ Array [
                       value="33"
                     />
                   </div>
-                  <label
+                  <div
                     class="errorLabel"
                   />
                 </div>
@@ -264,7 +264,7 @@ Array [
                       value="5"
                     />
                   </div>
-                  <label
+                  <div
                     class="errorLabel"
                   />
                 </div>
@@ -300,7 +300,7 @@ Array [
                         value="title-123"
                       />
                     </div>
-                    <label
+                    <div
                       class="errorLabel"
                     />
                   </div>
@@ -324,7 +324,7 @@ Array [
                         value="street-123"
                       />
                     </div>
-                    <label
+                    <div
                       class="errorLabel"
                     />
                   </div>
@@ -348,7 +348,7 @@ Array [
                         value=""
                       />
                     </div>
-                    <label
+                    <div
                       class="errorLabel"
                     />
                   </div>
@@ -372,7 +372,7 @@ Array [
                         value="code-123"
                       />
                     </div>
-                    <label
+                    <div
                       class="errorLabel"
                     />
                   </div>
@@ -396,7 +396,7 @@ Array [
                         value="town-123"
                       />
                     </div>
-                    <label
+                    <div
                       class="errorLabel"
                     />
                   </div>
@@ -420,7 +420,7 @@ Array [
                         value=""
                       />
                     </div>
-                    <label
+                    <div
                       class="errorLabel"
                     />
                   </div>
@@ -550,7 +550,7 @@ Array [
                       />
                     </div>
                   </div>
-                  <label
+                  <div
                     class="errorLabel"
                   />
                 </div>
@@ -690,7 +690,7 @@ Array [
                       />
                     </div>
                   </div>
-                  <label
+                  <div
                     class="errorLabel"
                   />
                 </div>
@@ -715,7 +715,7 @@ Array [
                       value=""
                     />
                   </div>
-                  <label
+                  <div
                     class="errorLabel"
                   />
                 </div>
@@ -740,7 +740,7 @@ Array [
                       value=""
                     />
                   </div>
-                  <label
+                  <div
                     class="errorLabel"
                   />
                 </div>
@@ -766,7 +766,7 @@ Array [
                       value="1"
                     />
                   </div>
-                  <label
+                  <div
                     class="errorLabel"
                   />
                 </div>
@@ -802,7 +802,7 @@ Array [
                         value=""
                       />
                     </div>
-                    <label
+                    <div
                       class="errorLabel"
                     />
                   </div>
@@ -826,7 +826,7 @@ Array [
                         value=""
                       />
                     </div>
-                    <label
+                    <div
                       class="errorLabel"
                     />
                   </div>
@@ -850,7 +850,7 @@ Array [
                         value=""
                       />
                     </div>
-                    <label
+                    <div
                       class="errorLabel"
                     />
                   </div>
@@ -874,7 +874,7 @@ Array [
                         value=""
                       />
                     </div>
-                    <label
+                    <div
                       class="errorLabel"
                     />
                   </div>
@@ -898,7 +898,7 @@ Array [
                         value=""
                       />
                     </div>
-                    <label
+                    <div
                       class="errorLabel"
                     />
                   </div>
@@ -922,7 +922,7 @@ Array [
                         value=""
                       />
                     </div>
-                    <label
+                    <div
                       class="errorLabel"
                     />
                   </div>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/tests/overlays/__snapshots__/MediaLinkTypeOverlay.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/tests/overlays/__snapshots__/MediaLinkTypeOverlay.test.js.snap
@@ -45,7 +45,7 @@ exports[`Render overlay with minimal config 1`] = `
       <div>
         single media selection overlay
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -98,7 +98,7 @@ exports[`Render overlay with target enabled 1`] = `
       <div>
         single media selection overlay
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -153,7 +153,7 @@ exports[`Render overlay with target enabled 1`] = `
           />
         </button>
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -206,7 +206,7 @@ exports[`Render overlay with title enabled 1`] = `
       <div>
         single media selection overlay
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>
@@ -230,7 +230,7 @@ exports[`Render overlay with title enabled 1`] = `
           value=""
         />
       </div>
-      <label
+      <div
         class="errorLabel"
       />
     </div>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | 
| Deprecations? | 
| Fixed tickets | 
| Related issues/PRs | #6444
| License | MIT
| Documentation PR | 

#### What's in this PR?

For help and error messages HTHL label elements are currently used, which is semantically incorrect and has an impact on the form accessibility. As a first step I replaced the labels with div elements.

#### Why?

To link help and error texts semantically with input elements the following structure could be used:

```html
<label for="/example">Example</label>
<input type="text" id="/example" aria-describedby="/example-hint /example-error">
<div id="/example-hint">Help message</div>
<div id="/example-error">Error message</div>
```

If interested, I can also make these additions.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
