### PR TITLE
Check if security->getUser() is instance of UserInterface

### DIFF
--- a/src/Sulu/Bundle/TrashBundle/Infrastructure/Doctrine/Repository/TrashItemRepository.php
+++ b/src/Sulu/Bundle/TrashBundle/Infrastructure/Doctrine/Repository/TrashItemRepository.php
@@ -122,6 +122,10 @@ final class TrashItemRepository implements TrashItemRepositoryInterface
         /** @var UserInterface $user */
         $user = $this->security->getUser();
 
+        if (!($user instanceof UserInterface)) {
+            return null;
+        }
+
         return $user;
     }
 }

--- a/src/Sulu/Bundle/TrashBundle/Infrastructure/Doctrine/Repository/TrashItemRepository.php
+++ b/src/Sulu/Bundle/TrashBundle/Infrastructure/Doctrine/Repository/TrashItemRepository.php
@@ -119,7 +119,6 @@ final class TrashItemRepository implements TrashItemRepositoryInterface
             return null;
         }
 
-        /** @var UserInterface $user */
         $user = $this->security->getUser();
 
         if (!($user instanceof UserInterface)) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets |
| Related issues/PRs |
| License | MIT
| Documentation PR |

#### What's in this PR?

Return null or UserInterface from security->getUser() instead of InMemoryUser.

#### Why?

While trying to delete articles via the documentManager we receive the following error message:
TrashItemRepository::getCurrentUser(): Return value must be of type ?Sulu\Component\Security\Authentication\UserInterface
