### PR TITLE
Fix copy article with live generation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -144,7 +144,7 @@
     "conflict": {
         "doctrine/dbal": "2.7.0",
         "doctrine/lexer": "1.0.0",
-        "doctrine/orm": "2.10.0",
+        "doctrine/orm": "2.10.0 || 2.14.2",
         "doctrine/doctrine-cache-bundle": "<1.3.1",
         "friendsofphp/php-cs-fixer": "3.9.1",
         "gedmo/doctrine-extensions" : "3.7.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1536,11 +1536,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
 
 		-
-			message: "#^Cannot call method merge\\(\\) on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\Metadata\\\\FormMetadata\\\\XmlFormMetadataLoader\\:\\:__construct\\(\\) has parameter \\$formDirectories with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
@@ -3971,7 +3966,7 @@ parameters:
 			path: src/Sulu/Bundle/CategoryBundle/Api/Category.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\CategoryBundle\\\\Api\\\\Category\\:\\:getMediasRawData\\(\\) should return string but returns array\\<string, array\\<int, int\\>\\>\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\CategoryBundle\\\\Api\\\\Category\\:\\:getMediasRawData\\(\\) should return string but returns array\\<string, array\\<int\\<0, max\\>, int\\>\\>\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/CategoryBundle/Api/Category.php
 
@@ -5996,7 +5991,7 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Api/Account.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\Account\\:\\:getBankAccounts\\(\\) should return array\\<Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\BankAccount\\> but returns array\\<int, Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\BankAccount\\>\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\Account\\:\\:getBankAccounts\\(\\) should return array\\<Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\BankAccount\\> but returns array\\<int\\<0, max\\>, Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\BankAccount\\>\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Api/Account.php
 
@@ -6006,12 +6001,12 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Api/Account.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\Account\\:\\:getEmails\\(\\) should return array\\<Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\Email\\> but returns array\\<int, Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\Email\\>\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\Account\\:\\:getEmails\\(\\) should return array\\<Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\Email\\> but returns array\\<int\\<0, max\\>, Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\Email\\>\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Api/Account.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\Account\\:\\:getFaxes\\(\\) should return array\\<Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\Fax\\> but returns array\\<int, Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\Fax\\>\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\Account\\:\\:getFaxes\\(\\) should return array\\<Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\Fax\\> but returns array\\<int\\<0, max\\>, Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\Fax\\>\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Api/Account.php
 
@@ -6046,17 +6041,17 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Api/Account.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\Account\\:\\:getPhones\\(\\) should return array\\<Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\Phone\\> but returns array\\<int, Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\Phone\\>\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\Account\\:\\:getPhones\\(\\) should return array\\<Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\Phone\\> but returns array\\<int\\<0, max\\>, Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\Phone\\>\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Api/Account.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\Account\\:\\:getSocialMediaProfiles\\(\\) should return array\\<Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\SocialMediaProfile\\> but returns array\\<int, Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\SocialMediaProfile\\>\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\Account\\:\\:getSocialMediaProfiles\\(\\) should return array\\<Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\SocialMediaProfile\\> but returns array\\<int\\<0, max\\>, Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\SocialMediaProfile\\>\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Api/Account.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\Account\\:\\:getUrls\\(\\) should return array\\<Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\Url\\> but returns array\\<int, Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\Url\\>\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\Account\\:\\:getUrls\\(\\) should return array\\<Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\Url\\> but returns array\\<int\\<0, max\\>, Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\Url\\>\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Api/Account.php
 
@@ -6916,7 +6911,7 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Api/Contact.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\Contact\\:\\:getSocialMediaProfiles\\(\\) should return array\\<Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\SocialMediaProfile\\> but returns array\\<int, Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\SocialMediaProfile\\>\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\Contact\\:\\:getSocialMediaProfiles\\(\\) should return array\\<Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\SocialMediaProfile\\> but returns array\\<int\\<0, max\\>, Sulu\\\\Bundle\\\\ContactBundle\\\\Api\\\\SocialMediaProfile\\>\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Api/Contact.php
 
@@ -15026,7 +15021,7 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Collection\\\\Manager\\\\CollectionManager\\:\\:get\\(\\) should return Doctrine\\\\ORM\\\\Tools\\\\Pagination\\\\Paginator but returns array\\<int, Sulu\\\\Bundle\\\\MediaBundle\\\\Api\\\\Collection\\>\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Collection\\\\Manager\\\\CollectionManager\\:\\:get\\(\\) should return Doctrine\\\\ORM\\\\Tools\\\\Pagination\\\\Paginator but returns array\\<int\\<0, max\\>, Sulu\\\\Bundle\\\\MediaBundle\\\\Api\\\\Collection\\>\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
 
@@ -15126,7 +15121,7 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
 
 		-
-			message: "#^Parameter \\#1 \\$children of method Sulu\\\\Bundle\\\\MediaBundle\\\\Api\\\\Collection\\:\\:setChildren\\(\\) expects array\\<Sulu\\\\Bundle\\\\MediaBundle\\\\Api\\\\Collection\\>, array\\<int, Sulu\\\\Bundle\\\\MediaBundle\\\\Api\\\\Collection\\>\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$children of method Sulu\\\\Bundle\\\\MediaBundle\\\\Api\\\\Collection\\:\\:setChildren\\(\\) expects array\\<Sulu\\\\Bundle\\\\MediaBundle\\\\Api\\\\Collection\\>, array\\<int\\<0, max\\>, Sulu\\\\Bundle\\\\MediaBundle\\\\Api\\\\Collection\\>\\|null given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
 
@@ -22931,7 +22926,7 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/EventListener/DomainEventSubscriber.php
 
 		-
-			message: "#^Parameter \\#1 \\$resources of method Sulu\\\\Bundle\\\\PageBundle\\\\EventListener\\\\PageRemoveSubscriber\\:\\:groupResourcesByDepth\\(\\) expects array\\<array\\{id\\: string, resourceKey\\: string, depth\\: int\\}\\>, non\\-empty\\-array\\<int, array\\{id\\: mixed, depth\\: int\\<0, max\\>, resourceKey\\: 'pages'\\}\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$resources of method Sulu\\\\Bundle\\\\PageBundle\\\\EventListener\\\\PageRemoveSubscriber\\:\\:groupResourcesByDepth\\(\\) expects array\\<array\\{id\\: string, resourceKey\\: string, depth\\: int\\}\\>, non\\-empty\\-array\\<int\\<0, max\\>, array\\{id\\: mixed, depth\\: int\\<0, max\\>, resourceKey\\: 'pages'\\}\\> given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/EventListener/PageRemoveSubscriber.php
 
@@ -31546,7 +31541,7 @@ parameters:
 			path: src/Sulu/Bundle/SecurityBundle/Entity/RoleRepository.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\SecurityBundle\\\\Entity\\\\RoleRepository\\:\\:getRoleNames\\(\\) should return array\\<string\\> but returns array\\<int, mixed\\>\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\SecurityBundle\\\\Entity\\\\RoleRepository\\:\\:getRoleNames\\(\\) should return array\\<string\\> but returns array\\<int\\<0, max\\>, mixed\\>\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/Entity/RoleRepository.php
 
@@ -34101,7 +34096,7 @@ parameters:
 			path: src/Sulu/Bundle/SnippetBundle/Snippet/SnippetRepository.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\SnippetBundle\\\\Snippet\\\\SnippetRepository\\:\\:getSnippetsByUuids\\(\\) should return Sulu\\\\Bundle\\\\SnippetBundle\\\\Document\\\\SnippetDocument but returns array\\<int, object\\>\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\SnippetBundle\\\\Snippet\\\\SnippetRepository\\:\\:getSnippetsByUuids\\(\\) should return Sulu\\\\Bundle\\\\SnippetBundle\\\\Document\\\\SnippetDocument but returns array\\<int\\<0, max\\>, object\\>\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/Snippet/SnippetRepository.php
 
@@ -43441,7 +43436,7 @@ parameters:
 			path: src/Sulu/Component/Content/Export/WebspaceExport.php
 
 		-
-			message: "#^Method Sulu\\\\Component\\\\Content\\\\Export\\\\WebspaceExport\\:\\:getExportData\\(\\) should return string but returns array\\<string, array\\<int, array\\<string, array\\|string\\>\\>\\|string\\>\\.$#"
+			message: "#^Method Sulu\\\\Component\\\\Content\\\\Export\\\\WebspaceExport\\:\\:getExportData\\(\\) should return string but returns array\\<string, array\\<int\\<0, max\\>, array\\<string, array\\|string\\>\\>\\|string\\>\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Export/WebspaceExport.php
 
@@ -44366,7 +44361,7 @@ parameters:
 			path: src/Sulu/Component/Content/Mapper/Event/ContentNodeDeleteEvent.php
 
 		-
-			message: "#^Method Sulu\\\\Component\\\\Content\\\\Mapper\\\\Event\\\\ContentNodeDeleteEvent\\:\\:getStructures\\(\\) should return array\\<Symfony\\\\Component\\\\Validator\\\\Mapping\\\\MetadataInterface\\> but returns array\\<int, Sulu\\\\Component\\\\Content\\\\Compat\\\\StructureInterface\\>\\.$#"
+			message: "#^Method Sulu\\\\Component\\\\Content\\\\Mapper\\\\Event\\\\ContentNodeDeleteEvent\\:\\:getStructures\\(\\) should return array\\<Symfony\\\\Component\\\\Validator\\\\Mapping\\\\MetadataInterface\\> but returns array\\<int\\<0, max\\>, Sulu\\\\Component\\\\Content\\\\Compat\\\\StructureInterface\\>\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Mapper/Event/ContentNodeDeleteEvent.php
 
@@ -44551,7 +44546,7 @@ parameters:
 			path: src/Sulu/Component/Content/Metadata/Factory/StructureMetadataFactory.php
 
 		-
-			message: "#^Method Sulu\\\\Component\\\\Content\\\\Metadata\\\\Factory\\\\StructureMetadataFactory\\:\\:getStructures\\(\\) should return array\\<Sulu\\\\Component\\\\Content\\\\Metadata\\\\StructureMetadata\\> but returns array\\<int, Sulu\\\\Component\\\\Content\\\\Metadata\\\\StructureMetadata\\|null\\>\\.$#"
+			message: "#^Method Sulu\\\\Component\\\\Content\\\\Metadata\\\\Factory\\\\StructureMetadataFactory\\:\\:getStructures\\(\\) should return array\\<Sulu\\\\Component\\\\Content\\\\Metadata\\\\StructureMetadata\\> but returns array\\<int\\<0, max\\>, Sulu\\\\Component\\\\Content\\\\Metadata\\\\StructureMetadata\\|null\\>\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Metadata/Factory/StructureMetadataFactory.php
 
@@ -53166,7 +53161,7 @@ parameters:
 			path: src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
 
 		-
-			message: "#^Method Sulu\\\\Component\\\\Media\\\\SmartContent\\\\MediaDataProvider\\:\\:getTypes\\(\\) should return array\\<int, array\\<string, string\\>\\> but returns array\\<int, array\\<string, int\\|string\\>\\>\\.$#"
+			message: "#^Method Sulu\\\\Component\\\\Media\\\\SmartContent\\\\MediaDataProvider\\:\\:getTypes\\(\\) should return array\\<int, array\\<string, string\\>\\> but returns array\\<int\\<0, max\\>, array\\<string, int\\|string\\>\\>\\.$#"
 			count: 1
 			path: src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
 
@@ -59066,7 +59061,7 @@ parameters:
 			path: src/Sulu/Component/Util/Tests/Unit/SortUtilsTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$values of static method Sulu\\\\Component\\\\Util\\\\SortUtils\\:\\:multisort\\(\\) expects array, ArrayObject\\<int, stdClass\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$values of static method Sulu\\\\Component\\\\Util\\\\SortUtils\\:\\:multisort\\(\\) expects array, ArrayObject\\<int, object\\{\\}&stdClass\\> given\\.$#"
 			count: 1
 			path: src/Sulu/Component/Util/Tests/Unit/SortUtilsTest.php
 

--- a/src/Sulu/Bundle/RouteBundle/Document/Subscriber/RoutableSubscriber.php
+++ b/src/Sulu/Bundle/RouteBundle/Document/Subscriber/RoutableSubscriber.php
@@ -275,7 +275,9 @@ class RoutableSubscriber implements EventSubscriberInterface
                 return;
             }
 
-            $route = $this->conflictResolver->resolve($this->chainRouteGenerator->generate($localizedDocument));
+            $route = $this->conflictResolver->resolve(
+                $this->chainRouteGenerator->generate($localizedDocument, $localizedDocument->getRoutePath())
+            );
             $localizedDocument->setRoutePath($route->getPath());
 
             $node = $this->documentInspector->getNode($localizedDocument);

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Document/Subscriber/RoutableSubscriberTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Document/Subscriber/RoutableSubscriberTest.php
@@ -112,7 +112,7 @@ class RoutableSubscriberTest extends TestCase
 
         $copyEvent = new CopyEvent(
             $document->reveal(),
-            'destId',
+            'destId'
         );
 
         $this->documentInspector->getLocales($document->reveal())

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Document/Subscriber/RoutableSubscriberTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Document/Subscriber/RoutableSubscriberTest.php
@@ -1,0 +1,203 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\RouteBundle\Tests\Unit\Document\Subscriber;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PHPCR\NodeInterface;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
+use Sulu\Bundle\DocumentManagerBundle\Bridge\PropertyEncoder;
+use Sulu\Bundle\RouteBundle\Document\Subscriber\RoutableSubscriber;
+use Sulu\Bundle\RouteBundle\Entity\RouteRepositoryInterface;
+use Sulu\Bundle\RouteBundle\Generator\ChainRouteGeneratorInterface;
+use Sulu\Bundle\RouteBundle\Manager\ConflictResolverInterface;
+use Sulu\Bundle\RouteBundle\Manager\RouteManagerInterface;
+use Sulu\Bundle\RouteBundle\Model\RouteInterface;
+use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Sulu\Component\DocumentManager\Event\CopyEvent;
+use Sulu\Component\Route\Document\Behavior\RoutableBehavior;
+
+class RoutableSubscriberTest extends TestCase
+{
+    /**
+     * @var ObjectProphecy<ChainRouteGeneratorInterface>
+     */
+    private $chainRouteGenerator;
+
+    /**
+     * @var ObjectProphecy<RouteManagerInterface>
+     */
+    private $routeManager;
+
+    /**
+     * @var ObjectProphecy<RouteRepositoryInterface>
+     */
+    private $routeRepository;
+
+    /**
+     * @var ObjectProphecy<EntityManagerInterface>
+     */
+    private $entityManager;
+
+    /**
+     * @var ObjectProphecy<DocumentManagerInterface>
+     */
+    private $documentManager;
+
+    /**
+     * @var ObjectProphecy<DocumentInspector>
+     */
+    private $documentInspector;
+
+    /**
+     * @var ObjectProphecy<PropertyEncoder>
+     */
+    private $propertyEncoder;
+
+    /**
+     * @var ObjectProphecy<StructureMetadataFactoryInterface>
+     */
+    private $metadataFactory;
+
+    /**
+     * @var ObjectProphecy<ConflictResolverInterface>
+     */
+    private $conflictResolver;
+
+    /**
+     * @var RoutableSubscriber
+     */
+    private $routableSubscriber;
+
+    public function setUp(): void
+    {
+        $this->chainRouteGenerator = $this->prophesize(ChainRouteGeneratorInterface::class);
+        $this->routeManager = $this->prophesize(RouteManagerInterface::class);
+        $this->routeRepository = $this->prophesize(RouteRepositoryInterface::class);
+        $this->entityManager = $this->prophesize(EntityManagerInterface::class);
+        $this->documentManager = $this->prophesize(DocumentManagerInterface::class);
+        $this->documentInspector = $this->prophesize(DocumentInspector::class);
+        $this->propertyEncoder = $this->prophesize(PropertyEncoder::class);
+        $this->metadataFactory = $this->prophesize(StructureMetadataFactoryInterface::class);
+        $this->conflictResolver = $this->prophesize(ConflictResolverInterface::class);
+
+        $this->routableSubscriber = new RoutableSubscriber(
+            $this->chainRouteGenerator->reveal(),
+            $this->routeManager->reveal(),
+            $this->routeRepository->reveal(),
+            $this->entityManager->reveal(),
+            $this->documentManager->reveal(),
+            $this->documentInspector->reveal(),
+            $this->propertyEncoder->reveal(),
+            $this->metadataFactory->reveal(),
+            $this->conflictResolver->reveal(),
+        );
+    }
+
+    public function testHandleCopy(): void
+    {
+        $document = $this->prophesize(RoutableBehavior::class);
+
+        $copyEvent = new CopyEvent(
+            $document->reveal(),
+            'destId',
+        );
+
+        $this->documentInspector->getLocales($document->reveal())
+            ->willReturn(['en', 'de'])
+            ->shouldBeCalled();
+
+        $localizedDocumentEn = $this->prophesize(RoutableBehavior::class);
+        $localizedDocumentDe = $this->prophesize(RoutableBehavior::class);
+
+        $this->documentManager->find($copyEvent->getCopiedPath(), 'en')
+            ->willReturn($localizedDocumentEn->reveal())
+            ->shouldBeCalled();
+
+        $this->documentManager->find($copyEvent->getCopiedPath(), 'de')
+            ->willReturn($localizedDocumentDe->reveal())
+            ->shouldBeCalled();
+
+        $localizedDocumentEn->getRoutePath() // this is required to be called that handle copy works correctly live generated urls
+            ->willReturn('/test-en')
+            ->shouldBeCalled();
+
+        $localizedDocumentDe->getRoutePath() // this is required to be called that handle copy works correctly live generated urls
+            ->willReturn('/test-de')
+            ->shouldBeCalled();
+
+        $routeEn = $this->prophesize(RouteInterface::class);
+        $routeEn->getPath()
+            ->willReturn('/test-en-2')
+            ->shouldBeCalled();
+
+        $routeDe = $this->prophesize(RouteInterface::class);
+        $routeDe->getPath()
+            ->willReturn('/test-de-2')
+            ->shouldBeCalled();
+
+        $this->conflictResolver->resolve($routeDe->reveal())
+            ->willReturn($routeDe->reveal())
+            ->shouldBeCalled();
+
+        $this->conflictResolver->resolve($routeEn->reveal())
+            ->willReturn($routeEn->reveal())
+            ->shouldBeCalled();
+
+        $this->chainRouteGenerator->generate($localizedDocumentEn, '/test-en')
+            ->willReturn($routeEn->reveal())
+            ->shouldBeCalled();
+
+        $this->chainRouteGenerator->generate($localizedDocumentDe, '/test-de')
+            ->willReturn($routeDe->reveal())
+            ->shouldBeCalled();
+
+        $nodeEn = $this->prophesize(NodeInterface::class);
+        $nodeEn->setProperty('i18n:en-routePath', '/test-en-2')
+            ->shouldBeCalled();
+
+        $nodeDe = $this->prophesize(NodeInterface::class);
+        $nodeDe->setProperty('i18n:de-routePath', '/test-de-2')
+            ->willReturn()
+            ->shouldBeCalled();
+
+        $node = $this->documentInspector->getNode($localizedDocumentEn)
+            ->willReturn($nodeEn)
+            ->shouldBeCalled();
+
+        $node = $this->documentInspector->getNode($localizedDocumentDe)
+            ->willReturn($nodeDe)
+            ->shouldBeCalled();
+
+        $this->documentInspector->getStructureMetadata(Argument::cetera())
+            ->shouldBeCalled();
+
+        $this->propertyEncoder->localizedSystemName(Argument::any(), 'en')
+            ->willReturn('i18n:en-routePath')
+            ->shouldBeCalled();
+
+        $this->propertyEncoder->localizedSystemName(Argument::any(), 'de')
+            ->willReturn('i18n:de-routePath')
+            ->shouldBeCalled();
+
+        $localizedDocumentEn->setRoutePath('/test-en-2')
+            ->shouldBeCalled();
+
+        $localizedDocumentDe->setRoutePath('/test-de-2')
+            ->shouldBeCalled();
+
+        $this->routableSubscriber->handleCopy($copyEvent);
+    }
+}

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Document/Subscriber/RoutableSubscriberTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Document/Subscriber/RoutableSubscriberTest.php
@@ -102,7 +102,7 @@ class RoutableSubscriberTest extends TestCase
             $this->documentInspector->reveal(),
             $this->propertyEncoder->reveal(),
             $this->metadataFactory->reveal(),
-            $this->conflictResolver->reveal(),
+            $this->conflictResolver->reveal()
         );
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/SuluArticleBundle/pull/610
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix copy article with live generation.

#### Why?

When using live generating the route generating currently ends in some error. For copy we can just reuse the previous document routepath which will correclty postfix. 