### PR TITLE
Fix constant hasser not working correctly

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,11 +26,6 @@ parameters:
 			path: src/Sulu/Bundle/ActivityBundle/Infrastructure/Doctrine/Repository/ActivityRepository.php
 
 		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ActivityBundle/Infrastructure/Symfony/DependencyInjection/SuluActivityExtension.php
-
-		-
 			message: "#^Parameter \\#2 \\$value of method Symfony\\\\Component\\\\DependencyInjection\\\\Container\\:\\:setParameter\\(\\) expects array\\|bool\\|float\\|int\\|string\\|UnitEnum\\|null, mixed given\\.$#"
 			count: 2
 			path: src/Sulu/Bundle/ActivityBundle/Infrastructure/Symfony/DependencyInjection/SuluActivityExtension.php
@@ -2501,11 +2496,6 @@ parameters:
 			path: src/Sulu/Bundle/AudienceTargetingBundle/DependencyInjection/Configuration.php
 
 		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/AudienceTargetingBundle/DependencyInjection/SuluAudienceTargetingExtension.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\DependencyInjection\\\\SuluAudienceTargetingExtension\\:\\:load\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/AudienceTargetingBundle/DependencyInjection/SuluAudienceTargetingExtension.php
@@ -4636,19 +4626,9 @@ parameters:
 			path: src/Sulu/Bundle/CategoryBundle/DependencyInjection/Configuration.php
 
 		-
-			message: "#^If condition is always true\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/CategoryBundle/DependencyInjection/DeprecationCompilerPass.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\CategoryBundle\\\\DependencyInjection\\\\DeprecationCompilerPass\\:\\:process\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/CategoryBundle/DependencyInjection/DeprecationCompilerPass.php
-
-		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/CategoryBundle/DependencyInjection/SuluCategoryExtension.php
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\CategoryBundle\\\\DependencyInjection\\\\SuluCategoryExtension\\:\\:load\\(\\) has no return type specified\\.$#"
@@ -5042,7 +5022,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'id' on mixed\\.$#"
-			count: 14
+			count: 12
 			path: src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/KeywordControllerTest.php
 
 		-
@@ -7132,7 +7112,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'addition' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
 
 		-
@@ -7142,82 +7122,82 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'billingAddress' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
 
 		-
 			message: "#^Cannot access offset 'city' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
 
 		-
 			message: "#^Cannot access offset 'countryCode' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
 
 		-
 			message: "#^Cannot access offset 'deliveryAddress' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
 
 		-
 			message: "#^Cannot access offset 'latitude' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
 
 		-
 			message: "#^Cannot access offset 'longitude' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
 
 		-
 			message: "#^Cannot access offset 'note' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
 
 		-
 			message: "#^Cannot access offset 'number' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
 
 		-
 			message: "#^Cannot access offset 'postboxCity' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
 
 		-
 			message: "#^Cannot access offset 'postboxNumber' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
 
 		-
 			message: "#^Cannot access offset 'postboxPostcode' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
 
 		-
 			message: "#^Cannot access offset 'primaryAddress' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
 
 		-
 			message: "#^Cannot access offset 'state' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
 
 		-
 			message: "#^Cannot access offset 'street' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
 
 		-
 			message: "#^Cannot access offset 'title' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
 
 		-
 			message: "#^Cannot access offset 'zip' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
 
 		-
@@ -9309,11 +9289,6 @@ parameters:
 			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\DependencyInjection\\\\Configuration\\:\\:addObjectsSection\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/DependencyInjection/Configuration.php
-
-		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\DependencyInjection\\\\SuluContactExtension\\:\\:load\\(\\) has no return type specified\\.$#"
@@ -11506,11 +11481,6 @@ parameters:
 			path: src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RemoveForeignContextServicesPass.php
 
 		-
-			message: "#^Negated boolean expression is always false\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RemoveForeignContextServicesPass.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\CoreBundle\\\\DependencyInjection\\\\Compiler\\\\ReplacersCompilerPass\\:\\:process\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/ReplacersCompilerPass.php
@@ -11867,7 +11837,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'prefix' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/CustomUrlBundle/Resources/phpcr-migrations/Version201904110902.php
 
 		-
@@ -12646,11 +12616,6 @@ parameters:
 			path: src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Compiler/InitializerPass.php
 
 		-
-			message: "#^Left side of && is always false\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\DependencyInjection\\\\SuluDocumentManagerExtension\\:\\:configureDocumentManager\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
@@ -12677,16 +12642,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\DependencyInjection\\\\SuluDocumentManagerExtension\\:\\:prepend\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
-
-		-
-			message: "#^Negated boolean expression is always true\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
-
-		-
-			message: "#^Ternary operator condition is always false\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
 
@@ -13446,11 +13401,6 @@ parameters:
 			path: src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/CacheLifetime/CacheLifetimeRequestStoreTest.php
 
 		-
-			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertTrue\\(\\) with false will always evaluate to false\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/DependencyInjection/SuluHttpCacheExtensionTest.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\HttpCacheBundle\\\\Tests\\\\Unit\\\\EventListener\\\\InvalidationSubscriberTest\\:\\:provideRequest\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/EventSubscriber/InvalidationSubscriberTest.php
@@ -13657,12 +13607,12 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'address' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/LocationBundle/Geolocator/Service/NominatimGeolocator.php
 
 		-
 			message: "#^Cannot access offset 'city'\\|'country_code'\\|'house_number'\\|'postcode'\\|'road' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/LocationBundle/Geolocator/Service/NominatimGeolocator.php
 
 		-
@@ -13859,11 +13809,6 @@ parameters:
 			message: "#^Method Sulu\\\\Bundle\\\\MarkupBundle\\\\DependencyInjection\\\\SuluMarkupExtension\\:\\:load\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MarkupBundle/DependencyInjection/SuluMarkupExtension.php
-
-		-
-			message: "#^Cannot access offset string\\|null on Sulu\\\\Bundle\\\\MarkupBundle\\\\Markup\\\\MarkupParserInterface\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MarkupBundle/Listener/MarkupListener.php
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\MarkupBundle\\\\Listener\\\\MarkupListener\\:\\:replaceMarkup\\(\\) has no return type specified\\.$#"
@@ -14084,11 +14029,6 @@ parameters:
 			message: "#^Property Sulu\\\\Bundle\\\\MarkupBundle\\\\Tag\\\\TagNotFoundException\\:\\:\\$type \\(string\\) does not accept int\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MarkupBundle/Tag/TagNotFoundException.php
-
-		-
-			message: "#^Cannot access offset string on Sulu\\\\Bundle\\\\MarkupBundle\\\\Tag\\\\TagInterface\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/MarkupBundle/Tag/TagRegistry.php
 
 		-
 			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, Sulu\\\\Bundle\\\\MarkupBundle\\\\Tag\\\\TagInterface given\\.$#"
@@ -15667,12 +15607,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'key' on mixed\\.$#"
-			count: 4
-			path: src/Sulu/Bundle/MediaBundle/DependencyInjection/AbstractImageFormatCompilerPass.php
-
-		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
+			count: 2
 			path: src/Sulu/Bundle/MediaBundle/DependencyInjection/AbstractImageFormatCompilerPass.php
 
 		-
@@ -15729,11 +15664,6 @@ parameters:
 			message: "#^Parameter \\#1 \\.\\.\\.\\$arrays of function array_merge expects array, mixed given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/DependencyInjection/S3ClientCompilerPass.php
-
-		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\DependencyInjection\\\\SuluMediaExtension\\:\\:checkCommandAvailability\\(\\) has no return type specified\\.$#"
@@ -18237,7 +18167,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'categories' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
 
 		-
@@ -19777,12 +19707,12 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 0 on Sulu\\\\Bundle\\\\MediaBundle\\\\Api\\\\Media\\.$#"
-			count: 4
+			count: 3
 			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Twig/MediaTwigExtensionTest.php
 
 		-
 			message: "#^Cannot access offset 1 on Sulu\\\\Bundle\\\\MediaBundle\\\\Api\\\\Media\\.$#"
-			count: 4
+			count: 3
 			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Twig/MediaTwigExtensionTest.php
 
 		-
@@ -21751,11 +21681,6 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/DependencyInjection/Compiler/WebspacesPass.php
 
 		-
-			message: "#^If condition is always false\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/DependencyInjection/SuluPageExtension.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\PageBundle\\\\DependencyInjection\\\\SuluPageExtension\\:\\:appendDefaultAuthor\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/DependencyInjection/SuluPageExtension.php
@@ -21782,11 +21707,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\PageBundle\\\\DependencyInjection\\\\SuluPageExtension\\:\\:processSearch\\(\\) has parameter \\$config with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/DependencyInjection/SuluPageExtension.php
-
-		-
-			message: "#^Negated boolean expression is always false\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/DependencyInjection/SuluPageExtension.php
 
@@ -24296,11 +24216,6 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Command/ValidatePagesCommandTest.php
 
 		-
-			message: "#^If condition is always false\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Command/ValidateWebspacesCommandTest.php
-
-		-
 			message: "#^PHPDoc tag @var for variable \\$controllerNameParser contains unknown class Symfony\\\\Bundle\\\\FrameworkBundle\\\\Controller\\\\ControllerNameParser\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Command/ValidateWebspacesCommandTest.php
@@ -24662,7 +24577,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'availableLocales' on mixed\\.$#"
-			count: 7
+			count: 5
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
 
 		-
@@ -24677,7 +24592,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'contentLocales' on mixed\\.$#"
-			count: 17
+			count: 11
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
 
 		-
@@ -27387,7 +27302,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'redirectTargetUuid' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
 
 		-
@@ -27611,11 +27526,6 @@ parameters:
 			path: src/Sulu/Bundle/PersistenceBundle/Tests/Unit/Fixture/Bundle/UsingPersistenceBundleTrait.php
 
 		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PersistenceBundle/Tests/Unit/Fixture/DependencyInjection/UsingPersistenceExtensionTrait.php
-
-		-
 			message: "#^Parameter \\#1 \\$objects of method Sulu\\\\Bundle\\\\PersistenceBundle\\\\Tests\\\\Unit\\\\Fixture\\\\DependencyInjection\\\\UsingPersistenceExtensionTrait\\:\\:configurePersistence\\(\\) expects array\\<string, array\\{model\\: class\\-string, repository\\?\\: class\\-string\\}\\>, mixed given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PersistenceBundle/Tests/Unit/Fixture/DependencyInjection/UsingPersistenceExtensionTrait.php
@@ -27639,11 +27549,6 @@ parameters:
 			message: "#^Method Sulu\\\\Bundle\\\\PreviewBundle\\\\Domain\\\\Model\\\\PreviewLink\\:\\:__construct\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PreviewBundle/Domain/Model/PreviewLink.php
-
-		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Infrastructure/Symfony/DependencyInjection/SuluPreviewExtension.php
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\PreviewBundle\\\\Preview\\\\Events\\\\PreRenderEvent\\:\\:getAttribute\\(\\) has no return type specified\\.$#"
@@ -27742,7 +27647,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'html' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
 
 		-
@@ -28416,16 +28321,6 @@ parameters:
 			path: src/Sulu/Bundle/RouteBundle/DependencyInjection/RouteGeneratorCompilerPass.php
 
 		-
-			message: "#^Negated boolean expression is always false\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/RouteBundle/DependencyInjection/RouteGeneratorCompilerPass.php
-
-		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/RouteBundle/DependencyInjection/SuluRouteExtension.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\RouteBundle\\\\DependencyInjection\\\\SuluRouteExtension\\:\\:load\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/RouteBundle/DependencyInjection/SuluRouteExtension.php
@@ -28627,7 +28522,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'locale' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/RouteBundle/Generator/SymfonyExpressionTokenProvider.php
 
 		-
@@ -29547,7 +29442,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'id' on mixed\\.$#"
-			count: 3
+			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/Controller/GroupController.php
 
 		-
@@ -30194,11 +30089,6 @@ parameters:
 			message: "#^Method Sulu\\\\Bundle\\\\SecurityBundle\\\\DependencyInjection\\\\Configuration\\:\\:addObjectsSection\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/DependencyInjection/Configuration.php
-
-		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/DependencyInjection/SuluSecurityExtension.php
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\SecurityBundle\\\\Entity\\\\AccessControl\\:\\:getEntityClass\\(\\) has no return type specified\\.$#"
@@ -33992,7 +33882,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'id' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/TagBundle/Controller/TagController.php
 
 		-
@@ -34054,11 +33944,6 @@ parameters:
 			message: "#^Property Sulu\\\\Bundle\\\\TagBundle\\\\Controller\\\\TagController\\:\\:\\$unsortable type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/TagBundle/Controller/TagController.php
-
-		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/TagBundle/DependencyInjection/SuluTagExtension.php
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\TagBundle\\\\DependencyInjection\\\\SuluTagExtension\\:\\:load\\(\\) has no return type specified\\.$#"
@@ -34766,11 +34651,6 @@ parameters:
 			path: src/Sulu/Bundle/TrashBundle/Application/DoctrineRestoreHelper/DoctrineRestoreHelper.php
 
 		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/TrashBundle/Infrastructure/Symfony/DependencyInjection/SuluTrashExtension.php
-
-		-
 			message: "#^Property Sulu\\\\Bundle\\\\TrashBundle\\\\Tests\\\\Application\\\\Entity\\\\TestResource\\:\\:\\$property1 is never read, only written\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/TrashBundle/Tests/Application/Entity/TestResource.php
@@ -35271,11 +35151,6 @@ parameters:
 			path: src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
 
 		-
-			message: "#^Negated boolean expression is always false\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
-
-		-
 			message: "#^Parameter \\#1 \\$format of method Symfony\\\\Component\\\\HttpFoundation\\\\Request\\:\\:getMimeType\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
@@ -35317,7 +35192,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'structure' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
 
 		-
@@ -35349,11 +35224,6 @@ parameters:
 			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\DependencyInjection\\\\Compiler\\\\RouteProviderCompilerPass\\:\\:process\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Compiler/RouteProviderCompilerPass.php
-
-		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/DependencyInjection/SuluWebsiteExtension.php
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\DependencyInjection\\\\SuluWebsiteExtension\\:\\:load\\(\\) has no return type specified\\.$#"
@@ -35977,12 +35847,12 @@ parameters:
 
 		-
 			message: "#^Cannot access offset '_locale' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
 
 		-
 			message: "#^Cannot access offset 'prefix' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
 
 		-
@@ -42142,7 +42012,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset mixed on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Component/Content/Mapper/ContentMapper.php
 
 		-
@@ -54872,7 +54742,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'tags' on mixed\\.$#"
-			count: 3
+			count: 1
 			path: src/Sulu/Component/SmartContent/ContentType.php
 
 		-
@@ -57017,12 +56887,12 @@ parameters:
 
 		-
 			message: "#^Cannot access offset string on mixed\\.$#"
-			count: 6
+			count: 4
 			path: src/Sulu/Component/Webspace/Manager/WebspaceManager.php
 
 		-
 			message: "#^Cannot access offset string\\|null on mixed\\.$#"
-			count: 3
+			count: 2
 			path: src/Sulu/Component/Webspace/Manager/WebspaceManager.php
 
 		-

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -27,8 +27,8 @@ parameters:
         # RestController extends FOSRestController which was removed in friendsofsymfony/rest-bundle:3.0
         - %currentWorkingDirectory%/src/Sulu/Component/Rest/RestController.php
     symfony:
-        container_xml_path: %currentWorkingDirectory%/var/cache/admin/dev/App_KernelDevDebugContainer.xml
-        console_application_loader: tests/phpstan/console-application.php
-        constant_hassers: false
+        containerXmlPath: %currentWorkingDirectory%/var/cache/admin/dev/App_KernelDevDebugContainer.xml
+        consoleApplicationLoader: tests/phpstan/console-application.php
+        constantHassers: false
     doctrine:
         objectManagerLoader: tests/phpstan/object-manager.php


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Use new parameters for symfony phpstan extension. In case of constant_hassers did not longer work as constantHassers was always true and so did overwrite it.

#### Why?

See https://github.com/phpstan/phpstan-symfony/issues/364