### PR TITLE
Add a seralization group to reduce the config when serializing

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -340,8 +340,15 @@ class AdminController
         $metadata = $this->metadataProviderRegistry->getMetadataProvider($type)
             ->getMetadata($key, $user->getLocale(), $metadataOptions);
 
+        $context = new Context();
+        $context->addGroup('Default');
+        if (filter_var($metadataOptions['onlyKeys'] ?? 'false', FILTER_VALIDATE_BOOLEAN) === true) {
+            $context->addGroup('admin_form_metadata_keys_only');
+        }
+
         $view = View::create($metadata);
         $view->setFormat('json');
+        $view->setContext($context);
 
         $response = $this->viewHandler->handle($view);
 

--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -342,7 +342,7 @@ class AdminController
 
         $context = new Context();
         $context->addGroup('Default');
-        if (filter_var($metadataOptions['onlyKeys'] ?? 'false', FILTER_VALIDATE_BOOLEAN) === true) {
+        if (true === \filter_var($metadataOptions['onlyKeys'] ?? 'false', \FILTER_VALIDATE_BOOLEAN)) {
             $context->addGroup('admin_form_metadata_keys_only');
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
 
+use JMS\Serializer\Annotation\Exclude;
 use JMS\Serializer\Annotation\SerializedName;
 use Sulu\Bundle\AdminBundle\Metadata\AbstractMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
@@ -19,11 +20,15 @@ class FormMetadata extends AbstractMetadata
 {
     /**
      * @var string
+     *
+     * @Exclude(if="'admin_form_metadata_keys_only' in context.getAttribute('groups')")
      */
     private $name;
 
     /**
      * @var string
+     *
+     * @Exclude(if="'admin_form_metadata_keys_only' in context.getAttribute('groups')")
      */
     private $title;
 
@@ -31,21 +36,28 @@ class FormMetadata extends AbstractMetadata
      * @var ItemMetadata[]
      *
      * @SerializedName("form")
+     * @Exclude(if="'admin_form_metadata_keys_only' in context.getAttribute('groups')")
      */
     private $items;
 
     /**
      * @var SchemaMetadata
+     *
+     * @Exclude(if="'admin_form_metadata_keys_only' in context.getAttribute('groups')")
      */
     private $schema;
 
     /**
      * @var string
+     *
+     * @Exclude(if="'admin_form_metadata_keys_only' in context.getAttribute('groups')")
      */
     private $key;
 
     /**
      * @var TagMetadata[]
+     *
+     * @Exclude(if="'admin_form_metadata_keys_only' in context.getAttribute('groups')")
      */
     protected $tags;
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -141,4 +141,28 @@ class AdminControllerTest extends SuluTestCase
 
         $this->assertHttpStatusCode(404, $this->client->getResponse());
     }
+
+    public function testGetMetaDataKeysOnly(): void
+    {
+        $this->initPhpcr();
+        $collectionType = new LoadCollectionTypes();
+        $collectionType->load($this->getEntityManager());
+
+        $this->client->request('GET', '/admin/metadata/form/page?onlyKeys=true');
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $json = $response->getContent();
+        $this->assertIsString($json);
+
+        $metaData = \json_decode($json, true, 512, \JSON_THROW_ON_ERROR);
+
+        $this->assertEquals([
+            'types' => [
+                'default' => [],
+                'overview' => [],
+            ],
+            'defaultType' => null,
+        ], $metaData);
+    }
 }

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/PageList.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/PageList.js
@@ -136,7 +136,7 @@ class PageList extends React.Component<Props> {
         );
         router.bind('active', this.listStore.active);
 
-        formMetadataStore.getSchemaTypes('page', {webspace}).then(action((schemaTypes: Object) => {
+        formMetadataStore.getSchemaTypes('page', {webspace, onlyKeys: true}).then(action((schemaTypes: Object) => {
             this.availablePageTypes = Object.keys(schemaTypes.types);
             this.availablePageTypesLoading = false;
         }));


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Adding an option to only get a list of page types without having to also get the configuration of the page types themselves.

#### Why?

**Before:** In the current version the React application requests the entire meta data configuration for all pages just to get a list of possible keys. This causes very long load times for complex structures.

```text
Stats*
> Time: 13.394 ms (aka 13 s)
> Peak Memory: 1089.21 MiB (aka 1.06 GiB)
> Time spend serializing: 11,561.1 ms (aka 11 s)

> Size of the output: 3,250 KB (aka 3.5 MB)
```

**After:** Now we only load what we really need and don't load stuff that is going to be thrown away.

```text
Stats*
> Time: 765 ms
> Peak Memory: 216.28 MiB
> Time spend serializing: 3ms

> Size of the output: 1.65 KB
```

* Those values are the performance values in dev. In prod it might even get a better result.

It does not affect the performance of the cache since we don't change the loading but we change the data after loading that gets serialized.

#### Example Usage
Open `/admin/metadata/form/page?only_keys=true&webspace=<webspace>` and see that the response doesn't contain the whole configuration
