### PR TITLE
Fix React-Styleguidist to ~13.0.0 for React 17 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
         "raw-loader": "^4.0.0",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
-        "react-styleguidist": "^13.0.0",
+        "react-styleguidist": "~13.0.0",
         "react-test-renderer": "^17.0.0",
         "regenerator-runtime": "^0.13.3",
         "stylelint": "^14.9.1",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? |no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Freeze React-Styleguidist to ~13.0.0 for React 17 support. This is only required for 2.6 as 2.5 is using already older ^11 version.

#### Why?

See: https://github.com/styleguidist/react-styleguidist/issues/2127
