### PR TITLE
Remove support for Node 12 in sulu admins

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -21,9 +21,10 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - node-version: '12'
-                      styleguide: false
                     - node-version: '14'
+                      styleguide: false
+                    - node-version: '16'
+                      npm-version: '6'
                       styleguide: true
 
         env:
@@ -37,6 +38,10 @@ jobs:
               uses: actions/setup-node@v2-beta
               with:
                   node-version: ${{ matrix.node-version }}
+
+            - name: Install npm
+              if: ${{ matrix.npm-version }}
+              run: npm install --global npm@${{ matrix.npm-version }}
 
             - name: Assert error when using yarn
               run: tests/js/check-yarn-warning.sh

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,13 @@
 # Upgrade
 
+## 2.4.15
+
+### Remove Node 12 Support for Custm Admin Builds
+
+Changes in the JS ecosystem not longer allows us to test Sulu Admin
+against Node 12. With this release so Sulu custom build may not longer
+work on Node 12, we recommend updating your CI to atleast Node 14.
+
 ## 2.4.6
 
 ### Add indexes to route table


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove support for Node 12 in sulu admins.

#### Why?

Because of changes in the JS ecosystem we are not longer able to test against Node 12 so we are now using Node 14 and 16 to test Sulu like already doing this for Sulu 2.5.