### PR TITLE
Make MediaCard keyboard operable

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
@@ -85,6 +85,23 @@ class MediaCard extends React.Component<Props> {
         }
     };
 
+    handleKeypress = (event: SyntheticKeyboardEvent<HTMLElement>) => {
+        const {
+            id,
+            onClick,
+            selected,
+        } = this.props;
+
+        if (!onClick) {
+            return;
+        }
+
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.stopPropagation();
+            onClick(id, !selected);
+        }
+    };
+
     handleHeaderClick = () => {
         const {
             id,
@@ -92,7 +109,24 @@ class MediaCard extends React.Component<Props> {
             onSelectionChange,
         } = this.props;
 
-        if (onSelectionChange && id) {
+        if (onSelectionChange) {
+            onSelectionChange(id, !selected);
+        }
+    };
+
+    handleHeaderKeypress = (event: SyntheticKeyboardEvent<HTMLElement>) => {
+        const {
+            id,
+            selected,
+            onSelectionChange,
+        } = this.props;
+
+        if (!onSelectionChange || !id) {
+            return;
+        }
+
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.stopPropagation();
             onSelectionChange(id, !selected);
         }
     };
@@ -168,7 +202,9 @@ class MediaCard extends React.Component<Props> {
                     <div
                         className={mediaCardStyles.description}
                         onClick={this.handleHeaderClick}
+                        onKeyPress={this.handleHeaderKeypress}
                         role="button"
+                        tabIndex="0"
                     >
                         <div className={mediaCardStyles.title}>
                             {onSelectionChange
@@ -214,7 +250,9 @@ class MediaCard extends React.Component<Props> {
                 <div
                     className={mediaCardStyles.media}
                     onClick={this.handleClick}
+                    onKeyPress={this.handleKeypress}
                     role="button"
+                    tabIndex="0"
                 >
                     {image && !this.imageError
                         ? (

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
@@ -121,7 +121,7 @@ class MediaCard extends React.Component<Props> {
             onSelectionChange,
         } = this.props;
 
-        if (!onSelectionChange || !id) {
+        if (!onSelectionChange) {
             return;
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/mediaCard.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/mediaCard.scss
@@ -45,6 +45,10 @@ $downloadButtonBorderColorActive: $shakespeare;
     border-radius: $mediaCardBorderRadius 0 0 0;
     background-color: $headerBackgroundColor;
 
+    &:focus .checkbox {
+        margin-left: 0;
+    }
+
     .no-download-list & {
         border-radius: $mediaCardBorderRadius $mediaCardBorderRadius 0 0;
     }
@@ -64,6 +68,7 @@ $downloadButtonBorderColorActive: $shakespeare;
     border-radius: 0 $mediaCardBorderRadius 0 0;
 
     &:hover,
+    &:focus,
     &.active {
         background-color: $downloadButtonBackgroundColorActive;
         color: $downloadButtonTextColorActive;
@@ -75,6 +80,10 @@ $downloadButtonBorderColorActive: $shakespeare;
     margin-left: -26px;
     will-change: margin-left;
     transition: margin-left .15s linear;
+
+    input[type='checkbox'] {
+        visibility: hidden;
+    }
 }
 
 .ghost-indicator {
@@ -119,6 +128,7 @@ $downloadButtonBorderColorActive: $shakespeare;
     }
 
     &:hover,
+    &:focus,
     .show-cover & {
         .cover {
             opacity: 1;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/__snapshots__/MediaCard.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/__snapshots__/MediaCard.test.js.snap
@@ -10,6 +10,7 @@ exports[`Render a MediaCard component 1`] = `
     <div
       class="description"
       role="button"
+      tabindex="0"
     >
       <div
         class="title"
@@ -78,6 +79,7 @@ exports[`Render a MediaCard component 1`] = `
   <div
     class="media"
     role="button"
+    tabindex="0"
   >
     <img
       alt="Test"
@@ -100,6 +102,7 @@ exports[`Render a MediaCard component with MimeTypeIndicator if an error appeare
     <div
       class="description"
       role="button"
+      tabindex="0"
     >
       <div
         class="title"
@@ -168,6 +171,7 @@ exports[`Render a MediaCard component with MimeTypeIndicator if an error appeare
   <div
     class="media"
     role="button"
+    tabindex="0"
   >
     <div
       class="mimeTypeIndicator"
@@ -195,6 +199,7 @@ exports[`Render a MediaCard component with a checkbox for selection 1`] = `
     <div
       class="description"
       role="button"
+      tabindex="0"
     >
       <div
         class="title"
@@ -279,6 +284,7 @@ exports[`Render a MediaCard component with a checkbox for selection 1`] = `
   <div
     class="media"
     role="button"
+    tabindex="0"
   >
     <img
       alt="Test"
@@ -301,6 +307,7 @@ exports[`Render a MediaCard component with ghostLocale 1`] = `
     <div
       class="description"
       role="button"
+      tabindex="0"
     >
       <div
         class="title"
@@ -374,6 +381,7 @@ exports[`Render a MediaCard component with ghostLocale 1`] = `
   <div
     class="media"
     role="button"
+    tabindex="0"
   >
     <img
       alt="Test"
@@ -396,6 +404,7 @@ exports[`Render a MediaCard component with loader if image has not been loaded y
     <div
       class="description"
       role="button"
+      tabindex="0"
     >
       <div
         class="title"
@@ -464,6 +473,7 @@ exports[`Render a MediaCard component with loader if image has not been loaded y
   <div
     class="media"
     role="button"
+    tabindex="0"
   >
     <img
       alt="Test"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/__snapshots__/MediaCardAdapter.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/__snapshots__/MediaCardAdapter.test.js.snap
@@ -18,6 +18,7 @@ exports[`Render a basic Masonry view with MediaCards 1`] = `
             <div
               class="description"
               role="button"
+              tabindex="0"
             >
               <div
                 class="title"
@@ -113,6 +114,7 @@ exports[`Render a basic Masonry view with MediaCards 1`] = `
           <div
             class="media"
             role="button"
+            tabindex="0"
           >
             <img
               alt="Title 1"
@@ -152,6 +154,7 @@ exports[`Render a basic Masonry view with MediaCards 1`] = `
             <div
               class="description"
               role="button"
+              tabindex="0"
             >
               <div
                 class="title"
@@ -252,6 +255,7 @@ exports[`Render a basic Masonry view with MediaCards 1`] = `
           <div
             class="media"
             role="button"
+            tabindex="0"
           >
             <img
               alt="Title 1"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/__snapshots__/MediaCardOverviewAdapter.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/__snapshots__/MediaCardOverviewAdapter.test.js.snap
@@ -18,6 +18,7 @@ exports[`Render a basic Masonry view with the MediaCardOverviewAdapter 1`] = `
             <div
               class="description"
               role="button"
+              tabindex="0"
             >
               <div
                 class="title"
@@ -113,6 +114,7 @@ exports[`Render a basic Masonry view with the MediaCardOverviewAdapter 1`] = `
           <div
             class="media"
             role="button"
+            tabindex="0"
           >
             <img
               alt="Title 1"
@@ -152,6 +154,7 @@ exports[`Render a basic Masonry view with the MediaCardOverviewAdapter 1`] = `
             <div
               class="description"
               role="button"
+              tabindex="0"
             >
               <div
                 class="title"
@@ -247,6 +250,7 @@ exports[`Render a basic Masonry view with the MediaCardOverviewAdapter 1`] = `
           <div
             class="media"
             role="button"
+            tabindex="0"
           >
             <img
               alt="Title 1"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
@@ -305,6 +305,7 @@ exports[`Render the MediaCollection 1`] = `
                   <div
                     class="description"
                     role="button"
+                    tabindex="0"
                   >
                     <div
                       class="title"
@@ -400,6 +401,7 @@ exports[`Render the MediaCollection 1`] = `
                 <div
                   class="media"
                   role="button"
+                  tabindex="0"
                 >
                   <img
                     alt="Title 1"
@@ -439,6 +441,7 @@ exports[`Render the MediaCollection 1`] = `
                   <div
                     class="description"
                     role="button"
+                    tabindex="0"
                   >
                     <div
                       class="title"
@@ -534,6 +537,7 @@ exports[`Render the MediaCollection 1`] = `
                 <div
                   class="media"
                   role="button"
+                  tabindex="0"
                 >
                   <img
                     alt="Title 1"
@@ -871,6 +875,7 @@ exports[`Render the MediaCollection for all media 1`] = `
                   <div
                     class="description"
                     role="button"
+                    tabindex="0"
                   >
                     <div
                       class="title"
@@ -966,6 +971,7 @@ exports[`Render the MediaCollection for all media 1`] = `
                 <div
                   class="media"
                   role="button"
+                  tabindex="0"
                 >
                   <img
                     alt="Title 1"
@@ -1005,6 +1011,7 @@ exports[`Render the MediaCollection for all media 1`] = `
                   <div
                     class="description"
                     role="button"
+                    tabindex="0"
                   >
                     <div
                       class="title"
@@ -1100,6 +1107,7 @@ exports[`Render the MediaCollection for all media 1`] = `
                 <div
                   class="media"
                   role="button"
+                  tabindex="0"
                 >
                   <img
                     alt="Title 1"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
@@ -362,6 +362,7 @@ Array [
                               <div
                                 class="description"
                                 role="button"
+                                tabindex="0"
                               >
                                 <div
                                   class="title"
@@ -457,6 +458,7 @@ Array [
                             <div
                               class="media"
                               role="button"
+                              tabindex="0"
                             >
                               <img
                                 alt="Title 1"
@@ -496,6 +498,7 @@ Array [
                               <div
                                 class="description"
                                 role="button"
+                                tabindex="0"
                               >
                                 <div
                                   class="title"
@@ -591,6 +594,7 @@ Array [
                             <div
                               class="media"
                               role="button"
+                              tabindex="0"
                             >
                               <img
                                 alt="Title 2"
@@ -1054,6 +1058,7 @@ Array [
                               <div
                                 class="description"
                                 role="button"
+                                tabindex="0"
                               >
                                 <div
                                   class="title"
@@ -1149,6 +1154,7 @@ Array [
                             <div
                               class="media"
                               role="button"
+                              tabindex="0"
                             >
                               <img
                                 alt="Title 1"
@@ -1188,6 +1194,7 @@ Array [
                               <div
                                 class="description"
                                 role="button"
+                                tabindex="0"
                               >
                                 <div
                                   class="title"
@@ -1283,6 +1290,7 @@ Array [
                             <div
                               class="media"
                               role="button"
+                              tabindex="0"
                             >
                               <img
                                 alt="Title 2"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/__snapshots__/MediaOverview.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/__snapshots__/MediaOverview.test.js.snap
@@ -319,6 +319,7 @@ exports[`Render a simple MediaOverview 1`] = `
                   <div
                     class="description"
                     role="button"
+                    tabindex="0"
                   >
                     <div
                       class="title"
@@ -414,6 +415,7 @@ exports[`Render a simple MediaOverview 1`] = `
                 <div
                   class="media"
                   role="button"
+                  tabindex="0"
                 >
                   <img
                     alt="Title 1"
@@ -453,6 +455,7 @@ exports[`Render a simple MediaOverview 1`] = `
                   <div
                     class="description"
                     role="button"
+                    tabindex="0"
                   >
                     <div
                       class="title"
@@ -548,6 +551,7 @@ exports[`Render a simple MediaOverview 1`] = `
                 <div
                   class="media"
                   role="button"
+                  tabindex="0"
                 >
                   <img
                     alt="Title 1"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no 
| Fixed tickets | 
| Related issues/PRs | #6444
| License | MIT
| Documentation PR | 

#### What's in this PR?

I added keyboard events and put interactive elements in tab order. Now the MediaCard can be selected and edited via keyboard. I have taken the opportunity to add a few missing focus states.