### PR TITLE
Fixed deprecation happening when content type is checked in AppendAnalyticsListener

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -34801,11 +34801,6 @@ parameters:
 			path: src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
 
 		-
-			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
-
-		-
 			message: "#^Parameter \\#1 \\$responseContent of method Sulu\\\\Bundle\\\\WebsiteBundle\\\\EventListener\\\\AppendAnalyticsListener\\:\\:setAnalyticsContent\\(\\) expects string, string\\|false given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
@@ -93,7 +93,7 @@ class AppendAnalyticsListener
 
         $response = $event->getResponse();
 
-        if (0 !== \strpos($response->headers->get('Content-Type'), 'text/html')
+        if (0 !== \strpos($response->headers->get('Content-Type', ''), 'text/html')
             || !$response->getContent()
             || null === $this->requestAnalyzer->getPortalInformation()
         ) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Setting default value in AppendAnalyticsListener when checking content type.

#### Why?

This is required, because the content type can be null (for example for responses with status code `204`), which results in the following deprecation message:

> strpos(): Passing null to parameter #1 () of type string is deprecated

in PHP 8.2

#### Example Usage

Add the following return statement to a controller action to reproduce the issue:

```php
return $this->json(null, Response::HTTP_NO_CONTENT);
```
