### PR TITLE
Add getAttributes method to RequestAttributes

### DIFF
--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/RequestAttributes.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/RequestAttributes.php
@@ -42,6 +42,14 @@ class RequestAttributes
     }
 
     /**
+     * @return mixed[]
+     */
+    public function getAttributes(): array
+    {
+        return $this->attributes;
+    }
+
+    /**
      * Merges this and the given attributes and returns a new instance.
      *
      * @param RequestAttributes $requestAttributes


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Adds a public `getAttributes` method to the `RequestAttributes`.

#### Why?

In a project we have to adjust existing attributes of the `RequestAttributes` in the `ContentRouteProvider` and modify them. This is currently only possible with a `ReflectionClass` because there is no way to access all attributes, you can only access specific attributes by name with the `getAttribute` method.
