### PR TITLE
Fix pre and postinstall parameters for custom admin build

### DIFF
--- a/symlink-vendor-directory.js
+++ b/symlink-vendor-directory.js
@@ -22,8 +22,8 @@ const path = require('path');
 
 const parameters = process.argv.slice(2);
 
-const from = parameters.length > 1 ? parameters[0] : '../../vendor';
-const to = parameters.length > 2 ? parameters[1] : 'node_modules/@sulu/vendor';
+const from = parameters.length >= 1 ? parameters[0] : '../../vendor';
+const to = parameters.length >= 2 ? parameters[1] : 'node_modules/@sulu/vendor';
 const doNotCheckCurrentDirectory = parameters.length > 3 && parameters[2] === '--force';
 
 if (


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix pre and postinstall parameters for custom admin build

#### Why?

Currently the Sulu ContentBundle fails which requires another path to vendor dir.

```
        "preinstall": "node ../../../../vendor/sulu/sulu/preinstall.js ../../../../vendor",
        "postinstall": "node ../../../../vendor/sulu/sulu/postinstall.js ../../../../vendor",
```