### PR TITLE
Wrap masonry item in unordered list element

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Masonry/Masonry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Masonry/Masonry.js
@@ -15,7 +15,7 @@ type Props = {
 };
 
 export default class Masonry extends React.PureComponent<Props> {
-    masonryRef: ?ElementRef<'div'>;
+    masonryRef: ?ElementRef<'ul'>;
 
     masonry: typeof MasonryLayout;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Masonry/Masonry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Masonry/Masonry.js
@@ -37,7 +37,7 @@ export default class Masonry extends React.PureComponent<Props> {
         this.handleImagesLoading();
     }
 
-    setMasonryRef = (ref: ?ElementRef<'div'>) => {
+    setMasonryRef = (ref: ?ElementRef<'ul'>) => {
         this.masonryRef = ref;
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Masonry/Masonry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Masonry/Masonry.js
@@ -155,12 +155,12 @@ export default class Masonry extends React.PureComponent<Props> {
         const clonedItems = this.cloneItems(children);
 
         return (
-            <div
+            <ul
                 className={masonryStyles.masonry}
                 ref={this.setMasonryRef}
             >
                 {clonedItems}
-            </div>
+            </ul>
         );
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Masonry/tests/__snapshots__/Masonry.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Masonry/tests/__snapshots__/Masonry.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Render a Masonry container with items 1`] = `
 <div>
-  <div
+  <ul
     class="masonry"
     style="position: relative; height: 0px;"
   >
@@ -33,13 +33,13 @@ exports[`Render a Masonry container with items 1`] = `
         />
       </div>
     </li>
-  </div>
+  </ul>
 </div>
 `;
 
 exports[`Render an empty Masonry container 1`] = `
 <div>
-  <div
+  <ul
     class="masonry"
     style="position: relative; height: 0px;"
   />

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/__snapshots__/MediaCardAdapter.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/__snapshots__/MediaCardAdapter.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Render a basic Masonry view with MediaCards 1`] = `
 <section>
   <div>
-    <div
+    <ul
       class="masonry"
     >
       <li
@@ -279,7 +279,7 @@ exports[`Render a basic Masonry view with MediaCards 1`] = `
           </div>
         </div>
       </li>
-    </div>
+    </ul>
   </div>
   <div
     class="indicator"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/__snapshots__/MediaCardOverviewAdapter.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/__snapshots__/MediaCardOverviewAdapter.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Render a basic Masonry view with the MediaCardOverviewAdapter 1`] = `
 <section>
   <div>
-    <div
+    <ul
       class="masonry"
     >
       <li
@@ -274,7 +274,7 @@ exports[`Render a basic Masonry view with the MediaCardOverviewAdapter 1`] = `
           </div>
         </div>
       </li>
-    </div>
+    </ul>
   </div>
   <div
     class="indicator"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
@@ -290,7 +290,7 @@ exports[`Render the MediaCollection 1`] = `
     >
       <section>
         <div>
-          <div
+          <ul
             class="masonry"
           >
             <li
@@ -561,7 +561,7 @@ exports[`Render the MediaCollection 1`] = `
                 </div>
               </div>
             </li>
-          </div>
+          </ul>
         </div>
         <div
           class="indicator"
@@ -856,7 +856,7 @@ exports[`Render the MediaCollection for all media 1`] = `
     >
       <section>
         <div>
-          <div
+          <ul
             class="masonry"
           >
             <li
@@ -1127,7 +1127,7 @@ exports[`Render the MediaCollection for all media 1`] = `
                 </div>
               </div>
             </li>
-          </div>
+          </ul>
         </div>
         <div
           class="indicator"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
@@ -346,7 +346,7 @@ Array [
                 >
                   <section>
                     <div>
-                      <div
+                      <ul
                         class="masonry"
                         style="position: relative; height: 0px;"
                       >
@@ -618,7 +618,7 @@ Array [
                             </div>
                           </div>
                         </li>
-                      </div>
+                      </ul>
                     </div>
                     <div
                       class="indicator"
@@ -1038,7 +1038,7 @@ Array [
                 >
                   <section>
                     <div>
-                      <div
+                      <ul
                         class="masonry"
                         style="position: relative; height: 0px;"
                       >
@@ -1310,7 +1310,7 @@ Array [
                             </div>
                           </div>
                         </li>
-                      </div>
+                      </ul>
                     </div>
                     <div
                       class="indicator"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/__snapshots__/MediaOverview.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/__snapshots__/MediaOverview.test.js.snap
@@ -304,7 +304,7 @@ exports[`Render a simple MediaOverview 1`] = `
     >
       <section>
         <div>
-          <div
+          <ul
             class="masonry"
           >
             <li
@@ -575,7 +575,7 @@ exports[`Render a simple MediaOverview 1`] = `
                 </div>
               </div>
             </li>
-          </div>
+          </ul>
         </div>
         <div
           class="indicator"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no 
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | #6444
| License | MIT
| Documentation PR | 

#### What's in this PR?

The MasonryItem is defined as a list item element, so the container should be an list (ul or ol) to provide correct relations.
CSS already sets `list-style: none`, is there a reason why a div element was used here?