### PR TITLE
Fix arguments and options for build command

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/CommandOptional/SuluBuildCommand.php
+++ b/src/Sulu/Bundle/CoreBundle/CommandOptional/SuluBuildCommand.php
@@ -24,6 +24,7 @@ class SuluBuildCommand extends BuildCommand
 {
     public function configure()
     {
+        parent::configure();
         $this->addOption('destroy', null, InputOption::VALUE_NONE, 'Destroy existing data');
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Readd call to parent::configure which was accidently removed in #6973.

#### Why?

The https://github.com/sulu/sulu/pull/6973 did accidently remove all options and arguments. /cc @StaffNowa FYI. 

<img width="1661" alt="Bildschirmfoto 2023-10-16 um 12 04 11" src="https://github.com/sulu/sulu/assets/1698337/132fb30b-d1c6-4da1-ba91-cdbce26c3cca">
