### PR TITLE
Fix tests for LinkContentType and AuthCodeMailer

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15811,11 +15811,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
 
 		-
-			message: "#^Cannot cast mixed to int\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
-
-		-
 			message: "#^If condition is always true\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
@@ -31419,11 +31414,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
 			count: 7
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/GroupControllerTest.php
-
-		-
-			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Response\\:\\:getTargetUrl\\(\\)\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/LoginControllerTest.php
 
 		-
 			message: "#^Array has 2 duplicate keys with value 'archive' \\('archive', 'archive'\\)\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15811,6 +15811,11 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
 
 		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
+
+		-
 			message: "#^If condition is always true\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Document/Subscriber/RoutableSubscriberTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Document/Subscriber/RoutableSubscriberTest.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\PropertyEncoder;
@@ -31,6 +32,8 @@ use Sulu\Component\Route\Document\Behavior\RoutableBehavior;
 
 class RoutableSubscriberTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var ObjectProphecy<ChainRouteGeneratorInterface>
      */

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/TwoFactor/AuthCodeMailerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/TwoFactor/AuthCodeMailerTest.php
@@ -31,9 +31,9 @@ class AuthCodeMailerTest extends SuluTestCase
         $this->getEntityManager()->flush();
         $client->enableProfiler();
 
-        $client->request('POST', '/admin/login', [
-            '_username' => 'test',
-            '_password' => 'test',
+        $client->jsonRequest('POST', '/admin/login', [
+            'username' => 'test',
+            'password' => 'test',
         ]);
 
         $this->assertHttpStatusCode(302, $client->getResponse());

--- a/src/Sulu/Component/Content/Tests/Unit/Types/LinkTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Types/LinkTest.php
@@ -127,6 +127,14 @@ class LinkTest extends TestCase
                 'query' => 'testQuery',
             ]);
 
+        $this->property->getStructure()
+            ->shouldBeCalled()
+            ->willReturn($this->structure->reveal());
+
+        $this->structure->getLanguageCode()
+            ->shouldBeCalled()
+            ->willReturn('de');
+
         $this->providerPool->getProvider(Argument::type('string'))
             ->shouldBeCalled()
             ->willReturn($this->provider->reveal());
@@ -157,17 +165,17 @@ class LinkTest extends TestCase
                 'anchor' => 'testAnchor',
             ]);
 
-        $this->providerPool->getProvider(Argument::type('string'))
+        $this->property->getStructure()
             ->shouldBeCalled()
-            ->willReturn($this->provider->reveal());
+            ->willReturn($this->structure->reveal());
 
         $this->structure->getLanguageCode()
             ->shouldBeCalled()
             ->willReturn('de');
 
-        $this->property->getStructure()
+        $this->providerPool->getProvider(Argument::type('string'))
             ->shouldBeCalled()
-            ->willReturn($this->structure->reveal());
+            ->willReturn($this->provider->reveal());
 
         $linkItem = $this->prophesize(LinkItem::class);
         $linkItem->getUrl()
@@ -195,6 +203,14 @@ class LinkTest extends TestCase
                 'query' => 'testQuery',
                 'anchor' => 'testAnchor',
             ]);
+
+        $this->property->getStructure()
+            ->shouldBeCalled()
+            ->willReturn($this->structure->reveal());
+
+        $this->structure->getLanguageCode()
+            ->shouldBeCalled()
+            ->willReturn('de');
 
         $this->providerPool->getProvider(Argument::type('string'))
             ->shouldBeCalled()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix tests for Link Content Type.

#### Why?

Currently failing because of backmerge 2.4 -> 2.5.
