### PR TITLE
Add field transformer for translation

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/TranslationFieldTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/TranslationFieldTransformer.js
@@ -1,0 +1,16 @@
+// @flow
+import {translate} from '../../../utils';
+import type {Node} from 'react';
+import type {FieldTransformer} from '../types';
+
+export default class TranslationFieldTransformer implements FieldTransformer {
+    transform(value: *, parameters: { [string]: any }): Node {
+        if (value === undefined) {
+            return null;
+        }
+
+        const {prefix = ''} = parameters;
+
+        return translate(prefix + value);
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/index.js
@@ -22,6 +22,7 @@ import NumberFieldFilterType from './fieldFilterTypes/NumberFieldFilterType';
 import NumberFieldTransformer from './fieldTransformers/NumberFieldTransformer';
 import SelectionFieldFilterType from './fieldFilterTypes/SelectionFieldFilterType';
 import TimeFieldTransformer from './fieldTransformers/TimeFieldTransformer';
+import TranslationFieldTransformer from './fieldTransformers/TranslationFieldTransformer';
 import HtmlFieldTransformer from './fieldTransformers/HtmlFieldTransformer';
 import ColumnListAdapter from './adapters/ColumnListAdapter';
 import TreeTableAdapter from './adapters/TreeTableAdapter';
@@ -67,6 +68,7 @@ export {
     StringFieldTransformer,
     TextFieldFilterType,
     TimeFieldTransformer,
+    TranslationFieldTransformer,
     ThumbnailFieldTransformer,
     BoolFieldTransformer,
     ColorFieldTransformer,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldTransformers/TranslationFieldTransformer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldTransformers/TranslationFieldTransformer.test.js
@@ -1,0 +1,20 @@
+// @flow
+import TranslationFieldTransformer from '../../fieldTransformers/TranslationFieldTransformer';
+
+const translationFieldTransformer = new TranslationFieldTransformer();
+
+jest.mock('../../../../utils/Translator/Translator', () => ({
+    translate: (value) => {
+        return value;
+    },
+}));
+
+test('Test undefined', () => {
+    expect(translationFieldTransformer.transform(undefined, {}))
+        .toBe(null);
+});
+
+test('Test transform with prefix', () => {
+    expect(translationFieldTransformer.transform('<value>', {prefix: 'sulu_admin.test.'}))
+        .toBe('sulu_admin.test.<value>');
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -57,6 +57,7 @@ import {
     TextFieldFilterType,
     ThumbnailFieldTransformer,
     TimeFieldTransformer,
+    TranslationFieldTransformer,
     TreeTableAdapter,
 } from './containers/List';
 import FieldBlocks, {
@@ -226,6 +227,7 @@ function registerListFieldTransformers() {
     listFieldTransformerRegistry.add('color', new ColorFieldTransformer());
     listFieldTransformerRegistry.add('icon', new IconFieldTransformer());
     listFieldTransformerRegistry.add('html', new HtmlFieldTransformer());
+    listFieldTransformerRegistry.add('translation', new TranslationFieldTransformer());
 
     // TODO: Remove this type when not needed anymore
     listFieldTransformerRegistry.add('title', new StringFieldTransformer());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? |  yes
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/6938
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add field transformer for translation.

#### Why?

For references we need to translated by the `resourceKey` but the `resourceKey` itself we require also for routing to the subresources. To avoid `resourceKey` and `resourceKeyTitle` which make the list and distinct complicated I added a translation field transformer.

```xml
<property
    name="referenceResourceKey"
    translation="sulu_admin.resource"
    visibility="yes"
    searchability="yes"
    sortable="false"
    width="auto"
>
    <transformer type="translation">
        <params>
            <param name="prefix" value="sulu_reference.resource."/>
        </params>
    </transformer>
</property>
```