### PR TITLE
Add AsSuluContext attribute for defining sulu context

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/Attribute/AsSuluContext.php
+++ b/src/Sulu/Bundle/CoreBundle/Attribute/AsSuluContext.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CoreBundle\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AsSuluContext
+{
+    public function __construct(public string $context)
+    {
+    }
+}

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -14,7 +14,9 @@ namespace Sulu\Bundle\CoreBundle\DependencyInjection;
 use Gedmo\Exception;
 use Oro\ORM\Query\AST\Functions\Cast;
 use Oro\ORM\Query\AST\Functions\String\GroupConcat;
+use Sulu\Bundle\CoreBundle\Attribute\AsSuluContext;
 use Sulu\Bundle\CoreBundle\CommandOptional\SuluBuildCommand;
+use Sulu\Bundle\CoreBundle\DependencyInjection\Compiler\RemoveForeignContextServicesPass;
 use Sulu\Component\Content\Types\Block\BlockVisitorInterface;
 use Sulu\Component\Rest\Csv\ObjectNotSupportedException;
 use Sulu\Component\Rest\Exception\InsufficientDescendantPermissionsException;
@@ -26,6 +28,7 @@ use Sulu\Component\Rest\ListBuilder\Filter\InvalidFilterTypeOptionsException;
 use Symfony\Bundle\TwigBundle\Controller\ExceptionController;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -333,6 +336,17 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
 
         $container->registerForAutoconfiguration(BlockVisitorInterface::class)
             ->addTag('sulu_content.block_visitor');
+        $container->registerAttributeForAutoconfiguration(
+            AsSuluContext::class,
+            static function(
+                ChildDefinition $definition,
+                AsSuluContext $attribute
+            ): void {
+                $definition->addTag(RemoveForeignContextServicesPass::SULU_CONTEXT_TAG, [
+                    'context' => $attribute->context,
+                ]);
+            }
+        );
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add ability to define sulu context for service by using PHP Attribute.

#### Why?

Since symfony 5.4, it is possible to register attributes for the autoconfigure service. In default configuration for sulu project, `src` directory is marked with `autoconfigure` flag for DI. Actually it is possible by adding `AutoconfigureTag` for class.

```php
#[AutoconfigureTag('sulu.context', ['context' => 'admin'])]
class EventController extends AbstractRestController
```
This change will simplify the process and improves DX.

#### Example Usage

For class which should only available in sulu admin context 

```php

#[AsSuluContext('admin')]
class EventController extends AbstractRestController

```

For class which should only available in sulu website context 

```php

#[AsSuluContext('website')]
class EventController extends WebsiteController

```


#### To Do

- [ ] Create a documentation PR
- [ ] Consider add validation for provided argument (only `admin` or `website` value)
- [ ] Consider add more attributes for sulu specific elements (e.g. `sulu.content.type`)
