### PR TITLE
Add support of noop proxy client in sulu http cache

### DIFF
--- a/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/Configuration.php
@@ -49,6 +49,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('proxy_client')
                     ->addDefaultsIfNotSet()
                     ->children()
+                        ->booleanNode('noop')->end()
                         ->arrayNode('symfony')
                             ->canBeEnabled()
                             ->addDefaultsIfNotSet()

--- a/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/SuluHttpCacheExtension.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/SuluHttpCacheExtension.php
@@ -44,6 +44,10 @@ class SuluHttpCacheExtension extends Extension implements PrependExtensionInterf
             ];
         }
 
+        if (\array_key_exists('noop', $config['proxy_client'])) {
+            $fosHttpCacheConfig['proxy_client']['noop'] = $config['proxy_client']['noop'];
+        }
+
         if ($config['proxy_client']['symfony']['enabled']) {
             $symfonyProxyClient = $config['proxy_client']['symfony'];
             $fosHttpCacheConfig['proxy_client']['symfony']['http']['servers'] =
@@ -90,7 +94,7 @@ class SuluHttpCacheExtension extends Extension implements PrependExtensionInterf
         $proxyClientAvailable = false;
         if (\array_key_exists('proxy_client', $config)) {
             foreach ($config['proxy_client'] as $proxyClient) {
-                if (true === $proxyClient['enabled']) {
+                if ((\is_bool($proxyClient) && $proxyClient) || true === $proxyClient['enabled']) {
                     $proxyClientAvailable = true;
                     break;
                 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Right now, to use http cache tagging and its features (especially **twig functions like `fos_httpcache_tag`**) in all environments, you need to have an enabled `proxy_client`. If you're in a different env that has no `proxy_client` enabled, **these functions will be missing** and need to be "polyfilled" in some way, in order not to throw an error, which seems unnecessary.

So now it's possible to set this in your `sulu_http_cache.yaml` and all functionality will be available:

```yaml
sulu_http_cache:
  proxy_client:
    noop: ~
```

https://foshttpcachebundle.readthedocs.io/en/latest/reference/configuration/proxy-client.html?highlight=noop#noop

Tested in a 2.5 project without issues but happy to hear your input :)

#### Why?

For better DX and less user code

#### Example Usage

No changes to the config

#### To Do

Nothing