### PR TITLE
[PHP 8.3] Fix and `get_parent_class()` deprecations

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
@@ -52,7 +52,7 @@ class PreviewKernel extends Kernel
     protected function getContainerClass(): string
     {
         // use parent class to normalize the generated container class.
-        return $this->generateContainerClass(\get_parent_class());
+        return $this->generateContainerClass(parent::class);
     }
 
     public function getProjectDir(): string


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | no
| Related issues/PRs | none
| License | MIT
| Documentation PR | NA

#### What's in this PR?

In PHP 8.3, [calling `get_class()` and `get_parent_class()` functions without arguments is deprecated](https://php.watch/versions/8.3/get_class-get_parent_class-parameterless-deprecated).

This fixes one instance with an identical alternative that does not cause the deprecation notice.

References:
 - [PHP RFC: Deprecate functions with overloaded signatures](https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures)
 - [PHP 8.3: get_class() and get_parent_class() function calls without arguments deprecated](https://php.watch/versions/8.3/get_class-get_parent_class-parameterless-deprecated)

