### PR TITLE
Fixed type annotation of addresses property of Account entity

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Entity/Account.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/Account.php
@@ -145,7 +145,7 @@ class Account implements AccountInterface
     protected $parent;
 
     /**
-     * @var Address[]
+     * @var Collection<int, Address>
      *
      * @Accessor(getter="getAddresses")
      */

--- a/src/Sulu/Bundle/ContactBundle/Entity/Account.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/Account.php
@@ -145,7 +145,7 @@ class Account implements AccountInterface
     protected $parent;
 
     /**
-     * @var string
+     * @var Address[]
      *
      * @Accessor(getter="getAddresses")
      */


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | not sure
| Deprecations? | no
| Fixed tickets | no
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

It fixes the type annotation of `Sulu\Bundle\ContactBundle\Entity\Account::$addresses`.

#### Why?

The current type  is invalid. The getter method  returns an array of Address, so I think it would be correct adjust the property's type annotation, too.

