### PR TITLE
Make folders keyboard operable

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/FolderList/Folder.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/FolderList/Folder.js
@@ -21,6 +21,19 @@ export default class Folder extends React.PureComponent<Props> {
         }
     };
 
+    handleKeypress = (event: SyntheticKeyboardEvent<HTMLElement>) => {
+        const {onClick, id} = this.props;
+
+        if (!onClick) {
+            return;
+        }
+
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.stopPropagation();
+            onClick(id);
+        }
+    };
+
     render() {
         const {
             hasPermissions,
@@ -32,6 +45,7 @@ export default class Folder extends React.PureComponent<Props> {
             <div
                 className={folderStyles.folder}
                 onClick={this.handleClick}
+                onKeyPress={this.handleKeypress}
                 role="button"
                 tabIndex="0"
             >


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | #6444
| License | MIT
| Documentation PR | 

#### What's in this PR?

Folders could be focused via keyboard, but there were no events to navigate to the folder. I have added these events.

#### Why?

#### Example Usage

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
