### PR TITLE
Add "AsCommand" annotation for deprecated "$defaultName" for all commands

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -30,6 +30,11 @@ Additionally, the following packages where upgraded:
 
 This update is also handled normally by the update build command automatically.
 
+### Static protected $defaultName property of commands removed
+
+As deprecated in Symfony 6.1 the `$defaultName` of Sulu Commands where replaced with the new
+`Symfony\Component\Console\Attribute\AsCommand` annotation.
+
 ### Deprecated urls variable in return value of sulu_content_load
 
 The `urls` variable in the return value of the `sulu_content_load` function was deprecated.

--- a/src/Sulu/Bundle/AdminBundle/Command/DownloadBuildCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/DownloadBuildCommand.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Attribute\AsCommand;
 
 @trigger_deprecation(
     'sulu/sulu',
@@ -27,15 +28,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * @deprecated use the "UpdateBuildCommand" class instead
  */
+#[AsCommand(name: 'sulu:admin:download-build', description: 'Downloads the current admin application build from the sulu/skeleton repository.')]
 class DownloadBuildCommand extends Command
 {
-    protected static $defaultName = 'sulu:admin:download-build';
-
-    protected function configure()
-    {
-        $this->setDescription('Downloads the current admin application build from the sulu/skeleton repository.');
-    }
-
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $application = $this->getApplication();

--- a/src/Sulu/Bundle/AdminBundle/Command/DownloadLanguageCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/DownloadLanguageCommand.php
@@ -19,11 +19,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:admin:download-language', description: 'Downloads the currently approved translations for the given language.')]
 class DownloadLanguageCommand extends Command
 {
-    protected static $defaultName = 'sulu:admin:download-language';
-
     /**
      * @var HttpClientInterface
      */
@@ -55,8 +55,7 @@ class DownloadLanguageCommand extends Command
 
     protected function configure()
     {
-        $this->setDescription('Downloads the currently approved translations for the given language.')
-            ->addArgument('languages', InputArgument::IS_ARRAY, 'The languages to download', $this->defaultLanguages)
+        $this->addArgument('languages', InputArgument::IS_ARRAY, 'The languages to download', $this->defaultLanguages)
             ->addOption(
                 'translation-endpoint',
                 null,

--- a/src/Sulu/Bundle/AdminBundle/Command/InfoCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/InfoCommand.php
@@ -15,11 +15,11 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:admin:info')]
 class InfoCommand extends Command
 {
-    protected static $defaultName = 'sulu:admin:info';
-
     /**
      * @var string string
      */

--- a/src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php
@@ -19,14 +19,14 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpClient\Exception\ClientException;
 use Symfony\Component\Process\Process;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:admin:update-build', description: 'Updates the administration application JavaScript build by downloading the official build from the sulu/skeleton repository or building the assets via npm.')]
 class UpdateBuildCommand extends Command
 {
     public const EXIT_CODE_ABORTED_MANUAL_BUILD = 1;
     public const EXIT_CODE_COULD_NOT_INSTALL_NPM_PACKAGES = 2;
     public const EXIT_CODE_COULD_NOT_BUILD_ADMIN_ASSETS = 3;
-
-    protected static $defaultName = 'sulu:admin:update-build';
 
     /**
      * @var HttpClientInterface
@@ -58,14 +58,6 @@ class UpdateBuildCommand extends Command
         $this->httpClient = $httpClient;
         $this->projectDir = $projectDir;
         $this->suluVersion = $suluVersion;
-    }
-
-    protected function configure()
-    {
-        $this->setDescription(
-            'Updates the administration application JavaScript build by downloading the official build '
-            . 'from the sulu/skeleton repository or building the assets via npm.'
-        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Sulu/Bundle/CategoryBundle/Command/RecoverCommand.php
+++ b/src/Sulu/Bundle/CategoryBundle/Command/RecoverCommand.php
@@ -17,15 +17,15 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 
 /**
  * Command for recovering categories.
  * This command is fixing wrong left/right and depths (see -d) assignments of the categories tree.
  */
+#[AsCommand(name: 'sulu:categories:recover')]
 class RecoverCommand extends Command
 {
-    protected static $defaultName = 'sulu:categories:recover';
-
     /**
      * @var EntityManagerInterface
      */

--- a/src/Sulu/Bundle/ContactBundle/Command/AccountRecoverCommand.php
+++ b/src/Sulu/Bundle/ContactBundle/Command/AccountRecoverCommand.php
@@ -17,15 +17,15 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 
 /**
  * Command for recovering nested tree of accounts.
  * This command is fixing wrong left/right and depths (see -d) assignments of the nested tree.
  */
+#[AsCommand(name: 'sulu:contacts:accounts:recover')]
 class AccountRecoverCommand extends Command
 {
-    protected static $defaultName = 'sulu:contacts:accounts:recover';
-
     /**
      * @var EntityManagerInterface
      */

--- a/src/Sulu/Bundle/CoreBundle/CommandOptional/SuluBuildCommand.php
+++ b/src/Sulu/Bundle/CoreBundle/CommandOptional/SuluBuildCommand.php
@@ -13,18 +13,17 @@ namespace Sulu\Bundle\CoreBundle\CommandOptional;
 
 use Massive\Bundle\BuildBundle\Command\BuildCommand;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Attribute\AsCommand;
 
 /**
  * This command extends the Massive BuildCommand and
  * adds a global "destroy" option and changes the name to "sulu:build".
  */
+#[AsCommand(name: 'sulu:build')]
 class SuluBuildCommand extends BuildCommand
 {
-    protected static $defaultName = 'sulu:build';
-
     public function configure()
     {
-        parent::configure();
         $this->addOption('destroy', null, InputOption::VALUE_NONE, 'Destroy existing data');
     }
 }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/FixturesLoadCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/FixturesLoadCommand.php
@@ -21,11 +21,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:document:fixtures:load', description: 'Loads data fixtures services tagged with "sulu.document_manager_fixture".')]
 class FixturesLoadCommand extends Command
 {
-    protected static $defaultName = 'sulu:document:fixtures:load';
-
     /**
      * @var DocumentExecutor
      */
@@ -49,7 +49,6 @@ class FixturesLoadCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('Loads data fixtures services tagged with "sulu.document_manager_fixture".')
             ->addOption('group', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'The group which should be loaded.')
             ->addOption('append', null, InputOption::VALUE_NONE, 'Append the data fixtures to the existing data - will not purge the workspace.')
             ->addOption('no-initialize', null, InputOption::VALUE_NONE, 'Do not run the repository initializers after purging the repository.')

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/InitializeCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/InitializeCommand.php
@@ -18,11 +18,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:document:initialize', description: 'Initialize the content repository/repositories.')]
 class InitializeCommand extends Command
 {
-    protected static $defaultName = 'sulu:document:initialize';
-
     /**
      * @var Initializer
      */
@@ -46,7 +46,6 @@ class InitializeCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('Initialize the content repository/repositories.')
             ->addOption('purge', null, InputOption::VALUE_NONE, 'Purge the content repository before initialization.')
             ->addOption('force', null, InputOption::VALUE_NONE, 'Do not ask for confirmation.')
             ->setHelp(<<<'EOT'

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/SubscriberDebugCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/SubscriberDebugCommand.php
@@ -18,11 +18,11 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:document:subscriber:debug', description: 'Show event listeners associated with the document manager')]
 class SubscriberDebugCommand extends Command
 {
-    protected static $defaultName = 'sulu:document:subscriber:debug';
-
     public const PREFIX = 'sulu_document_manager.';
 
     /**
@@ -40,7 +40,6 @@ class SubscriberDebugCommand extends Command
     public function configure()
     {
         $this->addArgument('event_name', InputArgument::OPTIONAL, 'Event name, without the sulu_document_manager. prefix');
-        $this->setDescription('Show event listeners associated with the document manager');
     }
 
     public function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Sulu/Bundle/MediaBundle/Command/ClearCacheCommand.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/ClearCacheCommand.php
@@ -16,11 +16,11 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:media:format:cache:clear', description: 'Clear all or the given Sulu media format cache')]
 class ClearCacheCommand extends Command
 {
-    protected static $defaultName = 'sulu:media:format:cache:clear';
-
     /**
      * @var FormatCacheClearerInterface
      */
@@ -35,7 +35,7 @@ class ClearCacheCommand extends Command
 
     protected function configure()
     {
-        $this->setDescription('Clear all or the given Sulu media format cache')
+        $this
             ->addArgument('cache', InputArgument::OPTIONAL, 'Optional alias to clear the specific cache')
         ;
     }

--- a/src/Sulu/Bundle/MediaBundle/Command/FormatCacheCleanupCommand.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/FormatCacheCleanupCommand.php
@@ -21,11 +21,11 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:media:format:cache:cleanup', description: 'Remove media formats which medias not longer exist in the database')]
 class FormatCacheCleanupCommand extends Command
 {
-    protected static $defaultName = 'sulu:media:format:cache:cleanup';
-
     /**
      * @var EntityRepository
      */
@@ -55,8 +55,7 @@ class FormatCacheCleanupCommand extends Command
 
     protected function configure()
     {
-        $this->setDescription('Remove media formats which medias not longer exist in the database')
-            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Do nothing')
+        $this->addOption('dry-run', null, InputOption::VALUE_NONE, 'Do nothing')
         ;
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateCommand.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateCommand.php
@@ -19,11 +19,11 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:media:regenerate-formats', description: 'Loops over sulu image cache, and regenerates the existing images')]
 class FormatCacheRegenerateCommand extends Command
 {
-    protected static $defaultName = 'sulu:media:regenerate-formats';
-
     /**
      * @var Filesystem
      */
@@ -49,11 +49,6 @@ class FormatCacheRegenerateCommand extends Command
         $this->fileSystem = $filesystem;
         $this->formatManager = $formatManager;
         $this->localFormatCachePath = $localFormatCachePath;
-    }
-
-    protected function configure()
-    {
-        $this->setDescription('Loops over sulu image cache, and regenerates the existing images');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Sulu/Bundle/MediaBundle/Command/InitCommand.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/InitCommand.php
@@ -15,11 +15,11 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:media:init', description: 'Init Sulu Media Bundle')]
 class InitCommand extends Command
 {
-    protected static $defaultName = 'sulu:media:init';
-
     /**
      * @var Filesystem
      */
@@ -36,11 +36,6 @@ class InitCommand extends Command
 
         $this->filesystem = $filesystem;
         $this->formatCacheDir = $formatCacheDir;
-    }
-
-    protected function configure()
-    {
-        $this->setDescription('Init Sulu Media Bundle');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Sulu/Bundle/MediaBundle/Command/MediaTypeUpdateCommand.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/MediaTypeUpdateCommand.php
@@ -19,11 +19,11 @@ use Sulu\Bundle\MediaBundle\Media\TypeManager\TypeManagerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:media:type:update', description: 'Update all media type by the set configuration')]
 class MediaTypeUpdateCommand extends Command
 {
-    protected static $defaultName = 'sulu:media:type:update';
-
     /**
      * @var TypeManagerInterface
      */
@@ -40,11 +40,6 @@ class MediaTypeUpdateCommand extends Command
 
         $this->mediaTypeManager = $mediaTypeManager;
         $this->entityManager = $entityManager;
-    }
-
-    protected function configure()
-    {
-        $this->setDescription('Update all media type by the set configuration');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Sulu/Bundle/PageBundle/Command/CleanupHistoryCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/CleanupHistoryCommand.php
@@ -19,11 +19,11 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:content:cleanup-history', description: 'Cleanup resource-locator history')]
 class CleanupHistoryCommand extends Command
 {
-    protected static $defaultName = 'sulu:content:cleanup-history';
-
     /**
      * @var SessionManagerInterface
      */
@@ -53,7 +53,6 @@ class CleanupHistoryCommand extends Command
 
     public function configure()
     {
-        $this->setDescription('Cleanup resource-locator history');
         $this->setHelp(
             <<<'EOT'
 The <info>%command.name%</info> command cleanup the history of the resource-locator of a <info>locale</info>.

--- a/src/Sulu/Bundle/PageBundle/Command/ContentLocaleCopyCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/ContentLocaleCopyCommand.php
@@ -21,11 +21,11 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:content:locale-copy', description: 'Copy content nodes from one locale to another')]
 class ContentLocaleCopyCommand extends Command
 {
-    protected static $defaultName = 'sulu:content:locale-copy';
-
     /**
      * The namespace for languages.
      *
@@ -64,7 +64,6 @@ class ContentLocaleCopyCommand extends Command
 
     public function configure()
     {
-        $this->setDescription('Copy content nodes from one locale to another');
         $this->setHelp(
             <<<'EOT'
             The <info>%command.name%</info> command copies the internationalized properties matching <info>srcLocale</info>

--- a/src/Sulu/Bundle/PageBundle/Command/ContentTypesDumpCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/ContentTypesDumpCommand.php
@@ -16,14 +16,14 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:content:types:dump', description: 'Dumps all ContentTypes registered in the system')]
 class ContentTypesDumpCommand extends Command
 {
-    protected static $defaultName = 'sulu:content:types:dump';
-
     protected function configure()
     {
-        $this->setDescription('Dumps all ContentTypes registered in the system')
+        $this
             ->setDefinition([
                 new InputOption('format', null, InputOption::VALUE_REQUIRED, 'The output format (txt, xml, json, or md)', 'txt'),
             ]);

--- a/src/Sulu/Bundle/PageBundle/Command/MaintainResourceLocatorCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/MaintainResourceLocatorCommand.php
@@ -24,15 +24,15 @@ use Sulu\Component\Webspace\Webspace;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 
 /**
  * Writes the current resource locator on the cached property of the node in the live workspace.
  * The default workspace should not be touched, because these might represent changes already entered by a user.
  */
+#[AsCommand(name: 'sulu:content:resource-locator:maintain', description: 'Resets the cached url value on every node in the live workspace')]
 class MaintainResourceLocatorCommand extends Command
 {
-    protected static $defaultName = 'sulu:content:resource-locator:maintain';
-
     /**
      * @var WebspaceManagerInterface
      */
@@ -79,11 +79,6 @@ class MaintainResourceLocatorCommand extends Command
         $this->metadataFactory = $metadataFactory;
         $this->structureMetadataFactory = $structureMetadataFactory;
         $this->propertyEncoder = $propertyEncoder;
-    }
-
-    protected function configure()
-    {
-        $this->setDescription('Resets the cached url value on every node in the live workspace');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Sulu/Bundle/PageBundle/Command/ValidatePagesCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/ValidatePagesCommand.php
@@ -23,11 +23,11 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:content:validate', description: 'Dumps pages without valid templates')]
 class ValidatePagesCommand extends Command
 {
-    protected static $defaultName = 'sulu:content:validate';
-
     /**
      * @var SessionInterface
      */
@@ -64,8 +64,7 @@ class ValidatePagesCommand extends Command
 
     protected function configure()
     {
-        $this->addArgument('webspaceKey', InputArgument::REQUIRED, 'Which webspace to search')
-            ->setDescription('Dumps pages without valid templates');
+        $this->addArgument('webspaceKey', InputArgument::REQUIRED, 'Which webspace to search');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Sulu/Bundle/PageBundle/Command/ValidateWebspacesCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/ValidateWebspacesCommand.php
@@ -25,11 +25,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Twig\Environment;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:content:validate:webspaces', description: 'Dumps webspaces and will show an error when template could not be loaded')]
 class ValidateWebspacesCommand extends Command
 {
-    protected static $defaultName = 'sulu:content:validate:webspaces';
-
     /**
      * @var OutputInterface
      */
@@ -93,11 +93,6 @@ class ValidateWebspacesCommand extends Command
         $this->structureProvider = $structureProvider;
         $this->webspaceManager = $webspaceManager;
         $this->eventDispatcher = $eventDispatcher;
-    }
-
-    protected function configure()
-    {
-        $this->setDescription('Dumps webspaces and will show an error when template could not be loaded');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
@@ -32,11 +32,11 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:webspaces:copy', description: 'Copies a given webspace with given locale to a destination webspace with a destination locale.')]
 class WebspaceCopyCommand extends Command
 {
-    protected static $defaultName = 'sulu:webspaces:copy';
-
     /**
      * @var SymfonyStyle
      */
@@ -97,10 +97,7 @@ class WebspaceCopyCommand extends Command
             ->addArgument('source-locale', InputArgument::REQUIRED)
             ->addArgument('destination-webspace', InputArgument::REQUIRED)
             ->addArgument('destination-locale', InputArgument::REQUIRED)
-            ->addOption('clear-destination-webspace')
-            ->setDescription(
-                'Copies a given webspace with given locale to a destination webspace with a destination locale.'
-            );
+            ->addOption('clear-destination-webspace');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Sulu/Bundle/PageBundle/Command/WebspaceExportCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/WebspaceExportCommand.php
@@ -18,11 +18,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:webspaces:export', description: 'Export webspace page translations from given language into xliff file for translating into a new language.')]
 class WebspaceExportCommand extends Command
 {
-    protected static $defaultName = 'sulu:webspaces:export';
-
     /**
      * @var WebspaceExportInterface
      */
@@ -43,8 +43,7 @@ class WebspaceExportCommand extends Command
             ->addOption('format', 'f', InputOption::VALUE_REQUIRED, '', '1.2.xliff')
             ->addOption('nodes', 'm', InputOption::VALUE_REQUIRED)
             ->addOption('ignored-nodes', 'i', InputOption::VALUE_REQUIRED)
-            ->addOption('uuid', 'u', InputOption::VALUE_REQUIRED)
-            ->setDescription('Export webspace page translations from given language into xliff file for translating into a new language.');
+            ->addOption('uuid', 'u', InputOption::VALUE_REQUIRED);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Sulu/Bundle/PageBundle/Command/WebspaceImportCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/WebspaceImportCommand.php
@@ -21,11 +21,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:webspaces:import', description: 'Import webspace page translations from xliff file into a specific language.')]
 class WebspaceImportCommand extends Command
 {
-    protected static $defaultName = 'sulu:webspaces:import';
-
     /**
      * @var WebspaceImportInterface
      */
@@ -52,8 +52,7 @@ class WebspaceImportCommand extends Command
             ->addOption('format', 'f', InputOption::VALUE_REQUIRED, '', '1.2.xliff')
             ->addOption('uuid', 'u', InputOption::VALUE_REQUIRED)
             ->addOption('exportSuluVersion', '', InputOption::VALUE_OPTIONAL, '1.2 or 1.3', '1.3')
-            ->addOption('overrideSettings', 'o', InputOption::VALUE_OPTIONAL, 'Override Settings-Tab', 'false')
-            ->setDescription('Import webspace page translations from xliff file into a specific language.');
+            ->addOption('overrideSettings', 'o', InputOption::VALUE_OPTIONAL, 'Override Settings-Tab', 'false');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Sulu/Bundle/RouteBundle/Command/MovePageTreeCommand.php
+++ b/src/Sulu/Bundle/RouteBundle/Command/MovePageTreeCommand.php
@@ -18,14 +18,14 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 
 /**
  * Move documents from given parent-page to another.
  */
+#[AsCommand(name: 'sulu:route:page-tree:move')]
 class MovePageTreeCommand extends Command
 {
-    protected static $defaultName = 'sulu:route:page-tree:move';
-
     /**
      * @var PageTreeMoverInterface
      */

--- a/src/Sulu/Bundle/RouteBundle/Command/UpdateRouteCommand.php
+++ b/src/Sulu/Bundle/RouteBundle/Command/UpdateRouteCommand.php
@@ -22,11 +22,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:route:update', description: 'Update the routes for all entities.')]
 class UpdateRouteCommand extends Command
 {
-    protected static $defaultName = 'sulu:route:update';
-
     /**
      * @var TranslatorInterface|LocaleAwareInterface
      */
@@ -68,7 +68,6 @@ class UpdateRouteCommand extends Command
         $this->addArgument('entity', InputArgument::REQUIRED)
             ->addArgument('locale', InputArgument::REQUIRED)
             ->addOption('batch-size', null, InputOption::VALUE_REQUIRED, '', '1000')
-            ->setDescription('Update the routes for all entities.')
             ->setHelp(
                 <<<'EOT'
 Update the routes for all entities which will be returned by the repository of given entity service:

--- a/src/Sulu/Bundle/SecurityBundle/Command/CreateRoleCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/CreateRoleCommand.php
@@ -22,11 +22,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:security:role:create', description: 'Create a role.')]
 class CreateRoleCommand extends Command
 {
-    protected static $defaultName = 'sulu:security:role:create';
-
     /**
      * @var EntityManagerInterface
      */
@@ -56,7 +56,7 @@ class CreateRoleCommand extends Command
 
     protected function configure()
     {
-        $this->setDescription('Create a role.')
+        $this
             ->setDefinition(
                 [
                     new InputArgument('name', InputArgument::REQUIRED, 'Name of role'),

--- a/src/Sulu/Bundle/SecurityBundle/Command/CreateUserCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/CreateUserCommand.php
@@ -30,11 +30,11 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:security:user:create', description: 'Create a user.')]
 class CreateUserCommand extends Command
 {
-    protected static $defaultName = 'sulu:security:user:create';
-
     /**
      * @var EntityManagerInterface
      */
@@ -102,7 +102,7 @@ class CreateUserCommand extends Command
 
     protected function configure()
     {
-        $this->setDescription('Create a user.')
+        $this
             ->setDefinition(
                 [
                     new InputArgument('username', InputArgument::REQUIRED, 'The username'),

--- a/src/Sulu/Bundle/SecurityBundle/Command/InitCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/InitCommand.php
@@ -21,14 +21,14 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Attribute\AsCommand;
 
 /**
  * @internal
  */
+#[AsCommand(name: 'sulu:security:init', description: 'Create required sulu security entities.')]
 final class InitCommand extends Command
 {
-    protected static $defaultName = 'sulu:security:init';
-
     /**
      * @var EntityManagerInterface
      */
@@ -54,11 +54,6 @@ final class InitCommand extends Command
         $this->entityManager = $entityManager;
         $this->roleRepository = $roleRepository;
         $this->adminPool = $adminPool;
-    }
-
-    protected function configure()
-    {
-        $this->setDescription('Create required sulu security entities.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Sulu/Bundle/SecurityBundle/Command/SyncPhpcrPermissionsCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/SyncPhpcrPermissionsCommand.php
@@ -23,11 +23,11 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:security:sync-phpcr-permissions', description: 'Sync existing object permissions from phpcr into database to make them usable in database queries')]
 class SyncPhpcrPermissionsCommand extends Command
 {
-    protected static $defaultName = 'sulu:security:sync-phpcr-permissions';
-
     /**
      * @var EntityManagerInterface
      */
@@ -57,7 +57,6 @@ class SyncPhpcrPermissionsCommand extends Command
 
     public function configure(): void
     {
-        $this->setDescription('Sync existing object permissions from phpcr into database to make them usable in database queries');
         $this->setHelp(
             'The <info>%command.name%</info> command syncs the object permissions of phpcr documents into the database.'
         );

--- a/src/Sulu/Bundle/SnippetBundle/Command/SnippetExportCommand.php
+++ b/src/Sulu/Bundle/SnippetBundle/Command/SnippetExportCommand.php
@@ -18,11 +18,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:snippet:export', description: 'Export snippet translations from given language into xliff file for translating into a new language.')]
 class SnippetExportCommand extends Command
 {
-    protected static $defaultName = 'sulu:snippet:export';
-
     /**
      * @var SnippetExportInterface
      */
@@ -37,7 +37,6 @@ class SnippetExportCommand extends Command
 
     public function configure()
     {
-        $this->setDescription('Export snippet translations from given language into xliff file for translating into a new language.');
         $this->addArgument('target', InputArgument::REQUIRED, 'Target for export (e.g. export_de.xliff)');
         $this->addArgument('locale', InputArgument::REQUIRED, 'Locale to export (e.g. de, en)');
         $this->addOption('format', 'f', InputOption::VALUE_REQUIRED, '', '1.2.xliff');

--- a/src/Sulu/Bundle/SnippetBundle/Command/SnippetImportCommand.php
+++ b/src/Sulu/Bundle/SnippetBundle/Command/SnippetImportCommand.php
@@ -21,11 +21,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:snippet:import', description: 'Import snippet translations from xliff file into a specific language.')]
 class SnippetImportCommand extends Command
 {
-    protected static $defaultName = 'sulu:snippet:import';
-
     /**
      * @var SnippetImportInterface
      */
@@ -48,8 +48,7 @@ class SnippetImportCommand extends Command
     {
         $this->addArgument('file', InputArgument::REQUIRED, 'test.xliff')
             ->addArgument('locale', InputArgument::REQUIRED)
-            ->addOption('format', 'f', InputOption::VALUE_REQUIRED, '', '1.2.xliff')
-            ->setDescription('Import snippet translations from xliff file into a specific language.');
+            ->addOption('format', 'f', InputOption::VALUE_REQUIRED, '', '1.2.xliff');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Sulu/Bundle/SnippetBundle/Command/SnippetLocaleCopyCommand.php
+++ b/src/Sulu/Bundle/SnippetBundle/Command/SnippetLocaleCopyCommand.php
@@ -23,11 +23,11 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:snippet:locale-copy', description: 'Copy snippet nodes from one locale to another')]
 class SnippetLocaleCopyCommand extends Command
 {
-    protected static $defaultName = 'sulu:snippet:locale-copy';
-
     /**
      * The namespace for languages.
      *
@@ -83,7 +83,6 @@ class SnippetLocaleCopyCommand extends Command
 
     public function configure()
     {
-        $this->setDescription('Copy snippet nodes from one locale to another');
         $this->setHelp(
             <<<'EOT'
             The <info>%command.name%</info> command copies the internationalized properties matching <info>srcLocale</info>

--- a/src/Sulu/Bundle/WebsiteBundle/Command/DumpSitemapCommand.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Command/DumpSitemapCommand.php
@@ -18,11 +18,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sulu:website:dump-sitemap')]
 class DumpSitemapCommand extends Command
 {
-    protected static $defaultName = 'sulu:website:dump-sitemap';
-
     /**
      * @var WebspaceManagerInterface
      */


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | fixes #
| Related issues/PRs | #
| License | MIT
| Documentation PR | sulu/sulu-docs#

Since symfony/console 6.1: Relying on the static property "$defaultName" for setting a command name is deprecated.