### PR TITLE
Use php-cs-fixer shim

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -197,6 +197,10 @@ jobs:
                   composer remove jackalope/jackalope-doctrine-dbal --dev --no-interaction --no-update
                   composer require jackalope/jackalope-jackrabbit:^1.4  --no-interaction --no-update
 
+            - name: Remove php-cs-fixer shim # avoid problems with PHP 7.2 for Sulu 2.4
+              run: |
+                  composer remove php-cs-fixer/shim --dev --no-interaction --no-update
+
             - name: Set composer stability
               if: ${{ matrix.composer-stability }}
               run: composer config minimum-stability ${{ matrix.composer-stability }}

--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,6 @@
         "webmozart/assert": "^1.9"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.0",
         "google/cloud-storage": "^1.0",
         "handcraftedinthealps/zendsearch": "^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.3",
@@ -119,6 +118,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "microsoft/azure-storage-blob": "^1.2",
         "php-ffmpeg/php-ffmpeg": "0.13 - 0.17",
+        "php-cs-fixer/shim": "^3.0",
         "phpcr/phpcr-shell": "^1.0",
         "phpspec/prophecy": "^1.14",
         "phpstan/phpstan": "^1.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Use php-cs-fixer shim.

#### Why?

The newer version of php-cs-fixer requires `doctrine/annotations` `^2.0` which is currently not yet supported by Sulu.