### PR TITLE
Migrate one remaining deprecation on 2.5 (#6977)

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Security/LogoutSuccessHandler.php
+++ b/src/Sulu/Bundle/SecurityBundle/Security/LogoutSuccessHandler.php
@@ -29,7 +29,7 @@ class LogoutSuccessHandler implements LogoutSuccessHandlerInterface
 
     public function __construct(RouterInterface $router)
     {
-        @\trigger_deprecation('sulu/sulu', '2.5', __CLASS__ . '() is deprecated and will be removed in 3.0. Use LogoutEventSubscriber instead.');
+        @trigger_deprecation('sulu/sulu', '2.5', __CLASS__ . '() is deprecated and will be removed in 3.0. Use LogoutEventSubscriber instead.');
 
         $this->router = $router;
     }

--- a/src/Sulu/Bundle/SecurityBundle/Security/LogoutSuccessHandler.php
+++ b/src/Sulu/Bundle/SecurityBundle/Security/LogoutSuccessHandler.php
@@ -29,7 +29,7 @@ class LogoutSuccessHandler implements LogoutSuccessHandlerInterface
 
     public function __construct(RouterInterface $router)
     {
-        @\trigger_error(__CLASS__ . '() is deprecated since version sulu/sulu 2.5 and will be removed in 3.0. Use LogoutEventSubscriber instead.', \E_USER_DEPRECATED);
+        @\trigger_deprecation('sulu/sulu', '2.5', __CLASS__ . '() is deprecated and will be removed in 3.0. Use LogoutEventSubscriber instead.');
 
         $this->router = $router;
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #6977
| Related issues/PRs | #7030
| License | MIT
| Documentation PR | not necessary

#### What's in this PR?

This PR migrates one deprecation warning on Sulu 2.5 to symfony/deprecation-contracts

#### Why?

Because [alex said so](https://github.com/sulu/sulu/pull/7030#issuecomment-1461762528) 😉 

#### Example Usage

Transparent user experience, deprecation messages will change slightly in their wording, but not much else to do.

#### To Do

none