### PR TITLE
Allow newer version of doctrine/annotations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "composer/package-versions-deprecated": "^1.8",
         "contao/imagine-svg": "^1.0",
         "dantleech/phpcr-migrations-bundle": "^1.3",
-        "doctrine/annotations": "^1.2",
+        "doctrine/annotations": "^1.2 || ^2.0",
         "doctrine/cache": "^1.0",
         "doctrine/collections": "^1.0",
         "doctrine/data-fixtures": "^1.3.3",
@@ -108,6 +108,7 @@
         "webmozart/assert": "^1.9"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.14",
         "google/cloud-storage": "^1.0",
         "handcraftedinthealps/zendsearch": "^2.0",
         "jackalope/jackalope": "^1.4.5",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no 
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Allow newer version of doctrine/annotations.

#### Why?

New version is required by php-cs-fixer. We can do this not on Sulu 2.4 because php-cs-fixer requires atleast sebastion/diff 4 but while using phpunit 8 on 2.4 only 3 is possible there.