### PR TITLE
Fix phpstan baseline by set FlattenExceptionNormalizer return type

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -54461,11 +54461,6 @@ parameters:
 			path: src/Sulu/Component/Rest/Exception/UniqueConstraintViolationException.php
 
 		-
-			message: "#^Cannot access offset 'code' on array\\|bool\\|float\\|int\\|string\\|null\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/FlattenExceptionNormalizer.php
-
-		-
 			message: "#^Cannot call method getCode\\(\\) on mixed\\.$#"
 			count: 1
 			path: src/Sulu/Component/Rest/FlattenExceptionNormalizer.php
@@ -56409,11 +56404,6 @@ parameters:
 			message: "#^Property Sulu\\\\Component\\\\Rest\\\\Tests\\\\Unit\\\\DoctrineRestHelperTest\\:\\:\\$listRestHelper has unknown class PHPUnit\\\\Framework\\\\MockObject_MockObject as its type\\.$#"
 			count: 1
 			path: src/Sulu/Component/Rest/Tests/Unit/DoctrineRestHelperTest.php
-
-		-
-			message: "#^Cannot access offset 'code' on array\\|bool\\|float\\|int\\|string\\|null\\.$#"
-			count: 4
-			path: src/Sulu/Component/Rest/Tests/Unit/FlattenExceptionNormalizerTest.php
 
 		-
 			message: "#^Access to an undefined property Sulu\\\\Component\\\\Rest\\\\Tests\\\\Unit\\\\ListBuilder\\\\Doctrine\\\\DoctrineListBuilderTest\\:\\:\\$systemStore\\.$#"

--- a/src/Sulu/Component/Rest/FlattenExceptionNormalizer.php
+++ b/src/Sulu/Component/Rest/FlattenExceptionNormalizer.php
@@ -42,8 +42,12 @@ class FlattenExceptionNormalizer implements ContextAwareNormalizerInterface
         $this->translator = $translator;
     }
 
+    /**
+     * @return array<int|string, mixed>
+     */
     public function normalize($exception, $format = null, array $context = [])
     {
+        /** @var array<int|string, mixed> $data */
         $data = $this->decoratedNormalizer->normalize($exception, $format, $context);
         $data['code'] = $exception->getCode();
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The Normalizer in this case returns always an array.

#### Why?

Fix phpstan baseline by set FlattenExceptionNormalizer return type. 