### PR TITLE
Add conflict to jackalope doctrine dbal 1.8.0, 1.8.1 and 1.9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -148,7 +148,7 @@
         "friendsofphp/php-cs-fixer": "3.9.1",
         "gedmo/doctrine-extensions" : "3.7.0",
         "jackalope/jackalope": "< 1.3.4",
-        "jackalope/jackalope-doctrine-dbal": "< 1.3.0",
+        "jackalope/jackalope-doctrine-dbal": "< 1.3.0 || 1.8.0 - 1.8.1 || 1.9.0",
         "jackalope/jackalope-jackrabbit": "< 1.3.0",
         "jms/serializer-bundle": "3.9.0 || 4.1.0",
         "php-http/discovery": "< 1.8.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix?  yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/jackalope/jackalope-doctrine-dbal/issues/412
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Conflict 1.8.0, 1.8.1 and 1.9.0 jackalope-doctrine-dbal version.

#### Why?

See: 
See https://github.com/jackalope/jackalope-doctrine-dbal/issues/412


> Item /cmf/example/contents/testaaaa/test not found in workspace default"
