### PR TITLE
Add media data provider datetime sorting

### DIFF
--- a/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
+++ b/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
@@ -100,6 +100,8 @@ class MediaDataProvider extends BaseDataProvider
                 ->enableSorting(
                     [
                         ['column' => 'fileVersionMeta.title', 'title' => 'sulu_admin.title'],
+                        ['column' => 'created', 'title' => 'sulu_admin.created'],
+                        ['column' => 'changed', 'title' => 'sulu_admin.changed'],
                     ]
                 )
                 ->enableTypes($this->getTypes())


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #7011
| License | MIT

#### What's in this PR?

Allow the possibility to sort media by creation and update datetime.

![Capture d’écran du 2023-02-16 11-32-16](https://user-images.githubusercontent.com/36476595/219341881-0cc25ac8-9700-4ab2-890d-092eb45c5266.png)

#### Why?

Because it is a common expected feature to be able to sort media by datetime.

#### Tests and docs

Maybe I'm wrong, but I think this isn't require any tests nor docs update.
Looking at the other data providers test class, no ones are testing sorting.
And the docs aren't mention detailed sorting options.