### PR TITLE
Migrate deprecations to symfony/deprecation-contracts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,7 @@
         "symfony/console": "^4.4 || ^5.0",
         "symfony/css-selector": "^4.4 || ^5.0",
         "symfony/dependency-injection": "^4.4 || ^5.0",
+        "symfony/deprecation-contracts": "^2.1 || ^3.0",
         "symfony/dom-crawler": "^4.4 || ^5.0",
         "symfony/event-dispatcher": "^4.4 || ^5.0",
         "symfony/event-dispatcher-contracts": "^1.0 || ^2.0",

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilder.php
@@ -58,7 +58,7 @@ class FormOverlayListViewBuilder implements FormOverlayListViewBuilderInterface
      */
     public function setRequestParameters(array $requestParameters): FormOverlayListViewBuilderInterface
     {
-        @\trigger_error('The usage of the "setRequestParameters" method in the FormOverlayListViewBuilder is deprecated. Please use "addRequestParameters" instead.', \E_USER_DEPRECATED);
+        @\trigger_deprecation('sulu/sulu', '2.1', 'The usage of the "setRequestParameters" method in the FormOverlayListViewBuilder is deprecated. Please use "addRequestParameters" instead.');
 
         $this->setRequestParametersToView($this->view, $requestParameters);
 

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilder.php
@@ -43,7 +43,7 @@ class FormViewBuilder implements FormViewBuilderInterface
      */
     public function setRequestParameters(array $requestParameters): FormViewBuilderInterface
     {
-        @\trigger_error('The usage of the "setRequestParameters" method in the FormViewBuilder is deprecated. Please use "addRequestParameters" instead.', \E_USER_DEPRECATED);
+        @\trigger_deprecation('sulu/sulu', '2.1', 'The usage of the "setRequestParameters" method in the FormViewBuilder is deprecated. Please use "addRequestParameters" instead.');
 
         $this->setRequestParametersToView($this->view, $requestParameters);
 

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilderTrait.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilderTrait.php
@@ -59,10 +59,9 @@ trait ListViewBuilderTrait
                     $this->addAdapterOptionsToView($route, [$defaultAdapter => $options]);
                     $listAdapters[$index] = $defaultAdapter;
 
-                    @\trigger_error(
+                    @\trigger_deprecation('sulu/sulu', '2.3',
                         'The usage of the "' . $adapter . '" is deprecated.' .
-                        'Please use "' . $defaultAdapter . '"  with adapterOptions instead.',
-                        \E_USER_DEPRECATED
+                        'Please use "' . $defaultAdapter . '"  with adapterOptions instead.'
                     );
                 }
             }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/PreviewFormViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/PreviewFormViewBuilder.php
@@ -57,7 +57,7 @@ class PreviewFormViewBuilder implements PreviewFormViewBuilderInterface
      */
     public function setRequestParameters(array $requestParameters): PreviewFormViewBuilderInterface
     {
-        @\trigger_error('The usage of the "setRequestParameters" method in the PreviewFormViewBuilder is deprecated. Please use "addRequestParameters" instead.', \E_USER_DEPRECATED);
+        @\trigger_deprecation('sulu/sulu', '2.1', 'The usage of the "setRequestParameters" method in the PreviewFormViewBuilder is deprecated. Please use "addRequestParameters" instead.');
 
         $this->setRequestParametersToView($this->view, $requestParameters);
 

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/TabViewBuilderTrait.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/TabViewBuilderTrait.php
@@ -26,7 +26,7 @@ trait TabViewBuilderTrait
      */
     private function setTabTitleToView(View $view, string $tabTitle): void
     {
-        @\trigger_error('The method TabViewBuilderTrait::setTabTitleToView() is deprecated since Sulu 2.1. Use TabViewChildBuilderTrait::setTabTitleToView() instead.', \E_USER_DEPRECATED);
+        @\trigger_deprecation('sulu/sulu', '2.1', 'The method TabViewBuilderTrait::setTabTitleToView() is deprecated. Use TabViewChildBuilderTrait::setTabTitleToView() instead.');
 
         $this->parentSetTabTitleToView($view, $tabTitle);
     }
@@ -37,7 +37,7 @@ trait TabViewBuilderTrait
      */
     private function setTabConditionToView(View $view, string $tabCondition): void
     {
-        @\trigger_error('The method TabViewBuilderTrait::setTabConditionToView() is deprecated since Sulu 2.1. Use TabViewChildBuilderTrait::setTabConditionToView() instead.', \E_USER_DEPRECATED);
+        @\trigger_deprecation('sulu/sulu', '2.1', 'The method TabViewBuilderTrait::setTabConditionToView() is deprecated. Use TabViewChildBuilderTrait::setTabConditionToView() instead.');
 
         $this->parentSetTabConditionToView($view, $tabCondition);
     }
@@ -48,7 +48,7 @@ trait TabViewBuilderTrait
      */
     private function setTabOrderToView(View $view, int $tabOrder): void
     {
-        @\trigger_error('The method TabViewBuilderTrait::setTabOrderToView() is deprecated since Sulu 2.1. Use TabViewChildBuilderTrait::setTabOrderToView() instead.', \E_USER_DEPRECATED);
+        @\trigger_deprecation('sulu/sulu', '2.1', 'The method TabViewBuilderTrait::setTabOrderToView() is deprecated. Use TabViewChildBuilderTrait::setTabOrderToView() instead.');
 
         $this->parentSetTabOrderToView($view, $tabOrder);
     }
@@ -59,7 +59,7 @@ trait TabViewBuilderTrait
      */
     private function setTabPriorityToView(View $view, int $tabPriority): void
     {
-        @\trigger_error('The method TabViewBuilderTrait::setTabPriorityToView() is deprecated since Sulu 2.1. Use TabViewChildBuilderTrait::setTabPriorityToView() instead.', \E_USER_DEPRECATED);
+        @\trigger_deprecation('sulu/sulu', '2.1', 'The method TabViewBuilderTrait::setTabPriorityToView() is deprecated. Use TabViewChildBuilderTrait::setTabPriorityToView() instead.');
 
         $this->parentSetTabPriorityToView($view, $tabPriority);
     }

--- a/src/Sulu/Bundle/AdminBundle/Command/DownloadBuildCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/DownloadBuildCommand.php
@@ -15,13 +15,12 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-@\trigger_error(
-    \sprintf(
-        'The "%s" class is deprecated since Sulu 2, use "%s" instead.',
-        DownloadBuildCommand::class,
-        UpdateBuildCommand::class
-    ),
-    \E_USER_DEPRECATED
+@\trigger_deprecation(
+    'sulu/sulu',
+    '2.0',
+    'The "%s" class is deprecated, use "%s" instead.',
+    DownloadBuildCommand::class,
+    UpdateBuildCommand::class
 );
 
 /**

--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -209,7 +209,7 @@ class AdminController
         $this->collaborationInterval = $collaborationInterval;
 
         if (null === $collaborationEnabled) {
-            @\trigger_error('Instantiating the AdminController without the $collaborationEnabled argument is deprecated!', \E_USER_DEPRECATED);
+            @\trigger_deprecation('sulu/sulu', '2.3', 'Instantiating the AdminController without the $collaborationEnabled argument is deprecated!');
         }
 
         $this->collaborationEnabled = $collaborationEnabled ?? true;

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
@@ -57,7 +57,7 @@ class FormMetadataProvider implements MetadataProviderInterface
         $this->typedFormMetadataVisitors = $typedFormMetadataVisitors;
 
         if (!$fallbackLocale) {
-            @\trigger_error('The usage of the "FormMetadataProvider" without "$fallbackLocale" is deprecated. Please add "$fallbackLocale" instead.', \E_USER_DEPRECATED);
+            @\trigger_deprecation('sulu/sulu', '2.4', 'The usage of the "FormMetadataProvider" without "$fallbackLocale" is deprecated. Please add "$fallbackLocale" instead.');
 
             $fallbackLocale = 'en';
         }

--- a/src/Sulu/Bundle/CategoryBundle/Category/CategoryManager.php
+++ b/src/Sulu/Bundle/CategoryBundle/Category/CategoryManager.php
@@ -440,9 +440,10 @@ class CategoryManager implements CategoryManagerInterface
 
     public function find($parent = null, $depth = null, $sortBy = null, $sortOrder = null)
     {
-        @\trigger_error(
-            __METHOD__ . '() is deprecated since version 1.4 and will be removed in 2.0. Use findChildrenByParentId() instead.',
-            \E_USER_DEPRECATED
+        @\trigger_deprecation(
+            'sulu/sulu',
+            '1.4',
+            __METHOD__ . '() is deprecated and will be removed in 2.0. Use findChildrenByParentId() instead.'
         );
 
         if ($parent && !$this->categoryRepository->isCategoryId($parent)) {
@@ -454,9 +455,10 @@ class CategoryManager implements CategoryManagerInterface
 
     public function findChildren($key, $sortBy = null, $sortOrder = null)
     {
-        @\trigger_error(
-            __METHOD__ . '() is deprecated since version 1.4 and will be removed in 2.0. Use findChildrenByParentKey() instead.',
-            \E_USER_DEPRECATED
+        @\trigger_deprecation(
+            'sulu/sulu',
+            '1.4',
+            __METHOD__ . '() is deprecated and will be removed in 2.0. Use findChildrenByParentKey() instead.'
         );
 
         return $this->categoryRepository->findChildren($key, $sortBy, $sortOrder);

--- a/src/Sulu/Bundle/CategoryBundle/Entity/Category.php
+++ b/src/Sulu/Bundle/CategoryBundle/Entity/Category.php
@@ -277,7 +277,7 @@ class Category implements CategoryInterface
 
     public function addChildren(CategoryInterface $child)
     {
-        @\trigger_error(__METHOD__ . '() is deprecated since version 1.4 and will be removed in 2.0. Use addChild() instead.', \E_USER_DEPRECATED);
+        @\trigger_deprecation('sulu/sulu', '1.4', __METHOD__ . '() is deprecated and will be removed in 2.0. Use addChild() instead.');
 
         $this->addChild($child);
     }
@@ -291,7 +291,7 @@ class Category implements CategoryInterface
 
     public function removeChildren(CategoryInterface $child)
     {
-        @\trigger_error(__METHOD__ . '() is deprecated since version 1.4 and will be removed in 2.0. Use removeChild() instead.', \E_USER_DEPRECATED);
+        @\trigger_deprecation('sulu/sulu', '1.4', __METHOD__ . '() is deprecated and will be removed in 2.0. Use removeChild() instead.');
 
         $this->removeChild($child);
     }

--- a/src/Sulu/Bundle/CategoryBundle/Entity/CategoryRepository.php
+++ b/src/Sulu/Bundle/CategoryBundle/Entity/CategoryRepository.php
@@ -174,14 +174,14 @@ class CategoryRepository extends NestedTreeRepository implements CategoryReposit
 
     public function findCategoryByIds(array $ids)
     {
-        @\trigger_error(__METHOD__ . '() is deprecated since version 1.4 and will be removed in 2.0. Use findCategoriesByIds() instead.', \E_USER_DEPRECATED);
+        @\trigger_deprecation('sulu/sulu', '1.4', __METHOD__ . '() is deprecated and will be removed in 2.0. Use findCategoriesByIds() instead.');
 
         return $this->findCategoriesByIds($ids);
     }
 
     public function findCategories($parent = null, $depth = null, $sortBy = null, $sortOrder = null)
     {
-        @\trigger_error(__METHOD__ . '() is deprecated since version 1.4 and will be removed in 2.0. Use findChildrenCategoriesByParentId() instead.', \E_USER_DEPRECATED);
+        @\trigger_deprecation('sulu/sulu', '1.4', __METHOD__ . '() is deprecated and will be removed in 2.0. Use findChildrenCategoriesByParentId() instead.');
 
         $queryBuilder = $this->getCategoryQuery();
         $queryBuilder->andWhere('category.parent IS NULL');
@@ -211,7 +211,7 @@ class CategoryRepository extends NestedTreeRepository implements CategoryReposit
 
     public function findChildren($key, $sortBy = null, $sortOrder = null)
     {
-        @\trigger_error(__METHOD__ . '() is deprecated since version 1.4 and will be removed in 2.0. Use findChildrenCategoriesByParentKey() instead.', \E_USER_DEPRECATED);
+        @\trigger_deprecation('sulu/sulu', '1.4', __METHOD__ . '() is deprecated and will be removed in 2.0. Use findChildrenCategoriesByParentKey() instead.');
 
         $queryBuilder = $this->getCategoryQuery()
             ->from('SuluCategoryBundle:Category', 'parent')

--- a/src/Sulu/Bundle/CategoryBundle/Event/CategoryDeleteEvent.php
+++ b/src/Sulu/Bundle/CategoryBundle/Event/CategoryDeleteEvent.php
@@ -32,13 +32,12 @@ class CategoryDeleteEvent extends Event
      */
     public function __construct(CategoryInterface $category)
     {
-        @\trigger_error(
-            \sprintf(
-                'The "%s" class is deprecated since Sulu 2.3. Use the "%s" class instead.',
-                CategoryDeleteEvent::class,
-                CategoryRemovedEvent::class
-            ),
-            \E_USER_DEPRECATED
+        @\trigger_deprecation(
+            'sulu/sulu',
+            '2.3',
+            'The "%s" class is deprecated. Use the "%s" class instead.',
+            __CLASS__,
+            CategoryRemovedEvent::class
         );
 
         $this->category = $category;

--- a/src/Sulu/Bundle/CategoryBundle/Event/CategoryEvents.php
+++ b/src/Sulu/Bundle/CategoryBundle/Event/CategoryEvents.php
@@ -11,12 +11,11 @@
 
 namespace Sulu\Bundle\CategoryBundle\Event;
 
-@\trigger_error(
-    \sprintf(
-        'The "%s" class is deprecated since Sulu 2.3. Use the respective event class directly instead.',
-        CategoryEvents::class
-    ),
-    \E_USER_DEPRECATED
+@\trigger_deprecation(
+    'sulu/sulu',
+    '2.3',
+    'The "%s" class is deprecated. Use the respective event class directly instead.',
+    CategoryEvents::class
 );
 
 /**

--- a/src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
@@ -374,9 +374,10 @@ class ContactManager extends AbstractContactManager implements DataProviderRepos
             }
 
             if (!\is_null($formOfAddress) && \is_array($formOfAddress) && \array_key_exists('id', $formOfAddress)) {
-                @\trigger_error(
-                    'Passing the "formOfAddress" as object is deprecated and will not be supported in Sulu 2.0',
-                    \E_USER_DEPRECATED
+                @\trigger_deprecation(
+                    'sulu/sulu',
+                    '1.x',
+                    'Passing the "formOfAddress" as object is deprecated and will not be supported in Sulu 2.0'
                 );
                 $contact->setFormOfAddress($formOfAddress['id']);
                 $contactModified = true;

--- a/src/Sulu/Bundle/ContactBundle/Content/Types/SingleAccountSelection.php
+++ b/src/Sulu/Bundle/ContactBundle/Content/Types/SingleAccountSelection.php
@@ -61,9 +61,10 @@ class SingleAccountSelection extends ComplexContentType implements PreResolvable
         $value = $property->getValue();
         if (null != $value) {
             if (\is_array($value)) {
-                @\trigger_error(
-                    'Passing a serialized account to the SingleAccountSelection deprecated. Please use an id instead.',
-                    \E_USER_DEPRECATED
+                @\trigger_deprecation(
+                    'sulu/sulu',
+                    '2.2',
+                    'Passing a serialized account to the SingleAccountSelection deprecated. Please use an id instead.'
                 );
 
                 $node->setProperty($property->getName(), $value['id']);

--- a/src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
@@ -122,9 +122,10 @@ abstract class AbstractMediaController extends AbstractRestController
         $this->fieldDescriptorFactory = $fieldDescriptorFactory;
 
         if (null === $this->mediaListBuilderFactory || null === $this->mediaListRepresentationFactory || null === $this->fieldDescriptorFactory) {
-            @\trigger_error(
-                'Instantiating AbstractMediaController without the $mediaListBuilderFactory, $mediaListRepresentationFactory or $fieldDescriptorFactory argument is deprecated.',
-                \E_USER_DEPRECATED
+            @\trigger_deprecation(
+                'sulu/sulu',
+                '2.3',
+                'Instantiating AbstractMediaController without the $mediaListBuilderFactory, $mediaListRepresentationFactory or $fieldDescriptorFactory argument is deprecated.'
             );
         }
     }

--- a/src/Sulu/Bundle/CoreBundle/Controller/LocalizationController.php
+++ b/src/Sulu/Bundle/CoreBundle/Controller/LocalizationController.php
@@ -19,13 +19,12 @@ use Sulu\Component\Rest\AbstractRestController;
 use Sulu\Component\Rest\ListBuilder\CollectionRepresentation;
 use Symfony\Component\HttpFoundation\Response;
 
-@\trigger_error(
-    \sprintf(
-        'The "%s" class is deprecated since Sulu 2.0, use data from "%s" instead.',
-        LocalizationController::class,
-        AdminController::class
-    ),
-    \E_USER_DEPRECATED
+@\trigger_deprecation(
+    'sulu/sulu',
+    '2.0',
+    'The "%s" class is deprecated since, use data from "%s" instead.',
+    LocalizationController::class,
+    AdminController::class
 );
 
 /**

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/FixturesLoadCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/FixturesLoadCommand.php
@@ -121,14 +121,15 @@ EOT
         // check for deprecated document fixtures using the container directly
         foreach ($fixtures as $fixture) {
             if ($fixture instanceof ContainerAwareInterface) {
-                @\trigger_error(
+                @\trigger_deprecation(
+                    'sulu/sulu',
+                    '2.1',
                     \sprintf(
-                        'Document fixtures with the "%s" are deprecated since sulu/sulu 2.1,' . \PHP_EOL .
+                        'Document fixtures with the "%s" are deprecated,' . \PHP_EOL .
                         'use dependency injection for the "%s" service instead.',
                         ContainerAwareInterface::class,
                         \get_class($fixture)
-                    ),
-                    \E_USER_DEPRECATED
+                    )
                 );
             }
         }

--- a/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Compiler/DocumentFixturePass.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Compiler/DocumentFixturePass.php
@@ -26,14 +26,15 @@ class DocumentFixturePass implements CompilerPassInterface
             $definition = $container->getDefinition($id);
 
             if (\is_subclass_of($definition->getClass(), ContainerAwareInterface::class)) {
-                @\trigger_error(
+                @\trigger_deprecation(
+                    'sulu/sulu',
+                    '2.1',
                     \sprintf(
-                        'Document fixtures with the "%s" are deprecated since sulu/sulu 2.1,' . \PHP_EOL .
+                        'Document fixtures with the "%s" are deprecated,' . \PHP_EOL .
                         'use dependency injection for the "%s" service instead.',
                         ContainerAwareInterface::class,
                         $id
-                    ),
-                    \E_USER_DEPRECATED
+                    )
                 );
 
                 $definition->addMethodCall('setContainer', [new Reference('service_container')]);

--- a/src/Sulu/Bundle/LocationBundle/Geolocator/Service/GoogleGeolocator.php
+++ b/src/Sulu/Bundle/LocationBundle/Geolocator/Service/GoogleGeolocator.php
@@ -43,12 +43,13 @@ class GoogleGeolocator implements GeolocatorInterface
         string $apiKey
     ) {
         if ($client instanceof ClientInterface) {
-            @\trigger_error(
+            @\trigger_deprecation(
+                'sulu/sulu',
+                '2.3',
                 \sprintf(
                     'Instantiating GoogleGeolocator with %s as first argument is deprecated, please use %s instead.',
                     ClientInterface::class, HttpClientInterface::class
-                ),
-                \E_USER_DEPRECATED
+                )
             );
         } elseif (!($client instanceof HttpClientInterface)) {
             throw new \InvalidArgumentException(

--- a/src/Sulu/Bundle/LocationBundle/Geolocator/Service/NominatimGeolocator.php
+++ b/src/Sulu/Bundle/LocationBundle/Geolocator/Service/NominatimGeolocator.php
@@ -47,12 +47,13 @@ class NominatimGeolocator implements GeolocatorInterface
         string $key
     ) {
         if ($client instanceof ClientInterface) {
-            @\trigger_error(
+            @\trigger_deprecation(
+                'sulu/sulu',
+                '2.3',
                 \sprintf(
                     'Instantiating NominatimGeolocator with %s as first argument is deprecated, please use %s instead.',
                     ClientInterface::class, HttpClientInterface::class
-                ),
-                \E_USER_DEPRECATED
+                )
             );
         } elseif (!($client instanceof HttpClientInterface)) {
             throw new \InvalidArgumentException(

--- a/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
@@ -49,9 +49,10 @@ class LinkTag implements TagInterface
         $this->urlHelper = $urlHelper;
 
         if (null === $this->urlHelper) {
-            @\trigger_error(
-                'Instantiating the LinkTag class without the $urlHelper argument is deprecated.',
-                \E_USER_DEPRECATED
+            @\trigger_deprecation(
+                'sulu/sulu',
+                '2.3',
+                'Instantiating the LinkTag class without the $urlHelper argument is deprecated.'
             );
         }
     }

--- a/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
@@ -123,11 +123,12 @@ class CollectionController extends AbstractRestController implements ClassResour
         if (!$this->collectionClass) {
             $this->collectionClass = CollectionEntity::class;
 
-            @\trigger_error(
+            @\trigger_deprecation(
+                'sulu/sulu',
+                '2.1',
                 \sprintf(
                     'Omitting the "collectionClass" argument is deprecated and will not longer work in Sulu 3.0.'
-                ),
-                \E_USER_DEPRECATED
+                )
             );
         }
     }

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
@@ -162,9 +162,11 @@ class MediaController extends AbstractMediaController implements
         $this->mediaListRepresentationFactory = $mediaListRepresentationFactory;
 
         if (null === $this->mediaListBuilderFactory || null === $this->mediaListRepresentationFactory) {
-            @\trigger_error(
-                'Instantiating MediaController without the $mediaListBuilderFactory or $mediaListRepresentationFactory argument is deprecated.',
-                \E_USER_DEPRECATED
+            @\trigger_deprecation(
+                'sulu/sulu',
+                '2.3',
+                'Instantiating MediaController without the $mediaListBuilderFactory or $mediaListRepresentationFactory argument is deprecated.'
+
             );
         }
     }

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader10.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader10.php
@@ -26,9 +26,11 @@ class XmlFormatLoader10 extends BaseXmlFormatLoader
 
     public function load($resource, $type = null)
     {
-        @\trigger_error(
-            'XmlFormatLoader10 is deprecated since version 1.4 and will be removed in 2.0. Use XmlFormatLoader11 instead.',
-            \E_USER_DEPRECATED
+        @\trigger_deprecation(
+            'sulu/sulu',
+            '1.4',
+            '%s is deprecated and will be removed in 2.0. Use XmlFormatLoader11 instead.',
+            __CLASS__
         );
 
         return parent::load($resource, $type);

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/MediaImageExtractor.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/MediaImageExtractor.php
@@ -50,9 +50,10 @@ class MediaImageExtractor implements MediaImageExtractorInterface
     public function extract($resource/*, string $resourceMimeType*/)
     {
         if (\func_num_args() <= 1) {
-            @\trigger_error(
-                \sprintf('Calling "%s()" without $resourceMimeType parameter is deprecated.', __METHOD__),
-                \E_USER_DEPRECATED
+            @\trigger_deprecation(
+                'sulu/sulu',
+                '2.2',
+                \sprintf('Calling "%s()" without $resourceMimeType parameter is deprecated.', __METHOD__)
             );
 
             $mimeType = \mime_content_type($resource);

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Transformation/CropTransformation.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Transformation/CropTransformation.php
@@ -24,9 +24,11 @@ class CropTransformation implements TransformationInterface
 {
     public function execute(ImageInterface $image, $parameters)
     {
-        @\trigger_error(
-            'CropTransformation is deprecated since version 1.4. Use the scale config instead',
-            \E_USER_DEPRECATED
+        @\trigger_deprecation(
+            'sulu/sulu',
+            '1.4',
+            '%s is deprecated. Use the scale config instead',
+            __CLASS__
         );
         $retina = isset($parameters['retina']) && 'false' != $parameters['retina'] ? 2 : 1;
         $x = isset($parameters['x']) ? \intval($parameters['x']) * $retina : 0;

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -219,24 +219,26 @@ class MediaManager implements MediaManagerInterface
         $this->trashManager = $trashManager;
 
         if (!$adminDownloadPath) {
-            @\trigger_error(
+            @\trigger_deprecation(
+                'sulu/sulu',
+                '2.2',
                 \sprintf(
                     'The usage of the "%s" without setting the "$adminDownloadPath" is deprecated and will not longer work in Sulu 3.0.',
                     MediaManager::class
-                ),
-                \E_USER_DEPRECATED
+                )
             );
         }
 
         $this->adminDownloadPath = $adminDownloadPath ?: '/admin' . $this->downloadPath;
 
         if (!\is_iterable($mediaPropertiesProviders)) {
-            @\trigger_error(
+            @\trigger_deprecation(
+                'sulu/sulu',
+                '2.3',
                 \sprintf(
                     'The usage of the "%s" without setting "$mediaPropertiesProviders" is deprecated and will not longer work in Sulu 3.0.',
                     MediaManager::class
-                ),
-                \E_USER_DEPRECATED
+                )
             );
 
             if ($mediaPropertiesProviders instanceof FFProbe) {

--- a/src/Sulu/Bundle/PageBundle/Content/PageSelectionContainer.php
+++ b/src/Sulu/Bundle/PageBundle/Content/PageSelectionContainer.php
@@ -118,7 +118,7 @@ class PageSelectionContainer implements ArrayableInterface
         $this->enabledTwigAttributes = $enabledTwigAttributes;
 
         if ($enabledTwigAttributes['path'] ?? true) {
-            @\trigger_error('Enabling the "path" parameter is deprecated since sulu/sulu 2.3.', \E_USER_DEPRECATED);
+            @\trigger_deprecation('sulu/sulu', '2.3', 'Enabling the "path" parameter is deprecated.');
         }
     }
 

--- a/src/Sulu/Bundle/PageBundle/Content/Types/PageSelection.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/PageSelection.php
@@ -78,7 +78,7 @@ class PageSelection extends ComplexContentType implements ContentTypeExportInter
         $this->enabledTwigAttributes = $enabledTwigAttributes;
 
         if ($enabledTwigAttributes['path'] ?? true) {
-            @\trigger_error('Enabling the "path" parameter is deprecated since sulu/sulu 2.3.', \E_USER_DEPRECATED);
+            @\trigger_deprecation('sulu/sulu', '2.3', 'Enabling the "path" parameter is deprecated.');
         }
     }
 

--- a/src/Sulu/Bundle/PageBundle/Controller/WebspaceController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/WebspaceController.php
@@ -28,13 +28,12 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
-@\trigger_error(
-    \sprintf(
-        'The "%s" class is deprecated since Sulu 2.0, use data from "%s" instead.',
-        WebspaceController::class,
-        AdminController::class
-    ),
-    \E_USER_DEPRECATED
+@\trigger_deprecation(
+    'sulu/sulu',
+    '2.0',
+    'The "%s" class is deprecated, use data from "%s" instead.',
+    WebspaceController::class,
+    AdminController::class
 );
 
 /**

--- a/src/Sulu/Bundle/PageBundle/Repository/NodeRepository.php
+++ b/src/Sulu/Bundle/PageBundle/Repository/NodeRepository.php
@@ -31,13 +31,12 @@ use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Webspace;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
-@\trigger_error(
-    \sprintf(
-        'The "%s" class is deprecated since Sulu 2.0, use data from "%s" instead.',
-        NodeRepository::class,
-        ContentRepository::class
-    ),
-    \E_USER_DEPRECATED
+@\trigger_deprecation(
+    'sulu/sulu',
+    '2.0',
+    'The "%s" class is deprecated, use data from "%s" instead.',
+    NodeRepository::class,
+    ContentRepository::class
 );
 
 /**
@@ -709,10 +708,11 @@ class NodeRepository implements NodeRepositoryInterface
 
     public function copyLocale($uuid, $userId, $webspaceKey, $srcLocale, $destLocales)
     {
-        @\trigger_error(
+        @\trigger_deprecation(
+            'sulu/sulu',
+            '2.3',
             'The NodeRepository::copyLocale method is deprecated and will be removed in the future.'
-            . ' Use DocumentManagerInterface::copyLocale instead.',
-            \E_USER_DEPRECATED
+            . ' Use DocumentManagerInterface::copyLocale instead.'
         );
 
         try {

--- a/src/Sulu/Bundle/PageBundle/Teaser/PageTeaserProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Teaser/PageTeaserProvider.php
@@ -60,9 +60,10 @@ class PageTeaserProvider implements TeaserProviderInterface
         $this->phpcrPageTeaserProvider = $phpcrPageTeaserProvider;
 
         if (null === $this->phpcrPageTeaserProvider) {
-            @\trigger_error(
-                'Instantiating a PageTeaserProvider without the $phpcrPageTeaserProvider argument is deprecated!',
-                \E_USER_DEPRECATED
+            @\trigger_deprecation(
+                'sulu/sulu',
+                '2.3',
+                'Instantiating a PageTeaserProvider without the $phpcrPageTeaserProvider argument is deprecated!'
             );
         }
     }

--- a/src/Sulu/Bundle/PreviewBundle/Preview/PreviewCache.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/PreviewCache.php
@@ -31,13 +31,12 @@ class PreviewCache
     public function __construct($cache)
     {
         if ($cache instanceof Cache) {
-            @\trigger_error(
-                \sprintf(
-                    'To inject $cache as instance of "%s" is deprecated use a "%s" instead.',
-                    \get_class($cache),
-                    CacheItemPoolInterface::class
-                ),
-                \E_USER_DEPRECATED
+            @\trigger_deprecation(
+                'sulu/sulu',
+                '2.1',
+                'To inject $cache as instance of "%s" is deprecated, use a "%s" instead.',
+                \get_class($cache),
+                CacheItemPoolInterface::class
             );
         }
 

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
@@ -63,7 +63,7 @@ class PreviewKernel extends Kernel
     public function getRootDir(/* $triggerDeprecation = true */)
     {
         if (0 === \func_num_args() || \func_get_arg(0)) {
-            @\trigger_error(\sprintf('The "%s()" method is deprecated since Symfony 4.2, use getProjectDir() instead.', __METHOD__), \E_USER_DEPRECATED);
+            @\trigger_deprecation('symfony/symfony', '4.2', 'The "%s()" method is deprecated, use getProjectDir() instead.', __METHOD__);
         }
 
         if (null === $this->rootDir) {

--- a/src/Sulu/Bundle/RouteBundle/Controller/RouteController.php
+++ b/src/Sulu/Bundle/RouteBundle/Controller/RouteController.php
@@ -76,9 +76,10 @@ class RouteController extends AbstractRestController implements ClassResourceInt
         $this->conflictResolver = $conflictResolver;
 
         if (null === $this->conflictResolver) {
-            @\trigger_error(
-                'Instantiating RouteController without the $conflictResolver argument is deprecated.',
-                \E_USER_DEPRECATED
+            @\trigger_deprecation(
+                'sulu/sulu',
+                '2.3',
+                'Instantiating RouteController without the $conflictResolver argument is deprecated.'
             );
         }
     }

--- a/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
+++ b/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
@@ -74,9 +74,10 @@ class WebsiteSearchController
         $this->templateAttributeResolver = $templateAttributeResolver;
 
         if (null === $this->templateAttributeResolver) {
-            @\trigger_error(
-                'Instantiating the WebsiteSearchController class without the $templateAttributeResolver argument is deprecated.',
-                \E_USER_DEPRECATED
+            @\trigger_deprecation(
+                'sulu/sulu',
+                '2.4',
+                'Instantiating the WebsiteSearchController class without the $templateAttributeResolver argument is deprecated.'
             );
         }
     }

--- a/src/Sulu/Bundle/SecurityBundle/Controller/ContextsController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/ContextsController.php
@@ -19,13 +19,12 @@ use Sulu\Bundle\AdminBundle\Controller\AdminController;
 use Sulu\Component\Rest\AbstractRestController;
 use Symfony\Component\HttpFoundation\Request;
 
-@\trigger_error(
-    \sprintf(
-        'The "%s" class is deprecated since Sulu 2.2, use data from "%s" instead.',
-        ContextsController::class,
-        AdminController::class
-    ),
-    \E_USER_DEPRECATED
+@\trigger_deprecation(
+    'sulu/sulu',
+    '2.2',
+    'The "%s" class is deprecated, use data from "%s" instead.',
+    ContextsController::class,
+    AdminController::class
 );
 
 /**

--- a/src/Sulu/Bundle/SecurityBundle/Entity/Role.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/Role.php
@@ -112,7 +112,7 @@ class Role implements RoleInterface
      */
     public function getRole()
     {
-        @\trigger_error(\sprintf('The "%s" method is deprecated since Sulu 2.1, use "%s" instead.', __METHOD__, 'getIdentifier'), \E_USER_DEPRECATED);
+        @\trigger_deprecation('sulu/sulu', '2.1', 'The "%s" method is deprecated, use "%s" instead.', __METHOD__, 'getIdentifier');
 
         return $this->getIdentifier();
     }

--- a/src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
+++ b/src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
@@ -235,10 +235,11 @@ class UserManager implements UserManagerInterface
 
             if (!$patch || (null !== $contact || null !== $contactId)) {
                 if ($contact && !$contactId) {
-                    @\trigger_error(
+                    @\trigger_deprecation(
+                        'sulu/sulu',
+                        '1.4',
                         'Usage of the contact object to define the contact corresponding to the user is deprecated'
-                        . ' since version 1.4 and will be removed in 2.0. Use the contactId query parameter instead.',
-                        \E_USER_DEPRECATED
+                        . ' since version 1.4 and will be removed in 2.0. Use the contactId query parameter instead.'
                     );
                 }
                 $user->setContact($this->getContact($contactId ?: $contact['id']));

--- a/src/Sulu/Bundle/SnippetBundle/Content/SnippetDataProvider.php
+++ b/src/Sulu/Bundle/SnippetBundle/Content/SnippetDataProvider.php
@@ -108,7 +108,7 @@ class SnippetDataProvider implements DataProviderInterface
         $this->tokenStorage = $tokenStorage;
 
         if (!$formMetadataProvider) {
-            @\trigger_error('The usage of the "SnippetDataProvider" without setting the "FormMetadataProvider" is deprecated. Please inject the "FormMetadataProvider".', \E_USER_DEPRECATED);
+            @\trigger_deprecation('sulu/sulu', '2.3', 'The usage of the "SnippetDataProvider" without setting the "FormMetadataProvider" is deprecated. Please inject the "FormMetadataProvider".');
         }
     }
 

--- a/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
@@ -396,7 +396,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
         }
 
         if ($request->query->has('language')) {
-            @\trigger_error('The usage of the "language" parameter in the SnippetController is deprecated. Please use "locale" instead.', \E_USER_DEPRECATED);
+            @\trigger_deprecation('sulu/sulu', '2.1', 'The usage of the "language" parameter in the SnippetController is deprecated. Please use "locale" instead.');
         }
 
         return $request->query->get('language', null);

--- a/src/Sulu/Bundle/SnippetBundle/Domain/Event/SnippetCopiedEvent.php
+++ b/src/Sulu/Bundle/SnippetBundle/Domain/Event/SnippetCopiedEvent.php
@@ -56,7 +56,7 @@ class SnippetCopiedEvent extends DomainEvent
      */
     public function getPageDocument(): SnippetDocument
     {
-        @\trigger_error(\sprintf('The "%s" method is deprecated. Use "%s" instead.', __METHOD__, 'getSnippetDocument'), \E_USER_DEPRECATED);
+        @\trigger_deprecation('sulu/sulu', '2.4', 'The "%s" method is deprecated. Use "%s" instead.', __METHOD__, 'getSnippetDocument');
 
         return $this->getSnippetDocument();
     }

--- a/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetRepository.php
+++ b/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetRepository.php
@@ -173,10 +173,11 @@ class SnippetRepository
      */
     public function copyLocale($uuid, $userId, $srcLocale, $destLocales)
     {
-        @\trigger_error(
+        @\trigger_deprecation(
+            'sulu/sulu',
+            '2.3',
             'The SnippetRepository::copyLocale method is deprecated and will be removed in the future.'
-            . ' Use DocumentManagerInterface::copyLocale instead.',
-            \E_USER_DEPRECATED
+            . ' Use DocumentManagerInterface::copyLocale instead.'
         );
 
         return $this->contentMapper->copyLanguage(

--- a/src/Sulu/Bundle/SnippetBundle/Twig/DefaultSnippetTwigExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/Twig/DefaultSnippetTwigExtension.php
@@ -61,7 +61,7 @@ class DefaultSnippetTwigExtension extends AbstractExtension
 
     public function getDefault($snippetType, $webspaceKey = null, $locale = null)
     {
-        @\trigger_error('Load snippets over the sulu_snippet_load_default is deprecated and will be removed in 2.0 use sulu_snippet_load_by_area instead', \E_USER_DEPRECATED);
+        @\trigger_deprecation('sulu/sulu', '1.6', 'Loading snippets over the sulu_snippet_load_default is deprecated and will be removed in 2.0, use sulu_snippet_load_by_area instead.');
 
         if (!$webspaceKey) {
             $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();

--- a/src/Sulu/Bundle/TagBundle/Event/TagDeleteEvent.php
+++ b/src/Sulu/Bundle/TagBundle/Event/TagDeleteEvent.php
@@ -32,13 +32,12 @@ class TagDeleteEvent extends Event
      */
     public function __construct(TagInterface $tag)
     {
-        @\trigger_error(
-            \sprintf(
-                'The "%s" class is deprecated since Sulu 2.3. Use the "%s" class instead.',
-                TagDeleteEvent::class,
-                TagRemovedEvent::class
-            ),
-            \E_USER_DEPRECATED
+        @\trigger_deprecation(
+            'sulu/sulu',
+            '2.3',
+            'The "%s" class is deprecated. Use the "%s" class instead.',
+            TagDeleteEvent::class,
+            TagRemovedEvent::class
         );
 
         $this->tag = $tag;

--- a/src/Sulu/Bundle/TagBundle/Event/TagEvents.php
+++ b/src/Sulu/Bundle/TagBundle/Event/TagEvents.php
@@ -11,12 +11,11 @@
 
 namespace Sulu\Bundle\TagBundle\Event;
 
-@\trigger_error(
-    \sprintf(
-        'The "%s" class is deprecated since Sulu 2.3. Use the respective event class directly instead.',
-        TagEvents::class
-    ),
-    \E_USER_DEPRECATED
+@\trigger_deprecation(
+    'sulu/sulu',
+    '2.3',
+    'The "%s" class is deprecated. Use the respective event class directly instead.',
+    TagEvents::class
 );
 
 /**

--- a/src/Sulu/Bundle/TagBundle/Event/TagMergeEvent.php
+++ b/src/Sulu/Bundle/TagBundle/Event/TagMergeEvent.php
@@ -42,13 +42,12 @@ class TagMergeEvent extends Event
      */
     public function __construct(array $srcTags, TagInterface $destTag)
     {
-        @\trigger_error(
-            \sprintf(
-                'The "%s" class is deprecated since Sulu 2.3. Use the "%s" class instead.',
-                TagMergeEvent::class,
-                TagMergedEvent::class
-            ),
-            \E_USER_DEPRECATED
+        @\trigger_deprecation(
+            'sulu/sulu',
+            '2.3',
+            'The "%s" class is deprecated. Use the "%s" class instead.',
+            __CLASS__,
+            TagMergedEvent::class
         );
 
         $this->srcTags = $srcTags;

--- a/src/Sulu/Bundle/WebsiteBundle/Cache/CacheClearer.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Cache/CacheClearer.php
@@ -79,10 +79,7 @@ class CacheClearer implements CacheClearerInterface
     public function clear(/*?array $tags = null*/)
     {
         if (0 === \func_num_args()) {
-            @\trigger_error(
-                \sprintf('Calling "%s()" without $tags parameter is deprecated.', __METHOD__),
-                \E_USER_DEPRECATED
-            );
+            @\trigger_deprecation('sulu/sulu', '2.3', 'Calling "%s()" without $tags parameter is deprecated.', __METHOD__);
         }
 
         $tags = \func_num_args() >= 1 ? \func_get_arg(0) : null;

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/ExceptionController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/ExceptionController.php
@@ -62,7 +62,7 @@ class ExceptionController
         Environment $twig,
         $debug
     ) {
-        @\trigger_error(__CLASS__ . ' is deprecated since version sulu/sulu 2.0 and will be removed in 3.0. Use the ErrorController instead.', \E_USER_DEPRECATED);
+        @\trigger_deprecation('sulu/sulu', '2.0', __CLASS__ . ' is deprecated and will be removed in 3.0. Use the ErrorController instead.');
 
         $this->exceptionController = $exceptionController;
         $this->requestAnalyzer = $requestAnalyzer;

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/RedirectController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/RedirectController.php
@@ -41,7 +41,7 @@ class RedirectController
      */
     public function redirectWebspaceAction(Request $request)
     {
-        @\trigger_error(__METHOD__ . '() is deprecated since version 1.6 and will be removed in 2.0. Replaced by ExceptionListener::redirectPartialMatch.', \E_USER_DEPRECATED);
+        @\trigger_deprecation('sulu/sulu', '1.6', __METHOD__ . '() is deprecated and will be removed in 2.0. Replaced by ExceptionListener::redirectPartialMatch.');
 
         $url = $this->resolveRedirectUrl(
             $request->get('redirect'),

--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Configuration.php
@@ -52,7 +52,7 @@ class Configuration implements ConfigurationInterface
                                 ->beforeNormalization()
                                     ->ifTrue(function($v) { return false !== $v; })
                                     ->then(function($v) {
-                                        @\trigger_error('Enabling the "urls" parameter is deprecated since sulu/sulu 2.2.', \E_USER_DEPRECATED);
+                                        @\trigger_deprecation('sulu/sulu', '2.2', 'Enabling the "urls" parameter is deprecated.');
 
                                         return $v;
                                     })
@@ -63,7 +63,7 @@ class Configuration implements ConfigurationInterface
                                 ->beforeNormalization()
                                     ->ifTrue(function($v) { return false !== $v; })
                                     ->then(function($v) {
-                                        @\trigger_error('Enabling the "path" parameter is deprecated since sulu/sulu 2.3.', \E_USER_DEPRECATED);
+                                        @\trigger_deprecation('sulu/sulu', '2.3', 'Enabling the "path" parameter is deprecated.');
 
                                         return $v;
                                     })

--- a/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationMapper.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationMapper.php
@@ -77,7 +77,7 @@ class NavigationMapper implements NavigationMapperInterface
         $this->enabledTwigAttributes = $enabledTwigAttributes;
 
         if ($enabledTwigAttributes['path'] ?? true) {
-            @\trigger_error('Enabling the "path" parameter is deprecated since sulu/sulu 2.3.', \E_USER_DEPRECATED);
+            @\trigger_deprecation('sulu/sulu', '2.3', 'Enabling the "path" parameter is deprecated.');
         }
     }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/ParameterResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/ParameterResolver.php
@@ -125,7 +125,7 @@ class ParameterResolver implements ParameterResolverInterface
         }
 
         if ($this->enabledTwigAttributes['urls'] ?? true) {
-            @\trigger_error('Enabling the "urls" parameter is deprecated since Sulu 2.2', \E_USER_DEPRECATED);
+            @\trigger_deprecation('sulu/sulu', '2.2', 'Enabling the "urls" parameter is deprecated.');
 
             $structureData['urls'] = [];
             foreach ($localizations as $localization) {

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
@@ -52,7 +52,7 @@ class StructureResolver implements StructureResolverInterface
         $this->enabledTwigAttributes = $enabledTwigAttributes;
 
         if ($enabledTwigAttributes['path'] ?? true) {
-            @\trigger_error('Enabling the "path" parameter is deprecated since sulu/sulu 2.3.', \E_USER_DEPRECATED);
+            @\trigger_deprecation('sulu/sulu', '2.3', 'Enabling the "path" parameter is deprecated.');
         }
     }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
@@ -105,7 +105,7 @@ class TemplateAttributeResolver implements TemplateAttributeResolverInterface
         }
 
         if ($this->enabledTwigAttributes['urls'] ?? true) {
-            @\trigger_error('Enabling the "urls" parameter is deprecated since Sulu 2.2', \E_USER_DEPRECATED);
+            @\trigger_deprecation('sulu/sulu', '2.2', 'Enabling the "urls" parameter is deprecated.');
 
             if (!isset($customParameters['urls'])) {
                 $customParameters['urls'] = [];

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/PortalLoader.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/PortalLoader.php
@@ -36,10 +36,7 @@ class PortalLoader extends FileLoader
         ?FileLocatorInterface $fileLocator = null
     ) {
         if (!$fileLocator) {
-            @\trigger_error(
-                'Initializing "' . __CLASS__ . '" without file locator is deprecated.',
-                \E_USER_DEPRECATED
-            );
+            @\trigger_deprecation('sulu/sulu', '2.3', 'Initializing "' . __CLASS__ . '" without file locator is deprecated.');
 
             $fileLocator = new FileLocator();
         }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
@@ -96,10 +96,7 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
         $this->logger = $logger ?: new NullLogger();
 
         if ($securityChecker instanceof RequestStack) {
-            @\trigger_error(
-                'Instantiating the "ContentTwigExtension" without the "$securityChecker" and "$webspaceManager" parameter is deprecated',
-                \E_USER_DEPRECATED
-            );
+            @\trigger_deprecation('sulu/sulu', '2.2','Instantiating the "ContentTwigExtension" without the "$securityChecker" and "$webspaceManager" parameter is deprecated');
 
             $requestStack = $securityChecker;
             $securityChecker = null;
@@ -110,10 +107,7 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
         $this->requestStack = $requestStack;
 
         if (null === $this->requestStack) {
-            @\trigger_error(
-                'Instantiating the "ContentTwigExtension" without the "$requestStack" parameter is deprecated',
-                \E_USER_DEPRECATED
-            );
+            @\trigger_deprecation('sulu/sulu', '2.3','Instantiating the "ContentTwigExtension" without the "$requestStack" parameter is deprecated');
         }
     }
 
@@ -169,10 +163,7 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
         }
 
         if (null === $properties) {
-            @\trigger_error(
-                'Calling the "sulu_content_load" function without a properties parameter is deprecated and has a negative impact on performance.',
-                \E_USER_DEPRECATED
-            );
+            @\trigger_deprecation('sulu/sulu', '2.3', 'Calling the "sulu_content_load" function without a properties parameter is deprecated and has a negative impact on performance.');
 
             return $this->resolveStructure($contentStructure);
         }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Core/UtilTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Core/UtilTwigExtension.php
@@ -42,10 +42,7 @@ class UtilTwigExtension extends AbstractExtension
      */
     public function extract($url, $mode = null)
     {
-        @\trigger_error(
-            'The "sulu_util_domain_info" is deprecated and will be removed with Sulu 3.0.',
-            \E_USER_DEPRECATED
-        );
+        @\trigger_deprecation('sulu/sulu', '2.3', 'The "sulu_util_domain_info" is deprecated and will be removed with Sulu 3.0.');
 
         if (\function_exists('tld_extract')) {
             return tld_extract($url, $mode);

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtension.php
@@ -72,10 +72,12 @@ class SeoTwigExtension extends AbstractExtension
     ) {
         $template = '@SuluWebsite/Extension/seo.html.twig';
 
-        @\trigger_error(\sprintf(
+        @\trigger_deprecation(
+            'sulu/sulu',
+            '1.x',
             'This twig extension is deprecated and should not be used anymore, include the "%s".',
             $template
-        ));
+        );
 
         $defaultLocale = null;
         $portal = $this->requestAnalyzer->getPortal();

--- a/src/Sulu/Component/Content/Exception/InvalidBlockDefaultTypeException.php
+++ b/src/Sulu/Component/Content/Exception/InvalidBlockDefaultTypeException.php
@@ -36,7 +36,7 @@ class InvalidBlockDefaultTypeException extends \Exception
      */
     public function __construct(string $name, string $defaultType, array $availableTypes)
     {
-        @\trigger_error('The InvalidBlockDefaultTypeException is deprecated since version 2.2 and will be removed in version 3.0. Use InvalidDefaultTypeException instead.', \E_USER_DEPRECATED);
+        @\trigger_deprecation('sulu/sulu', '2.2', 'The InvalidBlockDefaultTypeException is deprecated and will be removed in version 3.0. Use InvalidDefaultTypeException instead.');
 
         parent::__construct(\sprintf(
             'Block "%s" has invalid default-type "%s". Available types are %s',

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -483,10 +483,11 @@ class ContentMapper implements ContentMapperInterface
         $destLocales,
         $structureType = LegacyStructure::TYPE_PAGE
     ) {
-        @\trigger_error(
+        @\trigger_deprecation(
+            'sulu/sulu',
+            '2.3',
             'The ContentMapperInterface::copyLanguage method is deprecated and will be removed in the future.'
-            . ' Use DocumentManagerInterface::copyLocale instead.',
-            \E_USER_DEPRECATED
+            . ' Use DocumentManagerInterface::copyLocale instead.'
         );
 
         if (!\is_array($destLocales)) {

--- a/src/Sulu/Component/Content/Metadata/ItemMetadata.php
+++ b/src/Sulu/Component/Content/Metadata/ItemMetadata.php
@@ -89,19 +89,24 @@ abstract class ItemMetadata
 
     public function __get($name)
     {
-        @\trigger_error(
-            \sprintf('Do not use public property "%s" from "%s"', $name, __CLASS__),
-            \E_USER_DEPRECATED
-        );
+        @\trigger_deprecation(
+            'sulu/sulu',
+            '2.0',
+            'Do not use public property "%s" from "%s"',
+            $name,
+            __CLASS__);
 
         return $this[$name];
     }
 
     public function __set($name, $value)
     {
-        @\trigger_error(
-            \sprintf('Do not use public property "%s" from "%s"', $name, __CLASS__),
-            \E_USER_DEPRECATED
+        @\trigger_deprecation(
+            'sulu/sulu',
+            '2.0',
+            'Do not use public property "%s" from "%s"',
+            $name,
+            __CLASS__
         );
 
         return $this[$name] = $value;

--- a/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
+++ b/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
@@ -135,11 +135,11 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
         $this->enabledTwigAttributes = $enabledTwigAttributes;
 
         if (!$formMetadataProvider) {
-            @\trigger_error('The usage of the "PageDataProvider" without setting the "FormMetadataProvider" is deprecated. Please inject the "FormMetadataProvider".', \E_USER_DEPRECATED);
+            @\trigger_deprecation('sulu/sulu', '2.3', 'The usage of the "PageDataProvider" without setting the "FormMetadataProvider" is deprecated. Please inject the "FormMetadataProvider".');
         }
 
         if ($enabledTwigAttributes['path'] ?? true) {
-            @\trigger_error('Enabling the "path" parameter is deprecated since sulu/sulu 2.3.', \E_USER_DEPRECATED);
+            @\trigger_deprecation('sulu/sulu', '2.3', 'Enabling the "path" parameter is deprecated.');
         }
     }
 

--- a/src/Sulu/Component/Content/Types/BlockContentType.php
+++ b/src/Sulu/Component/Content/Types/BlockContentType.php
@@ -75,10 +75,7 @@ class BlockContentType extends ComplexContentType implements ContentTypeExportIn
         $this->blockVisitors = $blockVisitors;
 
         if (null === $this->blockVisitors) {
-            @\trigger_error(
-                'Instantiating BlockContentType without the $blockVisitors argument is deprecated.',
-                \E_USER_DEPRECATED
-            );
+            @\trigger_deprecation('sulu/sulu', '2.3', 'Instantiating BlockContentType without the $blockVisitors argument is deprecated.');
 
             $this->blockVisitors = [];
         }

--- a/src/Sulu/Component/Localization/Localization.php
+++ b/src/Sulu/Component/Localization/Localization.php
@@ -222,7 +222,7 @@ class Localization implements \JsonSerializable, ArrayableInterface
      */
     public function getLocalization($delimiter = '_')
     {
-        @\trigger_error(__METHOD__ . '() is deprecated since version 1.2 and will be removed in 2.0. Use getLocale() instead.', \E_USER_DEPRECATED);
+        @\trigger_deprecation('sulu/sulu', '1.2', __METHOD__ . '() is deprecated and will be removed in 2.0. Use getLocale() instead.');
 
         $localization = $this->getLanguage();
         if (null != $this->getCountry()) {
@@ -307,7 +307,7 @@ class Localization implements \JsonSerializable, ArrayableInterface
      */
     public function setXDefault($xDefault)
     {
-        @\trigger_error(\sprintf('The "%s" method is deprecated on "%s" use "setDefault" instead.', __METHOD__, __CLASS__), \E_USER_DEPRECATED);
+        @\trigger_deprecation('sulu/sulu', '2.3', 'The "%s" method is deprecated on "%s" use "setDefault" instead.', __METHOD__, __CLASS__);
 
         $this->xDefault = $xDefault;
     }
@@ -332,7 +332,7 @@ class Localization implements \JsonSerializable, ArrayableInterface
     public function isXDefault()
     {
         if (\func_num_args() < 1 || \func_get_arg(0)) {
-            @\trigger_error(\sprintf('The "%s" method is deprecated on "%s" use "isDefault" instead.', __METHOD__, __CLASS__), \E_USER_DEPRECATED);
+            @\trigger_deprecation('sulu/sulu', '2.4', 'The "%s" method is deprecated on "%s" use "isDefault" instead.', __METHOD__, __CLASS__);
         }
 
         return $this->xDefault;

--- a/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
+++ b/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
@@ -79,11 +79,11 @@ class MediaDataProvider extends BaseDataProvider
         $this->translator = $translator;
 
         if (!$entityManager) {
-            @\trigger_error('The usage of the "MediaDataProvider" without setting the "EntityManager" is deprecated. Please inject the "EntityManager".', \E_USER_DEPRECATED);
+            @\trigger_deprecation('sulu/sulu', '2.3', 'The usage of the "MediaDataProvider" without setting the "EntityManager" is deprecated. Please inject the "EntityManager".');
         }
 
         if (!$translator) {
-            @\trigger_error('The usage of the "MediaDataProvider" without setting the "Translator" is deprecated. Please inject the "Translator".', \E_USER_DEPRECATED);
+            @\trigger_deprecation('sulu/sulu', '2.3', 'The usage of the "MediaDataProvider" without setting the "Translator" is deprecated. Please inject the "Translator".');
         }
     }
 

--- a/src/Sulu/Component/PHPCR/PathCleanup.php
+++ b/src/Sulu/Component/PHPCR/PathCleanup.php
@@ -46,9 +46,10 @@ class PathCleanup implements PathCleanupInterface
     public function __construct(array $replacers, SluggerInterface $slugger = null)
     {
         if (null === $slugger) {
-            @\trigger_error(
-                'Initializing the PathCleanup without a slugger is deprecated since Sulu 2.1.',
-                \E_USER_DEPRECATED
+            @\trigger_deprecation(
+                'sulu/sulu',
+                '2.1',
+                'Initializing the PathCleanup without a slugger is deprecated.'
             );
             $slugger = new AsciiSlugger();
         }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/ListXmlLoader.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/ListXmlLoader.php
@@ -135,7 +135,7 @@ class ListXmlLoader
         if (null !== $type = XmlUtil::getValueFromXPath('x:transformer/@type', $xpath, $propertyNode)) {
             $propertyMetadata->setType($type);
         } elseif (null !== $type = XmlUtil::getValueFromXPath('@type', $xpath, $propertyNode)) {
-            @\trigger_error('Attribute "type" of list property should not be used anymore! Use "<transformer type="..."/>" inside of property instead.', \E_USER_DEPRECATED);
+            @\trigger_deprecation('sulu/sulu', '2.2', 'Attribute "type" of list property should not be used anymore! Use "<transformer type="..."/>" inside of property instead.');
             $propertyMetadata->setType($type);
         }
 

--- a/src/Sulu/Component/Security/Authorization/AccessControl/SecuredEntityRepositoryTrait.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/SecuredEntityRepositoryTrait.php
@@ -39,13 +39,12 @@ trait SecuredEntityRepositoryTrait
         $entityClass,
         $entityAlias
     ) {
-        @\trigger_error(
-            \sprintf(
-                'The "%s" is deprecated since Sulu 2.2. Use the "%s" service instead.',
-                __TRAIT__,
-                AccessControlQueryEnhancer::class
-            ),
-            \E_USER_DEPRECATED
+        @\trigger_deprecation(
+            'sulu/sulu',
+            '2.2',
+            'The "%s" is deprecated. Use the "%s" service instead.',
+            __TRAIT__,
+            AccessControlQueryEnhancer::class
         );
 
         $queryBuilder->leftJoin(

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
@@ -259,7 +259,7 @@ class XmlFileLoader10 extends BaseXmlFileLoader
         $xDefaultNode = $localizationNode->attributes->getNamedItem('x-default');
         if ($xDefaultNode) {
             // @deprecated
-            @\trigger_error('Set x-default="true" attribute on the `<localization>` tag in webspace is deprecated use default="true" instead.', \E_USER_DEPRECATED);
+            @\trigger_deprecation('sulu/sulu', '2.3', 'Set x-default="true" attribute on the `<localization>` tag in webspace is deprecated use default="true" instead.');
 
             $localization->setXDefault('true' == $xDefaultNode->nodeValue);
         } else {

--- a/src/Sulu/Component/Webspace/Portal.php
+++ b/src/Sulu/Component/Webspace/Portal.php
@@ -178,7 +178,7 @@ class Portal
     public function setXDefaultLocalization($xDefaultLocalization)
     {
         if (\func_num_args() < 2 || \func_get_arg(1)) {
-            @\trigger_error(\sprintf('The "%s" method is deprecated on "%s" use "setDefaultLocalization" instead.', __METHOD__, __CLASS__), \E_USER_DEPRECATED);
+            @\trigger_deprecation('sulu/sulu', '2.3', 'The "%s" method is deprecated on "%s" use "setDefaultLocalization" instead.', __METHOD__, __CLASS__);
         }
 
         $this->xDefaultLocalization = $xDefaultLocalization;
@@ -191,7 +191,7 @@ class Portal
      */
     public function getXDefaultLocalization()
     {
-        @\trigger_error(\sprintf('The "%s" method is deprecated on "%s" use "getDefaultLocalization" instead.', __METHOD__, __CLASS__), \E_USER_DEPRECATED);
+        @\trigger_deprecation('sulu/sulu', '2.3', 'The "%s" method is deprecated on "%s" use "getDefaultLocalization" instead.', __METHOD__, __CLASS__);
 
         return $this->xDefaultLocalization;
     }

--- a/src/Sulu/Component/Webspace/PortalInformation.php
+++ b/src/Sulu/Component/Webspace/PortalInformation.php
@@ -205,9 +205,10 @@ class PortalInformation implements ArrayableInterface
      */
     public function setSegment($segment)
     {
-        @\trigger_error(
-            'Segment on the PortalInformation will be removed and should not be used anymore since Sulu 2.2',
-            \E_USER_DEPRECATED
+        @\trigger_deprecation(
+            'sulu/sulu',
+            '2.2',
+            'Segment on the PortalInformation will be removed and should not be used anymore.'
         );
         $this->segment = $segment;
     }
@@ -221,9 +222,10 @@ class PortalInformation implements ArrayableInterface
      */
     public function getSegment()
     {
-        @\trigger_error(
-            'Segment on the PortalInformation will be removed and should not be used anymore since Sulu 2.2',
-            \E_USER_DEPRECATED
+        @\trigger_deprecation(
+            'sulu/sulu',
+            '2.2',
+            'Segment on the PortalInformation will be removed and should not be used anymore.'
         );
 
         return $this->segment;
@@ -234,9 +236,10 @@ class PortalInformation implements ArrayableInterface
      */
     public function getSegmentKey()
     {
-        @\trigger_error(
-            'Segment on the PortalInformation will be removed and should not be used anymore since Sulu 2.2',
-            \E_USER_DEPRECATED
+        @\trigger_deprecation(
+            'sulu/sulu',
+            '2.2',
+            'Segment on the PortalInformation will be removed and should not be used anymore.'
         );
 
         return $this->segment ? $this->segment->getKey() : null;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #6977
| Related issues/PRs | none
| License | MIT
| Documentation PR | not necessary

#### What's in this PR?

This PR adds a dependency to symfony/deprecation-contracts and utilizes the method `trigger_deprecations` from that package to trigger deprecations all throughout Sulu.

I have tried to guess the versions when a feature was deprecated as indicated by the timestamp of the commit when a version was not provided in the message.

#### Why?

Deprecations can be silenced or funneled at a central entry point in the `trigger_deprecations` function instead of the lower-level `trigger_error`. And to quote @alexander-schranz: "As this is the new way in Symfony we should switch to that one."

#### Example Usage

Transparent user experience, deprecation messages will change slightly in their wording, but not much else to do.

#### To Do

none