### PR TITLE
Make form of address in contact form gender neutral

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9791,12 +9791,12 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Entity/BankAccount.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\Contact\\:\\:getMainAccountContact\\(\\) has no return type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\Contact\\:\\:getFormOfAddress\\(\\) should return int but returns int\\|null\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Entity/Contact.php
 
 		-
-			message: "#^Property Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\Contact\\:\\:\\$formOfAddress type mapping mismatch\\: database can contain int\\|null but property expects int\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\Contact\\:\\:getMainAccountContact\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Entity/Contact.php
 

--- a/src/Sulu/Bundle/ContactBundle/Entity/Contact.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/Contact.php
@@ -125,9 +125,9 @@ class Contact extends ApiEntity implements ContactInterface
     protected $socialMediaProfiles;
 
     /**
-     * @var int
+     * @var int|null
      */
-    protected $formOfAddress = 0;
+    protected $formOfAddress;
 
     /**
      * @var string|null

--- a/src/Sulu/Bundle/ContactBundle/Provider/FormOfAddressProvider.php
+++ b/src/Sulu/Bundle/ContactBundle/Provider/FormOfAddressProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sulu\Bundle\ContactBundle\Provider;
+
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class FormOfAddressProvider implements FormOfAddressProviderInterface
+{
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    public function getValues(string $locale): array
+    {
+        return [
+            [
+                'name' => '1',
+                'title' => $this->translator->trans('sulu_contact.female_form_of_address', [], 'admin', $locale),
+            ],
+            [
+                'name' => '0',
+                'title' => $this->translator->trans('sulu_contact.male_form_of_address', [], 'admin', $locale),
+            ],
+            [
+                'name' => '2',
+                'title' => $this->translator->trans('sulu_contact.other_form_of_address', [], 'admin', $locale),
+            ],
+        ];
+    }
+}

--- a/src/Sulu/Bundle/ContactBundle/Provider/FormOfAddressProvider.php
+++ b/src/Sulu/Bundle/ContactBundle/Provider/FormOfAddressProvider.php
@@ -31,7 +31,7 @@ final class FormOfAddressProvider implements FormOfAddressProviderInterface
             ],
             [
                 'name' => '2',
-                'title' => $this->translator->trans('sulu_contact.other_form_of_address', [], 'admin', $locale),
+                'title' => $this->translator->trans('sulu_contact.neutral_form_of_address', [], 'admin', $locale),
             ],
         ];
     }

--- a/src/Sulu/Bundle/ContactBundle/Provider/FormOfAddressProvider.php
+++ b/src/Sulu/Bundle/ContactBundle/Provider/FormOfAddressProvider.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Sulu\Bundle\ContactBundle\Provider;
 
 use Symfony\Contracts\Translation\TranslatorInterface;

--- a/src/Sulu/Bundle/ContactBundle/Provider/FormOfAddressProviderInterface.php
+++ b/src/Sulu/Bundle/ContactBundle/Provider/FormOfAddressProviderInterface.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Sulu\Bundle\ContactBundle\Provider;
 
 interface FormOfAddressProviderInterface

--- a/src/Sulu/Bundle/ContactBundle/Provider/FormOfAddressProviderInterface.php
+++ b/src/Sulu/Bundle/ContactBundle/Provider/FormOfAddressProviderInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sulu\Bundle\ContactBundle\Provider;
+
+interface FormOfAddressProviderInterface
+{
+    /**
+     * @return array<array{
+     *     name: string,
+     *     title: string,
+     * }>
+     */
+    public function getValues(string $locale): array;
+}

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/forms/contact_details.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/forms/contact_details.xml
@@ -46,7 +46,7 @@
                     </params>
                 </property>
 
-                <property name="formOfAddress" type="single_select" colspan="3">
+                <property name="formOfAddress" type="single_select" mandatory="true" colspan="3">
                     <meta>
                         <title>sulu_contact.form_of_address</title>
                     </meta>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/forms/contact_details.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/forms/contact_details.xml
@@ -46,24 +46,12 @@
                     </params>
                 </property>
 
-                <property name="formOfAddress" type="single_select" mandatory="true" colspan="3">
+                <property name="formOfAddress" type="single_select" colspan="3">
                     <meta>
                         <title>sulu_contact.form_of_address</title>
                     </meta>
                     <params>
-                        <param name="default_value" value="0"/>
-                        <param name="values" type="collection">
-                            <param name="0">
-                                <meta>
-                                    <title>sulu_contact.male_form_of_address</title>
-                                </meta>
-                            </param>
-                            <param name="1">
-                                <meta>
-                                    <title>sulu_contact.female_form_of_address</title>
-                                </meta>
-                            </param>
-                        </param>
+                        <param name="values" type="expression" value="service('sulu_contact.form_of_address_provider').getValues(locale)"/>
                     </params>
                 </property>
 

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
@@ -210,5 +210,13 @@
         >
             <tag name="sulu_core.list_builder_filter_type" alias="country" />
         </service>
+
+        <service
+            id="sulu_contact.form_of_address_provider"
+            class="Sulu\Bundle\ContactBundle\Provider\FormOfAddressProvider"
+            public="true"
+        >
+            <argument type="service" id="translator"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.de.json
@@ -40,7 +40,7 @@
     "sulu_contact.form_of_address": "Anrede",
     "sulu_contact.male_form_of_address": "Herr",
     "sulu_contact.female_form_of_address": "Frau",
-    "sulu_contact.other_form_of_address": "Divers",
+    "sulu_contact.neutral_form_of_address": "Neutral",
     "sulu_contact.position": "Position",
     "sulu_contact.corporation": "Gesellschaft",
     "sulu_contact.main_contact": "Hauptansprechpartner",

--- a/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.de.json
@@ -40,6 +40,7 @@
     "sulu_contact.form_of_address": "Anrede",
     "sulu_contact.male_form_of_address": "Herr",
     "sulu_contact.female_form_of_address": "Frau",
+    "sulu_contact.other_form_of_address": "Divers",
     "sulu_contact.position": "Position",
     "sulu_contact.corporation": "Gesellschaft",
     "sulu_contact.main_contact": "Hauptansprechpartner",

--- a/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.en.json
@@ -40,7 +40,7 @@
     "sulu_contact.form_of_address": "Form of Address",
     "sulu_contact.male_form_of_address": "Mr.",
     "sulu_contact.female_form_of_address": "Ms.",
-    "sulu_contact.other_form_of_address": "Other",
+    "sulu_contact.neutral_form_of_address": "Neutral",
     "sulu_contact.position": "Position",
     "sulu_contact.corporation": "Corporation",
     "sulu_contact.main_contact": "Main Contact",

--- a/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.en.json
@@ -40,6 +40,7 @@
     "sulu_contact.form_of_address": "Form of Address",
     "sulu_contact.male_form_of_address": "Mr.",
     "sulu_contact.female_form_of_address": "Ms.",
+    "sulu_contact.other_form_of_address": "Other",
     "sulu_contact.position": "Position",
     "sulu_contact.corporation": "Corporation",
     "sulu_contact.main_contact": "Main Contact",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

This PR adds a `FormOfAddressProvider` which provides the options for the respective values in the contact form. That service can be overridden to adjust the possible values for that field.

#### Why?

To make form of address in contact form gender neutral
