### PR TITLE
Add frontend handling for 404 responses of form resources

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Hint/Hint.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Hint/Hint.js
@@ -1,0 +1,27 @@
+// @flow
+import React from 'react';
+import Icon from '../Icon';
+import hintStyles from './hint.scss';
+
+type Props = {
+    icon: string,
+    title: string,
+};
+
+export default class Hint extends React.Component<Props> {
+    render() {
+        const {
+            icon,
+            title,
+        } = this.props;
+
+        return (
+            <div className={hintStyles.hint}>
+                <div className={hintStyles.hintIcon}>
+                    <Icon name={icon} />
+                </div>
+                {title}
+            </div>
+        );
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Hint/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Hint/README.md
@@ -1,0 +1,5 @@
+This component shows a simple indicator telling the user what was going wrong.
+
+```javascript
+<Hint icon="su-lock" title={"No permissions"} />
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Hint/hint.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Hint/hint.scss
@@ -1,15 +1,15 @@
 @import 'sulu-admin-bundle/containers/Application/colors.scss';
 
-$permissionHintColor: $gray;
+$hintColor: $gray;
 
-.permission-hint {
+.hint {
     font-size: 18px;
     font-weight: bold;
-    color: $permissionHintColor;
+    color: $hintColor;
     width: 100%;
     text-align: center;
 }
 
-.permission-icon {
+.hint-icon {
     font-size: 32px;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Hint/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Hint/index.js
@@ -1,0 +1,4 @@
+// @flow
+import Hint from './Hint';
+
+export default Hint;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Hint/tests/Hint.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Hint/tests/Hint.test.js
@@ -1,0 +1,9 @@
+// @flow
+import React from 'react';
+import {render} from '@testing-library/react';
+import Hint from '../Hint';
+
+test('Render PermissionHint', () => {
+    const {container} = render(<Hint icon="su-lock" title="Hint Text" />);
+    expect(container).toMatchSnapshot();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Hint/tests/__snapshots__/Hint.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Hint/tests/__snapshots__/Hint.test.js.snap
@@ -13,7 +13,7 @@ exports[`Render PermissionHint 1`] = `
         class="su-lock"
       />
     </div>
-    sulu_admin.no_permissions
+    Hint Text
   </div>
 </div>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PermissionHint/PermissionHint.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PermissionHint/PermissionHint.js
@@ -1,20 +1,24 @@
 // @flow
 import React from 'react';
+import log from 'loglevel';
 import {translate} from '../../utils/Translator';
-import Icon from '../Icon';
-import permissionHintStyles from './permissionHint.scss';
+import Hint from '../Hint';
 
 type Props = {||};
 
 export default class PermissionHint extends React.Component<Props> {
+    constructor(props: Props) {
+        super(props);
+
+        log.warn(
+            'The "PermissionHint" component is deprecated since 3.0 and will ' +
+            'be removed. Use the "Hint" component instead.'
+        );
+    }
+
     render() {
         return (
-            <div className={permissionHintStyles.permissionHint}>
-                <div className={permissionHintStyles.permissionIcon}>
-                    <Icon name="su-lock" />
-                </div>
-                {translate('sulu_admin.no_permissions')}
-            </div>
+            <Hint icon="su-lock" title={translate('sulu_admin.no_permissions')} />
         );
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PermissionHint/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PermissionHint/README.md
@@ -3,3 +3,6 @@ This component shows a simple indicator telling the user that some permissions a
 ```javascript
 <PermissionHint />
 ```
+
+This component is deprecated and will be removed in the next major version.
+Use the `Hint` component instead.

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
@@ -4,8 +4,9 @@ import {observer} from 'mobx-react';
 import React, {Fragment} from 'react';
 import log from 'loglevel';
 import Loader from '../../components/Loader';
-import PermissionHint from '../../components/PermissionHint';
+import Hint from '../../components/Hint';
 import Router from '../../services/Router';
+import {translate} from '../../utils';
 import Renderer from './Renderer';
 import FormInspector from './FormInspector';
 import GhostDialog from './GhostDialog';
@@ -150,7 +151,15 @@ class Form extends React.Component<Props> {
         } = store;
 
         if (store.forbidden) {
-            return <PermissionHint />;
+            return <Hint icon="su-lock" title={translate('sulu_admin.no_permissions')} />;
+        }
+
+        if (store.notFound) {
+            return <Hint icon="su-battery-low" title={translate('sulu_admin.not_found')} />;
+        }
+
+        if (store.unexpectedError) {
+            return <Hint icon="su-exclamation-triangle" title={translate('sulu_admin.unexpected_error')} />;
         }
 
         if (store.loading) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
@@ -117,6 +117,14 @@ export default class AbstractFormStore
         return false;
     }
 
+    get notFound(): boolean {
+        return false;
+    }
+
+    get unexpectedError(): boolean {
+        return false;
+    }
+
     isFieldModified(dataPath: string): boolean {
         return this.modifiedFields.includes(dataPath);
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
@@ -310,6 +310,14 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
         return this.resourceStore.forbidden;
     }
 
+    @computed get notFound(): boolean {
+        return this.resourceStore.notFound;
+    }
+
+    @computed get unexpectedError(): boolean {
+        return this.resourceStore.unexpectedError;
+    }
+
     @computed get dirty(): boolean {
         return this.resourceStore.dirty;
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/SchemaFormStoreDecorator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/SchemaFormStoreDecorator.js
@@ -107,6 +107,22 @@ export default class SchemaFormStoreDecorator implements FormStoreInterface {
         return false;
     }
 
+    @computed get notFound() {
+        if (this.innerFormStore) {
+            return this.innerFormStore.notFound;
+        }
+
+        return false;
+    }
+
+    @computed get unexpectedError() {
+        if (this.innerFormStore) {
+            return this.innerFormStore.unexpectedError;
+        }
+
+        return false;
+    }
+
     finishField(dataPath: string) {
         when(
             () => !!this.innerFormStore,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Form.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Form.test.js.snap
@@ -2,10 +2,10 @@
 
 exports[`Render permission hint if permissions are missing 1`] = `
 <div
-  class="permissionHint"
+  class="hint"
 >
   <div
-    class="permissionIcon"
+    class="hintIcon"
   >
     <span
       aria-label="su-lock"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -105,10 +105,12 @@ export interface FormStoreInterface {
     +loading: boolean,
     +locale: ?IObservableValue<string>,
     +metadataOptions: ?{[string]: any},
+    +notFound: boolean,
     +options: SchemaOptions,
     +resourceKey: ?string,
     +schema: Object,
     +types: {[key: string]: SchemaType},
+    +unexpectedError: boolean,
     +validate: () => boolean,
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/__snapshots__/List.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/__snapshots__/List.test.js.snap
@@ -98,10 +98,10 @@ exports[`Render Loader instead of Adapter if nothing was loaded yet 1`] = `
 
 exports[`Render permission hint if permissions are missing 1`] = `
 <div
-  class="permissionHint"
+  class="hint"
 >
   <div
-    class="permissionIcon"
+    class="hintIcon"
   >
     <span
       aria-label="su-lock"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
@@ -36,13 +36,14 @@ test('Should be marked as not dirty after loading the data', () => {
     });
 });
 
-test('Should be marked as forbidden if loading failed with 403 and not forbidden if next request succeeds', (done) => {
+test('Should be marked as forbidden if loading failed with 403 and reset if next request succeeds', (done) => {
     const promise = Promise.reject({status: 403});
     ResourceRequester.get.mockReturnValue(promise);
     const resourceStore = new ResourceStore('snippets', '1');
 
     setTimeout(() => {
         expect(resourceStore.forbidden).toBe(true);
+        expect(resourceStore.loading).toBe(false);
 
         const promise = Promise.resolve({});
         ResourceRequester.get.mockReturnValue(promise);
@@ -51,6 +52,51 @@ test('Should be marked as forbidden if loading failed with 403 and not forbidden
 
         setTimeout(() => {
             expect(resourceStore.forbidden).toBe(false);
+            expect(resourceStore.loading).toBe(false);
+            done();
+        });
+    });
+});
+
+test('Should be marked as notFound if loading failed with 404 and reset if next request succeeds', (done) => {
+    const promise = Promise.reject({status: 404});
+    ResourceRequester.get.mockReturnValue(promise);
+    const resourceStore = new ResourceStore('snippets', '1');
+
+    setTimeout(() => {
+        expect(resourceStore.notFound).toBe(true);
+        expect(resourceStore.loading).toBe(false);
+
+        const promise = Promise.resolve({});
+        ResourceRequester.get.mockReturnValue(promise);
+
+        resourceStore.load();
+
+        setTimeout(() => {
+            expect(resourceStore.notFound).toBe(false);
+            expect(resourceStore.loading).toBe(false);
+            done();
+        });
+    });
+});
+
+test('Should be marked as unexpectedError if loading failed with 500 and reset if next request succeeds', (done) => {
+    const promise = Promise.reject({status: 500});
+    ResourceRequester.get.mockReturnValue(promise);
+    const resourceStore = new ResourceStore('snippets', '1');
+
+    setTimeout(() => {
+        expect(resourceStore.unexpectedError).toBe(true);
+        expect(resourceStore.loading).toBe(false);
+
+        const promise = Promise.resolve({});
+        ResourceRequester.get.mockReturnValue(promise);
+
+        resourceStore.load();
+
+        setTimeout(() => {
+            expect(resourceStore.unexpectedError).toBe(false);
+            expect(resourceStore.loading).toBe(false);
             done();
         });
     });

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -176,6 +176,8 @@
     "sulu_admin.edit_profile": "Profil bearbeiten",
     "sulu_admin.no_follow": "no-follow",
     "sulu_admin.no_permissions": "Keine Berechtigung",
+    "sulu_admin.not_found": "Nicht gefunden",
+    "sulu_admin.unexpected_error": "Nicht gefunden",
     "sulu_admin.no_options_available": "Keine Optionen verfügbar",
     "sulu_admin.form_contains_invalid_values": "Das Formular beinhaltet ungültige Werte",
     "sulu_admin.form_save_server_error": "Beim Speichern des Formulars ist ein Fehler aufgetreten",

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -177,6 +177,8 @@
     "sulu_admin.edit_profile": "Edit profile",
     "sulu_admin.no_follow": "no-follow",
     "sulu_admin.no_permissions": "No permissions",
+    "sulu_admin.not_found": "Not found",
+    "sulu_admin.unexpected_error": "Unexpected error",
     "sulu_admin.no_options_available": "No options available",
     "sulu_admin.form_contains_invalid_values": "The form contains invalid values",
     "sulu_admin.form_save_server_error": "There was an error when trying to save the form",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? |yes
| BC breaks? | no
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | References: https://github.com/sulu/sulu/pull/6938
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add frontend handling for 404 responses of form resources.

![Bildschirmfoto 2023-06-29 um 12 44 41](https://github.com/sulu/sulu/assets/1698337/49be1f2d-3fff-4992-a1d4-0d1f3de1beec)

![Bildschirmfoto 2023-06-29 um 13 21 04](https://github.com/sulu/sulu/assets/1698337/4a5503ca-ec35-45df-ba91-bc56a2c5074d)


#### Why?

Currently there was infinite loader shown when 404 was responded by a resource.
