### PR TITLE
Replace string class with Object::class

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3781,11 +3781,6 @@ parameters:
 			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/ReferrerRuleTest.php
 
 		-
-			message: "#^Method PHPUnit\\\\Framework\\\\TestCase\\:\\:expectException\\(\\) invoked with 2 parameters, 1 required\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/RuleCollectionTest.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Tests\\\\Unit\\\\Rule\\\\TargetGroupEvaluatorTest\\:\\:provideEvaluationData\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/TargetGroupEvaluatorTest.php
@@ -4654,11 +4649,6 @@ parameters:
 			message: "#^Property Sulu\\\\Bundle\\\\CategoryBundle\\\\Controller\\\\KeywordController\\:\\:\\$listBuilderFactory \\(Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\DoctrineListBuilderFactory\\) does not accept Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\DoctrineListBuilderFactoryInterface\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\CategoryBundle\\\\DependencyInjection\\\\Configuration\\:\\:addObjectsSection\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/CategoryBundle/DependencyInjection/Configuration.php
 
 		-
 			message: "#^If condition is always true\\.$#"
@@ -11676,17 +11666,7 @@ parameters:
 			path: src/Sulu/Bundle/CoreBundle/DependencyInjection/Configuration.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\CoreBundle\\\\DependencyInjection\\\\SuluCoreExtension\\:\\:initCache\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\CoreBundle\\\\DependencyInjection\\\\SuluCoreExtension\\:\\:initCache\\(\\) has parameter \\$cache with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\CoreBundle\\\\DependencyInjection\\\\SuluCoreExtension\\:\\:initContent\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
 
@@ -11696,32 +11676,12 @@ parameters:
 			path: src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\CoreBundle\\\\DependencyInjection\\\\SuluCoreExtension\\:\\:initFields\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\CoreBundle\\\\DependencyInjection\\\\SuluCoreExtension\\:\\:initFields\\(\\) has parameter \\$fieldsConfig with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\CoreBundle\\\\DependencyInjection\\\\SuluCoreExtension\\:\\:initListBuilder\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\CoreBundle\\\\DependencyInjection\\\\SuluCoreExtension\\:\\:initWebspace\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\CoreBundle\\\\DependencyInjection\\\\SuluCoreExtension\\:\\:initWebspace\\(\\) has parameter \\$webspaceConfig with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\CoreBundle\\\\DependencyInjection\\\\SuluCoreExtension\\:\\:load\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
 
@@ -12881,32 +12841,12 @@ parameters:
 			path: src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\DependencyInjection\\\\SuluDocumentManagerExtension\\:\\:configureDocumentManager\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\DependencyInjection\\\\SuluDocumentManagerExtension\\:\\:configureDocumentManager\\(\\) has parameter \\$config with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\DependencyInjection\\\\SuluDocumentManagerExtension\\:\\:configurePathSegmentRegistry\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\DependencyInjection\\\\SuluDocumentManagerExtension\\:\\:configurePathSegmentRegistry\\(\\) has parameter \\$config with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\DependencyInjection\\\\SuluDocumentManagerExtension\\:\\:load\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\DependencyInjection\\\\SuluDocumentManagerExtension\\:\\:prepend\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
 
@@ -13911,22 +13851,7 @@ parameters:
 			path: src/Sulu/Bundle/LocationBundle/Controller/GeolocatorController.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\LocationBundle\\\\DependencyInjection\\\\SuluLocationExtension\\:\\:configureGeolocators\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/LocationBundle/DependencyInjection/SuluLocationExtension.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\LocationBundle\\\\DependencyInjection\\\\SuluLocationExtension\\:\\:configureGeolocators\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/LocationBundle/DependencyInjection/SuluLocationExtension.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\LocationBundle\\\\DependencyInjection\\\\SuluLocationExtension\\:\\:load\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/LocationBundle/DependencyInjection/SuluLocationExtension.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\LocationBundle\\\\DependencyInjection\\\\SuluLocationExtension\\:\\:prepend\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/LocationBundle/DependencyInjection/SuluLocationExtension.php
 
@@ -19672,21 +19597,6 @@ parameters:
 
 		-
 			message: "#^Class Sulu\\\\Bundle\\\\MediaBundle\\\\Api\\\\Media constructor invoked with 4 parameters, 2\\-3 required\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/SearchIntegration/SearchIntegrationTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\SearchIntegration\\\\SearchIntegrationTest\\:\\:provideIndex\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/SearchIntegration/SearchIntegrationTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\SearchIntegration\\\\SearchIntegrationTest\\:\\:testIndex\\(\\) has parameter \\$expectException with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/SearchIntegration/SearchIntegrationTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\SearchIntegration\\\\SearchIntegrationTest\\:\\:testIndex\\(\\) has parameter \\$format with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/SearchIntegration/SearchIntegrationTest.php
 
@@ -26846,11 +26756,6 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Mapper/ContentMapperTest.php
 
 		-
-			message: "#^Method PHPUnit\\\\Framework\\\\TestCase\\:\\:expectException\\(\\) invoked with 2 parameters, 1 required\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Mapper/ContentMapperTest.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\Mapper\\\\ContentMapperTest\\:\\:getHomeUuid\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Mapper/ContentMapperTest.php
@@ -29111,11 +29016,6 @@ parameters:
 			path: src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
 
 		-
-			message: "#^Method PHPUnit\\\\Framework\\\\TestCase\\:\\:expectException\\(\\) invoked with 3 parameters, 1 required\\.$#"
-			count: 5
-			path: src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\PreviewBundle\\\\Tests\\\\Unit\\\\Preview\\\\Renderer\\\\PreviewRendererTest\\:\\:portalDataProvider\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
@@ -31249,11 +31149,6 @@ parameters:
 			message: "#^Strict comparison using \\=\\=\\= between 0 and int\\<1, 2\\> will always evaluate to false\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/DependencyInjection/Compiler/TwoFactorCompilerPass.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\SecurityBundle\\\\DependencyInjection\\\\Configuration\\:\\:addObjectsSection\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/DependencyInjection/Configuration.php
 
 		-
 			message: "#^If condition is always true\\.$#"
@@ -33787,11 +33682,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\SnippetBundle\\\\Form\\\\SnippetType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SnippetBundle/Form/SnippetType.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\SnippetBundle\\\\Form\\\\SnippetType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/Form/SnippetType.php
 
@@ -38263,11 +38153,6 @@ parameters:
 		-
 			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNull\\(\\) with array will always evaluate to false\\.$#"
 			count: 2
-			path: src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/ContentTwigExtensionTest.php
-
-		-
-			message: "#^Method PHPUnit\\\\Framework\\\\TestCase\\:\\:expectException\\(\\) invoked with 2 parameters, 1 required\\.$#"
-			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/ContentTwigExtensionTest.php
 
 		-

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/RuleCollectionTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/RuleCollectionTest.php
@@ -34,7 +34,8 @@ class RuleCollectionTest extends TestCase
 
     public function testGetNotExistingName(): void
     {
-        $this->expectException(RuleNotFoundException::class, 'The rule with the name "rule" could not be found.');
+        $this->expectException(RuleNotFoundException::class);
+        $this->expectExceptionMessage('The rule with the name "rule" could not be found.');
         $ruleCollection = new RuleCollection([]);
 
         $ruleCollection->getRule('rule');

--- a/src/Sulu/Bundle/CategoryBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/CategoryBundle/DependencyInjection/Configuration.php
@@ -11,6 +11,14 @@
 
 namespace Sulu\Bundle\CategoryBundle\DependencyInjection;
 
+use Sulu\Bundle\CategoryBundle\Entity\Category;
+use Sulu\Bundle\CategoryBundle\Entity\CategoryMeta;
+use Sulu\Bundle\CategoryBundle\Entity\CategoryMetaRepository;
+use Sulu\Bundle\CategoryBundle\Entity\CategoryRepository;
+use Sulu\Bundle\CategoryBundle\Entity\CategoryTranslation;
+use Sulu\Bundle\CategoryBundle\Entity\CategoryTranslationRepository;
+use Sulu\Bundle\CategoryBundle\Entity\Keyword;
+use Sulu\Bundle\CategoryBundle\Entity\KeywordRepository;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -34,6 +42,8 @@ class Configuration implements ConfigurationInterface
 
     /**
      * Adds `objects` section.
+     *
+     * @return void
      */
     private function addObjectsSection(ArrayNodeDefinition $node)
     {
@@ -45,29 +55,29 @@ class Configuration implements ConfigurationInterface
                         ->arrayNode('category')
                             ->addDefaultsIfNotSet()
                             ->children()
-                                ->scalarNode('model')->defaultValue('Sulu\Bundle\CategoryBundle\Entity\Category')->end()
-                                ->scalarNode('repository')->defaultValue('Sulu\Bundle\CategoryBundle\Entity\CategoryRepository')->end()
+                                ->scalarNode('model')->defaultValue(Category::class)->end()
+                                ->scalarNode('repository')->defaultValue(CategoryRepository::class)->end()
                             ->end()
                         ->end()
                         ->arrayNode('category_meta')
                             ->addDefaultsIfNotSet()
                             ->children()
-                                ->scalarNode('model')->defaultValue('Sulu\Bundle\CategoryBundle\Entity\CategoryMeta')->end()
-                                ->scalarNode('repository')->defaultValue('Sulu\Bundle\CategoryBundle\Entity\CategoryMetaRepository')->end()
+                                ->scalarNode('model')->defaultValue(CategoryMeta::class)->end()
+                                ->scalarNode('repository')->defaultValue(CategoryMetaRepository::class)->end()
                             ->end()
                         ->end()
                         ->arrayNode('category_translation')
                             ->addDefaultsIfNotSet()
                             ->children()
-                                ->scalarNode('model')->defaultValue('Sulu\Bundle\CategoryBundle\Entity\CategoryTranslation')->end()
-                                ->scalarNode('repository')->defaultValue('Sulu\Bundle\CategoryBundle\Entity\CategoryTranslationRepository')->end()
+                                ->scalarNode('model')->defaultValue(CategoryTranslation::class)->end()
+                                ->scalarNode('repository')->defaultValue(CategoryTranslationRepository::class)->end()
                             ->end()
                         ->end()
                         ->arrayNode('keyword')
                             ->addDefaultsIfNotSet()
                             ->children()
-                                    ->scalarNode('model')->defaultValue('Sulu\Bundle\CategoryBundle\Entity\Keyword')->end()
-                                    ->scalarNode('repository')->defaultValue('Sulu\Bundle\CategoryBundle\Entity\KeywordRepository')->end()
+                                    ->scalarNode('model')->defaultValue(Keyword::class)->end()
+                                    ->scalarNode('repository')->defaultValue(KeywordRepository::class)->end()
                             ->end()
                         ->end()
                     ->end()

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\CoreBundle\DependencyInjection;
 use Gedmo\Exception;
 use Oro\ORM\Query\AST\Functions\Cast;
 use Oro\ORM\Query\AST\Functions\String\GroupConcat;
+use Sulu\Bundle\CoreBundle\CommandOptional\SuluBuildCommand;
 use Sulu\Component\Content\Types\Block\BlockVisitorInterface;
 use Sulu\Component\Rest\Csv\ObjectNotSupportedException;
 use Sulu\Component\Rest\Exception\InsufficientDescendantPermissionsException;
@@ -80,7 +81,7 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
 
         if ($container->hasExtension('massive_build')) {
             $container->prependExtensionConfig('massive_build', [
-                'command_class' => 'Sulu\Bundle\CoreBundle\CommandOptional\SuluBuildCommand',
+                'command_class' => SuluBuildCommand::class,
             ]);
         }
 
@@ -255,6 +256,9 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
         }
     }
 
+    /**
+     * @return void
+     */
     public function load(array $configs, ContainerBuilder $container)
     {
         $configuration = new Configuration();
@@ -331,6 +335,9 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
             ->addTag('sulu_content.block_visitor');
     }
 
+    /**
+     * @return void
+     */
     private function initWebspace(array $webspaceConfig, ContainerBuilder $container, XmlFileLoader $loader)
     {
         $container->setParameter('sulu_core.webspace.config_dir', $webspaceConfig['config_dir']);
@@ -338,12 +345,18 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
         $loader->load('webspace.xml');
     }
 
+    /**
+     * @return void
+     */
     private function initFields(array $fieldsConfig, ContainerBuilder $container)
     {
         $container->setParameter('sulu.fields_defaults.translations', $fieldsConfig['translations']);
         $container->setParameter('sulu.fields_defaults.widths', $fieldsConfig['widths']);
     }
 
+    /**
+     * @return void
+     */
     private function initContent(array $contentConfig, ContainerBuilder $container, XmlFileLoader $loader)
     {
         // Default Language
@@ -401,6 +414,9 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
         $loader->load('content.xml');
     }
 
+    /**
+     * @return void
+     */
     private function initCache(array $cache, ContainerBuilder $container, XmlFileLoader $loader)
     {
         $container->setParameter('sulu_core.cache.memoize.default_lifetime', $cache['memoize']['default_lifetime']);
@@ -410,6 +426,8 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
 
     /**
      * Initializes list builder.
+     *
+     * @return void
      */
     private function initListBuilder(ContainerBuilder $container, XmlFileLoader $loader)
     {

--- a/src/Sulu/Bundle/CoreBundle/Tests/Unit/Cache/StructureWarmerTest.php
+++ b/src/Sulu/Bundle/CoreBundle/Tests/Unit/Cache/StructureWarmerTest.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\CoreBundle\Tests\Unit\Cache;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Bundle\CoreBundle\Cache\StructureWarmer;
+use Sulu\Component\Content\Compat\StructureManagerInterface;
 
 class StructureWarmerTest extends TestCase
 {
@@ -22,7 +23,7 @@ class StructureWarmerTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->structureManager = $this->prophesize('Sulu\Component\Content\Compat\StructureManagerInterface');
+        $this->structureManager = $this->prophesize(StructureManagerInterface::class);
         $this->warmer = new StructureWarmer($this->structureManager->reveal());
     }
 

--- a/src/Sulu/Bundle/CoreBundle/Tests/Unit/DependencyInjection/SuluCoreExtensionTest.php
+++ b/src/Sulu/Bundle/CoreBundle/Tests/Unit/DependencyInjection/SuluCoreExtensionTest.php
@@ -13,6 +13,8 @@ namespace Sulu\Bundle\CoreBundle\Tests\Unit\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Sulu\Bundle\CoreBundle\DependencyInjection\SuluCoreExtension;
+use Sulu\Component\Content\Compat\Structure\PageBridge;
+use Sulu\Component\Content\Compat\Structure\SnippetBridge;
 
 class SuluCoreExtensionTest extends AbstractExtensionTestCase
 {
@@ -44,9 +46,9 @@ class SuluCoreExtensionTest extends AbstractExtensionTestCase
                     ],
                     'paths' => [],
                     'type_map' => [
-                        'page' => '\Sulu\Component\Content\Compat\Structure\PageBridge',
-                        'home' => '\Sulu\Component\Content\Compat\Structure\PageBridge',
-                        'snippet' => '\Sulu\Component\Content\Compat\Structure\SnippetBridge',
+                        'page' => '\\' . PageBridge::class,
+                        'home' => '\\' . PageBridge::class,
+                        'snippet' => '\\' . SnippetBridge::class,
                     ],
                 ],
             ],
@@ -79,9 +81,9 @@ class SuluCoreExtensionTest extends AbstractExtensionTestCase
                     ],
                     'paths' => [],
                     'type_map' => [
-                        'page' => '\Sulu\Component\Content\Compat\Structure\PageBridge',
-                        'home' => '\Sulu\Component\Content\Compat\Structure\PageBridge',
-                        'snippet' => '\Sulu\Component\Content\Compat\Structure\SnippetBridge',
+                        'page' => '\\' . PageBridge::class,
+                        'home' => '\\' . PageBridge::class,
+                        'snippet' => '\\' . SnippetBridge::class,
                     ],
                 ],
             ],
@@ -107,9 +109,9 @@ class SuluCoreExtensionTest extends AbstractExtensionTestCase
                         ],
                         'paths' => [],
                         'type_map' => [
-                            'page' => '\Sulu\Component\Content\Compat\Structure\PageBridge',
-                            'home' => '\Sulu\Component\Content\Compat\Structure\PageBridge',
-                            'snippet' => '\Sulu\Component\Content\Compat\Structure\SnippetBridge',
+                            'page' => '\\' . PageBridge::class,
+                            'home' => '\\' . PageBridge::class,
+                            'snippet' => '\\' . SnippetBridge::class,
                         ],
                     ],
                 ],

--- a/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
@@ -28,6 +28,9 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class SuluDocumentManagerExtension extends Extension implements PrependExtensionInterface
 {
+    /**
+     * @return void
+     */
     public function prepend(ContainerBuilder $container)
     {
         $preview = $container->hasParameter('sulu.preview') ? $container->getParameter('sulu.preview') : false;
@@ -116,6 +119,9 @@ class SuluDocumentManagerExtension extends Extension implements PrependExtension
         }
     }
 
+    /**
+     * @return void
+     */
     public function load(array $configs, ContainerBuilder $container)
     {
         $configuration = new Configuration();
@@ -137,6 +143,9 @@ class SuluDocumentManagerExtension extends Extension implements PrependExtension
         }
     }
 
+    /**
+     * @return void
+     */
     private function configureDocumentManager($config, ContainerBuilder $container)
     {
         $debug = $config['debug'];
@@ -191,6 +200,9 @@ class SuluDocumentManagerExtension extends Extension implements PrependExtension
             ->addTag('sulu_document_manager.event_subscriber');
     }
 
+    /**
+     * @return void
+     */
     private function configurePathSegmentRegistry($config, ContainerBuilder $container)
     {
         $pathSegments = \array_merge(

--- a/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
@@ -13,6 +13,9 @@ namespace Sulu\Bundle\DocumentManagerBundle\DependencyInjection;
 
 use Sulu\Bundle\DocumentManagerBundle\DataFixtures\DocumentFixtureInterface;
 use Sulu\Bundle\DocumentManagerBundle\Session\Session;
+use Sulu\Component\Content\Exception\MandatoryPropertyException;
+use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
+use Sulu\Component\DocumentManager\Exception\VersionNotFoundException;
 use Sulu\Component\DocumentManager\Subscriber\EventSubscriberInterface;
 use Sulu\Component\HttpKernel\SuluKernel;
 use Symfony\Component\Config\FileLocator;
@@ -103,9 +106,9 @@ class SuluDocumentManagerExtension extends Extension implements PrependExtension
                 [
                     'exception' => [
                         'codes' => [
-                            'Sulu\Component\DocumentManager\Exception\DocumentNotFoundException' => 404,
-                            'Sulu\Component\DocumentManager\Exception\VersionNotFoundException' => 404,
-                            'Sulu\Component\Content\Exception\MandatoryPropertyException' => 400,
+                            DocumentNotFoundException::class => 404,
+                            VersionNotFoundException::class => 404,
+                            MandatoryPropertyException::class => 400,
                         ],
                     ],
                 ]

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/DependencyInjection/Compiler/InitializerPassTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/DependencyInjection/Compiler/InitializerPassTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\DocumentManagerBundle\Tests\Unit\DependencyInjection\Compi
 
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\DocumentManagerBundle\DependencyInjection\Compiler\InitializerPass;
+use Sulu\Bundle\DocumentManagerBundle\Initializer\Initializer;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class InitializerPassTest extends TestCase
@@ -21,7 +22,7 @@ class InitializerPassTest extends TestCase
     {
         $container = new ContainerBuilder();
 
-        $initializer = $container->register('sulu_document_manager.initializer', 'Sulu\Bundle\DocumentManagerBundle\Initializer\Initializer');
+        $initializer = $container->register('sulu_document_manager.initializer', Initializer::class);
         $initializer->addArgument('one');
         $initializer->addArgument('two');
         $initializer->addArgument('three');

--- a/src/Sulu/Bundle/LocationBundle/DependencyInjection/SuluLocationExtension.php
+++ b/src/Sulu/Bundle/LocationBundle/DependencyInjection/SuluLocationExtension.php
@@ -20,6 +20,9 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class SuluLocationExtension extends Extension implements PrependExtensionInterface
 {
+    /**
+     * @return void
+     */
     public function prepend(ContainerBuilder $container)
     {
         if ($container->hasExtension('sulu_admin')) {
@@ -49,6 +52,9 @@ class SuluLocationExtension extends Extension implements PrependExtensionInterfa
         }
     }
 
+    /**
+     * @return void
+     */
     public function load(array $configs, ContainerBuilder $container)
     {
         $configuration = new Configuration();
@@ -60,6 +66,9 @@ class SuluLocationExtension extends Extension implements PrependExtensionInterfa
         $this->configureGeolocators($config, $container, $loader);
     }
 
+    /**
+     * @return void
+     */
     private function configureGeolocators(array $config, ContainerBuilder $container, XmlFileLoader $loader)
     {
         $geolocatorName = $config['geolocator'] ?? null;

--- a/src/Sulu/Bundle/LocationBundle/DependencyInjection/SuluLocationExtension.php
+++ b/src/Sulu/Bundle/LocationBundle/DependencyInjection/SuluLocationExtension.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\LocationBundle\DependencyInjection;
 
+use GuzzleHttp\Client;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -66,7 +67,7 @@ class SuluLocationExtension extends Extension implements PrependExtensionInterfa
 
         $loader->load('geolocator.xml');
 
-        if (\class_exists('GuzzleHttp\Client')) {
+        if (\class_exists(Client::class)) {
             $loader->load('guzzle.xml');
         }
 

--- a/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/GeolocatorResponseTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/GeolocatorResponseTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\LocationBundle\Tests\Unit\Geolocator;
 
 use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorLocation;
 use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorResponse;
 
 class GeolocatorResponseTest extends TestCase
@@ -21,7 +22,7 @@ class GeolocatorResponseTest extends TestCase
     public function setUp(): void
     {
         $this->response = new GeolocatorResponse();
-        $this->location = $this->getMockBuilder('Sulu\Bundle\LocationBundle\Geolocator\GeolocatorLocation')->getMock();
+        $this->location = $this->getMockBuilder(GeolocatorLocation::class)->getMock();
     }
 
     public function testToArray(): void

--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\MediaBundle\Collection\Manager;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
+use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
 use Sulu\Bundle\MediaBundle\Api\Collection;
 use Sulu\Bundle\MediaBundle\Domain\Event\CollectionCreatedEvent;
 use Sulu\Bundle\MediaBundle\Domain\Event\CollectionModifiedEvent;
@@ -52,9 +53,9 @@ class CollectionManager implements CollectionManagerInterface
 
     private static $entityCollectionMeta = 'SuluMediaBUndle:CollectionMeta';
 
-    private static $entityUser = 'Sulu\Component\Security\Authentication\UserInterface';
+    private static $entityUser = UserInterface::class;
 
-    private static $entityContact = 'Sulu\Bundle\ContactBundle\Entity\ContactInterface';
+    private static $entityContact = ContactInterface::class;
 
     /**
      * @var CollectionRepositoryInterface

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
@@ -13,6 +13,8 @@ namespace Sulu\Bundle\MediaBundle\DependencyInjection;
 
 use League\Flysystem\AwsS3v3\AwsS3Adapter;
 use League\Flysystem\AzureBlobStorage\AzureBlobStorageAdapter;
+use Sulu\Bundle\MediaBundle\Entity\Media;
+use Sulu\Bundle\MediaBundle\Entity\MediaRepository;
 use Superbalist\Flysystem\GoogleStorage\GoogleStorageAdapter;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -272,10 +274,10 @@ class Configuration implements ConfigurationInterface
                             ->addDefaultsIfNotSet()
                             ->children()
                                 ->scalarNode('model')
-                                    ->defaultValue('Sulu\Bundle\MediaBundle\Entity\Media')
+                                    ->defaultValue(Media::class)
                                 ->end()
                                 ->scalarNode('repository')
-                                    ->defaultValue('Sulu\Bundle\MediaBundle\Entity\MediaRepository')
+                                    ->defaultValue(MediaRepository::class)
                                 ->end()
                             ->end()
                         ->end()

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -27,6 +27,7 @@ use Sulu\Bundle\MediaBundle\Media\Exception\MediaNotFoundException;
 use Sulu\Bundle\MediaBundle\Media\PropertiesProvider\MediaPropertiesProviderInterface;
 use Sulu\Bundle\MediaBundle\Media\Storage\StorageInterface;
 use Sulu\Bundle\PersistenceBundle\DependencyInjection\PersistenceExtensionTrait;
+use Sulu\Bundle\SearchBundle\SuluSearchBundle;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -348,7 +349,7 @@ class SuluMediaExtension extends Extension implements PrependExtensionInterface
 
         // enable search
         if (true === $config['search']['enabled']) {
-            if (!\class_exists('Sulu\Bundle\SearchBundle\SuluSearchBundle')) {
+            if (!\class_exists(SuluSearchBundle::class)) {
                 throw new \InvalidArgumentException(
                     'You have enabled sulu search integration for the SuluMediaBundle, but the SuluSearchBundle must be installed'
                 );

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/SearchIntegration/SearchIntegrationTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/SearchIntegration/SearchIntegrationTest.php
@@ -59,24 +59,29 @@ class SearchIntegrationTest extends SuluTestCase
         $this->media = new ApiMedia($mediaEntity, 'de', null, $tagManager);
     }
 
-    public function provideIndex()
+    /**
+     * @return array<array{string, class-string<\Throwable>|null}>
+     */
+    public function provideIndex(): array
     {
         return [
             ['sulu-100x100', null],
-            ['invalid', '\InvalidArgumentException'],
+            ['invalid', \InvalidArgumentException::class],
         ];
     }
 
     /**
      * @dataProvider provideIndex
+     *
+     * @param class-string<\Throwable> $expectException
      */
-    public function testIndex($format, $expectException): void
+    public function testIndex(string $format, ?string $expectException): void
     {
         $mediaSelectionContainer = $this->prophesize(MediaSelectionContainer::class);
         $mediaSelectionContainer->getData()->willReturn([$this->media]);
         $mediaSelectionContainer->toArray()->willReturn(null);
 
-        if ($expectException) {
+        if ($expectException !== null) {
             $this->expectException($expectException);
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/SearchIntegration/SearchIntegrationTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/SearchIntegration/SearchIntegrationTest.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\MediaBundle\Tests\Functional\SearchIntegration;
 
+use Massive\Bundle\SearchBundle\Search\Document;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Bundle\MediaBundle\Api\Media as ApiMedia;
 use Sulu\Bundle\MediaBundle\Content\MediaSelectionContainer;
@@ -105,7 +106,7 @@ class SearchIntegrationTest extends SuluTestCase
         $documents = $testAdapter->getDocuments();
         $this->assertCount(1, $documents);
         $document = \end($documents);
-        $this->assertInstanceOf('Massive\Bundle\SearchBundle\Search\Document', $document);
+        $this->assertInstanceOf(Document::class, $document);
         $this->assertEquals('myimage.jpg', $document->getImageUrl());
     }
 
@@ -139,7 +140,7 @@ class SearchIntegrationTest extends SuluTestCase
         $documents = $testAdapter->getDocuments();
         $this->assertCount(1, $documents);
         $document = \end($documents);
-        $this->assertInstanceOf('Massive\Bundle\SearchBundle\Search\Document', $document);
+        $this->assertInstanceOf(Document::class, $document);
         $this->assertNull($document->getImageUrl());
     }
 
@@ -167,7 +168,7 @@ class SearchIntegrationTest extends SuluTestCase
         $documents = $testAdapter->getDocuments();
         $this->assertCount(1, $documents);
         $document = \end($documents);
-        $this->assertInstanceOf('Massive\Bundle\SearchBundle\Search\Document', $document);
+        $this->assertInstanceOf(Document::class, $document);
         $this->assertNull($document->getImageUrl());
     }
 
@@ -195,7 +196,7 @@ class SearchIntegrationTest extends SuluTestCase
         $documents = $testAdapter->getDocuments();
         $this->assertCount(1, $documents);
         $document = \end($documents);
-        $this->assertInstanceOf('Massive\Bundle\SearchBundle\Search\Document', $document);
+        $this->assertInstanceOf(Document::class, $document);
         $this->assertNull($document->getImageUrl());
     }
 
@@ -214,7 +215,7 @@ class SearchIntegrationTest extends SuluTestCase
 
         $documents = $testAdapter->getDocuments();
         $document = \end($documents);
-        $this->assertInstanceOf('Massive\Bundle\SearchBundle\Search\Document', $document);
+        $this->assertInstanceOf(Document::class, $document);
         $this->assertNull($document->getImageUrl());
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/SearchIntegration/SearchIntegrationTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/SearchIntegration/SearchIntegrationTest.php
@@ -81,7 +81,7 @@ class SearchIntegrationTest extends SuluTestCase
         $mediaSelectionContainer->getData()->willReturn([$this->media]);
         $mediaSelectionContainer->toArray()->willReturn(null);
 
-        if ($expectException !== null) {
+        if (null !== $expectException) {
             $this->expectException($expectException);
         }
 

--- a/src/Sulu/Bundle/PageBundle/Form/Type/HomeDocumentType.php
+++ b/src/Sulu/Bundle/PageBundle/Form/Type/HomeDocumentType.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\PageBundle\Form\Type;
 
+use Sulu\Bundle\PageBundle\Document\HomeDocument;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class HomeDocumentType extends BasePageDocumentType
@@ -18,7 +19,7 @@ class HomeDocumentType extends BasePageDocumentType
     public function configureOptions(OptionsResolver $options)
     {
         $options->setDefaults([
-            'data_class' => 'Sulu\Bundle\PageBundle\Document\HomeDocument',
+            'data_class' => HomeDocument::class,
         ]);
 
         parent::configureOptions($options);

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/Kernel.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/Kernel.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\PageBundle\Tests\Application;
 
+use Sulu\Bundle\SearchBundle\SuluSearchBundle;
 use Sulu\Bundle\TestBundle\Kernel\SuluTestKernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
 
@@ -26,7 +27,7 @@ class Kernel extends SuluTestKernel
             $loader->load(__DIR__ . '/config/versioning.yml');
         }
 
-        if (\class_exists('Sulu\Bundle\SearchBundle\SuluSearchBundle')) {
+        if (\class_exists(SuluSearchBundle::class)) {
             $loader->load(__DIR__ . '/config/search.yml');
         }
     }

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Mapper/ContentMapperTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Mapper/ContentMapperTest.php
@@ -25,6 +25,7 @@ use Sulu\Component\Content\Document\Behavior\ShadowLocaleBehavior;
 use Sulu\Component\Content\Document\RedirectType;
 use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\Content\Exception\MandatoryPropertyException;
+use Sulu\Component\Content\Exception\TranslatedNodeNotFoundException;
 use Sulu\Component\Content\Extension\AbstractExtension;
 use Sulu\Component\Content\Extension\ExtensionInterface;
 use Sulu\Component\Content\Extension\ExtensionManager;
@@ -1284,10 +1285,8 @@ class ContentMapperTest extends SuluTestCase
             'url' => '/news/test',
         ];
 
-        $this->expectException(
-            MandatoryPropertyException::class,
-            'Property "mandatory" in structure "mandatory" is required but no value was given.'
-        );
+        $this->expectException(MandatoryPropertyException::class);
+        $this->expectExceptionMessage('Property "mandatory" in structure "mandatory" is required but no value was given.');
 
         $this->save($data, 'mandatory', 'sulu_io', 'de', 1);
     }
@@ -1987,10 +1986,8 @@ class ContentMapperTest extends SuluTestCase
             'b' => 'de test2 b',
         ];
 
-        $this->expectException(
-            'Sulu\Component\Content\Exception\TranslatedNodeNotFoundException',
-            'Node "' . $structure->getUuid() . '" not found in localization "de"'
-        );
+        $this->expectException(TranslatedNodeNotFoundException::class);
+        $this->expectExceptionMessage('Node "' . $structure->getUuid() . '" not found in localization "de"');
 
         $this->mapper->saveExtension($structure->getUuid(), $dataTest2DE, 'test2', 'sulu_io', 'de', 1);
     }

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/Mapper/PhpcrMapperTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/Mapper/PhpcrMapperTest.php
@@ -17,6 +17,9 @@ use Sulu\Bundle\PageBundle\Document\BasePageDocument;
 use Sulu\Bundle\PageBundle\Document\HomeDocument;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
+use Sulu\Component\Content\Exception\ResourceLocatorAlreadyExistsException;
+use Sulu\Component\Content\Exception\ResourceLocatorMovedException;
+use Sulu\Component\Content\Exception\ResourceLocatorNotFoundException;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\Content\Types\ResourceLocator\Mapper\PhpcrMapper;
 use Sulu\Component\Content\Types\ResourceLocator\Mapper\ResourceLocatorMapperInterface;
@@ -197,7 +200,7 @@ class PhpcrMapperTest extends SuluTestCase
 
     public function testSaveFailure(): void
     {
-        $this->expectException('Sulu\Component\Content\Exception\ResourceLocatorAlreadyExistsException');
+        $this->expectException(ResourceLocatorAlreadyExistsException::class);
         $this->document1->setResourceSegment('/products/machines/drill');
         $this->phpcrMapper->save($this->document1);
     }
@@ -241,7 +244,7 @@ class PhpcrMapperTest extends SuluTestCase
         $content->addMixin('mix:referenceable');
         $this->defaultSession->save();
 
-        $this->expectException('Sulu\Component\Content\Exception\ResourceLocatorNotFoundException');
+        $this->expectException(ResourceLocatorNotFoundException::class);
         $this->phpcrMapper->loadByContent($content, 'sulu_io', 'de');
     }
 
@@ -251,7 +254,7 @@ class PhpcrMapperTest extends SuluTestCase
         $content->addMixin('mix:referenceable');
         $this->defaultSession->save();
 
-        $this->expectException('Sulu\Component\Content\Exception\ResourceLocatorNotFoundException');
+        $this->expectException(ResourceLocatorNotFoundException::class);
         $this->phpcrMapper->loadByContentUuid($content->getIdentifier(), 'sulu_io', 'de');
     }
 
@@ -277,13 +280,13 @@ class PhpcrMapperTest extends SuluTestCase
 
     public function testLoadFailureNotFound(): void
     {
-        $this->expectException('Sulu\Component\Content\Exception\ResourceLocatorNotFoundException');
+        $this->expectException(ResourceLocatorNotFoundException::class);
         $this->phpcrMapper->loadByResourceLocator('/test/test-1', 'sulu_io', 'de');
     }
 
     public function testLoadFailureInvalidPath(): void
     {
-        $this->expectException('Sulu\Component\Content\Exception\ResourceLocatorNotFoundException');
+        $this->expectException(ResourceLocatorNotFoundException::class);
         $this->phpcrMapper->loadByResourceLocator('/https://sulu.io/test/test-1', 'sulu_io', 'de');
     }
 
@@ -337,7 +340,7 @@ class PhpcrMapperTest extends SuluTestCase
         $this->assertEquals($this->document1->getUuid(), $result);
 
         // get content from history should throw an exception
-        $this->expectException('Sulu\Component\Content\Exception\ResourceLocatorMovedException');
+        $this->expectException(ResourceLocatorMovedException::class);
         $this->phpcrMapper->loadByResourceLocator('/products/news/content1-news', 'sulu_io', 'de');
     }
 
@@ -378,7 +381,7 @@ class PhpcrMapperTest extends SuluTestCase
         $this->assertEquals($this->document1->getUuid(), $result);
 
         // get content from history should throw an exception
-        $this->expectException('Sulu\Component\Content\Exception\ResourceLocatorMovedException');
+        $this->expectException(ResourceLocatorMovedException::class);
         $this->phpcrMapper->loadByResourceLocator('/products/news/content1-news', 'sulu_io', 'de');
     }
 

--- a/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/PersistenceExtensionTrait.php
+++ b/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/PersistenceExtensionTrait.php
@@ -12,6 +12,8 @@
 namespace Sulu\Bundle\PersistenceBundle\DependencyInjection;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepositoryInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Sulu\Component\Persistence\Repository\ORM\EntityRepository;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -73,7 +75,7 @@ trait PersistenceExtensionTrait
         $repositoryKey = $this->getContainerKey('repository', $object, '.class');
 
         // default repository
-        $repositoryClass = 'Sulu\Component\Persistence\Repository\ORM\EntityRepository';
+        $repositoryClass = EntityRepository::class;
 
         if ($container->hasParameter($repositoryKey)) {
             /** @var class-string $repositoryClass */
@@ -111,7 +113,7 @@ trait PersistenceExtensionTrait
      */
     private function getClassMetadataDefinition($model)
     {
-        $definition = new Definition('Doctrine\ORM\Mapping\ClassMetadata');
+        $definition = new Definition(ClassMetadata::class);
         $definition
             ->setFactory([
                 new Reference($this->getEntityManagerServiceKey()),

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
@@ -417,7 +417,8 @@ class PreviewRendererTest extends TestCase
 
     public function testRenderRouteDefaultsProviderNotFound(): void
     {
-        $this->expectException(RouteDefaultsProviderNotFoundException::class, '', 9902);
+        $this->expectException(RouteDefaultsProviderNotFoundException::class);
+        $this->expectExceptionCode(9902);
 
         $object = $this->prophesize(\stdClass::class);
 
@@ -451,7 +452,8 @@ class PreviewRendererTest extends TestCase
 
     public function testRenderTwigError(): void
     {
-        $this->expectException(TwigException::class, '', 9903);
+        $this->expectException(TwigException::class);
+        $this->expectExceptionCode(9903);
 
         $object = $this->prophesize(\stdClass::class);
 
@@ -485,7 +487,8 @@ class PreviewRendererTest extends TestCase
 
     public function testRenderInvalidArgumentException(): void
     {
-        $this->expectException(TemplateNotFoundException::class, '', 9904);
+        $this->expectException(TemplateNotFoundException::class);
+       $this->expectExceptionCode( 9904);
 
         $object = $this->prophesize(\stdClass::class);
 
@@ -519,7 +522,8 @@ class PreviewRendererTest extends TestCase
 
     public function testRenderHttpExceptionWithPreviousException(): void
     {
-        $this->expectException(TemplateNotFoundException::class, '', 9904);
+        $this->expectException(TemplateNotFoundException::class);
+       $this->expectExceptionCode(9904);
 
         $object = $this->prophesize(\stdClass::class);
 
@@ -555,7 +559,8 @@ class PreviewRendererTest extends TestCase
 
     public function testRenderHttpExceptionWithoutPreviousException(): void
     {
-        $this->expectException(UnexpectedException::class, '', 9905);
+        $this->expectException(UnexpectedException::class);
+       $this->expectExceptionCode( 9905);
 
         $object = $this->prophesize(\stdClass::class);
 

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
@@ -488,7 +488,7 @@ class PreviewRendererTest extends TestCase
     public function testRenderInvalidArgumentException(): void
     {
         $this->expectException(TemplateNotFoundException::class);
-       $this->expectExceptionCode( 9904);
+        $this->expectExceptionCode(9904);
 
         $object = $this->prophesize(\stdClass::class);
 
@@ -523,7 +523,7 @@ class PreviewRendererTest extends TestCase
     public function testRenderHttpExceptionWithPreviousException(): void
     {
         $this->expectException(TemplateNotFoundException::class);
-       $this->expectExceptionCode(9904);
+        $this->expectExceptionCode(9904);
 
         $object = $this->prophesize(\stdClass::class);
 
@@ -560,7 +560,7 @@ class PreviewRendererTest extends TestCase
     public function testRenderHttpExceptionWithoutPreviousException(): void
     {
         $this->expectException(UnexpectedException::class);
-       $this->expectExceptionCode( 9905);
+        $this->expectExceptionCode(9905);
 
         $object = $this->prophesize(\stdClass::class);
 

--- a/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Configuration.php
@@ -28,6 +28,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('sulu_security');
@@ -128,6 +131,8 @@ class Configuration implements ConfigurationInterface
 
     /**
      * Adds `objects` section.
+     *
+     * @return void
      */
     private function addObjectsSection(ArrayNodeDefinition $node)
     {

--- a/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Configuration.php
@@ -11,6 +11,14 @@
 
 namespace Sulu\Bundle\SecurityBundle\DependencyInjection;
 
+use Sulu\Bundle\SecurityBundle\Entity\AccessControl;
+use Sulu\Bundle\SecurityBundle\Entity\AccessControlRepository;
+use Sulu\Bundle\SecurityBundle\Entity\Role;
+use Sulu\Bundle\SecurityBundle\Entity\RoleRepository;
+use Sulu\Bundle\SecurityBundle\Entity\RoleSetting;
+use Sulu\Bundle\SecurityBundle\Entity\RoleSettingRepository;
+use Sulu\Bundle\SecurityBundle\Entity\User;
+use Sulu\Bundle\SecurityBundle\Entity\UserRepository;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -131,29 +139,29 @@ class Configuration implements ConfigurationInterface
                         ->arrayNode('user')
                             ->addDefaultsIfNotSet()
                             ->children()
-                                ->scalarNode('model')->defaultValue('Sulu\Bundle\SecurityBundle\Entity\User')->end()
-                                ->scalarNode('repository')->defaultValue('Sulu\Bundle\SecurityBundle\Entity\UserRepository')->end()
+                                ->scalarNode('model')->defaultValue(User::class)->end()
+                                ->scalarNode('repository')->defaultValue(UserRepository::class)->end()
                             ->end()
                         ->end()
                         ->arrayNode('role')
                             ->addDefaultsIfNotSet()
                             ->children()
-                                ->scalarNode('model')->defaultValue('Sulu\Bundle\SecurityBundle\Entity\Role')->end()
-                                ->scalarNode('repository')->defaultValue('Sulu\Bundle\SecurityBundle\Entity\RoleRepository')->end()
+                                ->scalarNode('model')->defaultValue(Role::class)->end()
+                                ->scalarNode('repository')->defaultValue(RoleRepository::class)->end()
                             ->end()
                         ->end()
                         ->arrayNode('role_setting')
                             ->addDefaultsIfNotSet()
                             ->children()
-                                ->scalarNode('model')->defaultValue('Sulu\Bundle\SecurityBundle\Entity\RoleSetting')->end()
-                                ->scalarNode('repository')->defaultValue('Sulu\Bundle\SecurityBundle\Entity\RoleSettingRepository')->end()
+                                ->scalarNode('model')->defaultValue(RoleSetting::class)->end()
+                                ->scalarNode('repository')->defaultValue(RoleSettingRepository::class)->end()
                             ->end()
                         ->end()
                         ->arrayNode('access_control')
                             ->addDefaultsIfNotSet()
                             ->children()
-                                ->scalarNode('model')->defaultValue('Sulu\Bundle\SecurityBundle\Entity\AccessControl')->end()
-                                ->scalarNode('repository')->defaultValue('Sulu\Bundle\SecurityBundle\Entity\AccessControlRepository')->end()
+                                ->scalarNode('model')->defaultValue(AccessControl::class)->end()
+                                ->scalarNode('repository')->defaultValue(AccessControlRepository::class)->end()
                             ->end()
                         ->end()
                     ->end()

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Security/AuthenticationEntryPointTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Security/AuthenticationEntryPointTest.php
@@ -13,6 +13,8 @@ namespace Sulu\Bundle\SecurityBundle\Security;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class AuthenticationEntryPointTest extends TestCase
 {
@@ -27,14 +29,14 @@ class AuthenticationEntryPointTest extends TestCase
     {
         parent::setUp();
 
-        $urlGenerator = $this->prophesize('Symfony\Component\Routing\Generator\UrlGeneratorInterface');
+        $urlGenerator = $this->prophesize(UrlGeneratorInterface::class);
         $urlGenerator->generate('sulu_admin')->willReturn('/admin');
         $this->authenticationEntryPoint = new AuthenticationEntryPoint($urlGenerator->reveal());
     }
 
     public function testStart(): void
     {
-        $request = $this->prophesize('Symfony\Component\HttpFoundation\Request');
+        $request = $this->prophesize(Request::class);
         $result = $this->authenticationEntryPoint->start($request->reveal());
 
         $this->assertEquals(401, $result->getStatusCode());

--- a/src/Sulu/Bundle/SnippetBundle/Form/SnippetType.php
+++ b/src/Sulu/Bundle/SnippetBundle/Form/SnippetType.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\SnippetBundle\Form;
 
 use Sulu\Bundle\PageBundle\Form\Type\AbstractStructureBehaviorType;
 use Sulu\Bundle\PageBundle\Form\Type\UnstructuredType;
+use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -22,7 +23,7 @@ class SnippetType extends AbstractStructureBehaviorType
     public function configureOptions(OptionsResolver $options)
     {
         $options->setDefaults([
-            'data_class' => 'Sulu\Bundle\SnippetBundle\Document\SnippetDocument',
+            'data_class' => SnippetDocument::class,
         ]);
 
         parent::configureOptions($options);

--- a/src/Sulu/Bundle/SnippetBundle/Form/SnippetType.php
+++ b/src/Sulu/Bundle/SnippetBundle/Form/SnippetType.php
@@ -20,6 +20,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class SnippetType extends AbstractStructureBehaviorType
 {
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $options)
     {
         $options->setDefaults([

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/SnippetContentTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/SnippetContentTest.php
@@ -74,7 +74,7 @@ class SnippetContentTest extends BaseFunctionalTestCase
         $this->loadFixtures();
 
         $this->session = $this->getContainer()->get('doctrine_phpcr')->getConnection();
-        $this->property = $this->getMockBuilder('Sulu\Component\Content\Compat\PropertyInterface')->getMock();
+        $this->property = $this->getMockBuilder(PropertyInterface::class)->getMock();
 
         $this->defaultSnippetManager = $this->prophesize(DefaultSnippetManagerInterface::class);
 

--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Compiler/RouteProviderCompilerPass.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Compiler/RouteProviderCompilerPass.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\WebsiteBundle\DependencyInjection\Compiler;
 
+use Sulu\Bundle\WebsiteBundle\Routing\ContentRouteProvider;
 use Sulu\Component\HttpKernel\SuluKernel;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -27,7 +28,7 @@ class RouteProviderCompilerPass implements CompilerPassInterface
         if (SuluKernel::CONTEXT_WEBSITE === $container->getParameter('sulu.context')) {
             $container->setDefinition(
                 'sulu_website.provider.content',
-                new Definition('Sulu\Bundle\WebsiteBundle\Routing\ContentRouteProvider', [
+                new Definition(ContentRouteProvider::class, [
                     new Reference('sulu.content.mapper'),
                     new Reference('sulu_core.webspace.request_analyzer'),
                 ])

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Resolver/RequestAnalyzerResolverTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Resolver/RequestAnalyzerResolverTest.php
@@ -82,7 +82,7 @@ class RequestAnalyzerResolverTest extends TestCase
             $webspace->addLocalization($de);
             $webspace->addLocalization($es);
 
-            $this->webspaceManager = $this->prophesize('Sulu\Component\Webspace\Manager\WebspaceManagerInterface');
+            $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
             $this->webspaceManager->findWebspaceByKey('sulu_io')->willReturn($webspace);
         }
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Resolver/StructureResolverTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Resolver/StructureResolverTest.php
@@ -17,11 +17,14 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolver;
 use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;
+use Sulu\Component\Content\Compat\PropertyInterface;
+use Sulu\Component\Content\Compat\Structure\PageBridge;
 use Sulu\Component\Content\ContentTypeInterface;
 use Sulu\Component\Content\ContentTypeManagerInterface;
 use Sulu\Component\Content\Document\Behavior\ExtensionBehavior;
 use Sulu\Component\Content\Document\Behavior\LocalizedAuthorBehavior;
 use Sulu\Component\Content\Document\Extension\ExtensionContainer;
+use Sulu\Component\Content\Extension\ExtensionInterface;
 use Sulu\Component\Content\Extension\ExtensionManagerInterface;
 
 class StructureResolverTest extends TestCase
@@ -68,19 +71,19 @@ class StructureResolverTest extends TestCase
         $this->contentType->getViewData(Argument::any())->willReturn('view');
         $this->contentType->getContentData(Argument::any())->willReturn('content');
 
-        $excerptExtension = $this->prophesize('Sulu\Component\Content\Extension\ExtensionInterface');
+        $excerptExtension = $this->prophesize(ExtensionInterface::class);
         $excerptExtension->getContentData(['test1' => 'test1'])->willReturn(['test1' => 'test1']);
         $this->extensionManager->getExtension('test', 'excerpt')->willReturn($excerptExtension);
 
-        $property1 = $this->prophesize('Sulu\Component\Content\Compat\PropertyInterface');
+        $property1 = $this->prophesize(PropertyInterface::class);
         $property1->getName()->willReturn('property-1');
         $property1->getContentTypeName()->willReturn('content_type');
 
-        $property2 = $this->prophesize('Sulu\Component\Content\Compat\PropertyInterface');
+        $property2 = $this->prophesize(PropertyInterface::class);
         $property2->getName()->willReturn('property-2');
         $property2->getContentTypeName()->willReturn('content_type');
 
-        $structure = $this->prophesize('Sulu\Component\Content\Compat\Structure\PageBridge');
+        $structure = $this->prophesize(PageBridge::class);
         $structure->getKey()->willReturn('test');
         $structure->getExt()->willReturn(new ExtensionContainer(['excerpt' => ['test1' => 'test1']]));
         $structure->getUuid()->willReturn('some-uuid');
@@ -141,15 +144,15 @@ class StructureResolverTest extends TestCase
         $this->contentType->getViewData(Argument::any())->willReturn('view');
         $this->contentType->getContentData(Argument::any())->willReturn('content');
 
-        $excerptExtension = $this->prophesize('Sulu\Component\Content\Extension\ExtensionInterface');
+        $excerptExtension = $this->prophesize(ExtensionInterface::class);
         $excerptExtension->getContentData(['test1' => 'test1'])->willReturn(['test1' => 'test1']);
         $this->extensionManager->getExtension('test', 'excerpt')->willReturn($excerptExtension);
 
-        $property = $this->prophesize('Sulu\Component\Content\Compat\PropertyInterface');
+        $property = $this->prophesize(PropertyInterface::class);
         $property->getName()->willReturn('property');
         $property->getContentTypeName()->willReturn('content_type');
 
-        $structure = $this->prophesize('Sulu\Component\Content\Compat\Structure\PageBridge');
+        $structure = $this->prophesize(PageBridge::class);
         $structure->getKey()->willReturn('test');
         $structure->getExt()->willReturn(new ExtensionContainer(['excerpt' => ['test1' => 'test1']]));
         $structure->getUuid()->willReturn('some-uuid');
@@ -212,15 +215,15 @@ class StructureResolverTest extends TestCase
         $this->contentType->getViewData(Argument::any())->willReturn('view');
         $this->contentType->getContentData(Argument::any())->willReturn('content');
 
-        $excerptExtension = $this->prophesize('Sulu\Component\Content\Extension\ExtensionInterface');
+        $excerptExtension = $this->prophesize(ExtensionInterface::class);
         $excerptExtension->getContentData(['test1' => 'test1'])->willReturn(['test1' => 'test1']);
         $this->extensionManager->getExtension('test', 'excerpt')->willReturn($excerptExtension);
 
-        $property = $this->prophesize('Sulu\Component\Content\Compat\PropertyInterface');
+        $property = $this->prophesize(PropertyInterface::class);
         $property->getName()->willReturn('property');
         $property->getContentTypeName()->willReturn('content_type');
 
-        $structure = $this->prophesize('Sulu\Component\Content\Compat\Structure\PageBridge');
+        $structure = $this->prophesize(PageBridge::class);
         $structure->getKey()->willReturn('test');
         $structure->getExt()->willReturn(new ExtensionContainer(['excerpt' => ['test1' => 'test1']]));
         $structure->getUuid()->willReturn('some-uuid');
@@ -275,19 +278,19 @@ class StructureResolverTest extends TestCase
         $this->contentType->getViewData(Argument::any())->willReturn('view');
         $this->contentType->getContentData(Argument::any())->willReturn('content');
 
-        $excerptExtension = $this->prophesize('Sulu\Component\Content\Extension\ExtensionInterface');
+        $excerptExtension = $this->prophesize(ExtensionInterface::class);
         $excerptExtension->getContentData(['test1' => 'test1'])->willReturn(['test1' => 'test1']);
         $this->extensionManager->getExtension('test', 'excerpt')->willReturn($excerptExtension);
 
-        $property1 = $this->prophesize('Sulu\Component\Content\Compat\PropertyInterface');
+        $property1 = $this->prophesize(PropertyInterface::class);
         $property1->getName()->willReturn('property-1');
         $property1->getContentTypeName()->willReturn('content_type');
 
-        $property2 = $this->prophesize('Sulu\Component\Content\Compat\PropertyInterface');
+        $property2 = $this->prophesize(PropertyInterface::class);
         $property2->getName()->willReturn('property-2');
         $property2->getContentTypeName()->willReturn('content_type');
 
-        $structure = $this->prophesize('Sulu\Component\Content\Compat\Structure\PageBridge');
+        $structure = $this->prophesize(PageBridge::class);
         $structure->getKey()->willReturn('test');
         $structure->getExt()->willReturn(new ExtensionContainer(['excerpt' => ['test1' => 'test1']]));
         $structure->getUuid()->willReturn('some-uuid');

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapGeneratorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapGeneratorTest.php
@@ -164,7 +164,7 @@ class SitemapGeneratorTest extends SuluTestCase
             )
         );
 
-        $this->webspaceManager = $this->getMockBuilder('Sulu\Component\Webspace\Manager\WebspaceManagerInterface')->getMock();
+        $this->webspaceManager = $this->getMockBuilder(WebspaceManagerInterface::class)->getMock();
         $this->webspaceManager
             ->expects($this->any())
             ->method('findWebspaceByKey')

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/ContentTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/ContentTwigExtensionTest.php
@@ -21,6 +21,7 @@ use Psr\Log\LoggerInterface;
 use Sulu\Bundle\PageBundle\Admin\PageAdmin;
 use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;
 use Sulu\Bundle\WebsiteBundle\Twig\Content\ContentTwigExtension;
+use Sulu\Bundle\WebsiteBundle\Twig\Exception\ParentNotFoundException;
 use Sulu\Component\Content\Compat\Structure\SnippetBridge;
 use Sulu\Component\Content\Compat\Structure\StructureBridge;
 use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
@@ -709,10 +710,8 @@ class ContentTwigExtensionTest extends TestCase
 
     public function testLoadParentStartPage(): void
     {
-        $this->expectException(
-            'Sulu\Bundle\WebsiteBundle\Twig\Exception\ParentNotFoundException',
-            'Parent for "321-321-321" not found (perhaps it is the startpage?)'
-        );
+        $this->expectException(ParentNotFoundException::class);
+        $this->expectExceptionMessage('Parent for "321-321-321" not found (perhaps it is the startpage?)');
 
         $this->extension->loadParent('321-321-321');
     }

--- a/src/Sulu/Component/Content/Tests/Unit/Compat/StructureManagerTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Compat/StructureManagerTest.php
@@ -16,6 +16,8 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Component\Content\Compat\Structure\LegacyPropertyFactory;
+use Sulu\Component\Content\Compat\Structure\PageBridge;
+use Sulu\Component\Content\Compat\Structure\SnippetBridge;
 use Sulu\Component\Content\Compat\Structure\StructureBridge;
 use Sulu\Component\Content\Compat\StructureManager;
 use Sulu\Component\Content\Compat\StructureManagerInterface;
@@ -66,9 +68,9 @@ class StructureManagerTest extends TestCase
         $this->propertyFactory = $this->prophesize(LegacyPropertyFactory::class);
 
         $typemap = [
-            'page' => '\Sulu\Component\Content\Compat\Structure\PageBridge',
-            'home' => '\Sulu\Component\Content\Compat\Structure\PageBridge',
-            'snippet' => '\Sulu\Component\Content\Compat\Structure\SnippetBridge',
+            'page' => '\\' . PageBridge::class,
+            'home' => '\\' . PageBridge::class,
+            'snippet' => '\\' . SnippetBridge::class,
         ];
 
         $this->structureManager = new StructureManager(

--- a/src/Sulu/Component/Content/Tests/Unit/ContentTypeManagerTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/ContentTypeManagerTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\Content\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Sulu\Component\Content\ContentTypeManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class ContentTypeManagerTest extends TestCase
 {
@@ -20,7 +21,7 @@ class ContentTypeManagerTest extends TestCase
 
     public function setUp(): void
     {
-        $this->container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
+        $this->container = $this->getMockBuilder(ContainerInterface::class)->getMock();
         $this->manager = new ContentTypeManager($this->container);
 
         $this->manager->mapAliasToServiceId('content_1.alias', 'content_1.service.id');

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ChildrenCollectionTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ChildrenCollectionTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Component\DocumentManager\Collection\ChildrenCollection;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
 use Sulu\Component\DocumentManager\Events;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -47,11 +48,14 @@ class ChildrenCollectionTest extends TestCase
         ]);
         $this->parentNode->getNodes()->willReturn($children);
 
-        $this->dispatcher->dispatch(Argument::type('Sulu\Component\DocumentManager\Event\HydrateEvent'), Events::HYDRATE)->will(function($args) {
-            $args[0]->setDocument(new \stdClass());
+        $this->dispatcher
+            ->dispatch(Argument::type(HydrateEvent::class), Events::HYDRATE)
+            ->will(function($args) {
+                $args[0]->setDocument(new \stdClass());
 
-            return $args[0];
-        });
+                return $args[0];
+            })
+        ;
 
         $results = [];
 

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/QueryResultCollectionTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/QueryResultCollectionTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Component\DocumentManager\Collection\QueryResultCollection;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
 use Sulu\Component\DocumentManager\Events;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -59,11 +60,13 @@ class QueryResultCollectionTest extends TestCase
 
         $this->queryResult->getRows()->willReturn($results);
 
-        $this->dispatcher->dispatch(Argument::type('Sulu\Component\DocumentManager\Event\HydrateEvent'), Events::HYDRATE)->will(function($args) {
-            $args[0]->setDocument(new \stdClass());
+        $this->dispatcher
+            ->dispatch(Argument::type(HydrateEvent::class), Events::HYDRATE)
+            ->will(function($args) {
+                $args[0]->setDocument(new \stdClass());
 
-            return $args[0];
-        });
+                return $args[0];
+            });
 
         $results = [];
 

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ReferrerCollectionTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ReferrerCollectionTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Component\DocumentManager\Collection\ReferrerCollection;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
 use Sulu\Component\DocumentManager\Events;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -51,11 +52,13 @@ class ReferrerCollectionTest extends TestCase
         $this->reference->getParent()->willReturn($this->referrerNode->reveal());
         $this->referrerNode->getIdentifier()->willReturn('1234');
 
-        $this->dispatcher->dispatch(Argument::type('Sulu\Component\DocumentManager\Event\HydrateEvent'), Events::HYDRATE)->will(function($args) {
-            $args[0]->setDocument(new \stdClass());
+        $this->dispatcher
+            ->dispatch(Argument::type(HydrateEvent::class), Events::HYDRATE)
+            ->will(function($args) {
+                $args[0]->setDocument(new \stdClass());
 
-            return $args[0];
-        });
+                return $args[0];
+            });
 
         $results = [];
 

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Metadata/BaseMetadataFactoryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Metadata/BaseMetadataFactoryTest.php
@@ -153,7 +153,7 @@ class BaseMetadataFactoryTest extends TestCase
     {
         $metadatas = $this->factory->getAllMetadata();
         $this->assertCount(2, $metadatas);
-        $this->assertContainsOnlyInstancesOf('Sulu\Component\DocumentManager\Metadata', $metadatas);
+        $this->assertContainsOnlyInstancesOf(Metadata::class, $metadatas);
         $metadata = \reset($metadatas);
         $this->assertEquals('Class\Page', $metadata->getClass());
     }

--- a/src/Sulu/Component/Localization/Tests/Unit/Manager/LocalizationManagerTest.php
+++ b/src/Sulu/Component/Localization/Tests/Unit/Manager/LocalizationManagerTest.php
@@ -16,6 +16,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\Localization\Manager\LocalizationManager;
 use Sulu\Component\Localization\Manager\LocalizationManagerInterface;
+use Sulu\Component\Localization\Provider\LocalizationProviderInterface;
 
 class LocalizationManagerTest extends TestCase
 {
@@ -72,9 +73,7 @@ class LocalizationManagerTest extends TestCase
 
     private function addLocalizationProvider($localizations)
     {
-        $localizationProvider1 = $this->prophesize(
-            'Sulu\Component\Localization\Provider\LocalizationProviderInterface'
-        );
+        $localizationProvider1 = $this->prophesize(LocalizationProviderInterface::class);
         $localizationProvider1->getAllLocalizations()->willReturn($localizations);
 
         $this->localizationManager->addLocalizationProvider($localizationProvider1->reveal());

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/TimestampableSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/TimestampableSubscriber.php
@@ -45,7 +45,7 @@ class TimestampableSubscriber implements EventSubscriber
         $metadata = $event->getClassMetadata();
         $reflection = $metadata->getReflectionClass();
 
-        if (null !== $reflection && $reflection->implementsInterface('Sulu\Component\Persistence\Model\TimestampableInterface')) {
+        if (null !== $reflection && $reflection->implementsInterface(TimestampableInterface::class)) {
             if (!$metadata->hasField(self::CREATED_FIELD)) {
                 $metadata->mapField([
                     'fieldName' => self::CREATED_FIELD,

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
@@ -64,7 +64,7 @@ class UserBlameSubscriber implements EventSubscriber
         $metadata = $event->getClassMetadata();
         $reflection = $metadata->getReflectionClass();
 
-        if (null !== $reflection && $reflection->implementsInterface('Sulu\Component\Persistence\Model\UserBlameInterface')) {
+        if (null !== $reflection && $reflection->implementsInterface(UserBlameInterface::class)) {
             if (!$metadata->hasAssociation(self::CREATOR_FIELD)) {
                 $metadata->mapManyToOne([
                     'fieldName' => self::CREATOR_FIELD,

--- a/src/Sulu/Component/Rest/Tests/Unit/DoctrineRestHelperTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/DoctrineRestHelperTest.php
@@ -11,8 +11,10 @@
 
 namespace Sulu\Component\Rest\Tests\Unit;
 
+use Doctrine\Common\Collections\Collection;
 use PHPUnit\Framework\TestCase;
 use Sulu\Component\Rest\DoctrineRestHelper;
+use Sulu\Component\Rest\ListBuilder\ListRestHelper;
 
 class DoctrineRestHelperTest extends TestCase
 {
@@ -28,7 +30,7 @@ class DoctrineRestHelperTest extends TestCase
 
     public function setUp(): void
     {
-        $this->listRestHelper = $this->getMockBuilder('Sulu\Component\Rest\ListBuilder\ListRestHelper')
+        $this->listRestHelper = $this->getMockBuilder(ListRestHelper::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -37,8 +39,7 @@ class DoctrineRestHelperTest extends TestCase
 
     public function testProcessSubEntities(): void
     {
-        $entities = $this->getMockBuilder('Doctrine\Common\Collections\Collection')
-            ->getMockForAbstractClass();
+        $entities = $this->getMockBuilder(Collection::class)->getMockForAbstractClass();
 
         $entities->expects($this->once())->method('count')->willReturn(2);
         $entities->expects($this->once())->method('getValues')->willReturn([null, null]);

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineAndExpressionTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineAndExpressionTest.php
@@ -40,7 +40,7 @@ class DoctrineAndExpressionTest extends TestCase
 
     public function setUp(): void
     {
-        $this->queryBuilder = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')
+        $this->queryBuilder = $this->getMockBuilder(QueryBuilder::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineBetweenExpressionTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineBetweenExpressionTest.php
@@ -39,7 +39,7 @@ class DoctrineBetweenExpressionTest extends TestCase
 
     public function setUp(): void
     {
-        $this->queryBuilder = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')
+        $this->queryBuilder = $this->getMockBuilder(QueryBuilder::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineInExpressionTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineInExpressionTest.php
@@ -39,7 +39,7 @@ class DoctrineInExpressionTest extends TestCase
 
     public function setUp(): void
     {
-        $this->queryBuilder = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')
+        $this->queryBuilder = $this->getMockBuilder(QueryBuilder::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineOrExpressionTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineOrExpressionTest.php
@@ -40,7 +40,7 @@ class DoctrineOrExpressionTest extends TestCase
 
     public function setUp(): void
     {
-        $this->queryBuilder = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')
+        $this->queryBuilder = $this->getMockBuilder(QueryBuilder::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/src/Sulu/Component/Rest/Tests/Unit/RequestParametersTraitTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/RequestParametersTraitTest.php
@@ -29,7 +29,7 @@ class RequestParametersTraitTest extends TestCase
 
     public function setUp(): void
     {
-        $this->requestParametersTrait = $this->getObjectForTrait('Sulu\Component\Rest\RequestParametersTrait');
+        $this->requestParametersTrait = $this->getObjectForTrait(RequestParametersTrait::class);
     }
 
     private function getGetRequestParameterReflection()

--- a/src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
+++ b/src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
@@ -250,7 +250,7 @@ class SuluNodeHelperTest extends TestCase
     public function testSiblingNodes(): void
     {
         for ($i = 1; $i <= 3; ++$i) {
-            ${'node' . $i} = $this->getMockBuilder('Jackalope\Node')->disableOriginalConstructor()->getMock();
+            ${'node' . $i} = $this->getMockBuilder(Node::class)->disableOriginalConstructor()->getMock();
             ${'node' . $i}->expects($this->any())
                 ->method('getPath')
                 ->will($this->returnValue('/foobar/foobar-' . $i));

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\Webspace\Tests\Unit;
 
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Log\LoggerInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Exception\InvalidTemplateException;
 use Sulu\Component\Webspace\Loader\XmlFileLoader10;
@@ -51,7 +52,7 @@ class WebspaceCollectionBuilderTest extends WebspaceTestCase
 
         $this->loader = new DelegatingLoader($resolver);
 
-        $this->logger = $this->getMockBuilder('\Psr\Log\LoggerInterface')->getMock();
+        $this->logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
     }
 
     public function testBuild(): void

--- a/src/Sulu/Component/Webspace/Tests/Unit/PortalInformationTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/PortalInformationTest.php
@@ -13,7 +13,10 @@ namespace Sulu\Component\Webspace\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\PortalInformation;
+use Sulu\Component\Webspace\Webspace;
 
 class PortalInformationTest extends TestCase
 {
@@ -28,9 +31,9 @@ class PortalInformationTest extends TestCase
     {
         parent::setUp();
         $this->portalInformation = new PortalInformation(null, null, null, null, null);
-        $this->webspace = $this->prophesize('Sulu\Component\Webspace\Webspace');
-        $this->portal = $this->prophesize('Sulu\Component\Webspace\Portal');
-        $this->localization = $this->prophesize('Sulu\Component\Localization\Localization');
+        $this->webspace = $this->prophesize(Webspace::class);
+        $this->portal = $this->prophesize(Portal::class);
+        $this->localization = $this->prophesize(Localization::class);
     }
 
     public function provideUrl()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | in the tests (but that's okay)
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
```php
<?php

use Rector\Config\RectorConfig;
use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
use Rector\Set\ValueObject\LevelSetList;

return static function(RectorConfig $rectorConfig): void {
    $rectorConfig->paths([
        __DIR__ . '/config',
        __DIR__ . '/public',
        __DIR__ . '/src',
        __DIR__ . '/tests',
    ]);

    // register a single rule
    $rectorConfig->rule(StringClassNameToClassConstantRector::class);
};
```

* Running the `StringClassNameToClassConstantRector`
* fixing some more type issues
* Fixing test assertions since `expectException` can only take one argument.

#### Why?

Class References like `Something::class` is better than having a string to the class because of two reasons:
* Supported by tools (eg. go do definition and usages)
* If Class gets renamed, the rename will also change the reference but not the string version
