### PR TITLE
Remove sulu-link tags completely if they are invalid

### DIFF
--- a/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
@@ -101,15 +101,20 @@ class LinkTag implements TagInterface
                 $title = $this->getContent($attributes);
                 $attributes['href'] = null;
             } else {
-                // only render text instead of anchor to prevent dead links on website
-                $result[$tag] = $this->getContent($attributes);
+                // Completely remove the tag if this attribute is set
+                if ($attributes['remove-if-not-exists'] ?? false) {
+                    $result[$tag] = '';
+                } else {
+                    // only render text instead of anchor to prevent dead links on website
+                    $result[$tag] = $this->getContent($attributes);
+                }
 
                 continue;
             }
 
             $htmlAttributes = \array_map(
                 function($value, $name) use ($attributes) {
-                    if (empty($value) || \in_array($name, ['content', 'sulu-validation-state'])) {
+                    if (empty($value) || \in_array($name, ['content', 'sulu-validation-state', 'remove-if-not-exists'])) {
                         return null;
                     }
 

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
@@ -84,6 +84,18 @@ class LinkTagTest extends TestCase
                 '<a href="http://sulu.lo/de/test" title="Test-Title">Test-Content</a>',
             ],
             [
+                '<sulu-link href="123-123-123" title="Test-Title" provider="article" remove-if-not-exists="true">Test-Content</sulu-link>',
+                [
+                    'href' => '123-123-123',
+                    'title' => 'Test-Title',
+                    'content' => 'Test-Content',
+                    'provider' => 'article',
+                    'remove-if-not-exists' => true,
+                ],
+                [],
+                '',
+            ],
+            [
                 '<sulu-link href="123-123-123" title="Test-Title" provider="article"/>',
                 ['href' => '123-123-123', 'title' => 'Test-Title', 'provider' => 'article'],
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #6956  <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #6956 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs#773

#### What's in this PR?
When specifying the 'remove-if-not-exist' property on a link to be true, then the entire tag (including it's contents will be removed)

#### Why?
To prevent links that are invalid and text that (when it's not a link) looks weird. Like if you have a link list and one of the links is broken, it would be better to remove the text as well.

#### Example Usage
```html
<sulu-link href="123-123-123" title="Test-Title" provider="article" remove-if-not-exists="true">Test-Content</sulu-link>
```

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
