### PR TITLE
Add missing remove route domain events

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Domain/Event/PageRouteRemovedEvent.php
+++ b/src/Sulu/Bundle/PageBundle/Domain/Event/PageRouteRemovedEvent.php
@@ -47,6 +47,13 @@ class PageRouteRemovedEvent extends DomainEvent
         return 'route_removed';
     }
 
+    public function getEventContext(): array
+    {
+        return [
+            'route' => $this->route,
+        ];
+    }
+
     public function getResourceKey(): string
     {
         return BasePageDocument::RESOURCE_KEY;
@@ -70,18 +77,6 @@ class PageRouteRemovedEvent extends DomainEvent
     public function getResourceTitleLocale(): ?string
     {
         return $this->pageTitleLocale;
-    }
-
-    public function getRoute(): ?string
-    {
-        return $this->route;
-    }
-
-    public function setRoute(string $route): self
-    {
-        $this->route = $route;
-
-        return $this;
     }
 
     public function getResourceSecurityContext(): ?string

--- a/src/Sulu/Bundle/PageBundle/Domain/Event/PageRouteRemovedEvent.php
+++ b/src/Sulu/Bundle/PageBundle/Domain/Event/PageRouteRemovedEvent.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PageBundle\Domain\Event;
+
+use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
+use Sulu\Bundle\PageBundle\Admin\PageAdmin;
+use Sulu\Bundle\PageBundle\Document\BasePageDocument;
+use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
+
+class PageRouteRemovedEvent extends DomainEvent
+{
+    private string $pageId;
+    private string $webspaceKey;
+    private ?string $pageTitle;
+    private ?string $pageTitleLocale;
+    private string $route;
+
+    public function __construct(
+        string $pageId,
+        string $webspaceKey,
+        string $pageTitle,
+        string $pageTitleLocale,
+        string $route
+    ) {
+        parent::__construct();
+
+        $this->pageId = $pageId;
+        $this->webspaceKey = $webspaceKey;
+        $this->pageTitle = $pageTitle;
+        $this->pageTitleLocale = $pageTitleLocale;
+        $this->route = $route;
+    }
+
+    public function getEventType(): string
+    {
+        return 'route_removed';
+    }
+
+    public function getResourceKey(): string
+    {
+        return BasePageDocument::RESOURCE_KEY;
+    }
+
+    public function getResourceId(): string
+    {
+        return $this->pageId;
+    }
+
+    public function getResourceWebspaceKey(): string
+    {
+        return $this->webspaceKey;
+    }
+
+    public function getResourceTitle(): ?string
+    {
+        return $this->pageTitle;
+    }
+
+    public function getResourceTitleLocale(): ?string
+    {
+        return $this->pageTitleLocale;
+    }
+
+    public function getRoute(): ?string
+    {
+        return $this->route;
+    }
+
+    public function setRoute(string $route): self
+    {
+        $this->route = $route;
+
+        return $this;
+    }
+
+    public function getResourceSecurityContext(): ?string
+    {
+        return PageAdmin::getPageSecurityContext(static::getResourceWebspaceKey());
+    }
+
+    public function getResourceSecurityObjectType(): ?string
+    {
+        return SecurityBehavior::class;
+    }
+}

--- a/src/Sulu/Bundle/PageBundle/Domain/Event/PageRouteRemovedEvent.php
+++ b/src/Sulu/Bundle/PageBundle/Domain/Event/PageRouteRemovedEvent.php
@@ -20,11 +20,30 @@ use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
 
 class PageRouteRemovedEvent extends DomainEvent
 {
-    private string $pageId;
-    private string $webspaceKey;
-    private ?string $pageTitle;
-    private ?string $pageTitleLocale;
-    private string $route;
+    /**
+     * @var string
+     */
+    private $pageId;
+
+    /**
+     * @var string
+     */
+    private $webspaceKey;
+
+    /**
+     * @var string|null
+     */
+    private $pageTitle;
+
+    /**
+     * @var string|null
+     */
+    private $pageTitleLocale;
+
+    /**
+     * @var string
+     */
+    private $route;
 
     public function __construct(
         string $pageId,

--- a/src/Sulu/Bundle/PageBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/PageBundle/Resources/translations/admin.de.json
@@ -71,6 +71,7 @@
     "sulu_activity.description.pages.created": "{userFullName} hat die Seite \"{resourceTitle}\" erstellt",
     "sulu_activity.description.pages.modified": "{userFullName} hat die Seite \"{resourceTitle}\" geändert",
     "sulu_activity.description.pages.removed": "{userFullName} hat die Seite \"{resourceTitle}\" gelöscht",
+    "sulu_activity.description.pages.route_removed": "{userFullName} hat eine Route der Seite \"{resourceTitle}\" gelöscht",
     "sulu_activity.description.pages.published": "{userFullName} hat die Seite \"{resourceTitle}\" veröffentlicht",
     "sulu_activity.description.pages.unpublished": "{userFullName} hat die Seite \"{resourceTitle}\" nicht mehr veröffentlicht",
     "sulu_activity.description.pages.draft_removed": "{userFullName} hat den Entwurf der Seite \"{resourceTitle}\" verworfen",

--- a/src/Sulu/Bundle/PageBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/PageBundle/Resources/translations/admin.en.json
@@ -71,6 +71,7 @@
     "sulu_activity.description.pages.created": "{userFullName} has created the page \"{resourceTitle}\"",
     "sulu_activity.description.pages.modified": "{userFullName} has changed the page \"{resourceTitle}\"",
     "sulu_activity.description.pages.removed": "{userFullName} has removed the page \"{resourceTitle}\"",
+    "sulu_activity.description.pages.route_removed": "{userFullName} has removed a route from the page \"{resourceTitle}\"",
     "sulu_activity.description.pages.published": "{userFullName} has published the page \"{resourceTitle}\"",
     "sulu_activity.description.pages.unpublished": "{userFullName} has unpublished the page \"{resourceTitle}\"",
     "sulu_activity.description.pages.draft_removed": "{userFullName} has discarded the draft of the page \"{resourceTitle}\"",

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageResourcelocatorControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageResourcelocatorControllerTest.php
@@ -12,10 +12,11 @@
 namespace Sulu\Bundle\PageBundle\Tests\Functional\Controller;
 
 use PHPCR\SessionInterface;
-use Sulu\Bundle\ActivityBundle\Domain\Repository\ActivityRepositoryInterface;
+use Sulu\Bundle\ActivityBundle\Domain\Model\Activity;
 use Sulu\Bundle\PageBundle\Document\BasePageDocument;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Sulu\Component\Persistence\Repository\ORM\EntityRepository;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 /**
@@ -39,7 +40,7 @@ class PageResourcelocatorControllerTest extends SuluTestCase
     private $documentManager;
 
     /**
-     * @var ActivityRepositoryInterface
+     * @var EntityRepository<Activity>
      */
     private $activityRepository;
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageResourcelocatorControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageResourcelocatorControllerTest.php
@@ -262,7 +262,7 @@ class PageResourcelocatorControllerTest extends SuluTestCase
             )
         );
         $this->assertHttpStatusCode(204, $this->client->getResponse());
-        self::assertNotNull($this->activityRepository->findOneBy(['resourceKey' => 'pages', 'resoureceId' => $history['_embedded']['page_resourcelocators'][0]['id']]));
+        self::assertNotNull($this->activityRepository->findOneBy(['type' => 'route_removed', 'resourceKey' => BasePageDocument::RESOURCE_KEY, 'resourceId' => $newsData['id']]));
 
         $this->client->jsonRequest(
             'GET',

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageResourcelocatorControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageResourcelocatorControllerTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\PageBundle\Tests\Functional\Controller;
 
 use PHPCR\SessionInterface;
+use Sulu\Bundle\ActivityBundle\Domain\Repository\ActivityRepositoryInterface;
 use Sulu\Bundle\PageBundle\Document\BasePageDocument;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
@@ -38,6 +39,11 @@ class PageResourcelocatorControllerTest extends SuluTestCase
     private $documentManager;
 
     /**
+     * @var ActivityRepositoryInterface
+     */
+    private $activityRepository;
+
+    /**
      * @var array
      */
     private $data;
@@ -50,6 +56,7 @@ class PageResourcelocatorControllerTest extends SuluTestCase
         $this->session = $this->getContainer()->get('doctrine')->getConnection();
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
         $this->data = $this->prepareRepositoryContent();
+        $this->activityRepository = $this->getContainer()->get('sulu.repository.activity');
     }
 
     private function prepareRepositoryContent()
@@ -255,6 +262,7 @@ class PageResourcelocatorControllerTest extends SuluTestCase
             )
         );
         $this->assertHttpStatusCode(204, $this->client->getResponse());
+        self::assertNotNull($this->activityRepository->findOneBy(['resourceKey' => 'pages', 'resoureceId' => $history['_embedded']['page_resourcelocators'][0]['id']]));
 
         $this->client->jsonRequest(
             'GET',

--- a/src/Sulu/Bundle/RouteBundle/Controller/RouteController.php
+++ b/src/Sulu/Bundle/RouteBundle/Controller/RouteController.php
@@ -181,7 +181,8 @@ class RouteController extends AbstractRestController implements ClassResourceInt
                     $route->getPath(),
                     $route->getLocale(),
                     $route->getEntityId(),
-                    $route->getEntityClass()
+                    $route->getEntityClass(),
+                    \defined($route->getEntityClass() . '::RESOURCE_KEY') ? \constant($route->getEntityClass() . '::RESOURCE_KEY') : RouteInterface::RESOURCE_KEY
                 )
             );
         }

--- a/src/Sulu/Bundle/RouteBundle/Controller/RouteController.php
+++ b/src/Sulu/Bundle/RouteBundle/Controller/RouteController.php
@@ -177,16 +177,18 @@ class RouteController extends AbstractRestController implements ClassResourceInt
             $this->entityManager->remove($route);
             /** @var string $resourceKey */
             $resourceKey = \defined($route->getEntityClass() . '::RESOURCE_KEY') ? \constant($route->getEntityClass() . '::RESOURCE_KEY') : RouteInterface::RESOURCE_KEY;
-            $this->domainEventCollector?->collect(
-                new RouteRemovedEvent(
-                    $route->getId(),
-                    $route->getPath(),
-                    $route->getLocale(),
-                    $route->getEntityId(),
-                    $route->getEntityClass(),
-                    $resourceKey
-                )
-            );
+            if ($this->domainEventCollector instanceof DomainEventCollectorInterface) {
+                $this->domainEventCollector->collect(
+                    new RouteRemovedEvent(
+                        $route->getId(),
+                        $route->getPath(),
+                        $route->getLocale(),
+                        $route->getEntityId(),
+                        $route->getEntityClass(),
+                        $resourceKey
+                    )
+                );
+            }
         }
 
         $this->entityManager->flush();

--- a/src/Sulu/Bundle/RouteBundle/Controller/RouteController.php
+++ b/src/Sulu/Bundle/RouteBundle/Controller/RouteController.php
@@ -14,6 +14,8 @@ namespace Sulu\Bundle\RouteBundle\Controller;
 use Doctrine\ORM\EntityManagerInterface;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use HandcraftedInTheAlps\RestRoutingBundle\Routing\ClassResourceInterface;
+use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
+use Sulu\Bundle\RouteBundle\Domain\Event\RouteRemovedEvent;
 use Sulu\Bundle\RouteBundle\Entity\RouteRepositoryInterface;
 use Sulu\Bundle\RouteBundle\Generator\RouteGeneratorInterface;
 use Sulu\Bundle\RouteBundle\Manager\ConflictResolverInterface;
@@ -59,13 +61,19 @@ class RouteController extends AbstractRestController implements ClassResourceInt
      */
     private $conflictResolver;
 
+    /**
+     * @var DomainEventCollectorInterface|null
+     */
+    private $domainEventCollector;
+
     public function __construct(
         ViewHandlerInterface $viewHandler,
         RouteRepositoryInterface $routeRepository,
         EntityManagerInterface $entityManager,
         RouteGeneratorInterface $routeGenerator,
         array $resourceKeyMappings,
-        ?ConflictResolverInterface $conflictResolver = null
+        ?ConflictResolverInterface $conflictResolver = null,
+        ?DomainEventCollectorInterface $domainEventCollector = null
     ) {
         parent::__construct($viewHandler);
 
@@ -74,12 +82,21 @@ class RouteController extends AbstractRestController implements ClassResourceInt
         $this->routeGenerator = $routeGenerator;
         $this->resourceKeyMappings = $resourceKeyMappings;
         $this->conflictResolver = $conflictResolver;
+        $this->domainEventCollector = $domainEventCollector;
 
         if (null === $this->conflictResolver) {
             @trigger_deprecation(
                 'sulu/sulu',
                 '2.3',
                 'Instantiating RouteController without the $conflictResolver argument is deprecated.'
+            );
+        }
+
+        if (null == $this->domainEventCollector) {
+            @trigger_deprecation(
+                'sulu/sulu',
+                '2.5',
+                'Instantiating RouteController without the $domainEventCollector argument is deprecated.'
             );
         }
     }
@@ -158,6 +175,15 @@ class RouteController extends AbstractRestController implements ClassResourceInt
             }
 
             $this->entityManager->remove($route);
+            $this->domainEventCollector?->collect(
+                new RouteRemovedEvent(
+                    $route->getId(),
+                    $route->getPath(),
+                    $route->getLocale(),
+                    $route->getEntityId(),
+                    $route->getEntityClass()
+                )
+            );
         }
 
         $this->entityManager->flush();

--- a/src/Sulu/Bundle/RouteBundle/Controller/RouteController.php
+++ b/src/Sulu/Bundle/RouteBundle/Controller/RouteController.php
@@ -175,6 +175,8 @@ class RouteController extends AbstractRestController implements ClassResourceInt
             }
 
             $this->entityManager->remove($route);
+            /** @var string $resourceKey */
+            $resourceKey = \defined($route->getEntityClass() . '::RESOURCE_KEY') ? \constant($route->getEntityClass() . '::RESOURCE_KEY') : RouteInterface::RESOURCE_KEY;
             $this->domainEventCollector?->collect(
                 new RouteRemovedEvent(
                     $route->getId(),
@@ -182,7 +184,7 @@ class RouteController extends AbstractRestController implements ClassResourceInt
                     $route->getLocale(),
                     $route->getEntityId(),
                     $route->getEntityClass(),
-                    \defined($route->getEntityClass() . '::RESOURCE_KEY') ? \constant($route->getEntityClass() . '::RESOURCE_KEY') : RouteInterface::RESOURCE_KEY
+                    $resourceKey
                 )
             );
         }

--- a/src/Sulu/Bundle/RouteBundle/Domain/Event/RouteRemovedEvent.php
+++ b/src/Sulu/Bundle/RouteBundle/Domain/Event/RouteRemovedEvent.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\RouteBundle\Domain\Event;
+
+use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
+use Sulu\Bundle\RouteBundle\Model\RouteInterface;
+
+class RouteRemovedEvent extends DomainEvent
+{
+    private int $routeId;
+    private string $path;
+    private string $entityClass;
+    private string $locale;
+    private string $entityId;
+
+    public function __construct(
+        int $routeId,
+        string $path,
+        string $locale,
+        string $entityId,
+        string $entityClass,
+    ) {
+        parent::__construct();
+        $this->routeId = $routeId;
+        $this->path = $path;
+        $this->locale = $locale;
+        $this->entityId = $entityId;
+        $this->entityClass = $entityClass;
+    }
+
+    public function getEventType(): string
+    {
+        return 'route_removed';
+    }
+
+    public function getEventContext(): array
+    {
+        return [
+            'entityId' => $this->entityId,
+            'entityClass' => $this->entityClass,
+            'path' => $this->path,
+        ];
+    }
+
+    public function getResourceKey(): string
+    {
+        return RouteInterface::RESOURCE_KEY;
+    }
+
+    public function getResourceId(): string
+    {
+        return $this->entityId;
+    }
+
+    public function getResourceLocale(): ?string
+    {
+        return $this->locale;
+    }
+
+    public function getResourceTitle(): ?string
+    {
+        return $this->path;
+    }
+}

--- a/src/Sulu/Bundle/RouteBundle/Domain/Event/RouteRemovedEvent.php
+++ b/src/Sulu/Bundle/RouteBundle/Domain/Event/RouteRemovedEvent.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\RouteBundle\Domain\Event;
 
 use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
-use Sulu\Bundle\RouteBundle\Model\RouteInterface;
 
 class RouteRemovedEvent extends DomainEvent
 {
@@ -21,6 +20,7 @@ class RouteRemovedEvent extends DomainEvent
     private string $entityClass;
     private string $locale;
     private string $entityId;
+    private string $resourceKey;
 
     public function __construct(
         int $routeId,
@@ -28,6 +28,7 @@ class RouteRemovedEvent extends DomainEvent
         string $locale,
         string $entityId,
         string $entityClass,
+        string $resourceKey
     ) {
         parent::__construct();
         $this->routeId = $routeId;
@@ -35,6 +36,7 @@ class RouteRemovedEvent extends DomainEvent
         $this->locale = $locale;
         $this->entityId = $entityId;
         $this->entityClass = $entityClass;
+        $this->resourceKey = $resourceKey;
     }
 
     public function getEventType(): string
@@ -45,6 +47,7 @@ class RouteRemovedEvent extends DomainEvent
     public function getEventContext(): array
     {
         return [
+            'id' => $this->routeId,
             'entityId' => $this->entityId,
             'entityClass' => $this->entityClass,
             'path' => $this->path,
@@ -53,7 +56,7 @@ class RouteRemovedEvent extends DomainEvent
 
     public function getResourceKey(): string
     {
-        return RouteInterface::RESOURCE_KEY;
+        return $this->resourceKey;
     }
 
     public function getResourceId(): string

--- a/src/Sulu/Bundle/RouteBundle/Domain/Event/RouteRemovedEvent.php
+++ b/src/Sulu/Bundle/RouteBundle/Domain/Event/RouteRemovedEvent.php
@@ -15,12 +15,35 @@ use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
 
 class RouteRemovedEvent extends DomainEvent
 {
-    private int $routeId;
-    private string $path;
-    private string $entityClass;
-    private string $locale;
-    private string $entityId;
-    private string $resourceKey;
+    /**
+     * @var int
+     */
+    private $routeId;
+
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @var string
+     */
+    private $entityClass;
+
+    /**
+     * @var string
+     */
+    private $locale;
+
+    /**
+     * @var string
+     */
+    private $entityId;
+
+    /**
+     * @var string
+     */
+    private $resourceKey;
 
     public function __construct(
         int $routeId,

--- a/src/Sulu/Bundle/RouteBundle/Model/RouteInterface.php
+++ b/src/Sulu/Bundle/RouteBundle/Model/RouteInterface.php
@@ -18,6 +18,8 @@ use Doctrine\Common\Collections\Collection;
  */
 interface RouteInterface
 {
+    public const RESOURCE_KEY = 'routes';
+
     /**
      * Get id.
      *

--- a/src/Sulu/Bundle/RouteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/RouteBundle/Resources/config/services.xml
@@ -47,7 +47,7 @@
             <argument type="service" id="sulu_route.generator.route_generator"/>
             <argument>%sulu_route.resource_key_mappings%</argument>
             <argument type="service" id="sulu_route.manager.conflict_resolver.auto_increment"/>
-            <argument type="service" id="translator"/>
+            <argument type="service" id="sulu_activity.domain_event_collector"/>
 
             <tag name="sulu.context" context="admin"/>
         </service>

--- a/src/Sulu/Bundle/RouteBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/RouteBundle/Resources/translations/admin.de.json
@@ -1,0 +1,4 @@
+{
+    "sulu_activity.resource.routes": "Route",
+    "sulu_activity.description.routes.route_removed": "{userFullName} hat die Route \"{resourceTitle}\" gelöscht."
+}

--- a/src/Sulu/Bundle/RouteBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/RouteBundle/Resources/translations/admin.en.json
@@ -1,4 +1,4 @@
 {
     "sulu_activity.resource.routes": "Route",
-    "sulu_activity.description.routes.route_removed": "{userFullName} has removed the route \"{resourceTitle}\""
+    "sulu_activity.description.routes.route_removed": "{userFullName} has removed the route \"{resourceTitle}\"."
 }

--- a/src/Sulu/Bundle/RouteBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/RouteBundle/Resources/translations/admin.en.json
@@ -1,0 +1,4 @@
+{
+    "sulu_activity.resource.routes": "Route",
+    "sulu_activity.description.routes.route_removed": "{userFullName} has removed the route \"{resourceTitle}\""
+}

--- a/src/Sulu/Bundle/RouteBundle/Tests/Functional/Controller/RouteControllerTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Functional/Controller/RouteControllerTest.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\RouteBundle\Tests\Functional\Controller;
 use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\ActivityBundle\Domain\Repository\ActivityRepositoryInterface;
 use Sulu\Bundle\RouteBundle\Entity\Route;
+use Sulu\Bundle\RouteBundle\Model\RouteInterface;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
@@ -325,7 +326,7 @@ class RouteControllerTest extends SuluTestCase
 
         $this->client->jsonRequest('DELETE', '/api/routes?ids=' . $targetRouteId);
         $this->assertHttpStatusCode(204, $this->client->getResponse());
-        self::assertNotNull($this->activityRepository->findOneBy(['resourceKey' => 'routes', 'resourceId' => $targetRouteId]));
+        self::assertNotNull($this->activityRepository->findOneBy(['resourceKey' => RouteInterface::RESOURCE_KEY, 'resourceId' => self::TEST_ID]));
 
         $this->client->jsonRequest(
             'GET',

--- a/src/Sulu/Bundle/RouteBundle/Tests/Functional/Controller/RouteControllerTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Functional/Controller/RouteControllerTest.php
@@ -12,10 +12,11 @@
 namespace Sulu\Bundle\RouteBundle\Tests\Functional\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Sulu\Bundle\ActivityBundle\Domain\Repository\ActivityRepositoryInterface;
+use Sulu\Bundle\ActivityBundle\Domain\Model\Activity;
 use Sulu\Bundle\RouteBundle\Entity\Route;
 use Sulu\Bundle\RouteBundle\Model\RouteInterface;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Component\Persistence\Repository\ORM\EntityRepository;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 class RouteControllerTest extends SuluTestCase
@@ -39,7 +40,7 @@ class RouteControllerTest extends SuluTestCase
     private $client;
 
     /**
-     * @var ActivityRepositoryInterface
+     * @var EntityRepository<Activity>
      */
     private $activityRepository;
 

--- a/src/Sulu/Bundle/RouteBundle/Tests/Functional/Controller/RouteControllerTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Functional/Controller/RouteControllerTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\RouteBundle\Tests\Functional\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\ActivityBundle\Domain\Repository\ActivityRepositoryInterface;
 use Sulu\Bundle\RouteBundle\Entity\Route;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
@@ -36,10 +37,16 @@ class RouteControllerTest extends SuluTestCase
      */
     private $client;
 
+    /**
+     * @var ActivityRepositoryInterface
+     */
+    private $activityRepository;
+
     public function setUp(): void
     {
         $this->client = $this->createAuthenticatedClient();
         $this->entityManager = $this->getEntityManager();
+        $this->activityRepository = $this->getContainer()->get('sulu.repository.activity');
         $this->purgeDatabase();
     }
 
@@ -318,6 +325,7 @@ class RouteControllerTest extends SuluTestCase
 
         $this->client->jsonRequest('DELETE', '/api/routes?ids=' . $targetRouteId);
         $this->assertHttpStatusCode(204, $this->client->getResponse());
+        self::assertNotNull($this->activityRepository->findOneBy(['resourceKey' => 'routes', 'resourceId' => $targetRouteId]));
 
         $this->client->jsonRequest(
             'GET',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | yes <!-- if yes add them to the UPGRADE.md file -->
| License | MIT

#### What's in this PR?

Adds domain event for page routes and routes removals.

#### Why?

They were missing

#### To Do

- [ ] Add breaking changes to UPGRADE.md
