### PR TITLE
Cleaning up the StructureLoading

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -44856,17 +44856,7 @@ parameters:
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 
 		-
-			message: "#^Method Sulu\\\\Component\\\\Content\\\\Metadata\\\\Loader\\\\StructureXmlLoader\\:\\:isReservedProperty\\(\\) has parameter \\$propertyData with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
-
-		-
 			message: "#^Method Sulu\\\\Component\\\\Content\\\\Metadata\\\\Loader\\\\StructureXmlLoader\\:\\:load\\(\\) has parameter \\$type with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Content\\\\Metadata\\\\Loader\\\\StructureXmlLoader\\:\\:loadCacheLifetime\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 
@@ -44882,11 +44872,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Component\\\\Content\\\\Metadata\\\\Loader\\\\StructureXmlLoader\\:\\:loadTemplateAttributes\\(\\) has parameter \\$type with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Content\\\\Metadata\\\\Loader\\\\StructureXmlLoader\\:\\:mapMeta\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 
@@ -44942,11 +44927,6 @@ parameters:
 
 		-
 			message: "#^Property Sulu\\\\Component\\\\Content\\\\Metadata\\\\Loader\\\\StructureXmlLoader\\:\\:\\$requiredTagNames type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
-
-		-
-			message: "#^Property Sulu\\\\Component\\\\Content\\\\Metadata\\\\Loader\\\\StructureXmlLoader\\:\\:\\$reservedPropertyNames type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #6842
| License | MIT
| Documentation PR | -none-

#### What's in this PR?

* Adding types to some function in the StructureXmlLoader
* Merging the functions to find reserved properties
* Moving the template attributes out that are the same for every template
* Using php8 syntax to filter an array

#### Why?

Less code to maintain and easier to see what attributes are global for all templates and what aren't.

In this case adding deprecated attributes would affect all structure types in sulu.
