### PR TITLE
Allow DoctrineFixtureBundle 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "doctrine/data-fixtures": "^1.3.3",
         "doctrine/dbal": "^2.13 || ^3.0",
         "doctrine/doctrine-bundle": "^2.4",
-        "doctrine/doctrine-fixtures-bundle": "^3.3",
+        "doctrine/doctrine-fixtures-bundle": "^3.3 || ^4.0",
         "doctrine/inflector": "^1.4.1 || ^2.0.1",
         "doctrine/orm": "^2.8",
         "doctrine/persistence": "^2.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature?  yes
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | part of https://github.com/sulu/sulu/pull/7156
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Allow DoctrineFixtureBundle 4.0 and use that in the `@dev` builds:

<img width="632" alt="Bildschirmfoto 2023-09-16 um 13 45 50" src="https://github.com/sulu/sulu/assets/1698337/0117823d-b40f-48e0-9bdd-7ff7cf308e62">

#### Why?

A new major version of DoctrineFixtureBundle is coming soon. This PR allow it on the 2.6 branch, currently there are no major BC breaks but it will be required for the Symfony 7 release.