### PR TITLE
Add Router Attributes to Form Request to ResourceTabs View

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
@@ -89,7 +89,29 @@ class ResourceTabs extends React.Component<Props> {
             this.resourceStore.destroy();
         }
 
-        this.resourceStore = new ResourceStore(this.resourceKey, this.id, options);
+        let {
+            router: {
+                attributes,
+                route: {
+                    options: {
+                        requestParameters = {},
+                        routerAttributesToFormRequest = {},
+                    },
+                },
+            },
+        } = this.props;
+
+        const formStoreOptions = requestParameters ? requestParameters : {};
+
+        routerAttributesToFormRequest = toJS(routerAttributesToFormRequest);
+        Object.keys(toJS(routerAttributesToFormRequest)).forEach((key) => {
+            const formOptionKey = routerAttributesToFormRequest[key];
+            const attributeName = isNaN(key) ? key : routerAttributesToFormRequest[key];
+
+            formStoreOptions[formOptionKey] = attributes[attributeName];
+        });
+
+        this.resourceStore = new ResourceStore(this.resourceKey, this.id, options, formStoreOptions);
     };
 
     disposeCreateResourceStoreOnRouteChange = (route: ?Route) => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add Router Attributes to Form Request to ResourceTabs View

#### Why?

Currently the ResourceTabView is missing some important feature to set this kind of options.

#### TODO

 - [ ] Add addRouterAttributesToFormRequest to createResourceTabViewBuilder
 - [ ] Avoid duplicated logic
