### PR TITLE
Move admin build to dist directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,7 +2,7 @@
 **/vendor/
 **/flow-typed/
 styleguide/
-**/build/admin/
+**/dist/admin/
 
 .git/
 .github/

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ phpunit.stdout
 /public/bundles
 /public/uploads
 /public/build
+/public/dist
 
 # composer
 /composer.phar

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,11 @@
 
 The admin build directory was moved from `public/build/admin` to `public/dist/admin` to avoid conflicts with webpack encore.
 
+```bash
+mkdir public/dist/
+git mv public/build/admin public/dist/admin
+```
+
 ### Webpack 5 upgrade
 
 Sulu now uses Webpack 5 to build the administration interface application. To enable this, the following JavaScript dependencies were updated/changed:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,10 @@
 
 ## 2.6.0
 
+### Admin Build directory moved to dist
+
+The admin build directory was moved from `public/build/admin` to `public/dist/admin` to avoid conflicts with webpack encore.
+
 ### Webpack 5 upgrade
 
 Sulu now uses Webpack 5 to build the administration interface application. To enable this, the following JavaScript dependencies were updated/changed:

--- a/src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php
@@ -219,12 +219,20 @@ class UpdateBuildCommand extends Command
         ];
 
         foreach ($oldBuildDirs as $oldBuildDir) {
-            if ($filesystem->exists($this->projectDir . $oldBuildDir)) {
-                if ('y' === \strtolower(
-                    $ui->ask(\sprintf('Old admin build directory (%s) detected, move to new directory (%s))?', $oldBuildDir, static::BUILD_DIR), 'y')
-                )) {
-                    $filesystem->rename($this->projectDir . $oldBuildDir, $this->projectDir . static::BUILD_DIR);
+            if (!$filesystem->exists($this->projectDir . $oldBuildDir)) {
+                continue;
+            }
+
+            if ('y' === \strtolower(
+                $ui->ask(\sprintf('Old admin build directory (%s) detected, move to new directory (%s))?', $oldBuildDir, static::BUILD_DIR), 'y')
+            )) {
+                if ($filesystem->exists($this->projectDir . static::BUILD_DIR)) {
+                    $filesystem->remove($this->projectDir . $oldBuildDir);
+
+                    continue;
                 }
+
+                $filesystem->rename($this->projectDir . $oldBuildDir, $this->projectDir . static::BUILD_DIR);
             }
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php
@@ -45,7 +45,7 @@ class UpdateBuildCommand extends Command
 
     public const ASSETS_DIR = \DIRECTORY_SEPARATOR . 'assets' . \DIRECTORY_SEPARATOR . 'admin' . \DIRECTORY_SEPARATOR;
 
-    public const BUILD_DIR = \DIRECTORY_SEPARATOR . 'public' . \DIRECTORY_SEPARATOR . 'build' . \DIRECTORY_SEPARATOR . 'admin';
+    public const BUILD_DIR = \DIRECTORY_SEPARATOR . 'public' . \DIRECTORY_SEPARATOR . 'dist' . \DIRECTORY_SEPARATOR . 'admin';
 
     public const REPOSITORY_NAME = 'skeleton';
 
@@ -211,6 +211,22 @@ class UpdateBuildCommand extends Command
 
         $ui->section('Cleanup previously installed "node_modules" folders');
         $this->cleanupPreviouslyInstalledDependencies();
+
+        $ui->section('Checking: old build directories');
+
+        $oldBuildDirs = [
+            \DIRECTORY_SEPARATOR . 'public' . \DIRECTORY_SEPARATOR . 'build' . \DIRECTORY_SEPARATOR . 'admin',
+        ];
+
+        foreach ($oldBuildDirs as $oldBuildDir) {
+            if ($filesystem->exists($this->projectDir . $oldBuildDir)) {
+                if ('y' === \strtolower(
+                    $ui->ask(\sprintf('Old admin build directory (%s) detected, move to new directory (%s))?', $oldBuildDir, static::BUILD_DIR), 'y')
+                )) {
+                    $filesystem->rename($this->projectDir . $oldBuildDir, $this->projectDir . static::BUILD_DIR);
+                }
+            }
+        }
 
         if ($needManualBuild) {
             if ($isTaggedVersion) {

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
@@ -48,7 +48,7 @@ class SuluAdminExtension extends Extension implements PrependExtensionInterface
                     'assets' => [
                         'packages' => [
                             'sulu_admin' => [
-                                'json_manifest_path' => '%kernel.project_dir%/' . $publicDir . '/build/admin/manifest.json',
+                                'json_manifest_path' => '%kernel.project_dir%/' . $publicDir . '/dist/admin/manifest.json',
                             ],
                         ],
                     ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
     env = env ? env : {};
     argv = argv ? argv : {};
 
-    const outputPath = env && env.output_path ? env.output_path : path.join('build', 'admin');
+    const outputPath = env && env.output_path ? env.output_path : path.join('dist', 'admin');
     // eslint-disable-next-line no-undef
     const projectRootPath = env && env.project_root_path ? env.project_root_path : __dirname;
     const nodeModulesPath = env && env.node_modules_path


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |yes
| New feature? | no
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #5216
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Move admin build to dist directory.

#### Why?

Avoid conflict with webpack encore or asset mapper.


Webpack Encore uses: `public/build`
Assetmapper uses: `public/assets` 