### PR TITLE
Add support for Accept Language in Geolocators

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -206,8 +206,7 @@ Or the Merge request implementing this changes in Sulu [here](https://github.com
 
 ### GeolocatorInterface locate method GeolocatorOptions added
 
-To support to give the Accept-Language locale to the geolocator services a custom Geolocator
-requires now to support the new `GeolocatorOptions` parameter:
+To provide the Accept-Language locale to geolocator services, a custom Geolocator now requires support for the new ﻿`GeolocatorOptions` parameter:
 
 ```diff
 -    public function locate(string $query): GeolocatorResponse

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -204,6 +204,16 @@ Example:
 See also the documentation [official Doctrine Events documentation](https://symfony.com/doc/6.4/doctrine/events.html).  
 Or the Merge request implementing this changes in Sulu [here](https://github.com/sulu/sulu/pull/7374/files).
 
+### GeolocatorInterface locate method GeolocatorOptions added
+
+To support to give the Accept-Language locale to the geolocator services a custom Geolocator
+requires now to support the new `GeolocatorOptions` parameter:
+
+```diff
+-    public function locate(string $query): GeolocatorResponse
++    public function locate(string $query, ?GeolocatorOptions $options = null): GeolocatorResponse
+```
+
 ### Replace Symfony Security class
 
 The `Symfony\Component\Security\Core\Security` deprecated class was replaced by

--- a/src/Sulu/Bundle/LocationBundle/Controller/GeolocatorController.php
+++ b/src/Sulu/Bundle/LocationBundle/Controller/GeolocatorController.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\LocationBundle\Controller;
 
 use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorInterface;
+use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorOptions;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -22,8 +23,9 @@ class GeolocatorController
      */
     private $geolocator;
 
-    public function __construct(GeolocatorInterface $geolocator)
-    {
+    public function __construct(
+        GeolocatorInterface $geolocator,
+    ) {
         $this->geolocator = $geolocator;
     }
 
@@ -34,8 +36,23 @@ class GeolocatorController
     {
         $query = $request->get('search', '');
 
-        $res = $this->geolocator->locate($query);
+        $geolocatorOptions = new GeolocatorOptions();
+        $geolocatorOptions->setAcceptLanguage(
+            $this->getLocale($request),
+        );
+
+        $res = $this->geolocator->locate($query, $geolocatorOptions);
 
         return new JsonResponse(['_embedded' => ['geolocator_locations' => $res->toArray()]]);
+    }
+
+    private function getLocale(Request $request): ?string
+    {
+        $locale = $request->query->getString('locale');
+        if (!$locale) {
+            return null;
+        }
+
+        return $locale;
     }
 }

--- a/src/Sulu/Bundle/LocationBundle/Controller/GeolocatorController.php
+++ b/src/Sulu/Bundle/LocationBundle/Controller/GeolocatorController.php
@@ -23,9 +23,7 @@ class GeolocatorController
      */
     private $geolocator;
 
-    public function __construct(
-        GeolocatorInterface $geolocator,
-    ) {
+    public function __construct(GeolocatorInterface $geolocator,) {
         $this->geolocator = $geolocator;
     }
 
@@ -48,8 +46,8 @@ class GeolocatorController
 
     private function getLocale(Request $request): ?string
     {
-        $locale = $request->query->getString('locale');
-        if (!$locale) {
+        $locale = $request->query->get('locale');
+        if (!$locale && !\is_string($locale)) {
             return null;
         }
 

--- a/src/Sulu/Bundle/LocationBundle/Controller/GeolocatorController.php
+++ b/src/Sulu/Bundle/LocationBundle/Controller/GeolocatorController.php
@@ -23,7 +23,8 @@ class GeolocatorController
      */
     private $geolocator;
 
-    public function __construct(GeolocatorInterface $geolocator) {
+    public function __construct(GeolocatorInterface $geolocator)
+    {
         $this->geolocator = $geolocator;
     }
 

--- a/src/Sulu/Bundle/LocationBundle/Controller/GeolocatorController.php
+++ b/src/Sulu/Bundle/LocationBundle/Controller/GeolocatorController.php
@@ -23,7 +23,7 @@ class GeolocatorController
      */
     private $geolocator;
 
-    public function __construct(GeolocatorInterface $geolocator,) {
+    public function __construct(GeolocatorInterface $geolocator) {
         $this->geolocator = $geolocator;
     }
 

--- a/src/Sulu/Bundle/LocationBundle/Geolocator/GeolocatorInterface.php
+++ b/src/Sulu/Bundle/LocationBundle/Geolocator/GeolocatorInterface.php
@@ -13,5 +13,5 @@ namespace Sulu\Bundle\LocationBundle\Geolocator;
 
 interface GeolocatorInterface
 {
-    public function locate(string $query): GeolocatorResponse;
+    public function locate(string $query, ?GeolocatorOptions $options = null): GeolocatorResponse;
 }

--- a/src/Sulu/Bundle/LocationBundle/Geolocator/GeolocatorOptions.php
+++ b/src/Sulu/Bundle/LocationBundle/Geolocator/GeolocatorOptions.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Sulu\Bundle\LocationBundle\Geolocator;
+
+class GeolocatorOptions
+{
+    /**
+     * A string that represents the natural language and locale that the client prefers.
+     * Should be formatted with the syntax used for the Accept-Language HTTP header
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language
+     *
+     * @var string|null
+     */
+    private ?string $acceptLanguage = null;
+
+    public function getAcceptLanguage(): ?string
+    {
+        return $this->acceptLanguage;
+    }
+
+    public function setAcceptLanguage(?string $acceptLanguage): self
+    {
+        $this->acceptLanguage = $acceptLanguage;
+
+        return $this;
+    }
+}

--- a/src/Sulu/Bundle/LocationBundle/Geolocator/GeolocatorOptions.php
+++ b/src/Sulu/Bundle/LocationBundle/Geolocator/GeolocatorOptions.php
@@ -1,15 +1,23 @@
 <?php
 
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Sulu\Bundle\LocationBundle\Geolocator;
 
 class GeolocatorOptions
 {
     /**
      * A string that represents the natural language and locale that the client prefers.
-     * Should be formatted with the syntax used for the Accept-Language HTTP header
-     * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language
+     * Should be formatted with the syntax used for the Accept-Language HTTP header.
      *
-     * @var string|null
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language
      */
     private ?string $acceptLanguage = null;
 

--- a/src/Sulu/Bundle/LocationBundle/Geolocator/Service/GoogleGeolocator.php
+++ b/src/Sulu/Bundle/LocationBundle/Geolocator/Service/GoogleGeolocator.php
@@ -15,6 +15,7 @@ use GuzzleHttp\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
 use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorInterface;
 use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorLocation;
+use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorOptions;
 use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -61,12 +62,19 @@ class GoogleGeolocator implements GeolocatorInterface
         $this->apiKey = $apiKey;
     }
 
-    public function locate(string $query): GeolocatorResponse
+    public function locate(string $query, ?GeolocatorOptions $options = null): GeolocatorResponse
     {
+        $requestHeaders = [];
+
+        if ($options && $options->getAcceptLanguage()) {
+            $requestHeaders['Accept-Language'] = $options->getAcceptLanguage();
+        }
+
         $response = $this->client->request(
             'GET',
             self::ENDPOINT,
             [
+                'headers' => $requestHeaders,
                 'query' => [
                     'key' => $this->apiKey,
                     'address' => $query,

--- a/src/Sulu/Bundle/LocationBundle/Geolocator/Service/MapquestGeolocator.php
+++ b/src/Sulu/Bundle/LocationBundle/Geolocator/Service/MapquestGeolocator.php
@@ -15,15 +15,14 @@ namespace Sulu\Bundle\LocationBundle\Geolocator\Service;
 
 use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorInterface;
 use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorLocation;
+use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorOptions;
 use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Webmozart\Assert\Assert;
 
 /**
- * Geolocator which uses the open street maps nominatim service.
- *
- * http://wiki.openstreetmap.org/wiki/Nominatim
+ * https://developer.mapquest.com/documentation/
  */
 class MapquestGeolocator implements GeolocatorInterface
 {
@@ -52,12 +51,19 @@ class MapquestGeolocator implements GeolocatorInterface
         $this->key = $key;
     }
 
-    public function locate(string $query): GeolocatorResponse
+    public function locate(string $query, ?GeolocatorOptions $options = null): GeolocatorResponse
     {
+        $requestHeaders = [];
+
+        if ($options && $options->getAcceptLanguage()) {
+            $requestHeaders['Accept-Language'] = $options->getAcceptLanguage();
+        }
+
         $response = $this->client->request(
             'GET',
             $this->baseUrl,
             [
+                'headers' => $requestHeaders,
                 'query' => [
                     'location' => $query,
                     'format' => 'json',

--- a/src/Sulu/Bundle/LocationBundle/Geolocator/Service/MapquestGeolocator.php
+++ b/src/Sulu/Bundle/LocationBundle/Geolocator/Service/MapquestGeolocator.php
@@ -22,7 +22,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Webmozart\Assert\Assert;
 
 /**
- * https://developer.mapquest.com/documentation/
+ * https://developer.mapquest.com/documentation/.
  */
 class MapquestGeolocator implements GeolocatorInterface
 {

--- a/src/Sulu/Bundle/LocationBundle/Geolocator/Service/NominatimGeolocator.php
+++ b/src/Sulu/Bundle/LocationBundle/Geolocator/Service/NominatimGeolocator.php
@@ -15,6 +15,7 @@ use GuzzleHttp\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
 use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorInterface;
 use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorLocation;
+use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorOptions;
 use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -66,18 +67,24 @@ class NominatimGeolocator implements GeolocatorInterface
         $this->key = $key;
     }
 
-    public function locate(string $query): GeolocatorResponse
+    public function locate(string $query, ?GeolocatorOptions $options = null): GeolocatorResponse
     {
+        $requestQuery = [
+            'q' => $query,
+            'format' => 'json',
+            'addressdetails' => 1,
+            'key' => $this->key,
+        ];
+
+        if ($options && $options->getAcceptLanguage()) {
+            $requestQuery['accept-language'] = $options->getAcceptLanguage();
+        }
+
         $response = $this->client->request(
             'GET',
             $this->baseUrl,
             [
-                'query' => [
-                    'q' => $query,
-                    'format' => 'json',
-                    'addressdetails' => 1,
-                    'key' => $this->key,
-                ],
+                'query' => $requestQuery,
             ]
         );
 

--- a/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Form/fields/Location.js
+++ b/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Form/fields/Location.js
@@ -1,9 +1,14 @@
 // @flow
 import React from 'react';
+import {computed, observable} from 'mobx';
+import userStore from 'sulu-admin-bundle/stores/userStore';
+import {observer} from 'mobx-react';
 import LocationComponent from '../../../containers/Location';
 import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import type {Location as LocationValue} from '../../../types';
+import type {IObservableValue} from 'mobx/lib/mobx';
 
+@observer
 export default class Location extends React.Component<FieldTypeProps<?LocationValue>> {
     handleChange = (value: ?LocationValue) => {
         const {onChange, onFinish} = this.props;
@@ -21,9 +26,16 @@ export default class Location extends React.Component<FieldTypeProps<?LocationVa
         return (
             <LocationComponent
                 disabled={!!disabled}
+                locale={this.locale.get()}
                 onChange={this.handleChange}
                 value={value}
             />
         );
+    }
+
+    @computed get locale(): IObservableValue<string> {
+        const {formInspector} = this.props;
+
+        return formInspector.locale ? formInspector.locale : observable.box(userStore.contentLocale);
     }
 }

--- a/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/Location.js
+++ b/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/Location.js
@@ -14,6 +14,7 @@ import type {Location as LocationValue} from '../../types';
 
 type Props = {|
     disabled: boolean,
+    locale: string,
     onChange: (value: ?LocationValue) => void,
     value: ?LocationValue,
 |};
@@ -76,6 +77,7 @@ class Location extends React.Component<Props> {
         const {
             disabled,
             value,
+            locale,
         } = this.props;
 
         const locationClass = classNames(
@@ -127,6 +129,7 @@ class Location extends React.Component<Props> {
                     </MapContainer>
                 }
                 <LocationOverlay
+                    locale={locale}
                     onClose={this.handleOverlayClose}
                     onConfirm={this.handleOverlayConfirm}
                     open={this.overlayOpen}

--- a/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/LocationOverlay.js
+++ b/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/LocationOverlay.js
@@ -12,6 +12,7 @@ import locationOverlayStyles from './locationOverlay.scss';
 import type {Location as LocationValue} from '../../types';
 
 type Props = {
+    locale: ?string,
     onClose: () => void,
     onConfirm: (?LocationValue) => void,
     open: boolean,
@@ -39,7 +40,11 @@ class LocationOverlay extends React.Component<Props> {
     constructor(props: Props) {
         super(props);
 
-        this.geolocatorSelectionStore = new SingleSelectionStore('geolocator_locations');
+        this.geolocatorSelectionStore = new SingleSelectionStore(
+            'geolocator_locations',
+            undefined,
+            observable.box(props.locale)
+        );
 
         this.updateDataOnGeolocatorSelectDisposer = reaction(
             () => this.geolocatorSelectionStore.item,

--- a/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/Location.test.js
+++ b/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/Location.test.js
@@ -13,6 +13,7 @@ test('Component should render without a value', () => {
     const location = shallow(
         <Location
             disabled={true}
+            locale="en"
             onChange={jest.fn()}
             value={null}
         />
@@ -25,6 +26,7 @@ test('Component should render in disabled state', () => {
     const location = shallow(
         <Location
             disabled={true}
+            locale="en"
             onChange={jest.fn()}
             value={null}
         />
@@ -49,6 +51,7 @@ test('Component should render with a given value', () => {
     const location = shallow(
         <Location
             disabled={true}
+            locale="en"
             onChange={jest.fn()}
             value={locationData}
         />
@@ -73,6 +76,7 @@ test('Component should render a map, a marker and a tooltip with correct props a
     const location = mount(
         <Location
             disabled={true}
+            locale="en"
             onChange={jest.fn()}
             value={locationData}
         />
@@ -121,6 +125,7 @@ test('Component should not render a tooltip if given value has no additional inf
     const location = mount(
         <Location
             disabled={true}
+            locale="en"
             onChange={jest.fn()}
             value={locationData}
         />
@@ -145,6 +150,7 @@ test('Should pass correct props to the LocationOverlay', () => {
     const location = mount(
         <Location
             disabled={true}
+            locale="en"
             onChange={jest.fn()}
             value={locationData}
         />
@@ -160,6 +166,7 @@ test('Should open a LocationOverlay when the edit button is clicked', () => {
     const location = mount(
         <Location
             disabled={true}
+            locale="en"
             onChange={jest.fn()}
             value={null}
         />
@@ -174,6 +181,7 @@ test('Should close LocationOverlay when the onClose callback of the overlay is f
     const location = mount(
         <Location
             disabled={true}
+            locale="en"
             onChange={jest.fn()}
             value={null}
         />
@@ -204,6 +212,7 @@ test('Should close overlay and call callback with correct value when the Locatio
     const location = mount(
         <Location
             disabled={true}
+            locale="en"
             onChange={changeSpy}
             value={null}
         />
@@ -235,6 +244,7 @@ test('Should update view of map when value prop is changed', () => {
     const location = mount(
         <Location
             disabled={true}
+            locale="en"
             onChange={jest.fn()}
             value={locationData}
         />

--- a/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/LocationOverlay.test.js
+++ b/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/LocationOverlay.test.js
@@ -13,6 +13,7 @@ jest.mock('sulu-admin-bundle/utils/Translator', () => ({
 test('Component should render without a given initial-value', () => {
     const locationOverlay = mount(
         <LocationOverlay
+            locale="en"
             onClose={jest.fn()}
             onConfirm={jest.fn()}
             open={true}
@@ -38,6 +39,7 @@ test('Component should render with a given initial-value', () => {
 
     const locationOverlay = mount(
         <LocationOverlay
+            locale="en"
             onClose={jest.fn()}
             onConfirm={jest.fn()}
             open={true}
@@ -51,6 +53,7 @@ test('Component should render with a given initial-value', () => {
 test('Should pass correct props the the Overlay component', () => {
     const locationOverlay = mount(
         <LocationOverlay
+            locale="en"
             onClose={jest.fn()}
             onConfirm={jest.fn()}
             open={true}
@@ -70,6 +73,7 @@ test('Should pass correct props the the Overlay component', () => {
 test('Should pass correct props the the SingleAutoComplete component', () => {
     const locationOverlay = mount(
         <LocationOverlay
+            locale="en"
             onClose={jest.fn()}
             onConfirm={jest.fn()}
             open={true}
@@ -86,6 +90,7 @@ test('Should pass correct props the the SingleAutoComplete component', () => {
 test('Should pass correct props the Map component and Marker component when no initial-value is given', () => {
     const locationOverlay = mount(
         <LocationOverlay
+            locale="en"
             onClose={jest.fn()}
             onConfirm={jest.fn()}
             open={true}
@@ -120,6 +125,7 @@ test('Should pass correct props the Map component and Marker component when an i
 
     const locationOverlay = mount(
         <LocationOverlay
+            locale="en"
             onClose={jest.fn()}
             onConfirm={jest.fn()}
             open={true}
@@ -154,6 +160,7 @@ test('Should pass correct props to the input fields', () => {
 
     const locationOverlay = mount(
         <LocationOverlay
+            locale="en"
             onClose={jest.fn()}
             onConfirm={jest.fn()}
             open={true}
@@ -175,6 +182,7 @@ test('Should pass correct props to the input fields', () => {
 test('Should pass correct props to the map, marker and input fields after auto-complete was changed', () => {
     const locationOverlay = mount(
         <LocationOverlay
+            locale="en"
             onClose={jest.fn()}
             onConfirm={jest.fn()}
             open={true}
@@ -220,6 +228,7 @@ test('Should call onConfirm callback when the Overlay is confirmed after auto-co
 
     const locationOverlay = mount(
         <LocationOverlay
+            locale="en"
             onClose={jest.fn()}
             onConfirm={confirmSpy}
             open={true}
@@ -257,6 +266,7 @@ test('Should call onConfirm callback when the Overlay is confirmed after auto-co
 test('Should pass correct props to the map and input fields after map was zoomed', () => {
     const locationOverlay = mount(
         <LocationOverlay
+            locale="en"
             onClose={jest.fn()}
             onConfirm={jest.fn()}
             open={true}
@@ -292,6 +302,7 @@ test('Should call onConfirm callback when the Overlay is confirmed after map was
 
     const locationOverlay = mount(
         <LocationOverlay
+            locale="en"
             onClose={jest.fn()}
             onConfirm={confirmSpy}
             open={true}
@@ -324,6 +335,7 @@ test('Should call onConfirm callback when the Overlay is confirmed after map was
 test('Should pass correct props to the map, marker and input fields when marker is dragged', () => {
     const locationOverlay = mount(
         <LocationOverlay
+            locale="en"
             onClose={jest.fn()}
             onConfirm={jest.fn()}
             open={true}
@@ -367,6 +379,7 @@ test('Should call onConfirm callback when the Overlay is confirmed after marker 
 
     const locationOverlay = mount(
         <LocationOverlay
+            locale="en"
             onClose={jest.fn()}
             onConfirm={confirmSpy}
             open={true}
@@ -407,6 +420,7 @@ test('Should call onConfirm callback when the Overlay is confirmed after setting
 
     const locationOverlay = mount(
         <LocationOverlay
+            locale="en"
             onClose={jest.fn()}
             onConfirm={confirmSpy}
             open={true}
@@ -446,6 +460,7 @@ test('Should pass correct props to the map, marker and input fields after reset'
 
     const locationOverlay = mount(
         <LocationOverlay
+            locale="en"
             onClose={jest.fn()}
             onConfirm={jest.fn()}
             open={true}
@@ -489,6 +504,7 @@ test('Should call onConfirm callback when the Overlay is confirmed after reset',
 
     const locationOverlay = mount(
         <LocationOverlay
+            locale="en"
             onClose={jest.fn()}
             onConfirm={confirmSpy}
             open={true}
@@ -505,6 +521,7 @@ test('Should call onConfirm callback when the Overlay is confirmed after reset',
 test('Should pass correct props to the map, marker and input fields after input fields are changed', () => {
     const locationOverlay = mount(
         <LocationOverlay
+            locale="en"
             onClose={jest.fn()}
             onConfirm={jest.fn()}
             open={true}
@@ -545,6 +562,7 @@ test('Should call onConfirm callback when the Overlay is confirmed after input f
 
     const locationOverlay = mount(
         <LocationOverlay
+            locale="en"
             onClose={jest.fn()}
             onConfirm={confirmSpy}
             open={true}
@@ -581,6 +599,7 @@ test('Should call given onClose callback when onClose callback of Overlay is fir
 
     const locationOverlay = mount(
         <LocationOverlay
+            locale="en"
             onClose={closeSpy}
             onConfirm={jest.fn()}
             open={true}
@@ -598,6 +617,7 @@ test('Should enable confirm button if longitude and latitude are both not set or
 
     const locationOverlay = mount(
         <LocationOverlay
+            locale="en"
             onClose={closeSpy}
             onConfirm={jest.fn()}
             open={true}

--- a/src/Sulu/Bundle/LocationBundle/Tests/Unit/Controller/GeolocatorControllerTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Unit/Controller/GeolocatorControllerTest.php
@@ -12,9 +12,11 @@
 namespace Sulu\Bundle\LocationBundle\Tests\Unit\Controller;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Bundle\LocationBundle\Controller\GeolocatorController;
 use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorInterface;
+use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorOptions;
 use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorResponse;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -29,13 +31,18 @@ class GeolocatorControllerTest extends TestCase
         $geolocatorResponse->toArray()->willReturn(['test']);
 
         $locator = $this->prophesize(GeolocatorInterface::class);
-        $locator->locate('Dornbirn Teststraße 6')->willReturn($geolocatorResponse->reveal());
+        $locator->locate('Dornbirn Teststraße 6', Argument::that(function (GeolocatorOptions $options) {
+            $this->assertSame('de', $options->getAcceptLanguage());
+
+            return true;
+        }))
+            ->willReturn($geolocatorResponse->reveal())
+            ->shouldBeCalled();
 
         $controller = new GeolocatorController($locator->reveal());
-        $request = $this->prophesize(Request::class);
-        $request->get('search', '')->willReturn('Dornbirn Teststraße 6');
+        $request = Request::create('/test', 'GET', ['search' => 'Dornbirn Teststraße 6', 'locale' => 'de']);
 
-        $response = $controller->queryAction($request->reveal());
+        $response = $controller->queryAction($request);
 
         $this->assertInstanceOf(JsonResponse::class, $response);
         $this->assertEquals(

--- a/src/Sulu/Bundle/LocationBundle/Tests/Unit/Controller/GeolocatorControllerTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Unit/Controller/GeolocatorControllerTest.php
@@ -31,7 +31,7 @@ class GeolocatorControllerTest extends TestCase
         $geolocatorResponse->toArray()->willReturn(['test']);
 
         $locator = $this->prophesize(GeolocatorInterface::class);
-        $locator->locate('Dornbirn Teststraße 6', Argument::that(function (GeolocatorOptions $options) {
+        $locator->locate('Dornbirn Teststraße 6', Argument::that(function(GeolocatorOptions $options) {
             $this->assertSame('de', $options->getAcceptLanguage());
 
             return true;

--- a/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/Service/GoogleGeolocatorTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/Service/GoogleGeolocatorTest.php
@@ -18,6 +18,7 @@ use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorOptions;
 use Sulu\Bundle\LocationBundle\Geolocator\Service\GoogleGeolocator;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -95,6 +96,19 @@ class GoogleGeolocatorTest extends TestCase
 
         $this->assertArrayHasKey('key', $mockResponse->getRequestOptions()['query']);
         $this->assertEquals('foobar-key', $mockResponse->getRequestOptions()['query']['key']);
+    }
+
+    public function testAcceptLanguage(): void
+    {
+        $mockResponse = new MockResponse('{"status": "OK","results":[]}');
+
+        $httpClient = new MockHttpClient($mockResponse);
+        $geolocator = new GoogleGeolocator($httpClient, 'foobar-key');
+        $options = new GeolocatorOptions();
+        $options->setAcceptLanguage('it-IT, it;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5');
+        $geolocator->locate('foobar', $options);
+
+        $this->assertContains('Accept-Language: it-IT, it;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5', $mockResponse->getRequestOptions()['headers']);
     }
 
     /**

--- a/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/Service/MapquestGeolocatorTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/Service/MapquestGeolocatorTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\LocationBundle\Tests\Unit\Geolocator\Service;
 
 use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorOptions;
 use Sulu\Bundle\LocationBundle\Geolocator\Service\MapquestGeolocator;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -68,5 +69,17 @@ class MapquestGeolocatorTest extends TestCase
         foreach ($expectationMap as $field => $expectation) {
             $this->assertEquals($expectation, $result[$field]);
         }
+    }
+    public function testAcceptLanguage(): void
+    {
+        $mockResponse = new MockResponse('{"status": "OK","results":[]}');
+
+        $httpClient = new MockHttpClient($mockResponse);
+        $geolocator = new MapquestGeolocator($httpClient, 'https://example.org', 'key');
+        $options = new GeolocatorOptions();
+        $options->setAcceptLanguage('it-IT, it;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5');
+        $geolocator->locate('foobar', $options);
+
+        $this->assertContains('Accept-Language: it-IT, it;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5', $mockResponse->getRequestOptions()['headers']);
     }
 }

--- a/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/Service/MapquestGeolocatorTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/Service/MapquestGeolocatorTest.php
@@ -70,6 +70,7 @@ class MapquestGeolocatorTest extends TestCase
             $this->assertEquals($expectation, $result[$field]);
         }
     }
+
     public function testAcceptLanguage(): void
     {
         $mockResponse = new MockResponse('{"status": "OK","results":[]}');

--- a/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/Service/NominatimGeolocatorTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/Service/NominatimGeolocatorTest.php
@@ -16,6 +16,7 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorOptions;
 use Sulu\Bundle\LocationBundle\Geolocator\Service\NominatimGeolocator;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -95,5 +96,19 @@ class NominatimGeolocatorTest extends TestCase
         foreach ($expectationMap as $field => $expectation) {
             $this->assertEquals($expectation, $result[$field]);
         }
+    }
+
+    public function testAcceptLanguage(): void
+    {
+        $mockResponse = new MockResponse('[]');
+
+        $httpClient = new MockHttpClient($mockResponse);
+        $geolocator = new NominatimGeolocator($httpClient, 'https://example.org', 'key');
+        $options = new GeolocatorOptions();
+        $options->setAcceptLanguage('it-IT, it;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5');
+        $geolocator->locate('foobar', $options);
+
+        $this->assertArrayHasKey('accept-language', $mockResponse->getRequestOptions()['query']);
+        $this->assertEquals('it-IT, it;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5', $mockResponse->getRequestOptions()['query']['accept-language']);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Both Nominatim and Google Geolocator support additional parameters to optimize the result of the query, this PR adds a new optional parameter to the GeolocatorInterface::locate method to pass additional options specific for a single query.

As an initial implementation this PR adds the ability to pass to the geolocator an "accept language" string.

#### Why?

Google Geolocator, if you don't pass the language query string parameter or an Accept-Language http header, tries to infer the desired results' language from the remote IP that it's calling its API, but the server in which runs the Sulu instance may not be located in the same country of the user, this gives a wrong output (wrong labels and/or wrong order).

#### Example Usage

<!--
```php
use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorOptions;
use Sulu\Bundle\LocationBundle\Geolocator\Service\GoogleGeolocator;

$geolocator = new GoogleGeolocator(/* deps */); // Same with NominatimGeolocator

// A new GeolocatorOptions model allows to pass custom options to the geolocator for a single query
// The accept language should follow the Accept-Language HTTP header syntax: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language
$options = new GeolocatorOptions();
$options->setAcceptLanguage('it-IT, it;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5');

// Now we can pass the options object to the geolocator, this second parameter is optional
$geolocator->locate('foobar', $options);
```
-->

