### PR TITLE
404 on missing portal

### DIFF
--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
@@ -92,10 +92,7 @@ class WebsiteRequestProcessor implements RequestProcessorInterface
                 . (!\in_array($attributes->getAttribute('port'), ['80', '443'], true) ? ':' . $attributes->getAttribute('port') : '')
                     . $attributes->getAttribute('path');
 
-            throw new UrlMatchNotFoundException(
-                $fullUrl,
-                $portalUrls
-            );
+            throw new UrlMatchNotFoundException($fullUrl, $portalUrls);
         }
 
         return true;

--- a/src/Sulu/Component/Webspace/Analyzer/Exception/UrlMatchNotFoundException.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Exception/UrlMatchNotFoundException.php
@@ -11,22 +11,18 @@
 
 namespace Sulu\Component\Webspace\Analyzer\Exception;
 
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
 /**
  * Thrown by request analyzer, when there is no portal matching the given URL.
  */
-class UrlMatchNotFoundException extends \Exception
+class UrlMatchNotFoundException extends HttpException
 {
     /**
-     * The url for which no portal exists.
-     *
-     * @var string
-     */
-    private $url;
-
-    /**
+     * @param string   $url         The url for which no portal exists.
      * @param string[] $portalUrls
      */
-    public function __construct($url, array $portalUrls = [])
+    public function __construct(private $url, array $portalUrls = [])
     {
         $this->url = $url;
         $message = 'There exists no portal for the URL "' . $url . '"';
@@ -35,7 +31,7 @@ class UrlMatchNotFoundException extends \Exception
             $message .= ', the URL should begin with one of the following Portal URLs: "' . \implode('", "', $portalUrls) . '"';
         }
 
-        parent::__construct($message, 0);
+        parent::__construct(404, $message);
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Analyzer/Exception/UrlMatchNotFoundException.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Exception/UrlMatchNotFoundException.php
@@ -19,10 +19,16 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 class UrlMatchNotFoundException extends HttpException
 {
     /**
-     * @param string   $url         The url for which no portal exists.
+     * The url for which no portal exists.
+     *
+     * @var string
+     */
+    private $url;
+
+    /**
      * @param string[] $portalUrls
      */
-    public function __construct(private $url, array $portalUrls = [])
+    public function __construct($url, array $portalUrls = [])
     {
         $this->url = $url;
         $message = 'There exists no portal for the URL "' . $url . '"';


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #7045
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
When the user calls a url where no portal matches, we don't return a 500 anymore.

#### Why?
The 500 implies that the server couldn't process it properly, which is incorrect.