### PR TITLE
Fix webpack build and slim dependency

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,14 +1,3 @@
-and_chr >= 107
-and_ff >= 106
-and_qq >= 13.1
-and_uc >= 13.4
-android >= 107
-chrome >= 106
-edge >= 106
-firefox >= 105
-ios_saf >= 16.0
-kaios >= 2.5
-op_mob >= 64
-opera >= 90
-safari >= 16.0
-samsung >= 17.0
+last 2 versions and not dead
+not ie < 12
+not ie_mob < 12

--- a/babel.config.json
+++ b/babel.config.json
@@ -6,10 +6,7 @@
     "plugins": [
         ["@babel/plugin-proposal-decorators", {"legacy": true}],
         "@babel/plugin-transform-flow-strip-types",
-        "@babel/plugin-proposal-nullish-coalescing-operator",
-        "@babel/plugin-proposal-class-properties",
-        "@babel/plugin-proposal-optional-chaining",
-        "@babel/plugin-proposal-export-namespace-from"
+        "@babel/plugin-proposal-class-properties"
     ],
     "assumptions": {
         "setPublicClassFields": true

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
         ],
         "clearMocks": true,
         "transformIgnorePatterns": [
-            "node_modules/(?!(@ckeditor|ckeditor5|array-move)/)"
+            "node_modules/(?!(@ckeditor|ckeditor5|array-move|lodash-es)/)"
         ],
         "testPathIgnorePatterns": [
             "vendor/friendsofsymfony"

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
         ],
         "clearMocks": true,
         "transformIgnorePatterns": [
-            "node_modules/(?!(@ckeditor|ckeditor5)/)"
+            "node_modules/(?!(@ckeditor|ckeditor5|array-move)/)"
         ],
         "testPathIgnorePatterns": [
             "vendor/friendsofsymfony"

--- a/package.json
+++ b/package.json
@@ -36,9 +36,6 @@
         "@babel/eslint-parser": "^7.5.5",
         "@babel/plugin-proposal-class-properties": "^7.16.5",
         "@babel/plugin-proposal-decorators": "^7.4.4",
-        "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.2",
-        "@babel/plugin-proposal-optional-chaining": "^7.18.9",
         "@babel/plugin-transform-flow-strip-types": "^7.4.4",
         "@babel/preset-env": "^7.5.5",
         "@babel/preset-react": "^7.0.0",
@@ -115,7 +112,7 @@
         ],
         "clearMocks": true,
         "transformIgnorePatterns": [
-            "node_modules/(?!(@ckeditor|ckeditor5|array-move|lodash-es|@react-leaflet|react-leaflet)/)"
+            "node_modules/(?!(@ckeditor|ckeditor5)/)"
         ],
         "testPathIgnorePatterns": [
             "vendor/friendsofsymfony"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -90,7 +90,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                 {
                     test: /\.js$/,
                     // eslint-disable-next-line max-len
-                    exclude: /node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5|array-move|htmlparser2|lodash-es|@react-leaflet|react-leaflet)[/\\])/,
+                    exclude: /node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5)[/\\])/,
                     use: {
                         loader: 'babel-loader',
                         options: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -90,7 +90,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                 {
                     test: /\.js$/,
                     // eslint-disable-next-line max-len
-                    exclude: /node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5)[/\\])/,
+                    exclude: /node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5|array-move)[/\\])/,
                     use: {
                         loader: 'babel-loader',
                         options: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -90,7 +90,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                 {
                     test: /\.js$/,
                     // eslint-disable-next-line max-len
-                    exclude: /node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5|array-move)[/\\])/,
+                    exclude: /node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5|array-move|lodash-es)[/\\])/,
                     use: {
                         loader: 'babel-loader',
                         options: {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix?  yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/skeleton/pull/211
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix webpack build and slim dependency.

#### Why?

A lot of babel plugins where just required for webpack 4. We could remove them to as we upgraded to webpack 5. Even the latest change with `htmlparser2` actually does not work for webpack 5 just for 4. So we are not longer run that package and other via babel.
