### PR TITLE
Add PHP 8.3 Support

### DIFF
--- a/src/Sulu/Component/SmartContent/DataProviderInterface.php
+++ b/src/Sulu/Component/SmartContent/DataProviderInterface.php
@@ -36,9 +36,24 @@ interface DataProviderInterface
     /**
      * Resolves given filters and returns filtered data items.
      *
-     * @param array $filters Contains the filter configuration
+     * @param array{
+     *     dataSource?: string|int|null,
+     *     sortMethod?: 'asc'|'desc',
+     *     sortBy?: string,
+     *     tags?: string[],
+     *     tagOperator?: 'or'|'and',
+     *     types?: string[],
+     *     categories?: int[],
+     *     categoryOperator?: 'or'|'and',
+     *     targetGroupId?: string|int|null,
+     *     websiteTags?: string[],
+     *     websiteTagsOperator?: 'or'|'and',
+     *     websiteCategories?: int[],
+     *     websiteCategoriesOperator?: 'or'|'and',
+     *     limitResult?: int,
+     * } $filters Contains the filter configuration
      * @param PropertyParameter[] $propertyParameter Contains the parameter of resolved property
-     * @param array $options Options like webspace or locale
+     * @param mixed[] $options Options like webspace or locale
      * @param int|null $limit Indicates maximum size of result set
      * @param int $page Indicates page of result set
      * @param int|null $pageSize Indicates page-size of result set
@@ -57,9 +72,24 @@ interface DataProviderInterface
     /**
      * Resolves given filters and returns filtered resource items with ArrayAccess.
      *
-     * @param array $filters Contains the filter configuration
+     * @param array{
+     *      dataSource?: string|int|null,
+     *      sortMethod?: 'asc'|'desc',
+     *      sortBy?: string,
+     *      tags?: string[],
+     *      tagOperator?: 'or'|'and',
+     *      types?: string[],
+     *      categories?: int[],
+     *      categoryOperator?: 'or'|'and',
+     *      targetGroupId?: string|int|null,
+     *      websiteTags?: string[],
+     *      websiteTagsOperator?: 'or'|'and',
+     *      websiteCategories?: int[],
+     *      websiteCategoriesOperator?: 'or'|'and',
+     *      limitResult?: int,
+     *  } $filters Contains the filter configuration
      * @param PropertyParameter[] $propertyParameter Contains the parameter of resolved property
-     * @param array $options Options like webspace or locale
+     * @param mixed[] $options Options like webspace or locale
      * @param int|null $limit Indicates maximum size of result set
      * @param int $page Indicates page of result set
      * @param int|null $pageSize Indicates page-size of result set
@@ -78,9 +108,9 @@ interface DataProviderInterface
     /**
      * Resolves datasource and returns the data of it.
      *
-     * @param mixed $datasource Identification of datasource
+     * @param string|int|null $datasource Identification of datasource
      * @param PropertyParameter[] $propertyParameter Contains the parameter of resolved property
-     * @param array $options Options like webspace or locale
+     * @param mixed[] $options Options like webspace or locale
      *
      * @return DatasourceItemInterface
      */

--- a/src/Sulu/Component/SmartContent/Orm/BaseDataProvider.php
+++ b/src/Sulu/Component/SmartContent/Orm/BaseDataProvider.php
@@ -108,6 +108,9 @@ abstract class BaseDataProvider implements DataProviderInterface
         return;
     }
 
+    /**
+     * @param array{locale: string} $options
+     */
     public function resolveDataItems(
         array $filters,
         array $propertyParameter,

--- a/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryInterface.php
+++ b/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryInterface.php
@@ -25,7 +25,7 @@ interface DataProviderRepositoryInterface
      * @param int $pageSize
      * @param int $limit
      * @param string $locale
-     * @param mixed[] $options
+     * @param array{webspaceKey?: string, locale: string} $options
      *
      * @return object[]
      */

--- a/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
+++ b/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
@@ -31,7 +31,7 @@ trait DataProviderRepositoryTrait
      * @param int $pageSize
      * @param int $limit
      * @param string $locale
-     * @param array $options
+     * @param array{webspaceKey?: string, locale?: string} $options
      * @param string|null $entityClass
      * @param string|null $entityAlias
      * @param int|null $permission
@@ -92,9 +92,9 @@ trait DataProviderRepositoryTrait
      * @param int $pageSize
      * @param int $limit
      * @param string $locale
-     * @param array $options
+     * @param mixed[] $options
      *
-     * @return array
+     * @return int[]|string[]
      */
     private function findByFiltersIds(
         $filters,
@@ -252,6 +252,7 @@ trait DataProviderRepositoryTrait
 
         return \array_map(
             function($item) {
+                /** @var int|string */
                 return $item['id'];
             },
             $query->getScalarResult()
@@ -282,7 +283,7 @@ trait DataProviderRepositoryTrait
      * @param string $operator "and" or "or"
      * @param string $alias
      *
-     * @return array parameter for the query
+     * @return array<string, int|string|int[]|string[]> parameter for the query
      */
     private function appendRelation(QueryBuilder $queryBuilder, $relation, $values, $operator, $alias)
     {
@@ -303,7 +304,7 @@ trait DataProviderRepositoryTrait
      * @param int[] $values
      * @param string $alias
      *
-     * @return array parameter for the query
+     * @return array<string, int|string|int[]|string[]> parameter for the query
      */
     private function appendRelationOr(QueryBuilder $queryBuilder, $relation, $values, $alias)
     {
@@ -320,7 +321,7 @@ trait DataProviderRepositoryTrait
      * @param int[] $values
      * @param string $alias
      *
-     * @return array parameter for the query
+     * @return array<string, int|string|int[]|string[]> parameter for the query
      */
     private function appendRelationAnd(QueryBuilder $queryBuilder, $relation, $values, $alias)
     {
@@ -355,16 +356,19 @@ trait DataProviderRepositoryTrait
      *
      * @param string $alias
      * @param string $locale
+     *
+     * @return void
      */
     abstract protected function appendJoins(QueryBuilder $queryBuilder, $alias, $locale);
 
     /**
      * Append additional condition to query builder for "findByFilters" function.
      *
+     * @param string $alias
      * @param string $locale
-     * @param array $options
+     * @param mixed[] $options
      *
-     * @return array parameters for query
+     * @return array<string, int|string|int[]|string[]> parameters for query
      */
     protected function append(QueryBuilder $queryBuilder, $alias, $locale, $options = [])
     {
@@ -408,6 +412,11 @@ trait DataProviderRepositoryTrait
         return $alias . '.targetGroups';
     }
 
+    /**
+     * @param string $alias
+     *
+     * @return string
+     */
     protected function appendTypeRelation(QueryBuilder $queryBuilder, $alias)
     {
         return $alias . '.type';
@@ -416,10 +425,11 @@ trait DataProviderRepositoryTrait
     /**
      * Extension point to append datasource.
      *
+     * @param int|string $datasource
      * @param bool $includeSubFolders
      * @param string $alias
      *
-     * @return array parameters for query
+     * @return array<string, int|string|int[]|string[]> parameters for query
      */
     protected function appendDatasource($datasource, $includeSubFolders, QueryBuilder $queryBuilder, $alias)
     {
@@ -434,6 +444,8 @@ trait DataProviderRepositoryTrait
      * @param string $sortMethod
      * @param string $alias
      * @param string $locale
+     *
+     * @return void
      */
     protected function appendSortBy($sortBy, $sortMethod, QueryBuilder $queryBuilder, $alias, $locale)
     {
@@ -449,6 +461,8 @@ trait DataProviderRepositoryTrait
      *
      * @param string $alias
      * @param string $locale
+     *
+     * @return void
      */
     protected function appendSortByJoins(QueryBuilder $queryBuilder, $alias, $locale)
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add PHP 8.3 to CI task.

#### Why?

The PHP 8.3 First Release Candidate was published so time to check if Sulu already works with it.

#### TODO

 - [x] https://github.com/phpspec/prophecy/issues/607
 - [x] https://github.com/sebastianbergmann/phpunit/issues/5495
 - [x] https://github.com/laminas/laminas-code/pull/194
   - [x] PHP 8.3 Support laminas-stdlib: https://github.com/laminas/laminas-stdlib/commit/8ec8790aed1d0aead6d0155ff8ba15a6d06810c4 (merged not yet released)
