### PR TITLE
Add a focus outline to interactive elements

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/checkbox.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/checkbox.scss
@@ -27,6 +27,10 @@ $disabledColor: $silver;
     input:checked + span {
         background: $secondaryColor;
     }
+
+    input:focus-visible + span {
+        outline-color: $secondaryColor;
+    }
 }
 
 .checkbox.small {
@@ -67,5 +71,10 @@ $disabledColor: $silver;
     input:disabled:checked + span {
         background: $disabledColor;
         color: $white;
+    }
+
+    input:focus-visible + span {
+        outline-width: 2px;
+        outline-style: solid;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/input.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/input.scss
@@ -156,6 +156,7 @@ $darkIconColor: $doveGray;
 
         input {
             font-weight: bold;
+            height: 100%;
         }
 
         .prepended-container {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/input.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/input.scss
@@ -58,6 +58,10 @@ $darkIconColor: $doveGray;
             background-color: $inputDisabledBackgroundColor;
             -webkit-text-fill-color: $inputDisabledColor; /* Necessary for Safari and iOS */
         }
+
+        &:focus-visible {
+            outline-offset: 0;
+        }
     }
 
     &.left {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toggler/toggler.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toggler/toggler.scss
@@ -58,4 +58,9 @@ $transitionDuration: 200ms;
             background-color: transparent;
         }
     }
+
+    input:focus-visible + span {
+        outline-width: 2px;
+        outline-style: solid;
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/global.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/global.scss
@@ -15,6 +15,12 @@ $inputBackgroundColor: $white;
     box-sizing: border-box;
 }
 
+*:focus-visible {
+    outline-width: 2px;
+    outline-style: solid;
+    outline-offset: -2px;
+}
+
 html {
     width: 100%;
     height: 100%;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/global.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/global.scss
@@ -15,10 +15,29 @@ $inputBackgroundColor: $white;
     box-sizing: border-box;
 }
 
-*:focus-visible {
+:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-offset: -2px;
+}
+
+/* Fallback for browsers without :focus-visible support */
+@supports not selector(:focus-visible) {
+    :focus {
+        outline-width: 2px;
+        outline-style: solid;
+        outline-offset: -2px;
+    }
+}
+
+:focus {
+    outline-width: 2px;
+    outline-style: solid;
+    outline-offset: -2px;
+}
+
+:focus:not(:focus-visible) {
+    outline: none;
 }
 
 html {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | 
| Fixed tickets | 
| Related issues/PRs | #6444
| License | MIT
| Documentation PR | 

#### What's in this PR?

I added a focus outline to interactive elements. The focus outline is still reset globally, but then re-enabled with [focus-visible](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible) for keyboard use. Focusable elements get a focus outline only if they are focused while tabbing.

Text inputs and textareas are an exception to this logic, since they always match the pseudo-class `:focus` pseudo-class because they expect keyboard inputs.

I can remove the focus outline for text inputs, but it would be useful to think about whether the input fields should also have a custom focus state. For example, by making the border of the element darker.

A modern progressive enhancement would be a solution with `:has`:

```css
.input:has(input:focus, textarea:focus) {
    border-color: $black;
}
```

I tried not to make any major design decisions, the outline is based on the default outline of the UA stylesheet. Custom focus states would of course improve the experience.

#### Why?

An [important element for keyboard usability](https://hidde.blog/indicating-focus-to-improve-accessibility/) is the focus outline. Generally, overriding the browser's default outline is a [bad idea](https://www.a11yproject.com/posts/never-remove-css-outlines/).

#### Visual representation in Chromium browsers

<img width="266" alt="Bildschirm­foto 2022-12-15 um 11 44 07" src="https://user-images.githubusercontent.com/663702/207849844-8f71cf1e-86ff-4b3c-b3d6-28c02a0b8181.png">
<img width="494" alt="Bildschirm­foto 2022-12-15 um 11 43 46" src="https://user-images.githubusercontent.com/663702/207849863-33962fc8-3fe1-4e99-8b79-ff58a46a1561.png">
<img width="479" alt="Bildschirm­foto 2022-12-15 um 11 43 38" src="https://user-images.githubusercontent.com/663702/207849872-3ff40cb5-3698-45e0-921e-8d402df1bb58.png">
<img width="447" alt="Bildschirm­foto 2022-12-15 um 11 43 32" src="https://user-images.githubusercontent.com/663702/207849886-8d636149-dec4-4bb9-9cfb-21482359bb46.png">
<img width="138" alt="Bildschirm­foto 2022-12-15 um 12 38 32" src="https://user-images.githubusercontent.com/663702/207849956-9ea0676d-3f54-43c5-86d8-ed7c96e42e4f.png">

I am aware that this change has an influence on the design of the admin interface and probably has to be discussed internally. If design adjustments are necessary, I can implement them with pleasure.