### PR TITLE
remove snippet mention from export base class

### DIFF
--- a/src/Sulu/Component/Export/Export.php
+++ b/src/Sulu/Component/Export/Export.php
@@ -231,13 +231,13 @@ class Export
     protected function getTemplate($format)
     {
         if (!isset($this->formatFilePaths[$format])) {
-            throw new \Exception(\sprintf('No format "%s" configured for Snippet export', $format));
+            throw new \Exception(\sprintf('No format "%s" configured for export', $format));
         }
 
         $templatePath = $this->formatFilePaths[$format];
 
         if (!$this->templating->getLoader()->exists($templatePath)) {
-            throw new \Exception(\sprintf('No template file "%s" found for Snippet export', $format));
+            throw new \Exception(\sprintf('No template file "%s" found for export', $format));
         }
 
         return $templatePath;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #
| License | MIT
| Documentation PR | 

#### What's in this PR?

Class is also used for Webspace and Article Export, so mentioning snippet could be misleading.