### PR TITLE
Add cache invalidation for snippet areas

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -30731,11 +30731,6 @@ parameters:
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/SnippetContentTest.php
 
 		-
-			message: "#^Class Sulu\\\\Bundle\\\\SnippetBundle\\\\Content\\\\SnippetContent constructor invoked with 5 parameters, 4 required\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/SnippetContentTest.php
-
-		-
 			message: "#^Parameter \\#1 \\$array of function next expects array\\|object, mixed given\\.$#"
 			count: 2
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/SnippetContentTest.php
@@ -31234,16 +31229,6 @@ parameters:
 			message: "#^Method Sulu\\\\Bundle\\\\SnippetBundle\\\\Tests\\\\Unit\\\\Admin\\\\SnippetAdminTest\\:\\:testConfigureViews\\(\\) has parameter \\$locales with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
-
-		-
-			message: "#^Class Sulu\\\\Bundle\\\\SnippetBundle\\\\Content\\\\SnippetContent constructor invoked with 5 parameters, 4 required\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SnippetContentTest.php
-
-		-
-			message: "#^Parameter \\#4 \\$defaultEnabled of class Sulu\\\\Bundle\\\\SnippetBundle\\\\Content\\\\SnippetContent constructor expects true, false given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SnippetContentTest.php
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\SnippetBundle\\\\Tests\\\\Unit\\\\Content\\\\SnippetDataProviderTest\\:\\:provideResolveDataItems\\(\\) has no return type specified\\.$#"

--- a/src/Sulu/Bundle/SnippetBundle/Content/SingleSnippetSelection.php
+++ b/src/Sulu/Bundle/SnippetBundle/Content/SingleSnippetSelection.php
@@ -37,14 +37,21 @@ class SingleSnippetSelection extends SimpleContentType implements PreResolvableC
      */
     private $snippetReferenceStore;
 
+    /**
+     * @var ReferenceStoreInterface
+     */
+    private $snippetAreaReferenceStore;
+
     public function __construct(
         SnippetResolverInterface $snippetResolver,
         DefaultSnippetManagerInterface $defaultSnippetManager,
-        ReferenceStoreInterface $snippetReferenceStore
+        ReferenceStoreInterface $snippetReferenceStore,
+        ReferenceStoreInterface $snippetAreaReferenceStore
     ) {
         $this->snippetResolver = $snippetResolver;
         $this->defaultSnippetManager = $defaultSnippetManager;
         $this->snippetReferenceStore = $snippetReferenceStore;
+        $this->snippetAreaReferenceStore = $snippetAreaReferenceStore;
 
         parent::__construct('SingleSnippetSelection', null);
     }
@@ -123,6 +130,7 @@ class SingleSnippetSelection extends SimpleContentType implements PreResolvableC
     {
         try {
             $snippet = $this->defaultSnippetManager->load($webspaceKey, $snippetArea, $locale);
+            $this->snippetAreaReferenceStore->add($snippetArea);
         } catch (WrongSnippetTypeException $exception) {
             return null;
         }

--- a/src/Sulu/Bundle/SnippetBundle/Content/SingleSnippetSelection.php
+++ b/src/Sulu/Bundle/SnippetBundle/Content/SingleSnippetSelection.php
@@ -38,7 +38,7 @@ class SingleSnippetSelection extends SimpleContentType implements PreResolvableC
     private $snippetReferenceStore;
 
     /**
-     * @var ReferenceStoreInterface
+     * @var ReferenceStoreInterface|null
      */
     private $snippetAreaReferenceStore;
 

--- a/src/Sulu/Bundle/SnippetBundle/Content/SingleSnippetSelection.php
+++ b/src/Sulu/Bundle/SnippetBundle/Content/SingleSnippetSelection.php
@@ -46,7 +46,7 @@ class SingleSnippetSelection extends SimpleContentType implements PreResolvableC
         SnippetResolverInterface $snippetResolver,
         DefaultSnippetManagerInterface $defaultSnippetManager,
         ReferenceStoreInterface $snippetReferenceStore,
-        ReferenceStoreInterface $snippetAreaReferenceStore
+        ?ReferenceStoreInterface $snippetAreaReferenceStore = null
     ) {
         $this->snippetResolver = $snippetResolver;
         $this->defaultSnippetManager = $defaultSnippetManager;

--- a/src/Sulu/Bundle/SnippetBundle/Content/SingleSnippetSelection.php
+++ b/src/Sulu/Bundle/SnippetBundle/Content/SingleSnippetSelection.php
@@ -53,6 +53,14 @@ class SingleSnippetSelection extends SimpleContentType implements PreResolvableC
         $this->snippetReferenceStore = $snippetReferenceStore;
         $this->snippetAreaReferenceStore = $snippetAreaReferenceStore;
 
+        if (null === $this->snippetAreaReferenceStore) {
+            @trigger_deprecation(
+                'sulu/sulu',
+                '2.6',
+                'Instantiating the SingleSnippetSelection without the $snippetAreaReferenceStore argument is deprecated!'
+            );
+        }
+
         parent::__construct('SingleSnippetSelection', null);
     }
 
@@ -130,7 +138,7 @@ class SingleSnippetSelection extends SimpleContentType implements PreResolvableC
     {
         try {
             $snippet = $this->defaultSnippetManager->load($webspaceKey, $snippetArea, $locale);
-            $this->snippetAreaReferenceStore->add($snippetArea);
+            $this->snippetAreaReferenceStore?->add($snippetArea);
         } catch (WrongSnippetTypeException $exception) {
             return null;
         }

--- a/src/Sulu/Bundle/SnippetBundle/Content/SnippetContent.php
+++ b/src/Sulu/Bundle/SnippetBundle/Content/SnippetContent.php
@@ -44,22 +44,29 @@ class SnippetContent extends ComplexContentType implements ContentTypeExportInte
     private $referenceStore;
 
     /**
+     * @var ReferenceStoreInterface
+     */
+    private $snippetAreaReferenceStore;
+
+    /**
      * @var bool
      */
     protected $defaultEnabled;
 
     /**
-     * @param true $defaultEnabled
+     * @param bool $defaultEnabled
      */
     public function __construct(
         DefaultSnippetManagerInterface $defaultSnippetManager,
         SnippetResolverInterface $snippetResolver,
         ReferenceStoreInterface $referenceStore,
+        ReferenceStoreInterface $snippetAreaReferenceStore,
         $defaultEnabled
     ) {
         $this->snippetResolver = $snippetResolver;
         $this->defaultSnippetManager = $defaultSnippetManager;
         $this->referenceStore = $referenceStore;
+        $this->snippetAreaReferenceStore = $snippetAreaReferenceStore;
         $this->defaultEnabled = $defaultEnabled;
     }
 
@@ -172,6 +179,7 @@ class SnippetContent extends ComplexContentType implements ContentTypeExportInte
     {
         try {
             $snippet = $this->defaultSnippetManager->load($webspaceKey, $snippetArea, $locale);
+            $this->snippetAreaReferenceStore->add($snippetArea);
         } catch (WrongSnippetTypeException $exception) {
             return [];
         }

--- a/src/Sulu/Bundle/SnippetBundle/Content/SnippetContent.php
+++ b/src/Sulu/Bundle/SnippetBundle/Content/SnippetContent.php
@@ -60,8 +60,8 @@ class SnippetContent extends ComplexContentType implements ContentTypeExportInte
         DefaultSnippetManagerInterface $defaultSnippetManager,
         SnippetResolverInterface $snippetResolver,
         ReferenceStoreInterface $referenceStore,
-        ReferenceStoreInterface $snippetAreaReferenceStore,
-        $defaultEnabled
+        $defaultEnabled,
+        ?ReferenceStoreInterface $snippetAreaReferenceStore = null,
     ) {
         $this->snippetResolver = $snippetResolver;
         $this->defaultSnippetManager = $defaultSnippetManager;

--- a/src/Sulu/Bundle/SnippetBundle/Content/SnippetContent.php
+++ b/src/Sulu/Bundle/SnippetBundle/Content/SnippetContent.php
@@ -44,7 +44,7 @@ class SnippetContent extends ComplexContentType implements ContentTypeExportInte
     private $referenceStore;
 
     /**
-     * @var ReferenceStoreInterface
+     * @var ReferenceStoreInterface|null
      */
     private $snippetAreaReferenceStore;
 

--- a/src/Sulu/Bundle/SnippetBundle/Content/SnippetContent.php
+++ b/src/Sulu/Bundle/SnippetBundle/Content/SnippetContent.php
@@ -68,6 +68,14 @@ class SnippetContent extends ComplexContentType implements ContentTypeExportInte
         $this->referenceStore = $referenceStore;
         $this->snippetAreaReferenceStore = $snippetAreaReferenceStore;
         $this->defaultEnabled = $defaultEnabled;
+
+        if (null === $this->snippetAreaReferenceStore) {
+            @trigger_deprecation(
+                'sulu/sulu',
+                '2.6',
+                'Instantiating the SnippetContent without the $snippetAreaReferenceStore argument is deprecated!'
+            );
+        }
     }
 
     public function read(NodeInterface $node, PropertyInterface $property, $webspaceKey, $languageCode, $segmentKey)
@@ -179,7 +187,7 @@ class SnippetContent extends ComplexContentType implements ContentTypeExportInte
     {
         try {
             $snippet = $this->defaultSnippetManager->load($webspaceKey, $snippetArea, $locale);
-            $this->snippetAreaReferenceStore->add($snippetArea);
+            $this->snippetAreaReferenceStore?->add($snippetArea);
         } catch (WrongSnippetTypeException $exception) {
             return [];
         }

--- a/src/Sulu/Bundle/SnippetBundle/DependencyInjection/Compiler/SnippetAreaCompilerPass.php
+++ b/src/Sulu/Bundle/SnippetBundle/DependencyInjection/Compiler/SnippetAreaCompilerPass.php
@@ -44,6 +44,7 @@ class SnippetAreaCompilerPass implements CompilerPassInterface
                 'key' => $template,
                 'template' => $template,
                 'title' => $templateTitles,
+                'cache-invalidation' => 'false',
             ];
 
             foreach ($structure->getAreas() as $area) {
@@ -79,6 +80,7 @@ class SnippetAreaCompilerPass implements CompilerPassInterface
     private function getArea($template, $area, $locales, $templateTitles)
     {
         $key = $area['key'];
+        $cacheInvalidation = $area['cache-invalidation'];
 
         $titles = [];
 
@@ -95,6 +97,7 @@ class SnippetAreaCompilerPass implements CompilerPassInterface
             'key' => $key,
             'template' => $template,
             'title' => $titles,
+            'cache-invalidation' => $cacheInvalidation,
         ];
     }
 }

--- a/src/Sulu/Bundle/SnippetBundle/EventListener/CacheInvalidationSubscriber.php
+++ b/src/Sulu/Bundle/SnippetBundle/EventListener/CacheInvalidationSubscriber.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SnippetBundle\EventListener;
+
+use Sulu\Bundle\HttpCacheBundle\Cache\CacheManager;
+use Sulu\Bundle\SnippetBundle\Domain\Event\SnippetModifiedEvent;
+use Sulu\Bundle\SnippetBundle\Domain\Event\SnippetRemovedEvent;
+use Sulu\Bundle\SnippetBundle\Domain\Event\WebspaceDefaultSnippetModifiedEvent;
+use Sulu\Bundle\SnippetBundle\Domain\Event\WebspaceDefaultSnippetRemovedEvent;
+use Sulu\Bundle\SnippetBundle\Snippet\DefaultSnippetManagerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class CacheInvalidationSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var CacheManager|null
+     */
+    private $cacheManager;
+
+    /**
+     * @var DefaultSnippetManagerInterface
+     */
+    private $defaultSnippetManager;
+
+    public function __construct(
+        ?CacheManager $cacheManager,
+        DefaultSnippetManagerInterface $defaultSnippetManager
+    ) {
+        $this->cacheManager = $cacheManager;
+        $this->defaultSnippetManager = $defaultSnippetManager;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            WebspaceDefaultSnippetModifiedEvent::class => 'invalidateSnippetAreaOnAreaModified',
+            WebspaceDefaultSnippetRemovedEvent::class => 'invalidateSnippetAreaOnAreaRemoved',
+            SnippetModifiedEvent::class => 'invalidateSnippetAreaOnModified',
+            SnippetRemovedEvent::class => 'invalidateSnippetAreaOnRemoved',
+        ];
+    }
+
+    public function invalidateSnippetAreaOnModified(SnippetModifiedEvent $event): void
+    {
+        $this->invalidateSnippetAreaBySnippet($event->getResourceId());
+    }
+
+    public function invalidateSnippetAreaOnRemoved(SnippetRemovedEvent $event): void
+    {
+        $this->invalidateSnippetAreaBySnippet($event->getResourceId());
+    }
+
+    public function invalidateSnippetAreaOnAreaRemoved(WebspaceDefaultSnippetRemovedEvent $event): void
+    {
+        $this->invalidateSnippetAreaByKey($event->getSnippetAreaKey());
+    }
+
+    public function invalidateSnippetAreaOnAreaModified(WebspaceDefaultSnippetModifiedEvent $event): void
+    {
+        $this->invalidateSnippetAreaByKey($event->getSnippetAreaKey());
+    }
+
+    private function invalidateSnippetAreaBySnippet(string $snippetUuid): void
+    {
+        $areaKey = $this->defaultSnippetManager->loadType($snippetUuid);
+
+        if (!$areaKey) {
+            return;
+        }
+
+        $this->invalidateSnippetAreaByKey($areaKey);
+    }
+
+    private function invalidateSnippetAreaByKey(string $areaKey): void
+    {
+        if (!$this->cacheManager) {
+            return;
+        }
+
+        $this->cacheManager->invalidateReference('snippet_area', $areaKey);
+    }
+}

--- a/src/Sulu/Bundle/SnippetBundle/EventListener/CacheInvalidationSubscriber.php
+++ b/src/Sulu/Bundle/SnippetBundle/EventListener/CacheInvalidationSubscriber.php
@@ -23,6 +23,12 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class CacheInvalidationSubscriber implements EventSubscriberInterface
 {
+    /**
+     * @param array<int, array{
+     *     key: string,
+     *     cache-invalidation: string
+     * }> $areas
+     */
     public function __construct(
         private readonly DefaultSnippetManagerInterface $defaultSnippetManager,
         private readonly ?CacheManager $cacheManager,
@@ -60,13 +66,13 @@ class CacheInvalidationSubscriber implements EventSubscriberInterface
         $this->invalidateSnippetArea($event->getResourceId(), $event->getSnippetAreaKey());
     }
 
-    private function invalidateSnippetArea(string $snippetUuid, string $areaKey = null): void
+    private function invalidateSnippetArea(string $snippetUuid, ?string $areaKey = null): void
     {
         if (!$this->cacheManager) {
             return;
         }
 
-        if ($areaKey === null) {
+        if (null === $areaKey) {
             $areaKey = $this->defaultSnippetManager->loadType($snippetUuid);
         }
 

--- a/src/Sulu/Bundle/SnippetBundle/EventListener/CacheInvalidationSubscriber.php
+++ b/src/Sulu/Bundle/SnippetBundle/EventListener/CacheInvalidationSubscriber.php
@@ -30,9 +30,9 @@ class CacheInvalidationSubscriber implements EventSubscriberInterface
      * }> $areas
      */
     public function __construct(
-        private readonly DefaultSnippetManagerInterface $defaultSnippetManager,
-        private readonly ?CacheManager $cacheManager,
-        private readonly array $areas
+        private DefaultSnippetManagerInterface $defaultSnippetManager,
+        private ?CacheManager $cacheManager,
+        private array $areas
     ) {
     }
 

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/content.xml
@@ -10,6 +10,12 @@
             <tag name="kernel.reset" method="reset"/>
         </service>
 
+        <service id="sulu_snippet.reference_store.snippet_area"
+                 class="Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStore" public="true">
+            <tag name="sulu_website.reference_store" alias="snippet_area"/>
+            <tag name="kernel.reset" method="reset"/>
+        </service>
+
         <service id="sulu_snippet.default_snippet.manager" class="Sulu\Bundle\SnippetBundle\Snippet\DefaultSnippetManager" public="true">
             <argument type="service" id="sulu_core.webspace.settings_manager"/>
             <argument type="service" id="sulu_document_manager.document_manager"/>

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/content.xml
@@ -46,8 +46,8 @@
             <argument type="service" id="sulu_snippet.default_snippet.manager"/>
             <argument type="service" id="sulu_snippet.resolver"/>
             <argument type="service" id="sulu_snippet.reference_store.snippet"/>
-            <argument type="service" id="sulu_snippet.reference_store.snippet_area"/>
             <argument>%sulu_snippet.content-type.default_enabled%</argument>
+            <argument type="service" id="sulu_snippet.reference_store.snippet_area"/>
 
             <tag name="sulu.content.type" alias="snippet_selection"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/content.xml
@@ -37,6 +37,7 @@
             <argument type="service" id="sulu_snippet.resolver"/>
             <argument type="service" id="sulu_snippet.default_snippet.manager"/>
             <argument type="service" id="sulu_snippet.reference_store.snippet"/>
+            <argument type="service" id="sulu_snippet.reference_store.snippet_area"/>
 
             <tag name="sulu.content.type" alias="single_snippet_selection"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
@@ -45,6 +46,7 @@
             <argument type="service" id="sulu_snippet.default_snippet.manager"/>
             <argument type="service" id="sulu_snippet.resolver"/>
             <argument type="service" id="sulu_snippet.reference_store.snippet"/>
+            <argument type="service" id="sulu_snippet.reference_store.snippet_area"/>
             <argument>%sulu_snippet.content-type.default_enabled%</argument>
 
             <tag name="sulu.content.type" alias="snippet_selection"/>

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/snippet.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/snippet.xml
@@ -85,6 +85,7 @@
             <argument type="service" id="sulu_snippet.default_snippet.manager"/>
             <argument type="service" id="sulu_core.webspace.request_analyzer"/>
             <argument type="service" id="sulu_snippet.resolver"/>
+            <argument type="service" id="sulu_snippet.reference_store.snippet_area"/>
 
             <tag name="twig.extension"/>
         </service>
@@ -97,6 +98,13 @@
             <argument type="service" id="doctrine_phpcr" />
             <argument type="service" id="sulu_document_manager.path_builder" />
             <tag name="sulu_document_manager.initializer"/>
+        </service>
+
+        <service id="sulu_snippet.cache_invalidation_subscriber" class="Sulu\Bundle\SnippetBundle\EventListener\CacheInvalidationSubscriber">
+            <argument type="service" id="sulu_http_cache.cache_manager" on-invalid="null"/>
+            <argument type="service" id="sulu_snippet.default_snippet.manager"/>
+
+            <tag name="kernel.event_subscriber"/>
         </service>
 
         <!-- domain events -->

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/snippet.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/snippet.xml
@@ -101,8 +101,9 @@
         </service>
 
         <service id="sulu_snippet.cache_invalidation_subscriber" class="Sulu\Bundle\SnippetBundle\EventListener\CacheInvalidationSubscriber">
-            <argument type="service" id="sulu_http_cache.cache_manager" on-invalid="null"/>
             <argument type="service" id="sulu_snippet.default_snippet.manager"/>
+            <argument type="service" id="sulu_http_cache.cache_manager" on-invalid="null"/>
+            <argument>%sulu_snippet.areas%</argument>
 
             <tag name="kernel.event_subscriber"/>
         </service>

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/SnippetContentTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/SnippetContentTest.php
@@ -67,6 +67,11 @@ class SnippetContentTest extends BaseFunctionalTestCase
      */
     protected $defaultSnippetManager;
 
+    /**
+     * @var ReferenceStoreInterface
+     */
+    protected $snippetAreaReferenceStore;
+
     public function setUp(): void
     {
         $this->contentMapper = $this->getContainer()->get('sulu.content.mapper');
@@ -80,12 +85,13 @@ class SnippetContentTest extends BaseFunctionalTestCase
 
         $this->structureResolver = $this->getContainer()->get('sulu_website.resolver.structure');
         $this->referenceStore = $this->getContainer()->get('sulu_snippet.reference_store.snippet');
+        $this->snippetAreaReferenceStore = $this->getContainer()->get('sulu_snippet.reference_store.snippet_area');
         $this->contentType = new SnippetContent(
             $this->defaultSnippetManager->reveal(),
             $this->getContainer()->get('sulu_snippet.resolver'),
             $this->referenceStore,
-            true,
-            'SomeTemplate.html.twig'
+            $this->snippetAreaReferenceStore,
+            true
         );
 
         $this->getContainer()->get('sulu_document_manager.document_manager')->clear();
@@ -281,12 +287,16 @@ class SnippetContentTest extends BaseFunctionalTestCase
             ]
         );
 
+        self::assertNotContains('test', $this->snippetAreaReferenceStore->getAll());
+
         $this->defaultSnippetManager->load('sulu_io', 'test', 'de_at')
             ->shouldBeCalledTimes(1)
             ->willReturn($this->hotel1);
 
         $data = $this->contentType->getContentData($property->reveal());
         $this->assertCount(1, $data);
+
+        self::assertContains('test', $this->snippetAreaReferenceStore->getAll());
     }
 
     public function testGetContentDataDefaultWrongType(): void

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/SnippetContentTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/SnippetContentTest.php
@@ -90,8 +90,8 @@ class SnippetContentTest extends BaseFunctionalTestCase
             $this->defaultSnippetManager->reveal(),
             $this->getContainer()->get('sulu_snippet.resolver'),
             $this->referenceStore,
-            $this->snippetAreaReferenceStore,
-            true
+            true,
+            $this->snippetAreaReferenceStore
         );
 
         $this->getContainer()->get('sulu_document_manager.document_manager')->clear();

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SingleSnippetSelectionTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SingleSnippetSelectionTest.php
@@ -19,6 +19,7 @@ use Sulu\Bundle\SnippetBundle\Content\SingleSnippetSelection;
 use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Sulu\Bundle\SnippetBundle\Snippet\DefaultSnippetManagerInterface;
 use Sulu\Bundle\SnippetBundle\Snippet\SnippetResolverInterface;
+use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStore;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
@@ -44,6 +45,11 @@ class SingleSnippetSelectionTest extends TestCase
     private $referenceStore;
 
     /**
+     * @var ReferenceStoreInterface
+     */
+    private $snippetAreaReferenceStore;
+
+    /**
      * @var SingleSnippetSelection
      */
     private $singleSnippetSelection;
@@ -53,11 +59,13 @@ class SingleSnippetSelectionTest extends TestCase
         $this->defaultSnippetManager = $this->prophesize(DefaultSnippetManagerInterface::class);
         $this->snippetResolver = $this->prophesize(SnippetResolverInterface::class);
         $this->referenceStore = $this->prophesize(ReferenceStoreInterface::class);
+        $this->snippetAreaReferenceStore = new ReferenceStore();
 
         $this->singleSnippetSelection = new SingleSnippetSelection(
             $this->snippetResolver->reveal(),
             $this->defaultSnippetManager->reveal(),
-            $this->referenceStore->reveal()
+            $this->referenceStore->reveal(),
+            $this->snippetAreaReferenceStore
         );
     }
 
@@ -119,6 +127,8 @@ class SingleSnippetSelectionTest extends TestCase
         $defaultSnippet->getUuid()->willReturn('456-456-456');
         $this->defaultSnippetManager->load('sulu_io', 'footer-snippet', 'de')->willReturn($defaultSnippet->reveal());
 
+        self::assertNotContains('footer-snippet', $this->snippetAreaReferenceStore->getAll());
+
         $this->snippetResolver
             ->resolve(['456-456-456'], 'sulu_io', 'de', null, false)
             ->willReturn([
@@ -128,6 +138,7 @@ class SingleSnippetSelectionTest extends TestCase
         $result = $this->singleSnippetSelection->getContentData($property->reveal());
 
         $this->assertEquals(['title' => 'test-1'], $result);
+        self::assertContains('footer-snippet', $this->snippetAreaReferenceStore->getAll());
     }
 
     public function testGetContentDataWithExtensions(): void

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SingleSnippetSelectionTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SingleSnippetSelectionTest.php
@@ -230,4 +230,43 @@ class SingleSnippetSelectionTest extends TestCase
 
         $this->referenceStore->add(Argument::cetera())->shouldNotBeCalled();
     }
+
+    public function testSingleSnippetSelectionWithNullSnippetAreaReferenceStore(): void
+    {
+        $this->singleSnippetSelection = new SingleSnippetSelection(
+            $this->snippetResolver->reveal(),
+            $this->defaultSnippetManager->reveal(),
+            $this->referenceStore->reveal(),
+            null
+        );
+
+        $property = $this->prophesize(PropertyInterface::class);
+        $structure = $this->prophesize(StructureBridge::class);
+        $structure->getWebspaceKey()->willReturn('sulu_io');
+        $structure->getLanguageCode()->willReturn('de');
+        $structure->getIsShadow()->wilLReturn(false);
+        $property->getStructure()->willReturn($structure->reveal());
+        $property->getValue()->willReturn('123-123-123');
+        $property->getParams()->willReturn([]);
+
+        $this->snippetResolver->resolve(
+            ['123-123-123'],
+            'sulu_io',
+            'de',
+            null,
+            false
+        )
+            ->willReturn(
+                [
+                    [
+                        'content' => ['title' => 'test-1'],
+                        'view' => ['title' => 'test-2', 'template' => 'default'],
+                    ],
+                ]
+            );
+
+        $result = $this->singleSnippetSelection->getContentData($property->reveal());
+
+        $this->assertEquals(['title' => 'test-1'], $result);
+    }
 }

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SnippetContentTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SnippetContentTest.php
@@ -17,6 +17,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\SnippetBundle\Content\SnippetContent;
 use Sulu\Bundle\SnippetBundle\Snippet\DefaultSnippetManagerInterface;
 use Sulu\Bundle\SnippetBundle\Snippet\SnippetResolverInterface;
+use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStore;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
@@ -42,6 +43,11 @@ class SnippetContentTest extends TestCase
     private $referenceStore;
 
     /**
+     * @var ReferenceStoreInterface
+     */
+    private $snippetAreaReferenceStore;
+
+    /**
      * @var SnippetContent
      */
     private $contentType;
@@ -51,13 +57,14 @@ class SnippetContentTest extends TestCase
         $this->defaultSnippetManager = $this->prophesize(DefaultSnippetManagerInterface::class);
         $this->snippetResolver = $this->prophesize(SnippetResolverInterface::class);
         $this->referenceStore = $this->prophesize(ReferenceStoreInterface::class);
+        $this->snippetAreaReferenceStore = new ReferenceStore();
 
         $this->contentType = new SnippetContent(
             $this->defaultSnippetManager->reveal(),
             $this->snippetResolver->reveal(),
             $this->referenceStore->reveal(),
+            $this->snippetAreaReferenceStore,
             false,
-            ''
         );
     }
 

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SnippetContentTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SnippetContentTest.php
@@ -63,8 +63,8 @@ class SnippetContentTest extends TestCase
             $this->defaultSnippetManager->reveal(),
             $this->snippetResolver->reveal(),
             $this->referenceStore->reveal(),
-            $this->snippetAreaReferenceStore,
             false,
+            $this->snippetAreaReferenceStore,
         );
     }
 
@@ -154,5 +154,36 @@ class SnippetContentTest extends TestCase
         $this->contentType->preResolve($property->reveal());
 
         $this->referenceStore->add('123-123-123')->shouldBeCalled();
+    }
+
+    public function testSnippetContentWithNullSnippetAreaReferenceStore(): void
+    {
+        $this->contentType = new SnippetContent(
+            $this->defaultSnippetManager->reveal(),
+            $this->snippetResolver->reveal(),
+            $this->referenceStore->reveal(),
+            false,
+            null
+        );
+
+        $property = $this->prophesize(PropertyInterface::class);
+        $structure = $this->prophesize(StructureBridge::class);
+        $structure->getWebspaceKey()->willReturn('sulu_io');
+        $structure->getLanguageCode()->willReturn('de');
+        $structure->getIsShadow()->wilLReturn(true);
+        $structure->getShadowBaseLanguage()->wilLReturn('en');
+        $property->getStructure()->willReturn($structure->reveal());
+        $property->getValue()->willReturn(['123-123-123']);
+        $property->getParams()->willReturn([]);
+
+        $this->snippetResolver->resolve(['123-123-123'], 'sulu_io', 'de', 'en', false)
+            ->willReturn(
+                [['content' => ['title' => 'test-1'], 'view' => ['title' => 'test-2', 'template' => 'default']]]
+            );
+        $this->referenceStore->add('123-123-123')->shouldNotBeCalled();
+
+        $result = $this->contentType->getContentData($property->reveal());
+
+        $this->assertEquals([['title' => 'test-1']], $result);
     }
 }

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/DependencyInjection/Compiler/SnippetAreaCompilerPassTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/DependencyInjection/Compiler/SnippetAreaCompilerPassTest.php
@@ -58,6 +58,7 @@ class SnippetAreaCompilerPassTest extends TestCase
                 'test' => [
                     'key' => 'test',
                     'template' => 'test',
+                    'cache-invalidation' => 'false',
                     'title' => [
                         'de' => 'Test DE',
                         'en' => 'Test EN',
@@ -66,6 +67,7 @@ class SnippetAreaCompilerPassTest extends TestCase
                 'hotel' => [
                     'key' => 'hotel',
                     'template' => 'hotel',
+                    'cache-invalidation' => 'false',
                     'title' => [
                         'de' => 'Hotel DE',
                         'en' => 'Hotel EN',
@@ -86,6 +88,7 @@ class SnippetAreaCompilerPassTest extends TestCase
             [
                 'article' => [
                     'key' => 'article',
+                    'cache-invalidation' => 'true',
                     'title' => [
                         'de' => 'Artikel Test',
                         'en' => 'Article Test',
@@ -113,6 +116,7 @@ class SnippetAreaCompilerPassTest extends TestCase
                 'article' => [
                     'key' => 'article',
                     'template' => 'test',
+                    'cache-invalidation' => 'true',
                     'title' => [
                         'de' => 'Artikel Test',
                         'en' => 'Article Test',

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/EventListener/CacheInvalidationSubscriberTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/EventListener/CacheInvalidationSubscriberTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SnippetBundle\Tests\Unit\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\HttpCacheBundle\Cache\CacheManager;
+use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
+use Sulu\Bundle\SnippetBundle\Domain\Event\SnippetModifiedEvent;
+use Sulu\Bundle\SnippetBundle\Domain\Event\SnippetRemovedEvent;
+use Sulu\Bundle\SnippetBundle\Domain\Event\WebspaceDefaultSnippetModifiedEvent;
+use Sulu\Bundle\SnippetBundle\Domain\Event\WebspaceDefaultSnippetRemovedEvent;
+use Sulu\Bundle\SnippetBundle\EventListener\CacheInvalidationSubscriber;
+use Sulu\Bundle\SnippetBundle\Snippet\DefaultSnippetManagerInterface;
+use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
+
+class CacheInvalidationSubscriberTest extends TestCase
+{
+    use ProphecyTrait;
+    use SetGetPrivatePropertyTrait;
+
+    /**
+     * @var ObjectProphecy<DefaultSnippetManagerInterface>|DefaultSnippetManagerInterface
+     */
+    private $defaultSnippetManager;
+
+    /**
+     * @var ObjectProphecy<CacheManager>|CacheManager
+     */
+    private $cacheManager;
+
+    /**
+     * @var array<int, array{
+     *     key: string,
+     *     cache-invalidation: string
+     * }>
+     */
+    private array $areas;
+
+    private CacheInvalidationSubscriber $cacheInvalidationSubscriber;
+
+    protected function setUp(): void
+    {
+        $this->defaultSnippetManager = $this->prophesize(DefaultSnippetManagerInterface::class);
+        $this->cacheManager = $this->prophesize(CacheManager::class);
+        $this->areas = [
+            ['key' => 'area1', 'cache-invalidation' => 'true'],
+            ['key' => 'area2', 'cache-invalidation' => 'false'],
+        ];
+        $this->cacheInvalidationSubscriber = new CacheInvalidationSubscriber(
+            $this->defaultSnippetManager->reveal(),
+            $this->cacheManager->reveal(),
+            $this->areas
+        );
+    }
+
+    public function testInvalidateSnippetAreaOnModified(): void
+    {
+        $snippet = new SnippetDocument();
+        self::setPrivateProperty($snippet, 'uuid', '1234');
+
+        $event = new SnippetModifiedEvent($snippet, 'de', []);
+        $this->defaultSnippetManager->loadType('1234')->willReturn('area1');
+
+        $this->cacheManager->invalidateReference('snippet_area', 'area1')
+            ->shouldBeCalled();
+
+        $this->cacheInvalidationSubscriber->invalidateSnippetAreaOnModified($event);
+    }
+
+    public function testInvalidateSnippetAreaOnRemoved(): void
+    {
+        $event = new SnippetRemovedEvent('1234', null, null);
+        $this->defaultSnippetManager->loadType('1234')->willReturn('area1');
+
+        $this->cacheManager->invalidateReference('snippet_area', 'area1')
+            ->shouldBeCalled();
+
+        $this->cacheInvalidationSubscriber->invalidateSnippetAreaOnRemoved($event);
+    }
+
+    public function testInvalidateSnippetAreaOnAreaRemoved(): void
+    {
+        $event = new WebspaceDefaultSnippetRemovedEvent('1234', 'area1');
+
+        $this->cacheManager->invalidateReference('snippet_area', 'area1')
+            ->shouldBeCalled();
+
+        $this->cacheInvalidationSubscriber->invalidateSnippetAreaOnAreaRemoved($event);
+    }
+
+    public function testInvalidateSnippetAreaOnAreaModified(): void
+    {
+        $snippet = new SnippetDocument();
+        self::setPrivateProperty($snippet, 'uuid', '1234');
+
+        $event = new WebspaceDefaultSnippetModifiedEvent('1234', 'area1', $snippet);
+
+        $this->cacheManager->invalidateReference('snippet_area', 'area1')
+            ->shouldBeCalled();
+
+        $this->cacheInvalidationSubscriber->invalidateSnippetAreaOnAreaModified($event);
+    }
+
+    public function testInvalidateSnippetAreaWhenCacheManagerIsNull(): void
+    {
+        $cacheInvalidationSubscriber = new CacheInvalidationSubscriber(
+            $this->defaultSnippetManager->reveal(),
+            null,
+            $this->areas
+        );
+
+        $snippet = new SnippetDocument();
+        self::setPrivateProperty($snippet, 'uuid', '1234');
+        $event = new SnippetModifiedEvent($snippet, 'de', []);
+        $this->defaultSnippetManager->loadType('1234')
+            ->shouldNotBeCalled();
+
+        $cacheInvalidationSubscriber->invalidateSnippetAreaOnModified($event);
+    }
+
+    public function testInvalidateSnippetAreaWhenCacheInvalidationIsFalse(): void
+    {
+        $snippet = new SnippetDocument();
+        self::setPrivateProperty($snippet, 'uuid', '1234');
+        $event = new SnippetModifiedEvent($snippet, 'de', []);
+        $this->defaultSnippetManager->loadType('1234')
+            ->willReturn('area2');
+        $this->cacheManager->invalidateReference('snippet_area', 'area2')
+            ->shouldNotBeCalled();
+
+        $this->cacheInvalidationSubscriber->invalidateSnippetAreaOnModified($event);
+    }
+}

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Twig/SnippetAreaTwigExtensionTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Twig/SnippetAreaTwigExtensionTest.php
@@ -20,6 +20,7 @@ use Sulu\Bundle\SnippetBundle\Snippet\DefaultSnippetManagerInterface;
 use Sulu\Bundle\SnippetBundle\Snippet\SnippetResolverInterface;
 use Sulu\Bundle\SnippetBundle\Snippet\WrongSnippetTypeException;
 use Sulu\Bundle\SnippetBundle\Twig\SnippetAreaTwigExtension;
+use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Webspace;
@@ -53,6 +54,11 @@ class SnippetAreaTwigExtensionTest extends TestCase
      */
     private $snippetResolver;
 
+    /**
+     * @var ObjectProphecy<ReferenceStoreInterface>
+     */
+    private $snippetAreaReferenceStore;
+
     public function testLoadByArea(): void
     {
         $this->defaultSnippetManager = $this->prophesize(DefaultSnippetManagerInterface::class);
@@ -64,6 +70,7 @@ class SnippetAreaTwigExtensionTest extends TestCase
         $this->requestAnalyzer->getWebspace()->willReturn($this->webspace->reveal());
         $this->requestAnalyzer->getCurrentLocalization()->willReturn($this->localization);
         $this->snippetResolver = $this->prophesize(SnippetResolverInterface::class);
+        $this->snippetAreaReferenceStore = $this->prophesize(ReferenceStoreInterface::class);
 
         $snippet = $this->prophesize(SnippetDocument::class);
         $snippet->getUuid()->willReturn('1234');
@@ -74,7 +81,8 @@ class SnippetAreaTwigExtensionTest extends TestCase
         $twigExtension = new SnippetAreaTwigExtension(
             $this->defaultSnippetManager->reveal(),
             $this->requestAnalyzer->reveal(),
-            $this->snippetResolver->reveal()
+            $this->snippetResolver->reveal(),
+            $this->snippetAreaReferenceStore->reveal()
         );
 
         $this->assertEquals(
@@ -107,7 +115,8 @@ class SnippetAreaTwigExtensionTest extends TestCase
         $twigExtension = new SnippetAreaTwigExtension(
             $this->defaultSnippetManager->reveal(),
             $this->requestAnalyzer->reveal(),
-            $this->snippetResolver->reveal()
+            $this->snippetResolver->reveal(),
+            $this->snippetAreaReferenceStore->reveal()
         );
 
         $this->assertEquals(null, $twigExtension->loadByArea('test'));
@@ -131,7 +140,8 @@ class SnippetAreaTwigExtensionTest extends TestCase
         $twigExtension = new SnippetAreaTwigExtension(
             $this->defaultSnippetManager->reveal(),
             $this->requestAnalyzer->reveal(),
-            $this->snippetResolver->reveal()
+            $this->snippetResolver->reveal(),
+            $this->snippetAreaReferenceStore->reveal()
         );
 
         $this->assertEquals(
@@ -161,7 +171,8 @@ class SnippetAreaTwigExtensionTest extends TestCase
         $twigExtension = new SnippetAreaTwigExtension(
             $this->defaultSnippetManager->reveal(),
             $this->requestAnalyzer->reveal(),
-            $this->snippetResolver->reveal()
+            $this->snippetResolver->reveal(),
+            $this->snippetAreaReferenceStore->reveal()
         );
 
         $this->assertEquals(
@@ -191,7 +202,8 @@ class SnippetAreaTwigExtensionTest extends TestCase
         $twigExtension = new SnippetAreaTwigExtension(
             $this->defaultSnippetManager->reveal(),
             $this->requestAnalyzer->reveal(),
-            $this->snippetResolver->reveal()
+            $this->snippetResolver->reveal(),
+            $this->snippetAreaReferenceStore->reveal()
         );
 
         $this->assertEquals(

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Twig/SnippetAreaTwigExtensionTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Twig/SnippetAreaTwigExtensionTest.php
@@ -20,6 +20,7 @@ use Sulu\Bundle\SnippetBundle\Snippet\DefaultSnippetManagerInterface;
 use Sulu\Bundle\SnippetBundle\Snippet\SnippetResolverInterface;
 use Sulu\Bundle\SnippetBundle\Snippet\WrongSnippetTypeException;
 use Sulu\Bundle\SnippetBundle\Twig\SnippetAreaTwigExtension;
+use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStore;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
@@ -55,9 +56,15 @@ class SnippetAreaTwigExtensionTest extends TestCase
     private $snippetResolver;
 
     /**
-     * @var ObjectProphecy<ReferenceStoreInterface>
+     * @var ReferenceStoreInterface
      */
     private $snippetAreaReferenceStore;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->snippetAreaReferenceStore = new ReferenceStore();
+    }
 
     public function testLoadByArea(): void
     {
@@ -70,7 +77,6 @@ class SnippetAreaTwigExtensionTest extends TestCase
         $this->requestAnalyzer->getWebspace()->willReturn($this->webspace->reveal());
         $this->requestAnalyzer->getCurrentLocalization()->willReturn($this->localization);
         $this->snippetResolver = $this->prophesize(SnippetResolverInterface::class);
-        $this->snippetAreaReferenceStore = $this->prophesize(ReferenceStoreInterface::class);
 
         $snippet = $this->prophesize(SnippetDocument::class);
         $snippet->getUuid()->willReturn('1234');
@@ -82,13 +88,17 @@ class SnippetAreaTwigExtensionTest extends TestCase
             $this->defaultSnippetManager->reveal(),
             $this->requestAnalyzer->reveal(),
             $this->snippetResolver->reveal(),
-            $this->snippetAreaReferenceStore->reveal()
+            $this->snippetAreaReferenceStore
         );
+
+        self::assertNotContains('test', $this->snippetAreaReferenceStore->getAll());
 
         $this->assertEquals(
             ['title' => 'Test Snippet'],
             $twigExtension->loadByArea('test')
         );
+
+        self::assertContains('test', $this->snippetAreaReferenceStore->getAll());
     }
 
     public function testLoadByAreaWrongType(): void
@@ -116,7 +126,7 @@ class SnippetAreaTwigExtensionTest extends TestCase
             $this->defaultSnippetManager->reveal(),
             $this->requestAnalyzer->reveal(),
             $this->snippetResolver->reveal(),
-            $this->snippetAreaReferenceStore->reveal()
+            $this->snippetAreaReferenceStore
         );
 
         $this->assertEquals(null, $twigExtension->loadByArea('test'));
@@ -141,7 +151,7 @@ class SnippetAreaTwigExtensionTest extends TestCase
             $this->defaultSnippetManager->reveal(),
             $this->requestAnalyzer->reveal(),
             $this->snippetResolver->reveal(),
-            $this->snippetAreaReferenceStore->reveal()
+            $this->snippetAreaReferenceStore
         );
 
         $this->assertEquals(
@@ -172,7 +182,7 @@ class SnippetAreaTwigExtensionTest extends TestCase
             $this->defaultSnippetManager->reveal(),
             $this->requestAnalyzer->reveal(),
             $this->snippetResolver->reveal(),
-            $this->snippetAreaReferenceStore->reveal()
+            $this->snippetAreaReferenceStore
         );
 
         $this->assertEquals(
@@ -203,7 +213,7 @@ class SnippetAreaTwigExtensionTest extends TestCase
             $this->defaultSnippetManager->reveal(),
             $this->requestAnalyzer->reveal(),
             $this->snippetResolver->reveal(),
-            $this->snippetAreaReferenceStore->reveal()
+            $this->snippetAreaReferenceStore
         );
 
         $this->assertEquals(

--- a/src/Sulu/Bundle/SnippetBundle/Twig/SnippetAreaTwigExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/Twig/SnippetAreaTwigExtension.php
@@ -14,6 +14,8 @@ namespace Sulu\Bundle\SnippetBundle\Twig;
 use Sulu\Bundle\SnippetBundle\Snippet\DefaultSnippetManagerInterface;
 use Sulu\Bundle\SnippetBundle\Snippet\SnippetResolverInterface;
 use Sulu\Bundle\SnippetBundle\Snippet\WrongSnippetTypeException;
+use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStore;
+use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Twig\Extension\AbstractExtension;
@@ -39,14 +41,21 @@ class SnippetAreaTwigExtension extends AbstractExtension
      */
     private $snippetResolver;
 
+    /**
+     * @var ReferenceStore
+     */
+    private $snippetAreaReferenceStore;
+
     public function __construct(
         DefaultSnippetManagerInterface $defaultSnippetManager,
         RequestAnalyzerInterface $requestAnalyzer,
-        SnippetResolverInterface $snippetResolver
+        SnippetResolverInterface $snippetResolver,
+        ReferenceStoreInterface $snippetAreaReferenceStore
     ) {
         $this->defaultSnippetManager = $defaultSnippetManager;
         $this->requestAnalyzer = $requestAnalyzer;
         $this->snippetResolver = $snippetResolver;
+        $this->snippetAreaReferenceStore = $snippetAreaReferenceStore;
     }
 
     public function getFunctions()
@@ -73,6 +82,8 @@ class SnippetAreaTwigExtension extends AbstractExtension
         if (!$locale) {
             $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
         }
+
+        $this->snippetAreaReferenceStore->add($area);
 
         try {
             $snippet = $this->defaultSnippetManager->load($webspaceKey, $area, $locale);

--- a/src/Sulu/Bundle/SnippetBundle/Twig/SnippetAreaTwigExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/Twig/SnippetAreaTwigExtension.php
@@ -14,7 +14,6 @@ namespace Sulu\Bundle\SnippetBundle\Twig;
 use Sulu\Bundle\SnippetBundle\Snippet\DefaultSnippetManagerInterface;
 use Sulu\Bundle\SnippetBundle\Snippet\SnippetResolverInterface;
 use Sulu\Bundle\SnippetBundle\Snippet\WrongSnippetTypeException;
-use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStore;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
@@ -42,7 +41,7 @@ class SnippetAreaTwigExtension extends AbstractExtension
     private $snippetResolver;
 
     /**
-     * @var ReferenceStore
+     * @var ReferenceStoreInterface
      */
     private $snippetAreaReferenceStore;
 

--- a/src/Sulu/Component/Content/Metadata/Loader/AbstractLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/AbstractLoader.php
@@ -143,7 +143,7 @@ abstract class AbstractLoader implements LoaderInterface
                 }
             }
 
-            if(!isset($area['cache-invalidation'])) {
+            if (!isset($area['cache-invalidation'])) {
                 $area['cache-invalidation'] = 'true';
             }
 

--- a/src/Sulu/Component/Content/Metadata/Loader/AbstractLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/AbstractLoader.php
@@ -136,11 +136,15 @@ abstract class AbstractLoader implements LoaderInterface
             $area = [];
 
             foreach ($node->attributes as $key => $attr) {
-                if (\in_array($key, ['key'])) {
+                if (\in_array($key, ['key', 'cache-invalidation'])) {
                     $area[$key] = $attr->value;
                 } else {
                     $area['attributes'][$key] = $attr->value;
                 }
+            }
+
+            if(!isset($area['cache-invalidation'])) {
+                $area['cache-invalidation'] = 'true';
             }
 
             $meta = $this->loadMeta('x:meta/x:*', $xpath, $node);

--- a/src/Sulu/Component/Content/Metadata/Loader/schema/properties-1.0.xsd
+++ b/src/Sulu/Component/Content/Metadata/Loader/schema/properties-1.0.xsd
@@ -44,6 +44,7 @@
             </xs:element>
         </xs:sequence>
         <xs:attribute name="key" type="xs:string" use="required"/>
+        <xs:attribute name="cache-invalidation" type="xs:boolean" default="true"/>
     </xs:complexType>
 
     <xs:complexType name="langType">


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Invalidate snippet area cache, when the area snippet is modified/removed

#### Why?

Cache invalidation does not work properly for default area snippets that were updated
