### PR TITLE
WIP: Update default meta tags shipped with Sulu

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Extension/blocks.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Extension/blocks.html.twig
@@ -1,0 +1,12 @@
+{%- block determineImage -%}
+    {%- set fallbackImage = fallbackImage|default() -%}
+
+    {%- set image = extension.excerpt.images[0].formats[imageFormat]|default() -%}
+    {%- set image = image|default(fallbackImage) -%}
+
+    {%- if image is not empty -%}
+        {%- set image = absolute_url(asset(image)) -%}
+    {%- endif -%}
+
+    {{- image|default() -}}
+{%- endblock -%}

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Extension/seo_meta.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Extension/seo_meta.html.twig
@@ -1,0 +1,59 @@
+{% include "@SuluWebsite/Extension/seo.html.twig" with {
+    "seo": extension.seo|default([]),
+    "content": content|default([]),
+    "localizations": localizations|default([]),
+    "shadowBaseLocale": shadowBaseLocale|default(),
+} %}
+
+{% set domain = app.request.host %}
+{% set language = app.request.locale|split("_")[0] %}
+{% set url = app.request.uri %}
+
+{% set title = extension.seo.title|default(content.title|default()) %}
+{% set description = extension.seo.description|default() %}
+{% set image = null %}
+
+{% set defaultTags = {
+    "audience": "all",
+    "author": null,
+    "copyright": null,
+    "distribution": "global",
+    "image": image,
+    "language": language,
+    "publisher": null,
+} %}
+
+{% set facebookTags = {
+    "og:url": url,
+    "og:type": "website",
+    "og:title": title,
+    "og:description": description,
+    "og:image": image
+} %}
+
+{% set twitterTags = {
+    "twitter:card": "summary",
+    "twitter:domain": domain,
+    "twitter:url": url,
+    "twitter:title": title,
+    "twitter:description": description,
+    "twitter:image": image
+} %}
+
+{% block defaultTags %}
+    {% for name, content in defaultTags|filter(value => value) %}
+        <meta name="{{ name }}" content="{{ content }}">
+    {% endfor %}
+{% endblock %}
+
+{% block facebookTags %}
+    {% for name, content in facebookTags|filter(value => value) %}
+        <meta name="{{ name }}" content="{{ content }}">
+    {% endfor %}
+{% endblock %}
+
+{% block twitterTags %}
+    {% for name, content in twitterTags|filter(value => value) %}
+        <meta name="{{ name }}" content="{{ content }}">
+    {% endfor %}
+{% endblock %}

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Extension/seo_meta.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Extension/seo_meta.html.twig
@@ -14,14 +14,13 @@
     {% set distribution = meta.default.distribution ?? "global" %}
     {% set publisher = meta.default.publisher ?? null %}
 
-    {% set domain = meta.default.domain ?? app.request.host %}
     {% set language = meta.default.language ?? app.request.locale|split("_")[0] %}
     {% set url = meta.default.url ?? app.request.uri %}
 
     {% set title = meta.default.title ?? extension.seo.title|default(content.title|default()) %}
     {% set description = meta.default.description ?? extension.seo.description|default() %}
 
-    {% set imageFormat = meta.default.imageFormat|default("sulu-400x400-inset") %}
+    {% set imageFormat = meta.default.imageFormat ?? "sulu-400x400-inset" %}
     {% set fallbackImage = meta.default.fallbackImage|default() %}
 
     {% set defaultTags = {
@@ -34,6 +33,7 @@
         "publisher": publisher,
     } %}
 
+    {% set imageFormat = meta.facebook.imageFormat ?? imageFormat %}
     {% set fallbackImage = meta.facebook.fallbackImage|default(meta.default.fallbackImage|default()) %}
 
     {% set facebookTags = {
@@ -44,11 +44,11 @@
         "og:image": block("determineImage")
     } %}
 
+    {% set imageFormat = meta.twitter.imageFormat ?? imageFormat %}
     {% set fallbackImage = meta.twitter.fallbackImage|default(meta.default.fallbackImage|default()) %}
 
     {% set twitterTags = {
         "twitter:card": meta.twitter.card ?? "summary",
-        "twitter:domain": meta.twitter.domain ?? domain,
         "twitter:url": meta.twitter.url ?? url,
         "twitter:title": meta.twitter.title ?? title,
         "twitter:description": meta.twitter.description ?? description,

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Extension/seo_meta.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Extension/seo_meta.html.twig
@@ -5,40 +5,48 @@
     "shadowBaseLocale": shadowBaseLocale|default(),
 } %}
 
-{% set domain = app.request.host %}
-{% set language = app.request.locale|split("_")[0] %}
-{% set url = app.request.uri %}
+{% apply spaceless %}
+    {% set audience = meta.default.audience ?? "all" %}
+    {% set author = meta.default.author ?? null %}
+    {% set copyright = meta.default.copyright ?? null %}
+    {% set distribution = meta.default.distribution ?? "global" %}
+    {% set publisher = meta.default.publisher ?? null %}
 
-{% set title = extension.seo.title|default(content.title|default()) %}
-{% set description = extension.seo.description|default() %}
-{% set image = null %}
+    {% set domain = meta.default.domain ?? app.request.host %}
+    {% set language = meta.default.language ?? app.request.locale|split("_")[0] %}
+    {% set url = meta.default.url ?? app.request.uri %}
 
-{% set defaultTags = {
-    "audience": "all",
-    "author": null,
-    "copyright": null,
-    "distribution": "global",
-    "image": image,
-    "language": language,
-    "publisher": null,
-} %}
+    {% set title = meta.default.title ?? extension.seo.title|default(content.title|default()) %}
+    {% set description = meta.default.description ?? extension.seo.description|default() %}
+    {% set image = meta.default.image ?? null %}
 
-{% set facebookTags = {
-    "og:url": url,
-    "og:type": "website",
-    "og:title": title,
-    "og:description": description,
-    "og:image": image
-} %}
+    {% set defaultTags = {
+        "audience": audience,
+        "author": author,
+        "copyright": copyright,
+        "distribution": distribution,
+        "image": image,
+        "language": language,
+        "publisher": publisher,
+    } %}
 
-{% set twitterTags = {
-    "twitter:card": "summary",
-    "twitter:domain": domain,
-    "twitter:url": url,
-    "twitter:title": title,
-    "twitter:description": description,
-    "twitter:image": image
-} %}
+    {% set facebookTags = {
+        "og:url": meta.facebook.url ?? url,
+        "og:type": meta.facebook.type ?? "website",
+        "og:title": meta.facebook.title ?? title,
+        "og:description": meta.facebook.description ?? description,
+        "og:image": meta.facebook.image ?? image
+    } %}
+
+    {% set twitterTags = {
+        "twitter:card": meta.twitter.card ?? "summary",
+        "twitter:domain": meta.twitter.domain ?? domain,
+        "twitter:url": meta.twitter.url ?? url,
+        "twitter:title": meta.twitter.title ?? title,
+        "twitter:description": meta.twitter.description ?? description,
+        "twitter:image": meta.twitter.image ?? image
+    } %}
+{% endapply %}
 
 {% block defaultTags %}
     {% for name, content in defaultTags|filter(value => value) %}

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Extension/seo_meta.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Extension/seo_meta.html.twig
@@ -1,3 +1,5 @@
+{% use "@SuluWebsite/Extension/blocks.html.twig" %}
+
 {% include "@SuluWebsite/Extension/seo.html.twig" with {
     "seo": extension.seo|default([]),
     "content": content|default([]),
@@ -18,25 +20,31 @@
 
     {% set title = meta.default.title ?? extension.seo.title|default(content.title|default()) %}
     {% set description = meta.default.description ?? extension.seo.description|default() %}
-    {% set image = meta.default.image ?? null %}
+
+    {% set imageFormat = meta.default.imageFormat|default("sulu-400x400-inset") %}
+    {% set fallbackImage = meta.default.fallbackImage|default() %}
 
     {% set defaultTags = {
         "audience": audience,
         "author": author,
         "copyright": copyright,
         "distribution": distribution,
-        "image": image,
+        "image": block("determineImage"),
         "language": language,
         "publisher": publisher,
     } %}
+
+    {% set fallbackImage = meta.facebook.fallbackImage|default(meta.default.fallbackImage|default()) %}
 
     {% set facebookTags = {
         "og:url": meta.facebook.url ?? url,
         "og:type": meta.facebook.type ?? "website",
         "og:title": meta.facebook.title ?? title,
         "og:description": meta.facebook.description ?? description,
-        "og:image": meta.facebook.image ?? image
+        "og:image": block("determineImage")
     } %}
+
+    {% set fallbackImage = meta.twitter.fallbackImage|default(meta.default.fallbackImage|default()) %}
 
     {% set twitterTags = {
         "twitter:card": meta.twitter.card ?? "summary",
@@ -44,7 +52,7 @@
         "twitter:url": meta.twitter.url ?? url,
         "twitter:title": meta.twitter.title ?? title,
         "twitter:description": meta.twitter.description ?? description,
-        "twitter:image": meta.twitter.image ?? image
+        "twitter:image": block("determineImage")
     } %}
 {% endapply %}
 

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -11,14 +11,6 @@
             "content": content|default([]),
             "localizations": localizations|default([]),
             "shadowBaseLocale": shadowBaseLocale|default(),
-            "meta": {
-                "default": { "audience": false, "distribution": false },
-                "facebook": { "title": "Custom title for facebook" },
-                "twitter": {
-                    "fallbackImage": "/website/images/logo_for_twitter.svg",
-                    "card": "summary_large_image"
-                }
-            }
         } %}
     {% endblock %}
 

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -6,11 +6,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {% block meta %}
-        {% include "@SuluWebsite/Extension/seo.html.twig" with {
+        {% include "@SuluWebsite/Extension/seo_meta.html.twig" with {
             "seo": extension.seo|default([]),
             "content": content|default([]),
             "localizations": localizations|default([]),
             "shadowBaseLocale": shadowBaseLocale|default(),
+            "meta": {
+                "default": { "audience": false, "distribution": false },
+                "facebook": { "title": "Custom title for facebook" },
+                "twitter": {
+                    "fallbackImage": "/website/images/logo_for_twitter.svg",
+                    "card": "summary_large_image"
+                }
+            }
         } %}
     {% endblock %}
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | #6940 
| Related issues/PRs | #6940 
| License | MIT
| Documentation PR | Needs to be created when all ToDos are finished

#### What's in this PR?

Changes what meta tags Sulu renderes by default. As a guide I used the already defined tags used in the sulu-demo. The behavior of what gets outputted can be changed via a new array supplied to the template. For more information on that, see below.

#### Why?

As pointed out in #6940 the current state is that the default meta tags have to be overwritten with every new instance of Sulu. This new version extends the already existing output and adds additional meta information used by Twitter, Facebook and other social media platforms (e.g. Discord) and improves their social sharing display.

#### Example Usage

```twig
{% embed "@SuluWebsite/Extension/seo_meta.html.twig" with {
    "seo": extension.seo|default([]),
    "content": content|default([]),
    "localizations": localizations|default([]),
    "shadowBaseLocale": shadowBaseLocale|default(),
    "meta": {
        {# Used to configure the default meta tags, possible options: audience, author, copyright, distribution, image, imageFormat, language, publisher #}
        "default": {},
        {# Inherits data from default, but can also be customized with these options: url, type, title, description, image, imageFormat #}
        "twitter": {},
        {# Same as twitter, but a few different options: card, url, title, description, image, imageFormat #}
        "facebook": {},
    }
} %}
{% endembed %}
```

If a tag should be ommited completely, it can be set to false

```twig
"meta": {
    "default": {
        "author": false,
    },
}
```

Adding now tags could be achieved as follows

```twig
{% embed "@SuluWebsite/Extension/seo_meta.html.twig" with {
    ...
} %}
    {%- block twitterTags -%}
        {%- set twitterTags = twitterTags|merge({ "twitter:creator": "@sulu" }) -%}
        {{- parent() -}}
    {%- endblock -%}
{% endembed %}
```

#### Special note about how images are handled

In its current state images are loaded with the intern size `sulu-400x400-inset` which can be changed via the `imageFormat` variable, in either the `default`, `twitter` or `facebook` key. An image is only rendered if its found in the `extensions.excerpt.images` array. If there is no image present, you could also define a fallback image via the `fallbackImage` variable in `default`, `twitter` and `facebook`.

#### Current output

With the new default configuration the output would look as follows

```html
<title>Homepage</title>
<meta name="description" content="Example description for my homepage">
<meta name="robots" content="index,follow">
<link rel="canonical" href="https://sulu-dev.wip/">

<meta name="audience" content="all">
<meta name="distribution" content="global">
<meta name="image" content="https://sulu-dev.wip/uploads/media/sulu-400x400-inset/02/2-Forest.jpg?v=1-0">
<meta name="language" content="en">

<meta name="og:url" content="https://sulu-dev.wip/">
<meta name="og:type" content="website">
<meta name="og:title" content="Homepage">
<meta name="og:description" content="Example description for my homepage">
<meta name="og:image" content="https://sulu-dev.wip/uploads/media/sulu-400x400-inset/02/2-Forest.jpg?v=1-0">

<meta name="twitter:card" content="summary">
<meta name="twitter:url" content="https://sulu-dev.wip/">
<meta name="twitter:title" content="Homepage">
<meta name="twitter:description" content="Example description for my homepage">
<meta name="twitter:image" content="https://sulu-dev.wip/uploads/media/sulu-400x400-inset/02/2-Forest.jpg?v=1-0">
```

#### ToDo

- [ ] Create a documentation page
- [ ] Check if there are more tags that could be added
- [ ] Check if there are other/easier ways to extend the template
- [ ] Should all of this be enabled by default
- [ ] Which defaults should be set in the `base.html.twig` template
- [ ] Test if there are ways to crash the website
