### PR TITLE
Include categories and tags in the account/contact export

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -427,6 +427,7 @@ class AccountController extends AbstractRestController implements ClassResourceI
         if ('true' == $request->get('flat')) {
             $fieldDescriptors = $this->getFieldDescriptors();
             $listBuilder = $this->generateFlatListBuilder();
+            $listBuilder->addGroupBy($fieldDescriptors['id']);
             $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
             $this->applyRequestParameters($request, $listBuilder);
 

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -427,7 +427,6 @@ class AccountController extends AbstractRestController implements ClassResourceI
         if ('true' == $request->get('flat')) {
             $fieldDescriptors = $this->getFieldDescriptors();
             $listBuilder = $this->generateFlatListBuilder();
-            $listBuilder->addGroupBy($fieldDescriptors['id']);
             $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
             $this->applyRequestParameters($request, $listBuilder);
 

--- a/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
@@ -305,6 +305,7 @@ class ContactController extends AbstractRestController implements ClassResourceI
     {
         $fieldDescriptors = $this->getFieldDescriptors();
         $listBuilder = $this->listBuilderFactory->create($this->contactClass);
+        $listBuilder->addGroupBy($fieldDescriptors['id']);
         $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
 
         $account = $request->get('accountId');

--- a/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
@@ -305,7 +305,6 @@ class ContactController extends AbstractRestController implements ClassResourceI
     {
         $fieldDescriptors = $this->getFieldDescriptors();
         $listBuilder = $this->listBuilderFactory->create($this->contactClass);
-        $listBuilder->addGroupBy($fieldDescriptors['id']);
         $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
 
         $account = $request->get('accountId');

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/lists/accounts.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/lists/accounts.xml
@@ -248,6 +248,19 @@
             <joins ref="tags"/>
         </group-concat-property>
 
+        <group-concat-property
+            name="tagNames"
+            visibility="no"
+            translation="sulu_tag.tags"
+            glue=","
+            distinct="true"
+        >
+            <field-name>name</field-name>
+            <entity-name>SuluTagBundle:Tag</entity-name>
+
+            <joins ref="tags"/>
+        </group-concat-property>
+
         <!-- tagId property is only used for filtering and should never be included as column in a list -->
         <!-- when used as column, the property will lead to duplicated rows for entities with multiple tags -->
         <property
@@ -292,5 +305,28 @@
                 </params>
             </filter>
         </property>
+
+        <group-concat-property
+            name="categoryNames"
+            visibility="no"
+            translation="sulu_category.categories"
+            glue=","
+            distinct="true"
+        >
+            <field-name>translation</field-name>
+            <entity-name>SuluCategoryBundle:CategoryTranslation</entity-name>
+
+            <joins>
+                <join>
+                    <entity-name>SuluCategoryBundle:Category</entity-name>
+                    <field-name>%sulu.model.account.class%.categories</field-name>
+                </join>
+                <join>
+                    <entity-name>SuluCategoryBundle:CategoryTranslation</entity-name>
+                    <field-name>SuluCategoryBundle:Category.translations</field-name>
+                    <condition>SuluCategoryBundle:CategoryTranslation.locale = SuluCategoryBundle:Category.defaultLocale</condition>
+                </join>
+            </joins>
+        </group-concat-property>
     </properties>
 </list>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
@@ -307,6 +307,19 @@
             <joins ref="tags"/>
         </group-concat-property>
 
+        <group-concat-property
+            name="tagNames"
+            visibility="no"
+            translation="sulu_tag.tags"
+            glue=","
+            distinct="true"
+        >
+            <field-name>name</field-name>
+            <entity-name>SuluTagBundle:Tag</entity-name>
+
+            <joins ref="tags"/>
+        </group-concat-property>
+
         <!-- tagId property is only used for filtering and should never be included as column in a list -->
         <!-- when used as column, the property will lead to duplicated rows for entities with multiple tags -->
         <property
@@ -351,6 +364,28 @@
                 </params>
             </filter>
         </property>
+
+        <group-concat-property
+            name="categoryNames"
+            visibility="no"
+            translation="sulu_category.categories"
+            glue=","
+        >
+            <field-name>translation</field-name>
+            <entity-name>SuluCategoryBundle:CategoryTranslation</entity-name>
+
+            <joins>
+                <join>
+                    <entity-name>SuluCategoryBundle:Category</entity-name>
+                    <field-name>%sulu.model.contact.class%.categories</field-name>
+                </join>
+                <join>
+                    <entity-name>SuluCategoryBundle:CategoryTranslation</entity-name>
+                    <field-name>SuluCategoryBundle:Category.translations</field-name>
+                    <condition>SuluCategoryBundle:CategoryTranslation.locale = SuluCategoryBundle:Category.defaultLocale</condition>
+                </join>
+            </joins>
+        </group-concat-property>
 
         <property name="user" visibility="no" searchability="yes" translation="sulu_security.user_name">
             <field-name>username</field-name>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | #6558
| License | MIT
| Documentation PR |

#### What's in this PR?

This change adds 2 new fields (categories and tags) to the account/contact export. 

#### Why?

Some users would like to include this additional data in their exports.

#### Example Usage

Click on export in the account/contact admin interface as usual.

#### To Do

- [ ] Add tests as they have not been updated yet

