### PR TITLE
Better doc typing

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -141,42 +141,7 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItem.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\Admin\\\\Navigation\\\\NavigationItem\\:\\:addChild\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItem.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\Admin\\\\Navigation\\\\NavigationItem\\:\\:setChildViews\\(\\) has parameter \\$childViews with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItem.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\Admin\\\\Navigation\\\\NavigationItem\\:\\:setDisabled\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItem.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\Admin\\\\Navigation\\\\NavigationItem\\:\\:setIcon\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItem.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\Admin\\\\Navigation\\\\NavigationItem\\:\\:setId\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItem.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\Admin\\\\Navigation\\\\NavigationItem\\:\\:setName\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItem.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\Admin\\\\Navigation\\\\NavigationItem\\:\\:setPosition\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItem.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\Admin\\\\Navigation\\\\NavigationItem\\:\\:setVisible\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItem.php
 
@@ -669,11 +634,6 @@ parameters:
 			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\Admin\\\\View\\\\ViewRegistry\\:\\:mergeViewOptions\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Admin/View/ViewRegistry.php
-
-		-
-			message: "#^Cannot call method find\\(\\) on Symfony\\\\Component\\\\Console\\\\Application\\|null\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Command/DownloadBuildCommand.php
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\Command\\\\DownloadBuildCommand\\:\\:configure\\(\\) has no return type specified\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8326,12 +8326,7 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Content/Types/ContactAccountSelection.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Content\\\\Types\\\\ContactAccountSelection\\:\\:exportData\\(\\) should return string but returns string\\|false\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Content/Types/ContactAccountSelection.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Content\\\\Types\\\\ContactAccountSelection\\:\\:getDefaultParams\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Content\\\\Types\\\\ContactAccountSelection\\:\\:getContentData\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Content/Types/ContactAccountSelection.php
 
@@ -8346,32 +8341,12 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Content/Types/ContactAccountSelection.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Content\\\\Types\\\\ContactAccountSelection\\:\\:preResolve\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Content/Types/ContactAccountSelection.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Content\\\\Types\\\\ContactAccountSelection\\:\\:read\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Content/Types/ContactAccountSelection.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Content\\\\Types\\\\ContactAccountSelection\\:\\:read\\(\\) has parameter \\$node with no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Content/Types/ContactAccountSelection.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Content\\\\Types\\\\ContactAccountSelection\\:\\:remove\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Content/Types/ContactAccountSelection.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Content\\\\Types\\\\ContactAccountSelection\\:\\:remove\\(\\) has parameter \\$node with no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Content/Types/ContactAccountSelection.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Content\\\\Types\\\\ContactAccountSelection\\:\\:write\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Content/Types/ContactAccountSelection.php
 
@@ -11196,26 +11171,6 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/CacheInvalidationListenerTest.php
 
 		-
-			message: "#^Cannot access offset 0 on mixed\\.$#"
-			count: 3
-			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/ContactAccountSelectionTest.php
-
-		-
-			message: "#^Cannot access offset 1 on mixed\\.$#"
-			count: 3
-			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/ContactAccountSelectionTest.php
-
-		-
-			message: "#^Cannot access offset 2 on mixed\\.$#"
-			count: 3
-			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/ContactAccountSelectionTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$haystack of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertCount\\(\\) expects Countable\\|iterable, mixed given\\.$#"
-			count: 6
-			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/ContactAccountSelectionTest.php
-
-		-
 			message: "#^Property Sulu\\\\Bundle\\\\ContactBundle\\\\Tests\\\\Unit\\\\ContactAccountSelectionTest\\:\\:\\$accountManager with generic interface Sulu\\\\Bundle\\\\ContactBundle\\\\Contact\\\\ContactManagerInterface does not specify its types\\: DoctrineEntity, ApiEntity, AddressRelationEntity$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/ContactAccountSelectionTest.php
@@ -11241,13 +11196,8 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/ContactSelectionTest.php
 
 		-
-			message: "#^Call to an undefined method Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\ContactInterface\\:\\:getFullName\\(\\)\\.$#"
+			message: "#^Cannot call method getFullName\\(\\) on Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\ContactInterface\\|null\\.$#"
 			count: 2
-			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/ContactTwigExtensionTest.php
-
-		-
-			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNull\\(\\) with Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\ContactInterface will always evaluate to false\\.$#"
-			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/ContactTwigExtensionTest.php
 
 		-
@@ -11261,17 +11211,17 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/CustomerIdConverterTest.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Util\\\\CustomerIdConverterTest\\:\\:testConvertGroupedIdsToIds\\(\\) has parameter \\$expected with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Util\\\\CustomerIdConverterTest\\:\\:testConvertGroupedIdsToIds\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/CustomerIdConverterTest.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Util\\\\CustomerIdConverterTest\\:\\:testConvertGroupedIdsToIds\\(\\) has parameter \\$groupedIds with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Util\\\\CustomerIdConverterTest\\:\\:testConvertGroupedIdsToIds\\(\\) has parameter \\$groupedIds with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/CustomerIdConverterTest.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Util\\\\CustomerIdConverterTest\\:\\:testConvertIdsToGroupedIds\\(\\) has parameter \\$default with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Util\\\\CustomerIdConverterTest\\:\\:testConvertIdsToGroupedIds\\(\\) has parameter \\$default with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/CustomerIdConverterTest.php
 
@@ -11281,12 +11231,12 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/CustomerIdConverterTest.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Util\\\\CustomerIdConverterTest\\:\\:testConvertIdsToGroupedIds\\(\\) has parameter \\$ids with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Util\\\\CustomerIdConverterTest\\:\\:testConvertIdsToGroupedIds\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/CustomerIdConverterTest.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Util\\\\IndexComparatorTest\\:\\:testUsortCallback\\(\\) has parameter \\$array with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Util\\\\IndexComparatorTest\\:\\:testUsortCallback\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/IndexComparatorTest.php
 
@@ -11296,7 +11246,7 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/IndexComparatorTest.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Util\\\\IndexComparatorTest\\:\\:testUsortCallback\\(\\) has parameter \\$ids with no type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Util\\\\IndexComparatorTest\\:\\:testUsortCallback\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/IndexComparatorTest.php
 
@@ -11306,7 +11256,7 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/IndexComparatorTest.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Util\\\\IndexComparatorTest\\:\\:usortProvider\\(\\) has no return type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Util\\\\IndexComparatorTest\\:\\:usortProvider\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/IndexComparatorTest.php
 
@@ -11371,12 +11321,7 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Trash/ContactTrashItemHandler.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Twig\\\\ContactTwigExtension\\:\\:resolveContactFunction\\(\\) should return Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\ContactInterface but empty return statement found\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Twig/ContactTwigExtension.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Twig\\\\ContactTwigExtension\\:\\:resolveContactFunction\\(\\) should return Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\ContactInterface but returns mixed\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\Twig\\\\ContactTwigExtension\\:\\:resolveContactFunction\\(\\) should return Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\ContactInterface\\|null but returns mixed\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Twig/ContactTwigExtension.php
 
@@ -15362,11 +15307,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Content\\\\Types\\\\ImageMapContentType\\:\\:exportData\\(\\) should return string but returns mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Content/Types/ImageMapContentType.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Content\\\\Types\\\\ImageMapContentType\\:\\:hasValue\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Content/Types/ImageMapContentType.php
 
@@ -41101,11 +41041,6 @@ parameters:
 			path: src/Sulu/Component/Content/ComplexContentType.php
 
 		-
-			message: "#^Method Sulu\\\\Component\\\\Content\\\\ComplexContentType\\:\\:hasValue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/ComplexContentType.php
-
-		-
 			message: "#^Method Sulu\\\\Component\\\\Content\\\\ComplexContentType\\:\\:hasValue\\(\\) has parameter \\$node with no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/ComplexContentType.php
@@ -47587,11 +47522,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Component\\\\Content\\\\Types\\\\BlockContentType\\:\\:exportData\\(\\) should return string but returns mixed\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Types/BlockContentType.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Content\\\\Types\\\\BlockContentType\\:\\:hasValue\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Types/BlockContentType.php
 
@@ -59426,11 +59356,6 @@ parameters:
 			path: src/Sulu/Component/Webspace/Manager/WebspaceManager.php
 
 		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Manager\\\\WebspaceManager\\:\\:getAllLocalesByWebspaces\\(\\) should return array\\<Sulu\\\\Component\\\\Localization\\\\Localization\\> but returns array\\<string, array\\<string, Sulu\\\\Component\\\\Localization\\\\Localization\\>\\>\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Manager/WebspaceManager.php
-
-		-
 			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Manager\\\\WebspaceManager\\:\\:setOptions\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -60136,181 +60061,6 @@ parameters:
 			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
 
 		-
-			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) with 'en_us' and Sulu\\\\Component\\\\Localization\\\\Localization will always evaluate to false\\.$#"
-			count: 2
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNull\\(\\) with Sulu\\\\Component\\\\Webspace\\\\Segment will always evaluate to false\\.$#"
-			count: 4
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Cannot call method getAllLocalizations\\(\\) on Sulu\\\\Component\\\\Webspace\\\\Webspace\\|null\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Cannot call method getEnvironment\\(\\) on Sulu\\\\Component\\\\Webspace\\\\Portal\\|null\\.$#"
-			count: 2
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Cannot call method getEnvironments\\(\\) on Sulu\\\\Component\\\\Webspace\\\\Portal\\|null\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Cannot call method getKey\\(\\) on Sulu\\\\Component\\\\Webspace\\\\Portal\\|null\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Cannot call method getKey\\(\\) on Sulu\\\\Component\\\\Webspace\\\\Webspace\\|null\\.$#"
-			count: 4
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Cannot call method getLocale\\(\\) on Sulu\\\\Component\\\\Webspace\\\\PortalInformation\\|false\\.$#"
-			count: 2
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Cannot call method getLocalization\\(\\) on Sulu\\\\Component\\\\Webspace\\\\PortalInformation\\|false\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Cannot call method getLocalization\\(\\) on Sulu\\\\Component\\\\Webspace\\\\PortalInformation\\|null\\.$#"
-			count: 3
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Cannot call method getLocalizations\\(\\) on Sulu\\\\Component\\\\Webspace\\\\Portal\\|null\\.$#"
-			count: 7
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Cannot call method getLocalizations\\(\\) on Sulu\\\\Component\\\\Webspace\\\\Webspace\\|null\\.$#"
-			count: 18
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Cannot call method getName\\(\\) on Sulu\\\\Component\\\\Webspace\\\\Portal\\|null\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Cannot call method getName\\(\\) on Sulu\\\\Component\\\\Webspace\\\\Webspace\\|null\\.$#"
-			count: 4
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Cannot call method getNavigation\\(\\) on Sulu\\\\Component\\\\Webspace\\\\Webspace\\|null\\.$#"
-			count: 9
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Cannot call method getPortal\\(\\) on Sulu\\\\Component\\\\Webspace\\\\PortalInformation\\|false\\.$#"
-			count: 2
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Cannot call method getPortal\\(\\) on Sulu\\\\Component\\\\Webspace\\\\PortalInformation\\|null\\.$#"
-			count: 3
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Cannot call method getPortals\\(\\) on Sulu\\\\Component\\\\Webspace\\\\Webspace\\|null\\.$#"
-			count: 3
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Cannot call method getRedirect\\(\\) on Sulu\\\\Component\\\\Webspace\\\\PortalInformation\\|null\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Cannot call method getSecurity\\(\\) on Sulu\\\\Component\\\\Webspace\\\\Webspace\\|null\\.$#"
-			count: 2
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Cannot call method getSegment\\(\\) on Sulu\\\\Component\\\\Webspace\\\\PortalInformation\\|false\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Cannot call method getSegment\\(\\) on Sulu\\\\Component\\\\Webspace\\\\PortalInformation\\|null\\.$#"
-			count: 3
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Cannot call method getSystem\\(\\) on Sulu\\\\Component\\\\Webspace\\\\Security\\|null\\.$#"
-			count: 7
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Cannot call method getTheme\\(\\) on Sulu\\\\Component\\\\Webspace\\\\Webspace\\|null\\.$#"
-			count: 2
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Cannot call method getUrl\\(\\) on Sulu\\\\Component\\\\Webspace\\\\PortalInformation\\|null\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Cannot call method getWebspace\\(\\) on Sulu\\\\Component\\\\Webspace\\\\PortalInformation\\|false\\.$#"
-			count: 2
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Cannot call method getWebspace\\(\\) on Sulu\\\\Component\\\\Webspace\\\\PortalInformation\\|null\\.$#"
-			count: 4
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Tests\\\\Unit\\\\WebspaceManagerTest\\:\\:provideFindPortalInformationByUrl\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Tests\\\\Unit\\\\WebspaceManagerTest\\:\\:testFindPortalInformationByUrlWithInvalidSuffix\\(\\) has parameter \\$shouldFind with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Tests\\\\Unit\\\\WebspaceManagerTest\\:\\:testFindPortalInformationByUrlWithInvalidSuffix\\(\\) has parameter \\$url with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$array of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) expects array\\|ArrayAccess, Sulu\\\\Component\\\\Localization\\\\Localization given\\.$#"
-			count: 2
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\Webspace\\\\Tests\\\\Unit\\\\PortalInformationTest\\:\\:\\$localization\\.$#"
-			count: 3
-			path: src/Sulu/Component/Webspace/Tests/Unit/PortalInformationTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\Webspace\\\\Tests\\\\Unit\\\\PortalInformationTest\\:\\:\\$portal\\.$#"
-			count: 3
-			path: src/Sulu/Component/Webspace/Tests/Unit/PortalInformationTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\Webspace\\\\Tests\\\\Unit\\\\PortalInformationTest\\:\\:\\$webspace\\.$#"
-			count: 3
-			path: src/Sulu/Component/Webspace/Tests/Unit/PortalInformationTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Tests\\\\Unit\\\\PortalInformationTest\\:\\:provideUrl\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/PortalInformationTest.php
-
-		-
 			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Tests\\\\Unit\\\\PortalInformationTest\\:\\:testGetHostAndPrefix\\(\\) has parameter \\$host with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Webspace/Tests/Unit/PortalInformationTest.php
@@ -60606,112 +60356,7 @@ parameters:
 			path: src/Sulu/Component/Webspace/Webspace.php
 
 		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Webspace\\:\\:addDefaultTemplate\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Webspace.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Webspace\\:\\:addExcludedTemplate\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Webspace.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Webspace\\:\\:addLocalization\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Webspace.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Webspace\\:\\:addPortal\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Webspace.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Webspace\\:\\:addSegment\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Webspace.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Webspace\\:\\:addTemplate\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Webspace.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Webspace\\:\\:getDefaultTemplate\\(\\) should return string\\|null but empty return statement found\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Webspace.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Webspace\\:\\:getLocalization\\(\\) should return Sulu\\\\Component\\\\Localization\\\\Localization\\|null but empty return statement found\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Webspace.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Webspace\\:\\:getTemplate\\(\\) should return string\\|null but empty return statement found\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Webspace.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Webspace\\:\\:hasWebsiteSecurity\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Webspace.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Webspace\\:\\:setDefaultLocalization\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Webspace.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Webspace\\:\\:setDefaultSegment\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Webspace.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Webspace\\:\\:setKey\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Webspace.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Webspace\\:\\:setLocalizations\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Webspace.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Webspace\\:\\:setName\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Webspace.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Webspace\\:\\:setNavigation\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Webspace.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Webspace\\:\\:setPortals\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Webspace.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Webspace\\:\\:setResourceLocatorStrategy\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Webspace.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Webspace\\:\\:setSecurity\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Webspace.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Webspace\\:\\:setSegments\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Webspace.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Webspace\\:\\:setTheme\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Webspace.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Webspace\\:\\:toArray\\(\\) has no return type specified\\.$#"
+			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Webspace\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Component/Webspace/Webspace.php
 

--- a/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItem.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItem.php
@@ -96,6 +96,8 @@ class NavigationItem implements \Iterator
      * Sets the id of the NavigationItem.
      *
      * @param string $id
+     *
+     * @return void
      */
     public function setId($id)
     {
@@ -116,6 +118,8 @@ class NavigationItem implements \Iterator
      * Sets the name being displayed in the navigation.
      *
      * @param string $name The name being displayed in the navigation
+     *
+     * @return void
      */
     public function setName($name)
     {
@@ -146,6 +150,8 @@ class NavigationItem implements \Iterator
      * Set the icon of the NavigaitonItem.
      *
      * @param string $icon The icon of the NavigationItem
+     *
+     * @return void
      */
     public function setIcon($icon)
     {
@@ -192,6 +198,8 @@ class NavigationItem implements \Iterator
 
     /**
      * Adds a child to the navigation item.
+     *
+     * @return void
      */
     public function addChild(self $child)
     {
@@ -210,6 +218,8 @@ class NavigationItem implements \Iterator
 
     /**
      * @param int $position
+     *
+     * @return void
      */
     public function setPosition($position)
     {
@@ -236,6 +246,8 @@ class NavigationItem implements \Iterator
 
     /**
      * @param bool $disabled
+     *
+     * @return void
      */
     public function setDisabled($disabled)
     {
@@ -252,6 +264,8 @@ class NavigationItem implements \Iterator
 
     /**
      * @param bool $visible
+     *
+     * @return void
      */
     public function setVisible($visible)
     {

--- a/src/Sulu/Bundle/AdminBundle/Command/DownloadBuildCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/DownloadBuildCommand.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\AdminBundle\Command;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 @trigger_deprecation(
     'sulu/sulu',
@@ -37,7 +38,14 @@ class DownloadBuildCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $command = $this->getApplication()->find('sulu:admin:update-build');
+        $application = $this->getApplication();
+        if (null === $application) {
+            $ui = new SymfonyStyle($input, $output);
+            $ui->error('Could not find application');
+
+            return 1;
+        }
+        $command = $application->find('sulu:admin:update-build');
 
         return $command->run($input, $output);
     }

--- a/src/Sulu/Bundle/ContactBundle/Content/Types/ContactAccountSelection.php
+++ b/src/Sulu/Bundle/ContactBundle/Content/Types/ContactAccountSelection.php
@@ -88,6 +88,9 @@ class ContactAccountSelection extends ComplexContentType implements ContentTypeE
         $this->contactReferenceStore = $contactReferenceStore;
     }
 
+    /**
+     * @return void
+     */
     public function read(
         NodeInterface $node,
         PropertyInterface $property,
@@ -104,6 +107,9 @@ class ContactAccountSelection extends ComplexContentType implements ContentTypeE
         $property->setValue($refs);
     }
 
+    /**
+     * @return void
+     */
     public function write(
         NodeInterface $node,
         PropertyInterface $property,
@@ -116,6 +122,9 @@ class ContactAccountSelection extends ComplexContentType implements ContentTypeE
         $node->setProperty($property->getName(), null === $value ? [] : $value);
     }
 
+    /**
+     * @return void
+     */
     public function remove(
         NodeInterface $node,
         PropertyInterface $property,
@@ -128,6 +137,9 @@ class ContactAccountSelection extends ComplexContentType implements ContentTypeE
         }
     }
 
+    /**
+     * @return array
+     */
     public function getContentData(PropertyInterface $property)
     {
         $value = $property->getValue();
@@ -179,6 +191,9 @@ class ContactAccountSelection extends ComplexContentType implements ContentTypeE
         return [];
     }
 
+    /**
+     * @return array{contact: PropertyParameter, account: PropertyParameter}
+     */
     public function getDefaultParams(PropertyInterface $property = null)
     {
         return [
@@ -187,6 +202,9 @@ class ContactAccountSelection extends ComplexContentType implements ContentTypeE
         ];
     }
 
+    /**
+     * @return string|bool
+     */
     public function exportData($propertyValue)
     {
         if (\is_array($propertyValue)) {
@@ -196,6 +214,9 @@ class ContactAccountSelection extends ComplexContentType implements ContentTypeE
         return '';
     }
 
+    /**
+     * @return void
+     */
     public function importData(
         NodeInterface $node,
         PropertyInterface $property,
@@ -209,6 +230,9 @@ class ContactAccountSelection extends ComplexContentType implements ContentTypeE
         $this->write($node, $property, $userId, $webspaceKey, $languageCode, $segmentKey);
     }
 
+    /**
+     * @return void
+     */
     public function preResolve(PropertyInterface $property)
     {
         $value = $property->getValue();

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/CustomerIdConverterTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/CustomerIdConverterTest.php
@@ -32,7 +32,7 @@ class CustomerIdConverterTest extends TestCase
     /**
      * @dataProvider convertIdsToGroupedIdsProvider
      */
-    public function testConvertIdsToGroupedIds($ids, $default, $expected): void
+    public function testConvertIdsToGroupedIds(array $ids, array $default, $expected): void
     {
         $converter = new CustomerIdConverter();
         $result = $converter->convertIdsToGroupedIds($ids, $default);
@@ -56,7 +56,7 @@ class CustomerIdConverterTest extends TestCase
     /**
      * @dataProvider convertGroupedIdsToIdsProvider
      */
-    public function testConvertGroupedIdsToIds($groupedIds, $expected): void
+    public function testConvertGroupedIdsToIds(array $groupedIds, array $expected): void
     {
         $converter = new CustomerIdConverter();
         $result = $converter->convertGroupedIdsToIds($groupedIds);

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/IndexComparatorTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/IndexComparatorTest.php
@@ -15,6 +15,9 @@ use PHPUnit\Framework\TestCase;
 
 class IndexComparatorTest extends TestCase
 {
+    /**
+     * @return array
+     */
     public function usortProvider()
     {
         return [
@@ -36,7 +39,7 @@ class IndexComparatorTest extends TestCase
     /**
      * @dataProvider usortProvider
      */
-    public function testUsortCallback($array, $ids, $startsWith, $contains): void
+    public function testUsortCallback(array $array, array $ids, $startsWith, $contains): void
     {
         $comparator = new IndexComparator();
         // the @ is necessary in case of a PHP bug https://bugs.php.net/bug.php?id=50688

--- a/src/Sulu/Bundle/ContactBundle/Twig/ContactTwigExtension.php
+++ b/src/Sulu/Bundle/ContactBundle/Twig/ContactTwigExtension.php
@@ -38,6 +38,9 @@ class ContactTwigExtension extends AbstractExtension
         $this->contactRepository = $contactRepository;
     }
 
+    /**
+     * @return array<TwigFunction>
+     */
     public function getFunctions()
     {
         return [
@@ -48,7 +51,7 @@ class ContactTwigExtension extends AbstractExtension
     /**
      * @param int $id id to resolve
      *
-     * @return ContactInterface
+     * @return ContactInterface|null
      */
     public function resolveContactFunction($id)
     {
@@ -58,7 +61,7 @@ class ContactTwigExtension extends AbstractExtension
 
         $contact = $this->contactRepository->find($id);
         if (null === $contact) {
-            return;
+            return null;
         }
 
         $this->cache->save($id, $contact);

--- a/src/Sulu/Component/Content/ComplexContentType.php
+++ b/src/Sulu/Component/Content/ComplexContentType.php
@@ -33,6 +33,9 @@ abstract class ComplexContentType implements ContentTypeInterface
         }
     }
 
+    /**
+     * @return bool
+     */
     public function hasValue(
         NodeInterface $node,
         PropertyInterface $property,
@@ -45,7 +48,7 @@ abstract class ComplexContentType implements ContentTypeInterface
 
     public function getDefaultValue()
     {
-        return;
+        return null;
     }
 
     public function getViewData(PropertyInterface $property)

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -406,6 +406,9 @@ class WebspaceManager implements WebspaceManagerInterface
         );
     }
 
+    /**
+     * @return array<string, array<string, Localization>>
+     */
     public function getAllLocalesByWebspaces(): array
     {
         $webspaces = [];

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManagerInterface.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManagerInterface.php
@@ -117,7 +117,10 @@ interface WebspaceManagerInterface extends LocalizationProviderInterface
      * for each website the default locale is provided. The default locales of
      * the webspaces are always on the first position.
      *
-     * @return Localization[]
+     * The first dimension is the webspace key, the second dimension is the locale code. Using it like this:
+     * $webspaceLocalesByCode['webspace-key']['en_us'] will return you the localization for that.
+     *
+     * @return array<string, array<string, Localization>>
      */
     public function getAllLocalesByWebspaces(): array;
 }

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
@@ -22,6 +22,7 @@ use Sulu\Component\Webspace\Loader\XmlFileLoader10;
 use Sulu\Component\Webspace\Loader\XmlFileLoader11;
 use Sulu\Component\Webspace\Manager\WebspaceManager;
 use Sulu\Component\Webspace\Portal;
+use Sulu\Component\Webspace\PortalInformation;
 use Sulu\Component\Webspace\Url\Replacer;
 use Sulu\Component\Webspace\Webspace;
 use Symfony\Component\Config\FileLocatorInterface;
@@ -108,37 +109,39 @@ class WebspaceManagerTest extends WebspaceTestCase
         $webspaces = $this->webspaceManager->getWebspaceCollection();
 
         $webspace = $webspaces->getWebspace('massiveart');
-
+        $this->assertInstanceOf(Webspace::class, $webspace);
         $this->assertEquals('Massive Art', $webspace->getName());
         $this->assertEquals('massiveart', $webspace->getKey());
-        $this->assertEquals('massiveart', $webspace->getSecurity()->getSystem());
+        $this->assertEquals('massiveart', $webspace->getSecurity()?->getSystem());
 
-        $this->assertEquals('en', $webspace->getLocalizations()[0]->getLanguage());
-        $this->assertEquals('us', $webspace->getLocalizations()[0]->getCountry());
-        $this->assertEquals('auto', $webspace->getLocalizations()[0]->getShadow());
+        $webspaceLocalizations = $webspace->getLocalizations();
+        $this->assertCount(2, $webspaceLocalizations);
+        $this->assertEquals('en', $webspaceLocalizations[0]->getLanguage());
+        $this->assertEquals('us', $webspaceLocalizations[0]->getCountry());
+        $this->assertEquals('auto', $webspaceLocalizations[0]->getShadow());
 
-        $this->assertEquals(1, \count($webspace->getLocalizations()[0]->getChildren()));
-        $this->assertEquals('en', $webspace->getLocalizations()[0]->getChildren()[0]->getLanguage());
-        $this->assertEquals('ca', $webspace->getLocalizations()[0]->getChildren()[0]->getCountry());
-        $this->assertEquals(null, $webspace->getLocalizations()[0]->getChildren()[0]->getShadow());
+        $this->assertEquals(1, \count($webspaceLocalizations[0]->getChildren()));
+        $this->assertEquals('en', $webspaceLocalizations[0]->getChildren()[0]->getLanguage());
+        $this->assertEquals('ca', $webspaceLocalizations[0]->getChildren()[0]->getCountry());
+        $this->assertEquals(null, $webspaceLocalizations[0]->getChildren()[0]->getShadow());
 
-        $this->assertEquals('fr', $webspace->getLocalizations()[1]->getLanguage());
-        $this->assertEquals('ca', $webspace->getLocalizations()[1]->getCountry());
-        $this->assertEquals(null, $webspace->getLocalizations()[1]->getShadow());
+        $this->assertEquals('fr', $webspaceLocalizations[1]->getLanguage());
+        $this->assertEquals('ca', $webspaceLocalizations[1]->getCountry());
+        $this->assertEquals(null, $webspaceLocalizations[1]->getShadow());
 
         $this->assertEquals('massiveart', $webspace->getTheme());
 
-        $this->assertEquals(2, \count($webspace->getNavigation()->getContexts()));
+        $webspaceNavigationContext = $webspace->getNavigation()->getContexts();
+        $this->assertEquals(2, \count($webspaceNavigationContext));
+        $this->assertEquals('main', $webspaceNavigationContext[0]->getKey());
+        $this->assertEquals('Hauptnavigation', $webspaceNavigationContext[0]->getTitle('de'));
+        $this->assertEquals('Mainnavigation', $webspaceNavigationContext[0]->getTitle('en'));
+        $this->assertEquals('Main', $webspaceNavigationContext[0]->getTitle('fr'));
 
-        $this->assertEquals('main', $webspace->getNavigation()->getContexts()[0]->getKey());
-        $this->assertEquals('Hauptnavigation', $webspace->getNavigation()->getContexts()[0]->getTitle('de'));
-        $this->assertEquals('Mainnavigation', $webspace->getNavigation()->getContexts()[0]->getTitle('en'));
-        $this->assertEquals('Main', $webspace->getNavigation()->getContexts()[0]->getTitle('fr'));
-
-        $this->assertEquals('footer', $webspace->getNavigation()->getContexts()[1]->getKey());
-        $this->assertEquals('Unten', $webspace->getNavigation()->getContexts()[1]->getTitle('de'));
-        $this->assertEquals('Footer', $webspace->getNavigation()->getContexts()[1]->getTitle('en'));
-        $this->assertEquals('Footer', $webspace->getNavigation()->getContexts()[1]->getTitle('fr'));
+        $this->assertEquals('footer', $webspaceNavigationContext[1]->getKey());
+        $this->assertEquals('Unten', $webspaceNavigationContext[1]->getTitle('de'));
+        $this->assertEquals('Footer', $webspaceNavigationContext[1]->getTitle('en'));
+        $this->assertEquals('Footer', $webspaceNavigationContext[1]->getTitle('fr'));
 
         $portal = $webspace->getPortals()[0];
 
@@ -192,7 +195,6 @@ class WebspaceManagerTest extends WebspaceTestCase
         $this->assertEquals('{language}.massiveart.{country}', $environmentProd->getUrls()[0]->getUrl());
         $this->assertEquals(null, $environmentProd->getUrls()[0]->getLanguage());
         $this->assertEquals(null, $environmentProd->getUrls()[0]->getCountry());
-        $this->assertEquals(null, $environmentProd->getUrls()[0]->getSegment());
         $this->assertEquals(null, $environmentProd->getUrls()[0]->getRedirect());
         $this->assertEquals('www.massiveart.com', $environmentProd->getUrls()[1]->getUrl());
         $this->assertEquals('en', $environmentProd->getUrls()[1]->getLanguage());
@@ -208,10 +210,11 @@ class WebspaceManagerTest extends WebspaceTestCase
     public function testFindWebspaceByKey(): void
     {
         $webspace = $this->webspaceManager->findWebspaceByKey('sulu_io');
+        $this->assertInstanceOf(Webspace::class, $webspace);
 
         $this->assertEquals('Sulu CMF', $webspace->getName());
         $this->assertEquals('sulu_io', $webspace->getKey());
-        $this->assertEquals('sulu_io', $webspace->getSecurity()->getSystem());
+        $this->assertEquals('sulu_io', $webspace->getSecurity()?->getSystem());
 
         $this->assertEquals(2, \count($webspace->getLocalizations()));
         $this->assertEquals('en', $webspace->getLocalizations()[0]->getLanguage());
@@ -254,6 +257,7 @@ class WebspaceManagerTest extends WebspaceTestCase
     public function testFindPortalByKey(): void
     {
         $portal = $this->webspaceManager->findPortalByKey('sulucmf_at');
+        $this->assertInstanceOf(Portal::class, $portal);
 
         $this->assertEquals('Sulu CMF AT', $portal->getName());
         $this->assertEquals('sulucmf_at', $portal->getKey());
@@ -295,15 +299,15 @@ class WebspaceManagerTest extends WebspaceTestCase
     public function testFindPortalInformationByUrl(): void
     {
         $portalInformation = $this->webspaceManager->findPortalInformationByUrl('sulu.at/test/test/test', 'prod');
+        $this->assertNotNull($portalInformation);
         $this->assertEquals('de_at', $portalInformation->getLocalization()->getLocale());
-        $this->assertNull($portalInformation->getSegment());
 
         /** @var Webspace $webspace */
         $webspace = $portalInformation->getWebspace();
 
         $this->assertEquals('Sulu CMF', $webspace->getName());
         $this->assertEquals('sulu_io', $webspace->getKey());
-        $this->assertEquals('sulu_io', $webspace->getSecurity()->getSystem());
+        $this->assertEquals('sulu_io', $webspace->getSecurity()?->getSystem());
         $this->assertCount(2, $webspace->getLocalizations());
         $this->assertEquals('en', $webspace->getLocalizations()[0]->getLanguage());
         $this->assertEquals('us', $webspace->getLocalizations()[0]->getCountry());
@@ -341,16 +345,15 @@ class WebspaceManagerTest extends WebspaceTestCase
         $this->assertEquals('sulu.lo', $environmentDev->getUrls()[0]->getUrl());
 
         $portalInformation = $this->webspaceManager->findPortalInformationByUrl('sulu.lo', 'dev');
+        $this->assertInstanceOf(PortalInformation::class, $portalInformation);
         $this->assertEquals('de_at', $portalInformation->getLocalization()->getLocale());
-        $this->assertNull($portalInformation->getSegment());
 
-        /* @var Portal $portal */
         /** @var Webspace $webspace */
         $webspace = $portalInformation->getWebspace();
 
         $this->assertEquals('Sulu CMF', $webspace->getName());
         $this->assertEquals('sulu_io', $webspace->getKey());
-        $this->assertEquals('sulu_io', $webspace->getSecurity()->getSystem());
+        $this->assertEquals('sulu_io', $webspace->getSecurity()?->getSystem());
         $this->assertCount(2, $webspace->getLocalizations());
         $this->assertEquals('en', $webspace->getLocalizations()[0]->getLanguage());
         $this->assertEquals('us', $webspace->getLocalizations()[0]->getCountry());
@@ -391,22 +394,23 @@ class WebspaceManagerTest extends WebspaceTestCase
     {
         $portalInformations = $this->webspaceManager->findPortalInformationsByUrl('sulu.at/test/test/test', 'prod');
         $portalInformation = \reset($portalInformations);
+        $this->assertInstanceOf(PortalInformation::class, $portalInformation);
         $this->assertEquals('de_at', $portalInformation->getLocalization()->getLocale());
-        $this->assertNull($portalInformation->getSegment());
 
-        /** @var Webspace $webspace */
         $webspace = $portalInformation->getWebspace();
 
         $this->assertEquals('Sulu CMF', $webspace->getName());
         $this->assertEquals('sulu_io', $webspace->getKey());
-        $this->assertEquals('sulu_io', $webspace->getSecurity()->getSystem());
-        $this->assertCount(2, $webspace->getLocalizations());
-        $this->assertEquals('en', $webspace->getLocalizations()[0]->getLanguage());
-        $this->assertEquals('us', $webspace->getLocalizations()[0]->getCountry());
-        $this->assertEquals('auto', $webspace->getLocalizations()[0]->getShadow());
-        $this->assertEquals('de', $webspace->getLocalizations()[1]->getLanguage());
-        $this->assertEquals('at', $webspace->getLocalizations()[1]->getCountry());
-        $this->assertEquals('', $webspace->getLocalizations()[1]->getShadow());
+        $this->assertEquals('sulu_io', $webspace->getSecurity()?->getSystem());
+
+        $webspaceLocalizations = $webspace->getLocalizations();
+        $this->assertCount(2, $webspaceLocalizations);
+        $this->assertEquals('en', $webspaceLocalizations[0]->getLanguage());
+        $this->assertEquals('us', $webspaceLocalizations[0]->getCountry());
+        $this->assertEquals('auto', $webspaceLocalizations[0]->getShadow());
+        $this->assertEquals('de', $webspaceLocalizations[1]->getLanguage());
+        $this->assertEquals('at', $webspaceLocalizations[1]->getCountry());
+        $this->assertEquals('', $webspaceLocalizations[1]->getShadow());
         $this->assertEquals('sulu', $webspace->getTheme());
 
         /** @var Portal $portal */
@@ -437,16 +441,16 @@ class WebspaceManagerTest extends WebspaceTestCase
         $this->assertEquals('sulu.lo', $environmentDev->getUrls()[0]->getUrl());
 
         $portalInformation = $this->webspaceManager->findPortalInformationByUrl('sulu.lo', 'dev');
+        $this->assertInstanceOf(PortalInformation::class, $portalInformation);
         $this->assertEquals('de_at', $portalInformation->getLocalization()->getLocale());
-        $this->assertNull($portalInformation->getSegment());
 
-        /* @var Portal $portal */
         /** @var Webspace $webspace */
         $webspace = $portalInformation->getWebspace();
 
         $this->assertEquals('Sulu CMF', $webspace->getName());
         $this->assertEquals('sulu_io', $webspace->getKey());
-        $this->assertEquals('sulu_io', $webspace->getSecurity()->getSystem());
+        $this->assertEquals('sulu_io', $webspace->getSecurity()?->getSystem());
+
         $this->assertCount(2, $webspace->getLocalizations());
         $this->assertEquals('en', $webspace->getLocalizations()[0]->getLanguage());
         $this->assertEquals('us', $webspace->getLocalizations()[0]->getCountry());
@@ -457,17 +461,17 @@ class WebspaceManagerTest extends WebspaceTestCase
         $this->assertEquals('sulu', $webspace->getTheme());
 
         $portal = $portalInformation->getPortal();
-
         $this->assertEquals('Sulu CMF AT', $portal->getName());
         $this->assertEquals('sulucmf_at', $portal->getKey());
 
-        $this->assertEquals(2, \count($portal->getLocalizations()));
-        $this->assertEquals('en', $portal->getLocalizations()[0]->getLanguage());
-        $this->assertEquals('us', $portal->getLocalizations()[0]->getCountry());
-        $this->assertEquals('', $portal->getLocalizations()[0]->getShadow());
-        $this->assertEquals('de', $portal->getLocalizations()[1]->getLanguage());
-        $this->assertEquals('at', $portal->getLocalizations()[1]->getCountry());
-        $this->assertEquals('', $portal->getLocalizations()[1]->getShadow());
+        $portalLocalizations = $portal->getLocalizations();
+        $this->assertEquals(2, \count($portalLocalizations));
+        $this->assertEquals('en', $portalLocalizations[0]->getLanguage());
+        $this->assertEquals('us', $portalLocalizations[0]->getCountry());
+        $this->assertEquals('', $portalLocalizations[0]->getShadow());
+        $this->assertEquals('de', $portalLocalizations[1]->getLanguage());
+        $this->assertEquals('at', $portalLocalizations[1]->getCountry());
+        $this->assertEquals('', $portalLocalizations[1]->getShadow());
 
         $this->assertEquals(3, \count($portal->getEnvironments()));
 
@@ -483,6 +487,9 @@ class WebspaceManagerTest extends WebspaceTestCase
         $this->assertEquals('sulu.lo', $environmentDev->getUrls()[0]->getUrl());
     }
 
+    /**
+     * @return array<array{string, bool}>
+     */
     public function provideFindPortalInformationByUrl()
     {
         return [
@@ -501,8 +508,10 @@ class WebspaceManagerTest extends WebspaceTestCase
 
     /**
      * @dataProvider provideFindPortalInformationByUrl
+     *
+     * @param bool $shouldFind
      */
-    public function testFindPortalInformationByUrlWithInvalidSuffix($url, $shouldFind): void
+    public function testFindPortalInformationByUrlWithInvalidSuffix(string $url, $shouldFind): void
     {
         $portalInformation = $this->webspaceManager->findPortalInformationByUrl($url, 'dev');
 
@@ -523,6 +532,7 @@ class WebspaceManagerTest extends WebspaceTestCase
 
         $this->assertCount(1, $portalInformations);
         $portalInformation = \reset($portalInformations);
+        $this->assertInstanceOf(PortalInformation::class, $portalInformation);
 
         $this->assertEquals('sulu_io', $portalInformation->getWebspace()->getKey());
         $this->assertEquals('de_at', $portalInformation->getLocale());
@@ -535,10 +545,9 @@ class WebspaceManagerTest extends WebspaceTestCase
             'de_at',
             'dev'
         );
-
-        $this->assertCount(1, $portalInformations);
-
         $portalInformation = \reset($portalInformations);
+        $this->assertInstanceOf(PortalInformation::class, $portalInformation);
+
         $this->assertEquals('sulucmf_at', $portalInformation->getPortal()->getKey());
         $this->assertEquals('de_at', $portalInformation->getLocale());
     }
@@ -565,12 +574,12 @@ class WebspaceManagerTest extends WebspaceTestCase
         $this->assertEquals(2, $webspaces->length());
 
         $webspace = $webspaces->getWebspace('massiveart');
-
+        $this->assertInstanceOf(Webspace::class, $webspace);
         $this->assertEquals('Massive Art', $webspace->getName());
         $this->assertEquals('massiveart', $webspace->getKey());
 
         $webspace = $webspaces->getWebspace('sulu_io');
-
+        $this->assertInstanceOf(Webspace::class, $webspace);
         $this->assertEquals('Sulu CMF', $webspace->getName());
         $this->assertEquals('sulu_io', $webspace->getKey());
     }
@@ -624,6 +633,7 @@ class WebspaceManagerTest extends WebspaceTestCase
     public function testRedirectUrl(): void
     {
         $portalInformation = $this->webspaceManager->findPortalInformationByUrl('www.sulu.at/test/test', 'prod');
+        $this->assertInstanceOf(PortalInformation::class, $portalInformation);
 
         $this->assertEquals('sulu.at', $portalInformation->getRedirect());
         $this->assertEquals('www.sulu.at', $portalInformation->getUrl());
@@ -633,7 +643,8 @@ class WebspaceManagerTest extends WebspaceTestCase
 
         $this->assertEquals('Sulu CMF', $webspace->getName());
         $this->assertEquals('sulu_io', $webspace->getKey());
-        $this->assertEquals('sulu_io', $webspace->getSecurity()->getSystem());
+        $this->assertEquals('sulu_io', $webspace->getSecurity()?->getSystem());
+
         $this->assertCount(2, $webspace->getLocalizations());
         $this->assertEquals('en', $webspace->getLocalizations()[0]->getLanguage());
         $this->assertEquals('us', $webspace->getLocalizations()[0]->getCountry());
@@ -646,7 +657,8 @@ class WebspaceManagerTest extends WebspaceTestCase
 
     public function testLocalizations(): void
     {
-        $localizations = $this->webspaceManager->findWebspaceByKey('massiveart')->getLocalizations();
+        $localizations = $this->webspaceManager->findWebspaceByKey('massiveart')?->getLocalizations();
+        $this->assertNotNull($localizations);
 
         $this->assertEquals('en', $localizations[0]->getLanguage());
         $this->assertEquals('us', $localizations[0]->getCountry());
@@ -664,7 +676,8 @@ class WebspaceManagerTest extends WebspaceTestCase
         $this->assertEquals('ca', $localizations[1]->getCountry());
         $this->assertEquals(null, $localizations[1]->getShadow());
 
-        $allLocalizations = $this->webspaceManager->findWebspaceByKey('massiveart')->getAllLocalizations();
+        $allLocalizations = $this->webspaceManager->findWebspaceByKey('massiveart')?->getAllLocalizations();
+        $this->assertNotNull($allLocalizations);
         $this->assertEquals('en', $allLocalizations[0]->getLanguage());
         $this->assertEquals('us', $allLocalizations[0]->getCountry());
         $this->assertEquals('auto', $allLocalizations[0]->getShadow());

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
@@ -115,7 +115,7 @@ class WebspaceManagerTest extends WebspaceTestCase
         $this->assertEquals('massiveart', $webspace->getSecurity()?->getSystem());
 
         $webspaceLocalizations = $webspace->getLocalizations();
-        $this->assertCount(2, $webspaceLocalizations);
+        $this->assertCount(3, $webspaceLocalizations);
         $this->assertEquals('en', $webspaceLocalizations[0]->getLanguage());
         $this->assertEquals('us', $webspaceLocalizations[0]->getCountry());
         $this->assertEquals('auto', $webspaceLocalizations[0]->getShadow());

--- a/src/Sulu/Component/Webspace/Tests/Unit/PortalInformationTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/PortalInformationTest.php
@@ -13,7 +13,11 @@ namespace Sulu\Component\Webspace\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\PortalInformation;
+use Sulu\Component\Webspace\Webspace;
 
 class PortalInformationTest extends TestCase
 {
@@ -24,15 +28,33 @@ class PortalInformationTest extends TestCase
      */
     private $portalInformation;
 
+    /**
+     * @var ObjectProphecy<Webspace>
+     */
+    private ObjectProphecy $webspace;
+
+    /**
+     * @var ObjectProphecy<Portal>
+     */
+    private ObjectProphecy $portal;
+
+    /**
+     * @var ObjectProphecy<Localization>
+     */
+    private ObjectProphecy $localization;
+
     public function setUp(): void
     {
         parent::setUp();
         $this->portalInformation = new PortalInformation(null, null, null, null, null);
-        $this->webspace = $this->prophesize('Sulu\Component\Webspace\Webspace');
-        $this->portal = $this->prophesize('Sulu\Component\Webspace\Portal');
-        $this->localization = $this->prophesize('Sulu\Component\Localization\Localization');
+        $this->webspace = $this->prophesize(Webspace::class);
+        $this->portal = $this->prophesize(Portal::class);
+        $this->localization = $this->prophesize(Localization::class);
     }
 
+    /**
+     * @return array<array{string, string, ?string}>
+     */
     public function provideUrl()
     {
         return [

--- a/src/Sulu/Component/Webspace/Webspace.php
+++ b/src/Sulu/Component/Webspace/Webspace.php
@@ -126,6 +126,8 @@ class Webspace implements ArrayableInterface
      * Sets the key of the webspace.
      *
      * @param string $key
+     *
+     * @return void
      */
     public function setKey($key)
     {
@@ -144,6 +146,8 @@ class Webspace implements ArrayableInterface
 
     /**
      * Adds a localization to the webspace.
+     *
+     * @return void
      */
     public function addLocalization(Localization $localization)
     {
@@ -162,6 +166,8 @@ class Webspace implements ArrayableInterface
      * Returns the localizations of this webspace.
      *
      * @param Localization[] $localizations
+     *
+     * @return void
      */
     public function setLocalizations($localizations)
     {
@@ -214,13 +220,15 @@ class Webspace implements ArrayableInterface
             }
         }
 
-        return;
+        return null;
     }
 
     /**
      * Sets the default localization for this webspace.
      *
      * @param Localization $defaultLocalization
+     *
+     * @return void
      */
     public function setDefaultLocalization($defaultLocalization)
     {
@@ -263,6 +271,8 @@ class Webspace implements ArrayableInterface
      * Sets the name of the webspace.
      *
      * @param string $name
+     *
+     * @return void
      */
     public function setName($name)
     {
@@ -281,6 +291,8 @@ class Webspace implements ArrayableInterface
 
     /**
      * Adds a portal to the webspace.
+     *
+     * @return void
      */
     public function addPortal(Portal $portal)
     {
@@ -291,6 +303,8 @@ class Webspace implements ArrayableInterface
      * Sets the portals of this webspace.
      *
      * @param Portal[] $portals
+     *
+     * @return void
      */
     public function setPortals($portals)
     {
@@ -309,6 +323,8 @@ class Webspace implements ArrayableInterface
 
     /**
      * Adds a segment to the webspace.
+     *
+     * @return void
      */
     public function addSegment(Segment $segment)
     {
@@ -323,6 +339,8 @@ class Webspace implements ArrayableInterface
      * Sets the segments of this webspace.
      *
      * @param Segment[] $segments
+     *
+     * @return void
      */
     public function setSegments($segments)
     {
@@ -354,6 +372,8 @@ class Webspace implements ArrayableInterface
      * Sets the default segment of this webspace.
      *
      * @param Segment $defaultSegment
+     *
+     * @return void
      */
     public function setDefaultSegment($defaultSegment)
     {
@@ -374,6 +394,8 @@ class Webspace implements ArrayableInterface
      * Sets the theme for this portal.
      *
      * @param string|null $theme this parameter is options
+     *
+     * @return void
      */
     public function setTheme($theme = null)
     {
@@ -394,6 +416,8 @@ class Webspace implements ArrayableInterface
      * Sets the security system.
      *
      * @param Security|null $security
+     *
+     * @return void
      */
     public function setSecurity($security)
     {
@@ -410,6 +434,9 @@ class Webspace implements ArrayableInterface
         return $this->security;
     }
 
+    /**
+     * @return bool
+     */
     public function hasWebsiteSecurity()
     {
         $security = $this->getSecurity();
@@ -431,6 +458,8 @@ class Webspace implements ArrayableInterface
 
     /**
      * @param Navigation $navigation
+     *
+     * @return void
      */
     public function setNavigation($navigation)
     {
@@ -473,6 +502,8 @@ class Webspace implements ArrayableInterface
      *
      * @param string $type
      * @param string $template
+     *
+     * @return void
      */
     public function addTemplate($type, $template)
     {
@@ -493,7 +524,7 @@ class Webspace implements ArrayableInterface
             return $this->templates[$type] . '.' . $format . '.twig';
         }
 
-        return;
+        return null;
     }
 
     /**
@@ -511,6 +542,8 @@ class Webspace implements ArrayableInterface
      *
      * @param string $type
      * @param string $template
+     *
+     * @return void
      */
     public function addDefaultTemplate($type, $template)
     {
@@ -530,7 +563,7 @@ class Webspace implements ArrayableInterface
             return $this->defaultTemplates[$type];
         }
 
-        return;
+        return null;
     }
 
     /**
@@ -547,6 +580,8 @@ class Webspace implements ArrayableInterface
      * Add a new template for given type.
      *
      * @param string $excludedTemplate
+     *
+     * @return void
      */
     public function addExcludedTemplate($excludedTemplate)
     {
@@ -565,6 +600,8 @@ class Webspace implements ArrayableInterface
      * Set resource-locator strategy.
      *
      * @param string $resourceLocatorStrategy
+     *
+     * @return void
      */
     public function setResourceLocatorStrategy($resourceLocatorStrategy)
     {
@@ -581,6 +618,9 @@ class Webspace implements ArrayableInterface
         return $this->resourceLocatorStrategy;
     }
 
+    /**
+     * @return array
+     */
     public function toArray($depth = null)
     {
         $res = [];


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | don't write untyped code :) 
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

* Adding some types in doc comments
* Improving types in some tests
* Adding explicit null return for non void functions (not a bc break)
* Updated some incorrect doctypes

#### Why?

As preparation for 3.0 we want the doc types to be as correct as possible for tools to rely on them when refactoring.
