### PR TITLE
Change google tag manager and google analytics templates for JS and iframes to always use https

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Analytics/google/head-close.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Analytics/google/head-close.html.twig
@@ -2,7 +2,7 @@
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
                 (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
             m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
     ga('create', '{{ analytics.content }}', 'auto');
     ga('set', 'anonymizeIp', true);

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Analytics/google_tag_manager/body-open.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Analytics/google_tag_manager/body-open.html.twig
@@ -1,4 +1,4 @@
 <!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="//www.googletagmanager.com/ns.html?id={{ analytics.content }}"
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ analytics.content }}"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Analytics/google_tag_manager/head-open.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Analytics/google_tag_manager/head-open.html.twig
@@ -2,6 +2,6 @@
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','{{ analytics.content }}');</script>
 <!-- End Google Tag Manager -->


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR changes the google analytics and google tag manager integrations to use "protocol absolute" paths as sources for JS scripts and iframes. 

#### Why?

I saw that the [mozilla observatory](https://observatory.mozilla.org/) lowers the score on a Sulu page because the `src` attribute of the `iframe` tag in `src/Sulu/Bundle/WebsiteBundle/Resources/views/Analytics/google_tag_manager/body-open.html.twig` is set to `src="//www.googletagmanager.com<......>"`. This means that if a website visitor gets to the Sulu page via HTTP, the google tag manager iframe will also be loaded via HTTP. Only if the website is accessed via HTTPS, the iframe will also be loaded via HTTPS. This causes the mozilla observatory to lower the security rating of the page dramatically. 

By changing these sources to `src="https://www.googletagmanager.com<.....>"` as google suggests [here](https://developers.google.com/tag-platform/tag-manager/web#custom_web_installations) the iframe will be loaded via HTTPS regardless of the visitor getting on the page via HTTP or HTTPS. 

I fixed this for the GTM JS source, GTM no-script iframe source and the google analytics JS source.

#### To Do

- [ ] Testing if files are loaded via HTTPS now
