### PR TITLE
Expand conflicting versions for doctrine/orm

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -144,7 +144,7 @@
     "conflict": {
         "doctrine/dbal": "2.7.0",
         "doctrine/lexer": "1.0.0",
-        "doctrine/orm": "2.10.0 || 2.14.2 || 2.16.0",
+        "doctrine/orm": "2.10.0 || 2.14.2 || >= 2.16.0",
         "doctrine/doctrine-cache-bundle": "<1.3.1",
         "friendsofphp/php-cs-fixer": "3.9.1",
         "gedmo/doctrine-extensions" : "3.7.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets |
| Related issues/PRs | #7128, https://github.com/sulu/sulu/issues/7142
| License | MIT
| Documentation PR |

#### What's in this PR?

Marks all versions of doctrine/orm since the 2.16.x release as conflicting versions

#### Why?

As already stated in #7128 there are issues with the newest doctrine/orm releases since 2.16.x which cause errors in Sulu
