### PR TITLE
Add debug flag to CustomTtlListener

### DIFF
--- a/src/Sulu/Bundle/HttpCacheBundle/Cache/SuluHttpCache.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Cache/SuluHttpCache.php
@@ -60,7 +60,7 @@ class SuluHttpCache extends HttpCache implements CacheInvalidation
     protected function getSubscribers(): array
     {
         $subscribers = [
-            CustomTtlListener::class => new CustomTtlListener(static::HEADER_REVERSE_PROXY_TTL),
+            CustomTtlListener::class => new CustomTtlListener(static::HEADER_REVERSE_PROXY_TTL, $this->kernel->isDebug()),
             PurgeListener::class => new PurgeListener(),
             PurgeTagsListener::class => new PurgeTagsListener(),
             SegmentCacheListener::class => new SegmentCacheListener(),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

When in debug mode the Header X-Reverse-Proxy-TTL will be kept.