### PR TITLE
Fix incompatibility to Symfony 6.4 renderBlock method

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,15 @@
 # Upgrade
 
+## 2.5.11
+
+### Rename WebsiteController::renderBlock to WebsiteController::renderBlockView
+
+Symfony 6.4 did add an own `renderBlock` method to its `AbstractController`.
+This would actually throw an error when projects upgrading to Symfony 6.4
+as the `renderBlock` method of Sulu is incompatible to Symfony `renderBlock`
+method. For these cases we rename `renderBlock` to `renderBlockView`.
+
+>>>>>>> adff3439d0 (Fix incompatibility to Symfony 6.4 renderBlock method)
 ## 2.5.7
 
 ### Constructor of ValidateWebspacesCommand changed

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,12 +4,10 @@
 
 ### Rename WebsiteController::renderBlock to WebsiteController::renderBlockView
 
-Symfony 6.4 did add an own `renderBlock` method to its `AbstractController`.
-This would actually throw an error when projects upgrading to Symfony 6.4
-as the `renderBlock` method of Sulu is incompatible to Symfony `renderBlock`
-method. For these cases we rename `renderBlock` to `renderBlockView`.
+In Symfony 6.4, an independent `renderBlock` method was introduced to its `AbstractController`.
+This change poses issues for projects upgrading to Symfony 6.4, as the `renderBlock` method in Sulu is incompatible with Symfony's `renderBlock` method.
+To address this issue, we have to rename the Sulu `renderBlock` method to `renderBlockView`.
 
->>>>>>> adff3439d0 (Fix incompatibility to Symfony 6.4 renderBlock method)
 ## 2.5.7
 
 ### Constructor of ValidateWebspacesCommand changed

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -35276,26 +35276,6 @@ parameters:
 			path: src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Controller\\\\WebsiteController\\:\\:renderBlock\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Controller\\\\WebsiteController\\:\\:renderBlock\\(\\) has parameter \\$attributes with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Controller\\\\WebsiteController\\:\\:renderBlock\\(\\) has parameter \\$block with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Controller\\\\WebsiteController\\:\\:renderBlock\\(\\) has parameter \\$template with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Controller\\\\WebsiteController\\:\\:renderPreview\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
@@ -66,7 +66,7 @@ abstract class WebsiteController extends AbstractController
 
         // if partial render only content block else full page
         if ($partial) {
-            $content = $this->renderBlock(
+            $content = $this->renderBlockView(
                 $viewTemplate,
                 'content',
                 $data
@@ -121,19 +121,23 @@ abstract class WebsiteController extends AbstractController
 
     /**
      * Returns rendered part of template specified by block.
+     *
+     * @param string $view
+     * @param string $block
+     * @param array<string, mixed> $parameters
      */
-    protected function renderBlock($template, $block, $attributes = [])
+    protected function renderBlockView($view, $block, $parameters = []): string
     {
         $twig = $this->container->get('twig');
-        $attributes = $twig->mergeGlobals($attributes);
+        $parameters = $twig->mergeGlobals($parameters);
 
-        $template = $twig->load($template);
+        $template = $twig->load($view);
 
         $level = \ob_get_level();
         \ob_start();
 
         try {
-            $rendered = $template->renderBlock($block, $attributes);
+            $rendered = $template->renderBlock($block, $parameters);
             \ob_end_clean();
 
             return $rendered;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix?  yes
| New feature? | no
| BC breaks? | yes
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/SuluArticleBundle/pull/647
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix incompatibility to Symfony 6.4 renderBlock method.

#### Why?

Symfony introduced its own `renderBlock` method and we need to migrate to the compatible `renderBlockView` method.

#### Upgrade

Actually the upgrade here is hard, from Sulu side it would be.

```php
// before
$this->renderBlock(...);

// after
$this->renderBlockView(...);
```

but this would manipulate all `renderBlock` methods and rector rules should work always. So in this case we would need a custom rule which checks if the result of renderBlock/renderBlockView is used as a string or response.

```php
// before
$response = $this->renderBlock(...);
$string = $this->renderBlock(...);

new Response($string);

// after
$response = $this->renderBlock(...);
$string = $this->renderBlockView(...);

new Response($string);
```

So that is the hard case here to create automatic upgrade 🤔 . Inheritance make things always harder then composition.