### PR TITLE
Fix icon button active+hover state

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/button.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/button.scss
@@ -150,6 +150,10 @@ $iconColorActive: $white;
 
     &:hover:not(:disabled) {
         background-color: $silver;
+
+        &.active {
+            background-color: $scorpion;
+        }
     }
 
     &:disabled {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #6925
| License | MIT

### What's in this PR?

Add style for icon button active-hovered state

**Before:**

![image](https://user-images.githubusercontent.com/36476595/205454919-6ecec83b-fdea-4439-ab33-c81ab2dc453a.png)
_normal, active, active hovered_

**After:**

![Capture d’écran du 2022-12-03 19-05-00](https://user-images.githubusercontent.com/36476595/205455464-6df1a1df-bde5-4c4d-a5a8-43ab21dd0142.png)

_Redo of #6935, for Sulu `2.4`_

@alexander-schranz I am sorry for unnecessary noise cause to my error with the target branch.