### PR TITLE
Fix issue with lost query-parameter for history-urls

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
@@ -247,10 +247,15 @@ class ContentRouteProvider implements RouteProviderInterface
         } catch (ResourceLocatorNotFoundException $exc) {
             // just do not add any routes to the collection
         } catch (ResourceLocatorMovedException $exc) {
+            $url = $prefix . $exc->getNewResourceLocator();
+            if ($request->getQueryString()) {
+                $url .= '?' . $request->getQueryString();
+            }
+
             // old url resource was moved
             $collection->add(
                 $exc->getNewResourceLocatorUuid() . '_' . \uniqid(),
-                $this->getRedirectRoute($request, $prefix . $exc->getNewResourceLocator())
+                $this->getRedirectRoute($request, $url)
             );
         } catch (RepositoryException $exc) {
             // just do not add any routes to the collection

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/ContentRouteProviderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/ContentRouteProviderTest.php
@@ -905,6 +905,45 @@ class ContentRouteProviderTest extends TestCase
         $this->assertEquals('/de/new-test', $route->getDefaults()['url']);
     }
 
+    public function testGetCollectionMovedResourceLocatorWithQueryParameter(): void
+    {
+        $attributes = $this->prophesize(RequestAttributes::class);
+
+        $portal = new Portal();
+        $portal->setKey('portal');
+        $webspace = new Webspace();
+        $webspace->setKey('webspace');
+        $webspace->setTheme('theme');
+        $portal->setWebspace($webspace);
+        $attributes->getAttribute('portal', null)->willReturn($portal);
+
+        $localization = new Localization('de', 'at');
+        $attributes->getAttribute('localization', null)->willReturn($localization);
+        $attributes->getAttribute('matchType', null)->willReturn(RequestAnalyzer::MATCH_TYPE_FULL);
+
+        $attributes->getAttribute('resourceLocator', null)->willReturn('/qwertz/');
+        $attributes->getAttribute('resourceLocatorPrefix', null)->willReturn('/de');
+
+        $this->resourceLocatorStrategy->loadByResourceLocator('/qwertz', 'webspace', 'de_at')
+            ->willThrow(new ResourceLocatorMovedException('/new-test', '123-123-123'));
+
+        $request = new Request(
+            [], [], ['_sulu' => $attributes->reveal()], [], [], [
+                'REQUEST_URI' => \rawurlencode('/de/qwertz/'),
+                'QUERY_STRING' => 'q=search',
+            ]
+        );
+
+        // Test the route provider
+        $contentRouteProvider = $this->createContentRouteProvider();
+        $routes = $contentRouteProvider->getRouteCollectionForRequest($request);
+
+        $this->assertCount(1, $routes);
+        $route = $routes->getIterator()->current();
+        $this->assertEquals('sulu_website.redirect_controller::redirectAction', $route->getDefaults()['_controller']);
+        $this->assertEquals('/de/new-test?q=search', $route->getDefaults()['url']);
+    }
+
     public function testGetCollectionForSingleLanguageRequestSlashOnly(): void
     {
         $attributes = $this->prophesize(RequestAttributes::class);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the issue that the query-parameter will be removed for a history route redirect.
