### PR TITLE
Fix trash action failure with null security context

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -36131,11 +36131,6 @@ parameters:
 			path: src/Sulu/Bundle/TrashBundle/Tests/Functional/UserInterface/Controller/Admin/TrashItemControllerTest.php
 
 		-
-			message: "#^Unsafe call to private method Sulu\\\\Bundle\\\\TrashBundle\\\\Tests\\\\Functional\\\\UserInterface\\\\Controller\\\\Admin\\\\TrashItemControllerTest\\:\\:setUpUserRole\\(\\) through static\\:\\:\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/TrashBundle/Tests/Functional/UserInterface/Controller/Admin/TrashItemControllerTest.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\TrashBundle\\\\UserInterface\\\\Controller\\\\Admin\\\\TrashItemController\\:\\:getBooleanRequestParameter\\(\\) should return bool but returns bool\\|null\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/TrashBundle/UserInterface/Controller/Admin/TrashItemController.php

--- a/src/Sulu/Bundle/TrashBundle/Tests/Functional/UserInterface/Controller/Admin/TrashItemControllerTest.php
+++ b/src/Sulu/Bundle/TrashBundle/Tests/Functional/UserInterface/Controller/Admin/TrashItemControllerTest.php
@@ -21,6 +21,7 @@ use Sulu\Bundle\SecurityBundle\Entity\UserRole;
 use Sulu\Bundle\TestBundle\Kernel\SuluKernelBrowser;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Bundle\TrashBundle\Domain\Repository\TrashItemRepositoryInterface;
+use Sulu\Bundle\TrashBundle\Infrastructure\Sulu\Admin\TrashAdmin;
 use Sulu\Bundle\TrashBundle\Tests\Functional\Traits\CreateTrashItemTrait;
 use Sulu\Component\Security\Authorization\AccessControl\SecuredEntityInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
@@ -31,6 +32,8 @@ class TrashItemControllerTest extends SuluTestCase
 
     public const GRANTED_CONTEXT = 'sulu.context.granted';
     public const NOT_GRANTED_CONTEXT = 'sulu.context.not_granted';
+
+    public const ALT_USER_USERNAME = 'test_alt';
 
     /**
      * @var EntityManagerInterface
@@ -157,6 +160,22 @@ class TrashItemControllerTest extends SuluTestCase
         static::assertSame($id, $content->id);
     }
 
+    public function testGetActionWithPermissionCheck(): void
+    {
+        static::setUpUserRole();
+        // Needed to rename the username to bypass TestVoter.
+        static::renameUserUsername(self::ALT_USER_USERNAME);
+
+        $trashItem = static::createTrashItem();
+        $id = $trashItem->getId();
+
+        $this->client->jsonRequest('GET', '/api/trash-items/' . $id, [], [
+            'PHP_AUTH_USER' => self::ALT_USER_USERNAME,
+            'PHP_AUTH_PW' => 'test',
+        ]);
+        static::assertHttpStatusCode(200, $this->client->getResponse());
+    }
+
     public function testDeleteAction(): void
     {
         $trashItem = static::createTrashItem();
@@ -194,6 +213,22 @@ class TrashItemControllerTest extends SuluTestCase
         static::assertHttpStatusCode(404, $this->client->getResponse());
     }
 
+    public function testPostTriggerActionRestoreWithPermissionCheck(): void
+    {
+        static::setUpUserRole();
+        // Needed to rename the username to bypass TestVoter.
+        static::renameUserUsername(self::ALT_USER_USERNAME);
+
+        $trashItem = static::createTrashItem();
+        $id = $trashItem->getId();
+
+        $this->client->jsonRequest('POST', '/api/trash-items/' . $id, ['action' => 'restore'], [
+            'PHP_AUTH_USER' => self::ALT_USER_USERNAME,
+            'PHP_AUTH_PW' => 'test',
+        ]);
+        static::assertHttpStatusCode(200, $this->client->getResponse());
+    }
+
     private static function setUpUserRole(): Role
     {
         $entityManager = static::getEntityManager();
@@ -225,6 +260,15 @@ class TrashItemControllerTest extends SuluTestCase
 
         $role->addPermission($notGrantedPermission);
 
+        $trashPermission = new Permission();
+        $trashPermission->setContext(TrashAdmin::SECURITY_CONTEXT);
+        $trashPermission->setPermissions(127);
+        $trashPermission->setRole($role);
+
+        $entityManager->persist($trashPermission);
+
+        $role->addPermission($trashPermission);
+
         $userRole = new UserRole();
         $userRole->setRole($role);
         $userRole->setLocale('["en"]');
@@ -236,6 +280,16 @@ class TrashItemControllerTest extends SuluTestCase
         $entityManager->flush();
 
         return $role;
+    }
+
+    public static function renameUserUsername(string $username)
+    {
+        $entityManager = static::getEntityManager();
+        $user = static::getTestUser();
+
+        $user->setUsername($username);
+
+        $entityManager->flush();
     }
 
     protected static function getTrashItemRepository(): TrashItemRepositoryInterface

--- a/src/Sulu/Bundle/TrashBundle/Tests/Functional/UserInterface/Controller/Admin/TrashItemControllerTest.php
+++ b/src/Sulu/Bundle/TrashBundle/Tests/Functional/UserInterface/Controller/Admin/TrashItemControllerTest.php
@@ -65,7 +65,7 @@ class TrashItemControllerTest extends SuluTestCase
 
     public function testCgetAction(): void
     {
-        static::setUpUserRole();
+        self::setUpUserRole();
 
         static::createTrashItem(
             'pages',
@@ -106,7 +106,7 @@ class TrashItemControllerTest extends SuluTestCase
     {
         $accessControlManager = static::getContainer()->get('sulu_security.access_control_manager');
 
-        $role = static::setUpUserRole();
+        $role = self::setUpUserRole();
 
         $count = 0;
         foreach ([null, self::GRANTED_CONTEXT, self::NOT_GRANTED_CONTEXT] as $resourceSecurityContext) {
@@ -162,9 +162,9 @@ class TrashItemControllerTest extends SuluTestCase
 
     public function testGetActionWithPermissionCheck(): void
     {
-        static::setUpUserRole();
+        self::setUpUserRole();
         // Needed to rename the username to bypass TestVoter.
-        static::renameUserUsername(self::ALT_USER_USERNAME);
+        self::renameUserUsername(self::ALT_USER_USERNAME);
 
         $trashItem = static::createTrashItem();
         $id = $trashItem->getId();
@@ -215,9 +215,9 @@ class TrashItemControllerTest extends SuluTestCase
 
     public function testPostTriggerActionRestoreWithPermissionCheck(): void
     {
-        static::setUpUserRole();
+        self::setUpUserRole();
         // Needed to rename the username to bypass TestVoter.
-        static::renameUserUsername(self::ALT_USER_USERNAME);
+        self::renameUserUsername(self::ALT_USER_USERNAME);
 
         $trashItem = static::createTrashItem();
         $id = $trashItem->getId();
@@ -282,7 +282,7 @@ class TrashItemControllerTest extends SuluTestCase
         return $role;
     }
 
-    public static function renameUserUsername(string $username)
+    private static function renameUserUsername(string $username): void
     {
         $entityManager = static::getEntityManager();
         $user = static::getTestUser();

--- a/src/Sulu/Bundle/TrashBundle/UserInterface/Controller/Admin/TrashItemController.php
+++ b/src/Sulu/Bundle/TrashBundle/UserInterface/Controller/Admin/TrashItemController.php
@@ -227,15 +227,17 @@ class TrashItemController extends AbstractRestController implements ClassResourc
 
         $trashItem = $this->trashItemRepository->getOneBy(['id' => $id]);
 
-        $this->securityChecker->checkPermission(
-            new SecurityCondition(
-                $trashItem->getResourceSecurityContext(),
-                null,
-                $trashItem->getResourceSecurityObjectType(),
-                $trashItem->getResourceSecurityObjectId()
-            ),
-            PermissionTypes::VIEW
-        );
+        if (null !== $trashItem->getResourceSecurityContext()) {
+            $this->securityChecker->checkPermission(
+                new SecurityCondition(
+                    $trashItem->getResourceSecurityContext(),
+                    null,
+                    $trashItem->getResourceSecurityObjectType(),
+                    $trashItem->getResourceSecurityObjectId()
+                ),
+                PermissionTypes::VIEW
+            );
+        }
 
         $context = new Context();
         $context->setGroups(['trash_item_admin_api']);
@@ -287,15 +289,17 @@ class TrashItemController extends AbstractRestController implements ClassResourc
     {
         $trashItem = $this->trashItemRepository->getOneBy(['id' => $id]);
 
-        $this->securityChecker->checkPermission(
-            new SecurityCondition(
-                $trashItem->getResourceSecurityContext(),
-                null,
-                $trashItem->getResourceSecurityObjectType(),
-                $trashItem->getResourceSecurityObjectId()
-            ),
-            PermissionTypes::ADD
-        );
+        if (null !== $trashItem->getResourceSecurityContext()) {
+            $this->securityChecker->checkPermission(
+                new SecurityCondition(
+                    $trashItem->getResourceSecurityContext(),
+                    null,
+                    $trashItem->getResourceSecurityObjectType(),
+                    $trashItem->getResourceSecurityObjectId()
+                ),
+                PermissionTypes::ADD
+            );
+        }
 
         $restoredObject = $this->trashManager->restore($trashItem, $restoreFormData);
         $this->entityManager->flush();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #6969

#### What's in this PR?

Check for null trash item security context before perform a permissions check.

#### Why?

Currently, trashing or restore an item without a security context throw an exception.
