### PR TITLE
Fix mocking of none existing classes

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -47676,11 +47676,6 @@ parameters:
 			path: src/Sulu/Component/Content/Tests/Unit/SmartContent/PageDataProviderTest.php
 
 		-
-			message: "#^Class Sulu\\\\Bundle\\\\ContentBundle\\\\Document\\\\BasePageDocument not found\\.$#"
-			count: 13
-			path: src/Sulu/Component/Content/Tests/Unit/SmartContent/PageDataProviderTest.php
-
-		-
 			message: "#^Method Sulu\\\\Component\\\\Content\\\\Tests\\\\Unit\\\\SmartContent\\\\PageDataProviderTest\\:\\:getContentQueryBuilder\\(\\) has parameter \\$initValue with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Tests/Unit/SmartContent/PageDataProviderTest.php
@@ -51903,21 +51898,6 @@ parameters:
 		-
 			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\tests\\\\Unit\\\\Metadata\\\\BaseMetadataFactoryTest\\:\\:\\$factory\\.$#"
 			count: 14
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Metadata/BaseMetadataFactoryTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\tests\\\\Unit\\\\Metadata\\\\BaseMetadataFactoryTest\\:\\:\\$strategy\\.$#"
-			count: 1
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Metadata/BaseMetadataFactoryTest.php
-
-		-
-			message: "#^Class Sulu\\\\Component\\\\DocumentManager\\\\DocumentStrategyInterface not found\\.$#"
-			count: 1
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Metadata/BaseMetadataFactoryTest.php
-
-		-
-			message: "#^Class Sulu\\\\Component\\\\DocumentManager\\\\Metadata\\\\BaseMetadataFactory constructor invoked with 3 parameters, 2 required\\.$#"
-			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Metadata/BaseMetadataFactoryTest.php
 
 		-

--- a/src/Sulu/Component/Content/Tests/Unit/SmartContent/PageDataProviderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/SmartContent/PageDataProviderTest.php
@@ -23,7 +23,7 @@ use ProxyManager\GeneratorStrategy\FileWriterGeneratorStrategy;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataProvider;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
-use Sulu\Bundle\ContentBundle\Document\BasePageDocument;
+use Sulu\Bundle\PageBundle\Document\BasePageDocument;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStore;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Content\Query\ContentQueryBuilderInterface;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Metadata/BaseMetadataFactoryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Metadata/BaseMetadataFactoryTest.php
@@ -13,7 +13,6 @@ namespace Sulu\Component\DocumentManager\tests\Unit\Metadata;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
-use Sulu\Component\DocumentManager\DocumentStrategyInterface;
 use Sulu\Component\DocumentManager\Exception\MetadataNotFoundException;
 use Sulu\Component\DocumentManager\Metadata;
 use Sulu\Component\DocumentManager\Metadata\BaseMetadataFactory;
@@ -23,7 +22,6 @@ class BaseMetadataFactoryTest extends TestCase
 {
     public function setUp(): void
     {
-        $this->strategy = $this->prophesize(DocumentStrategyInterface::class);
         $this->dispatcher = $this->prophesize(EventDispatcherInterface::class);
         $this->dispatcher
             ->dispatch(Argument::any(), Argument::any())
@@ -42,7 +40,6 @@ class BaseMetadataFactoryTest extends TestCase
                     'phpcr_type' => 'sulu:snippet',
                 ],
             ],
-            $this->strategy->reveal()
         );
     }
 

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Metadata/BaseMetadataFactoryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Metadata/BaseMetadataFactoryTest.php
@@ -39,7 +39,7 @@ class BaseMetadataFactoryTest extends TestCase
                     'class' => 'Class\Snippet',
                     'phpcr_type' => 'sulu:snippet',
                 ],
-            ],
+            ]
         );
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Classes where mocked which actually did not exist and even added to a constructor which didn't even expect additional parameter.

#### Why?

Happening on current prophecy verison.

https://github.com/sulu/sulu/actions/runs/5334800336/jobs/9667088862?pr=7098

<img width="1275" alt="Bildschirmfoto 2023-06-21 um 16 16 43" src="https://github.com/sulu/sulu/assets/1698337/0bcb081c-cc81-46fd-b87e-f0cd09c7a2a7">

