### PR TITLE
Using interfaces

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,7 @@
 # Copy this file to .env file for development, create environment variables when deploying to production
 # https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
 
+
 ###> symfony/framework-bundle ###
 APP_ENV=dev
 APP_SECRET=a448d1dfcaa563fce56c2fd9981f662b

--- a/src/Sulu/Bundle/PageBundle/Command/MaintainResourceLocatorCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/MaintainResourceLocatorCommand.php
@@ -15,7 +15,7 @@ use PHPCR\NodeInterface;
 use PHPCR\SessionInterface;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\PropertyEncoder;
 use Sulu\Component\Content\Compat\Structure;
-use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactory;
+use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
 use Sulu\Component\DocumentManager\MetadataFactoryInterface;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
@@ -54,7 +54,7 @@ class MaintainResourceLocatorCommand extends Command
     private $metadataFactory;
 
     /**
-     * @var StructureMetadataFactory
+     * @var StructureMetadataFactoryInterface
      */
     private $structureMetadataFactory;
 
@@ -68,7 +68,7 @@ class MaintainResourceLocatorCommand extends Command
         SessionManagerInterface $sessionManager,
         SessionInterface $liveSession,
         MetadataFactoryInterface $metadataFactory,
-        StructureMetadataFactory $structureMetadataFactory,
+        StructureMetadataFactoryInterface $structureMetadataFactory,
         PropertyEncoder $propertyEncoder
     ) {
         parent::__construct();

--- a/src/Sulu/Bundle/PageBundle/Search/Metadata/StructureProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Search/Metadata/StructureProvider.php
@@ -30,7 +30,7 @@ use Sulu\Component\Content\Document\RedirectType;
 use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\Content\Extension\ExtensionManagerInterface;
 use Sulu\Component\Content\Metadata\BlockMetadata;
-use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactory;
+use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
 use Sulu\Component\Content\Metadata\ItemMetadata;
 use Sulu\Component\Content\Metadata\StructureMetadata;
 use Sulu\Component\DocumentManager\Behavior\Mapping\TitleBehavior;
@@ -61,7 +61,7 @@ class StructureProvider implements ProviderInterface
     private $mapping;
 
     /**
-     * @var StructureMetadataFactory
+     * @var StructureMetadataFactoryInterface
      */
     private $structureFactory;
 
@@ -78,7 +78,7 @@ class StructureProvider implements ProviderInterface
     public function __construct(
         Factory $factory,
         MetadataFactory $metadataFactory,
-        StructureMetadataFactory $structureFactory,
+        StructureMetadataFactoryInterface $structureFactory,
         ExtensionManagerInterface $extensionManager,
         array $mapping = []
     ) {

--- a/src/Sulu/Component/Content/Compat/Serializer/PageBridgeHandler.php
+++ b/src/Sulu/Component/Content/Compat/Serializer/PageBridgeHandler.php
@@ -18,7 +18,7 @@ use JMS\Serializer\Visitor\DeserializationVisitorInterface;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Component\Content\Compat\Structure\LegacyPropertyFactory;
 use Sulu\Component\Content\Compat\Structure\PageBridge;
-use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactory;
+use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
 
 /**
  * Handle serialization and deserialization of the PageBridge.
@@ -26,7 +26,7 @@ use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactory;
 class PageBridgeHandler implements SubscribingHandlerInterface
 {
     /**
-     * @var StructureMetadataFactory
+     * @var StructureMetadataFactoryInterface
      */
     private $structureFactory;
 
@@ -43,7 +43,7 @@ class PageBridgeHandler implements SubscribingHandlerInterface
     public function __construct(
         DocumentInspector $inspector,
         LegacyPropertyFactory $propertyFactory,
-        StructureMetadataFactory $structureFactory
+        StructureMetadataFactoryInterface $structureFactory
     ) {
         $this->structureFactory = $structureFactory;
         $this->inspector = $inspector;

--- a/src/Sulu/Component/Content/Compat/StructureManager.php
+++ b/src/Sulu/Component/Content/Compat/StructureManager.php
@@ -14,7 +14,7 @@ namespace Sulu\Component\Content\Compat;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Component\Content\Compat\Structure\LegacyPropertyFactory;
 use Sulu\Component\Content\Metadata\Factory\Exception\StructureTypeNotFoundException;
-use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactory;
+use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
 use Sulu\Component\Content\Metadata\StructureMetadata;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
@@ -35,7 +35,7 @@ class StructureManager implements StructureManagerInterface
     private $typeMap;
 
     public function __construct(
-        StructureMetadataFactory $structureFactory,
+        StructureMetadataFactoryInterface $structureFactory,
         DocumentInspector $inspector,
         LegacyPropertyFactory $propertyFactory,
         array $typeMap


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Replacing the type hint for the `StructureMetadataFactory` with its interface.

#### Why?
If the user wants to replace the implementation of the `StructureMetadataFactory`, we should use the interface instead of the class.

#### Example Usage
Same as before