### PR TITLE
Refactored usages of short namespace aliases of entities to use of FQCN

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -47,6 +47,45 @@ This update is also handled normally by the update build command automatically.
 As deprecated in Symfony 6.1 the `$defaultName` of Sulu Commands where replaced with the new
 `Symfony\Component\Console\Attribute\AsCommand` annotation.
 
+### ListBuilder Doctrine Changes
+
+Bundle aliases where deprecated by [`doctrine/persistence` 3.0](https://github.com/doctrine/persistence/blob/3.2.0/UPGRADE.md#bc-break-removed-support-for-short-namespace-aliases) the full FQCN need to be used when upgrading to `doctrine/persistence:^3.0`:
+
+```diff
+    <joins name="address">
+        <join>
+-            <entity-name>SuluContactBundle:AccountAddress</entity-name>
++            <entity-name>Sulu\Bundle\ContactBundle\Entity\AccountAddress</entity-name>
+            <field-name>%sulu.model.account.class%.accountAddresses</field-name>
+            <method>LEFT</method>
+-            <condition>SuluContactBundle:AccountAddress.main = TRUE</condition>
++            <condition>Sulu\Bundle\ContactBundle\Entity\AccountAddress.main = TRUE</condition>
+        </join>
+
+        <join>
+-            <entity-name>SuluContactBundle:Address</entity-name>
++            <entity-name>Sulu\Bundle\ContactBundle\Entity\Address</entity-name>
+-            <field-name>SuluContactBundle:AccountAddress.address</field-name>
++            <field-name>Sulu\Bundle\ContactBundle\Entity\AccountAddress.address</field-name>
+        </join>
+    </joins>
+
+    <properties>
+        <property
+            name="state"
+            visibility="no"
+            translation="sulu_contact.state"
+        >
+            <field-name>state</field-name>
+-            <entity-name>SuluContactBundle:Address</entity-name>
++            <entity-name>Sulu\Bundle\ContactBundle\Entity\Address</entity-name>
+
+            <joins ref="address"/>
+
+            <filter type="text" />
+        </property>
+```
+
 ### Deprecated urls variable in return value of sulu_content_load
 
 The `urls` variable in the return value of the `sulu_content_load` function was deprecated.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1875,7 +1875,7 @@ you had some `filter-type` attributes in your configurations, which would not ha
 -        <identity-property name="accountId" visibility="never" filter-type="auto-complete" translation="sulu_contact.organization">
 +        <identity-property name="accountId" visibility="never" translation="sulu_contact.organization">
              <field-name>account</field-name>
-             <entity-name>SuluContactBundle:AccountContact</entity-name>
+             <entity-name>Sulu\Bundle\ContactBundle\Entity\AccountContact</entity-name>
  
              <joins ref="accountContact"/>
  

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1875,7 +1875,7 @@ you had some `filter-type` attributes in your configurations, which would not ha
 -        <identity-property name="accountId" visibility="never" filter-type="auto-complete" translation="sulu_contact.organization">
 +        <identity-property name="accountId" visibility="never" translation="sulu_contact.organization">
              <field-name>account</field-name>
-             <entity-name>Sulu\Bundle\ContactBundle\Entity\AccountContact</entity-name>
+             <entity-name>SuluContactBundle:AccountContact</entity-name>
  
              <joins ref="accountContact"/>
  

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5361,36 +5361,6 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
 
 		-
-			message: "#^Parameter \\#1 \\$persistentObject of method Doctrine\\\\Persistence\\\\ManagerRegistry\\:\\:getRepository\\(\\) expects class\\-string\\<SuluContactBundle\\:AddressType\\>, string given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
-
-		-
-			message: "#^Parameter \\#1 \\$persistentObject of method Doctrine\\\\Persistence\\\\ManagerRegistry\\:\\:getRepository\\(\\) expects class\\-string\\<SuluContactBundle\\:EmailType\\>, string given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
-
-		-
-			message: "#^Parameter \\#1 \\$persistentObject of method Doctrine\\\\Persistence\\\\ManagerRegistry\\:\\:getRepository\\(\\) expects class\\-string\\<SuluContactBundle\\:FaxType\\>, string given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
-
-		-
-			message: "#^Parameter \\#1 \\$persistentObject of method Doctrine\\\\Persistence\\\\ManagerRegistry\\:\\:getRepository\\(\\) expects class\\-string\\<SuluContactBundle\\:PhoneType\\>, string given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
-
-		-
-			message: "#^Parameter \\#1 \\$persistentObject of method Doctrine\\\\Persistence\\\\ManagerRegistry\\:\\:getRepository\\(\\) expects class\\-string\\<SuluContactBundle\\:SocialMediaProfileType\\>, string given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
-
-		-
-			message: "#^Parameter \\#1 \\$persistentObject of method Doctrine\\\\Persistence\\\\ManagerRegistry\\:\\:getRepository\\(\\) expects class\\-string\\<SuluContactBundle\\:UrlType\\>, string given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
-
-		-
 			message: "#^Call to an undefined method object\\:\\:GetExternalId\\(\\)\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Api/Account.php
@@ -7671,11 +7641,6 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Contact/AccountFactory.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\EntityRepository\\<SuluContactBundle\\:Address\\>\\:\\:findById\\(\\)\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
-
-		-
 			message: "#^Call to an undefined method Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\AccountRepositoryInterface\\:\\:findByFilters\\(\\)\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
@@ -7776,11 +7741,6 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
 
 		-
-			message: "#^Parameter \\#1 \\$className of method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:getRepository\\(\\) expects class\\-string\\<SuluContactBundle\\:Address\\>, string given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
-
-		-
 			message: "#^Parameter \\#1 \\$contact of class Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\Contact constructor expects Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\Contact, Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\ContactInterface given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
@@ -7804,11 +7764,6 @@ parameters:
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\EntityRepository\\<SuluContactBundle\\:Address\\>\\:\\:findById\\(\\)\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
 
 		-
 			message: "#^Call to an undefined method Sulu\\\\Bundle\\\\MediaBundle\\\\Entity\\\\MediaRepositoryInterface\\:\\:findById\\(\\)\\.$#"
@@ -7912,11 +7867,6 @@ parameters:
 
 		-
 			message: "#^Offset 'id' does not exist on non\\-falsy\\-string\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
-
-		-
-			message: "#^Parameter \\#1 \\$className of method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:getRepository\\(\\) expects class\\-string\\<SuluContactBundle\\:Address\\>, string given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
 
@@ -14381,11 +14331,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
 
 		-
-			message: "#^Parameter \\#1 \\$entityName of method Doctrine\\\\ORM\\\\EntityManager\\:\\:getRepository\\(\\) expects class\\-string\\<SuluMediaBundle\\:CollectionType\\>, string given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
-
-		-
 			message: "#^Parameter \\#1 \\$userId of method Sulu\\\\Bundle\\\\MediaBundle\\\\Collection\\\\Manager\\\\CollectionManager\\:\\:getUser\\(\\) expects int, int\\|null given\\.$#"
 			count: 2
 			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
@@ -14514,11 +14459,6 @@ parameters:
 			message: "#^Property Sulu\\\\Bundle\\\\MediaBundle\\\\Command\\\\FormatCacheRegenerateCommand\\:\\:\\$fileSystem is never read, only written\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$className of method Doctrine\\\\ORM\\\\EntityManagerInterface\\:\\:getRepository\\(\\) expects class\\-string\\<SuluMediaBundle\\:Media\\>, string given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Command/MediaTypeUpdateCommand.php
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Content\\\\MediaSelectionContainer\\:\\:__construct\\(\\) has parameter \\$config with no type specified\\.$#"
@@ -17131,11 +17071,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Media/TypeManager/TypeManager.php
 
 		-
-			message: "#^Parameter \\#1 \\$className of method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:getRepository\\(\\) expects class\\-string\\<SuluMediaBundle\\:MediaType\\>, string given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Media/TypeManager/TypeManager.php
-
-		-
 			message: "#^Property Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\TypeManager\\\\TypeManager\\:\\:\\$blockedMimeTypes is never read, only written\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Media/TypeManager/TypeManager.php
@@ -18326,97 +18261,87 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/SmartContentItemControllerTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\CollectionRepositoryTest\\:\\:addMedia\\(\\) has parameter \\$numberMedia with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\CollectionRepositoryTest\\:\\:addMedia\\(\\) has parameter \\$numberMedia with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/CollectionRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\CollectionRepositoryTest\\:\\:createCollection\\(\\) has no return type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\CollectionRepositoryTest\\:\\:createCollection\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/CollectionRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\CollectionRepositoryTest\\:\\:createCollection\\(\\) has parameter \\$collectionType with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\CollectionRepositoryTest\\:\\:createCollection\\(\\) has parameter \\$collectionType with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/CollectionRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\CollectionRepositoryTest\\:\\:createCollection\\(\\) has parameter \\$name with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\CollectionRepositoryTest\\:\\:createCollection\\(\\) has parameter \\$name with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/CollectionRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\CollectionRepositoryTest\\:\\:createCollection\\(\\) has parameter \\$numberMedia with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\CollectionRepositoryTest\\:\\:createCollection\\(\\) has parameter \\$numberMedia with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/CollectionRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\CollectionRepositoryTest\\:\\:createCollection\\(\\) has parameter \\$parent with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\CollectionRepositoryTest\\:\\:createCollection\\(\\) has parameter \\$parent with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/CollectionRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\CollectionRepositoryTest\\:\\:provideTreeData\\(\\) has no return type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\CollectionRepositoryTest\\:\\:provideTreeData\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/CollectionRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\CollectionRepositoryTest\\:\\:testTree\\(\\) has parameter \\$expectedIndexes with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\CollectionRepositoryTest\\:\\:testTree\\(\\) has parameter \\$expectedIndexes with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/CollectionRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\CollectionRepositoryTest\\:\\:testTree\\(\\) has parameter \\$index with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\CollectionRepositoryTest\\:\\:testTree\\(\\) has parameter \\$index with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/CollectionRepositoryTest.php
 
 		-
-			message: "#^Property Functional\\\\Entity\\\\CollectionRepositoryTest\\:\\:\\$collectionData type has no value type specified in iterable type array\\.$#"
+			message: "#^Property Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\CollectionRepositoryTest\\:\\:\\$collectionData type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/CollectionRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\FileVersionMetaRepositoryTest\\:\\:createFile\\(\\) has parameter \\$collection with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\FileVersionMetaRepositoryTest\\:\\:createFile\\(\\) has parameter \\$collection with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/FileVersionMetaRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\FileVersionMetaRepositoryTest\\:\\:createFile\\(\\) has parameter \\$newTitle with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\FileVersionMetaRepositoryTest\\:\\:createFile\\(\\) has parameter \\$newTitle with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/FileVersionMetaRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\FileVersionMetaRepositoryTest\\:\\:createFile\\(\\) has parameter \\$oldTitle with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\FileVersionMetaRepositoryTest\\:\\:createFile\\(\\) has parameter \\$oldTitle with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/FileVersionMetaRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\FileVersionMetaRepositoryTest\\:\\:createFileVersion\\(\\) has parameter \\$title with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\FileVersionMetaRepositoryTest\\:\\:createFileVersion\\(\\) has parameter \\$title with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/FileVersionMetaRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\FileVersionMetaRepositoryTest\\:\\:createFileVersion\\(\\) has parameter \\$version with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\FileVersionMetaRepositoryTest\\:\\:createFileVersion\\(\\) has parameter \\$version with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/FileVersionMetaRepositoryTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$className of method Doctrine\\\\ORM\\\\EntityManagerInterface\\:\\:getRepository\\(\\) expects class\\-string\\<SuluMediaBundle\\:FileVersionMeta\\>, string given\\.$#"
+			message: "#^Property Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\FileVersionMetaRepositoryTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManager\\) does not accept Doctrine\\\\ORM\\\\EntityManagerInterface\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/FileVersionMetaRepositoryTest.php
 
 		-
-			message: "#^Property Functional\\\\Entity\\\\FileVersionMetaRepositoryTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManager\\) does not accept Doctrine\\\\ORM\\\\EntityManagerInterface\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/FileVersionMetaRepositoryTest.php
-
-		-
-			message: "#^Property Functional\\\\Entity\\\\FileVersionMetaRepositoryTest\\:\\:\\$fileVersionMetaRepository \\(Sulu\\\\Bundle\\\\MediaBundle\\\\Entity\\\\FileVersionMetaRepository\\) does not accept Doctrine\\\\ORM\\\\EntityRepository\\<SuluMediaBundle\\:FileVersionMeta\\>\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/FileVersionMetaRepositoryTest.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\EntityRepository\\<SuluTagBundle\\:Tag\\>\\:\\:createNew\\(\\)\\.$#"
+			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\EntityRepository\\<Sulu\\\\Bundle\\\\TagBundle\\\\Tag\\\\TagInterface\\>\\:\\:createNew\\(\\)\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
@@ -18426,167 +18351,162 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createAccessControl\\(\\) has no return type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createAccessControl\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createAccessControl\\(\\) has parameter \\$entityClass with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createAccessControl\\(\\) has parameter \\$entityClass with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createAccessControl\\(\\) has parameter \\$id with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createAccessControl\\(\\) has parameter \\$id with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createAccessControl\\(\\) has parameter \\$permissions with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createAccessControl\\(\\) has parameter \\$permissions with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createCollection\\(\\) has no return type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createCollection\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createCollection\\(\\) has parameter \\$name with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createCollection\\(\\) has parameter \\$name with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createCollection\\(\\) has parameter \\$parent with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createCollection\\(\\) has parameter \\$parent with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createMedia\\(\\) has no return type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createMedia\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createMedia\\(\\) has parameter \\$collection with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createMedia\\(\\) has parameter \\$collection with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createMedia\\(\\) has parameter \\$mimeType with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createMedia\\(\\) has parameter \\$mimeType with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createMedia\\(\\) has parameter \\$tags with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createMedia\\(\\) has parameter \\$tags with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createMedia\\(\\) has parameter \\$targetGroups with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createMedia\\(\\) has parameter \\$targetGroups with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createMedia\\(\\) has parameter \\$title with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createMedia\\(\\) has parameter \\$title with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createMedia\\(\\) has parameter \\$type with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createMedia\\(\\) has parameter \\$type with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createRole\\(\\) has no return type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createRole\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createRole\\(\\) has parameter \\$name with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createRole\\(\\) has parameter \\$name with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createRole\\(\\) has parameter \\$system with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createRole\\(\\) has parameter \\$system with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createTag\\(\\) has no return type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createTag\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createTag\\(\\) has parameter \\$name with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createTag\\(\\) has parameter \\$name with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createType\\(\\) has no return type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createType\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createType\\(\\) has parameter \\$name with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createType\\(\\) has parameter \\$name with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:findByProvider\\(\\) has no return type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:findByProvider\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:provideFindByFiltersWithAudienceTargeting\\(\\) has no return type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:provideFindByFiltersWithAudienceTargeting\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFilters\\(\\) has parameter \\$expected with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFilters\\(\\) has parameter \\$expected with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFilters\\(\\) has parameter \\$filters with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFilters\\(\\) has parameter \\$filters with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFilters\\(\\) has parameter \\$limit with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFilters\\(\\) has parameter \\$limit with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFilters\\(\\) has parameter \\$options with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFilters\\(\\) has parameter \\$options with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFilters\\(\\) has parameter \\$page with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFilters\\(\\) has parameter \\$page with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFilters\\(\\) has parameter \\$pageSize with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFilters\\(\\) has parameter \\$pageSize with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFilters\\(\\) has parameter \\$tags with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFilters\\(\\) has parameter \\$tags with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFiltersWithAudienceTargeting\\(\\) has parameter \\$expectedIndexes with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFiltersWithAudienceTargeting\\(\\) has parameter \\$expectedIndexes with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFiltersWithAudienceTargeting\\(\\) has parameter \\$targetGroupIndex with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$entityName of method Doctrine\\\\ORM\\\\EntityManager\\:\\:getRepository\\(\\) expects class\\-string\\<SuluTagBundle\\:Tag\\>, string given\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFiltersWithAudienceTargeting\\(\\) has parameter \\$targetGroupIndex with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
@@ -18596,32 +18516,32 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Property Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:\\$collectionData type has no value type specified in iterable type array\\.$#"
+			message: "#^Property Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:\\$collectionData type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Property Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManager\\) does not accept Doctrine\\\\ORM\\\\EntityManagerInterface\\.$#"
+			message: "#^Property Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManager\\) does not accept Doctrine\\\\ORM\\\\EntityManagerInterface\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Property Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:\\$mediaData type has no value type specified in iterable type array\\.$#"
+			message: "#^Property Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:\\$mediaData type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Property Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:\\$mediaTypeData type has no value type specified in iterable type array\\.$#"
+			message: "#^Property Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:\\$mediaTypeData type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Property Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:\\$medias is never read, only written\\.$#"
+			message: "#^Property Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:\\$medias is never read, only written\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Property Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:\\$tagData type has no value type specified in iterable type array\\.$#"
+			message: "#^Property Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:\\$tagData type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
@@ -18631,62 +18551,57 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaRepositoryTest\\:\\:createAccessControl\\(\\) has parameter \\$entity with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaRepositoryTest\\:\\:createAccessControl\\(\\) has parameter \\$entity with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaRepositoryTest\\:\\:createCollection\\(\\) has no return type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaRepositoryTest\\:\\:createCollection\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaRepositoryTest\\:\\:createMedia\\(\\) has no return type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaRepositoryTest\\:\\:createMedia\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaRepositoryTest\\:\\:createMedia\\(\\) has parameter \\$collection with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaRepositoryTest\\:\\:createMedia\\(\\) has parameter \\$collection with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaRepositoryTest\\:\\:createMedia\\(\\) has parameter \\$name with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaRepositoryTest\\:\\:createMedia\\(\\) has parameter \\$name with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaRepositoryTest\\:\\:createMedia\\(\\) has parameter \\$title with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaRepositoryTest\\:\\:createMedia\\(\\) has parameter \\$title with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaRepositoryTest\\:\\:createMedia\\(\\) has parameter \\$type with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaRepositoryTest\\:\\:createMedia\\(\\) has parameter \\$type with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaRepositoryTest\\:\\:createRole\\(\\) has no return type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaRepositoryTest\\:\\:createRole\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaRepositoryTest\\:\\:createUser\\(\\) has no return type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaRepositoryTest\\:\\:createUser\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaRepositoryTest\\:\\:setUpMedia\\(\\) has no return type specified\\.$#"
+			message: "#^Property Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaRepositoryTest\\:\\:\\$collections is unused\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
 
 		-
-			message: "#^Property Functional\\\\Entity\\\\MediaRepositoryTest\\:\\:\\$collections is unused\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
-
-		-
-			message: "#^Property Functional\\\\Entity\\\\MediaRepositoryTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManager\\) does not accept Doctrine\\\\ORM\\\\EntityManagerInterface\\.$#"
+			message: "#^Property Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaRepositoryTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManager\\) does not accept Doctrine\\\\ORM\\\\EntityManagerInterface\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
 
@@ -29066,11 +28981,6 @@ parameters:
 			path: src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\EntityRepository\\<SuluSecurityBundle\\:SecurityType\\>\\:\\:findSecurityTypeById\\(\\)\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
-
-		-
 			message: "#^Call to an undefined method object\\:\\:setRole\\(\\)\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
@@ -29138,11 +29048,6 @@ parameters:
 		-
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 2
-			path: src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
-
-		-
-			message: "#^Parameter \\#1 \\$className of method Doctrine\\\\ORM\\\\EntityManagerInterface\\:\\:getRepository\\(\\) expects class\\-string\\<SuluSecurityBundle\\:SecurityType\\>, string given\\.$#"
-			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
 
 		-
@@ -30476,17 +30381,12 @@ parameters:
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/UserControllerTest.php
 
 		-
-			message: "#^Cannot call method getSalt\\(\\) on SuluSecurityBundle\\:User\\|null\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/UserControllerTest.php
-
-		-
 			message: "#^Cannot call method getSalt\\(\\) on Sulu\\\\Bundle\\\\SecurityBundle\\\\Entity\\\\User\\|null\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/UserControllerTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$entityName of method Doctrine\\\\ORM\\\\EntityManager\\:\\:getRepository\\(\\) expects class\\-string\\<SuluSecurityBundle\\:User\\>, string given\\.$#"
+			message: "#^Cannot call method getSalt\\(\\) on Sulu\\\\Component\\\\Security\\\\Authentication\\\\UserInterface\\|null\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/UserControllerTest.php
 

--- a/src/Sulu/Bundle/CategoryBundle/Entity/CategoryRepository.php
+++ b/src/Sulu/Bundle/CategoryBundle/Entity/CategoryRepository.php
@@ -215,7 +215,7 @@ class CategoryRepository extends NestedTreeRepository implements CategoryReposit
         @trigger_deprecation('sulu/sulu', '1.4', __METHOD__ . '() is deprecated and will be removed in 2.0. Use findChildrenCategoriesByParentKey() instead.');
 
         $queryBuilder = $this->getCategoryQuery()
-            ->from('SuluCategoryBundle:Category', 'parent')
+            ->from(\Sulu\Bundle\CategoryBundle\Entity\Category::class, 'parent')
             ->andWhere('parent.key = :key')
             ->andWhere('category.parent = parent');
 

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -327,14 +327,14 @@ class ContactAdmin extends Admin
     public function getConfig(): ?array
     {
         return [
-            'addressTypes' => $this->managerRegistry->getRepository('SuluContactBundle:AddressType')->findAll(),
+            'addressTypes' => $this->managerRegistry->getRepository(\Sulu\Bundle\ContactBundle\Entity\AddressType::class)->findAll(),
             'countries' => Countries::getNames(),
-            'emailTypes' => $this->managerRegistry->getRepository('SuluContactBundle:EmailType')->findAll(),
-            'faxTypes' => $this->managerRegistry->getRepository('SuluContactBundle:FaxType')->findAll(),
-            'phoneTypes' => $this->managerRegistry->getRepository('SuluContactBundle:PhoneType')->findAll(),
+            'emailTypes' => $this->managerRegistry->getRepository(\Sulu\Bundle\ContactBundle\Entity\EmailType::class)->findAll(),
+            'faxTypes' => $this->managerRegistry->getRepository(\Sulu\Bundle\ContactBundle\Entity\FaxType::class)->findAll(),
+            'phoneTypes' => $this->managerRegistry->getRepository(\Sulu\Bundle\ContactBundle\Entity\PhoneType::class)->findAll(),
             'socialMediaTypes' => $this->managerRegistry
-                ->getRepository('SuluContactBundle:SocialMediaProfileType')->findAll(),
-            'websiteTypes' => $this->managerRegistry->getRepository('SuluContactBundle:UrlType')->findAll(),
+                ->getRepository(\Sulu\Bundle\ContactBundle\Entity\SocialMediaProfileType::class)->findAll(),
+            'websiteTypes' => $this->managerRegistry->getRepository(\Sulu\Bundle\ContactBundle\Entity\UrlType::class)->findAll(),
         ];
     }
 }

--- a/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
@@ -57,29 +57,29 @@ abstract class AbstractContactManager implements ContactManagerInterface
 {
     use RelationTrait;
 
-    protected static $accountContactEntityName = 'SuluContactBundle:AccountContact';
+    protected static $accountContactEntityName = AccountContact::class;
 
-    protected static $positionEntityName = 'SuluContactBundle:Position';
+    protected static $positionEntityName = Position::class;
 
-    protected static $addressTypeEntityName = 'SuluContactBundle:AddressType';
+    protected static $addressTypeEntityName = AddressType::class;
 
-    protected static $urlTypeEntityName = 'SuluContactBundle:UrlType';
+    protected static $urlTypeEntityName = UrlType::class;
 
-    protected static $emailTypeEntityName = 'SuluContactBundle:EmailType';
+    protected static $emailTypeEntityName = EmailType::class;
 
-    protected static $faxTypeEntityName = 'SuluContactBundle:FaxType';
+    protected static $faxTypeEntityName = FaxType::class;
 
-    protected static $socialMediaProfileTypeEntityName = 'SuluContactBundle:SocialMediaProfileType';
+    protected static $socialMediaProfileTypeEntityName = SocialMediaProfileType::class;
 
-    protected static $phoneTypeEntityName = 'SuluContactBundle:PhoneType';
+    protected static $phoneTypeEntityName = PhoneType::class;
 
-    protected static $addressEntityName = 'SuluContactBundle:Address';
+    protected static $addressEntityName = Address::class;
 
-    protected static $emailEntityName = 'SuluContactBundle:Email';
+    protected static $emailEntityName = Email::class;
 
-    protected static $urlEntityName = 'SuluContactBundle:Url';
+    protected static $urlEntityName = Url::class;
 
-    protected static $phoneEntityName = 'SuluContactBundle:Phone';
+    protected static $phoneEntityName = Phone::class;
 
     protected static $categoryEntityName = CategoryInterface::class;
 
@@ -1078,7 +1078,7 @@ abstract class AbstractContactManager implements ContactManagerInterface
      */
     protected function addFax($contact, $faxData)
     {
-        $faxEntity = 'SuluContactBundle:Fax';
+        $faxEntity = Fax::class;
 
         $faxType = $this->em
             ->getRepository(self::$faxTypeEntityName)
@@ -1177,7 +1177,7 @@ abstract class AbstractContactManager implements ContactManagerInterface
      */
     protected function addSocialMediaProfile($contact, $socialMediaProfileData)
     {
-        $socialMediaProfileEntity = 'SuluContactBundle:SocialMediaProfile';
+        $socialMediaProfileEntity = SocialMediaProfile::class;
 
         $socialMediaProfileType = $this->em
             ->getRepository(self::$socialMediaProfileTypeEntityName)
@@ -1473,7 +1473,7 @@ abstract class AbstractContactManager implements ContactManagerInterface
      */
     protected function addNote($contact, $noteData)
     {
-        $noteEntity = 'SuluContactBundle:Note';
+        $noteEntity = Note::class;
 
         if (isset($noteData['id'])) {
             throw new EntityIdAlreadySetException($noteEntity, $noteData['id']);
@@ -1619,7 +1619,7 @@ abstract class AbstractContactManager implements ContactManagerInterface
      */
     protected function addBankAccount($contact, $data = null)
     {
-        $entityName = 'SuluContactBundle:BankAccount';
+        $entityName = BankAccount::class;
 
         if (isset($data['id'])) {
             throw new EntityIdAlreadySetException($entityName, $data['id']);

--- a/src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
@@ -37,7 +37,7 @@ use Sulu\Component\SmartContent\Orm\DataProviderRepositoryInterface;
  */
 class AccountManager extends AbstractContactManager implements DataProviderRepositoryInterface
 {
-    protected $addressEntity = 'SuluContactBundle:Address';
+    protected $addressEntity = AddressEntity::class;
 
     /**
      * @var AccountFactory
@@ -132,7 +132,7 @@ class AccountManager extends AbstractContactManager implements DataProviderRepos
         // Reload address to get all data (including relational data).
         /** @var AddressEntity $address */
         $address = $accountAddress->getAddress();
-        $address = $this->em->getRepository('SuluContactBundle:Address')
+        $address = $this->em->getRepository(AddressEntity::class)
             ->findById($address->getId());
 
         $isMain = $accountAddress->getMain();

--- a/src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
@@ -503,9 +503,7 @@ class ContactManager extends AbstractContactManager implements DataProviderRepos
         // reload address to get all data (including relational data)
         /** @var Address $address */
         $address = $contactAddress->getAddress();
-        $address = $this->em->getRepository(
-            'SuluContactBundle:Address'
-        )->findById($address->getId());
+        $address = $this->em->getRepository(Address::class)->findById($address->getId());
 
         $isMain = $contactAddress->getMain();
 

--- a/src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
@@ -40,13 +40,13 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  */
 abstract class AbstractMediaController extends AbstractRestController
 {
-    protected static $collectionEntityName = 'SuluMediaBundle:Collection';
+    protected static $collectionEntityName = \Sulu\Bundle\MediaBundle\Entity\Collection::class;
 
-    protected static $fileVersionEntityName = 'SuluMediaBundle:FileVersion';
+    protected static $fileVersionEntityName = \Sulu\Bundle\MediaBundle\Entity\FileVersion::class;
 
-    protected static $fileEntityName = 'SuluMediaBundle:File';
+    protected static $fileEntityName = \Sulu\Bundle\MediaBundle\Entity\File::class;
 
-    protected static $fileVersionMetaEntityName = 'SuluMediaBundle:FileVersionMeta';
+    protected static $fileVersionMetaEntityName = \Sulu\Bundle\MediaBundle\Entity\FileVersionMeta::class;
 
     protected static $mediaEntityKey = 'media';
 

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -61,18 +61,18 @@ class AccountController extends AbstractRestController implements ClassResourceI
      */
     protected static $entityKey = 'accounts';
 
-    protected static $positionEntityName = 'SuluContactBundle:Position';
+    protected static $positionEntityName = \Sulu\Bundle\ContactBundle\Entity\Position::class;
 
     /**
      * @deprecated Use the ContactInterface::RESOURCE_KEY constant instead
      */
     protected static $contactEntityKey = 'contacts';
 
-    protected static $accountContactEntityName = 'SuluContactBundle:AccountContact';
+    protected static $accountContactEntityName = AccountContactEntity::class;
 
-    protected static $addressEntityName = 'SuluContactBundle:Address';
+    protected static $addressEntityName = AddressEntity::class;
 
-    protected static $accountAddressEntityName = 'SuluContactBundle:AccountAddress';
+    protected static $accountAddressEntityName = \Sulu\Bundle\ContactBundle\Entity\AccountAddress::class;
 
     protected static $accountSerializationGroups = [
         'fullAccount',

--- a/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
@@ -54,9 +54,9 @@ class ContactController extends AbstractRestController implements ClassResourceI
      */
     protected static $entityKey = ContactInterface::RESOURCE_KEY;
 
-    protected static $accountContactEntityName = 'SuluContactBundle:AccountContact';
+    protected static $accountContactEntityName = \Sulu\Bundle\ContactBundle\Entity\AccountContact::class;
 
-    protected static $positionEntityName = 'SuluContactBundle:Position';
+    protected static $positionEntityName = \Sulu\Bundle\ContactBundle\Entity\Position::class;
 
     // serialization groups for contact
     protected static $contactSerializationGroups = [

--- a/src/Sulu/Bundle/ContactBundle/Controller/ContactTitleController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/ContactTitleController.php
@@ -33,7 +33,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class ContactTitleController extends AbstractRestController implements ClassResourceInterface
 {
-    protected static $entityName = 'SuluContactBundle:ContactTitle';
+    protected static $entityName = ContactTitle::class;
 
     /**
      * @var string

--- a/src/Sulu/Bundle/ContactBundle/Controller/PositionController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/PositionController.php
@@ -33,7 +33,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class PositionController extends AbstractRestController implements ClassResourceInterface
 {
-    protected static $entityName = 'SuluContactBundle:Position';
+    protected static $entityName = Position::class;
 
     /**
      * @var string

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/lists/accounts.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/lists/accounts.xml
@@ -4,14 +4,14 @@
 
     <joins name="address">
         <join>
-            <entity-name>SuluContactBundle:AccountAddress</entity-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\AccountAddress</entity-name>
             <field-name>%sulu.model.account.class%.accountAddresses</field-name>
             <method>LEFT</method>
-            <condition>SuluContactBundle:AccountAddress.main = TRUE</condition>
+            <condition>Sulu\Bundle\ContactBundle\Entity\AccountAddress.main = TRUE</condition>
         </join>
         <join>
-            <entity-name>SuluContactBundle:Address</entity-name>
-            <field-name>SuluContactBundle:AccountAddress.address</field-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\Address</entity-name>
+            <field-name>Sulu\Bundle\ContactBundle\Entity\AccountAddress.address</field-name>
         </join>
     </joins>
 
@@ -24,7 +24,7 @@
 
     <joins name="tags">
         <join>
-            <entity-name>SuluTagBundle:Tag</entity-name>
+            <entity-name>Sulu\Bundle\TagBundle\Entity\Tag</entity-name>
             <field-name>%sulu.model.account.class%.tags</field-name>
         </join>
     </joins>
@@ -32,10 +32,10 @@
     <properties>
         <property name="logo" visibility="always" translation="sulu_contact.logo" sortable="false">
             <field-name>id</field-name>
-            <entity-name>SuluMediaBundle:Media</entity-name>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\Media</entity-name>
             <joins>
                 <join>
-                    <entity-name>SuluMediaBundle:Media</entity-name>
+                    <entity-name>Sulu\Bundle\MediaBundle\Entity\Media</entity-name>
                     <field-name>%sulu.model.account.class%.logo</field-name>
                 </join>
             </joins>
@@ -79,7 +79,7 @@
             translation="sulu_contact.city"
         >
             <field-name>city</field-name>
-            <entity-name>SuluContactBundle:Address</entity-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\Address</entity-name>
 
             <joins ref="address"/>
 
@@ -92,7 +92,7 @@
             translation="sulu_contact.zip"
         >
             <field-name>zip</field-name>
-            <entity-name>SuluContactBundle:Address</entity-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\Address</entity-name>
 
             <joins ref="address"/>
 
@@ -104,7 +104,7 @@
             translation="sulu_contact.street"
         >
             <field-name>street</field-name>
-            <entity-name>SuluContactBundle:Address</entity-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\Address</entity-name>
 
             <joins ref="address"/>
 
@@ -113,7 +113,7 @@
 
         <property name="streetNumber" translation="sulu_contact.number">
             <field-name>number</field-name>
-            <entity-name>SuluContactBundle:Address</entity-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\Address</entity-name>
 
             <joins ref="address"/>
         </property>
@@ -134,7 +134,7 @@
             translation="sulu_contact.state"
         >
             <field-name>state</field-name>
-            <entity-name>SuluContactBundle:Address</entity-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\Address</entity-name>
 
             <joins ref="address"/>
 
@@ -147,7 +147,7 @@
             translation="sulu_contact.country"
         >
             <field-name>countryCode</field-name>
-            <entity-name>SuluContactBundle:Address</entity-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\Address</entity-name>
 
             <joins ref="address"/>
 
@@ -243,7 +243,7 @@
             glue=","
         >
             <field-name>id</field-name>
-            <entity-name>SuluTagBundle:Tag</entity-name>
+            <entity-name>Sulu\Bundle\TagBundle\Entity\Tag</entity-name>
 
             <joins ref="tags"/>
         </group-concat-property>
@@ -256,7 +256,7 @@
             distinct="true"
         >
             <field-name>name</field-name>
-            <entity-name>SuluTagBundle:Tag</entity-name>
+            <entity-name>Sulu\Bundle\TagBundle\Entity\Tag</entity-name>
 
             <joins ref="tags"/>
         </group-concat-property>
@@ -269,7 +269,7 @@
             translation="sulu_tag.tags"
         >
             <field-name>id</field-name>
-            <entity-name>SuluTagBundle:Tag</entity-name>
+            <entity-name>Sulu\Bundle\TagBundle\Entity\Tag</entity-name>
 
             <joins ref="tags"/>
 
@@ -289,11 +289,11 @@
             translation="sulu_category.categories"
         >
             <field-name>id</field-name>
-            <entity-name>SuluCategoryBundle:Category</entity-name>
+            <entity-name>Sulu\Bundle\CategoryBundle\Entity\Category</entity-name>
 
             <joins>
                 <join>
-                    <entity-name>SuluCategoryBundle:Category</entity-name>
+                    <entity-name>Sulu\Bundle\CategoryBundle\Entity\Category</entity-name>
                     <field-name>%sulu.model.account.class%.categories</field-name>
                 </join>
             </joins>
@@ -314,17 +314,17 @@
             distinct="true"
         >
             <field-name>translation</field-name>
-            <entity-name>SuluCategoryBundle:CategoryTranslation</entity-name>
+            <entity-name>Sulu\Bundle\CategoryBundle\Entity\CategoryTranslation</entity-name>
 
             <joins>
                 <join>
-                    <entity-name>SuluCategoryBundle:Category</entity-name>
+                    <entity-name>Sulu\Bundle\CategoryBundle\Entity\Category</entity-name>
                     <field-name>%sulu.model.account.class%.categories</field-name>
                 </join>
                 <join>
-                    <entity-name>SuluCategoryBundle:CategoryTranslation</entity-name>
-                    <field-name>SuluCategoryBundle:Category.translations</field-name>
-                    <condition>SuluCategoryBundle:CategoryTranslation.locale = SuluCategoryBundle:Category.defaultLocale</condition>
+                    <entity-name>Sulu\Bundle\CategoryBundle\Entity\CategoryTranslation</entity-name>
+                    <field-name>Sulu\Bundle\CategoryBundle\Entity\Category.translations</field-name>
+                    <condition>Sulu\Bundle\CategoryBundle\Entity\CategoryTranslation.locale = Sulu\Bundle\CategoryBundle\Entity\Category.defaultLocale</condition>
                 </join>
             </joins>
         </group-concat-property>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
@@ -4,36 +4,36 @@
 
     <joins name="address">
         <join>
-            <entity-name>SuluContactBundle:ContactAddress</entity-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\ContactAddress</entity-name>
             <field-name>%sulu.model.contact.class%.contactAddresses</field-name>
             <method>LEFT</method>
-            <condition>SuluContactBundle:ContactAddress.main = TRUE</condition>
+            <condition>Sulu\Bundle\ContactBundle\Entity\ContactAddress.main = TRUE</condition>
         </join>
         <join>
-            <entity-name>SuluContactBundle:Address</entity-name>
-            <field-name>SuluContactBundle:ContactAddress.address</field-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\Address</entity-name>
+            <field-name>Sulu\Bundle\ContactBundle\Entity\ContactAddress.address</field-name>
         </join>
     </joins>
 
     <joins name="position" ref="accountContact">
         <join>
-            <entity-name>SuluContactBundle:Position</entity-name>
-            <field-name>SuluContactBundle:AccountContact.position</field-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\Position</entity-name>
+            <field-name>Sulu\Bundle\ContactBundle\Entity\AccountContact.position</field-name>
         </join>
     </joins>
 
     <joins name="accountContact">
         <join>
-            <entity-name>SuluContactBundle:AccountContact</entity-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\AccountContact</entity-name>
             <field-name>%sulu.model.contact.class%.accountContacts</field-name>
             <method>LEFT</method>
-            <condition>SuluContactBundle:AccountContact.main = true</condition>
+            <condition>Sulu\Bundle\ContactBundle\Entity\AccountContact.main = true</condition>
         </join>
     </joins>
 
     <joins name="tags">
         <join>
-            <entity-name>SuluTagBundle:Tag</entity-name>
+            <entity-name>Sulu\Bundle\TagBundle\Entity\Tag</entity-name>
             <field-name>%sulu.model.contact.class%.tags</field-name>
         </join>
     </joins>
@@ -46,10 +46,10 @@
             sortable="false"
         >
             <field-name>id</field-name>
-            <entity-name>SuluMediaBundle:Media</entity-name>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\Media</entity-name>
             <joins>
                 <join>
-                    <entity-name>SuluMediaBundle:Media</entity-name>
+                    <entity-name>Sulu\Bundle\MediaBundle\Entity\Media</entity-name>
                     <field-name>%sulu.model.contact.class%.avatar</field-name>
                 </join>
             </joins>
@@ -105,14 +105,14 @@
             <joins ref="accountContact">
                 <join>
                     <entity-name>%sulu.model.account.class%</entity-name>
-                    <field-name>SuluContactBundle:AccountContact.account</field-name>
+                    <field-name>Sulu\Bundle\ContactBundle\Entity\AccountContact.account</field-name>
                 </join>
             </joins>
         </property>
 
         <identity-property name="accountId" visibility="never" translation="sulu_contact.organization">
             <field-name>account</field-name>
-            <entity-name>SuluContactBundle:AccountContact</entity-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\AccountContact</entity-name>
 
             <joins ref="accountContact"/>
 
@@ -126,7 +126,7 @@
 
         <property name="city" visibility="always" translation="sulu_contact.city">
             <field-name>city</field-name>
-            <entity-name>SuluContactBundle:Address</entity-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\Address</entity-name>
 
             <joins ref="address"/>
 
@@ -135,7 +135,7 @@
 
         <property name="zip" translation="sulu_contact.zip">
             <field-name>zip</field-name>
-            <entity-name>SuluContactBundle:Address</entity-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\Address</entity-name>
 
             <joins ref="address"/>
 
@@ -144,7 +144,7 @@
 
         <property name="street" translation="sulu_contact.street">
             <field-name>street</field-name>
-            <entity-name>SuluContactBundle:Address</entity-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\Address</entity-name>
 
             <joins ref="address"/>
 
@@ -153,7 +153,7 @@
 
         <property name="number" translation="sulu_contact.number">
             <field-name>number</field-name>
-            <entity-name>SuluContactBundle:Address</entity-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\Address</entity-name>
 
             <joins ref="address"/>
         </property>
@@ -170,7 +170,7 @@
 
         <property name="state" translation="sulu_contact.state">
             <field-name>state</field-name>
-            <entity-name>SuluContactBundle:Address</entity-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\Address</entity-name>
 
             <joins ref="address"/>
 
@@ -179,7 +179,7 @@
 
         <property name="countryCode" translation="sulu_contact.country">
             <field-name>countryCode</field-name>
-            <entity-name>SuluContactBundle:Address</entity-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\Address</entity-name>
 
             <joins ref="address"/>
 
@@ -229,11 +229,11 @@
 
         <property name="title" translation="sulu_contact.title">
             <field-name>title</field-name>
-            <entity-name>SuluContactBundle:ContactTitle</entity-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\ContactTitle</entity-name>
 
             <joins>
                 <join>
-                    <entity-name>SuluContactBundle:ContactTitle</entity-name>
+                    <entity-name>Sulu\Bundle\ContactBundle\Entity\ContactTitle</entity-name>
                     <field-name>%sulu.model.contact.class%.title</field-name>
                 </join>
             </joins>
@@ -271,7 +271,7 @@
 
         <identity-property name="positionId" visibility="never" translation="sulu_contact.position">
             <field-name>position</field-name>
-            <entity-name>SuluContactBundle:AccountContact</entity-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\AccountContact</entity-name>
 
             <joins ref="position"/>
 
@@ -290,7 +290,7 @@
             sortable="false"
         >
             <field-name>position</field-name>
-            <entity-name>SuluContactBundle:Position</entity-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\Position</entity-name>
 
             <joins ref="position"/>
         </property>
@@ -302,7 +302,7 @@
             glue=","
         >
             <field-name>id</field-name>
-            <entity-name>SuluTagBundle:Tag</entity-name>
+            <entity-name>Sulu\Bundle\TagBundle\Entity\Tag</entity-name>
 
             <joins ref="tags"/>
         </group-concat-property>
@@ -315,7 +315,7 @@
             distinct="true"
         >
             <field-name>name</field-name>
-            <entity-name>SuluTagBundle:Tag</entity-name>
+            <entity-name>Sulu\Bundle\TagBundle\Entity\Tag</entity-name>
 
             <joins ref="tags"/>
         </group-concat-property>
@@ -328,7 +328,7 @@
             translation="sulu_tag.tags"
         >
             <field-name>id</field-name>
-            <entity-name>SuluTagBundle:Tag</entity-name>
+            <entity-name>Sulu\Bundle\TagBundle\Entity\Tag</entity-name>
 
             <joins ref="tags"/>
 
@@ -348,11 +348,11 @@
             translation="sulu_category.categories"
         >
             <field-name>id</field-name>
-            <entity-name>SuluCategoryBundle:Category</entity-name>
+            <entity-name>Sulu\Bundle\CategoryBundle\Entity\Category</entity-name>
 
             <joins>
                 <join>
-                    <entity-name>SuluCategoryBundle:Category</entity-name>
+                    <entity-name>Sulu\Bundle\CategoryBundle\Entity\Category</entity-name>
                     <field-name>%sulu.model.contact.class%.categories</field-name>
                 </join>
             </joins>
@@ -372,17 +372,17 @@
             glue=","
         >
             <field-name>translation</field-name>
-            <entity-name>SuluCategoryBundle:CategoryTranslation</entity-name>
+            <entity-name>Sulu\Bundle\CategoryBundle\Entity\CategoryTranslation</entity-name>
 
             <joins>
                 <join>
-                    <entity-name>SuluCategoryBundle:Category</entity-name>
+                    <entity-name>Sulu\Bundle\CategoryBundle\Entity\Category</entity-name>
                     <field-name>%sulu.model.contact.class%.categories</field-name>
                 </join>
                 <join>
-                    <entity-name>SuluCategoryBundle:CategoryTranslation</entity-name>
-                    <field-name>SuluCategoryBundle:Category.translations</field-name>
-                    <condition>SuluCategoryBundle:CategoryTranslation.locale = SuluCategoryBundle:Category.defaultLocale</condition>
+                    <entity-name>Sulu\Bundle\CategoryBundle\Entity\CategoryTranslation</entity-name>
+                    <field-name>Sulu\Bundle\CategoryBundle\Entity\Category.translations</field-name>
+                    <condition>Sulu\Bundle\CategoryBundle\Entity\CategoryTranslation.locale = Sulu\Bundle\CategoryBundle\Entity\Category.defaultLocale</condition>
                 </join>
             </joins>
         </group-concat-property>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
@@ -2,8 +2,8 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
-        <parameter key="sulu_contact.contact_title.entity">SuluContactBundle:ContactTitle</parameter>
-        <parameter key="sulu_contact.position.entity">SuluContactBundle:Position</parameter>
+        <parameter key="sulu_contact.contact_title.entity">Sulu\Bundle\ContactBundle\Entity\ContactTitle</parameter>
+        <parameter key="sulu_contact.position.entity">Sulu\Bundle\ContactBundle\Entity\Position</parameter>
     </parameters>
     <services>
         <service id="sulu_contact.admin" class="Sulu\Bundle\ContactBundle\Admin\ContactAdmin">

--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
@@ -47,11 +47,11 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  */
 class CollectionManager implements CollectionManagerInterface
 {
-    private static $entityName = 'SuluMediaBundle:Collection';
+    private static $entityName = \Sulu\Bundle\MediaBundle\Entity\Collection::class;
 
-    private static $entityCollectionType = 'SuluMediaBundle:Collection';
+    private static $entityCollectionType = \Sulu\Bundle\MediaBundle\Entity\Collection::class;
 
-    private static $entityCollectionMeta = 'SuluMediaBUndle:CollectionMeta';
+    private static $entityCollectionMeta = \Sulu\Bundle\MediaBundle\Entity\CollectionMeta::class;
 
     private static $entityUser = UserInterface::class;
 
@@ -571,7 +571,7 @@ class CollectionManager implements CollectionManagerInterface
     protected function getTypeById($typeId)
     {
         /** @var CollectionType $type */
-        $type = $this->em->getRepository('SuluMediaBundle:CollectionType')->find($typeId);
+        $type = $this->em->getRepository(CollectionType::class)->find($typeId);
         if (!$type) {
             throw new CollectionTypeNotFoundException('Collection Type with the ID ' . $typeId . ' not found');
         }

--- a/src/Sulu/Bundle/MediaBundle/Command/MediaTypeUpdateCommand.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/MediaTypeUpdateCommand.php
@@ -45,7 +45,7 @@ class MediaTypeUpdateCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $em = $this->entityManager;
-        $repo = $em->getRepository('SuluMediaBundle:Media');
+        $repo = $em->getRepository(\Sulu\Bundle\MediaBundle\Entity\Media::class);
         $medias = $repo->findAll();
         $counter = 0;
         /** @var MediaInterface $media */

--- a/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
@@ -47,7 +47,7 @@ class CollectionController extends AbstractRestController implements ClassResour
     /**
      * @var string
      */
-    protected static $entityName = 'SuluMediaBundle:Collection';
+    protected static $entityName = \Sulu\Bundle\MediaBundle\Entity\Collection::class;
 
     /**
      * @var string

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -67,7 +67,7 @@ class MediaManager implements MediaManagerInterface
     /**
      * @deprecated This const is deprecated and will be removed in Sulu 3.0 use the CollectionInterface::class instead.
      */
-    public const ENTITY_NAME_COLLECTION = 'SuluMediaBundle:Collection';
+    public const ENTITY_NAME_COLLECTION = \Sulu\Bundle\MediaBundle\Entity\Collection::class;
 
     /**
      * The repository for communication with the database.
@@ -825,7 +825,7 @@ class MediaManager implements MediaManagerInterface
 
     public function increaseDownloadCounter($fileVersionId)
     {
-        $query = $this->em->createQueryBuilder()->update('SuluMediaBundle:FileVersion', 'fV')
+        $query = $this->em->createQueryBuilder()->update(FileVersion::class, 'fV')
             ->set('fV.downloadCounter', 'fV.downloadCounter + 1')
             ->where('fV.id = :id')
             ->setParameter('id', $fileVersionId)

--- a/src/Sulu/Bundle/MediaBundle/Media/TypeManager/TypeManagerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/TypeManager/TypeManagerInterface.php
@@ -19,9 +19,9 @@ use Sulu\Bundle\MediaBundle\Entity\MediaType;
  */
 interface TypeManagerInterface
 {
-    public const ENTITY_CLASS_MEDIATYPE = 'Sulu\Bundle\MediaBundle\Entity\MediaType';
+    public const ENTITY_CLASS_MEDIATYPE = MediaType::class;
 
-    public const ENTITY_NAME_MEDIATYPE = 'SuluMediaBundle:MediaType';
+    public const ENTITY_NAME_MEDIATYPE = MediaType::class;
 
     /**
      * Returns a Media Type by a given ID.

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/lists/collections.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/lists/collections.xml
@@ -5,17 +5,17 @@
     <properties>
         <property name="id" translation="sulu_admin.id" visibility="no">
             <field-name>id</field-name>
-            <entity-name>SuluMediaBundle:Collection</entity-name>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\Collection</entity-name>
         </property>
 
         <property name="title" translation="sulu_admin.title" visibility="yes">
             <field-name>title</field-name>
-            <entity-name>SuluMediaBundle:Collection</entity-name>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\Collection</entity-name>
         </property>
 
         <property name="objectCount" visibility="yes">
             <field-name>objectCount</field-name>
-            <entity-name>SuluMediaBundle:Collection</entity-name>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\Collection</entity-name>
             <transformer type="number"/>
         </property>
     </properties>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/lists/media.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/lists/media.xml
@@ -4,7 +4,7 @@
 
     <joins name="type">
         <join>
-            <entity-name>SuluMediaBundle:MediaType</entity-name>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\MediaType</entity-name>
             <field-name>%sulu.model.media.class%.type</field-name>
         </join>
     </joins>
@@ -15,40 +15,40 @@
         </join>
 
         <join>
-            <entity-name>SuluMediaBundle:FilePreviewImage</entity-name>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\FilePreviewImage</entity-name>
             <field-name>%sulu.model.media.class%PreviewImage.files</field-name>
         </join>
 
         <join>
-            <entity-name>SuluMediaBundle:FileVersionPreviewImage</entity-name>
-            <field-name>SuluMediaBundle:FilePreviewImage.fileVersions</field-name>
-            <condition>SuluMediaBundle:FileVersionPreviewImage.version = SuluMediaBundle:FilePreviewImage.version</condition>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\FileVersionPreviewImage</entity-name>
+            <field-name>Sulu\Bundle\MediaBundle\Entity\FilePreviewImage.fileVersions</field-name>
+            <condition>Sulu\Bundle\MediaBundle\Entity\FileVersionPreviewImage.version = Sulu\Bundle\MediaBundle\Entity\FilePreviewImage.version</condition>
         </join>
     </joins>
     <joins name="file">
         <join>
-            <entity-name>SuluMediaBundle:File</entity-name>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\File</entity-name>
             <field-name>%sulu.model.media.class%.files</field-name>
         </join>
     </joins>
     <joins name="fileVersion" ref="file">
         <join>
-            <entity-name>SuluMediaBundle:FileVersion</entity-name>
-            <field-name>SuluMediaBundle:File.fileVersions</field-name>
-            <condition>SuluMediaBundle:FileVersion.version = SuluMediaBundle:File.version</condition>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\FileVersion</entity-name>
+            <field-name>Sulu\Bundle\MediaBundle\Entity\File.fileVersions</field-name>
+            <condition>Sulu\Bundle\MediaBundle\Entity\FileVersion.version = Sulu\Bundle\MediaBundle\Entity\File.version</condition>
         </join>
     </joins>
     <joins name="fileVersionMeta" ref="fileVersion">
         <join>
-            <entity-name>SuluMediaBundle:FileVersionMeta</entity-name>
-            <field-name>SuluMediaBundle:FileVersion.meta</field-name>
-            <condition>SuluMediaBundle:FileVersionMeta.locale = :locale</condition>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\FileVersionMeta</entity-name>
+            <field-name>Sulu\Bundle\MediaBundle\Entity\FileVersion.meta</field-name>
+            <condition>Sulu\Bundle\MediaBundle\Entity\FileVersionMeta.locale = :locale</condition>
         </join>
     </joins>
     <joins name="defaultFileVersionMeta" ref="fileVersion">
         <join>
-            <entity-name>SuluMediaBundle:DefaultFileVersionMeta</entity-name>
-            <field-name>SuluMediaBundle:FileVersion.defaultMeta</field-name>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\DefaultFileVersionMeta</entity-name>
+            <field-name>Sulu\Bundle\MediaBundle\Entity\FileVersion.defaultMeta</field-name>
         </join>
     </joins>
     <joins name="collection">
@@ -71,28 +71,28 @@
 
         <property name="previewImageName" visibility="never">
             <field-name>name</field-name>
-            <entity-name>SuluMediaBundle:FileVersionPreviewImage</entity-name>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\FileVersionPreviewImage</entity-name>
 
             <joins ref="previewImageFileVersion"/>
         </property>
 
         <property name="previewImageVersion" visibility="never">
             <field-name>version</field-name>
-            <entity-name>SuluMediaBundle:FileVersionPreviewImage</entity-name>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\FileVersionPreviewImage</entity-name>
 
             <joins ref="previewImageFileVersion"/>
         </property>
 
         <property name="previewImageSubVersion" visibility="never">
             <field-name>subVersion</field-name>
-            <entity-name>SuluMediaBundle:FileVersionPreviewImage</entity-name>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\FileVersionPreviewImage</entity-name>
 
             <joins ref="previewImageFileVersion"/>
         </property>
 
         <property name="previewImageMimeType" visibility="never">
             <field-name>mimeType</field-name>
-            <entity-name>SuluMediaBundle:FileVersionPreviewImage</entity-name>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\FileVersionPreviewImage</entity-name>
 
             <joins ref="previewImageFileVersion"/>
         </property>
@@ -133,7 +133,7 @@
 
         <property name="type" translation="sulu_media.type" visibility="always">
             <field-name>name</field-name>
-            <entity-name>SuluMediaBundle:MediaType</entity-name>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\MediaType</entity-name>
 
             <joins ref="type"/>
 
@@ -162,28 +162,28 @@
 
         <property name="version" translation="sulu_media.version">
             <field-name>version</field-name>
-            <entity-name>SuluMediaBundle:File</entity-name>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\File</entity-name>
 
             <joins ref="file"/>
         </property>
 
         <property name="name" translation="sulu_admin.name" visibility="always" searchability="yes">
             <field-name>name</field-name>
-            <entity-name>SuluMediaBundle:FileVersion</entity-name>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\FileVersion</entity-name>
 
             <joins ref="fileVersion"/>
         </property>
 
         <property name="subVersion" visibility="never">
             <field-name>subVersion</field-name>
-            <entity-name>SuluMediaBundle:FileVersion</entity-name>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\FileVersion</entity-name>
 
             <joins ref="fileVersion"/>
         </property>
 
         <property name="size" translation="sulu_media.size" visibility="always">
             <field-name>size</field-name>
-            <entity-name>SuluMediaBundle:FileVersion</entity-name>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\FileVersion</entity-name>
             <joins ref="fileVersion"/>
 
             <transformer type="bytes"/>
@@ -191,21 +191,21 @@
 
         <property name="mimeType" translation="sulu_media.mime_type" visibility="always">
             <field-name>mimeType</field-name>
-            <entity-name>SuluMediaBundle:FileVersion</entity-name>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\FileVersion</entity-name>
 
             <joins ref="fileVersion"/>
         </property>
 
         <property name="downloadCounter" translation="sulu_media.download_counter">
             <field-name>downloadCounter</field-name>
-            <entity-name>SuluMediaBundle:FileVersion</entity-name>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\FileVersion</entity-name>
 
             <joins ref="fileVersion"/>
         </property>
 
         <property name="storageOptions" visibility="never">
             <field-name>storageOptions</field-name>
-            <entity-name>SuluMediaBundle:FileVersion</entity-name>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\FileVersion</entity-name>
 
             <joins ref="fileVersion"/>
         </property>
@@ -213,13 +213,13 @@
         <case-property name="locale" visibility="never">
             <field>
                 <field-name>locale</field-name>
-                <entity-name>SuluMediaBundle:FileVersionMeta</entity-name>
+                <entity-name>Sulu\Bundle\MediaBundle\Entity\FileVersionMeta</entity-name>
 
                 <joins ref="fileVersionMeta"/>
             </field>
             <field>
                 <field-name>locale</field-name>
-                <entity-name>SuluMediaBundle:DefaultFileVersionMeta</entity-name>
+                <entity-name>Sulu\Bundle\MediaBundle\Entity\DefaultFileVersionMeta</entity-name>
 
                 <joins ref="defaultFileVersionMeta"/>
             </field>
@@ -228,13 +228,13 @@
         <case-property name="title" translation="sulu_admin.title" visibility="always" searchability="yes">
             <field>
                 <field-name>title</field-name>
-                <entity-name>SuluMediaBundle:FileVersionMeta</entity-name>
+                <entity-name>Sulu\Bundle\MediaBundle\Entity\FileVersionMeta</entity-name>
 
                 <joins ref="fileVersionMeta"/>
             </field>
             <field>
                 <field-name>title</field-name>
-                <entity-name>SuluMediaBundle:DefaultFileVersionMeta</entity-name>
+                <entity-name>Sulu\Bundle\MediaBundle\Entity\DefaultFileVersionMeta</entity-name>
 
                 <joins ref="defaultFileVersionMeta"/>
             </field>
@@ -243,7 +243,7 @@
 
         <property name="description" translation="sulu_admin.description" searchability="yes">
             <field-name>description</field-name>
-            <entity-name>SuluMediaBundle:FileVersionMeta</entity-name>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\FileVersionMeta</entity-name>
 
             <joins ref="fileVersionMeta"/>
         </property>
@@ -256,12 +256,12 @@
             translation="sulu_tag.tags"
         >
             <field-name>id</field-name>
-            <entity-name>SuluTagBundle:Tag</entity-name>
+            <entity-name>Sulu\Bundle\TagBundle\Entity\Tag</entity-name>
 
             <joins ref="fileVersion">
                 <join>
-                    <entity-name>SuluTagBundle:Tag</entity-name>
-                    <field-name>SuluMediaBundle:FileVersion.tags</field-name>
+                    <entity-name>Sulu\Bundle\TagBundle\Entity\Tag</entity-name>
+                    <field-name>Sulu\Bundle\MediaBundle\Entity\FileVersion.tags</field-name>
                 </join>
             </joins>
 
@@ -281,12 +281,12 @@
             translation="sulu_category.categories"
         >
             <field-name>id</field-name>
-            <entity-name>SuluCategoryBundle:Category</entity-name>
+            <entity-name>Sulu\Bundle\CategoryBundle\Entity\Category</entity-name>
 
             <joins ref="fileVersion">
                 <join>
-                    <entity-name>SuluCategoryBundle:Category</entity-name>
-                    <field-name>SuluMediaBundle:FileVersion.categories</field-name>
+                    <entity-name>Sulu\Bundle\CategoryBundle\Entity\Category</entity-name>
+                    <field-name>Sulu\Bundle\MediaBundle\Entity\FileVersion.categories</field-name>
                 </join>
             </joins>
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -17,9 +17,9 @@
         <parameter key="sulu_media.collection_manager.class">Sulu\Bundle\MediaBundle\Collection\Manager\CollectionManager</parameter>
         <parameter key="sulu_media.type_manager.class">Sulu\Bundle\MediaBundle\Media\TypeManager\TypeManager</parameter>
         <parameter key="sulu_media.format_options_manager.class">Sulu\Bundle\MediaBundle\Media\FormatOptions\FormatOptionsManager</parameter>
-        <parameter key="sulu_media.collection_entity">SuluMediaBundle:Collection</parameter>
-        <parameter key="sulu_media.format_options_entity">SuluMediaBundle:FormatOptions</parameter>
-        <parameter key="sulu_media.entity.file_version_meta">SuluMediaBundle:FileVersionMeta</parameter>
+        <parameter key="sulu_media.collection_entity">Sulu\Bundle\MediaBundle\Entity\Collection</parameter>
+        <parameter key="sulu_media.format_options_entity">Sulu\Bundle\MediaBundle\Entity\FormatOptions</parameter>
+        <parameter key="sulu_media.entity.file_version_meta">Sulu\Bundle\MediaBundle\Entity\FileVersionMeta</parameter>
         <parameter key="sulu_media.twig_extension.disposition_type.class">Sulu\Bundle\MediaBundle\Twig\DispositionTypeTwigExtension</parameter>
         <parameter key="sulu_media.twig_extension.media.class">Sulu\Bundle\MediaBundle\Twig\MediaTwigExtension</parameter>
         <parameter key="tmp">Sulu\Bundle\MediaBundle\Twig\MediaTwigExtension</parameter>

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/CollectionRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/CollectionRepositoryTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Functional\Entity;
+namespace Sulu\Bundle\MediaBundle\Tests\Functional\Entity;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\MediaBundle\Entity\Collection;

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/FileVersionMetaRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/FileVersionMetaRepositoryTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Functional\Entity;
+namespace Sulu\Bundle\MediaBundle\Tests\Functional\Entity;
 
 use Doctrine\ORM\EntityManager;
 use Sulu\Bundle\MediaBundle\Entity\Collection;

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/FileVersionMetaRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/FileVersionMetaRepositoryTest.php
@@ -55,7 +55,7 @@ class FileVersionMetaRepositoryTest extends SuluTestCase
 
         $this->purgeDatabase();
         $this->em = $this->getEntityManager();
-        $this->fileVersionMetaRepository = $this->em->getRepository('SuluMediaBundle:FileVersionMeta');
+        $this->fileVersionMetaRepository = $this->em->getRepository(FileVersionMeta::class);
 
         $this->collectionType = new CollectionType();
         $this->collectionType->setName('image');

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Functional\Entity;
+namespace Sulu\Bundle\MediaBundle\Tests\Functional\Entity;
 
 use Doctrine\ORM\EntityManager;
 use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroup;
@@ -171,7 +171,7 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
 
     private function createTag($name)
     {
-        $tag = $this->em->getRepository(Tag::class)->createNew();
+        $tag = $this->em->getRepository(TagInterface::class)->createNew();
         $tag->setName($name);
 
         $this->em->persist($tag);

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
@@ -171,7 +171,7 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
 
     private function createTag($name)
     {
-        $tag = $this->em->getRepository('SuluTagBundle:Tag')->createNew();
+        $tag = $this->em->getRepository(Tag::class)->createNew();
         $tag->setName($name);
 
         $this->em->persist($tag);

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Functional\Entity;
+namespace Sulu\Bundle\MediaBundle\Tests\Functional\Entity;
 
 use Doctrine\ORM\EntityManager;
 use Sulu\Bundle\ContactBundle\Entity\Contact;

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
@@ -76,7 +76,7 @@ class MediaRepositoryTest extends SuluTestCase
         $this->mediaRepository = $this->getContainer()->get('sulu.repository.media');
     }
 
-    protected function setUpMedia()
+    protected function setUpMedia(): void
     {
         // Create Media Type
         $documentType = new MediaType();

--- a/src/Sulu/Bundle/SecurityBundle/Controller/GroupController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/GroupController.php
@@ -67,7 +67,7 @@ class GroupController extends AbstractRestController implements ClassResourceInt
      */
     private $entityManager;
 
-    public const ENTITY_NAME_ROLE = Role::class;
+    public const ENTITY_NAME_ROLE = RoleInterface::class;
 
     // TODO: move the field descriptors to a manager
     public function __construct(

--- a/src/Sulu/Bundle/SecurityBundle/Controller/GroupController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/GroupController.php
@@ -36,7 +36,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class GroupController extends AbstractRestController implements ClassResourceInterface, SecuredControllerInterface
 {
-    protected static $entityName = 'SuluSecurityBundle:Group';
+    protected static $entityName = Group::class;
 
     protected static $entityKey = 'groups';
 
@@ -67,7 +67,7 @@ class GroupController extends AbstractRestController implements ClassResourceInt
      */
     private $entityManager;
 
-    public const ENTITY_NAME_ROLE = 'SuluSecurityBundle:Role';
+    public const ENTITY_NAME_ROLE = Role::class;
 
     // TODO: move the field descriptors to a manager
     public function __construct(

--- a/src/Sulu/Bundle/SecurityBundle/Controller/ProfileController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/ProfileController.php
@@ -34,7 +34,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  */
 class ProfileController implements ClassResourceInterface
 {
-    protected static $entityNameUserSetting = 'SuluSecurityBundle:UserSetting';
+    protected static $entityNameUserSetting = UserSetting::class;
 
     /**
      * @var TokenStorageInterface

--- a/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
@@ -49,7 +49,7 @@ class RoleController extends AbstractRestController implements ClassResourceInte
      */
     protected static $entityKey = 'roles';
 
-    public const ENTITY_NAME_PERMISSION = 'SuluSecurityBundle:Permission';
+    public const ENTITY_NAME_PERMISSION = Permission::class;
 
     protected $bundlePrefix = 'security.roles.';
 
@@ -481,11 +481,11 @@ class RoleController extends AbstractRestController implements ClassResourceInte
     private function setSecurityType($role, $securityTypeData)
     {
         $securityType = $this->entityManager
-            ->getRepository('SuluSecurityBundle:SecurityType')
+            ->getRepository(\Sulu\Bundle\SecurityBundle\Entity\SecurityType::class)
             ->findSecurityTypeById($securityTypeData['id']);
 
         if (!$securityType) {
-            throw new EntityNotFoundException('SuluSecurityBundle:SecurityType', $securityTypeData['id']);
+            throw new EntityNotFoundException(\Sulu\Bundle\SecurityBundle\Entity\SecurityType::class, $securityTypeData['id']);
         }
         $role->setSecurityType($securityType);
     }

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -32,9 +32,9 @@
         <parameter key="sulu_security.user_setting_repository.class">Sulu\Bundle\SecurityBundle\Entity\UserSettingRepository</parameter>
         <parameter key="sulu_security.user_repository_factory.class">Sulu\Component\Security\Authentication\UserRepositoryFactory</parameter>
         <parameter key="sulu_security.build.user.class">Sulu\Bundle\SecurityBundle\Build\UserBuilder</parameter>
-        <parameter key="sulu_security.entity.role">SuluSecurityBundle:Role</parameter>
-        <parameter key="sulu_security.entity.group">SuluSecurityBundle:Group</parameter>
-        <parameter key="sulu_security.entity.user_setting">SuluSecurityBundle:UserSetting</parameter>
+        <parameter key="sulu_security.entity.role">Sulu\Bundle\SecurityBundle\Entity\Role</parameter>
+        <parameter key="sulu_security.entity.group">Sulu\Bundle\SecurityBundle\Entity\Group</parameter>
+        <parameter key="sulu_security.entity.user_setting">Sulu\Bundle\SecurityBundle\Entity\UserSetting</parameter>
         <parameter key="sulu_security.profile_controller.class">Sulu\Bundle\SecurityBundle\Controller\ProfileController</parameter>
     </parameters>
 

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/LegacyResettingControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/LegacyResettingControllerTest.php
@@ -103,7 +103,7 @@ class LegacyResettingControllerTest extends SuluTestCase
 
         // asserting user properties
         $user = $this->client->getContainer()->get('doctrine')->getManager()->find(
-            'SuluSecurityBundle:User',
+            User::class,
             $this->users[0]->getId()
         );
         $this->assertTrue(\is_string($user->getPasswordResetToken()));
@@ -141,7 +141,7 @@ class LegacyResettingControllerTest extends SuluTestCase
 
         // asserting user properties
         $user = $this->client->getContainer()->get('doctrine')->getManager()->find(
-            'SuluSecurityBundle:User',
+            User::class,
             $this->users[0]->getId()
         );
         $this->assertTrue(\is_string($user->getPasswordResetToken()));
@@ -180,7 +180,7 @@ class LegacyResettingControllerTest extends SuluTestCase
 
         // asserting user properties
         $user = $this->client->getContainer()->get('doctrine')->getManager()->find(
-            'SuluSecurityBundle:User',
+            User::class,
             $this->users[1]->getId()
         );
         $this->assertTrue(\is_string($user->getPasswordResetToken()));
@@ -229,7 +229,7 @@ class LegacyResettingControllerTest extends SuluTestCase
         $mailCollector = $this->client->getProfile()->getCollector('swiftmailer');
         $response = \json_decode($this->client->getResponse()->getContent());
         $user = $this->client->getContainer()->get('doctrine')->getManager()->find(
-            'SuluSecurityBundle:User',
+            User::class,
             $this->users[2]->getId()
         );
 
@@ -313,7 +313,7 @@ class LegacyResettingControllerTest extends SuluTestCase
         ]);
 
         $user = $this->client->getContainer()->get('doctrine')->getManager()->find(
-            'SuluSecurityBundle:User',
+            User::class,
             $this->users[2]->getId()
         );
 
@@ -337,7 +337,7 @@ class LegacyResettingControllerTest extends SuluTestCase
             'password' => 'thispasswordshouldnotbeapplied',
         ]);
         $response = \json_decode($this->client->getResponse()->getContent());
-        $user = $this->em->find('SuluSecurityBundle:User', $this->users[2]->getId());
+        $user = $this->em->find(User::class, $this->users[2]->getId());
 
         $this->assertHttpStatusCode(400, $this->client->getResponse());
         $this->assertEquals(1006, $response->code);
@@ -353,7 +353,7 @@ class LegacyResettingControllerTest extends SuluTestCase
             'password' => 'thispasswordshouldnotbeapplied',
         ]);
         $response = \json_decode($this->client->getResponse()->getContent());
-        $user = $this->em->find('SuluSecurityBundle:User', $this->users[2]->getId());
+        $user = $this->em->find(User::class, $this->users[2]->getId());
 
         $this->assertHttpStatusCode(400, $this->client->getResponse());
         $this->assertEquals(1005, $response->code);

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/UserControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/UserControllerTest.php
@@ -1108,7 +1108,7 @@ class UserControllerTest extends SuluTestCase
         $this->assertEquals('Role2', $response->userRoles[1]->role->name);
         $this->assertEquals('en', $response->userRoles[1]->locales[0]);
 
-        $refreshedUser = $this->em->getRepository('SuluSecurityBundle:User')->find($this->user1->getId());
+        $refreshedUser = $this->em->getRepository(User::class)->find($this->user1->getId());
         $this->assertEquals($this->user1->getSalt(), $refreshedUser->getSalt());
     }
 

--- a/src/Sulu/Bundle/TagBundle/Controller/TagController.php
+++ b/src/Sulu/Bundle/TagBundle/Controller/TagController.php
@@ -40,7 +40,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  */
 class TagController extends AbstractRestController implements ClassResourceInterface, SecuredControllerInterface
 {
-    protected static $entityName = 'SuluTagBundle:Tag';
+    protected static $entityName = \Sulu\Bundle\TagBundle\Entity\Tag::class;
 
     /**
      * @deprecated Use the TagInterface::RESOURCE_KEY constant instead

--- a/src/Sulu/Bundle/TagBundle/Tests/Functional/Controller/TagControllerTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Functional/Controller/TagControllerTest.php
@@ -413,7 +413,7 @@ class TagControllerTest extends SuluTestCase
 
         $response = \json_decode($this->client->getResponse()->getContent());
 
-        $this->assertEquals('Entity with the type "SuluTagBundle:Tag" and the id "1233" not found.', $response->message);
+        $this->assertEquals('Entity with the type "Sulu\Bundle\TagBundle\Entity\Tag" and the id "1233" not found.', $response->message);
     }
 
     public function testPatch(): void

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/analytics.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/analytics.xml
@@ -9,7 +9,7 @@
                  class="Sulu\Bundle\WebsiteBundle\Entity\DomainRepository">
             <factory service="doctrine.orm.entity_manager" method="getRepository"/>
 
-            <argument type="string">SuluWebsiteBundle:Domain</argument>
+            <argument type="string">Sulu\Bundle\WebsiteBundle\Entity\Domain</argument>
         </service>
 
         <service id="sulu_website.analytics.manager"

--- a/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/FieldDescriptorFactoryTest.php
+++ b/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/FieldDescriptorFactoryTest.php
@@ -56,12 +56,12 @@ class FieldDescriptorFactoryTest extends TestCase
     public function setup(): void
     {
         $parameterBag = $this->prophesize(ParameterBagInterface::class);
-        $parameterBag->resolveValue('%sulu.model.contact.class%')->willReturn('SuluContactBundle:Contact');
+        $parameterBag->resolveValue('%sulu.model.contact.class%')->willReturn('Sulu\Bundle\ContactBundle\Entity\Contact');
         $parameterBag->resolveValue('%sulu.model.contact.class%.avatar')->willReturn(
-            'SuluContactBundle:Contact.avatar'
+            'Sulu\Bundle\ContactBundle\Entity\Contact.avatar'
         );
         $parameterBag->resolveValue('%sulu.model.contact.class%.contactAddresses')->willReturn(
-            'SuluContactBundle:Contact.contactAddresses'
+            'Sulu\Bundle\ContactBundle\Entity\Contact.contactAddresses'
         );
         $parameterBag->resolveValue(Argument::any())->willReturnArgument(0);
 
@@ -178,7 +178,7 @@ class FieldDescriptorFactoryTest extends TestCase
         $this->assertInstanceOf(DoctrineCaseFieldDescriptor::class, $tagFieldDescriptor);
 
         $this->assertEquals(
-            '(CASE WHEN SuluTagBundle_Tag.name IS NOT NULL THEN SuluTagBundle_Tag.name ELSE SuluTagBundle_Tag.name END)',
+            '(CASE WHEN Sulu_Bundle_TagBundle_Entity_Tag.name IS NOT NULL THEN Sulu_Bundle_TagBundle_Entity_Tag.name ELSE Sulu_Bundle_TagBundle_Entity_Tag.name END)',
             $tagFieldDescriptor->getSelect()
         );
     }
@@ -216,15 +216,15 @@ class FieldDescriptorFactoryTest extends TestCase
                 'translation' => 'City',
                 'disabled' => true,
                 'joins' => [
-                    'SuluContactBundle:ContactAddress' => [
-                        'entity-name' => 'SuluContactBundle:ContactAddress',
-                        'field-name' => 'SuluContactBundle_Contact.contactAddresses',
+                    'Sulu\Bundle\ContactBundle\Entity\ContactAddress' => [
+                        'entity-name' => 'Sulu\Bundle\ContactBundle\Entity\ContactAddress',
+                        'field-name' => 'Sulu_Bundle_ContactBundle_Entity_Contact.contactAddresses',
                         'method' => 'LEFT',
-                        'condition' => 'SuluContactBundle_ContactAddress.locale = :locale',
+                        'condition' => 'Sulu_Bundle_ContactBundle_Entity_ContactAddress.locale = :locale',
                     ],
                     'user' => [
                         'entity-name' => 'user',
-                        'field-name' => 'SuluSecurityBundle:User',
+                        'field-name' => 'Sulu\Bundle\SecurityBundle\Entity\User',
                         'method' => 'LEFT',
                         'condition' => 'user.idContacts = contact.id',
                     ],

--- a/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/Resources/case.xml
+++ b/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/Resources/case.xml
@@ -4,22 +4,22 @@
         <case-property name="tag" width="shrink">
             <field>
                 <field-name>name</field-name>
-                <entity-name>SuluTagBundle:Tag</entity-name>
+                <entity-name>Sulu\Bundle\TagBundle\Entity\Tag</entity-name>
 
                 <joins>
                     <join>
-                        <entity-name>SuluTagBundle:Tag</entity-name>
+                        <entity-name>Sulu\Bundle\TagBundle\Entity\Tag</entity-name>
                         <field-name>%sulu.model.contact.class%.tag</field-name>
                     </join>
                 </joins>
             </field>
             <field>
                 <field-name>name</field-name>
-                <entity-name>SuluTagBundle:Tag</entity-name>
+                <entity-name>Sulu\Bundle\TagBundle\Entity\Tag</entity-name>
 
                 <joins>
                     <join>
-                        <entity-name>SuluTagBundle:Tag</entity-name>
+                        <entity-name>Sulu\Bundle\TagBundle\Entity\Tag</entity-name>
                         <field-name>%sulu.model.contact.class%.defaultTag</field-name>
                     </join>
                 </joins>

--- a/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/Resources/complete.xml
+++ b/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/Resources/complete.xml
@@ -3,14 +3,14 @@
 
     <joins name="address">
         <join>
-            <entity-name>SuluContactBundle:ContactAddress</entity-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\ContactAddress</entity-name>
             <field-name>%sulu.model.contact.class%.contactAddresses</field-name>
             <method>LEFT</method>
-            <condition>SuluContactBundle:ContactAddress.main = TRUE</condition>
+            <condition>Sulu\Bundle\ContactBundle\Entity\ContactAddress.main = TRUE</condition>
         </join>
         <join>
-            <entity-name>SuluContactBundle:Address</entity-name>
-            <field-name>SuluContactBundle:ContactAddress.address</field-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\Address</entity-name>
+            <field-name>Sulu\Bundle\ContactBundle\Entity\ContactAddress.address</field-name>
         </join>
     </joins>
 
@@ -33,11 +33,11 @@
         <property name="avatar" translation="public.avatar" visibility="always" type="thumbnails"
             sortable="false">
             <field-name>id</field-name>
-            <entity-name>SuluMediaBundle:Media</entity-name>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\Media</entity-name>
 
             <joins>
                 <join>
-                    <entity-name>SuluMediaBundle:Media</entity-name>
+                    <entity-name>Sulu\Bundle\MediaBundle\Entity\Media</entity-name>
                     <field-name>%sulu.model.contact.class%.avatar</field-name>
                 </join>
             </joins>
@@ -59,7 +59,7 @@
 
         <property name="city" translation="contact.address.city" visibility="always">
             <field-name>city</field-name>
-            <entity-name>SuluContactBundle:Address</entity-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\Address</entity-name>
 
             <joins ref="address"/>
         </property>

--- a/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/Resources/group-concat.xml
+++ b/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/Resources/group-concat.xml
@@ -4,11 +4,11 @@
     <properties>
         <group-concat-property name="tags" glue="," width="shrink">
             <field-name>name</field-name>
-            <entity-name>SuluTagBundle:Tag</entity-name>
+            <entity-name>Sulu\Bundle\TagBundle\Entity\Tag</entity-name>
 
             <joins>
                 <join>
-                    <entity-name>SuluTagBundle:Tag</entity-name>
+                    <entity-name>Sulu\Bundle\TagBundle\Entity\Tag</entity-name>
                     <field-name>%sulu.model.contact.class%.tags</field-name>
                 </join>
             </joins>

--- a/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/Resources/options.xml
+++ b/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/Resources/options.xml
@@ -3,18 +3,18 @@
     <properties>
         <property name="city">
             <field-name>city</field-name>
-            <entity-name>SuluContactBundle:Address</entity-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\Address</entity-name>
 
             <joins>
                 <join>
-                    <entity-name>SuluContactBundle:ContactAddress</entity-name>
+                    <entity-name>Sulu\Bundle\ContactBundle\Entity\ContactAddress</entity-name>
                     <field-name>%sulu.model.contact.class%.contactAddresses</field-name>
                     <method>LEFT</method>
-                    <condition>SuluContactBundle:ContactAddress.locale = :locale</condition>
+                    <condition>Sulu\Bundle\ContactBundle\Entity\ContactAddress.locale = :locale</condition>
                 </join>
                 <join>
                     <entity-name>user</entity-name>
-                    <field-name>SuluSecurityBundle:User</field-name>
+                    <field-name>Sulu\Bundle\SecurityBundle\Entity\User</field-name>
                     <method>LEFT</method>
                     <condition>user.idContacts = contact.id</condition>
                 </join>

--- a/src/Sulu/Component/Rest/Tests/Unit/AbstractRestControllerTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/AbstractRestControllerTest.php
@@ -221,7 +221,7 @@ class AbstractRestControllerTest extends TestCase
 
         $id = 1;
         $deleteCallBack = function($id) {
-            throw new EntityNotFoundException('SuluCoreBundle:Example', 7);
+            throw new EntityNotFoundException('Sulu\Bundle\CoreBundle\Entity\Example', 7);
         };
 
         /** @var View $view */

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -103,13 +103,13 @@ class DoctrineListBuilderTest extends TestCase
         ['id' => '3'],
     ];
 
-    private static $entityName = 'SuluCoreBundle:Example';
+    private static $entityName = 'Sulu\Bundle\CoreBundle\Entity\Example';
 
-    private static $entityNameAlias = 'SuluCoreBundle_Example';
+    private static $entityNameAlias = 'Sulu_Bundle_CoreBundle_Entity_Example';
 
-    private static $translationEntityName = 'SuluCoreBundle:ExampleTranslation';
+    private static $translationEntityName = 'Sulu\Bundle\CoreBundle\Entity\ExampleTranslation';
 
-    private static $translationEntityNameAlias = 'SuluCoreBundle_ExampleTranslation';
+    private static $translationEntityNameAlias = 'Sulu_Bundle_CoreBundle_Entity_ExampleTranslation';
 
     public function setUp(): void
     {
@@ -479,7 +479,7 @@ class DoctrineListBuilderTest extends TestCase
         )->shouldBeCalledTimes(1);
 
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect('SuluCoreBundle_ExampleTranslation.name AS name')->shouldBeCalledTimes(1);
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_ExampleTranslation.name AS name')->shouldBeCalledTimes(1);
 
         $this->doctrineListBuilder->execute();
     }
@@ -508,9 +508,9 @@ class DoctrineListBuilderTest extends TestCase
 
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
         // will be called for preselect query
-        $this->queryBuilder->addSelect('SuluCoreBundle_ExampleTranslation.desc AS desc_alias')->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_ExampleTranslation.desc AS desc_alias')->shouldBeCalled();
         // will be called for result (should not be displayed)
-        $this->queryBuilder->addSelect('SuluCoreBundle_ExampleTranslation.desc AS HIDDEN desc_alias')->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_ExampleTranslation.desc AS HIDDEN desc_alias')->shouldBeCalled();
         $this->queryBuilder->addOrderBy('desc_alias', 'ASC')->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
@@ -597,9 +597,9 @@ class DoctrineListBuilderTest extends TestCase
 
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
         // will be called for result (should not be displayed)
-        $this->queryBuilder->addSelect('SuluCoreBundle_Example.desc AS HIDDEN desc')->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.desc AS HIDDEN desc')->shouldBeCalled();
         // will be called for id query
-        $this->queryBuilder->addSelect('SuluCoreBundle_Example.desc AS desc')->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.desc AS desc')->shouldBeCalled();
         $this->queryBuilder->addOrderBy('desc', 'ASC')->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
@@ -609,13 +609,13 @@ class DoctrineListBuilderTest extends TestCase
     {
         $this->doctrineListBuilder->sort(new DoctrineFieldDescriptor('desc', 'desc', self::$entityName));
 
-        $this->queryBuilder->getDQLPart('select')->willReturn([new Select('SuluCoreBundle_Example.desc AS desc')]);
+        $this->queryBuilder->getDQLPart('select')->willReturn([new Select('Sulu_Bundle_CoreBundle_Entity_Example.desc AS desc')]);
 
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
         // will NOT be called for result (should not be displayed)
-        $this->queryBuilder->addSelect('SuluCoreBundle_Example.desc AS HIDDEN desc')->shouldNotBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.desc AS HIDDEN desc')->shouldNotBeCalled();
         // will be called for id query
-        $this->queryBuilder->addSelect('SuluCoreBundle_Example.desc AS desc')->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.desc AS desc')->shouldBeCalled();
         $this->queryBuilder->addOrderBy('desc', 'ASC')->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
@@ -626,13 +626,13 @@ class DoctrineListBuilderTest extends TestCase
      */
     public function testSortWithMultipleSort(): void
     {
-        $this->queryBuilder->getDQLPart('select')->willReturn([new Select('SuluCoreBundle_Example.desc AS desc')]);
+        $this->queryBuilder->getDQLPart('select')->willReturn([new Select('Sulu_Bundle_CoreBundle_Entity_Example.desc AS desc')]);
 
         $this->doctrineListBuilder->sort(new DoctrineFieldDescriptor('desc', 'desc', self::$entityName));
         $this->doctrineListBuilder->sort(new DoctrineFieldDescriptor('desc', 'desc', self::$entityName));
 
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect('SuluCoreBundle_Example.desc AS desc')->shouldBeCalledTimes(1);
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.desc AS desc')->shouldBeCalledTimes(1);
         $this->queryBuilder->addOrderBy('desc', 'ASC')->shouldBeCalledTimes(2);
 
         $this->doctrineListBuilder->execute();
@@ -643,13 +643,13 @@ class DoctrineListBuilderTest extends TestCase
      */
     public function testChangeSortOrder(): void
     {
-        $this->queryBuilder->getDQLPart('select')->willReturn([new Select('SuluCoreBundle_Example.desc AS desc')]);
+        $this->queryBuilder->getDQLPart('select')->willReturn([new Select('Sulu_Bundle_CoreBundle_Entity_Example.desc AS desc')]);
 
         $this->doctrineListBuilder->sort(new DoctrineFieldDescriptor('desc', 'desc', self::$entityName), 'ASC');
         $this->doctrineListBuilder->sort(new DoctrineFieldDescriptor('desc', 'desc', self::$entityName), 'DESC');
 
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect('SuluCoreBundle_Example.desc AS desc')->shouldBeCalledTimes(1);
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.desc AS desc')->shouldBeCalledTimes(1);
         $this->queryBuilder->addOrderBy('desc', 'DESC')->shouldBeCalledTimes(2);
 
         $this->doctrineListBuilder->execute();
@@ -667,7 +667,7 @@ class DoctrineListBuilderTest extends TestCase
 
     public function testSortConcat(): void
     {
-        $select = 'CONCAT(SuluCoreBundle_Example.name, CONCAT(\' \', SuluCoreBundle_Example.desc)) AS name_desc';
+        $select = 'CONCAT(Sulu_Bundle_CoreBundle_Entity_Example.name, CONCAT(\' \', Sulu_Bundle_CoreBundle_Entity_Example.desc)) AS name_desc';
 
         $this->doctrineListBuilder->sort(new DoctrineConcatenationFieldDescriptor(
             [
@@ -707,7 +707,7 @@ class DoctrineListBuilderTest extends TestCase
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
         $this->queryBuilder->setParameter(Argument::containingString('id'), [11, 22])->shouldBeCalled();
         $this->queryBuilder->andWhere(
-            Argument::containingString('SuluCoreBundle_Example.id IN (:id')
+            Argument::containingString('Sulu_Bundle_CoreBundle_Entity_Example.id IN (:id')
         )->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
@@ -731,7 +731,7 @@ class DoctrineListBuilderTest extends TestCase
 
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
         $this->queryBuilder->andWhere(
-            Argument::containingString('SuluCoreBundle_Example.id IN (:id')
+            Argument::containingString('Sulu_Bundle_CoreBundle_Entity_Example.id IN (:id')
         )->shouldNotBeCalled();
 
         $this->doctrineListBuilder->execute();
@@ -744,7 +744,7 @@ class DoctrineListBuilderTest extends TestCase
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
         $this->queryBuilder->setParameter(Argument::containingString('id'), [55, 99])->shouldBeCalled();
         $this->queryBuilder->andWhere(
-            Argument::containingString('NOT(SuluCoreBundle_Example.id IN (:id')
+            Argument::containingString('NOT(Sulu_Bundle_CoreBundle_Entity_Example.id IN (:id')
         )->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
@@ -756,7 +756,7 @@ class DoctrineListBuilderTest extends TestCase
 
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
         $this->queryBuilder->andWhere(
-            Argument::containingString('NOT(SuluCoreBundle_Example.id IN (:id')
+            Argument::containingString('NOT(Sulu_Bundle_CoreBundle_Entity_Example.id IN (:id')
         )->shouldNotBeCalled();
 
         $this->doctrineListBuilder->execute();
@@ -768,7 +768,7 @@ class DoctrineListBuilderTest extends TestCase
 
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
         $this->queryBuilder->andWhere(
-            Argument::containingString('NOT(SuluCoreBundle_Example.id IN (:id')
+            Argument::containingString('NOT(Sulu_Bundle_CoreBundle_Entity_Example.id IN (:id')
         )->shouldNotBeCalled();
 
         $this->doctrineListBuilder->execute();
@@ -819,15 +819,15 @@ class DoctrineListBuilderTest extends TestCase
         ];
 
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect('SuluCoreBundle_Example.id AS title_id')->shouldBeCalled();
-        $this->queryBuilder->addSelect('SuluCoreBundle_Example.id AS desc_id')->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.id AS title_id')->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.id AS desc_id')->shouldBeCalled();
         $this->queryBuilder->setParameter(Argument::containingString('title'), 3)->shouldBeCalled();
         $this->queryBuilder->setParameter(Argument::containingString('desc'), 1)->shouldBeCalled();
         $this->queryBuilder->andWhere(
-            Argument::containingString('SuluCoreBundle_Example.id = :title_id')
+            Argument::containingString('Sulu_Bundle_CoreBundle_Entity_Example.id = :title_id')
         )->shouldBeCalled();
         $this->queryBuilder->andWhere(
-            Argument::containingString('SuluCoreBundle_Example.id = :desc_id')
+            Argument::containingString('Sulu_Bundle_CoreBundle_Entity_Example.id = :desc_id')
         )->shouldBeCalled();
 
         foreach ($filter as $key => $value) {
@@ -857,7 +857,7 @@ class DoctrineListBuilderTest extends TestCase
         ];
 
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect('SuluCoreBundle_Example.id AS title_id')->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.id AS title_id')->shouldBeCalled();
         $this->queryBuilder->setParameter(Argument::containingString('title_id'), Argument::any())->shouldNotBeCalled();
 
         foreach ($filter as $key => $value) {
@@ -865,7 +865,7 @@ class DoctrineListBuilderTest extends TestCase
             $this->doctrineListBuilder->where($fieldDescriptors[$key], $value);
         }
 
-        $this->queryBuilder->andWhere('(SuluCoreBundle_Example.id IS NULL)')->shouldBeCalled();
+        $this->queryBuilder->andWhere('(Sulu_Bundle_CoreBundle_Entity_Example.id IS NULL)')->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -881,7 +881,7 @@ class DoctrineListBuilderTest extends TestCase
         ];
 
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect('SuluCoreBundle_Example.id AS title_id')->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.id AS title_id')->shouldBeCalled();
         $this->queryBuilder->setParameter(Argument::containingString('title_id'), Argument::any())->shouldNotBeCalled();
 
         foreach ($filter as $key => $value) {
@@ -889,7 +889,7 @@ class DoctrineListBuilderTest extends TestCase
             $this->doctrineListBuilder->where($fieldDescriptors[$key], $value, ListBuilderInterface::WHERE_COMPARATOR_UNEQUAL);
         }
 
-        $this->queryBuilder->andWhere('(SuluCoreBundle_Example.id IS NOT NULL)')->shouldBeCalled();
+        $this->queryBuilder->andWhere('(Sulu_Bundle_CoreBundle_Entity_Example.id IS NOT NULL)')->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -907,15 +907,15 @@ class DoctrineListBuilderTest extends TestCase
         ];
 
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect('SuluCoreBundle_Example.id AS title_id')->shouldBeCalled();
-        $this->queryBuilder->addSelect('SuluCoreBundle_Example.id AS desc_id')->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.id AS title_id')->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.id AS desc_id')->shouldBeCalled();
         $this->queryBuilder->setParameter(Argument::containingString('title_id'), 3)->shouldBeCalled();
         $this->queryBuilder->setParameter(Argument::containingString('desc_id'), 1)->shouldBeCalled();
         $this->queryBuilder->andWhere(
-            Argument::containingString('SuluCoreBundle_Example.id != :title_id')
+            Argument::containingString('Sulu_Bundle_CoreBundle_Entity_Example.id != :title_id')
         )->shouldBeCalled();
         $this->queryBuilder->andWhere(
-            Argument::containingString('SuluCoreBundle_Example.id != :desc_id')
+            Argument::containingString('Sulu_Bundle_CoreBundle_Entity_Example.id != :desc_id')
         )->shouldBeCalled();
 
         foreach ($filter as $key => $value) {
@@ -939,10 +939,10 @@ class DoctrineListBuilderTest extends TestCase
         $fieldDescriptor = new DoctrineFieldDescriptor('id', 'title_id', self::$entityName);
 
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect('SuluCoreBundle_Example.id AS title_id')->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.id AS title_id')->shouldBeCalled();
         $this->queryBuilder->setParameter(Argument::containingString('title_id'), [1, 2])->shouldBeCalled();
         $this->queryBuilder->andWhere(
-            Argument::containingString('SuluCoreBundle_Example.id IN (:title_id')
+            Argument::containingString('Sulu_Bundle_CoreBundle_Entity_Example.id IN (:title_id')
         )->shouldBeCalled();
 
         $this->doctrineListBuilder->addSelectField($fieldDescriptor);
@@ -1109,7 +1109,7 @@ class DoctrineListBuilderTest extends TestCase
         $nameFieldDescriptor = new DoctrineFieldDescriptor('name', 'name_alias', self::$entityName);
 
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect('SuluCoreBundle_Example.name AS name_alias')->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.name AS name_alias')->shouldBeCalled();
         $this->queryBuilder->groupBy(self::$entityNameAlias . '.name')->shouldBeCalledTimes(1);
 
         $this->doctrineListBuilder->setSelectFields(
@@ -1128,9 +1128,9 @@ class DoctrineListBuilderTest extends TestCase
         $nameFieldDescriptor = new DoctrineFieldDescriptor('name', 'name_alias', self::$entityName);
 
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect('SuluCoreBundle_Example.name AS name_alias')->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.name AS name_alias')->shouldBeCalled();
         $this->queryBuilder->andWhere(
-            Argument::containingString('SuluCoreBundle_Example.name BETWEEN :name_alias')
+            Argument::containingString('Sulu_Bundle_CoreBundle_Entity_Example.name BETWEEN :name_alias')
         )->shouldBeCalledTimes(1);
         $this->queryBuilder->setParameter(Argument::containingString('name_alias'), 0)->shouldBeCalled();
         $this->queryBuilder->setParameter(Argument::containingString('name_alias'), 1)->shouldBeCalled();
@@ -1209,11 +1209,11 @@ class DoctrineListBuilderTest extends TestCase
     public function testNoIdField(): void
     {
         $this->queryBuilder
-            ->addSelect('SuluCoreBundle_Example.id AS id')
+            ->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.id AS id')
             ->shouldBeCalled()
             ->willReturn($this->queryBuilder->reveal());
         $this->queryBuilder
-            ->where('SuluCoreBundle_Example.id IN (:ids)')
+            ->where('Sulu_Bundle_CoreBundle_Entity_Example.id IN (:ids)')
             ->shouldBeCalled()
             ->willReturn($this->queryBuilder->reveal());
 
@@ -1270,7 +1270,7 @@ class DoctrineListBuilderTest extends TestCase
         $accessQueryBuilder->getQuery()->willReturn($accessQuery->reveal());
         $accessQuery->getScalarResult()->willReturn([['id' => 42]]);
 
-        $this->queryBuilder->andWhere('SuluCoreBundle_Example.id NOT IN (:accessControlIds)')
+        $this->queryBuilder->andWhere('Sulu_Bundle_CoreBundle_Entity_Example.id NOT IN (:accessControlIds)')
             ->shouldBeCalled();
 
         $this->queryBuilder->setParameter('accessControlIds', [42])->shouldBeCalled();
@@ -1332,7 +1332,7 @@ class DoctrineListBuilderTest extends TestCase
         $accessQueryBuilder->getQuery()->willReturn($accessQuery->reveal());
         $accessQuery->getScalarResult()->willReturn([['id' => 42]]);
 
-        $this->queryBuilder->andWhere('SuluCoreBundle_Example.id NOT IN (:accessControlIds)')
+        $this->queryBuilder->andWhere('Sulu_Bundle_CoreBundle_Entity_Example.id NOT IN (:accessControlIds)')
             ->shouldBeCalled();
 
         $this->queryBuilder->setParameter('accessControlIds', [42])->shouldBeCalled();

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineAndExpressionTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineAndExpressionTest.php
@@ -22,7 +22,7 @@ class DoctrineAndExpressionTest extends TestCase
     /**
      * @var string
      */
-    private static $entityName = 'SuluCoreBundle:Example';
+    private static $entityName = 'Sulu\Bundle\CoreBundle\Entity\Example';
 
     /**
      * http://php.net/manual/en/function.uniqid.php
@@ -60,7 +60,7 @@ class DoctrineAndExpressionTest extends TestCase
         $statement = $andExpression->getStatement($this->queryBuilder);
         $result = \preg_match(
             \sprintf(
-                '/^SuluCoreBundle_Example\.name1 = :name1[\S]{%1$s} AND SuluCoreBundle_Example\.name2 = :name2[\S]{%1$s}/',
+                '/^Sulu_Bundle_CoreBundle_Entity_Example\.name1 = :name1[\S]{%1$s} AND Sulu_Bundle_CoreBundle_Entity_Example\.name2 = :name2[\S]{%1$s}/',
                 $this->uniqueIdLength
             ),
             $statement

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineBetweenExpressionTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineBetweenExpressionTest.php
@@ -21,7 +21,7 @@ class DoctrineBetweenExpressionTest extends TestCase
     /**
      * @var string
      */
-    private static $entityName = 'SuluCoreBundle:Example';
+    private static $entityName = 'Sulu\Bundle\CoreBundle\Entity\Example';
 
     /**
      * http://php.net/manual/en/function.uniqid.php
@@ -56,7 +56,7 @@ class DoctrineBetweenExpressionTest extends TestCase
         $statement = $whereExpression->getStatement($this->queryBuilder);
         $result = \preg_match(
             \sprintf(
-                '/^SuluCoreBundle_Example\.name BETWEEN :name[\S]{%1$s} AND :name[\S]{%1$s}/',
+                '/^Sulu_Bundle_CoreBundle_Entity_Example\.name BETWEEN :name[\S]{%1$s} AND :name[\S]{%1$s}/',
                 $this->uniqueIdLength
             ),
             $statement

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineInExpressionTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineInExpressionTest.php
@@ -21,7 +21,7 @@ class DoctrineInExpressionTest extends TestCase
     /**
      * @var string
      */
-    private static $entityName = 'SuluCoreBundle:Example';
+    private static $entityName = 'Sulu\Bundle\CoreBundle\Entity\Example';
 
     /**
      * http://php.net/manual/en/function.uniqid.php
@@ -54,7 +54,7 @@ class DoctrineInExpressionTest extends TestCase
 
         $statement = $whereExpression->getStatement($this->queryBuilder);
         $result = \preg_match(
-            \sprintf('/^SuluCoreBundle_Example\.name IN \(:name\S{%s}\)/', $this->uniqueIdLength),
+            \sprintf('/^Sulu_Bundle_CoreBundle_Entity_Example\.name IN \(:name\S{%s}\)/', $this->uniqueIdLength),
             $statement
         );
 
@@ -69,7 +69,7 @@ class DoctrineInExpressionTest extends TestCase
 
         $statement = $whereExpression->getStatement($this->queryBuilder);
         $result = \preg_match(
-            '/^SuluCoreBundle_Example\.name IS NULL/',
+            '/^Sulu_Bundle_CoreBundle_Entity_Example\.name IS NULL/',
             $statement
         );
 

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineNotExpressionTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineNotExpressionTest.php
@@ -22,7 +22,7 @@ class DoctrineNotExpressionTest extends TestCase
     /**
      * @var string
      */
-    private static $entityName = 'SuluCoreBundle:Example';
+    private static $entityName = 'Sulu\Bundle\CoreBundle\Entity\Example';
 
     /**
      * http://php.net/manual/en/function.uniqid.php
@@ -55,7 +55,7 @@ class DoctrineNotExpressionTest extends TestCase
 
         $notExpression = new DoctrineNotExpression($whereExpression);
         $result = \preg_match(
-            \sprintf('/^NOT\(SuluCoreBundle_Example\.name IN \(:name\S{%s}\)\)/', $this->uniqueIdLength),
+            \sprintf('/^NOT\(Sulu_Bundle_CoreBundle_Entity_Example\.name IN \(:name\S{%s}\)\)/', $this->uniqueIdLength),
             $notExpression->getStatement($this->queryBuilder)
         );
 

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineOrExpressionTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineOrExpressionTest.php
@@ -22,7 +22,7 @@ class DoctrineOrExpressionTest extends TestCase
     /**
      * @var string
      */
-    private static $entityName = 'SuluCoreBundle:Example';
+    private static $entityName = 'Sulu\Bundle\CoreBundle\Entity\Example';
 
     /**
      * http://php.net/manual/en/function.uniqid.php
@@ -60,7 +60,7 @@ class DoctrineOrExpressionTest extends TestCase
         $statement = $andExpression->getStatement($this->queryBuilder);
         $result = \preg_match(
             \sprintf(
-                '/^SuluCoreBundle_Example\.name1 = :name1[\S]{%1$s} OR SuluCoreBundle_Example\.name2 = :name2[\S]{%1$s}/',
+                '/^Sulu_Bundle_CoreBundle_Entity_Example\.name1 = :name1[\S]{%1$s} OR Sulu_Bundle_CoreBundle_Entity_Example\.name2 = :name2[\S]{%1$s}/',
                 $this->uniqueIdLength
             ),
             $statement

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineWhereExpressionTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineWhereExpressionTest.php
@@ -27,7 +27,7 @@ class DoctrineWhereExpressionTest extends TestCase
     /**
      * @var string
      */
-    private static $entityName = 'SuluCoreBundle:Example';
+    private static $entityName = 'Sulu\Bundle\CoreBundle\Entity\Example';
 
     /**
      * http://php.net/manual/en/function.uniqid.php
@@ -58,7 +58,7 @@ class DoctrineWhereExpressionTest extends TestCase
         // parameter names will be generated (combined with unique ids with length of 23 characters)
         $statement = $whereExpression->getStatement($this->queryBuilder->reveal());
         $result = \preg_match(
-            \sprintf('/^SuluCoreBundle_Example\.name = :name[\S]{%s}/', $this->uniqueIdLength),
+            \sprintf('/^Sulu_Bundle_CoreBundle_Entity_Example\.name = :name[\S]{%s}/', $this->uniqueIdLength),
             $statement
         );
         $this->assertEquals(1, $result);
@@ -81,7 +81,7 @@ class DoctrineWhereExpressionTest extends TestCase
         $whereExpression = new DoctrineWhereExpression($fieldDescriptor, null, $comparator);
 
         $this->assertEquals(
-            'SuluCoreBundle_Example.name ' . $expected,
+            'Sulu_Bundle_CoreBundle_Entity_Example.name ' . $expected,
             $whereExpression->getStatement($this->queryBuilder->reveal())
         );
     }
@@ -97,7 +97,7 @@ class DoctrineWhereExpressionTest extends TestCase
         // parameter names will be generated (combined with unique ids with length of 23 characters)
         $statement = $whereExpression->getStatement($this->queryBuilder->reveal());
         $result = \preg_match(
-            \sprintf('/^SuluCoreBundle_Example\.name LIKE :name[\S]{%s}/', $this->uniqueIdLength),
+            \sprintf('/^Sulu_Bundle_CoreBundle_Entity_Example\.name LIKE :name[\S]{%s}/', $this->uniqueIdLength),
             $statement
         );
         $this->assertEquals(1, $result);
@@ -124,7 +124,7 @@ class DoctrineWhereExpressionTest extends TestCase
         $statement = $whereExpression->getStatement($this->queryBuilder->reveal());
         $result = \preg_match(
             \sprintf(
-                '/^(SuluCoreBundle_Example\.name = :name[\S]{%s}[\S]{1}( %s )?){3}/',
+                '/^(Sulu_Bundle_CoreBundle_Entity_Example\.name = :name[\S]{%s}[\S]{1}( %s )?){3}/',
                 $this->uniqueIdLength,
                 $comparator
             ),

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
@@ -48,15 +48,15 @@ class ListXmlLoaderTest extends TestCase
 
         $this->parameterBag = $this->prophesize(ParameterBagInterface::class);
 
-        $this->parameterBag->resolveValue('%sulu.model.contact.class%')->willReturn('SuluContactBundle:Contact');
+        $this->parameterBag->resolveValue('%sulu.model.contact.class%')->willReturn('Sulu\Bundle\ContactBundle\Entity\Contact');
         $this->parameterBag->resolveValue('%sulu.model.contact.class%.avatar')->willReturn(
-            'SuluContactBundle:Contact.avatar'
+            'Sulu\Bundle\ContactBundle\Entity\Contact.avatar'
         );
         $this->parameterBag->resolveValue('%sulu.model.contact.class%.contactAddresses')->willReturn(
-            'SuluContactBundle:Contact.contactAddresses'
+            'Sulu\Bundle\ContactBundle\Entity\Contact.contactAddresses'
         );
         $this->parameterBag->resolveValue('%sulu.model.contact.class%.tags')->willReturn(
-            'SuluContactBundle:Contact.tags'
+            'Sulu\Bundle\ContactBundle\Entity\Contact.tags'
         );
         $this->parameterBag->resolveValue('%test-parameter%')->willReturn('test-value');
         $this->parameterBag->resolveValue(Argument::any())->willReturnArgument(0);
@@ -76,7 +76,7 @@ class ListXmlLoaderTest extends TestCase
         $this->assertSingleMetadata(
             [
                 'name' => 'id',
-                'entityName' => 'SuluContactBundle:Contact',
+                'entityName' => 'Sulu\Bundle\ContactBundle\Entity\Contact',
                 'translation' => 'public.id',
                 'type' => 'integer',
             ],
@@ -85,7 +85,7 @@ class ListXmlLoaderTest extends TestCase
         $this->assertSingleMetadata(
             [
                 'name' => 'firstName',
-                'entityName' => 'SuluContactBundle:Contact',
+                'entityName' => 'Sulu\Bundle\ContactBundle\Entity\Contact',
                 'translation' => 'contact.contacts.firstName',
                 'visibility' => FieldDescriptorInterface::VISIBILITY_ALWAYS,
             ],
@@ -94,7 +94,7 @@ class ListXmlLoaderTest extends TestCase
         $this->assertSingleMetadata(
             [
                 'name' => 'lastName',
-                'entityName' => 'SuluContactBundle:Contact',
+                'entityName' => 'Sulu\Bundle\ContactBundle\Entity\Contact',
                 'translation' => 'contact.contacts.lastName',
                 'visibility' => FieldDescriptorInterface::VISIBILITY_ALWAYS,
             ],
@@ -103,15 +103,15 @@ class ListXmlLoaderTest extends TestCase
         $this->assertSingleMetadata(
             [
                 'name' => 'avatar',
-                'entityName' => 'SuluMediaBundle:Media',
+                'entityName' => 'Sulu\Bundle\MediaBundle\Entity\Media',
                 'translation' => 'public.avatar',
                 'visibility' => FieldDescriptorInterface::VISIBILITY_ALWAYS,
                 'type' => 'thumbnails',
                 'sortable' => false,
                 'joins' => [
                     [
-                        'entityName' => 'SuluMediaBundle:Media',
-                        'entityField' => 'SuluContactBundle:Contact.avatar',
+                        'entityName' => 'Sulu\Bundle\MediaBundle\Entity\Media',
+                        'entityField' => 'Sulu\Bundle\ContactBundle\Entity\Contact.avatar',
                     ],
                 ],
             ],
@@ -129,11 +129,11 @@ class ListXmlLoaderTest extends TestCase
                 'fields' => [
                     [
                         'name' => 'firstName',
-                        'entityName' => 'SuluContactBundle:Contact',
+                        'entityName' => 'Sulu\Bundle\ContactBundle\Entity\Contact',
                     ],
                     [
                         'name' => 'lastName',
-                        'entityName' => 'SuluContactBundle:Contact',
+                        'entityName' => 'Sulu\Bundle\ContactBundle\Entity\Contact',
                     ],
                 ],
             ],
@@ -156,7 +156,7 @@ class ListXmlLoaderTest extends TestCase
                 'name' => 'id',
                 'translation' => 'public.id',
                 'type' => 'integer',
-                'entityName' => 'SuluContactBundle:Contact',
+                'entityName' => 'Sulu\Bundle\ContactBundle\Entity\Contact',
             ],
             $propertiesMetadata[0]
         );
@@ -166,7 +166,7 @@ class ListXmlLoaderTest extends TestCase
                 'translation' => 'contact.contacts.firstName',
                 'visibility' => FieldDescriptorInterface::VISIBILITY_ALWAYS,
                 'searchability' => FieldDescriptorInterface::SEARCHABILITY_YES,
-                'entityName' => 'SuluContactBundle:Contact',
+                'entityName' => 'Sulu\Bundle\ContactBundle\Entity\Contact',
                 'width' => FieldDescriptorInterface::WIDTH_SHRINK,
             ],
             $propertiesMetadata[1]
@@ -177,7 +177,7 @@ class ListXmlLoaderTest extends TestCase
                 'translation' => 'contact.contacts.lastName',
                 'visibility' => FieldDescriptorInterface::VISIBILITY_ALWAYS,
                 'searchability' => FieldDescriptorInterface::SEARCHABILITY_NO,
-                'entityName' => 'SuluContactBundle:Contact',
+                'entityName' => 'Sulu\Bundle\ContactBundle\Entity\Contact',
             ],
             $propertiesMetadata[2]
         );
@@ -198,7 +198,7 @@ class ListXmlLoaderTest extends TestCase
                 'name' => 'id',
                 'translation' => 'public.id',
                 'type' => 'integer',
-                'entityName' => 'SuluContactBundle:Contact',
+                'entityName' => 'Sulu\Bundle\ContactBundle\Entity\Contact',
             ],
             $propertiesMetadata[0]
         );
@@ -208,7 +208,7 @@ class ListXmlLoaderTest extends TestCase
                 'translation' => 'contact.contacts.firstName',
                 'visibility' => FieldDescriptorInterface::VISIBILITY_ALWAYS,
                 'searchability' => FieldDescriptorInterface::SEARCHABILITY_YES,
-                'entityName' => 'SuluContactBundle:Contact',
+                'entityName' => 'Sulu\Bundle\ContactBundle\Entity\Contact',
             ],
             $propertiesMetadata[1]
         );
@@ -218,7 +218,7 @@ class ListXmlLoaderTest extends TestCase
                 'translation' => 'contact.contacts.lastName',
                 'visibility' => FieldDescriptorInterface::VISIBILITY_ALWAYS,
                 'searchability' => FieldDescriptorInterface::SEARCHABILITY_NO,
-                'entityName' => 'SuluContactBundle:Contact',
+                'entityName' => 'Sulu\Bundle\ContactBundle\Entity\Contact',
             ],
             $propertiesMetadata[2]
         );
@@ -358,11 +358,11 @@ class ListXmlLoaderTest extends TestCase
             [
                 'name' => 'tags',
                 'translation' => 'Tags',
-                'entityName' => 'SuluTagBundle:Tag',
+                'entityName' => 'Sulu\Bundle\TagBundle\Entity\Tag',
                 'joins' => [
                     [
-                        'entityName' => 'SuluTagBundle:Tag',
-                        'entityField' => 'SuluContactBundle:Contact.tags',
+                        'entityName' => 'Sulu\Bundle\TagBundle\Entity\Tag',
+                        'entityField' => 'Sulu\Bundle\ContactBundle\Entity\Contact.tags',
                     ],
                 ],
                 'filter-type' => 'test',
@@ -391,7 +391,7 @@ class ListXmlLoaderTest extends TestCase
             [
                 'name' => 'tags',
                 'translation' => 'Tags',
-                'entityName' => 'SuluContactBundle:Contact',
+                'entityName' => 'Sulu\Bundle\ContactBundle\Entity\Contact',
                 'filter-type' => 'test',
                 'filter-type-params' => [
                     'testCollection' => [
@@ -419,7 +419,7 @@ class ListXmlLoaderTest extends TestCase
             [
                 'name' => 'tags',
                 'translation' => 'Tags',
-                'entityName' => 'SuluContactBundle:Contact',
+                'entityName' => 'Sulu\Bundle\ContactBundle\Entity\Contact',
                 'filter-type' => 'test',
                 'filter-type-params' => [
                     'testCollection' => [

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/Resources/complete.xml
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/Resources/complete.xml
@@ -3,14 +3,14 @@
 
     <joins name="address">
         <join>
-            <entity-name>SuluContactBundle:ContactAddress</entity-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\ContactAddress</entity-name>
             <field-name>%sulu.model.contact.class%.contactAddresses</field-name>
             <method>LEFT</method>
-            <condition>SuluContactBundle:ContactAddress.main = TRUE</condition>
+            <condition>Sulu\Bundle\ContactBundle\Entity\ContactAddress.main = TRUE</condition>
         </join>
         <join>
-            <entity-name>SuluContactBundle:Address</entity-name>
-            <field-name>SuluContactBundle:ContactAddress.address</field-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\Address</entity-name>
+            <field-name>Sulu\Bundle\ContactBundle\Entity\ContactAddress.address</field-name>
         </join>
     </joins>
 
@@ -34,10 +34,10 @@
 
         <property name="avatar" translation="public.avatar" visibility="always" sortable="false">
             <field-name>id</field-name>
-            <entity-name>SuluMediaBundle:Media</entity-name>
+            <entity-name>Sulu\Bundle\MediaBundle\Entity\Media</entity-name>
             <joins>
                 <join>
-                    <entity-name>SuluMediaBundle:Media</entity-name>
+                    <entity-name>Sulu\Bundle\MediaBundle\Entity\Media</entity-name>
                     <field-name>%sulu.model.contact.class%.avatar</field-name>
                 </join>
             </joins>
@@ -62,7 +62,7 @@
 
         <property name="city" translation="contact.address.city" visibility="yes">
             <field-name>city</field-name>
-            <entity-name>SuluContactBundle:Address</entity-name>
+            <entity-name>Sulu\Bundle\ContactBundle\Entity\Address</entity-name>
             <joins ref="address"/>
         </property>
     </properties>

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/Resources/group-concat.xml
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/Resources/group-concat.xml
@@ -4,11 +4,11 @@
     <properties>
         <group-concat-property name="tags" glue=",">
             <field-name>name</field-name>
-            <entity-name>SuluTagBundle:Tag</entity-name>
+            <entity-name>Sulu\Bundle\TagBundle\Entity\Tag</entity-name>
 
             <joins>
                 <join>
-                    <entity-name>SuluTagBundle:Tag</entity-name>
+                    <entity-name>Sulu\Bundle\TagBundle\Entity\Tag</entity-name>
                     <field-name>%sulu.model.contact.class%.tags</field-name>
                 </join>
             </joins>

--- a/src/Sulu/Component/Rest/Tests/Unit/Listing/ListQueryBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/Listing/ListQueryBuilderTest.php
@@ -21,7 +21,7 @@ class ListQueryBuilderTest extends TestCase
         $builder = new ListQueryBuilder(
             [],
             [],
-            'SuluCoreBundle:Example',
+            'Sulu\Bundle\CoreBundle\Entity\Example',
             [],
             [],
             [],
@@ -30,7 +30,7 @@ class ListQueryBuilderTest extends TestCase
 
         $dql = \str_replace(' ,', ',', \trim(\preg_replace('/\s+/', ' ', $builder->find())));
 
-        $this->assertEquals('SELECT u FROM SuluCoreBundle:Example u', $dql);
+        $this->assertEquals('SELECT u FROM Sulu\Bundle\CoreBundle\Entity\Example u', $dql);
     }
 
     public function testFindWithFields(): void
@@ -38,7 +38,7 @@ class ListQueryBuilderTest extends TestCase
         $builder = new ListQueryBuilder(
             [],
             ['field1', 'field2', 'field3'],
-            'SuluCoreBundle:Example',
+            'Sulu\Bundle\CoreBundle\Entity\Example',
             ['field1', 'field2', 'field3'],
             [],
             [],
@@ -47,7 +47,7 @@ class ListQueryBuilderTest extends TestCase
 
         $dql = \str_replace(' ,', ',', \trim(\preg_replace('/\s+/', ' ', $builder->find())));
 
-        $this->assertEquals('SELECT u.field1, u.field2, u.field3 FROM SuluCoreBundle:Example u', $dql);
+        $this->assertEquals('SELECT u.field1, u.field2, u.field3 FROM Sulu\Bundle\CoreBundle\Entity\Example u', $dql);
     }
 
     public function testFindWithSorting(): void
@@ -55,7 +55,7 @@ class ListQueryBuilderTest extends TestCase
         $builder = new ListQueryBuilder(
             [],
             [],
-            'SuluCoreBundle:Example',
+            'Sulu\Bundle\CoreBundle\Entity\Example',
             [],
             ['sortField' => 'ASC'],
             [],
@@ -64,7 +64,7 @@ class ListQueryBuilderTest extends TestCase
 
         $dql = \str_replace(' ,', ',', \trim(\preg_replace('/\s+/', ' ', $builder->find())));
 
-        $this->assertEquals('SELECT u FROM SuluCoreBundle:Example u ORDER BY u.sortField ASC', $dql);
+        $this->assertEquals('SELECT u FROM Sulu\Bundle\CoreBundle\Entity\Example u ORDER BY u.sortField ASC', $dql);
     }
 
     public function testFindWithWhere(): void
@@ -72,7 +72,7 @@ class ListQueryBuilderTest extends TestCase
         $builder = new ListQueryBuilder(
             [],
             [],
-            'SuluCoreBundle:Example',
+            'Sulu\Bundle\CoreBundle\Entity\Example',
             [],
             [],
             ['field1' => 1, 'field2' => 2],
@@ -81,7 +81,7 @@ class ListQueryBuilderTest extends TestCase
 
         $dql = \str_replace(' ,', ',', \trim(\preg_replace('/\s+/', ' ', $builder->find())));
 
-        $this->assertEquals('SELECT u FROM SuluCoreBundle:Example u WHERE u.field1 = 1 AND u.field2 = 2', $dql);
+        $this->assertEquals('SELECT u FROM Sulu\Bundle\CoreBundle\Entity\Example u WHERE u.field1 = 1 AND u.field2 = 2', $dql);
     }
 
     public function testFindWithSearch(): void
@@ -89,7 +89,7 @@ class ListQueryBuilderTest extends TestCase
         $builder = new ListQueryBuilder(
             [],
             [],
-            'SuluCoreBundle:Example',
+            'Sulu\Bundle\CoreBundle\Entity\Example',
             [],
             [],
             [],
@@ -98,7 +98,7 @@ class ListQueryBuilderTest extends TestCase
 
         $dql = \str_replace(' ,', ',', \trim(\preg_replace('/\s+/', ' ', $builder->find())));
 
-        $this->assertEquals('SELECT u FROM SuluCoreBundle:Example u WHERE (u.field LIKE :search)', $dql);
+        $this->assertEquals('SELECT u FROM Sulu\Bundle\CoreBundle\Entity\Example u WHERE (u.field LIKE :search)', $dql);
     }
 
     public function testFindWithWhereAndSearch(): void
@@ -106,7 +106,7 @@ class ListQueryBuilderTest extends TestCase
         $builder = new ListQueryBuilder(
             [],
             [],
-            'SuluCoreBundle:Example',
+            'Sulu\Bundle\CoreBundle\Entity\Example',
             [],
             [],
             ['field1' => 1, 'field2' => 2],
@@ -116,7 +116,7 @@ class ListQueryBuilderTest extends TestCase
         $dql = \str_replace(' ,', ',', \trim(\preg_replace('/\s+/', ' ', $builder->find())));
 
         $this->assertEquals(
-            'SELECT u FROM SuluCoreBundle:Example u WHERE u.field1 = 1 AND u.field2 = 2 AND (u.field LIKE :search)',
+            'SELECT u FROM Sulu\Bundle\CoreBundle\Entity\Example u WHERE u.field1 = 1 AND u.field2 = 2 AND (u.field LIKE :search)',
             $dql
         );
     }
@@ -126,7 +126,7 @@ class ListQueryBuilderTest extends TestCase
         $builder = new ListQueryBuilder(
             [],
             [],
-            'SuluCoreBundle:Example',
+            'Sulu\Bundle\CoreBundle\Entity\Example',
             [],
             [],
             ['field1' => 1, 'field2' => 2],
@@ -137,7 +137,7 @@ class ListQueryBuilderTest extends TestCase
         $dql = \str_replace(' ,', ',', \trim(\preg_replace('/\s+/', ' ', $builder->find())));
 
         $this->assertEquals(
-            'SELECT u FROM SuluCoreBundle:Example u WHERE u.field1 = 1 AND u.field2 = 2 AND (u.field1 LIKE :search OR u.field2 = :strictSearch OR u.field3 = :strictSearch)',
+            'SELECT u FROM Sulu\Bundle\CoreBundle\Entity\Example u WHERE u.field1 = 1 AND u.field2 = 2 AND (u.field1 LIKE :search OR u.field2 = :strictSearch OR u.field3 = :strictSearch)',
             $dql
         );
     }
@@ -147,7 +147,7 @@ class ListQueryBuilderTest extends TestCase
         $builder = new ListQueryBuilder(
             ['object', 'otherobject'],
             [],
-            'SuluCoreBundle:Example',
+            'Sulu\Bundle\CoreBundle\Entity\Example',
             ['object_field1', 'object_field2', 'otherobject_field3'],
             [],
             [],
@@ -158,7 +158,7 @@ class ListQueryBuilderTest extends TestCase
 
         $this->assertEquals(
             'SELECT object.field1 object_field1, object.field2 object_field2, otherobject.field3 otherobject_field3 ' .
-            'FROM SuluCoreBundle:Example u LEFT JOIN u.object object LEFT JOIN u.otherobject otherobject',
+            'FROM Sulu\Bundle\CoreBundle\Entity\Example u LEFT JOIN u.object object LEFT JOIN u.otherobject otherobject',
             $dql
         );
     }
@@ -168,7 +168,7 @@ class ListQueryBuilderTest extends TestCase
         $builder = new ListQueryBuilder(
             [],
             [],
-            'SuluCoreBundle:Example',
+            'Sulu\Bundle\CoreBundle\Entity\Example',
             [],
             [],
             [],
@@ -179,6 +179,6 @@ class ListQueryBuilderTest extends TestCase
 
         $dql = \str_replace(' ,', ',', \trim(\preg_replace('/\s+/', ' ', $builder->find())));
 
-        $this->assertEquals('SELECT COUNT(u.id) as total FROM SuluCoreBundle:Example u', $dql);
+        $this->assertEquals('SELECT COUNT(u.id) as total FROM Sulu\Bundle\CoreBundle\Entity\Example u', $dql);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no (but not really sure)
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

This is a refactoring only PR. All usages of short namespace aliases for doctrine entities are changed to FQCN.


#### Why?

This is required to allow doctrine/persistence 3.0, because it has removed support for those aliases (see [here](https://github.com/doctrine/persistence/blob/8bf8ab15960787f1a49d405f6eb8c787b4841119/UPGRADE.md)).

