### PR TITLE
Fix copy locale with no destination exception

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -24146,61 +24146,6 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerFieldsTest.php
 
 		-
-			message: "#^Call to an undefined method object\\:\\:getResourceSegment\\(\\)\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getStructure\\(\\)\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getUuid\\(\\)\\.$#"
-			count: 34
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setPermissions\\(\\)\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setRedirectTarget\\(\\)\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setRedirectType\\(\\)\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setResourceSegment\\(\\)\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setShadowLocale\\(\\)\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setShadowLocaleEnabled\\(\\)\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setStructureType\\(\\)\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setTitle\\(\\)\\.$#"
-			count: 3
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
-
-		-
 			message: "#^Cannot access an offset on mixed\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
@@ -24247,7 +24192,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'contentLocales' on mixed\\.$#"
-			count: 11
+			count: 10
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
 
 		-
@@ -24267,7 +24212,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'id' on mixed\\.$#"
-			count: 48
+			count: 47
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
 
 		-
@@ -24357,7 +24302,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'title' on mixed\\.$#"
-			count: 38
+			count: 37
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
 
 		-
@@ -24367,7 +24312,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'url' on mixed\\.$#"
-			count: 21
+			count: 20
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
 
 		-
@@ -24477,7 +24422,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
-			count: 86
+			count: 88
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
 
 		-

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -190,7 +190,7 @@ class PageAdmin extends Admin
                     new ToolbarAction(
                         'sulu_admin.copy_locale',
                         [
-                            'visible_condition' => '(!_permissions || _permissions.edit)',
+                            'visible_condition' => '(!_permissions || _permissions.edit) && __webspace.localizations|length > 1',
                         ]
                     ),
                     new ToolbarAction(

--- a/src/Sulu/Bundle/PageBundle/Controller/PageController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/PageController.php
@@ -243,7 +243,7 @@ class PageController extends AbstractRestController implements ClassResourceInte
                 case 'copy-locale':
                     $srcLocale = $this->getRequestParameter($request, 'src', false, $locale);
                     $destLocales = $this->getRequestParameter($request, 'dest', true);
-                    $destLocales = \explode(',', $destLocales);
+                    $destLocales = \array_filter(\explode(',', $destLocales));
 
                     $document = $this->documentManager->find($id, $srcLocale);
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
@@ -378,6 +378,7 @@ class PageControllerTest extends SuluTestCase
             'article' => 'Test',
         ];
 
+        /** @var BasePageDocument $homeDocument */
         $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         $permissions = [
@@ -455,6 +456,7 @@ class PageControllerTest extends SuluTestCase
             'article' => 'Test',
         ];
 
+        /** @var BasePageDocument $homeDocument */
         $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         $this->client->jsonRequest(
@@ -507,6 +509,7 @@ class PageControllerTest extends SuluTestCase
             'article' => 'Test',
         ];
 
+        /** @var BasePageDocument $homeDocument */
         $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         $this->client->jsonRequest(
@@ -546,6 +549,7 @@ class PageControllerTest extends SuluTestCase
             ],
         ];
 
+        /** @var BasePageDocument $homeDocument */
         $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         $this->client->request(
@@ -771,6 +775,7 @@ class PageControllerTest extends SuluTestCase
         $this->documentManager->persist($internalLinkPage, 'en', ['parent_path' => '/cmf/sulu_io/contents']);
         $this->documentManager->flush();
 
+        /** @var BasePageDocument $internalLinkPage */
         $internalLinkPage = $this->documentManager->find($internalLinkPage->getUuid());
         $internalLinkPage->setRedirectType(RedirectType::INTERNAL);
         $internalLinkPage->setRedirectTarget($targetPage);
@@ -1062,6 +1067,7 @@ class PageControllerTest extends SuluTestCase
             'url' => '/test',
         ];
 
+        /** @var BasePageDocument $homeDocument */
         $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         $this->client->jsonRequest(
@@ -1200,6 +1206,7 @@ class PageControllerTest extends SuluTestCase
             'article' => 'Test',
         ];
 
+        /** @var BasePageDocument $homeDocument */
         $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         $this->client->jsonRequest('POST', '/api/pages?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&language=en', $data);
@@ -1311,6 +1318,7 @@ class PageControllerTest extends SuluTestCase
             'url' => '/test',
         ];
 
+        /** @var BasePageDocument $homeDocument */
         $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         $this->client->jsonRequest(
@@ -1404,6 +1412,7 @@ class PageControllerTest extends SuluTestCase
             'url' => '/test',
         ];
 
+        /** @var BasePageDocument $homeDocument */
         $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         $this->client->jsonRequest('POST', '/api/pages?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&language=en', $data);
@@ -1429,6 +1438,7 @@ class PageControllerTest extends SuluTestCase
             'url' => '/test',
         ];
 
+        /** @var BasePageDocument $homeDocument */
         $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         $this->client->jsonRequest(
@@ -1466,6 +1476,7 @@ class PageControllerTest extends SuluTestCase
             'url' => '/test',
         ];
 
+        /** @var BasePageDocument $homeDocument */
         $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         $this->client->jsonRequest(
@@ -1477,6 +1488,7 @@ class PageControllerTest extends SuluTestCase
 
         $data['url'] = '/test2';
 
+        /** @var BasePageDocument $homeDocument */
         $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         $this->client->jsonRequest(
@@ -1511,6 +1523,7 @@ class PageControllerTest extends SuluTestCase
             'article' => 'Test',
         ];
 
+        /** @var BasePageDocument $homeDocument */
         $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         $this->client->jsonRequest(
@@ -1685,6 +1698,7 @@ class PageControllerTest extends SuluTestCase
         $this->documentManager->persist($internalLinkPage, 'en', ['parent_path' => '/cmf/sulu_io/contents']);
         $this->documentManager->flush();
 
+        /** @var BasePageDocument $internalLinkPage */
         $internalLinkPage = $this->documentManager->find($internalLinkPage->getUuid());
         $internalLinkPage->setRedirectType(RedirectType::INTERNAL);
         $internalLinkPage->setRedirectTarget($externalLinkPage);
@@ -1885,6 +1899,7 @@ class PageControllerTest extends SuluTestCase
         $this->documentManager->publish($document, 'en');
         $this->documentManager->flush();
 
+        /** @var BasePageDocument $document */
         $document = $this->documentManager->find($document->getUuid(), 'de', ['load_ghost_content' => false]);
         $document->setTitle('test_de');
         $document->setResourceSegment('/test_de');
@@ -1917,9 +1932,11 @@ class PageControllerTest extends SuluTestCase
 
         $uuid = \json_decode($this->client->getResponse()->getContent(), true)['id'];
 
+        /** @var BasePageDocument $germanDocument */
         $germanDocument = $this->documentManager->find($uuid, 'de');
         $this->assertStringStartsWith('/test-de/test-de', $germanDocument->getResourceSegment());
 
+        /** @var BasePageDocument $englishDocument */
         $englishDocument = $this->documentManager->find($uuid, 'en');
         $this->assertStringStartsWith('/test-en/test-en', $englishDocument->getResourceSegment());
     }
@@ -1980,6 +1997,7 @@ class PageControllerTest extends SuluTestCase
         $this->documentManager->publish($document, 'de');
         $this->documentManager->flush();
 
+        /** @var BasePageDocument $document */
         $document = $this->documentManager->find($document->getUuid(), 'de');
         $document->setTitle('draft title');
         $this->documentManager->persist($document, 'de');
@@ -2017,6 +2035,7 @@ class PageControllerTest extends SuluTestCase
         $this->documentManager->publish($document, 'de');
         $this->documentManager->flush();
 
+        /** @var BasePageDocument $document */
         $document = $this->documentManager->find($document->getUuid(), 'de');
         $document->setTitle('draft title');
         $this->documentManager->persist($document, 'de');
@@ -2163,6 +2182,7 @@ class PageControllerTest extends SuluTestCase
             ],
         ];
 
+        /** @var BasePageDocument $homeDocument */
         $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         $this->client->jsonRequest(
@@ -2195,6 +2215,7 @@ class PageControllerTest extends SuluTestCase
             'navContexts' => ['main', 'footer'],
         ];
 
+        /** @var BasePageDocument $homeDocument */
         $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         $this->client->jsonRequest(
@@ -2243,6 +2264,7 @@ class PageControllerTest extends SuluTestCase
             ],
         ];
 
+        /** @var BasePageDocument $homeDocument */
         $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         $this->client->request(
@@ -2285,6 +2307,7 @@ class PageControllerTest extends SuluTestCase
             'article' => 'Test',
         ];
 
+        /** @var BasePageDocument $homeDocument */
         $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         $this->client->jsonRequest(
@@ -2333,6 +2356,7 @@ class PageControllerTest extends SuluTestCase
             'article' => 'Test',
         ];
 
+        /** @var BasePageDocument $homeDocument */
         $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         $this->client->jsonRequest(
@@ -2379,6 +2403,7 @@ class PageControllerTest extends SuluTestCase
             'article' => 'Test',
         ];
 
+        /** @var BasePageDocument $homeDocument */
         $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         $this->client->jsonRequest(
@@ -2386,6 +2411,7 @@ class PageControllerTest extends SuluTestCase
             '/api/pages?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&language=en&action=publish',
             $data
         );
+        /** @var array<string, mixed> $data */
         $data = \json_decode($this->client->getResponse()->getContent(), true);
 
         $this->client->jsonRequest(
@@ -2393,15 +2419,15 @@ class PageControllerTest extends SuluTestCase
             '/api/pages/' . $data['id'] . '?action=copy-locale&webspace=sulu_io&locale=en&dest='
         );
         $this->assertHttpStatusCode(200, $this->client->getResponse());
+        /** @var array<string, mixed> $result */
         $result = \json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertEquals($data['id'], $result['id']);
-        $this->assertEquals($data['title'], $result['title']);
-        $this->assertEquals($data['url'], $result['url']);
-        $this->assertEquals($data['article'], $result['article']);
-        $this->assertTrue($result['publishedState']);
-        $this->assertContains('en', $result['contentLocales']);
-        $this->assertCount(1, $result['contentLocales']);
+        $this->assertSame($data['id'], $result['id'] ?? null);
+        $this->assertSame($data['title'], $result['title'] ?? null);
+        $this->assertSame($data['url'], $result['url'] ?? null);
+        $this->assertSame($data['article'], $result['article'] ?? null);
+        $this->assertTrue($result['publishedState'] ?? null);
+        $this->assertSame(['en'], $result['contentLocales'] ?? null);
     }
 
     public function testCopyMultipleLocales(): void
@@ -2413,6 +2439,7 @@ class PageControllerTest extends SuluTestCase
             'article' => 'Test',
         ];
 
+        /** @var BasePageDocument $homeDocument */
         $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         $this->client->jsonRequest(
@@ -2432,6 +2459,7 @@ class PageControllerTest extends SuluTestCase
             'GET',
             '/api/pages/' . $data['id'] . '?webspace=sulu_io&language=de'
         );
+        /** @var array<string, mixed> $result */
         $result = \json_decode($this->client->getResponse()->getContent(), true);
         $this->assertEquals($data['id'], $result['id']);
         $this->assertEquals($data['title'], $result['title']);
@@ -2467,6 +2495,7 @@ class PageControllerTest extends SuluTestCase
             ],
         ];
 
+        /** @var BasePageDocument $homeDocument */
         $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         $this->client->jsonRequest(
@@ -2494,6 +2523,7 @@ class PageControllerTest extends SuluTestCase
     {
         $this->importer->import(__DIR__ . '/../../fixtures/exports/tree.xml');
 
+        /** @var BasePageDocument $document */
         $document = $this->documentManager->find('585ccd35-a98e-4e41-a62c-e502ca905496', 'en');
         $document->setStructureType('internallinks');
         $document->getStructure()->bind(
@@ -2613,6 +2643,7 @@ class PageControllerTest extends SuluTestCase
 
     private function setUpContent($data)
     {
+        /** @var BasePageDocument $homeDocument */
         $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         for ($i = 0; $i < \count($data); ++$i) {

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
@@ -2370,7 +2370,6 @@ class PageControllerTest extends SuluTestCase
         $this->assertContains('en', $result['contentLocales']);
     }
 
-
     public function testCopyLocaleWithNoDest(): void
     {
         $data = [
@@ -2404,8 +2403,6 @@ class PageControllerTest extends SuluTestCase
         $this->assertContains('en', $result['contentLocales']);
         $this->assertCount(1, $result['contentLocales']);
     }
-
-
 
     public function testCopyMultipleLocales(): void
     {

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
@@ -2370,6 +2370,43 @@ class PageControllerTest extends SuluTestCase
         $this->assertContains('en', $result['contentLocales']);
     }
 
+
+    public function testCopyLocaleWithNoDest(): void
+    {
+        $data = [
+            'title' => 'test1',
+            'template' => 'default',
+            'url' => '/test1',
+            'article' => 'Test',
+        ];
+
+        $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
+
+        $this->client->jsonRequest(
+            'POST',
+            '/api/pages?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&language=en&action=publish',
+            $data
+        );
+        $data = \json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->client->jsonRequest(
+            'POST',
+            '/api/pages/' . $data['id'] . '?action=copy-locale&webspace=sulu_io&locale=en&dest='
+        );
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+        $result = \json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals($data['id'], $result['id']);
+        $this->assertEquals($data['title'], $result['title']);
+        $this->assertEquals($data['url'], $result['url']);
+        $this->assertEquals($data['article'], $result['article']);
+        $this->assertTrue($result['publishedState']);
+        $this->assertContains('en', $result['contentLocales']);
+        $this->assertCount(1, $result['contentLocales']);
+    }
+
+
+
     public function testCopyMultipleLocales(): void
     {
         $data = [

--- a/src/Sulu/Bundle/PageBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/PageBundle/phpunit.xml.dist
@@ -21,7 +21,6 @@
         <server name="APP_ENV" value="test" force="true"/>
         <env name="KERNEL_CLASS" value="Sulu\Bundle\PageBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
-        <ini name="date.timezone" value="UTC"/>
     </php>
 
     <listeners>

--- a/src/Sulu/Bundle/PageBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/PageBundle/phpunit.xml.dist
@@ -21,6 +21,7 @@
         <server name="APP_ENV" value="test" force="true"/>
         <env name="KERNEL_CLASS" value="Sulu\Bundle\PageBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <ini name="date.timezone" value="UTC"/>
     </php>
 
     <listeners>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no 
| Deprecations? | no 
| Fixed tickets | fixes #6950
| Related issues/PRs | #6950
| License | MIT
| Documentation PR | 

#### What's in this PR?

Fixes issue #6950 Users saw "Copy locale" toolbar action, even if webspace had just one locale. 
Api was throwing an error when no destination locale was specified, interface was frozen, fixed.

#### Why?

#6950 

#### Example Usage

- Ensure to have only one locale (already done in the linked repository) ;
- Create a page (this issue is not reproducible with the root page) ;
- Add a title and save;
- You shouldn't see "copy locale" in the toolbar.

#### To Do

