### PR TITLE
Fixed setting ghost locale to have consistant count of columns in exp…

### DIFF
--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -292,7 +292,8 @@ class CategoryController extends AbstractRestController implements ClassResource
 
         foreach ($categories as &$category) {
             $category['hasChildren'] = ($category['lft'] + 1) !== $category['rgt'];
-
+            
+            $category['ghostLocale'] = null;
             if ($category['locale'] !== $locale) {
                 $category['ghostLocale'] = $category['locale'];
             }

--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -293,7 +293,7 @@ class CategoryController extends AbstractRestController implements ClassResource
         foreach ($categories as &$category) {
             $category['hasChildren'] = ($category['lft'] + 1) !== $category['rgt'];
             
-            $category['ghostLocale'] = null;
+            $category['ghostLocale'] = null; // need always be set as the csv requires all columns have the same count
             if ($category['locale'] !== $locale) {
                 $category['ghostLocale'] = $category['locale'];
             }

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
@@ -321,12 +321,12 @@ class CategoryControllerTest extends SuluTestCase
         $this->assertEquals('en', $categories[0]->locale);
         $this->assertEquals('first-category-key', $categories[0]->key);
         $this->assertTrue($categories[0]->hasChildren);
-        $this->assertObjectNotHasAttribute('ghostLocale', $categories[0]);
+        $this->assertNull($categories[0]->ghostLocale);
 
         $this->assertEquals('second-category-key', $categories[1]->key);
         $this->assertEquals('en', $categories[1]->defaultLocale);
         $this->assertFalse($categories[1]->hasChildren);
-        $this->assertObjectNotHasAttribute('ghostLocale', $categories[1]);
+        $this->assertNull($categories[1]->ghostLocale);
 
         $this->assertEquals('Vierte Kategorie', $categories[2]->name);
         $this->assertEquals('de', $categories[2]->locale);


### PR DESCRIPTION
…ort.

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
#### What's in this PR?

Initial set of array key `ghostLocale` in `CategoryController::getListRepresentation`. 

#### Why?

If the `ghostLocale` is set during csv export for some and not all category rows, there will be an exception.

