### PR TITLE
Fix prophecy error for SuluSecurityListenerTest

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -32776,11 +32776,6 @@ parameters:
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/PermissionInheritanceSubscriberTest.php
 
 		-
-			message: "#^Class Symfony\\\\Bundle\\\\FrameworkBundle\\\\Controller\\\\Controller not found\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/SuluSecurityListenerTest.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\SecurityBundle\\\\EventListener\\\\SuluSecurityListenerTest\\:\\:createControllerEvent\\(\\) has parameter \\$controller with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/SuluSecurityListenerTest.php

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/SuluSecurityListenerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/SuluSecurityListenerTest.php
@@ -18,7 +18,7 @@ use Sulu\Component\Security\Authorization\AccessControl\SecuredObjectControllerI
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Sulu\Component\Security\Authorization\SecurityCondition;
 use Sulu\Component\Security\SecuredControllerInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
@@ -146,7 +146,7 @@ class SuluSecurityListenerTest extends TestCase
     {
         $this->securityChecker->checkPermission(Argument::cetera())->shouldNotHaveBeenCalled();
 
-        $controller = $this->prophesize(Controller::class);
+        $controller = $this->prophesize(AbstractController::class);
 
         $request = $this->prophesize(Request::class);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix prophecy error for SuluSecurityListenerTest using a class which exists.

#### Why?

Prophecy currently fails if the class does not exist.

<img width="1217" alt="Bildschirmfoto 2023-06-27 um 17 08 50" src="https://github.com/sulu/sulu/assets/1698337/90f5be46-4caf-414d-9560-9996cd286fac">

