### PR TITLE
Backport skip if webspace unavailable in deleteUnavailableLocales

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -43136,11 +43136,6 @@ parameters:
 			path: src/Sulu/Component/Content/Document/Subscriber/TitleSubscriber.php
 
 		-
-			message: "#^Cannot call method getAllLocalizations\\(\\) on Sulu\\\\Component\\\\Webspace\\\\Webspace\\|null\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Document/Subscriber/WebspaceSubscriber.php
-
-		-
 			message: "#^Cannot call method remove\\(\\) on mixed\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Document/Subscriber/WebspaceSubscriber.php

--- a/src/Sulu/Component/Content/Document/Subscriber/WebspaceSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/WebspaceSubscriber.php
@@ -89,7 +89,6 @@ class WebspaceSubscriber implements EventSubscriberInterface
         if (!$webspace) {
             return;
         }
-        
         $webspaceLocales = \array_map(function($localization) {
             return $localization->getLocale();
         }, $webspace->getAllLocalizations());

--- a/src/Sulu/Component/Content/Document/Subscriber/WebspaceSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/WebspaceSubscriber.php
@@ -86,7 +86,10 @@ class WebspaceSubscriber implements EventSubscriberInterface
         );
 
         $webspace = $this->webspaceManager->findWebspaceByKey($this->documentInspector->getWebspace($copiedDocument));
-
+        if (!$webspace) {
+            return;
+        }
+        
         $webspaceLocales = \array_map(function($localization) {
             return $localization->getLocale();
         }, $webspace->getAllLocalizations());

--- a/src/Sulu/Component/Content/Document/Subscriber/WebspaceSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/WebspaceSubscriber.php
@@ -89,6 +89,7 @@ class WebspaceSubscriber implements EventSubscriberInterface
         if (!$webspace) {
             return;
         }
+
         $webspaceLocales = \array_map(function($localization) {
             return $localization->getLocale();
         }, $webspace->getAllLocalizations());

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/WebspaceSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/WebspaceSubscriberTest.php
@@ -13,10 +13,12 @@ namespace Sulu\Component\Content\Tests\Unit\Document\Subscriber;
 
 use PHPCR\NodeInterface;
 use PHPCR\PropertyInterface;
+use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Component\Content\Document\Behavior\WebspaceBehavior;
 use Sulu\Component\Content\Document\Subscriber\WebspaceSubscriber;
+use Sulu\Component\DocumentManager\Document\UnknownDocument;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Event\CopyEvent;
 use Sulu\Component\Localization\Localization;
@@ -118,5 +120,29 @@ class WebspaceSubscriberTest extends SubscriberTestCase
         $germanProperty1->remove()->shouldBeCalled();
         $germanProperty2->remove()->shouldBeCalled();
         $englishProperty1->remove()->shouldNotBeCalled();
+    }
+
+    public function testDeleteUnavailableLocalesNoneWebspaceDocument()
+    {
+        $copyEvent = $this->prophesize(CopyEvent::class);
+
+        $document = $this->prophesize(UnknownDocument::class);
+        $this->inspector->getLocale($document)->willReturn('fr');
+        $copyEvent->getDocument()->willReturn($document->reveal());
+
+        $copyEvent->getCopiedPath()->willReturn('/cmf/test_io/contents');
+
+        $copiedNode = $this->prophesize(NodeInterface::class);
+        $copyEvent->getCopiedNode()->willReturn($copiedNode->reveal());
+
+        $copiedDocument = $this->prophesize(UnknownDocument::class);
+        $this->documentManager->find('/cmf/test_io/contents', 'fr')->willReturn($copiedDocument->reveal());
+        $this->inspector->getWebspace($copiedDocument)->willReturn(null);
+
+        $this->webspaceManager->findWebspaceByKey(null)->willReturn(null);
+
+        $this->inspector->getLocales(Argument::any())->shouldNotBecalled();
+
+        $this->subscriber->deleteUnavailableLocales($copyEvent->reveal());
     }
 }

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/WebspaceSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/WebspaceSubscriberTest.php
@@ -122,7 +122,7 @@ class WebspaceSubscriberTest extends SubscriberTestCase
         $englishProperty1->remove()->shouldNotBeCalled();
     }
 
-    public function testDeleteUnavailableLocalesNoneWebspaceDocument()
+    public function testDeleteUnavailableLocalesNoneWebspaceDocument(): void
     {
         $copyEvent = $this->prophesize(CopyEvent::class);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #6859, https://github.com/sulu/SuluArticleBundle/pull/610
| License | MIT
| Documentation PR | -

#### What's in this PR?

Backport of https://github.com/sulu/sulu/pull/6859/files#diff-579b061b25841f1a028b4adc7b447e987e298306a441dd13346d08de3ec2d5baR89

Will be needed for https://github.com/sulu/SuluArticleBundle/pull/610
