### PR TITLE
Marking the ContentMapper as lazy

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
@@ -52,7 +52,7 @@
         <service id="sulu.content.template_resolver" public="false" class="%sulu.content.template_resolver.class%"/>
 
         <!-- content mapper -->
-        <service id="sulu.content.mapper" class="%sulu.content.mapper.class%" public="true">
+        <service id="sulu.content.mapper" class="%sulu.content.mapper.class%" public="true" lazy="true">
             <argument type="service" id="sulu_document_manager.document_manager" />
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="form.factory" />

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Mapper/ContentMapperTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Mapper/ContentMapperTest.php
@@ -641,7 +641,7 @@ class ContentMapperTest extends SuluTestCase
         $subChild = $this->save($data[3], 'overview', 'sulu_io', 'de', 1, true, null, $child->getUuid());
 
         // delete /news/test-2/test-1
-        $this->mapper->delete($child->getUuid(), 'sulu_io', true);
+        $this->mapper->delete($child->getUuid(), true);
 
         // check
         try {
@@ -2598,7 +2598,7 @@ class ContentMapperTest extends SuluTestCase
         $this->documentManager->flush();
 
         // delete /a/d
-        $this->mapper->delete($data[3]->getUuid(), 'sulu_io', true);
+        $this->mapper->delete($data[3]->getUuid(), true);
 
         // check
         try {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | backport of #7169
| License | MIT
| Documentation PR | -

#### What's in this PR?
Making the service definition of the ContentMapper.

#### Why?
The `ContentMapper` is a heavy service (lots of dependencies) so we only want to instantiate the service when it's really needed.

#### Example Usage
Same as before Symfony does the magic under the hood.