### PR TITLE
Make table actions reachable for keyboards

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/table.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/table.scss
@@ -134,7 +134,7 @@ $borderRadius: 3px;
             font-size: 16px;
 
             button {
-                visibility: visible;
+                opacity: 1;
             }
         }
     }
@@ -181,17 +181,8 @@ $borderRadius: 3px;
     color: $buttonCellColor;
     text-align: center;
 
-    &:hover {
-        button:not(:disabled) {
-            visibility: visible;
-            background-color: $buttonCellBackgroundColorHover;
-            border-right: $borderWidth solid $buttonCellBorderColor;
-            color: $buttonCellColorHover;
-        }
-    }
-
     button {
-        visibility: hidden;
+        opacity: 0;
         width: 100%;
         height: 100%;
         border: none;
@@ -202,6 +193,15 @@ $borderRadius: 3px;
         &:disabled {
             color: $buttonCellColorDisabled;
             cursor: default;
+        }
+
+        &:hover:not(:disabled),
+        &:focus:not(:disabled) {
+            opacity: 1;
+            font-size: 16px;
+            background-color: $buttonCellBackgroundColorHover;
+            border-right: $borderWidth solid $buttonCellBorderColor;
+            color: $buttonCellColorHover;
         }
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no 
| Fixed tickets | 
| Related issues/PRs | #6444
| License | MIT
| Documentation PR | 

#### What's in this PR?

I've restructured the CSS code a bit to allow the table actions to be visible when focussing using the keyboard. Since `visibility` also removes the element from the tab order, I had to solve the show and hide via the `opacity`.

#### Why?

Until now, entries in the list and tree list could only be edited using the mouse.
