### PR TITLE
Fix dynamic property issues in phpstan via rector

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10171,11 +10171,6 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/SuluContactBundle.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\ContactBundle\\\\Tests\\\\Functional\\\\Controller\\\\AccountControllerTest\\:\\:\\$category\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
-
-		-
 			message: "#^Array has 2 duplicate keys with value 'id' \\('id', 'id'\\)\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
@@ -10531,11 +10526,6 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\ContactBundle\\\\Tests\\\\Functional\\\\Controller\\\\AccountMediaControllerTest\\:\\:\\$em\\.$#"
-			count: 14
-			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountMediaControllerTest.php
-
-		-
 			message: "#^Cannot access property \\$_embedded on mixed\\.$#"
 			count: 4
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountMediaControllerTest.php
@@ -10594,11 +10584,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$object of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertObjectHasAttribute\\(\\) expects object, mixed given\\.$#"
 			count: 4
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AdminControllerTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\ContactBundle\\\\Tests\\\\Functional\\\\Controller\\\\ContactControllerTest\\:\\:\\$category\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
 
 		-
 			message: "#^Cannot access offset 'account' on mixed\\.$#"
@@ -11814,16 +11799,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$haystack of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertCount\\(\\) expects Countable\\|iterable, mixed given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/CoreBundle/Tests/Functional/Controller/LocalizationControllerTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\CoreBundle\\\\Tests\\\\Unit\\\\Cache\\\\StructureWarmerTest\\:\\:\\$structureManager\\.$#"
-			count: 3
-			path: src/Sulu/Bundle/CoreBundle/Tests/Unit/Cache/StructureWarmerTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\CoreBundle\\\\Tests\\\\Unit\\\\Cache\\\\StructureWarmerTest\\:\\:\\$warmer\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/CoreBundle/Tests/Unit/Cache/StructureWarmerTest.php
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\CoreBundle\\\\Tests\\\\Unit\\\\DependencyInjection\\\\Compiler\\\\ListBuilderMetadataProviderCompilerPassTest\\:\\:dataProcessProvider\\(\\) has no return type specified\\.$#"
@@ -13426,11 +13401,6 @@ parameters:
 			path: src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/FixturesLoadCommandTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\Tests\\\\Unit\\\\Command\\\\InitializeCommandTest\\:\\:\\$command\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/InitializeCommandTest.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\Tests\\\\Unit\\\\Command\\\\InitializeCommandTest\\:\\:exec\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/InitializeCommandTest.php
@@ -13439,31 +13409,6 @@ parameters:
 			message: "#^Method Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\Tests\\\\Unit\\\\Command\\\\InitializeCommandTest\\:\\:exec\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/InitializeCommandTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\Tests\\\\Unit\\\\DataFixtures\\\\DocumentExecutorTest\\:\\:\\$documentManager\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/DataFixtures/DocumentExecutorTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\Tests\\\\Unit\\\\DataFixtures\\\\DocumentExecutorTest\\:\\:\\$executer\\.$#"
-			count: 4
-			path: src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/DataFixtures/DocumentExecutorTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\Tests\\\\Unit\\\\DataFixtures\\\\DocumentExecutorTest\\:\\:\\$fixture1\\.$#"
-			count: 3
-			path: src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/DataFixtures/DocumentExecutorTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\Tests\\\\Unit\\\\DataFixtures\\\\DocumentExecutorTest\\:\\:\\$initializer\\.$#"
-			count: 3
-			path: src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/DataFixtures/DocumentExecutorTest.php
-
-		-
-			message: "#^Access to private property \\$output of parent class PHPUnit\\\\Framework\\\\TestCase\\.$#"
-			count: 6
-			path: src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/DataFixtures/DocumentExecutorTest.php
 
 		-
 			message: "#^Class Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\DataFixtures\\\\DocumentExecutor constructor invoked with 3 parameters, 2 required\\.$#"
@@ -13484,11 +13429,6 @@ parameters:
 			message: "#^Property Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\Tests\\\\Unit\\\\Initialalizer\\\\RootPathPurgeInitializerTest\\:\\:\\$node type has no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Initialalizer/RootPathPurgeInitializerTest.php
-
-		-
-			message: "#^Access to private property \\$output of parent class PHPUnit\\\\Framework\\\\TestCase\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Initialalizer/WorkspaceInitializerTest.php
 
 		-
 			message: "#^Parameter \\#2 \\$haystack of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertCount\\(\\) expects Countable\\|iterable, mixed given\\.$#"
@@ -13719,11 +13659,6 @@ parameters:
 			message: "#^Method Sulu\\\\Bundle\\\\HttpCacheBundle\\\\Tests\\\\Unit\\\\CacheLifetime\\\\CacheLifetimeRequestStoreTest\\:\\:testSetCacheLifetime\\(\\) has parameter \\$previousCacheLifetime with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/CacheLifetime/CacheLifetimeRequestStoreTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\HttpCacheBundle\\\\Tests\\\\Unit\\\\DependencyInjection\\\\SuluHttpCacheExtensionTest\\:\\:\\$replacer\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/DependencyInjection/SuluHttpCacheExtensionTest.php
 
 		-
 			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertTrue\\(\\) with false will always evaluate to false\\.$#"
@@ -14056,17 +13991,7 @@ parameters:
 			path: src/Sulu/Bundle/LocationBundle/Tests/Unit/Controller/GeolocatorControllerTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\LocationBundle\\\\Tests\\\\Unit\\\\Geolocator\\\\GeolocatorResponseTest\\:\\:\\$location\\.$#"
-			count: 3
-			path: src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/GeolocatorResponseTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\LocationBundle\\\\Tests\\\\Unit\\\\Geolocator\\\\GeolocatorResponseTest\\:\\:\\$response\\.$#"
-			count: 3
-			path: src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/GeolocatorResponseTest.php
-
-		-
-			message: "#^Property Sulu\\\\Bundle\\\\LocationBundle\\\\Tests\\\\Unit\\\\Geolocator\\\\GeolocatorResponseTest\\:\\:\\$geolocatorResponse has no type specified\\.$#"
+			message: "#^Parameter \\#1 \\$location of method Sulu\\\\Bundle\\\\LocationBundle\\\\Geolocator\\\\GeolocatorResponse\\:\\:addLocation\\(\\) expects Sulu\\\\Bundle\\\\LocationBundle\\\\Geolocator\\\\GeolocatorLocation, PHPUnit\\\\Framework\\\\MockObject\\\\MockObject given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/GeolocatorResponseTest.php
 
@@ -19091,21 +19016,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaStreamControllerTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Controller\\\\MediaWebsiteControllerTest\\:\\:\\$audioType\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaWebsiteControllerTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Controller\\\\MediaWebsiteControllerTest\\:\\:\\$documentType\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaWebsiteControllerTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Controller\\\\MediaWebsiteControllerTest\\:\\:\\$videoType\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaWebsiteControllerTest.php
-
-		-
 			message: "#^Argument of an invalid type array\\<int, string\\>\\|false supplied for foreach, only iterables are supported\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaWebsiteControllerTest.php
@@ -19132,11 +19042,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Controller\\\\MediaWebsiteControllerTest\\:\\:createMedia\\(\\) has parameter \\$name with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaWebsiteControllerTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Controller\\\\MediaWebsiteControllerTest\\:\\:createMedia\\(\\) has parameter \\$type with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaWebsiteControllerTest.php
 
@@ -19186,11 +19091,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaWebsiteControllerTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Controller\\\\SmartContentItemControllerTest\\:\\:\\$collections\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/SmartContentItemControllerTest.php
-
-		-
 			message: "#^Cannot access offset '_embedded' on mixed\\.$#"
 			count: 10
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/SmartContentItemControllerTest.php
@@ -19232,11 +19132,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Controller\\\\SmartContentItemControllerTest\\:\\:createCollection\\(\\) has parameter \\$name with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/SmartContentItemControllerTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Controller\\\\SmartContentItemControllerTest\\:\\:createCollection\\(\\) has parameter \\$parent with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/SmartContentItemControllerTest.php
 
@@ -20154,31 +20049,6 @@ parameters:
 			message: "#^Parameter \\#3 \\$permissions of class Sulu\\\\Component\\\\Security\\\\Event\\\\PermissionUpdateEvent constructor expects array, null given\\.$#"
 			count: 2
 			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Search/EventListener/PermissionListenerTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Unit\\\\Search\\\\Subscriber\\\\MediaSearchSubscriberTest\\:\\:\\$collection\\.$#"
-			count: 3
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Search/Subscriber/MediaSearchSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Unit\\\\Search\\\\Subscriber\\\\MediaSearchSubscriberTest\\:\\:\\$field1\\.$#"
-			count: 5
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Search/Subscriber/MediaSearchSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Unit\\\\Search\\\\Subscriber\\\\MediaSearchSubscriberTest\\:\\:\\$field2\\.$#"
-			count: 5
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Search/Subscriber/MediaSearchSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Unit\\\\Search\\\\Subscriber\\\\MediaSearchSubscriberTest\\:\\:\\$field3\\.$#"
-			count: 5
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Search/Subscriber/MediaSearchSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Unit\\\\Search\\\\Subscriber\\\\MediaSearchSubscriberTest\\:\\:\\$logger\\.$#"
-			count: 3
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Search/Subscriber/MediaSearchSubscriberTest.php
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Unit\\\\Search\\\\Subscriber\\\\MediaSearchSubscriberTest\\:\\:setupSubscriber\\(\\) has parameter \\$collectionId with no type specified\\.$#"
@@ -23971,11 +23841,6 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201511171538.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\PageBundle\\\\Version201511240843\\:\\:\\$propertyFactory\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201511240843.php
-
-		-
 			message: "#^Call to an undefined method Sulu\\\\Component\\\\Content\\\\Metadata\\\\ItemMetadata\\:\\:getType\\(\\)\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201511240843.php
@@ -23983,11 +23848,6 @@ parameters:
 		-
 			message: "#^Cannot call method format\\(\\) on string\\.$#"
 			count: 1
-			path: src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201511240843.php
-
-		-
-			message: "#^Cannot call method get\\(\\) on Symfony\\\\Component\\\\DependencyInjection\\\\ContainerInterface\\|null\\.$#"
-			count: 6
 			path: src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201511240843.php
 
 		-
@@ -25971,11 +25831,6 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\Controller\\\\PageResourcelocatorControllerTest\\:\\:\\$documentManager\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageResourcelocatorControllerTest.php
-
-		-
 			message: "#^Cannot access offset 'id' on mixed\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageResourcelocatorControllerTest.php
@@ -26039,11 +25894,6 @@ parameters:
 			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\Controller\\\\PageResourcelocatorControllerTest\\:\\:\\$session is never read, only written\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageResourcelocatorControllerTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\Controller\\\\ResourcelocatorControllerTest\\:\\:\\$documentManager\\.$#"
-			count: 3
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/ResourcelocatorControllerTest.php
 
 		-
 			message: "#^Cannot access offset 'id' on mixed\\.$#"
@@ -27114,16 +26964,6 @@ parameters:
 			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\Mapper\\\\ContentMapperTest\\:\\:\\$session \\(Jackalope\\\\Session\\) does not accept Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\Session\\\\Session\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Mapper/ContentMapperTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\Markup\\\\LinkTagTest\\:\\:\\$accessControlManager\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Markup/LinkTagTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\Markup\\\\LinkTagTest\\:\\:\\$tokenStorage\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Markup/LinkTagTest.php
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\Markup\\\\LinkTagTest\\:\\:createContent\\(\\) has no return type specified\\.$#"
@@ -32086,11 +31926,6 @@ parameters:
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/CreateUserCommandTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\SecurityBundle\\\\Tests\\\\Functional\\\\Controller\\\\GroupControllerTest\\:\\:\\$em\\.$#"
-			count: 7
-			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/GroupControllerTest.php
-
-		-
 			message: "#^Cannot access property \\$_embedded on mixed\\.$#"
 			count: 4
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/GroupControllerTest.php
@@ -32354,16 +32189,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$user of method Sulu\\\\Bundle\\\\SecurityBundle\\\\Tests\\\\Functional\\\\Controller\\\\ResettingControllerTest\\:\\:getExpectedEmailData\\(\\) expects Sulu\\\\Bundle\\\\SecurityBundle\\\\Entity\\\\User, SuluSecurityBundle\\:User\\|null given\\.$#"
 			count: 3
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ResettingControllerTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\SecurityBundle\\\\Tests\\\\Functional\\\\Controller\\\\RoleControllerTest\\:\\:\\$permission1\\.$#"
-			count: 3
-			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\SecurityBundle\\\\Tests\\\\Functional\\\\Controller\\\\RoleControllerTest\\:\\:\\$permission2\\.$#"
-			count: 3
-			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
 
 		-
 			message: "#^Cannot access property \\$_embedded on mixed\\.$#"
@@ -34536,38 +34361,8 @@ parameters:
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\Export\\\\SnippetTest\\:\\:\\$snippet1\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Export/SnippetTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\Export\\\\SnippetTest\\:\\:\\$snippet2\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Export/SnippetTest.php
-
-		-
 			message: "#^Call to an undefined method Sulu\\\\Component\\\\Snippet\\\\Export\\\\SnippetExportInterface\\:\\:getExportData\\(\\)\\.$#"
 			count: 1
-			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Export/SnippetTest.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getStructure\\(\\)\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Export/SnippetTest.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setStructureType\\(\\)\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Export/SnippetTest.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setTitle\\(\\)\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Export/SnippetTest.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setWorkflowStage\\(\\)\\.$#"
-			count: 2
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Export/SnippetTest.php
 
 		-
@@ -37621,11 +37416,6 @@ parameters:
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Application/AppCache.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\WebsiteBundle\\\\Tests\\\\Application\\\\Kernel\\:\\:\\$name\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Tests/Application/Kernel.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Tests\\\\Application\\\\TestController\\:\\:index\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Application/TestController.php
@@ -37834,11 +37624,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$haystack of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringContainsString\\(\\) expects string, string\\|false given\\.$#"
 			count: 2
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/ErrorControllerTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\WebsiteBundle\\\\Tests\\\\Functional\\\\Controller\\\\SitemapControllerTest\\:\\:\\$anonymousRole\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/SitemapControllerTest.php
 
 		-
 			message: "#^Parameter \\#2 \\$string of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringStartsWith\\(\\) expects string, string\\|null given\\.$#"
@@ -38231,11 +38016,6 @@ parameters:
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/SegmentCacheListenerTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\WebsiteBundle\\\\Tests\\\\Unit\\\\EventListener\\\\SegmentSubscriberTest\\:\\:\\$requestAnalyzer\\.$#"
-			count: 5
-			path: src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/SegmentSubscriberTest.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Tests\\\\Unit\\\\EventListener\\\\SegmentSubscriberTest\\:\\:provideAddCookieHeader\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/SegmentSubscriberTest.php
@@ -38267,11 +38047,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Tests\\\\Unit\\\\EventListener\\\\SegmentSubscriberTest\\:\\:testAddCookieHeader\\(\\) has parameter \\$segmentKeys with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/SegmentSubscriberTest.php
-
-		-
-			message: "#^Property Sulu\\\\Bundle\\\\WebsiteBundle\\\\Tests\\\\Unit\\\\EventListener\\\\SegmentSubscriberTest\\:\\:\\$segmentSubscriber has no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/SegmentSubscriberTest.php
 
@@ -38339,11 +38114,6 @@ parameters:
 			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Tests\\\\Unit\\\\Routing\\\\RedirectExceptionSubscriberTest\\:\\:testRedirectPartialMatchResolve\\(\\) has parameter \\$requestUri with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RedirectExceptionSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\WebsiteBundle\\\\Tests\\\\Unit\\\\Sitemap\\\\SitemapGeneratorTest\\:\\:\\$contentTypeManager\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapGeneratorTest.php
 
 		-
 			message: "#^Call to an undefined method object\\:\\:setExtension\\(\\)\\.$#"
@@ -38464,11 +38234,6 @@ parameters:
 			message: "#^Property Sulu\\\\Bundle\\\\WebsiteBundle\\\\Tests\\\\Unit\\\\Sitemap\\\\SitemapGeneratorTest\\:\\:\\$contents type has no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapGeneratorTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Bundle\\\\WebsiteBundle\\\\Tests\\\\Unit\\\\Sitemap\\\\SitemapProviderPoolTest\\:\\:\\$providers\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapProviderPoolTest.php
 
 		-
 			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNull\\(\\) with DateTime will always evaluate to false\\.$#"
@@ -39043,11 +38808,6 @@ parameters:
 		-
 			message: "#^Call to method getFunctions\\(\\) on an unknown class Sulu\\\\Component\\\\Cache\\\\MemoizeTwigExtensionTrait\\.$#"
 			count: 1
-			path: src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTwigExtensionTraitTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$callback of function call_user_func expects callable\\(\\)\\: mixed, array\\<class\\-string, string\\>\\|\\(callable\\(\\)\\: mixed\\)\\|null given\\.$#"
-			count: 2
 			path: src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTwigExtensionTraitTest.php
 
 		-
@@ -46796,11 +46556,6 @@ parameters:
 			path: src/Sulu/Component/Content/Tests/Unit/Compat/StructureManagerTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\Content\\\\Tests\\\\Unit\\\\ContentTypeManagerTest\\:\\:\\$manager\\.$#"
-			count: 5
-			path: src/Sulu/Component/Content/Tests/Unit/ContentTypeManagerTest.php
-
-		-
 			message: "#^Method Sulu\\\\Component\\\\Content\\\\Tests\\\\Unit\\\\ContentTypeManagerTest\\:\\:provideHas\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Tests/Unit/ContentTypeManagerTest.php
@@ -46812,11 +46567,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Component\\\\Content\\\\Tests\\\\Unit\\\\ContentTypeManagerTest\\:\\:testHas\\(\\) has parameter \\$expected with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Tests/Unit/ContentTypeManagerTest.php
-
-		-
-			message: "#^Property Sulu\\\\Component\\\\Content\\\\Tests\\\\Unit\\\\ContentTypeManagerTest\\:\\:\\$container has no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Tests/Unit/ContentTypeManagerTest.php
 
@@ -51436,94 +51186,54 @@ parameters:
 			path: src/Sulu/Component/DocumentManager/Subscriber/Phpcr/ReorderSubscriber.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\ChildrenCollectionTest\\:\\:\\$childNode\\.$#"
-			count: 2
+			message: "#^Property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\ChildrenCollectionTest\\:\\:\\$childNode type has no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
+			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ChildrenCollectionTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\ChildrenCollectionTest\\:\\:\\$collection\\.$#"
-			count: 2
+			message: "#^Property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\ChildrenCollectionTest\\:\\:\\$parentNode type has no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
+			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ChildrenCollectionTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\ChildrenCollectionTest\\:\\:\\$dispatcher\\.$#"
-			count: 2
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ChildrenCollectionTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\ChildrenCollectionTest\\:\\:\\$parentNode\\.$#"
-			count: 2
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ChildrenCollectionTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\QueryResultCollectionTest\\:\\:\\$collection\\.$#"
-			count: 2
+			message: "#^Property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\QueryResultCollectionTest\\:\\:\\$node1 type has no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
+			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Collection/QueryResultCollectionTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\QueryResultCollectionTest\\:\\:\\$dispatcher\\.$#"
-			count: 2
+			message: "#^Property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\QueryResultCollectionTest\\:\\:\\$node2 type has no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
+			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Collection/QueryResultCollectionTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\QueryResultCollectionTest\\:\\:\\$node1\\.$#"
-			count: 2
+			message: "#^Property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\QueryResultCollectionTest\\:\\:\\$queryResult type has no value type specified in iterable type PHPCR\\\\Query\\\\QueryResultInterface\\.$#"
+			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Collection/QueryResultCollectionTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\QueryResultCollectionTest\\:\\:\\$node2\\.$#"
-			count: 2
+			message: "#^Property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\QueryResultCollectionTest\\:\\:\\$row1 type has no value type specified in iterable type PHPCR\\\\Query\\\\RowInterface\\.$#"
+			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Collection/QueryResultCollectionTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\QueryResultCollectionTest\\:\\:\\$queryResult\\.$#"
-			count: 2
+			message: "#^Property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\QueryResultCollectionTest\\:\\:\\$row2 type has no value type specified in iterable type PHPCR\\\\Query\\\\RowInterface\\.$#"
+			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Collection/QueryResultCollectionTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\QueryResultCollectionTest\\:\\:\\$row1\\.$#"
-			count: 3
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Collection/QueryResultCollectionTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\QueryResultCollectionTest\\:\\:\\$row2\\.$#"
-			count: 3
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Collection/QueryResultCollectionTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\ReferrerCollectionTest\\:\\:\\$collection\\.$#"
-			count: 2
+			message: "#^Property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\ReferrerCollectionTest\\:\\:\\$node type has no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
+			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ReferrerCollectionTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\ReferrerCollectionTest\\:\\:\\$dispatcher\\.$#"
-			count: 2
+			message: "#^Property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\ReferrerCollectionTest\\:\\:\\$reference type has no value type specified in iterable type PHPCR\\\\PropertyInterface\\.$#"
+			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ReferrerCollectionTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\ReferrerCollectionTest\\:\\:\\$node\\.$#"
-			count: 2
+			message: "#^Property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\ReferrerCollectionTest\\:\\:\\$referrerNode type has no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
+			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ReferrerCollectionTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\ReferrerCollectionTest\\:\\:\\$reference\\.$#"
-			count: 3
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ReferrerCollectionTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Collection\\\\ReferrerCollectionTest\\:\\:\\$referrerNode\\.$#"
-			count: 3
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ReferrerCollectionTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\Tests\\\\Unit\\\\DocumentAccessorTest\\:\\:\\$accessor\\.$#"
-			count: 3
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/DocumentAccessorTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\Tests\\\\Unit\\\\DocumentAccessorTest\\:\\:\\$object\\.$#"
-			count: 2
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/DocumentAccessorTest.php
 
 		-
 			message: "#^Method Sulu\\\\Component\\\\DocumentManager\\\\Tests\\\\Unit\\\\TestAccessObject\\:\\:getPrivateProperty\\(\\) has no return type specified\\.$#"
@@ -51541,43 +51251,8 @@ parameters:
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/DocumentAccessorTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\tests\\\\Unit\\\\DocumentHelperTest\\:\\:\\$document\\.$#"
-			count: 2
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/DocumentHelperTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\tests\\\\Unit\\\\DocumentHelperTest\\:\\:\\$titleDocument\\.$#"
-			count: 3
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/DocumentHelperTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\tests\\\\Unit\\\\DocumentInspectorTest\\:\\:\\$document\\.$#"
-			count: 15
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/DocumentInspectorTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\tests\\\\Unit\\\\DocumentInspectorTest\\:\\:\\$documentInspector\\.$#"
-			count: 8
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/DocumentInspectorTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\tests\\\\Unit\\\\DocumentInspectorTest\\:\\:\\$documentRegistry\\.$#"
-			count: 7
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/DocumentInspectorTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\tests\\\\Unit\\\\DocumentInspectorTest\\:\\:\\$node\\.$#"
-			count: 11
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/DocumentInspectorTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\tests\\\\Unit\\\\DocumentInspectorTest\\:\\:\\$pathRegistry\\.$#"
+			message: "#^Property Sulu\\\\Component\\\\DocumentManager\\\\tests\\\\Unit\\\\DocumentInspectorTest\\:\\:\\$node type has no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
 			count: 1
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/DocumentInspectorTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\tests\\\\Unit\\\\DocumentInspectorTest\\:\\:\\$proxyFactory\\.$#"
-			count: 2
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/DocumentInspectorTest.php
 
 		-
@@ -51796,13 +51471,8 @@ parameters:
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/DocumentManagerTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\tests\\\\Unit\\\\DocumentRegistryTest\\:\\:\\$document\\.$#"
-			count: 17
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/DocumentRegistryTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\tests\\\\Unit\\\\DocumentRegistryTest\\:\\:\\$node\\.$#"
-			count: 14
+			message: "#^Property Sulu\\\\Component\\\\DocumentManager\\\\tests\\\\Unit\\\\DocumentRegistryTest\\:\\:\\$node type has no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
+			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/DocumentRegistryTest.php
 
 		-
@@ -51819,11 +51489,6 @@ parameters:
 			message: "#^Property Sulu\\\\Component\\\\DocumentManager\\\\tests\\\\Unit\\\\NameResolverTest\\:\\:\\$parentNode type has no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/NameResolverTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\tests\\\\Unit\\\\NamespaceRegistryTest\\:\\:\\$registry\\.$#"
-			count: 3
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/NamespaceRegistryTest.php
 
 		-
 			message: "#^Call to an undefined method Jackalope\\\\Workspace\\:\\:reveal\\(\\)\\.$#"
@@ -51906,23 +51571,8 @@ parameters:
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/ProxyFactoryTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Query\\\\QueryTest\\:\\:\\$dispatcher\\.$#"
-			count: 2
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Query/QueryTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Query\\\\QueryTest\\:\\:\\$phpcrQuery\\.$#"
-			count: 5
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Query/QueryTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Query\\\\QueryTest\\:\\:\\$phpcrResult\\.$#"
-			count: 3
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Query/QueryTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Query\\\\QueryTest\\:\\:\\$query\\.$#"
-			count: 6
+			message: "#^Property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Query\\\\QueryTest\\:\\:\\$phpcrResult type has no value type specified in iterable type PHPCR\\\\Query\\\\QueryResultInterface\\.$#"
+			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Query/QueryTest.php
 
 		-
@@ -51941,47 +51591,22 @@ parameters:
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Slugifier/NodeNameSlugifierTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\Behavior\\\\LocaleSubscriberTest\\:\\:\\$accessor\\.$#"
-			count: 2
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\Behavior\\\\LocaleSubscriberTest\\:\\:\\$document\\.$#"
-			count: 4
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\Behavior\\\\LocaleSubscriberTest\\:\\:\\$hydrateEvent\\.$#"
-			count: 6
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\Behavior\\\\LocaleSubscriberTest\\:\\:\\$node\\.$#"
-			count: 1
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\Behavior\\\\LocaleSubscriberTest\\:\\:\\$notImplementing\\.$#"
-			count: 2
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\Behavior\\\\LocaleSubscriberTest\\:\\:\\$registry\\.$#"
-			count: 2
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\Behavior\\\\LocaleSubscriberTest\\:\\:\\$subscriber\\.$#"
-			count: 3
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
-
-		-
 			message: "#^Method Sulu\\\\Component\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\Behavior\\\\TestLocaleDocument\\:\\:setLocale\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
 
 		-
 			message: "#^Method Sulu\\\\Component\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\Behavior\\\\TestLocaleDocument\\:\\:setOriginalLocale\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
+
+		-
+			message: "#^Property Sulu\\\\Component\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\Behavior\\\\LocaleSubscriberTest\\:\\:\\$node is never read, only written\\.$#"
+			count: 1
+			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
+
+		-
+			message: "#^Property Sulu\\\\Component\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\Behavior\\\\LocaleSubscriberTest\\:\\:\\$node type has no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
 
@@ -52046,42 +51671,17 @@ parameters:
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/PathSubscriberTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\Behavior\\\\Mapping\\\\UuidSubscriberTest\\:\\:\\$accessor\\.$#"
-			count: 2
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/UuidSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\Behavior\\\\Mapping\\\\UuidSubscriberTest\\:\\:\\$document\\.$#"
-			count: 3
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/UuidSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\Behavior\\\\Mapping\\\\UuidSubscriberTest\\:\\:\\$hydrateEvent\\.$#"
-			count: 7
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/UuidSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\Behavior\\\\Mapping\\\\UuidSubscriberTest\\:\\:\\$node\\.$#"
-			count: 3
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/UuidSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\Behavior\\\\Mapping\\\\UuidSubscriberTest\\:\\:\\$notImplementing\\.$#"
-			count: 2
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/UuidSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\Behavior\\\\Mapping\\\\UuidSubscriberTest\\:\\:\\$subscriber\\.$#"
-			count: 3
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/UuidSubscriberTest.php
-
-		-
 			message: "#^Property Sulu\\\\Component\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\Behavior\\\\Mapping\\\\TestUuidDocument\\:\\:\\$uuid has no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/UuidSubscriberTest.php
 
 		-
 			message: "#^Property Sulu\\\\Component\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\Behavior\\\\Mapping\\\\TestUuidDocument\\:\\:\\$uuid is never written, only read\\.$#"
+			count: 1
+			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/UuidSubscriberTest.php
+
+		-
+			message: "#^Property Sulu\\\\Component\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\Behavior\\\\Mapping\\\\UuidSubscriberTest\\:\\:\\$node type has no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/UuidSubscriberTest.php
 
@@ -52211,32 +51811,7 @@ parameters:
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/VersionSubscriberTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\tests\\\\Unit\\\\Subscriber\\\\Core\\\\InstantiatorSubscriberTest\\:\\:\\$createEvent\\.$#"
-			count: 4
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/InstantiatorSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\tests\\\\Unit\\\\Subscriber\\\\Core\\\\InstantiatorSubscriberTest\\:\\:\\$hydrateEvent\\.$#"
-			count: 7
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/InstantiatorSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\tests\\\\Unit\\\\Subscriber\\\\Core\\\\InstantiatorSubscriberTest\\:\\:\\$metadata\\.$#"
-			count: 5
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/InstantiatorSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\tests\\\\Unit\\\\Subscriber\\\\Core\\\\InstantiatorSubscriberTest\\:\\:\\$metadataFactory\\.$#"
-			count: 3
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/InstantiatorSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\DocumentManager\\\\tests\\\\Unit\\\\Subscriber\\\\Core\\\\InstantiatorSubscriberTest\\:\\:\\$node\\.$#"
-			count: 3
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/InstantiatorSubscriberTest.php
-
-		-
-			message: "#^Property Sulu\\\\Component\\\\DocumentManager\\\\tests\\\\Unit\\\\Subscriber\\\\Core\\\\InstantiatorSubscriberTest\\:\\:\\$subscriber has no type specified\\.$#"
+			message: "#^Property Sulu\\\\Component\\\\DocumentManager\\\\tests\\\\Unit\\\\Subscriber\\\\Core\\\\InstantiatorSubscriberTest\\:\\:\\$node type has no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/InstantiatorSubscriberTest.php
 
@@ -52249,41 +51824,6 @@ parameters:
 			message: "#^Property Sulu\\\\Component\\\\DocumentManager\\\\tests\\\\Unit\\\\Subscriber\\\\Core\\\\RegistratorSubscriberTest\\:\\:\\$node type has no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/RegistratorSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Subscriber\\\\Phpcr\\\\FindSubscriberTest\\:\\:\\$document\\.$#"
-			count: 1
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Subscriber\\\\Phpcr\\\\FindSubscriberTest\\:\\:\\$eventDispatcher\\.$#"
-			count: 2
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Subscriber\\\\Phpcr\\\\FindSubscriberTest\\:\\:\\$metadata\\.$#"
-			count: 3
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Subscriber\\\\Phpcr\\\\FindSubscriberTest\\:\\:\\$metadataFactory\\.$#"
-			count: 5
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Subscriber\\\\Phpcr\\\\FindSubscriberTest\\:\\:\\$node\\.$#"
-			count: 2
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Subscriber\\\\Phpcr\\\\FindSubscriberTest\\:\\:\\$nodeManager\\.$#"
-			count: 2
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Subscriber\\\\Phpcr\\\\FindSubscriberTest\\:\\:\\$subscriber\\.$#"
-			count: 2
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
 
 		-
 			message: "#^Method Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Subscriber\\\\Phpcr\\\\FindSubscriberTest\\:\\:doTestFind\\(\\) has no return type specified\\.$#"
@@ -52316,6 +51856,11 @@ parameters:
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
 
 		-
+			message: "#^Property Sulu\\\\Comonent\\\\DocumentManager\\\\tests\\\\Unit\\\\Subscriber\\\\Phpcr\\\\FindSubscriberTest\\:\\:\\$node type has no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
+			count: 1
+			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
+
+		-
 			message: "#^Property Sulu\\\\Comonent\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\GeneralSubscriberTest\\:\\:\\$node type has no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/GeneralSubscriberTest.php
@@ -52331,53 +51876,8 @@ parameters:
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/QuerySubscriberTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\RemoveSubscriberTest\\:\\:\\$document\\.$#"
-			count: 2
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RemoveSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\RemoveSubscriberTest\\:\\:\\$documentRegistry\\.$#"
+			message: "#^Property Sulu\\\\Comonent\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\RemoveSubscriberTest\\:\\:\\$node type has no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
 			count: 1
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RemoveSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\RemoveSubscriberTest\\:\\:\\$node\\.$#"
-			count: 2
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RemoveSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\RemoveSubscriberTest\\:\\:\\$node1\\.$#"
-			count: 1
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RemoveSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\RemoveSubscriberTest\\:\\:\\$node2\\.$#"
-			count: 1
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RemoveSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\RemoveSubscriberTest\\:\\:\\$nodeManager\\.$#"
-			count: 1
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RemoveSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\RemoveSubscriberTest\\:\\:\\$property1\\.$#"
-			count: 1
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RemoveSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\RemoveSubscriberTest\\:\\:\\$property2\\.$#"
-			count: 1
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RemoveSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\RemoveSubscriberTest\\:\\:\\$removeEvent\\.$#"
-			count: 3
-			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RemoveSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Comonent\\\\DocumentManager\\\\Tests\\\\Unit\\\\Subscriber\\\\RemoveSubscriberTest\\:\\:\\$subscriber\\.$#"
-			count: 2
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RemoveSubscriberTest.php
 
 		-
@@ -53051,17 +52551,7 @@ parameters:
 			path: src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\Media\\\\SystemCollections\\\\SystemCollectionBuilder\\:\\:\\$container\\.$#"
-			count: 1
-			path: src/Sulu/Component/Media/SystemCollections/SystemCollectionBuilder.php
-
-		-
 			message: "#^Method Sulu\\\\Component\\\\Media\\\\SystemCollections\\\\SystemCollectionBuilder\\:\\:getDependencies\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Component/Media/SystemCollections/SystemCollectionBuilder.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Media\\\\SystemCollections\\\\SystemCollectionBuilder\\:\\:setContainer\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Media/SystemCollections/SystemCollectionBuilder.php
 
@@ -53911,47 +53401,22 @@ parameters:
 			path: src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/OrderByTraitTest.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\Persistence\\\\Tests\\\\Unit\\\\EventSubscriber\\\\ORM\\\\TimestampableSubscriberTest\\:\\:\\$classMetadata\\.$#"
-			count: 11
-			path: src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\Persistence\\\\Tests\\\\Unit\\\\EventSubscriber\\\\ORM\\\\TimestampableSubscriberTest\\:\\:\\$entityManager\\.$#"
-			count: 3
-			path: src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\Persistence\\\\Tests\\\\Unit\\\\EventSubscriber\\\\ORM\\\\TimestampableSubscriberTest\\:\\:\\$lifecycleEvent\\.$#"
-			count: 4
-			path: src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\Persistence\\\\Tests\\\\Unit\\\\EventSubscriber\\\\ORM\\\\TimestampableSubscriberTest\\:\\:\\$loadClassMetadataEvent\\.$#"
-			count: 3
-			path: src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\Persistence\\\\Tests\\\\Unit\\\\EventSubscriber\\\\ORM\\\\TimestampableSubscriberTest\\:\\:\\$refl\\.$#"
-			count: 3
-			path: src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\Persistence\\\\Tests\\\\Unit\\\\EventSubscriber\\\\ORM\\\\TimestampableSubscriberTest\\:\\:\\$subscriber\\.$#"
-			count: 3
-			path: src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\Persistence\\\\Tests\\\\Unit\\\\EventSubscriber\\\\ORM\\\\TimestampableSubscriberTest\\:\\:\\$timestampableObject\\.$#"
-			count: 3
-			path: src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
-
-		-
 			message: "#^Method Sulu\\\\Component\\\\Persistence\\\\Tests\\\\Unit\\\\EventSubscriber\\\\ORM\\\\TimestampableSubscriberTest\\:\\:provideOnPreUpdate\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
 
 		-
 			message: "#^Method Sulu\\\\Component\\\\Persistence\\\\Tests\\\\Unit\\\\EventSubscriber\\\\ORM\\\\TimestampableSubscriberTest\\:\\:testOnPreUpdate\\(\\) has parameter \\$created with no type specified\\.$#"
+			count: 1
+			path: src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
+
+		-
+			message: "#^Property Sulu\\\\Component\\\\Persistence\\\\Tests\\\\Unit\\\\EventSubscriber\\\\ORM\\\\TimestampableSubscriberTest\\:\\:\\$refl with generic class ReflectionClass does not specify its types\\: T$#"
+			count: 1
+			path: src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
+
+		-
+			message: "#^Property Sulu\\\\Component\\\\Persistence\\\\Tests\\\\Unit\\\\EventSubscriber\\\\ORM\\\\TimestampableSubscriberTest\\:\\:\\$timestampableObject \\(Prophecy\\\\Prophecy\\\\ObjectProphecy\\<stdClass\\>\\) does not accept Prophecy\\\\Prophecy\\\\ObjectProphecy\\<stdClass&Sulu\\\\Component\\\\Persistence\\\\Model\\\\TimestampableInterface\\>\\.$#"
 			count: 1
 			path: src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
 
@@ -56151,11 +55616,6 @@ parameters:
 			path: src/Sulu/Component/Rest/RestHelperInterface.php
 
 		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\Rest\\\\Tests\\\\Functional\\\\ListBuilder\\\\Metadata\\\\FieldDescriptorFactoryTest\\:\\:\\$fieldDescriptorFactory\\.$#"
-			count: 10
-			path: src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/FieldDescriptorFactoryTest.php
-
-		-
 			message: "#^Call to an undefined method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\FieldDescriptorInterface\\:\\:getJoins\\(\\)\\.$#"
 			count: 1
 			path: src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/FieldDescriptorFactoryTest.php
@@ -56214,11 +55674,6 @@ parameters:
 			message: "#^Property Sulu\\\\Component\\\\Rest\\\\Tests\\\\Unit\\\\DoctrineRestHelperTest\\:\\:\\$listRestHelper has unknown class PHPUnit\\\\Framework\\\\MockObject_MockObject as its type\\.$#"
 			count: 1
 			path: src/Sulu/Component/Rest/Tests/Unit/DoctrineRestHelperTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\Rest\\\\Tests\\\\Unit\\\\ListBuilder\\\\Doctrine\\\\DoctrineListBuilderTest\\:\\:\\$systemStore\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
 
 		-
 			message: "#^Method Sulu\\\\Component\\\\Rest\\\\Tests\\\\Unit\\\\ListBuilder\\\\Doctrine\\\\DoctrineListBuilderTest\\:\\:readObjectAttribute\\(\\) has no return type specified\\.$#"
@@ -60799,21 +60254,6 @@ parameters:
 			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Tests\\\\Unit\\\\WebspaceManagerTest\\:\\:testFindPortalInformationByUrlWithInvalidSuffix\\(\\) has parameter \\$url with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\Webspace\\\\Tests\\\\Unit\\\\PortalInformationTest\\:\\:\\$localization\\.$#"
-			count: 3
-			path: src/Sulu/Component/Webspace/Tests/Unit/PortalInformationTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\Webspace\\\\Tests\\\\Unit\\\\PortalInformationTest\\:\\:\\$portal\\.$#"
-			count: 3
-			path: src/Sulu/Component/Webspace/Tests/Unit/PortalInformationTest.php
-
-		-
-			message: "#^Access to an undefined property Sulu\\\\Component\\\\Webspace\\\\Tests\\\\Unit\\\\PortalInformationTest\\:\\:\\$webspace\\.$#"
-			count: 3
-			path: src/Sulu/Component/Webspace/Tests/Unit/PortalInformationTest.php
 
 		-
 			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Tests\\\\Unit\\\\PortalInformationTest\\:\\:provideUrl\\(\\) has no return type specified\\.$#"

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
@@ -2417,8 +2417,6 @@ class AccountControllerTest extends SuluTestCase
         $category->setKey($name);
         $category->setDefaultLocale($locale);
 
-        $this->category = $category;
-
         // name for first category
         $categoryTrans = $this->getContainer()->get('sulu.repository.category_translation')->createNew();
         $categoryTrans->setLocale($locale);

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountMediaControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountMediaControllerTest.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\ContactBundle\Tests\Functional\Controller;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ObjectRepository;
 use Sulu\Bundle\ActivityBundle\Domain\Model\ActivityInterface;
 use Sulu\Bundle\ContactBundle\Entity\Account;
@@ -59,6 +60,11 @@ class AccountMediaControllerTest extends SuluTestCase
      * @var ObjectRepository<ActivityInterface>
      */
     private $activityRepository;
+
+    /**
+     * @var EntityManagerInterface
+     */
+    private $em;
 
     public function setUp(): void
     {

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
@@ -2803,8 +2803,6 @@ class ContactControllerTest extends SuluTestCase
         $category->setKey($name);
         $category->setDefaultLocale($locale);
 
-        $this->category = $category;
-
         // name for first category
         $categoryTrans = $this->getContainer()->get('sulu.repository.category_translation')->createNew();
         $categoryTrans->setLocale($locale);

--- a/src/Sulu/Bundle/CoreBundle/Tests/Unit/Cache/StructureWarmerTest.php
+++ b/src/Sulu/Bundle/CoreBundle/Tests/Unit/Cache/StructureWarmerTest.php
@@ -12,14 +12,25 @@
 namespace Sulu\Bundle\CoreBundle\Tests\Unit\Cache;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\CoreBundle\Cache\StructureWarmer;
+use Sulu\Component\Content\Compat\StructureManagerInterface;
 
 class StructureWarmerTest extends TestCase
 {
+    /**
+     * @var ObjectProphecy<StructureManagerInterface>
+     */
+    private $structureManager;
+
+    /**
+     * @var StructureWarmer
+     */
+    private $warmer;
+
     public function setUp(): void
     {
-        parent::setUp();
-        $this->structureManager = $this->prophesize('Sulu\Component\Content\Compat\StructureManagerInterface');
+        $this->structureManager = $this->prophesize(StructureManagerInterface::class);
         $this->warmer = new StructureWarmer($this->structureManager->reveal());
     }
 

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/InitializeCommandTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/InitializeCommandTest.php
@@ -34,6 +34,11 @@ class InitializeCommandTest extends TestCase
      */
     private $initializer;
 
+    /**
+     * @var InitializeCommand
+     */
+    private $command;
+
     public function setUp(): void
     {
         $this->questionHelper = $this->prophesize(QuestionHelper::class);

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/DataFixtures/DocumentExecutorTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/DataFixtures/DocumentExecutorTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\DocumentManagerBundle\Tests\Unit\DataFixtures;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\DocumentManagerBundle\DataFixtures\DocumentExecutor;
 use Sulu\Bundle\DocumentManagerBundle\DataFixtures\DocumentFixtureInterface;
 use Sulu\Bundle\DocumentManagerBundle\Initializer\Initializer;
@@ -20,6 +21,31 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 class DocumentExecutorTest extends TestCase
 {
+    /**
+     * @var ObjectProphecy<DocumentManager>
+     */
+    private $documentManager;
+
+    /**
+     * @var ObjectProphecy<Initializer>
+     */
+    private $initializer;
+
+    /**
+     * @var BufferedOutput
+     */
+    private $output;
+
+    /**
+     * @var ObjectProphecy<DocumentFixtureInterface>
+     */
+    private $fixture1;
+
+    /**
+     * @var DocumentExecutor
+     */
+    private $executer;
+
     public function setUp(): void
     {
         $this->documentManager = $this->prophesize(DocumentManager::class);

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Initialalizer/WorkspaceInitializerTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Initialalizer/WorkspaceInitializerTest.php
@@ -38,11 +38,6 @@ class WorkspaceInitializerTest extends TestCase
     private $connectionRegistry;
 
     /**
-     * @var WorkspaceInitializer
-     */
-    private $initializer;
-
-    /**
      * @var ObjectProphecy<WorkspaceInterface>
      */
     private $workspace1;
@@ -51,6 +46,16 @@ class WorkspaceInitializerTest extends TestCase
      * @var ObjectProphecy<WorkspaceInterface>
      */
     private $workspace2;
+
+    /**
+     * @var BufferedOutput
+     */
+    private $output;
+
+    /**
+     * @var WorkspaceInitializer
+     */
+    private $initializer;
 
     public function setUp(): void
     {

--- a/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/DependencyInjection/SuluHttpCacheExtensionTest.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/DependencyInjection/SuluHttpCacheExtensionTest.php
@@ -45,6 +45,11 @@ class SuluHttpCacheExtensionTest extends AbstractExtensionTestCase
     private $requestStack;
 
     /**
+     * @var ObjectProphecy<ReplacerInterface>
+     */
+    private $replacer;
+
+    /**
      * @var ReplacerInterface
      */
     /**

--- a/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/GeolocatorResponseTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/GeolocatorResponseTest.php
@@ -11,17 +11,27 @@
 
 namespace Sulu\Bundle\LocationBundle\Tests\Unit\Geolocator;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorLocation;
 use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorResponse;
 
 class GeolocatorResponseTest extends TestCase
 {
-    protected $geolocatorResponse;
+    /**
+     * @var GeolocatorResponse
+     */
+    private $response;
+
+    /**
+     * @var MockObject
+     */
+    private $location;
 
     public function setUp(): void
     {
         $this->response = new GeolocatorResponse();
-        $this->location = $this->getMockBuilder('Sulu\Bundle\LocationBundle\Geolocator\GeolocatorLocation')->getMock();
+        $this->location = $this->getMockBuilder(GeolocatorLocation::class)->getMock();
     }
 
     public function testToArray(): void

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaWebsiteControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaWebsiteControllerTest.php
@@ -123,27 +123,13 @@ class MediaWebsiteControllerTest extends WebsiteTestCase
         $this->em->flush();
     }
 
-    protected function createMedia($name, $locale = 'en-gb', $type = 'image')
+    protected function createMedia($name, $locale = 'en-gb')
     {
         $media = new Media();
 
-        if ('image' === $type) {
-            $media->setType($this->imageType);
-            $extension = 'jpeg';
-            $mimeType = 'image/jpg';
-        } elseif ('audio' === $type) {
-            $media->setType($this->audioType);
-            $extension = 'mp3';
-            $mimeType = 'audio/mp3';
-        } elseif ('video' === $type) {
-            $media->setType($this->videoType);
-            $extension = 'mp4';
-            $mimeType = 'video/mp4';
-        } else {
-            $media->setType($this->documentType);
-            $extension = 'txt';
-            $mimeType = 'text/plain';
-        }
+        $media->setType($this->imageType);
+        $extension = 'jpeg';
+        $mimeType = 'image/jpg';
 
         // create file
         $file = new File();

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/SmartContentItemControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/SmartContentItemControllerTest.php
@@ -142,7 +142,7 @@ class SmartContentItemControllerTest extends SuluTestCase
         return $media;
     }
 
-    private function createCollection($name, $parent = null)
+    private function createCollection($name)
     {
         $collection = new Collection();
         $collectionType = new CollectionType();
@@ -156,11 +156,6 @@ class SmartContentItemControllerTest extends SuluTestCase
         $collection->setType($collectionType);
         $collectionMeta->setCollection($collection);
         $collection->addMeta($collectionMeta);
-
-        if (null !== $parent) {
-            $collection->setParent($this->collections[$parent]);
-            $this->collections[$parent]->addChildren($collection);
-        }
 
         $this->em->persist($collection);
         $this->em->persist($collectionMeta);

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Search/Subscriber/MediaSearchSubscriberTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Search/Subscriber/MediaSearchSubscriberTest.php
@@ -85,6 +85,31 @@ class MediaSearchSubscriberTest extends TestCase
      */
     private $factory;
 
+    /**
+     * @var ObjectProphecy<LoggerInterface>
+     */
+    private $logger;
+
+    /**
+     * @var ObjectProphecy<Collection>
+     */
+    private $collection;
+
+    /**
+     * @var ObjectProphecy<Field>
+     */
+    private $field1;
+
+    /**
+     * @var ObjectProphecy<Field>
+     */
+    private $field2;
+
+    /**
+     * @var ObjectProphecy<Field>
+     */
+    private $field3;
+
     public function setUp(): void
     {
         $this->mediaManager = $this->prophesize(MediaManagerInterface::class);

--- a/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201511240843.php
+++ b/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201511240843.php
@@ -65,12 +65,15 @@ class Version201511240843 implements VersionInterface, ContainerAwareInterface
 
     public function setContainer(?ContainerInterface $container = null)
     {
+        if (null === $container) {
+            throw new \RuntimeException('Expected "container" to be set.');
+        }
+
         $this->structureMetadataFactory = $container->get('sulu_page.structure.factory');
         $this->propertyEncoder = $container->get('sulu_document_manager.property_encoder');
         $this->localizationManager = $container->get('sulu.core.localization_manager');
         $this->documentManager = $container->get('sulu_document_manager.document_manager');
         $this->documentInspector = $container->get('sulu_document_manager.document_inspector');
-        $this->propertyFactory = $container->get('sulu_page.compat.structure.legacy_property_factory');
     }
 
     /**

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageResourcelocatorControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageResourcelocatorControllerTest.php
@@ -12,7 +12,9 @@
 namespace Sulu\Bundle\PageBundle\Tests\Functional\Controller;
 
 use PHPCR\SessionInterface;
+use Sulu\Bundle\PageBundle\Document\BasePageDocument;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 /**
@@ -29,6 +31,11 @@ class PageResourcelocatorControllerTest extends SuluTestCase
      * @var KernelBrowser
      */
     protected $client;
+
+    /**
+     * @var DocumentManagerInterface
+     */
+    private $documentManager;
 
     /**
      * @var array
@@ -100,6 +107,7 @@ class PageResourcelocatorControllerTest extends SuluTestCase
             ],
         ];
 
+        /** @var BasePageDocument $homeDocument */
         $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         $this->client->jsonRequest(

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/ResourcelocatorControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/ResourcelocatorControllerTest.php
@@ -11,7 +11,9 @@
 
 namespace Sulu\Bundle\PageBundle\Tests\Functional\Controller;
 
+use Sulu\Bundle\PageBundle\Document\BasePageDocument;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 class ResourcelocatorControllerTest extends SuluTestCase
@@ -20,6 +22,11 @@ class ResourcelocatorControllerTest extends SuluTestCase
      * @var KernelBrowser
      */
     private $client;
+
+    /**
+     * @var DocumentManagerInterface
+     */
+    private $documentManager;
 
     public function setUp(): void
     {
@@ -43,6 +50,7 @@ class ResourcelocatorControllerTest extends SuluTestCase
 
     public function testGenerateWithParent(): void
     {
+        /** @var BasePageDocument $homeDocument */
         $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         $this->client->jsonRequest(
@@ -69,6 +77,7 @@ class ResourcelocatorControllerTest extends SuluTestCase
 
     public function testGenerateWithConflict(): void
     {
+        /** @var BasePageDocument $homeDocument */
         $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         $this->client->jsonRequest(

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Markup/LinkTagTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Markup/LinkTagTest.php
@@ -33,6 +33,16 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class LinkTagTest extends TestCase
 {
     /**
+     * @var ObjectProphecy<AccessControlManagerInterface>
+     */
+    private $accessControlManager;
+
+    /**
+     * @var ObjectProphecy<TokenStorageInterface>
+     */
+    private $tokenStorage;
+
+    /**
      * @var ObjectProphecy<ContentRepositoryInterface>
      */
     private $contentRepository;

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/GroupControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/GroupControllerTest.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\SecurityBundle\Tests\Functional\Controller;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\SecurityBundle\Entity\Group;
 use Sulu\Bundle\SecurityBundle\Entity\Role;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
@@ -37,6 +38,11 @@ class GroupControllerTest extends SuluTestCase
      * @var Group
      */
     protected $group2;
+
+    /**
+     * @var EntityManagerInterface
+     */
+    private $em;
 
     /**
      * @var KernelBrowser

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
@@ -53,6 +53,16 @@ class RoleControllerTest extends SuluTestCase
     protected $securityType2;
 
     /**
+     * @var Permission
+     */
+    private $permission1;
+
+    /**
+     * @var Permission
+     */
+    private $permission2;
+
+    /**
      * @var KernelBrowser
      */
     private $client;

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Export/SnippetTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Export/SnippetTest.php
@@ -34,6 +34,16 @@ class SnippetTest extends SuluTestCase
     private $documentManager;
 
     /**
+     * @var SnippetDocument
+     */
+    private $snippet1;
+
+    /**
+     * @var SnippetDocument
+     */
+    private $snippet2;
+
+    /**
      * @var ExtensionManagerInterface
      */
     private $extensionManager;
@@ -76,7 +86,9 @@ class SnippetTest extends SuluTestCase
      */
     protected function prepareData()
     {
-        $this->snippet1 = $this->documentManager->create('snippet');
+        /** @var SnippetDocument $snippet1 */
+        $snippet1 = $this->documentManager->create('snippet');
+        $this->snippet1 = $snippet1;
         $this->snippet1->setStructureType('hotel');
         $this->snippet1->setTitle('ElePHPant1');
         $this->snippet1->getStructure()->bind([
@@ -86,7 +98,9 @@ class SnippetTest extends SuluTestCase
         $this->documentManager->persist($this->snippet1, 'en');
         $this->documentManager->flush();
 
-        $this->snippet2 = $this->documentManager->create('snippet');
+        /** @var SnippetDocument $snippet2 */
+        $snippet2 = $this->documentManager->create('snippet');
+        $this->snippet2 = $snippet2;
         $this->snippet2->setStructureType('hotel');
         $this->snippet2->setTitle('ElePHPant2');
         $this->snippet2->getStructure()->bind([

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/Kernel.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/Kernel.php
@@ -24,8 +24,6 @@ class Kernel extends SuluTestKernel
     public function __construct($environment, $debug, $suluContext = self::CONTEXT_ADMIN)
     {
         parent::__construct($environment, $debug, $suluContext);
-
-        $this->name = $suluContext;
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader): void

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/SitemapControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/SitemapControllerTest.php
@@ -13,10 +13,16 @@ namespace Sulu\Bundle\WebsiteBundle\Tests\Functional\Controller;
 
 use Sulu\Bundle\SecurityBundle\Entity\Permission;
 use Sulu\Bundle\TestBundle\Testing\WebsiteTestCase;
+use Sulu\Component\Security\Authentication\RoleInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 class SitemapControllerTest extends WebsiteTestCase
 {
+    /**
+     * @var RoleInterface
+     */
+    private $anonymousRole;
+
     /**
      * @var KernelBrowser
      */

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/SegmentSubscriberTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/SegmentSubscriberTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\WebsiteBundle\Tests\Unit\EventListener;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\WebsiteBundle\EventListener\SegmentSubscriber;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Segment;
@@ -23,10 +24,15 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class SegmentSubscriberTest extends TestCase
 {
-    /*
+    /**
      * @var SegmentSubscriber
      */
     private $segmentSubscriber;
+
+    /**
+     * @var ObjectProphecy<RequestAnalyzerInterface>
+     */
+    private $requestAnalyzer;
 
     public function setUp(): void
     {

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapGeneratorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapGeneratorTest.php
@@ -86,6 +86,11 @@ class SitemapGeneratorTest extends SuluTestCase
     private $languageNamespace;
 
     /**
+     * @var ContentTypeManagerInterface
+     */
+    private $contentTypeManager;
+
+    /**
      * @var NodeInterface
      */
     private $contents;
@@ -106,6 +111,7 @@ class SitemapGeneratorTest extends SuluTestCase
         $this->extensionManager = $this->getContainer()->get('sulu_page.extension.manager');
         $this->languageNamespace = $this->getContainer()->getParameter('sulu.content.language.namespace');
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
+        $this->contentTypeManager = $this->getContainer()->get('sulu.content.type_manager');
 
         $this->getContainer()->get('sulu_security.system_store')->setSystem('sulu_io');
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapProviderPoolTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapProviderPoolTest.php
@@ -21,6 +21,11 @@ use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapProviderPool;
 class SitemapProviderPoolTest extends TestCase
 {
     /**
+     * @var mixed[]
+     */
+    public $providers;
+
+    /**
      * @var ObjectProphecy<SitemapProviderInterface>
      */
     public $pagesSitemapProvider;

--- a/src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTwigExtensionTraitTest.php
+++ b/src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTwigExtensionTraitTest.php
@@ -112,11 +112,14 @@ class MemoizeTwigExtensionTraitTest extends TestCase
 
         $this->assertInstanceOf(TwigFunction::class, $result[0]);
         $this->assertEquals('sulu_content_load', $result[0]->getName());
+        $callable1 = $result[0]->getCallable();
+        $this->assertIsCallable($callable1);
+        $this->assertEquals(1, $callable1());
 
         $this->assertInstanceOf(TwigFunction::class, $result[1]);
         $this->assertEquals('sulu_content_load_parent', $result[1]->getName());
-
-        $this->assertEquals(1, \call_user_func($result[0]->getCallable()));
-        $this->assertEquals(2, \call_user_func($result[1]->getCallable()));
+        $callable2 = $result[1]->getCallable();
+        $this->assertIsCallable($callable2);
+        $this->assertEquals(2, $callable2());
     }
 }

--- a/src/Sulu/Component/Content/Tests/Unit/ContentTypeManagerTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/ContentTypeManagerTest.php
@@ -11,12 +11,21 @@
 
 namespace Sulu\Component\Content\Tests\Unit;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sulu\Component\Content\ContentTypeManager;
 
 class ContentTypeManagerTest extends TestCase
 {
-    protected $container;
+    /**
+     * @var ContentTypeManager
+     */
+    private $manager;
+
+    /**
+     * @var MockObject
+     */
+    private $container;
 
     public function setUp(): void
     {

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ChildrenCollectionTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ChildrenCollectionTest.php
@@ -14,12 +14,33 @@ namespace Sulu\Comonent\DocumentManager\tests\Unit\Collection;
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Component\DocumentManager\Collection\ChildrenCollection;
 use Sulu\Component\DocumentManager\Events;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ChildrenCollectionTest extends TestCase
 {
+    /**
+     * @var ObjectProphecy<NodeInterface>
+     */
+    private $childNode;
+
+    /**
+     * @var ObjectProphecy<NodeInterface>
+     */
+    private $parentNode;
+
+    /**
+     * @var ObjectProphecy<EventDispatcherInterface>
+     */
+    private $dispatcher;
+
+    /**
+     * @var ChildrenCollection
+     */
+    private $collection;
+
     public function setUp(): void
     {
         $this->childNode = $this->prophesize(NodeInterface::class);

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/QueryResultCollectionTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/QueryResultCollectionTest.php
@@ -16,12 +16,48 @@ use PHPCR\Query\QueryResultInterface;
 use PHPCR\Query\RowInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Component\DocumentManager\Collection\QueryResultCollection;
 use Sulu\Component\DocumentManager\Events;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class QueryResultCollectionTest extends TestCase
 {
+    /**
+     * @var ObjectProphecy<QueryResultInterface>
+     */
+    private $queryResult;
+
+    /**
+     * @var ObjectProphecy<EventDispatcherInterface>
+     */
+    private $dispatcher;
+
+    /**
+     * @var QueryResultCollection
+     */
+    private $collection;
+
+    /**
+     * @var ObjectProphecy<RowInterface>
+     */
+    private $row1;
+
+    /**
+     * @var ObjectProphecy<RowInterface>
+     */
+    private $row2;
+
+    /**
+     * @var ObjectProphecy<NodeInterface>
+     */
+    private $node1;
+
+    /**
+     * @var ObjectProphecy<NodeInterface>
+     */
+    private $node2;
+
     public function setUp(): void
     {
         $this->queryResult = $this->prophesize(QueryResultInterface::class);

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ReferrerCollectionTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ReferrerCollectionTest.php
@@ -15,12 +15,38 @@ use PHPCR\NodeInterface;
 use PHPCR\PropertyInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Component\DocumentManager\Collection\ReferrerCollection;
 use Sulu\Component\DocumentManager\Events;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ReferrerCollectionTest extends TestCase
 {
+    /**
+     * @var ObjectProphecy<PropertyInterface>
+     */
+    private $reference;
+
+    /**
+     * @var ObjectProphecy<NodeInterface>
+     */
+    private $referrerNode;
+
+    /**
+     * @var ObjectProphecy<NodeInterface>
+     */
+    private $node;
+
+    /**
+     * @var ObjectProphecy<EventDispatcherInterface>
+     */
+    private $dispatcher;
+
+    /**
+     * @var ReferrerCollection
+     */
+    private $collection;
+
     public function setUp(): void
     {
         $this->reference = $this->prophesize(PropertyInterface::class);

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentAccessorTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentAccessorTest.php
@@ -17,6 +17,16 @@ use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
 
 class DocumentAccessorTest extends TestCase
 {
+    /**
+     * @var TestAccessObject
+     */
+    private $object;
+
+    /**
+     * @var DocumentAccessor
+     */
+    private $accessor;
+
     public function setUp(): void
     {
         $this->object = new TestAccessObject();

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentHelperTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentHelperTest.php
@@ -12,11 +12,22 @@
 namespace Sulu\Component\DocumentManager\tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Component\DocumentManager\Behavior\Mapping\TitleBehavior;
 use Sulu\Component\DocumentManager\DocumentHelper;
 
 class DocumentHelperTest extends TestCase
 {
+    /**
+     * @var object
+     */
+    private $document;
+
+    /**
+     * @var ObjectProphecy<TitleBehavior >
+     */
+    private $titleDocument;
+
     public function setUp(): void
     {
         $this->document = new \stdClass();

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentInspectorTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentInspectorTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\DocumentManager\tests\Unit;
 
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Component\DocumentManager\DocumentInspector;
 use Sulu\Component\DocumentManager\DocumentRegistry;
 use Sulu\Component\DocumentManager\PathSegmentRegistry;
@@ -20,6 +21,36 @@ use Sulu\Component\DocumentManager\ProxyFactory;
 
 class DocumentInspectorTest extends TestCase
 {
+    /**
+     * @var ObjectProphecy<DocumentRegistry>
+     */
+    private $documentRegistry;
+
+    /**
+     * @var ObjectProphecy<PathSegmentRegistry>
+     */
+    private $pathRegistry;
+
+    /**
+     * @var object
+     */
+    private $document;
+
+    /**
+     * @var ObjectProphecy<NodeInterface>
+     */
+    private $node;
+
+    /**
+     * @var ObjectProphecy<ProxyFactory>
+     */
+    private $proxyFactory;
+
+    /**
+     * @var DocumentInspector
+     */
+    private $documentInspector;
+
     public function setUp(): void
     {
         $this->documentRegistry = $this->prophesize(DocumentRegistry::class);

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentRegistryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentRegistryTest.php
@@ -13,10 +13,21 @@ namespace Sulu\Component\DocumentManager\tests\Unit;
 
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Component\DocumentManager\DocumentRegistry;
 
 class DocumentRegistryTest extends TestCase
 {
+    /**
+     * @var ObjectProphecy<NodeInterface>
+     */
+    private $node;
+
+    /**
+     * @var object
+     */
+    private $document;
+
     /**
      * @var DocumentRegistry
      */

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/NamespaceRegistryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/NamespaceRegistryTest.php
@@ -17,6 +17,11 @@ use Sulu\Component\DocumentManager\NamespaceRegistry;
 
 class NamespaceRegistryTest extends TestCase
 {
+    /**
+     * @var NamespaceRegistry
+     */
+    private $registry;
+
     public function setUp(): void
     {
         $this->registry = new NamespaceRegistry([

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Query/QueryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Query/QueryTest.php
@@ -14,6 +14,7 @@ namespace Sulu\Comonent\DocumentManager\tests\Unit\Query;
 use PHPCR\Query\QueryInterface;
 use PHPCR\Query\QueryResultInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Component\DocumentManager\Collection\QueryResultCollection;
 use Sulu\Component\DocumentManager\Event\QueryExecuteEvent;
 use Sulu\Component\DocumentManager\Events;
@@ -22,6 +23,26 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class QueryTest extends TestCase
 {
+    /**
+     * @var ObjectProphecy<QueryInterface>
+     */
+    private $phpcrQuery;
+
+    /**
+     * @var ObjectProphecy<QueryResultInterface>
+     */
+    private $phpcrResult;
+
+    /**
+     * @var ObjectProphecy<EventDispatcherInterface>
+     */
+    private $dispatcher;
+
+    /**
+     * @var Query
+     */
+    private $query;
+
     public function setUp(): void
     {
         $this->phpcrQuery = $this->prophesize(QueryInterface::class);

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior;
 
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Component\DocumentManager\Behavior\Mapping\LocaleBehavior;
 use Sulu\Component\DocumentManager\DocumentAccessor;
 use Sulu\Component\DocumentManager\DocumentRegistry;
@@ -21,6 +22,41 @@ use Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\LocaleSubscriber;
 
 class LocaleSubscriberTest extends TestCase
 {
+    /**
+     * @var ObjectProphecy<HydrateEvent>
+     */
+    private $hydrateEvent;
+
+    /**
+     * @var object
+     */
+    private $notImplementing;
+
+    /**
+     * @var ObjectProphecy<NodeInterface>
+     */
+    private $node;
+
+    /**
+     * @var TestLocaleDocument
+     */
+    private $document;
+
+    /**
+     * @var DocumentAccessor
+     */
+    private $accessor;
+
+    /**
+     * @var ObjectProphecy<DocumentRegistry>
+     */
+    private $registry;
+
+    /**
+     * @var LocaleSubscriber
+     */
+    private $subscriber;
+
     public function setUp(): void
     {
         $this->hydrateEvent = $this->prophesize(HydrateEvent::class);

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/UuidSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/UuidSubscriberTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Mapping;
 
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Component\DocumentManager\Behavior\Mapping\UuidBehavior;
 use Sulu\Component\DocumentManager\DocumentAccessor;
 use Sulu\Component\DocumentManager\Event\HydrateEvent;
@@ -20,6 +21,36 @@ use Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\UuidSubscriber;
 
 class UuidSubscriberTest extends TestCase
 {
+    /**
+     * @var ObjectProphecy<HydrateEvent>
+     */
+    private $hydrateEvent;
+
+    /**
+     * @var object
+     */
+    private $notImplementing;
+
+    /**
+     * @var ObjectProphecy<NodeInterface>
+     */
+    private $node;
+
+    /**
+     * @var TestUuidDocument
+     */
+    private $document;
+
+    /**
+     * @var DocumentAccessor
+     */
+    private $accessor;
+
+    /**
+     * @var UuidSubscriber
+     */
+    private $subscriber;
+
     public function setUp(): void
     {
         $this->hydrateEvent = $this->prophesize(HydrateEvent::class);

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/InstantiatorSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/InstantiatorSubscriberTest.php
@@ -14,6 +14,7 @@ namespace Sulu\Component\DocumentManager\tests\Unit\Subscriber\Core;
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Component\DocumentManager\Event\CreateEvent;
 use Sulu\Component\DocumentManager\Event\HydrateEvent;
 use Sulu\Component\DocumentManager\Metadata;
@@ -22,8 +23,35 @@ use Sulu\Component\DocumentManager\Subscriber\Core\InstantiatorSubscriber;
 
 class InstantiatorSubscriberTest extends TestCase
 {
-    public const ALIAS = 'alias';
+    private const ALIAS = 'alias';
 
+    /**
+     * @var ObjectProphecy<MetadataFactoryInterface>
+     */
+    private $metadataFactory;
+
+    /**
+     * @var ObjectProphecy<Metadata>
+     */
+    private $metadata;
+
+    /**
+     * @var ObjectProphecy<HydrateEvent>
+     */
+    private $hydrateEvent;
+    /**
+     * @var ObjectProphecy<CreateEvent>
+     */
+    private $createEvent;
+
+    /**
+     * @var ObjectProphecy<NodeInterface>
+     */
+    private $node;
+
+    /**
+     * @var InstantiatorSubscriber
+     */
     private $subscriber;
 
     public function setUp(): void

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
@@ -14,6 +14,7 @@ namespace Sulu\Comonent\DocumentManager\tests\Unit\Subscriber\Phpcr;
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Component\DocumentManager\Event\FindEvent;
 use Sulu\Component\DocumentManager\Event\HydrateEvent;
 use Sulu\Component\DocumentManager\Events;
@@ -26,6 +27,36 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class FindSubscriberTest extends TestCase
 {
+    /**
+     * @var ObjectProphecy<EventDispatcherInterface>
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var ObjectProphecy<NodeManager>
+     */
+    private $nodeManager;
+
+    /**
+     * @var ObjectProphecy<NodeInterface>
+     */
+    private $node;
+
+    /**
+     * @var ObjectProphecy<MetadataFactoryInterface>
+     */
+    private $metadataFactory;
+
+    /**
+     * @var ObjectProphecy<Metadata>
+     */
+    private $metadata;
+
+    /**
+     * @var FindSubscriber
+     */
+    private $subscriber;
+
     public function setUp(): void
     {
         $this->eventDispatcher = $this->prophesize(EventDispatcherInterface::class);
@@ -33,7 +64,6 @@ class FindSubscriberTest extends TestCase
         $this->node = $this->prophesize(NodeInterface::class);
         $this->metadataFactory = $this->prophesize(MetadataFactoryInterface::class);
         $this->metadata = $this->prophesize(Metadata::class);
-        $this->document = new \stdClass();
         $this->subscriber = new FindSubscriber(
             $this->metadataFactory->reveal(),
             $this->nodeManager->reveal(),

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RemoveSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RemoveSubscriberTest.php
@@ -12,8 +12,8 @@
 namespace Sulu\Comonent\DocumentManager\Tests\Unit\Subscriber;
 
 use PHPCR\NodeInterface;
-use PHPCR\PropertyInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Component\DocumentManager\DocumentRegistry;
 use Sulu\Component\DocumentManager\Event\RemoveEvent;
 use Sulu\Component\DocumentManager\NodeManager;
@@ -21,6 +21,36 @@ use Sulu\Component\DocumentManager\Subscriber\Phpcr\RemoveSubscriber;
 
 class RemoveSubscriberTest extends TestCase
 {
+    /**
+     * @var ObjectProphecy<NodeManager>
+     */
+    private $nodeManager;
+
+    /**
+     * @var ObjectProphecy<DocumentRegistry>
+     */
+    private $documentRegistry;
+
+    /**
+     * @var ObjectProphecy<RemoveEvent>
+     */
+    private $removeEvent;
+
+    /**
+     * @var object
+     */
+    private $document;
+
+    /**
+     * @var ObjectProphecy<NodeInterface>
+     */
+    private $node;
+
+    /**
+     * @var RemoveSubscriber
+     */
+    private $subscriber;
+
     public function setUp(): void
     {
         $this->nodeManager = $this->prophesize(NodeManager::class);
@@ -28,10 +58,6 @@ class RemoveSubscriberTest extends TestCase
         $this->removeEvent = $this->prophesize(RemoveEvent::class);
         $this->document = new \stdClass();
         $this->node = $this->prophesize(NodeInterface::class);
-        $this->node1 = $this->prophesize(NodeInterface::class);
-        $this->node2 = $this->prophesize(NodeInterface::class);
-        $this->property1 = $this->prophesize(PropertyInterface::class);
-        $this->property2 = $this->prophesize(PropertyInterface::class);
 
         $this->subscriber = new RemoveSubscriber(
             $this->documentRegistry->reveal(),

--- a/src/Sulu/Component/Media/SystemCollections/SystemCollectionBuilder.php
+++ b/src/Sulu/Component/Media/SystemCollections/SystemCollectionBuilder.php
@@ -14,7 +14,6 @@ namespace Sulu\Component\Media\SystemCollections;
 use Massive\Bundle\BuildBundle\Build\BuilderContext;
 use Massive\Bundle\BuildBundle\Build\BuilderInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Build task to initialize system collections.
@@ -54,10 +53,5 @@ class SystemCollectionBuilder implements BuilderInterface
     public function setContext(BuilderContext $context)
     {
         $this->output = $context->getOutput();
-    }
-
-    public function setContainer(?ContainerInterface $container = null)
-    {
-        $this->container = $container;
     }
 }

--- a/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
+++ b/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
@@ -17,14 +17,49 @@ use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Component\Persistence\EventSubscriber\ORM\TimestampableSubscriber;
 use Sulu\Component\Persistence\Model\TimestampableInterface;
 
 class TimestampableSubscriberTest extends TestCase
 {
+    /**
+     * @var ObjectProphecy<LoadClassMetadataEventArgs>
+     */
+    private $loadClassMetadataEvent;
+
+    /**
+     * @var ObjectProphecy<LifecycleEventArgs>
+     */
+    private $lifecycleEvent;
+
+    /**
+     * @var ObjectProphecy<\stdClass>
+     */
+    private $timestampableObject;
+
+    /**
+     * @var ObjectProphecy<ClassMetadata>
+     */
+    private $classMetadata;
+
+    /**
+     * @var ObjectProphecy<\ReflectionClass>
+     */
+    private $refl;
+
+    /**
+     * @var ObjectProphecy<EntityManager>
+     */
+    private $entityManager;
+
+    /**
+     * @var TimestampableSubscriber
+     */
+    private $subscriber;
+
     public function setUp(): void
     {
-        parent::setUp();
         $this->loadClassMetadataEvent = $this->prophesize(LoadClassMetadataEventArgs::class);
         $this->lifecycleEvent = $this->prophesize(LifecycleEventArgs::class);
         $this->timestampableObject = $this->prophesize(\stdClass::class)

--- a/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/FieldDescriptorFactoryTest.php
+++ b/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/FieldDescriptorFactoryTest.php
@@ -45,10 +45,13 @@ class FieldDescriptorFactoryTest extends TestCase
      */
     private $chain;
 
+    /**
+     * @var FieldDescriptorFactory
+     */
+    private $fieldDescriptorFactory;
+
     public function setup(): void
     {
-        parent::setUp();
-
         $parameterBag = $this->prophesize(ParameterBagInterface::class);
         $parameterBag->resolveValue('%sulu.model.contact.class%')->willReturn('SuluContactBundle:Contact');
         $parameterBag->resolveValue('%sulu.model.contact.class%.avatar')->willReturn(
@@ -76,6 +79,7 @@ class FieldDescriptorFactoryTest extends TestCase
 
     public function testGetFieldDescriptors(): void
     {
+        /** @var FieldDescriptorInterface[] $fieldDescriptor */
         $fieldDescriptor = $this->fieldDescriptorFactory->getFieldDescriptors('complete');
 
         $expectedFieldDescriptors = ['extension', 'id', 'firstName', 'lastName', 'avatar', 'fullName', 'city'];
@@ -114,6 +118,7 @@ class FieldDescriptorFactoryTest extends TestCase
 
     public function testGetFieldDescriptorsMinimal(): void
     {
+        /** @var FieldDescriptorInterface[] $fieldDescriptor */
         $fieldDescriptor = $this->fieldDescriptorFactory->getFieldDescriptors('minimal');
 
         $this->assertEquals(['id', 'firstName', 'lastName'], \array_keys($fieldDescriptor));
@@ -129,6 +134,7 @@ class FieldDescriptorFactoryTest extends TestCase
 
     public function testGetFieldDescriptorsGroupConcat(): void
     {
+        /** @var FieldDescriptorInterface[] $fieldDescriptor */
         $fieldDescriptor = $this->fieldDescriptorFactory->getFieldDescriptors('group-concat');
 
         $this->assertEquals(['tags'], \array_keys($fieldDescriptor));
@@ -148,6 +154,7 @@ class FieldDescriptorFactoryTest extends TestCase
 
     public function testGetFieldDescriptorsCase(): void
     {
+        /** @var FieldDescriptorInterface[] $fieldDescriptor */
         $fieldDescriptor = $this->fieldDescriptorFactory->getFieldDescriptors('case');
 
         $this->assertEquals(['tag'], \array_keys($fieldDescriptor));
@@ -164,14 +171,18 @@ class FieldDescriptorFactoryTest extends TestCase
 
         $this->assertFieldDescriptors($expected, $fieldDescriptor);
 
+        $tagFieldDescriptor = $fieldDescriptor['tag'] ?? null;
+        $this->assertInstanceOf(DoctrineCaseFieldDescriptor::class, $tagFieldDescriptor);
+
         $this->assertEquals(
             '(CASE WHEN SuluTagBundle_Tag.name IS NOT NULL THEN SuluTagBundle_Tag.name ELSE SuluTagBundle_Tag.name END)',
-            $fieldDescriptor['tag']->getSelect()
+            $tagFieldDescriptor->getSelect()
         );
     }
 
     public function testGetFieldDescriptorsIdentity(): void
     {
+        /** @var FieldDescriptorInterface[] $fieldDescriptor */
         $fieldDescriptor = $this->fieldDescriptorFactory->getFieldDescriptors('identity');
 
         $this->assertEquals(['tags'], \array_keys($fieldDescriptor));
@@ -191,6 +202,7 @@ class FieldDescriptorFactoryTest extends TestCase
 
     public function testGetFieldDescriptorsOptions(): void
     {
+        /** @var FieldDescriptorInterface[] $fieldDescriptor */
         $fieldDescriptor = $this->fieldDescriptorFactory->getFieldDescriptors('options');
 
         $this->assertEquals(['city'], \array_keys($fieldDescriptor));
@@ -222,6 +234,7 @@ class FieldDescriptorFactoryTest extends TestCase
 
     public function testGetFieldDescriptorsCount(): void
     {
+        /** @var FieldDescriptorInterface[] $fieldDescriptor */
         $fieldDescriptor = $this->fieldDescriptorFactory->getFieldDescriptors('count');
 
         $this->assertEquals(['tags'], \array_keys($fieldDescriptor));
@@ -241,6 +254,7 @@ class FieldDescriptorFactoryTest extends TestCase
 
     public function testGetFieldDescriptorsMixed(): void
     {
+        /** @var FieldDescriptorInterface[] $fieldDescriptor */
         $fieldDescriptor = $this->fieldDescriptorFactory->getFieldDescriptors('mixed');
 
         $this->assertCount(2, $fieldDescriptor);
@@ -259,8 +273,10 @@ class FieldDescriptorFactoryTest extends TestCase
         $this->assertNull($this->fieldDescriptorFactory->getFieldDescriptors('not-existing'));
     }
 
-    private function assertFieldDescriptors(array $expected, array $fieldDescriptors)
+    private function assertFieldDescriptors(array $expected, ?array $fieldDescriptors)
     {
+        $this->assertNotNull($fieldDescriptors);
+
         foreach ($expected as $name => $expectedData) {
             $this->assertFieldDescriptor($expectedData, $fieldDescriptors[$name]);
         }

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -81,6 +81,11 @@ class DoctrineListBuilderTest extends TestCase
     private $query;
 
     /**
+     * @var ObjectProphecy<SystemStoreInterface>
+     */
+    private $systemStore;
+
+    /**
      * @var \ReflectionMethod
      */
     private $findIdsByGivenCriteria;

--- a/src/Sulu/Component/Webspace/Tests/Unit/PortalInformationTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/PortalInformationTest.php
@@ -12,10 +12,29 @@
 namespace Sulu\Component\Webspace\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\PortalInformation;
+use Sulu\Component\Webspace\Webspace;
 
 class PortalInformationTest extends TestCase
 {
+    /**
+     * @var ObjectProphecy<Webspace>
+     */
+    private $webspace;
+
+    /**
+     * @var ObjectProphecy<Portal>
+     */
+    private $portal;
+
+    /**
+     * @var ObjectProphecy<Localization>
+     */
+    private $localization;
+
     /**
      * @var PortalInformation
      */
@@ -23,11 +42,10 @@ class PortalInformationTest extends TestCase
 
     public function setUp(): void
     {
-        parent::setUp();
         $this->portalInformation = new PortalInformation(null, null, null, null, null);
-        $this->webspace = $this->prophesize('Sulu\Component\Webspace\Webspace');
-        $this->portal = $this->prophesize('Sulu\Component\Webspace\Portal');
-        $this->localization = $this->prophesize('Sulu\Component\Localization\Localization');
+        $this->webspace = $this->prophesize(Webspace::class);
+        $this->portal = $this->prophesize(Portal::class);
+        $this->localization = $this->prophesize(Localization::class);
     }
 
     public function provideUrl()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

First run rector with the following rule:

```php
<?php

declare(strict_types=1);

use Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
use Rector\Config\RectorConfig;

return static function (RectorConfig $rectorConfig): void {
    $rectorConfig->paths([
        __DIR__ . '/src',
    ]);
};
```

Then go over all newly creatded `public $var` and change them to `private` and set the correct typehint. Mostly it are tests and mock which would need a fix here.


#### Why?

Make the PHPStan baseline smaller and activate better static analyzer by not build on top of any dynamic properties.
