### PR TITLE
Migrate one remaining deprecation on 2.6 (#6977)

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
@@ -104,7 +104,7 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
         $this->logger = $logger ?: new NullLogger();
 
         if ($securityChecker instanceof RequestStack) {
-            @\trigger_deprecation('sulu/sulu', '2.2', 'Instantiating the "ContentTwigExtension" without the "$securityChecker" and "$webspaceManager" parameter is deprecated');
+            @trigger_deprecation('sulu/sulu', '2.2', 'Instantiating the "ContentTwigExtension" without the "$securityChecker" and "$webspaceManager" parameter is deprecated');
 
             $requestStack = $securityChecker;
             $securityChecker = null;
@@ -115,7 +115,7 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
         $this->requestStack = $requestStack;
 
         if (null === $this->requestStack) {
-            @\trigger_deprecation('sulu/sulu', '2.3', 'Instantiating the "ContentTwigExtension" without the "$requestStack" parameter is deprecated');
+            @trigger_deprecation('sulu/sulu', '2.3', 'Instantiating the "ContentTwigExtension" without the "$requestStack" parameter is deprecated');
         }
 
         $this->enabledTwigAttributes = $enabledTwigAttributes;
@@ -173,7 +173,7 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
         }
 
         if (null === $properties) {
-            @\trigger_deprecation('sulu/sulu', '2.3', 'Calling the "sulu_content_load" function without a properties parameter is deprecated and has a negative impact on performance.');
+            @trigger_deprecation('sulu/sulu', '2.3', 'Calling the "sulu_content_load" function without a properties parameter is deprecated and has a negative impact on performance.');
 
             return $this->resolveStructure($contentStructure);
         }
@@ -216,7 +216,7 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
         }
 
         if ($this->enabledTwigAttributes['urls'] ?? true) {
-            @\trigger_deprecation('sulu/sulu', '2.2', 'Enabling the "urls" parameter is deprecated');
+            @trigger_deprecation('sulu/sulu', '2.2', 'Enabling the "urls" parameter is deprecated');
         } else {
             unset($structureData['urls']);
         }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
@@ -104,7 +104,7 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
         $this->logger = $logger ?: new NullLogger();
 
         if ($securityChecker instanceof RequestStack) {
-            @trigger_deprecation('sulu/sulu', '2.2', 'Instantiating the "ContentTwigExtension" without the "$securityChecker" and "$webspaceManager" parameter is deprecated');
+            @\trigger_deprecation('sulu/sulu', '2.2', 'Instantiating the "ContentTwigExtension" without the "$securityChecker" and "$webspaceManager" parameter is deprecated');
 
             $requestStack = $securityChecker;
             $securityChecker = null;
@@ -115,7 +115,7 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
         $this->requestStack = $requestStack;
 
         if (null === $this->requestStack) {
-            @trigger_deprecation('sulu/sulu', '2.3', 'Instantiating the "ContentTwigExtension" without the "$requestStack" parameter is deprecated');
+            @\trigger_deprecation('sulu/sulu', '2.3', 'Instantiating the "ContentTwigExtension" without the "$requestStack" parameter is deprecated');
         }
 
         $this->enabledTwigAttributes = $enabledTwigAttributes;
@@ -173,7 +173,7 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
         }
 
         if (null === $properties) {
-            @trigger_deprecation('sulu/sulu', '2.3', 'Calling the "sulu_content_load" function without a properties parameter is deprecated and has a negative impact on performance.');
+            @\trigger_deprecation('sulu/sulu', '2.3', 'Calling the "sulu_content_load" function without a properties parameter is deprecated and has a negative impact on performance.');
 
             return $this->resolveStructure($contentStructure);
         }
@@ -216,7 +216,7 @@ class ContentTwigExtension extends AbstractExtension implements ContentTwigExten
         }
 
         if ($this->enabledTwigAttributes['urls'] ?? true) {
-            @\trigger_error('Enabling the "urls" parameter is deprecated since Sulu 2.2', \E_USER_DEPRECATED);
+            @\trigger_deprecation('sulu/sulu', '2.2', 'Enabling the "urls" parameter is deprecated');
         } else {
             unset($structureData['urls']);
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #6977
| Related issues/PRs | #7030, #7035
| License | MIT
| Documentation PR | not necessary

#### What's in this PR?

This PR migrates one deprecation warning on Sulu 2.6 to symfony/deprecation-contracts

#### Why?

Because [alex said so](https://github.com/sulu/sulu/pull/7030#issuecomment-1461762528) 😉 

#### Example Usage

Transparent user experience, deprecation messages will change slightly in their wording, but not much else to do.

#### To Do

none