### PR TITLE
Fix session ini_set issue with Symfony 6.3

### DIFF
--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/security-5-4.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/security-5-4.yml
@@ -1,6 +1,7 @@
 framework:
     session:
         storage_id: session.storage.mock_file
+        handler_id: ~
 
 security:
     access_decision_manager:

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/security-6.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/security-6.yml
@@ -1,6 +1,7 @@
 framework:
     session:
         storage_factory_id: session.storage.factory.mock_file
+        handler_id: ~
 
 security:
     access_decision_manager:

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/symfony-5-4.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/symfony-5-4.yml
@@ -1,3 +1,4 @@
 framework:
     session:
         storage_id: session.storage.mock_file
+        handler_id: ~

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/symfony-6.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/symfony-6.yml
@@ -1,3 +1,4 @@
 framework:
     session:
         storage_factory_id: session.storage.factory.mock_file
+        handler_id: ~


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | https://github.com/symfony/symfony/issues/49387, fixes #7086
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The `handler_id` was using native file still and so errors in the mocked state.

#### Why?

See https://github.com/symfony/symfony/issues/49387, https://github.com/sulu/sulu/issues/7086