### PR TITLE
CannotEvaluateTokenException exception with array

### DIFF
--- a/src/Sulu/Bundle/RouteBundle/Generator/CannotEvaluateTokenException.php
+++ b/src/Sulu/Bundle/RouteBundle/Generator/CannotEvaluateTokenException.php
@@ -35,7 +35,7 @@ class CannotEvaluateTokenException extends \Exception
             \sprintf(
                 'Cannot evaluate token "%s" for entity with type "%s"',
                 $token,
-                \is_object($entity) ? \get_class($entity) : \gettype($entity),
+                \is_object($entity) ? \get_class($entity) : \gettype($entity)
             ),
             0,
             $previous

--- a/src/Sulu/Bundle/RouteBundle/Generator/CannotEvaluateTokenException.php
+++ b/src/Sulu/Bundle/RouteBundle/Generator/CannotEvaluateTokenException.php
@@ -32,7 +32,11 @@ class CannotEvaluateTokenException extends \Exception
     public function __construct($token, $entity, \Exception $previous)
     {
         parent::__construct(
-            \sprintf('Cannot evaluate token "%s" for entity with type "%s"', $token, \get_class($entity)),
+            \sprintf(
+                'Cannot evaluate token "%s" for entity with type "%s"',
+                $token,
+                \is_object($entity) ? \get_class($entity) : \gettype($entity),
+            ),
             0,
             $previous
         );


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #7013

#### What's in this PR?

Handle `array` typed `$entity` of `CannotEvaluateTokenException`.
