### PR TITLE
Add original locale to snippet document in case of shadows

### DIFF
--- a/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetResolver.php
+++ b/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetResolver.php
@@ -11,7 +11,9 @@
 
 namespace Sulu\Bundle\SnippetBundle\Snippet;
 
+use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;
+use Sulu\Component\Content\Compat\Structure\SnippetBridge;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 
@@ -55,7 +57,12 @@ class SnippetResolver implements SnippetResolverInterface
                 }
 
                 if (!$snippet->getHasTranslation() && null !== $shadowLocale) {
+                    /** @var SnippetBridge $snippet */
                     $snippet = $this->contentMapper->load($uuid, $webspaceKey, $shadowLocale);
+                    /** @var SnippetDocument $document */
+                    $document = $snippet->getDocument();
+                    $document->setLocale($shadowLocale);
+                    $document->setOriginalLocale($locale);
                 }
 
                 $snippet->setIsShadow(null !== $shadowLocale);

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\SnippetBundle\Snippet;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
@@ -13,6 +13,9 @@ namespace Sulu\Bundle\SnippetBundle\Snippet;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;
 use Sulu\Component\Content\Compat\Structure\SnippetBridge;
 use Sulu\Component\Content\Compat\StructureInterface;
@@ -132,6 +135,12 @@ class SnippetResolverTest extends TestCase
         $structure2->getHasTranslation()->willReturn(false);
         $structure2->setIsShadow(true)->shouldBeCalled();
         $structure2->setShadowBaseLanguage('en')->shouldBeCalled();
+
+        /** @var SnippetDocument|ObjectProphecy $snippetDocument */
+        $snippetDocument = $this->prophesize(SnippetDocument::class);
+        $structure2->getDocument()->willReturn($snippetDocument->reveal());
+        $snippetDocument->setLocale('en')->shouldBeCalled();
+        $snippetDocument->setOriginalLocale('de')->shouldBeCalled();
 
         $resolver = new SnippetResolver($contentMapper->reveal(), $structureResolver->reveal());
 

--- a/src/Sulu/Component/Content/Compat/Structure/SnippetBridge.php
+++ b/src/Sulu/Component/Content/Compat/Structure/SnippetBridge.php
@@ -51,12 +51,12 @@ class SnippetBridge extends StructureBridge
 
     public function getLanguageCode()
     {
-        if (!$this->document) {
+        if (null === $this->document) {
             return $this->locale;
         }
 
         // return original locale for shadow or ghost pages
-        if ($this->getIsShadow() || ($this->getType() && 'ghost' === $this->getType()->getName())) {
+        if ($this->getIsShadow() || (null !== $this->getType() && 'ghost' === $this->getType()->getName())) {
             return $this->inspector->getOriginalLocale($this->getDocument());
         }
 

--- a/src/Sulu/Component/Content/Compat/Structure/SnippetBridge.php
+++ b/src/Sulu/Component/Content/Compat/Structure/SnippetBridge.php
@@ -48,4 +48,18 @@ class SnippetBridge extends StructureBridge
     {
         $this->shadowBaseLanguage = $shadowBaseLanguage;
     }
+
+    public function getLanguageCode()
+    {
+        if (!$this->document) {
+            return $this->locale;
+        }
+
+        // return original locale for shadow or ghost pages
+        if ($this->getIsShadow() || ($this->getType() && 'ghost' === $this->getType()->getName())) {
+            return $this->inspector->getOriginalLocale($this->getDocument());
+        }
+
+        return parent::getLanguageCode();
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

Sets the language correctly on the snippet document, so that in case of a shadowdocument the original locale can be used from the document itself.

#### Why?

Urls were not correctly resolved for shadow pages in a multi-domain setup
