### PR TITLE
Fix unexpected jackalope behaviour by making phpcr sessions lazy

### DIFF
--- a/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
@@ -159,6 +159,7 @@ class SuluDocumentManagerExtension extends Extension implements PrependExtension
 
         $defaultSessionDefinition = new Definition(Session::class, [new Reference('sulu_document_manager.decorated_default_session.inner')]);
         $defaultSessionDefinition->setDecoratedService($defaultSessionId);
+        $defaultSessionDefinition->setLazy(true); // see https://github.com/jackalope/jackalope-doctrine-dbal/issues/412#issuecomment-1447062722
         $container->setDefinition('sulu_document_manager.decorated_default_session', $defaultSessionDefinition);
 
         $liveSessionId = $this->getSessionServiceId($config['live_session']);
@@ -169,6 +170,7 @@ class SuluDocumentManagerExtension extends Extension implements PrependExtension
 
         $liveSessionDefinition = new Definition(Session::class, [new Reference('sulu_document_manager.decorated_live_session.inner')]);
         $liveSessionDefinition->setDecoratedService($liveSessionId);
+        $liveSessionDefinition->setLazy(true); // see https://github.com/jackalope/jackalope-doctrine-dbal/issues/412#issuecomment-1447062722
         $container->setDefinition('sulu_document_manager.decorated_live_session', $liveSessionDefinition);
 
         $container->setParameter(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #7025
| Related issues/PRs | https://github.com/symfony/symfony/issues/49591, https://github.com/jackalope/jackalope-doctrine-dbal/issues/412#issuecomment-1447062722
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Make the definitions of the phpcr sessions lazy.

#### Why?

This is currently a workaround for the following issue @dbu debugged here: https://github.com/jackalope/jackalope-doctrine-dbal/issues/412#issuecomment-1447062722. The current open issue on the symfony side can be found here: https://github.com/symfony/symfony/issues/49591

