### PR TITLE
Adding an `OnlyKeysVisitor` to reduce the config size when serializing

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/OnlyKeysVisistor.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/OnlyKeysVisistor.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
+
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
+
+class OnlyKeysVisistor implements TypedFormMetadataVisitorInterface
+{
+    public function visitTypedFormMetadata(
+        TypedFormMetadata $formMetadata,
+        string $key,
+        string $locale,
+        array $metadataOptions = []
+    ): void {
+        $onlyKeys = $metadataOptions['onlyKeys'] ?? false;
+        if (!$onlyKeys) {
+            return;
+        }
+
+        foreach ($formMetadata->getForms() as $metaData) {
+            $metaData->setItems([]);
+            $metaData->setSchema(new SchemaMetadata([], [], []));
+        }
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -68,6 +68,13 @@
         </service>
 
         <service
+            id="sulu_admin.only_keys_metadata_visitor"
+            class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OnlyKeysVisistor"
+        >
+            <tag name="sulu_admin.typed_form_metadata_visitor" />
+        </service>
+
+        <service
             id="sulu_admin.tag_filter_typed_form_metadata_visitor"
             class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TagFilterTypedFormMetadataVisitor"
         >

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/PageList.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/PageList.js
@@ -136,7 +136,7 @@ class PageList extends React.Component<Props> {
         );
         router.bind('active', this.listStore.active);
 
-        formMetadataStore.getSchemaTypes('page', {webspace}).then(action((schemaTypes: Object) => {
+        formMetadataStore.getSchemaTypes('page', {webspace, onlyKeys: true}).then(action((schemaTypes: Object) => {
             this.availablePageTypes = Object.keys(schemaTypes.types);
             this.availablePageTypesLoading = false;
         }));


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no 
| License | MIT

#### What's in this PR?

Adding an option to only get a list of page types without having to also get the configuration of the page types themselves.

#### Why?

**Before:** In the current version the React application requests the entire meta data configuration for all pages just to get a list of possible keys. This causes very long load times for complex structures.

```text
Stats*
> Time: 13.394 ms (aka 13 s)
> Peak Memory: 1089.21 MiB (aka 1.06 GiB)
> Time spend serializing: 11,561.1 ms (aka 11 s)

> Size of the output: 3,250 KB (aka 3.5 MB)
```

**After:** Now we only load what we really need and don't load stuff that is going to be thrown away.

```text
Stats*
> Time: 765 ms
> Peak Memory: 216.28 MiB
> Time spend serializing: 3ms

> Size of the output: 1.65 KB
```

* Those values are the performance values in dev. In prod it might even get a better result.

It does not affect the performance of the cache since we don't change the loading but we change the data after loading that gets serialized.

#### Example Usage
Open `/admin/metadata/form/page?only_keys=true&webspace=<webspace>` and see that the response doesn't contain the whole configuration
