### PR TITLE
Fixed deprecated calls of getEntity and getEntityManager on doctrine lifecycle events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "doctrine/doctrine-bundle": "^2.4",
         "doctrine/doctrine-fixtures-bundle": "^3.3 || ^4.0",
         "doctrine/inflector": "^1.4.1 || ^2.0.1",
-        "doctrine/orm": "^2.8",
+        "doctrine/orm": "^2.13",
         "doctrine/persistence": "^2.0",
         "doctrine/phpcr-bundle": "^2.2",
         "dragonmantank/cron-expression": "^1.1 || ^2.0 || ^3.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -18836,11 +18836,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Content/Types/SingleMediaSelectionTest.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Unit\\\\EventListener\\\\CacheInvalidationListenerTest\\:\\:provideFunctionName\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/EventListener/CacheInvalidationListenerTest.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Unit\\\\EventListener\\\\CacheInvalidationListenerTest\\:\\:testPostUpdate\\(\\) has parameter \\$functionName with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/EventListener/CacheInvalidationListenerTest.php
@@ -30644,11 +30639,6 @@ parameters:
 			message: "#^Property Sulu\\\\Bundle\\\\SecurityBundle\\\\Tests\\\\Unit\\\\Controller\\\\PermissionControllerTest\\:\\:\\$resources type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Unit/Controller/PermissionControllerTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\SecurityBundle\\\\Tests\\\\Unit\\\\EventListener\\\\PermissionInheritanceSubscriberTest\\:\\:createPostPersistEvent\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/PermissionInheritanceSubscriberTest.php
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\SecurityBundle\\\\Tests\\\\Unit\\\\EventListener\\\\PermissionInheritanceSubscriberTest\\:\\:createPostPersistEvent\\(\\) has parameter \\$entity with no type specified\\.$#"
@@ -49826,6 +49816,11 @@ parameters:
 			path: src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
 
 		-
+			message: "#^Property Sulu\\\\Component\\\\Persistence\\\\Tests\\\\Unit\\\\EventSubscriber\\\\ORM\\\\TimestampableSubscriberTest\\:\\:\\$lifecycleEvent \\(Prophecy\\\\Prophecy\\\\ObjectProphecy\\<Doctrine\\\\Persistence\\\\Event\\\\LifecycleEventArgs\\<Doctrine\\\\ORM\\\\EntityManager\\>\\>\\) does not accept Prophecy\\\\Prophecy\\\\ObjectProphecy\\<Doctrine\\\\Persistence\\\\Event\\\\LifecycleEventArgs\\>\\.$#"
+			count: 1
+			path: src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
+
+		-
 			message: "#^Property Sulu\\\\Component\\\\Persistence\\\\Tests\\\\Unit\\\\EventSubscriber\\\\ORM\\\\TimestampableSubscriberTest\\:\\:\\$refl with generic class ReflectionClass does not specify its types\\: T$#"
 			count: 1
 			path: src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
@@ -51477,22 +51472,12 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\|null given\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Component/Rest/Listing/ListRepository.php
 
 		-
 			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
 			count: 1
-			path: src/Sulu/Component/Rest/Listing/ListRepository.php
-
-		-
-			message: "#^Parameter \\#2 \\$haystack of function array_search expects array, array\\|null given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/Listing/ListRepository.php
-
-		-
-			message: "#^Parameter \\#2 \\$intersectArray of method Sulu\\\\Component\\\\Rest\\\\Listing\\\\ListRepository\\:\\:getFieldsWitTypes\\(\\) expects null, array\\|null given\\.$#"
-			count: 2
 			path: src/Sulu/Component/Rest/Listing/ListRepository.php
 
 		-

--- a/src/Sulu/Bundle/ContactBundle/EventListener/AccountListener.php
+++ b/src/Sulu/Bundle/ContactBundle/EventListener/AccountListener.php
@@ -19,6 +19,9 @@ use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
  */
 class AccountListener
 {
+    /**
+     * @param LifecycleEventArgs<\Doctrine\Persistence\ObjectManager> $args
+     */
     public function postPersist(LifecycleEventArgs $args)
     {
         $entity = $args->getObject();

--- a/src/Sulu/Bundle/ContactBundle/EventListener/AccountListener.php
+++ b/src/Sulu/Bundle/ContactBundle/EventListener/AccountListener.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Bundle\ContactBundle\EventListener;
 
-use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
 
 /**
@@ -21,10 +21,10 @@ class AccountListener
 {
     public function postPersist(LifecycleEventArgs $args)
     {
-        $entity = $args->getEntity();
+        $entity = $args->getObject();
 
         if ($entity instanceof AccountInterface) {
-            $entityManager = $args->getEntityManager();
+            $entityManager = $args->getObjectManager();
             // after saving account check if number is set, else set a new one
             if (null === $entity->getNumber()) {
                 $entity->setNumber(\sprintf('%05d', $entity->getId()));

--- a/src/Sulu/Bundle/ContactBundle/EventListener/CacheInvalidationListener.php
+++ b/src/Sulu/Bundle/ContactBundle/EventListener/CacheInvalidationListener.php
@@ -35,6 +35,8 @@ class CacheInvalidationListener
     }
 
     /**
+     * @param LifecycleEventArgs<\Doctrine\Persistence\ObjectManager> $eventArgs
+     *
      * @return void
      */
     public function postPersist(LifecycleEventArgs $eventArgs)
@@ -43,6 +45,8 @@ class CacheInvalidationListener
     }
 
     /**
+     * @param LifecycleEventArgs<\Doctrine\Persistence\ObjectManager> $eventArgs
+     *
      * @return void
      */
     public function postUpdate(LifecycleEventArgs $eventArgs)
@@ -51,6 +55,8 @@ class CacheInvalidationListener
     }
 
     /**
+     * @param LifecycleEventArgs<\Doctrine\Persistence\ObjectManager> $eventArgs
+     *
      * @return void
      */
     public function preRemove(LifecycleEventArgs $eventArgs)

--- a/src/Sulu/Bundle/ContactBundle/EventListener/CacheInvalidationListener.php
+++ b/src/Sulu/Bundle/ContactBundle/EventListener/CacheInvalidationListener.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\ContactBundle\EventListener;
 
 use Doctrine\Common\Collections\Collection;
-use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
 use Sulu\Bundle\ContactBundle\Entity\ContactInterface;

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/CacheInvalidationListenerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/CacheInvalidationListenerTest.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\ContactBundle\Tests\Unit;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;

--- a/src/Sulu/Bundle/MediaBundle/EventListener/CacheInvalidationListener.php
+++ b/src/Sulu/Bundle/MediaBundle/EventListener/CacheInvalidationListener.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\MediaBundle\EventListener;
 
 use Doctrine\Common\Collections\Collection;
-use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\HttpCacheBundle\Cache\CacheManagerInterface;
 use Sulu\Bundle\MediaBundle\Entity\File;

--- a/src/Sulu/Bundle/MediaBundle/EventListener/CacheInvalidationListener.php
+++ b/src/Sulu/Bundle/MediaBundle/EventListener/CacheInvalidationListener.php
@@ -37,6 +37,8 @@ class CacheInvalidationListener
     }
 
     /**
+     * @param LifecycleEventArgs<\Doctrine\Persistence\ObjectManager> $eventArgs
+     *
      * @return void
      */
     public function postPersist(LifecycleEventArgs $eventArgs)
@@ -45,6 +47,8 @@ class CacheInvalidationListener
     }
 
     /**
+     * @param LifecycleEventArgs<\Doctrine\Persistence\ObjectManager> $eventArgs
+     *
      * @return void
      */
     public function postUpdate(LifecycleEventArgs $eventArgs)
@@ -53,6 +57,8 @@ class CacheInvalidationListener
     }
 
     /**
+     * @param LifecycleEventArgs<\Doctrine\Persistence\ObjectManager> $eventArgs
+     *
      * @return void
      */
     public function preRemove(LifecycleEventArgs $eventArgs)

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/EventListener/CacheInvalidationListenerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/EventListener/CacheInvalidationListenerTest.php
@@ -47,6 +47,9 @@ class CacheInvalidationListenerTest extends TestCase
         $this->listener = new CacheInvalidationListener($this->cacheManager->reveal());
     }
 
+    /**
+     * @return string[][]
+     */
     public function provideFunctionName(): array
     {
         return [

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/EventListener/CacheInvalidationListenerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/EventListener/CacheInvalidationListenerTest.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\MediaBundle\Tests\Unit\EventListener;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -47,7 +47,7 @@ class CacheInvalidationListenerTest extends TestCase
         $this->listener = new CacheInvalidationListener($this->cacheManager->reveal());
     }
 
-    public function provideFunctionName()
+    public function provideFunctionName(): array
     {
         return [
             ['postPersist'],

--- a/src/Sulu/Bundle/SecurityBundle/EventListener/ForceTwoFactorSubscriber.php
+++ b/src/Sulu/Bundle/SecurityBundle/EventListener/ForceTwoFactorSubscriber.php
@@ -12,8 +12,8 @@
 namespace Sulu\Bundle\SecurityBundle\EventListener;
 
 use Doctrine\Common\EventSubscriber;
-use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Events;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\SecurityBundle\Entity\UserTwoFactor;
 
@@ -63,7 +63,7 @@ class ForceTwoFactorSubscriber implements EventSubscriber
 
         if (!$twoFactor) {
             $twoFactor = new UserTwoFactor($entity);
-            $event->getEntityManager()->persist($twoFactor);
+            $event->getObjectManager()->persist($twoFactor);
         }
 
         if (!$twoFactor->getMethod()) {

--- a/src/Sulu/Bundle/SecurityBundle/EventListener/ForceTwoFactorSubscriber.php
+++ b/src/Sulu/Bundle/SecurityBundle/EventListener/ForceTwoFactorSubscriber.php
@@ -37,16 +37,25 @@ class ForceTwoFactorSubscriber implements EventSubscriber
         ];
     }
 
+    /**
+     * @param LifecycleEventArgs<\Doctrine\Persistence\ObjectManager> $event
+     */
     public function preUpdate(LifecycleEventArgs $event): void
     {
         $this->handleTwoFactorForce($event);
     }
 
+    /**
+     * @param LifecycleEventArgs<\Doctrine\Persistence\ObjectManager> $event
+     */
     public function prePersist(LifecycleEventArgs $event): void
     {
         $this->handleTwoFactorForce($event);
     }
 
+    /**
+     * @param LifecycleEventArgs<\Doctrine\Persistence\ObjectManager> $event
+     */
     private function handleTwoFactorForce(LifecycleEventArgs $event): void
     {
         $entity = $event->getObject();

--- a/src/Sulu/Bundle/SecurityBundle/EventListener/PermissionInheritanceSubscriber.php
+++ b/src/Sulu/Bundle/SecurityBundle/EventListener/PermissionInheritanceSubscriber.php
@@ -38,6 +38,9 @@ class PermissionInheritanceSubscriber implements EventSubscriber
         return $events;
     }
 
+    /**
+     * @param LifecycleEventArgs<\Doctrine\Persistence\ObjectManager> $event
+     */
     public function postPersist(LifecycleEventArgs $event)
     {
         $entity = $event->getObject();

--- a/src/Sulu/Bundle/SecurityBundle/EventListener/PermissionInheritanceSubscriber.php
+++ b/src/Sulu/Bundle/SecurityBundle/EventListener/PermissionInheritanceSubscriber.php
@@ -12,8 +12,8 @@
 namespace Sulu\Bundle\SecurityBundle\EventListener;
 
 use Doctrine\Common\EventSubscriber;
-use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Events;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Sulu\Bundle\SecurityBundle\Entity\PermissionInheritanceInterface;
 use Sulu\Component\Security\Authorization\AccessControl\AccessControlManagerInterface;
 
@@ -40,7 +40,7 @@ class PermissionInheritanceSubscriber implements EventSubscriber
 
     public function postPersist(LifecycleEventArgs $event)
     {
-        $entity = $event->getEntity();
+        $entity = $event->getObject();
 
         if (!$entity instanceof PermissionInheritanceInterface) {
             return;

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/ForceTwoFactorSubscriberTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/ForceTwoFactorSubscriberTest.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\SecurityBundle\Tests\Unit\EventListener;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/ForceTwoFactorSubscriberTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/ForceTwoFactorSubscriberTest.php
@@ -110,6 +110,9 @@ class ForceTwoFactorSubscriberTest extends TestCase
         $this->assertSame('other', $userTwoFactor->getMethod());
     }
 
+    /**
+     * @return LifecycleEventArgs<EntityManagerInterface>
+     */
     private function createEvent(object $object): LifecycleEventArgs
     {
         return new LifecycleEventArgs($object, $this->entityManager->reveal());

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/PermissionInheritanceSubscriberTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/PermissionInheritanceSubscriberTest.php
@@ -93,6 +93,9 @@ class PermissionInheritanceSubscriberTest extends TestCase
         $this->permissionInheritanceSubscriber->postPersist($event);
     }
 
+    /**
+     * @return LifecycleEventArgs<EntityManagerInterface>
+     */
     private function createPostPersistEvent($entity): LifecycleEventArgs
     {
         $event = new LifecycleEventArgs($entity, $this->entityManager->reveal());

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/PermissionInheritanceSubscriberTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/PermissionInheritanceSubscriberTest.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\SecurityBundle\Tests\Unit\EventListener;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -93,7 +93,7 @@ class PermissionInheritanceSubscriberTest extends TestCase
         $this->permissionInheritanceSubscriber->postPersist($event);
     }
 
-    private function createPostPersistEvent($entity)
+    private function createPostPersistEvent($entity): LifecycleEventArgs
     {
         $event = new LifecycleEventArgs($entity, $this->entityManager->reveal());
 

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
@@ -120,6 +120,8 @@ class UserBlameSubscriber implements EventSubscriber
 
     private function handleUserBlame(OnFlushEventArgs $event, UserInterface $user, bool $insertions)
     {
+        // TODO: calling getEntityManager on the event is deprecated, but access to the UnitOfWork is not
+        // guaranteed for an ObjectManager. So we need to get an EntityManager somehow different.
         $manager = $event->getEntityManager();
         $unitOfWork = $manager->getUnitOfWork();
 

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\Persistence\EventSubscriber\ORM;
 
 use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
@@ -120,9 +121,12 @@ class UserBlameSubscriber implements EventSubscriber
 
     private function handleUserBlame(OnFlushEventArgs $event, UserInterface $user, bool $insertions)
     {
-        // TODO: calling getEntityManager on the event is deprecated, but access to the UnitOfWork is not
-        // guaranteed for an ObjectManager. So we need to get an EntityManager somehow different.
-        $manager = $event->getEntityManager();
+        $manager = $event->getObjectManager();
+
+        if (!$manager instanceof EntityManagerInterface) {
+            return;
+        }
+
         $unitOfWork = $manager->getUnitOfWork();
 
         $entities = $insertions ? $unitOfWork->getScheduledEntityInsertions() :

--- a/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
+++ b/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
@@ -12,9 +12,9 @@
 namespace Sulu\Component\Persistence\Tests\Unit\EventSubscriber\ORM;
 
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;

--- a/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
+++ b/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
@@ -32,7 +32,7 @@ class TimestampableSubscriberTest extends TestCase
     private $loadClassMetadataEvent;
 
     /**
-     * @var ObjectProphecy<LifecycleEventArgs>
+     * @var ObjectProphecy<LifecycleEventArgs<EntityManager>>
      */
     private $lifecycleEvent;
 

--- a/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/UserBlameSubscriberTest.php
+++ b/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/UserBlameSubscriberTest.php
@@ -109,7 +109,7 @@ class UserBlameSubscriberTest extends TestCase
 
         $this->tokenStorage->getToken()->willReturn($this->token->reveal());
         $this->token->getUser()->willReturn($this->user->reveal());
-        $this->onFlushEvent->getEntityManager()->willReturn($this->entityManager);
+        $this->onFlushEvent->getObjectManager()->willReturn($this->entityManager);
         $this->entityManager->getUnitOfWork()->willReturn($this->unitOfWork);
     }
 

--- a/src/Sulu/Component/Rest/Listing/ListRepository.php
+++ b/src/Sulu/Component/Rest/Listing/ListRepository.php
@@ -113,8 +113,9 @@ class ListRepository extends EntityRepository
         // and filter result
         if (\count($filters = $queryBuilder->getRelationalFilters()) > 0) {
             $filteredResults = [];
+            $fields = $this->helper->getFields();
             // check if fields do contain id, else skip
-            if (\count($fields = $this->helper->getFields()) > 0 && false !== \array_search('id', $fields)) {
+            if (!\is_null($fields) && \count($fields) > 0 && false !== \array_search('id', $fields)) {
                 $ids = [];
                 foreach ($results as $result) {
                     $id = $result['id'];
@@ -178,11 +179,11 @@ class ListRepository extends EntityRepository
     /**
      * returns all fields with a specified type.
      *
-     * @param null $intersectArray only return fields that are defined in this array
+     * @param string[]|null $intersectArray only return fields that are defined in this array
      *
      * @return array
      */
-    public function getFieldsWitTypes(array $types, $intersectArray = null)
+    public function getFieldsWitTypes(array $types, ?array $intersectArray = null)
     {
         $result = [];
         foreach ($this->getClassMetadata()->getFieldNames() as $field) {

--- a/src/Sulu/Component/Rest/Listing/ListRepository.php
+++ b/src/Sulu/Component/Rest/Listing/ListRepository.php
@@ -50,7 +50,7 @@ class ListRepository extends EntityRepository
 
         // if search string is set, but search fields are not, take all fields into account
         if (!\is_null($searchPattern) && '' != $searchPattern && (\is_null($searchFields) || 0 == \count($searchFields))) {
-            $searchFields = $this->getEntityManager()->getClassMetadata($this->getEntityName())->getFieldNames();
+            $searchFields = $this->getObjectManager()->getClassMetadata($this->getEntityName())->getFieldNames();
         }
 
         $textFields = $this->getFieldsWitTypes(['text', 'string', 'guid'], $searchFields);

--- a/src/Sulu/Component/Rest/Listing/ListRepository.php
+++ b/src/Sulu/Component/Rest/Listing/ListRepository.php
@@ -50,7 +50,7 @@ class ListRepository extends EntityRepository
 
         // if search string is set, but search fields are not, take all fields into account
         if (!\is_null($searchPattern) && '' != $searchPattern && (\is_null($searchFields) || 0 == \count($searchFields))) {
-            $searchFields = $this->getObjectManager()->getClassMetadata($this->getEntityName())->getFieldNames();
+            $searchFields = $this->getEntityManager()->getClassMetadata($this->getEntityName())->getFieldNames();
         }
 
         $textFields = $this->getFieldsWitTypes(['text', 'string', 'guid'], $searchFields);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | 
| License | MIT
| Documentation PR |

#### What's in this PR?

I have changed almost all calls of `getEntity` and `getEntityManager` to `getObject` and `getObjectManager` on the `LifecycleEventArgs`. 

There is one place, where an `EntityManager` is needed (have a look at `Sulu\Component\Persistence\EventSubscriber\ORM\UserBlameSubscriber`) and because it is not a bundle I am unsure if it is okay to use dependency injection in the constructor and inject the `EntityManager` per lazy service subscriber.

Additionally I have changed `Doctrine\ORM\Event\LifecycleEventArgs` to `Doctrine\Persistence\Event\LifecycleEventArgs`, because the use of the former is deprecated. But I assume that this is a bc break in case people have extended the event handlers.

Please give me feedback to the two issues and I'll adjust the PR accordingly.

#### Why?

Because of deprecations in doctrine/orm.


#### To Do

- [x] Fixing `getEntityManager` in `UserBlameSubscriber`
- [ ] Eventually revert the change of the `LifecycleEventArgs` class
