### PR TITLE
[DX] Adding types for list metadata configuration

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -54471,12 +54471,22 @@ parameters:
 			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
 
 		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+
+		-
 			message: "#^Left side of && is always true\\.$#"
 			count: 2
 			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
 
 		-
 			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\DoctrineListBuilder\\:\\:__construct\\(\\) has parameter \\$permissions with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+
+		-
+			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\DoctrineListBuilder\\:\\:addAccessControl\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
 
@@ -55781,12 +55791,82 @@ parameters:
 			path: src/Sulu/Component/Rest/Listing/ListRestHelper.php
 
 		-
+			message: "#^Left side of && is always true\\.$#"
+			count: 1
+			path: src/Sulu/Component/Rest/RestHelper.php
+
+		-
+			message: "#^Method Sulu\\\\Component\\\\Rest\\\\RestHelper\\:\\:compareData\\(\\) has parameter \\$entities with no value type specified in iterable type Traversable\\.$#"
+			count: 1
+			path: src/Sulu/Component/Rest/RestHelper.php
+
+		-
+			message: "#^Method Sulu\\\\Component\\\\Rest\\\\RestHelper\\:\\:compareData\\(\\) has parameter \\$requestEntities with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Sulu/Component/Rest/RestHelper.php
+
+		-
+			message: "#^Method Sulu\\\\Component\\\\Rest\\\\RestHelper\\:\\:compareEntitiesWithData\\(\\) has parameter \\$entities with no value type specified in iterable type Traversable\\.$#"
+			count: 1
+			path: src/Sulu/Component/Rest/RestHelper.php
+
+		-
+			message: "#^Method Sulu\\\\Component\\\\Rest\\\\RestHelper\\:\\:compareEntitiesWithData\\(\\) has parameter \\$requestEntities with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Sulu/Component/Rest/RestHelper.php
+
+		-
+			message: "#^Method Sulu\\\\Component\\\\Rest\\\\RestHelper\\:\\:findMatchByCallback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Sulu/Component/Rest/RestHelper.php
+
+		-
+			message: "#^Method Sulu\\\\Component\\\\Rest\\\\RestHelper\\:\\:findMatchByCallback\\(\\) has parameter \\$entity with no value type specified in iterable type Traversable\\.$#"
+			count: 1
+			path: src/Sulu/Component/Rest/RestHelper.php
+
+		-
+			message: "#^Method Sulu\\\\Component\\\\Rest\\\\RestHelper\\:\\:findMatchByCallback\\(\\) has parameter \\$matchedEntry with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Sulu/Component/Rest/RestHelper.php
+
+		-
+			message: "#^Method Sulu\\\\Component\\\\Rest\\\\RestHelper\\:\\:findMatchByCallback\\(\\) has parameter \\$requestEntities with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Sulu/Component/Rest/RestHelper.php
+
+		-
 			message: "#^Method Sulu\\\\Component\\\\Rest\\\\RestHelper\\:\\:initializeListBuilder\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Rest/RestHelper.php
 
 		-
+			message: "#^Method Sulu\\\\Component\\\\Rest\\\\RestHelper\\:\\:processSubEntities\\(\\) has parameter \\$entities with no value type specified in iterable type Traversable\\.$#"
+			count: 1
+			path: src/Sulu/Component/Rest/RestHelper.php
+
+		-
+			message: "#^Method Sulu\\\\Component\\\\Rest\\\\RestHelper\\:\\:processSubEntities\\(\\) has parameter \\$requestEntities with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Sulu/Component/Rest/RestHelper.php
+
+		-
 			message: "#^Parameter \\#1 \\$filter of method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\ListBuilderInterface\\:\\:filter\\(\\) expects array, array\\|null given\\.$#"
+			count: 1
+			path: src/Sulu/Component/Rest/RestHelper.php
+
+		-
+			message: "#^Strict comparison using \\!\\=\\= between null and null will always evaluate to false\\.$#"
+			count: 1
+			path: src/Sulu/Component/Rest/RestHelper.php
+
+		-
+			message: "#^Trying to invoke \\(callable\\(\\)\\: mixed\\)\\|null but it might not be a callable\\.$#"
+			count: 1
+			path: src/Sulu/Component/Rest/RestHelper.php
+
+		-
+			message: "#^Variable \\$entities in empty\\(\\) always exists and is not falsy\\.$#"
 			count: 1
 			path: src/Sulu/Component/Rest/RestHelper.php
 
@@ -58799,16 +58879,6 @@ parameters:
 			message: "#^Method Sulu\\\\Component\\\\Util\\\\WildcardUrlUtil\\:\\:resolve\\(\\) should return string but empty return statement found\\.$#"
 			count: 1
 			path: src/Sulu/Component/Util/WildcardUrlUtil.php
-
-		-
-			message: "#^Cannot access property \\$length on DOMNodeList\\<DOMNode\\>\\|false\\.$#"
-			count: 1
-			path: src/Sulu/Component/Util/XmlUtil.php
-
-		-
-			message: "#^Cannot call method item\\(\\) on DOMNodeList\\<DOMNode\\>\\|false\\.$#"
-			count: 1
-			path: src/Sulu/Component/Util/XmlUtil.php
 
 		-
 			message: "#^Method Sulu\\\\Component\\\\Util\\\\XmlUtil\\:\\:getBooleanValueFromXPath\\(\\) has parameter \\$default with no type specified\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -54471,22 +54471,12 @@ parameters:
 			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
 
 		-
-			message: "#^Cannot cast mixed to int\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
-
-		-
 			message: "#^Left side of && is always true\\.$#"
 			count: 2
 			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
 
 		-
 			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\DoctrineListBuilder\\:\\:__construct\\(\\) has parameter \\$permissions with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\DoctrineListBuilder\\:\\:addAccessControl\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
 
@@ -55161,111 +55151,6 @@ parameters:
 			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelperInterface.php
 
 		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\AbstractPropertyMetadata\\:\\:__construct\\(\\) has parameter \\$name with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/AbstractPropertyMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\AbstractPropertyMetadata\\:\\:getFilterTypeParameters\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/AbstractPropertyMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\AbstractPropertyMetadata\\:\\:getTransformerTypeParameters\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/AbstractPropertyMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\AbstractPropertyMetadata\\:\\:setFilterType\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/AbstractPropertyMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\AbstractPropertyMetadata\\:\\:setFilterTypeParameters\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/AbstractPropertyMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\AbstractPropertyMetadata\\:\\:setFilterTypeParameters\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/AbstractPropertyMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\AbstractPropertyMetadata\\:\\:setSearchability\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/AbstractPropertyMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\AbstractPropertyMetadata\\:\\:setSortable\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/AbstractPropertyMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\AbstractPropertyMetadata\\:\\:setTransformerTypeParameters\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/AbstractPropertyMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\AbstractPropertyMetadata\\:\\:setTransformerTypeParameters\\(\\) has parameter \\$transformerTypeParameters with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/AbstractPropertyMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\AbstractPropertyMetadata\\:\\:setTranslation\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/AbstractPropertyMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\AbstractPropertyMetadata\\:\\:setType\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/AbstractPropertyMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\AbstractPropertyMetadata\\:\\:setVisibility\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/AbstractPropertyMetadata.php
-
-		-
-			message: "#^Property Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\AbstractPropertyMetadata\\:\\:\\$filterTypeParameters type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/AbstractPropertyMetadata.php
-
-		-
-			message: "#^Property Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\AbstractPropertyMetadata\\:\\:\\$transformerTypeParameters type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/AbstractPropertyMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\CasePropertyMetadata\\:\\:addCase\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/CasePropertyMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\ConcatenationPropertyMetadata\\:\\:addField\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/ConcatenationPropertyMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\ConcatenationPropertyMetadata\\:\\:getFields\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/ConcatenationPropertyMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\ConcatenationPropertyMetadata\\:\\:setGlue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/ConcatenationPropertyMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\CountPropertyMetadata\\:\\:setDistinct\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/CountPropertyMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\CountPropertyMetadata\\:\\:setField\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/CountPropertyMetadata.php
-
-		-
 			message: "#^Call to an undefined method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\AbstractPropertyMetadata\\:\\:getDistinct\\(\\)\\.$#"
 			count: 1
 			path: src/Sulu/Component/Rest/ListBuilder/Metadata/FieldDescriptorFactory.php
@@ -55416,21 +55301,6 @@ parameters:
 			path: src/Sulu/Component/Rest/ListBuilder/Metadata/FieldDescriptorFactory.php
 
 		-
-			message: "#^Parameter \\#1 \\$string of method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\FieldDescriptorFactory\\:\\:resolveOptions\\(\\) expects string, bool given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/FieldDescriptorFactory.php
-
-		-
-			message: "#^Parameter \\#10 \\$distinct of class Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\FieldDescriptor\\\\DoctrineCountFieldDescriptor constructor expects bool, string given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/FieldDescriptorFactory.php
-
-		-
-			message: "#^Parameter \\#9 \\$distinct of class Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\FieldDescriptor\\\\DoctrineGroupConcatFieldDescriptor constructor expects bool, string given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/FieldDescriptorFactory.php
-
-		-
 			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\FieldMetadata\\:\\:__construct\\(\\) has parameter \\$entityName with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Rest/ListBuilder/Metadata/FieldMetadata.php
@@ -55439,96 +55309,6 @@ parameters:
 			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\FieldMetadata\\:\\:__construct\\(\\) has parameter \\$name with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Rest/ListBuilder/Metadata/FieldMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\FieldMetadata\\:\\:addJoin\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/FieldMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\FieldMetadata\\:\\:setJoins\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/FieldMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\GroupConcatPropertyMetadata\\:\\:setDistinct\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/GroupConcatPropertyMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\GroupConcatPropertyMetadata\\:\\:setField\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/GroupConcatPropertyMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\GroupConcatPropertyMetadata\\:\\:setGlue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/GroupConcatPropertyMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\IdentityPropertyMetadata\\:\\:setField\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/IdentityPropertyMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\JoinMetadata\\:\\:setCondition\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/JoinMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\JoinMetadata\\:\\:setConditionMethod\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/JoinMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\JoinMetadata\\:\\:setEntityField\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/JoinMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\JoinMetadata\\:\\:setEntityName\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/JoinMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\JoinMetadata\\:\\:setMethod\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/JoinMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\ListMetadata\\:\\:addPropertyMetadata\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/ListMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\ListMetadata\\:\\:getKey\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/ListMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\ListMetadata\\:\\:getPropertiesMetadata\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/ListMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\ListMetadata\\:\\:getResource\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/ListMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\ListMetadata\\:\\:setKey\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/ListMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\ListMetadata\\:\\:setResource\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/ListMetadata.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\ListMetadata\\:\\:setResource\\(\\) has parameter \\$resource with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/ListMetadata.php
 
 		-
 			message: "#^Argument of an invalid type DOMNodeList\\<DOMNode\\>\\|false supplied for foreach, only iterables are supported\\.$#"
@@ -55631,32 +55411,7 @@ parameters:
 			path: src/Sulu/Component/Rest/ListBuilder/Metadata/ListXmlLoader.php
 
 		-
-			message: "#^Parameter \\#1 \\$distinct of method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\CountPropertyMetadata\\:\\:setDistinct\\(\\) expects bool, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/ListXmlLoader.php
-
-		-
-			message: "#^Parameter \\#1 \\$distinct of method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\GroupConcatPropertyMetadata\\:\\:setDistinct\\(\\) expects bool, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/ListXmlLoader.php
-
-		-
-			message: "#^Parameter \\#1 \\$glue of method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\ConcatenationPropertyMetadata\\:\\:setGlue\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/ListXmlLoader.php
-
-		-
-			message: "#^Parameter \\#1 \\$glue of method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\GroupConcatPropertyMetadata\\:\\:setGlue\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/ListXmlLoader.php
-
-		-
 			message: "#^Parameter \\#1 \\$key of method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\ListMetadata\\:\\:setKey\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/ListXmlLoader.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function trim expects string, mixed given\\.$#"
 			count: 1
 			path: src/Sulu/Component/Rest/ListBuilder/Metadata/ListXmlLoader.php
 
@@ -55699,16 +55454,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$propertyNode of method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\ListXmlLoader\\:\\:loadIdentityPropertyMetadata\\(\\) expects DOMElement, DOMNode given\\.$#"
 			count: 1
 			path: src/Sulu/Component/Rest/ListBuilder/Metadata/ListXmlLoader.php
-
-		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
-			count: 4
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/ListXmlLoader.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Metadata\\\\SinglePropertyMetadata\\:\\:setField\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Metadata/SinglePropertyMetadata.php
 
 		-
 			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\PaginatedRepresentation\\:\\:__construct\\(\\) has parameter \\$data with no type specified\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -55781,82 +55781,12 @@ parameters:
 			path: src/Sulu/Component/Rest/Listing/ListRestHelper.php
 
 		-
-			message: "#^Left side of && is always true\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/RestHelper.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\RestHelper\\:\\:compareData\\(\\) has parameter \\$entities with no value type specified in iterable type Traversable\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/RestHelper.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\RestHelper\\:\\:compareData\\(\\) has parameter \\$requestEntities with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/RestHelper.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\RestHelper\\:\\:compareEntitiesWithData\\(\\) has parameter \\$entities with no value type specified in iterable type Traversable\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/RestHelper.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\RestHelper\\:\\:compareEntitiesWithData\\(\\) has parameter \\$requestEntities with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/RestHelper.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\RestHelper\\:\\:findMatchByCallback\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/RestHelper.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\RestHelper\\:\\:findMatchByCallback\\(\\) has parameter \\$entity with no value type specified in iterable type Traversable\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/RestHelper.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\RestHelper\\:\\:findMatchByCallback\\(\\) has parameter \\$matchedEntry with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/RestHelper.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\RestHelper\\:\\:findMatchByCallback\\(\\) has parameter \\$requestEntities with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/RestHelper.php
-
-		-
 			message: "#^Method Sulu\\\\Component\\\\Rest\\\\RestHelper\\:\\:initializeListBuilder\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Rest/RestHelper.php
 
 		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\RestHelper\\:\\:processSubEntities\\(\\) has parameter \\$entities with no value type specified in iterable type Traversable\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/RestHelper.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\RestHelper\\:\\:processSubEntities\\(\\) has parameter \\$requestEntities with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/RestHelper.php
-
-		-
 			message: "#^Parameter \\#1 \\$filter of method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\ListBuilderInterface\\:\\:filter\\(\\) expects array, array\\|null given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/RestHelper.php
-
-		-
-			message: "#^Strict comparison using \\!\\=\\= between null and null will always evaluate to false\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/RestHelper.php
-
-		-
-			message: "#^Trying to invoke \\(callable\\(\\)\\: mixed\\)\\|null but it might not be a callable\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/RestHelper.php
-
-		-
-			message: "#^Variable \\$entities in empty\\(\\) always exists and is not falsy\\.$#"
 			count: 1
 			path: src/Sulu/Component/Rest/RestHelper.php
 

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/AbstractPropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/AbstractPropertyMetadata.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of Sulu.
  *

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/AbstractPropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/AbstractPropertyMetadata.php
@@ -18,195 +18,120 @@ use Sulu\Component\Rest\ListBuilder\FieldDescriptorInterface;
  */
 abstract class AbstractPropertyMetadata
 {
-    /**
-     * @var string
-     */
-    private $name;
+    private string $name;
 
-    /**
-     * @var string
-     */
-    private $translation;
+    private string $translation;
 
-    /**
-     * @var string
-     */
-    private $visibility = FieldDescriptorInterface::VISIBILITY_NEVER;
+    private string $visibility = FieldDescriptorInterface::VISIBILITY_NEVER;
 
-    /**
-     * @var string
-     */
-    private $searchability = FieldDescriptorInterface::SEARCHABILITY_NEVER;
+    private string $searchability = FieldDescriptorInterface::SEARCHABILITY_NEVER;
 
-    /**
-     * @var string
-     */
-    private $type = 'string';
+    private string $type = 'string';
 
-    /**
-     * @var bool
-     */
-    private $sortable = true;
+    private bool $sortable = true;
 
-    /**
-     * @var array
-     */
-    private $transformerTypeParameters;
+    /** @var array<mixed> */
+    private array $transformerTypeParameters;
 
-    /**
-     * @var string
-     */
-    private $filterType;
+    private string $filterType;
 
-    /**
-     * @var array
-     */
-    private $filterTypeParameters;
+    /** @var array<mixed> */
+    private array $filterTypeParameters;
 
-    /**
-     * @var string
-     */
-    private $width;
+    private string $width;
 
-    public function __construct($name)
+    public function __construct(string $name)
     {
         $this->name = $name;
         // default for translation can be overwritten by setter
         $this->translation = \ucfirst($name);
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @return string
-     */
-    public function getTranslation()
+    public function getTranslation(): string
     {
         return $this->translation;
     }
 
-    /**
-     * @param string $translation
-     */
-    public function setTranslation($translation)
+    public function setTranslation(string $translation): void
     {
         $this->translation = $translation;
     }
 
-    /**
-     * @return string
-     */
-    public function getVisibility()
+    public function getVisibility(): string
     {
         return $this->visibility;
     }
 
-    /**
-     * @param string $visibility
-     */
-    public function setVisibility($visibility)
+    public function setVisibility(string $visibility): void
     {
         $this->visibility = $visibility;
     }
 
-    /**
-     * @return string
-     */
-    public function getSearchability()
+    public function getSearchability(): string
     {
         return $this->searchability;
     }
 
-    /**
-     * @param string $searchability
-     */
-    public function setSearchability($searchability)
+    public function setSearchability(string $searchability): void
     {
         $this->searchability = $searchability;
     }
 
-    /**
-     * @return string
-     */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
 
-    /**
-     * @param string $type
-     */
-    public function setType($type)
+    public function setType(string $type): void
     {
         $this->type = $type;
     }
 
-    /**
-     * @return bool
-     */
-    public function isSortable()
+    public function isSortable(): bool
     {
         return $this->sortable;
     }
 
-    /**
-     * @param bool $sortable
-     */
-    public function setSortable($sortable)
+    public function setSortable(bool $sortable): void
     {
         $this->sortable = $sortable;
     }
 
-    /**
-     * @return array
-     */
-    public function getTransformerTypeParameters()
+    /** @return array<mixed> */
+    public function getTransformerTypeParameters(): array
     {
         return $this->transformerTypeParameters;
     }
 
-    /**
-     * @param array $transformerTypeParameters
-     */
-    public function setTransformerTypeParameters($transformerTypeParameters)
+    /** @param array<mixed> $transformerTypeParameters */
+    public function setTransformerTypeParameters(array $transformerTypeParameters): void
     {
         $this->transformerTypeParameters = $transformerTypeParameters;
     }
 
-    /**
-     * @return string
-     */
-    public function getFilterType()
+    public function getFilterType(): string
     {
         return $this->filterType;
     }
 
-    /**
-     * @param string $filterType
-     */
-    public function setFilterType($filterType)
+    public function setFilterType(string $filterType): void
     {
         $this->filterType = $filterType;
     }
 
-    /**
-     * @return array
-     */
-    public function getFilterTypeParameters()
+    /** @return array<mixed> */
+    public function getFilterTypeParameters(): array
     {
         return $this->filterTypeParameters;
     }
 
-    /**
-     * @param array $parameters
-     */
-    public function setFilterTypeParameters($parameters)
+    /** @param array<mixed> $parameters */
+    public function setFilterTypeParameters(array $parameters): void
     {
         $this->filterTypeParameters = $parameters;
     }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/AbstractPropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/AbstractPropertyMetadata.php
@@ -104,10 +104,10 @@ abstract class AbstractPropertyMetadata
         $this->sortable = $sortable;
     }
 
-    /** @return array<mixed> */
-    public function getTransformerTypeParameters(): array
+    /** @return array<mixed>|null */
+    public function getTransformerTypeParameters(): ?array
     {
-        return $this->transformerTypeParameters;
+        return $this->transformerTypeParameters ?? null;
     }
 
     /** @param array<mixed> $transformerTypeParameters */
@@ -126,10 +126,10 @@ abstract class AbstractPropertyMetadata
         $this->filterType = $filterType;
     }
 
-    /** @return array<mixed> */
-    public function getFilterTypeParameters(): array
+    /** @return array<mixed>|null */
+    public function getFilterTypeParameters(): ?array
     {
-        return $this->filterTypeParameters;
+        return $this->filterTypeParameters ?? null;
     }
 
     /** @param array<mixed> $parameters */

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/AbstractPropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/AbstractPropertyMetadata.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of Sulu.
  *
@@ -20,120 +18,214 @@ use Sulu\Component\Rest\ListBuilder\FieldDescriptorInterface;
  */
 abstract class AbstractPropertyMetadata
 {
-    private string $name;
+    /**
+     * @var string
+     */
+    private $name;
 
-    private string $translation;
+    /**
+     * @var string
+     */
+    private $translation;
 
-    private string $visibility = FieldDescriptorInterface::VISIBILITY_NEVER;
+    /**
+     * @var string
+     */
+    private $visibility = FieldDescriptorInterface::VISIBILITY_NEVER;
 
-    private string $searchability = FieldDescriptorInterface::SEARCHABILITY_NEVER;
+    /**
+     * @var string
+     */
+    private $searchability = FieldDescriptorInterface::SEARCHABILITY_NEVER;
 
-    private string $type = 'string';
+    /**
+     * @var string
+     */
+    private $type = 'string';
 
-    private bool $sortable = true;
+    /**
+     * @var bool
+     */
+    private $sortable = true;
 
-    /** @var array<mixed> */
-    private array $transformerTypeParameters;
+    /**
+     * @var array<mixed>|null
+     */
+    private $transformerTypeParameters = null;
 
-    private string $filterType;
+    /**
+     * @var string
+     */
+    private $filterType;
 
-    /** @var array<mixed> */
-    private array $filterTypeParameters;
+    /**
+     * @var array<mixed>|null
+     */
+    private $filterTypeParameters = null;
 
-    private string $width;
+    /**
+     * @var string
+     */
+    private $width;
 
-    public function __construct(string $name)
+    /**
+     * @param string $name
+     */
+    public function __construct($name)
     {
         $this->name = $name;
         // default for translation can be overwritten by setter
         $this->translation = \ucfirst($name);
     }
 
-    public function getName(): string
+    /**
+     * @return string
+     */
+    public function getName()
     {
         return $this->name;
     }
 
-    public function getTranslation(): string
+    /**
+     * @return string
+     */
+    public function getTranslation()
     {
         return $this->translation;
     }
 
-    public function setTranslation(string $translation): void
+    /**
+     * @param string $translation
+     *
+     * @return void
+     */
+    public function setTranslation($translation)
     {
         $this->translation = $translation;
     }
 
-    public function getVisibility(): string
+    /**
+     * @return string
+     */
+    public function getVisibility()
     {
         return $this->visibility;
     }
 
-    public function setVisibility(string $visibility): void
+    /**
+     * @param string $visibility
+     *
+     * @return void
+     */
+    public function setVisibility($visibility)
     {
         $this->visibility = $visibility;
     }
 
-    public function getSearchability(): string
+    /**
+     * @return string
+     */
+    public function getSearchability()
     {
         return $this->searchability;
     }
 
-    public function setSearchability(string $searchability): void
+    /**
+     * @param string $searchability
+     *
+     * @return void
+     */
+    public function setSearchability($searchability)
     {
         $this->searchability = $searchability;
     }
 
-    public function getType(): string
+    /**
+     * @return string
+     */
+    public function getType()
     {
         return $this->type;
     }
 
-    public function setType(string $type): void
+    /**
+     * @param string $type
+     *
+     * @return void
+     */
+    public function setType($type)
     {
         $this->type = $type;
     }
 
-    public function isSortable(): bool
+    /**
+     * @return bool
+     */
+    public function isSortable()
     {
         return $this->sortable;
     }
 
-    public function setSortable(bool $sortable): void
+    /**
+     * @param bool $sortable
+     *
+     * @return void
+     */
+    public function setSortable($sortable)
     {
         $this->sortable = $sortable;
     }
 
-    /** @return array<mixed>|null */
-    public function getTransformerTypeParameters(): ?array
+    /**
+     * @return array<mixed>|null
+     */
+    public function getTransformerTypeParameters()
     {
-        return $this->transformerTypeParameters ?? null;
+        return $this->transformerTypeParameters;
     }
 
-    /** @param array<mixed> $transformerTypeParameters */
-    public function setTransformerTypeParameters(array $transformerTypeParameters): void
+    /**
+     * @param array<mixed> $transformerTypeParameters
+     *
+     * @return void
+     */
+    public function setTransformerTypeParameters($transformerTypeParameters)
     {
         $this->transformerTypeParameters = $transformerTypeParameters;
     }
 
-    public function getFilterType(): string
+    /**
+     * @return string
+     */
+    public function getFilterType()
     {
         return $this->filterType;
     }
 
-    public function setFilterType(string $filterType): void
+    /**
+     * @param string $filterType
+     *
+     * @return void
+     */
+    public function setFilterType($filterType)
     {
         $this->filterType = $filterType;
     }
 
-    /** @return array<mixed>|null */
-    public function getFilterTypeParameters(): ?array
+    /**
+     * @return array<mixed>|null
+     */
+    public function getFilterTypeParameters()
     {
-        return $this->filterTypeParameters ?? null;
+        return $this->filterTypeParameters;
     }
 
-    /** @param array<mixed> $parameters */
-    public function setFilterTypeParameters(array $parameters): void
+    /**
+     * @param array<mixed> $parameters
+     *
+     * @return void
+     */
+    public function setFilterTypeParameters($parameters)
     {
         $this->filterTypeParameters = $parameters;
     }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/CasePropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/CasePropertyMetadata.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of Sulu.
  *

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/CasePropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/CasePropertyMetadata.php
@@ -19,26 +19,22 @@ class CasePropertyMetadata extends AbstractPropertyMetadata
     /**
      * @var FieldMetadata[]
      */
-    private $cases = [];
+    private array $cases = [];
 
     /**
      * Returns all cases.
      *
      * @return FieldMetadata[]
      */
-    public function getCases()
+    public function getCases(): array
     {
         return $this->cases;
     }
 
     /**
      * Returns a single case.
-     *
-     * @param int $index
-     *
-     * @return FieldMetadata
      */
-    public function getCase($index)
+    public function getCase(int $index): FieldMetadata
     {
         return $this->cases[$index];
     }
@@ -46,7 +42,7 @@ class CasePropertyMetadata extends AbstractPropertyMetadata
     /**
      * Add a case.
      */
-    public function addCase(FieldMetadata $case)
+    public function addCase(FieldMetadata $case): void
     {
         $this->cases[] = $case;
     }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/CasePropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/CasePropertyMetadata.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of Sulu.
  *
@@ -28,23 +26,29 @@ class CasePropertyMetadata extends AbstractPropertyMetadata
      *
      * @return FieldMetadata[]
      */
-    public function getCases(): array
+    public function getCases()
     {
         return $this->cases;
     }
 
     /**
      * Returns a single case.
+     *
+     * @param int $index
+     *
+     * @return FieldMetadata
      */
-    public function getCase(int $index): FieldMetadata
+    public function getCase($index)
     {
         return $this->cases[$index];
     }
 
     /**
      * Add a case.
+     *
+     * @return void
      */
-    public function addCase(FieldMetadata $case): void
+    public function addCase(FieldMetadata $case)
     {
         $this->cases[] = $case;
     }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/ConcatenationPropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/ConcatenationPropertyMetadata.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of Sulu.
  *

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/ConcatenationPropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/ConcatenationPropertyMetadata.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of Sulu.
  *
@@ -25,7 +23,10 @@ class ConcatenationPropertyMetadata extends AbstractPropertyMetadata
 
     private string $glue;
 
-    public function setGlue(string $glue): void
+    /**
+     * @return void
+     */
+    public function setGlue(string $glue)
     {
         $this->glue = $glue;
     }
@@ -43,7 +44,10 @@ class ConcatenationPropertyMetadata extends AbstractPropertyMetadata
         return $this->fields;
     }
 
-    public function addField(FieldMetadata $field): void
+    /**
+     * @return void
+     */
+    public function addField(FieldMetadata $field)
     {
         $this->fields[] = $field;
     }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/ConcatenationPropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/ConcatenationPropertyMetadata.php
@@ -19,14 +19,11 @@ class ConcatenationPropertyMetadata extends AbstractPropertyMetadata
     /**
      * @var FieldMetadata[]
      */
-    private $fields = [];
+    private array $fields = [];
 
-    /**
-     * @var string
-     */
-    private $glue;
+    private string $glue;
 
-    public function setGlue(string $glue)
+    public function setGlue(string $glue): void
     {
         $this->glue = $glue;
     }
@@ -36,12 +33,15 @@ class ConcatenationPropertyMetadata extends AbstractPropertyMetadata
         return $this->glue;
     }
 
+    /**
+     * @return FieldMetadata[]
+     */
     public function getFields(): array
     {
         return $this->fields;
     }
 
-    public function addField(FieldMetadata $field)
+    public function addField(FieldMetadata $field): void
     {
         $this->fields[] = $field;
     }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/CountPropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/CountPropertyMetadata.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of Sulu.
  *

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/CountPropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/CountPropertyMetadata.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of Sulu.
  *
@@ -22,20 +20,28 @@ class CountPropertyMetadata extends AbstractPropertyMetadata
 
     private bool $distinct;
 
-    public function setField(FieldMetadata $field): void
+    /**
+     * @return void
+     */
+    public function setField(FieldMetadata $field)
     {
         $this->field = $field;
     }
 
     /**
      * Returns metadata for field.
+     *
+     * @return FieldMetadata
      */
-    public function getField(): FieldMetadata
+    public function getField()
     {
         return $this->field;
     }
 
-    public function setDistinct(bool $distinct): void
+    /**
+     * @return void
+     */
+    public function setDistinct(bool $distinct)
     {
         $this->distinct = $distinct;
     }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/CountPropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/CountPropertyMetadata.php
@@ -16,32 +16,24 @@ namespace Sulu\Component\Rest\ListBuilder\Metadata;
  */
 class CountPropertyMetadata extends AbstractPropertyMetadata
 {
-    /**
-     * @var FieldMetadata
-     */
-    private $field;
+    private FieldMetadata $field;
 
-    /**
-     * @var bool
-     */
-    private $distinct;
+    private bool $distinct;
 
-    public function setField(FieldMetadata $field)
+    public function setField(FieldMetadata $field): void
     {
         $this->field = $field;
     }
 
     /**
      * Returns metadata for field.
-     *
-     * @return FieldMetadata
      */
-    public function getField()
+    public function getField(): FieldMetadata
     {
         return $this->field;
     }
 
-    public function setDistinct(bool $distinct)
+    public function setDistinct(bool $distinct): void
     {
         $this->distinct = $distinct;
     }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/FieldDescriptorFactory.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/FieldDescriptorFactory.php
@@ -168,9 +168,14 @@ class FieldDescriptorFactory implements FieldDescriptorFactoryInterface, CacheWa
                     $condition = $this->resolveOptions($condition, $options);
                 }
 
+                $joinEntity = $joinMetadata->getEntityField();
+                if (null !== $joinEntity) {
+                    $joinEntity = $this->resolveOptions($joinEntity, $options);
+                }
+
                 $joins[$joinMetadata->getEntityName()] = new DoctrineJoinDescriptor(
                     $this->resolveOptions($joinMetadata->getEntityName(), $options),
-                    $this->resolveOptions($joinMetadata->getEntityField(), $options),
+                    $joinEntity,
                     $condition,
                     $joinMetadata->getMethod(),
                     $joinMetadata->getConditionMethod()

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/FieldDescriptorFactory.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/FieldDescriptorFactory.php
@@ -164,7 +164,7 @@ class FieldDescriptorFactory implements FieldDescriptorFactoryInterface, CacheWa
         if ($fieldMetadata) {
             foreach ($fieldMetadata->getJoins() as $joinMetadata) {
                 $condition = $joinMetadata->getCondition();
-                if ($condition !== null) {
+                if (null !== $condition) {
                     $condition = $this->resolveOptions($condition, $options);
                 }
 

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/FieldDescriptorFactory.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/FieldDescriptorFactory.php
@@ -163,10 +163,15 @@ class FieldDescriptorFactory implements FieldDescriptorFactoryInterface, CacheWa
         $joins = [];
         if ($fieldMetadata) {
             foreach ($fieldMetadata->getJoins() as $joinMetadata) {
+                $condition = $joinMetadata->getCondition();
+                if ($condition !== null) {
+                    $condition = $this->resolveOptions($condition, $options);
+                }
+
                 $joins[$joinMetadata->getEntityName()] = new DoctrineJoinDescriptor(
                     $this->resolveOptions($joinMetadata->getEntityName(), $options),
                     $this->resolveOptions($joinMetadata->getEntityField(), $options),
-                    $this->resolveOptions($joinMetadata->getCondition(), $options),
+                    $condition,
                     $joinMetadata->getMethod(),
                     $joinMetadata->getConditionMethod()
                 );
@@ -223,7 +228,7 @@ class FieldDescriptorFactory implements FieldDescriptorFactoryInterface, CacheWa
             $propertyMetadata->getSearchability(),
             $propertyMetadata->getType(),
             $propertyMetadata->isSortable(),
-            $this->resolveOptions($propertyMetadata->getDistinct(), $options),
+            $propertyMetadata->getDistinct(),
             $propertyMetadata->getWidth()
         );
     }
@@ -263,7 +268,7 @@ class FieldDescriptorFactory implements FieldDescriptorFactoryInterface, CacheWa
             $propertyMetadata->getSearchability(),
             $propertyMetadata->getType(),
             $propertyMetadata->isSortable(),
-            $this->resolveOptions($propertyMetadata->getDistinct(), $options),
+            $propertyMetadata->getDistinct(),
             $propertyMetadata->getWidth()
         );
     }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/FieldMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/FieldMetadata.php
@@ -16,20 +16,14 @@ namespace Sulu\Component\Rest\ListBuilder\Metadata;
  */
 class FieldMetadata
 {
-    /**
-     * @var string
-     */
-    private $name;
+    private string $name;
 
-    /**
-     * @var string
-     */
-    private $entityName;
+    private string $entityName;
 
     /**
      * @var JoinMetadata[]
      */
-    private $joins = [];
+    private array $joins = [];
 
     public function __construct($name, $entityName)
     {
@@ -37,18 +31,12 @@ class FieldMetadata
         $this->entityName = $entityName;
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @return string
-     */
-    public function getEntityName()
+    public function getEntityName(): string
     {
         return $this->entityName;
     }
@@ -56,7 +44,7 @@ class FieldMetadata
     /**
      * @return JoinMetadata[]
      */
-    public function getJoins()
+    public function getJoins(): array
     {
         return $this->joins;
     }
@@ -64,12 +52,12 @@ class FieldMetadata
     /**
      * @param JoinMetadata[] $joins
      */
-    public function setJoins(array $joins)
+    public function setJoins(array $joins): void
     {
         $this->joins = $joins;
     }
 
-    public function addJoin(JoinMetadata $join)
+    public function addJoin(JoinMetadata $join): void
     {
         $this->joins[] = $join;
     }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/FieldMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/FieldMetadata.php
@@ -16,9 +16,15 @@ namespace Sulu\Component\Rest\ListBuilder\Metadata;
  */
 class FieldMetadata
 {
-    private string $name;
+    /**
+     * @var string
+     */
+    private $name;
 
-    private string $entityName;
+    /**
+     * @var string
+     */
+    private $entityName;
 
     /**
      * @var JoinMetadata[]
@@ -31,12 +37,18 @@ class FieldMetadata
         $this->entityName = $entityName;
     }
 
-    public function getName(): string
+    /**
+     * @return string
+     */
+    public function getName()
     {
         return $this->name;
     }
 
-    public function getEntityName(): string
+    /**
+     * @return string
+     */
+    public function getEntityName()
     {
         return $this->entityName;
     }
@@ -44,20 +56,25 @@ class FieldMetadata
     /**
      * @return JoinMetadata[]
      */
-    public function getJoins(): array
+    public function getJoins()
     {
         return $this->joins;
     }
 
     /**
      * @param JoinMetadata[] $joins
+     *
+     * @return void
      */
-    public function setJoins(array $joins): void
+    public function setJoins(array $joins)
     {
         $this->joins = $joins;
     }
 
-    public function addJoin(JoinMetadata $join): void
+    /**
+     * @return void
+     */
+    public function addJoin(JoinMetadata $join)
     {
         $this->joins[] = $join;
     }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/GroupConcatPropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/GroupConcatPropertyMetadata.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of Sulu.
  *

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/GroupConcatPropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/GroupConcatPropertyMetadata.php
@@ -16,22 +16,13 @@ namespace Sulu\Component\Rest\ListBuilder\Metadata;
  */
 class GroupConcatPropertyMetadata extends AbstractPropertyMetadata
 {
-    /**
-     * @var ?FieldMetadata
-     */
-    private $field;
+    private ?FieldMetadata $field;
 
-    /**
-     * @var string
-     */
-    private $glue;
+    private string $glue;
 
-    /**
-     * @var bool
-     */
-    private $distinct;
+    private bool $distinct;
 
-    public function setField(?FieldMetadata $field)
+    public function setField(?FieldMetadata $field): void
     {
         $this->field = $field;
     }
@@ -41,7 +32,7 @@ class GroupConcatPropertyMetadata extends AbstractPropertyMetadata
         return $this->field;
     }
 
-    public function setGlue(string $glue)
+    public function setGlue(string $glue): void
     {
         $this->glue = $glue;
     }
@@ -51,7 +42,7 @@ class GroupConcatPropertyMetadata extends AbstractPropertyMetadata
         return $this->glue;
     }
 
-    public function setDistinct(bool $distinct)
+    public function setDistinct(bool $distinct): void
     {
         $this->distinct = $distinct;
     }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/GroupConcatPropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/GroupConcatPropertyMetadata.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of Sulu.
  *
@@ -18,13 +16,16 @@ namespace Sulu\Component\Rest\ListBuilder\Metadata;
  */
 class GroupConcatPropertyMetadata extends AbstractPropertyMetadata
 {
-    private ?FieldMetadata $field;
+    private ?FieldMetadata $field = null;
 
     private string $glue;
 
     private bool $distinct;
 
-    public function setField(?FieldMetadata $field): void
+    /**
+     * @return void
+     */
+    public function setField(?FieldMetadata $field)
     {
         $this->field = $field;
     }
@@ -34,7 +35,10 @@ class GroupConcatPropertyMetadata extends AbstractPropertyMetadata
         return $this->field;
     }
 
-    public function setGlue(string $glue): void
+    /**
+     * @return void
+     */
+    public function setGlue(string $glue)
     {
         $this->glue = $glue;
     }
@@ -44,7 +48,10 @@ class GroupConcatPropertyMetadata extends AbstractPropertyMetadata
         return $this->glue;
     }
 
-    public function setDistinct(bool $distinct): void
+    /**
+     * @return void
+     */
+    public function setDistinct(bool $distinct)
     {
         $this->distinct = $distinct;
     }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/IdentityPropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/IdentityPropertyMetadata.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of Sulu.
  *

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/IdentityPropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/IdentityPropertyMetadata.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of Sulu.
  *
@@ -20,7 +18,10 @@ class IdentityPropertyMetadata extends AbstractPropertyMetadata
 {
     private ?FieldMetadata $field;
 
-    public function setField(?FieldMetadata $field): void
+    /**
+     * @return void
+     */
+    public function setField(?FieldMetadata $field)
     {
         $this->field = $field;
     }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/IdentityPropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/IdentityPropertyMetadata.php
@@ -16,12 +16,9 @@ namespace Sulu\Component\Rest\ListBuilder\Metadata;
  */
 class IdentityPropertyMetadata extends AbstractPropertyMetadata
 {
-    /**
-     * @var ?FieldMetadata
-     */
-    private $field;
+    private ?FieldMetadata $field;
 
-    public function setField(?FieldMetadata $field)
+    public function setField(?FieldMetadata $field): void
     {
         $this->field = $field;
     }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/JoinMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/JoinMetadata.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of Sulu.
  *

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/JoinMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/JoinMetadata.php
@@ -24,83 +24,59 @@ class JoinMetadata
 
     public const JOIN_CONDITION_METHOD_WITH = 'WITH';
 
-    /**
-     * @var string
-     */
-    private $entityName;
+    private string $entityName;
 
-    /**
-     * @var string
-     */
-    private $entityField;
+    private string $entityField;
 
-    /**
-     * @var string
-     */
-    private $condition = null;
+    private ?string $condition = null;
 
     /**
      * @var 'ON'|'WITH'
      */
-    private $conditionMethod = self::JOIN_CONDITION_METHOD_WITH;
+    private string $conditionMethod = self::JOIN_CONDITION_METHOD_WITH;
 
     /**
      * Defines the join method (left, right or inner join).
      *
      * @var 'LEFT'|'INNER'|'RIGHT'
      */
-    private $method = self::JOIN_METHOD_LEFT;
+    private string $method = self::JOIN_METHOD_LEFT;
 
     /**
      * The name of the entity to join.
-     *
-     * @return string
      */
-    public function getEntityName()
+    public function getEntityName(): string
     {
         return $this->entityName;
     }
 
-    /**
-     * @param string $entityName
-     */
-    public function setEntityName($entityName)
+    public function setEntityName(string $entityName): void
     {
         $this->entityName = $entityName;
     }
 
     /**
      * The field, which should be joined.
-     *
-     * @return string
      */
-    public function getEntityField()
+    public function getEntityField(): string
     {
         return $this->entityField;
     }
 
-    /**
-     * @param string $entityField
-     */
-    public function setEntityField($entityField)
+    public function setEntityField(string $entityField): void
     {
         $this->entityField = $entityField;
     }
 
     /**
      * The additional condition which should apply to the join.
-     *
-     * @return string
      */
-    public function getCondition()
+    public function getCondition(): ?string
     {
         return $this->condition;
     }
 
-    /**
-     * @param string $condition
-     */
-    public function setCondition($condition)
+    public function setCondition(string $condition): void
     {
         $this->condition = $condition;
     }
@@ -108,7 +84,7 @@ class JoinMetadata
     /**
      * @return 'ON'|'WITH'
      */
-    public function getConditionMethod()
+    public function getConditionMethod(): string
     {
         return $this->conditionMethod;
     }
@@ -116,7 +92,7 @@ class JoinMetadata
     /**
      * @param 'ON'|'WITH' $conditionMethod
      */
-    public function setConditionMethod($conditionMethod)
+    public function setConditionMethod(string $conditionMethod): void
     {
         $this->conditionMethod = $conditionMethod;
     }
@@ -126,7 +102,7 @@ class JoinMetadata
      *
      * @return 'LEFT'|'INNER'|'RIGHT'
      */
-    public function getMethod()
+    public function getMethod(): string
     {
         return $this->method;
     }
@@ -134,7 +110,7 @@ class JoinMetadata
     /**
      * @param 'LEFT'|'INNER'|'RIGHT' $method
      */
-    public function setMethod($method)
+    public function setMethod(string $method): void
     {
         $this->method = $method;
     }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/JoinMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/JoinMetadata.php
@@ -28,7 +28,7 @@ class JoinMetadata
 
     private string $entityName;
 
-    private string $entityField;
+    private ?string $entityField = null;
 
     private ?string $condition = null;
 
@@ -60,7 +60,7 @@ class JoinMetadata
     /**
      * The field, which should be joined.
      */
-    public function getEntityField(): string
+    public function getEntityField(): ?string
     {
         return $this->entityField;
     }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/JoinMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/JoinMetadata.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of Sulu.
  *
@@ -26,59 +24,89 @@ class JoinMetadata
 
     public const JOIN_CONDITION_METHOD_WITH = 'WITH';
 
-    private string $entityName;
+    /**
+     * @var string
+     */
+    private $entityName;
 
-    private ?string $entityField = null;
+    /**
+     * @var string|null
+     */
+    private $entityField = null;
 
-    private ?string $condition = null;
+    /**
+     * @var string|null
+     */
+    private $condition = null;
 
     /**
      * @var 'ON'|'WITH'
      */
-    private string $conditionMethod = self::JOIN_CONDITION_METHOD_WITH;
+    private $conditionMethod = self::JOIN_CONDITION_METHOD_WITH;
 
     /**
      * Defines the join method (left, right or inner join).
      *
      * @var 'LEFT'|'INNER'|'RIGHT'
      */
-    private string $method = self::JOIN_METHOD_LEFT;
+    private $method = self::JOIN_METHOD_LEFT;
 
     /**
      * The name of the entity to join.
+     *
+     * @return string
      */
-    public function getEntityName(): string
+    public function getEntityName()
     {
         return $this->entityName;
     }
 
-    public function setEntityName(string $entityName): void
+    /**
+     * @param string $entityName
+     *
+     * @return void
+     */
+    public function setEntityName($entityName)
     {
         $this->entityName = $entityName;
     }
 
     /**
      * The field, which should be joined.
+     *
+     * @return string|null
      */
-    public function getEntityField(): ?string
+    public function getEntityField()
     {
         return $this->entityField;
     }
 
-    public function setEntityField(string $entityField): void
+    /**
+     * @param string $entityField
+     *
+     * @return void
+     */
+    public function setEntityField($entityField)
     {
         $this->entityField = $entityField;
     }
 
     /**
      * The additional condition which should apply to the join.
+     *
+     * @return string|null
      */
-    public function getCondition(): ?string
+    public function getCondition()
     {
         return $this->condition;
     }
 
-    public function setCondition(string $condition): void
+    /**
+     * @param string $condition
+     *
+     * @return void
+     */
+    public function setCondition($condition)
     {
         $this->condition = $condition;
     }
@@ -86,15 +114,17 @@ class JoinMetadata
     /**
      * @return 'ON'|'WITH'
      */
-    public function getConditionMethod(): string
+    public function getConditionMethod()
     {
         return $this->conditionMethod;
     }
 
     /**
      * @param 'ON'|'WITH' $conditionMethod
+     *
+     * @return void
      */
-    public function setConditionMethod(string $conditionMethod): void
+    public function setConditionMethod($conditionMethod)
     {
         $this->conditionMethod = $conditionMethod;
     }
@@ -104,15 +134,17 @@ class JoinMetadata
      *
      * @return 'LEFT'|'INNER'|'RIGHT'
      */
-    public function getMethod(): string
+    public function getMethod()
     {
         return $this->method;
     }
 
     /**
      * @param 'LEFT'|'INNER'|'RIGHT' $method
+     *
+     * @return void
      */
-    public function setMethod(string $method): void
+    public function setMethod($method)
     {
         $this->method = $method;
     }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/ListMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/ListMetadata.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of Sulu.
  *

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/ListMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/ListMetadata.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of Sulu.
  *
@@ -15,31 +13,51 @@ namespace Sulu\Component\Rest\ListBuilder\Metadata;
 
 class ListMetadata
 {
-    private string $resource;
+    /**
+     * @var string
+     */
+    private $resource;
 
-    private string $key;
+    /**
+     * @var string
+     */
+    private $key;
 
     /**
      * @var AbstractPropertyMetadata[]
      */
-    private array $propertiesMetadata = [];
+    private $propertiesMetadata = [];
 
-    public function setResource(string $resource): void
+    /**
+     * @param string $resource
+     *
+     * @return void
+     */
+    public function setResource($resource)
     {
         $this->resource = $resource;
     }
 
-    public function getResource(): string
+    /**
+     * @return string
+     */
+    public function getResource()
     {
         return $this->resource;
     }
 
-    public function setKey(string $key): void
+    /**
+     * @return void
+     */
+    public function setKey(string $key)
     {
         $this->key = $key;
     }
 
-    public function getKey(): string
+    /**
+     * @return string
+     */
+    public function getKey()
     {
         return $this->key;
     }
@@ -47,12 +65,15 @@ class ListMetadata
     /**
      * @return AbstractPropertyMetadata[]
      */
-    public function getPropertiesMetadata(): array
+    public function getPropertiesMetadata()
     {
         return $this->propertiesMetadata;
     }
 
-    public function addPropertyMetadata(AbstractPropertyMetadata $propertyMetadata): void
+    /**
+     * @return void
+     */
+    public function addPropertyMetadata(AbstractPropertyMetadata $propertyMetadata)
     {
         $this->propertiesMetadata[] = $propertyMetadata;
     }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/ListMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/ListMetadata.php
@@ -13,47 +13,44 @@ namespace Sulu\Component\Rest\ListBuilder\Metadata;
 
 class ListMetadata
 {
-    /**
-     * @var string
-     */
-    private $resource;
+    private string $resource;
 
-    /**
-     * @var string
-     */
-    private $key;
+    private string $key;
 
     /**
      * @var AbstractPropertyMetadata[]
      */
-    private $propertiesMetadata = [];
+    private array $propertiesMetadata = [];
 
-    public function setResource($resource)
+    public function setResource(string $resource): void
     {
         $this->resource = $resource;
     }
 
-    public function getResource()
+    public function getResource(): string
     {
         return $this->resource;
     }
 
-    public function setKey(string $key)
+    public function setKey(string $key): void
     {
         $this->key = $key;
     }
 
-    public function getKey()
+    public function getKey(): string
     {
         return $this->key;
     }
 
-    public function getPropertiesMetadata()
+    /**
+     * @return AbstractPropertyMetadata[]
+     */
+    public function getPropertiesMetadata(): array
     {
         return $this->propertiesMetadata;
     }
 
-    public function addPropertyMetadata(AbstractPropertyMetadata $propertyMetadata)
+    public function addPropertyMetadata(AbstractPropertyMetadata $propertyMetadata): void
     {
         $this->propertiesMetadata[] = $propertyMetadata;
     }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/ListXmlLoader.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/ListXmlLoader.php
@@ -149,7 +149,7 @@ class ListXmlLoader
             );
         }
 
-        $propertyMetadata->setFilterType(XmlUtil::getValueFromXPath('x:filter/@type', $xpath, $propertyNode));
+        $propertyMetadata->setFilterType((string) XmlUtil::getValueFromXPath('x:filter/@type', $xpath, $propertyNode));
 
         $filterParamNodes = $xpath->query('x:filter/x:params', $propertyNode);
         if (\count($filterParamNodes) > 0) {
@@ -242,7 +242,7 @@ class ListXmlLoader
             (string) XmlUtil::getValueFromXPath('@name', $xpath, $propertyNode)
         );
 
-        $propertyMetadata->setGlue(XmlUtil::getValueFromXPath('@glue', $xpath, $propertyNode) ?? ' ');
+        $propertyMetadata->setGlue((string) (XmlUtil::getValueFromXPath('@glue', $xpath, $propertyNode) ?? ' '));
 
         foreach ($xpath->query('x:field', $propertyNode) as $fieldNode) {
             if (null === $field = $this->getField($xpath, $fieldNode)) {

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/ListXmlLoader.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/ListXmlLoader.php
@@ -169,7 +169,7 @@ class ListXmlLoader
         $field = $this->getField($xpath, $propertyNode);
 
         $propertyMetadata = new IdentityPropertyMetadata(
-            XmlUtil::getValueFromXPath('@name', $xpath, $propertyNode)
+            (string) XmlUtil::getValueFromXPath('@name', $xpath, $propertyNode)
         );
 
         $propertyMetadata->setField($field);
@@ -180,7 +180,7 @@ class ListXmlLoader
     private function loadCasePropertyMetadata(\DOMXPath $xpath, \DOMElement $propertyNode)
     {
         $propertyMetadata = new CasePropertyMetadata(
-            XmlUtil::getValueFromXPath('@name', $xpath, $propertyNode)
+            (string) XmlUtil::getValueFromXPath('@name', $xpath, $propertyNode)
         );
 
         foreach ($xpath->query('x:field', $propertyNode) as $fieldNode) {
@@ -199,12 +199,12 @@ class ListXmlLoader
         $field = $this->getField($xpath, $propertyNode);
 
         $propertyMetadata = new GroupConcatPropertyMetadata(
-            XmlUtil::getValueFromXPath('@name', $xpath, $propertyNode)
+            (string) XmlUtil::getValueFromXPath('@name', $xpath, $propertyNode)
         );
 
         $propertyMetadata->setField($field);
-        $propertyMetadata->setGlue(XmlUtil::getValueFromXPath('@glue', $xpath, $propertyNode, ' '));
-        $propertyMetadata->setDistinct(XmlUtil::getBooleanValueFromXPath('@distinct', $xpath, $propertyNode, false));
+        $propertyMetadata->setGlue((string) XmlUtil::getValueFromXPath('@glue', $xpath, $propertyNode, ' '));
+        $propertyMetadata->setDistinct(XmlUtil::getBooleanValueFromXPath('@distinct', $xpath, $propertyNode) ?? false);
 
         return $propertyMetadata;
     }
@@ -214,7 +214,7 @@ class ListXmlLoader
         $field = $this->getField($xpath, $propertyNode);
 
         $propertyMetadata = new SinglePropertyMetadata(
-            XmlUtil::getValueFromXPath('@name', $xpath, $propertyNode)
+            (string) XmlUtil::getValueFromXPath('@name', $xpath, $propertyNode)
         );
 
         $propertyMetadata->setField($field);
@@ -227,11 +227,11 @@ class ListXmlLoader
         $field = $this->getField($xpath, $propertyNode);
 
         $propertyMetadata = new CountPropertyMetadata(
-            XmlUtil::getValueFromXPath('@name', $xpath, $propertyNode)
+            (string) XmlUtil::getValueFromXPath('@name', $xpath, $propertyNode)
         );
 
         $propertyMetadata->setField($field);
-        $propertyMetadata->setDistinct(XmlUtil::getBooleanValueFromXPath('@distinct', $xpath, $propertyNode, false));
+        $propertyMetadata->setDistinct(XmlUtil::getBooleanValueFromXPath('@distinct', $xpath, $propertyNode) ?? false);
 
         return $propertyMetadata;
     }
@@ -239,10 +239,10 @@ class ListXmlLoader
     private function loadConcatenationPropertyMetadata(\DOMXPath $xpath, \DOMNode $propertyNode)
     {
         $propertyMetadata = new ConcatenationPropertyMetadata(
-            XmlUtil::getValueFromXPath('@name', $xpath, $propertyNode)
+            (string) XmlUtil::getValueFromXPath('@name', $xpath, $propertyNode)
         );
 
-        $propertyMetadata->setGlue(XmlUtil::getValueFromXPath('@glue', $xpath, $propertyNode, ' '));
+        $propertyMetadata->setGlue(XmlUtil::getValueFromXPath('@glue', $xpath, $propertyNode) ?? ' ');
 
         foreach ($xpath->query('x:field', $propertyNode) as $fieldNode) {
             if (null === $field = $this->getField($xpath, $fieldNode)) {
@@ -271,7 +271,7 @@ class ListXmlLoader
                 $parameters[$name] = $this->getParameters($xpath, $paramNode);
             } else {
                 $value = $this->parameterBag->resolveValue(
-                    \trim(XmlUtil::getValueFromXPath('@value', $xpath, $paramNode))
+                    \trim((string) XmlUtil::getValueFromXPath('@value', $xpath, $paramNode))
                 );
 
                 if (null === $name) {

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/SinglePropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/SinglePropertyMetadata.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of Sulu.
  *

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/SinglePropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/SinglePropertyMetadata.php
@@ -16,12 +16,9 @@ namespace Sulu\Component\Rest\ListBuilder\Metadata;
  */
 class SinglePropertyMetadata extends AbstractPropertyMetadata
 {
-    /**
-     * @var ?FieldMetadata
-     */
-    private $field;
+    private ?FieldMetadata $field;
 
-    public function setField(?FieldMetadata $field)
+    public function setField(?FieldMetadata $field): void
     {
         $this->field = $field;
     }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/SinglePropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/SinglePropertyMetadata.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of Sulu.
  *
@@ -18,9 +16,12 @@ namespace Sulu\Component\Rest\ListBuilder\Metadata;
  */
 class SinglePropertyMetadata extends AbstractPropertyMetadata
 {
-    private ?FieldMetadata $field;
+    private ?FieldMetadata $field = null;
 
-    public function setField(?FieldMetadata $field): void
+    /**
+     * @return void
+     */
+    public function setField(?FieldMetadata $field)
     {
         $this->field = $field;
     }

--- a/src/Sulu/Component/Util/XmlUtil.php
+++ b/src/Sulu/Component/Util/XmlUtil.php
@@ -27,7 +27,7 @@ class XmlUtil
     public static function getValueFromXPath($path, \DOMXPath $xpath, \DOMNode $context = null, $default = null)
     {
         $result = $xpath->query($path, $context);
-        if (0 === $result->length) {
+        if (false === $result || 0 === $result->length) {
             return $default;
         }
 
@@ -44,8 +44,10 @@ class XmlUtil
      *
      * @param string $path
      * @param \DOMNode $context
+     *
+     * @return bool|null
      */
-    public static function getBooleanValueFromXPath($path, \DOMXPath $xpath, \DOMNode $context = null, $default = null): ?bool
+    public static function getBooleanValueFromXPath($path, \DOMXPath $xpath, \DOMNode $context = null, $default = null)
     {
         $value = self::getValueFromXPath($path, $xpath, $context, $default);
 

--- a/src/Sulu/Component/Util/XmlUtil.php
+++ b/src/Sulu/Component/Util/XmlUtil.php
@@ -22,7 +22,7 @@ class XmlUtil
      * @param string $path
      * @param \DOMNode $context
      *
-     * @return bool|null|string|mixed
+     * @return string|null
      */
     public static function getValueFromXPath($path, \DOMXPath $xpath, \DOMNode $context = null, $default = null)
     {
@@ -45,14 +45,14 @@ class XmlUtil
      * @param string $path
      * @param \DOMNode $context
      *
-     * @return bool|null|string|mixed
+     * @return bool|null
      */
-    public static function getBooleanValueFromXPath($path, \DOMXPath $xpath, \DOMNode $context = null, $default = null)
+    public static function getBooleanValueFromXPath($path, \DOMXPath $xpath, \DOMNode $context = null, $default = null): ?bool
     {
         $value = self::getValueFromXPath($path, $xpath, $context, $default);
 
         if (null === $value) {
-            return;
+            return null;
         }
 
         return 'true' === $value || true === $value;

--- a/src/Sulu/Component/Util/XmlUtil.php
+++ b/src/Sulu/Component/Util/XmlUtil.php
@@ -11,6 +11,8 @@
 
 namespace Sulu\Component\Util;
 
+use Webmozart\Assert\Assert;
+
 /**
  * Utilties for extracting data from a dom-document using xpath.
  */
@@ -27,7 +29,9 @@ class XmlUtil
     public static function getValueFromXPath($path, \DOMXPath $xpath, \DOMNode $context = null, $default = null)
     {
         $result = $xpath->query($path, $context);
-        if (false === $result || 0 === $result->length) {
+        Assert::object($result, \sprintf('XPath Expression "%s" is invalid.', $path));
+
+        if (0 === $result->length) {
             return $default;
         }
 

--- a/src/Sulu/Component/Util/XmlUtil.php
+++ b/src/Sulu/Component/Util/XmlUtil.php
@@ -21,8 +21,10 @@ class XmlUtil
      *
      * @param string $path
      * @param \DOMNode $context
+     *
+     * @return bool|float|int|string|null
      */
-    public static function getValueFromXPath($path, \DOMXPath $xpath, \DOMNode $context = null, $default = null): mixed
+    public static function getValueFromXPath($path, \DOMXPath $xpath, \DOMNode $context = null, $default = null)
     {
         $result = $xpath->query($path, $context);
         if (0 === $result->length) {

--- a/src/Sulu/Component/Util/XmlUtil.php
+++ b/src/Sulu/Component/Util/XmlUtil.php
@@ -21,10 +21,8 @@ class XmlUtil
      *
      * @param string $path
      * @param \DOMNode $context
-     *
-     * @return string|null
      */
-    public static function getValueFromXPath($path, \DOMXPath $xpath, \DOMNode $context = null, $default = null)
+    public static function getValueFromXPath($path, \DOMXPath $xpath, \DOMNode $context = null, $default = null): mixed
     {
         $result = $xpath->query($path, $context);
         if (0 === $result->length) {
@@ -44,8 +42,6 @@ class XmlUtil
      *
      * @param string $path
      * @param \DOMNode $context
-     *
-     * @return bool|null
      */
     public static function getBooleanValueFromXPath($path, \DOMXPath $xpath, \DOMNode $context = null, $default = null): ?bool
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Using proper typing for the sulu list metadata objects. Many of them can be converted to readonly objects in PHP 8.1

#### Why?

Two reasons:
* Typing makes it easier to see what values are actually expected from the config
* It makes it easier to provide an option to accept php as an alternative configuration language
* I found a bug by adding types

#### Example Usage

This should not change the usage of the value objects at all.