### PR TITLE
Fix warning optional parameter defined before required

### DIFF
--- a/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
@@ -187,7 +187,7 @@ class PropertiesXmlParser
         return $result;
     }
 
-    private function loadTypes(&$tags, \DOMXPath $xpath, ?\DOMNode $context = null, $formKey)
+    private function loadTypes(&$tags, \DOMXPath $xpath, ?\DOMNode $context, $formKey)
     {
         $result = [];
 

--- a/src/Sulu/Component/Content/Repository/ContentRepository.php
+++ b/src/Sulu/Component/Content/Repository/ContentRepository.php
@@ -675,7 +675,7 @@ class ContentRepository implements ContentRepositoryInterface, DescendantProvide
         $locales,
         MappingInterface $mapping,
         ?UserInterface $user = null,
-        array $permissions
+        array $permissions = []
     ) {
         $webspaceKey = $this->nodeHelper->extractWebspaceFromPath($row->getPath());
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Set one parameter to optional another to required. Both `private` methods so no BC break here.

#### Why?

Fix:

```
Deprecated: Optional parameter $user declared before required parameter $permissions is implicitly treated as a required parameter in /Users/alexanderschranz/Documents/Projects/sulu-develop.localhost/vendor/sulu/sulu/src/Sulu/Component/Content/Repository/ContentRepository.php on line 672
PHP Deprecated:  Optional parameter $context declared before required parameter $formKey is implicitly treated as a required parameter in /Users/alexanderschranz/Documents/Projects/sulu-develop.localhost/vendor/sulu/sulu/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php on line 190

Deprecated: Optional parameter $context declared before required parameter $formKey is implicitly treated as a required parameter in /Users/alexanderschranz/Documents/Projects/sulu-develop.localhost/vendor/sulu/sulu/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php on line 190
```

This happens because of the introducing of `'nullable_type_declaration_for_default_null_value' => true,` `php-cs-fixer` rule.

Seems like there is a small different between `?stdClass = null` vs `stdClass = null` if optional parameters where not correctly used.

https://3v4l.org/haVtF