### PR TITLE
Remove reference to LiipThemeBundle and dispatch event instead

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,11 @@
 # Upgrade
 
+## 2.5.7
+
+### Constructor of ValidateWebspacesCommand changed
+
+The constructor of `ValidateWebspacesCommand` requires now EventDispatcherInterface instead of activeTheme.
+
 ## 2.5.2
 
 ### Add indexes to route table

--- a/src/Sulu/Bundle/PageBundle/Resources/config/command.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/command.xml
@@ -54,7 +54,7 @@
             <argument type="service" id="sulu.content.structure_manager"/>
             <argument type="service" id="sulu.content.webspace_structure_provider"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
-            <argument type="service" id="liip_theme.active_theme" on-invalid="null"/>
+            <argument type="service" id="event_dispatcher"/>
 
             <tag name="console.command"/>
         </service>

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Command/ValidateWebspacesCommandTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Command/ValidateWebspacesCommandTest.php
@@ -45,7 +45,8 @@ class ValidateWebspacesCommandTest extends SuluTestCase
             $controllerNameParser,
             $this->getContainer()->get('sulu.content.structure_manager'),
             $this->getContainer()->get('sulu.content.webspace_structure_provider'),
-            $this->getContainer()->get('sulu_core.webspace.webspace_manager')
+            $this->getContainer()->get('sulu_core.webspace.webspace_manager'),
+            $this->getContainer()->get('event_dispatcher')
         );
         $command->setApplication($application);
         $this->tester = new CommandTester($command);

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Command/ValidateWebspacesCommandTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Command/ValidateWebspacesCommandTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PageBundle\Tests\Unit\Command;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\PageBundle\Command\ValidateWebspacesCommand;
+use Sulu\Bundle\PreviewBundle\Preview\Events;
+use Sulu\Bundle\PreviewBundle\Preview\Events\PreRenderEvent;
+use Sulu\Component\Content\Compat\StructureManagerInterface;
+use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactory;
+use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
+use Sulu\Component\Webspace\Manager\WebspaceCollection;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Component\Webspace\StructureProvider\WebspaceStructureProvider;
+use Sulu\Component\Webspace\Webspace;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Twig\Environment;
+
+class ValidateWebspacesCommandTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<Environment>
+     */
+    private $twig;
+
+    /**
+     * @var ObjectProphecy<StructureMetadataFactory>
+     */
+    private $structureMetadataFactory;
+
+    /**
+     * @var ObjectProphecy<StructureManagerInterface>
+     */
+    private $structureManager;
+
+    /**
+     * @var ObjectProphecy<WebspaceStructureProvider>
+     */
+    private $structureProvider;
+
+    /**
+     * @var ObjectProphecy<WebspaceManagerInterface>
+     */
+    private $webspaceManager;
+
+    /**
+     * @var ObjectProphecy<EventDispatcherInterface>
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var ValidateWebspacesCommand
+     */
+    private $validateWebspacesCommand;
+
+    /**
+     * @var ObjectProphecy<InputInterface>
+     */
+    private $input;
+
+    /**
+     * @var ObjectProphecy<OutputInterface>
+     */
+    private $output;
+
+    public function setUp(): void
+    {
+        $this->twig = $this->prophesize(Environment::class);
+        $this->structureMetadataFactory = $this->prophesize(StructureMetadataFactoryInterface::class);
+        $this->structureManager = $this->prophesize(StructureManagerInterface::class);
+        $this->structureProvider = $this->prophesize(WebspaceStructureProvider::class);
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $this->eventDispatcher = $this->prophesize(EventDispatcherInterface::class);
+
+        $this->validateWebspacesCommand = new ValidateWebspacesCommand(
+            $this->twig->reveal(),
+            $this->structureMetadataFactory->reveal(),
+            null,
+            $this->structureManager->reveal(),
+            $this->structureProvider->reveal(),
+            $this->webspaceManager->reveal(),
+            $this->eventDispatcher->reveal()
+        );
+
+        $this->input = $this->prophesize(InputInterface::class);
+        $this->output = $this->prophesize(OutputInterface::class);
+    }
+
+    public function testExecute(): void
+    {
+        $webspace = new Webspace();
+        $webspace->setKey('sulu_io');
+        $webspace->addLocalization(new Localization('de'));
+
+        $this->structureManager->getStructures()->willReturn([]);
+        $this->webspaceManager->getWebspaceCollection()->willReturn(new WebspaceCollection([$webspace]));
+
+        $executeMethod = new \ReflectionMethod(ValidateWebspacesCommand::class, 'execute');
+        $executeMethod->setAccessible(true);
+
+        $this->eventDispatcher->dispatch(new PreRenderEvent(new RequestAttributes([
+            'webspace' => $webspace,
+        ])), Events::PRE_RENDER)
+            ->shouldBeCalled();
+
+        $executeMethod->invoke($this->validateWebspacesCommand, $this->input->reveal(), $this->output->reveal());
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #
| License | MIT

#### What's in this PR?

The SuluThemeBundle switched to SyliusThemeBundle some time ago. See https://github.com/sulu/SuluThemeBundle/pull/19

~~This PR updates the ValidateWebspacesCommand to use the correct components to set the theme and use it when checking for the existence of templates.~~

This PR updates the ValidateWebspacesCommand to dispatch a PreRenderEvent instead which causes the SuluThemeBundle to correctly set the correct theme.

#### Why?

Without this fix, when using themes, the command will report missing templates even if the templates exist.
