### PR TITLE
Improve the device detector runtime by wiring the system cache if present

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "jms/serializer-bundle": "^3.8 || ^4.0",
         "massive/build-bundle": "^0.5",
         "massive/search-bundle": "^2.6.4",
-        "matomo/device-detector": "^3.7 || ^4.0.1 || ^5.0 || ^6.0",
+        "matomo/device-detector": "^3.9 || ^4.0.1 || ^5.0 || ^6.0",
         "nyholm/psr7": "^1.3",
         "oro/doctrine-extensions": "^1.0.8 || ^2.0",
         "phpcr/phpcr-migrations": "^1.3.1",

--- a/src/Sulu/Bundle/AudienceTargetingBundle/DependencyInjection/Compiler/DeviceDetectorCachePass.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/DependencyInjection/Compiler/DeviceDetectorCachePass.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AudienceTargetingBundle\DependencyInjection\Compiler;
+
+use DeviceDetector\Cache\PSR6Bridge;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class DeviceDetectorCachePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->has('sulu_audience_targeting.device_detector') || !$container->has('cache.system')) {
+            return;
+        }
+
+        $deviceDetector = $container->findDefinition('sulu_audience_targeting.device_detector');
+        $deviceDetector->addMethodCall('setCache', [new Definition(PSR6Bridge::class, [new Reference('cache.system')])]);
+    }
+}

--- a/src/Sulu/Bundle/AudienceTargetingBundle/SuluAudienceTargetingBundle.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/SuluAudienceTargetingBundle.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\AudienceTargetingBundle;
 
 use Sulu\Bundle\AudienceTargetingBundle\DependencyInjection\Compiler\AddRulesPass;
+use Sulu\Bundle\AudienceTargetingBundle\DependencyInjection\Compiler\DeviceDetectorCachePass;
 use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupConditionInterface;
 use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupInterface;
 use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupRuleInterface;
@@ -41,5 +42,6 @@ class SuluAudienceTargetingBundle extends Bundle
         );
 
         $container->addCompilerPass(new AddRulesPass());
+        $container->addCompilerPass(new DeviceDetectorCachePass());
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | 
| License | MIT
| Documentation PR | 

#### What's in this PR?

Use Symfony's system cache pool when it is present to cache data read from YAML files by the device detector.

#### Why?

The `DeviceDetector` class scans several YAML files which never change during runtime. This consumes most of the CPU time when e.g. `/_sulu_target_group` is requested. Caching the parsed result improves this a lot.