### PR TITLE
Fix Symfony deprecation for not declaring getSupportedTypes on FlattenExceptionNormalizer

### DIFF
--- a/src/Sulu/Component/Rest/FlattenExceptionNormalizer.php
+++ b/src/Sulu/Component/Rest/FlattenExceptionNormalizer.php
@@ -42,6 +42,9 @@ class FlattenExceptionNormalizer implements ContextAwareNormalizerInterface
         $this->translator = $translator;
     }
 
+    /**
+     * @return array<class-string, bool>  
+     */
     public function getSupportedTypes(?string $format): array
     {
         return [

--- a/src/Sulu/Component/Rest/FlattenExceptionNormalizer.php
+++ b/src/Sulu/Component/Rest/FlattenExceptionNormalizer.php
@@ -43,7 +43,7 @@ class FlattenExceptionNormalizer implements ContextAwareNormalizerInterface
     }
 
     /**
-     * @return array<class-string, bool>  
+     * @return array<class-string, bool>
      */
     public function getSupportedTypes(?string $format): array
     {

--- a/src/Sulu/Component/Rest/FlattenExceptionNormalizer.php
+++ b/src/Sulu/Component/Rest/FlattenExceptionNormalizer.php
@@ -42,6 +42,13 @@ class FlattenExceptionNormalizer implements ContextAwareNormalizerInterface
         $this->translator = $translator;
     }
 
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            FlattenException::class => false,
+        ];
+    }
+
     /**
      * @return array<int|string, mixed>
      */


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | deprecation fix for Symfony 7 support
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no 
| Fixed tickets | 
| Related issues/PRs | 
| License | MIT

#### What's in this PR?

I have added a `getSupportedTypes` method to the `FlattenExceptionNormalizer`.

#### Why?

Classes that implement the `Symfony\Component\Serializer\NormalizerInterface` will require the `getSupportedTypes` method for Symfony >= 7.0.

Currently Symfony's phpunit-bridge reports a deprecation message.

***Update***:
In the Symfony docs you'll find the details about that method (see [here](https://symfony.com/doc/current/serializer/custom_normalizer.html#improving-performance-of-normalizers-denormalizers)).