### PR TITLE
Conflict incompatible version 2.16.0 of doctrine/orm

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -144,7 +144,7 @@
     "conflict": {
         "doctrine/dbal": "2.7.0",
         "doctrine/lexer": "1.0.0",
-        "doctrine/orm": "2.10.0 || 2.14.2",
+        "doctrine/orm": "2.10.0 || 2.14.2 || 2.16.0",
         "doctrine/doctrine-cache-bundle": "<1.3.1",
         "friendsofphp/php-cs-fixer": "3.9.1",
         "gedmo/doctrine-extensions" : "3.7.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/issues/7126, https://github.com/doctrine/orm/issues/10867, https://github.com/doctrine/orm/issues/10820, https://github.com/doctrine/orm/issues/10864, https://github.com/doctrine/orm/issues/10869
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Conflict incompatible version 2.16.0 of doctrine/orm.

#### Why?

There are currently various issue with the doctrine/orm 2.16.0 version which crashes sulu.