### PR TITLE
Catch MediaNotFoundException in MediaRedirectController

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaRedirectController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaRedirectController.php
@@ -53,7 +53,7 @@ class MediaRedirectController
             /** @var Media $media */
             $media = $this->mediaManager->getById($id, $locale);
         } catch (MediaNotFoundException $e) {
-            throw new NotFoundHttpException($e->getMessage());
+            throw new NotFoundHttpException($e->getMessage(), $e);
         }
 
         if (null === $format) {

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaRedirectController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaRedirectController.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\MediaBundle\Controller;
 
 use Sulu\Bundle\MediaBundle\Api\Media;
+use Sulu\Bundle\MediaBundle\Media\Exception\MediaNotFoundException;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
 use Sulu\Component\Rest\RequestParametersTrait;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -48,8 +49,12 @@ class MediaRedirectController
         $locale = $this->getRequestParameter($request, 'locale', true);
         $format = $this->getRequestParameter($request, 'format');
 
-        /** @var Media $media */
-        $media = $this->mediaManager->getById($id, $locale);
+        try {
+            /** @var Media $media */
+            $media = $this->mediaManager->getById($id, $locale);
+        } catch (MediaNotFoundException $e) {
+            throw new NotFoundHttpException($e->getMessage());
+        }
 
         if (null === $format) {
             return new RedirectResponse($media->getUrl());

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaRedirectControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaRedirectControllerTest.php
@@ -23,6 +23,7 @@ use Sulu\Bundle\MediaBundle\Entity\Media;
 use Sulu\Bundle\MediaBundle\Entity\MediaType;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\Response;
 
 class MediaRedirectControllerTest extends SuluTestCase
 {
@@ -304,6 +305,13 @@ class MediaRedirectControllerTest extends SuluTestCase
         $this->em->persist($this->collectionType);
         $this->em->persist($this->collectionMeta);
         $this->em->persist($collectionMeta2);
+    }
+
+    public function test404NotFound(): void
+    {
+        $this->client->jsonRequest('GET', '/redirect/media/1?locale=en-gb');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #6924
| License | MIT

#### What's in this PR?

Catch `MediaNotFoundException` in `MediaRedirectController`.

#### Why?

To avoid 500 error, and return the correct 404 http code.