### PR TITLE
Fixed tested methods in ForceTwoFactorSubscriberTest unit tests

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/ForceTwoFactorSubscriberTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/ForceTwoFactorSubscriberTest.php
@@ -57,7 +57,7 @@ class ForceTwoFactorSubscriberTest extends TestCase
         $user->setEmail('other@localhost');
         $event = $this->createEvent($user);
 
-        $this->forceTwoFactorSubscriber->preUpdate($event);
+        $this->forceTwoFactorSubscriber->prePersist($event);
 
         $this->entityManager->persist(Argument::cetera())->shouldNotBeCalled();
     }
@@ -68,7 +68,7 @@ class ForceTwoFactorSubscriberTest extends TestCase
         $user->setEmail('other@sulu.io');
         $event = $this->createEvent($user);
 
-        $this->forceTwoFactorSubscriber->preUpdate($event);
+        $this->forceTwoFactorSubscriber->prePersist($event);
 
         $this->entityManager->persist(Argument::that(function(UserTwoFactor $userTwoFactor) {
             $this->assertSame('email', $userTwoFactor->getMethod());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no 
| Fixed tickets | 
| Related issues/PRs | 
| License | MIT
| Documentation PR | 

#### What's in this PR?

I have fixed the methods that were tested in the unit tests.

#### Why?

I think there is a typo, because the tested methods do not match the test name.
In fact this is not really a problem because both methods do the same, but theoretically this may change in the future..
