### PR TITLE
Add support for translation keys in snippet areas meta

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -30016,31 +30016,6 @@ parameters:
 			path: src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\SnippetBundle\\\\DependencyInjection\\\\Compiler\\\\SnippetAreaCompilerPass\\:\\:getArea\\(\\) has parameter \\$area with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SnippetBundle/DependencyInjection/Compiler/SnippetAreaCompilerPass.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\SnippetBundle\\\\DependencyInjection\\\\Compiler\\\\SnippetAreaCompilerPass\\:\\:getArea\\(\\) has parameter \\$locales with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SnippetBundle/DependencyInjection/Compiler/SnippetAreaCompilerPass.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\SnippetBundle\\\\DependencyInjection\\\\Compiler\\\\SnippetAreaCompilerPass\\:\\:getArea\\(\\) has parameter \\$template with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SnippetBundle/DependencyInjection/Compiler/SnippetAreaCompilerPass.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\SnippetBundle\\\\DependencyInjection\\\\Compiler\\\\SnippetAreaCompilerPass\\:\\:getArea\\(\\) has parameter \\$templateTitles with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SnippetBundle/DependencyInjection/Compiler/SnippetAreaCompilerPass.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\SnippetBundle\\\\DependencyInjection\\\\Compiler\\\\SnippetAreaCompilerPass\\:\\:getArea\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SnippetBundle/DependencyInjection/Compiler/SnippetAreaCompilerPass.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\SnippetBundle\\\\DependencyInjection\\\\SuluSnippetExtension\\:\\:load\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/DependencyInjection/SuluSnippetExtension.php

--- a/src/Sulu/Bundle/SnippetBundle/DependencyInjection/Compiler/SnippetAreaCompilerPass.php
+++ b/src/Sulu/Bundle/SnippetBundle/DependencyInjection/Compiler/SnippetAreaCompilerPass.php
@@ -76,7 +76,7 @@ class SnippetAreaCompilerPass implements CompilerPassInterface
     }
 
     /**
-     * @param array{key: string, title: array<string>} $area
+     * @param array{key: string, title: array<string>, cache-invalidation: string} $area
      * @param array<string> $locales
      * @param array<string, string> $templateTitles
      *

--- a/src/Sulu/Bundle/SnippetBundle/DependencyInjection/Compiler/SnippetAreaCompilerPass.php
+++ b/src/Sulu/Bundle/SnippetBundle/DependencyInjection/Compiler/SnippetAreaCompilerPass.php
@@ -76,7 +76,6 @@ class SnippetAreaCompilerPass implements CompilerPassInterface
     }
 
     /**
-     * @param string $template
      * @param array{key: string, title: array<string>} $area
      * @param array<string> $locales
      * @param array<string, string> $templateTitles

--- a/src/Sulu/Bundle/SnippetBundle/DependencyInjection/Compiler/SnippetAreaCompilerPass.php
+++ b/src/Sulu/Bundle/SnippetBundle/DependencyInjection/Compiler/SnippetAreaCompilerPass.php
@@ -90,15 +90,14 @@ class SnippetAreaCompilerPass implements CompilerPassInterface
         $titles = [];
         $areaTitles = $area['title'];
 
-        // If we only have one title, it is probably a translation key
-        if (1 === \count($areaTitles)) {
+        // If we only have one title and no locale (indexed 0) then it's a translation key
+        if (1 === \count($areaTitles) && \array_key_exists(0, $areaTitles)) {
             $translator = $container->get('translator');
             $titleToTranslate = \reset($areaTitles);
             foreach ($locales as $locale) {
                 $titles[$locale] = $translator->trans($titleToTranslate, [], 'admin', $locale);
             }
         } else {
-            \trigger_error('Translating snippet areas in the XML is deprecated use a translation instead.', \E_USER_DEPRECATED);
             foreach ($locales as $locale) {
                 $title = $templateTitles[$locale] . ' ' . \ucfirst($key);
                 if (isset($areaTitles[$locale])) {

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/DependencyInjection/Compiler/SnippetAreaCompilerPassTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/DependencyInjection/Compiler/SnippetAreaCompilerPassTest.php
@@ -146,7 +146,7 @@ class SnippetAreaCompilerPassTest extends TestCase
         );
 
         $this->structureFactory = $this->prophesize(StructureMetadataFactoryInterface::class);
-        $this->structureFactory->getStructures('snippet')->willReturn([ $structureMetaData->reveal() ]);
+        $this->structureFactory->getStructures('snippet')->willReturn([$structureMetaData->reveal()]);
 
         $translator = $this->prophesize(TranslatorInterface::class);
         $translator->trans('sulu_snippet.areas.article.title', [], 'admin', 'en')->willReturn('Article Test');

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/DependencyInjection/Compiler/SnippetAreaCompilerPassTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/DependencyInjection/Compiler/SnippetAreaCompilerPassTest.php
@@ -18,6 +18,7 @@ use Sulu\Bundle\SnippetBundle\DependencyInjection\Compiler\SnippetAreaCompilerPa
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
 use Sulu\Component\Content\Metadata\StructureMetadata;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class SnippetAreaCompilerPassTest extends TestCase
 {
@@ -120,6 +121,50 @@ class SnippetAreaCompilerPassTest extends TestCase
                     'title' => [
                         'de' => 'Artikel Test',
                         'en' => 'Article Test',
+                    ],
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $compiler->process($this->container->reveal());
+    }
+
+    public function testWithTranslatedAreas(): void
+    {
+        $compiler = new SnippetAreaCompilerPass();
+
+        $structureMetaData = $this->createStructureMetaData(
+            'test',
+            [
+                'article' => [
+                    'key' => 'article',
+                    'title' => [
+                        'sulu_snippet.areas.article.title',
+                    ],
+                ],
+            ]
+        );
+
+        $this->structureFactory = $this->prophesize(StructureMetadataFactoryInterface::class);
+        $this->structureFactory->getStructures('snippet')->willReturn([ $structureMetaData->reveal() ]);
+
+        $translator = $this->prophesize(TranslatorInterface::class);
+        $translator->trans('sulu_snippet.areas.article.title', [], 'admin', 'en')->willReturn('Article Test');
+        $translator->trans('sulu_snippet.areas.article.title', [], 'admin', 'de')->willReturn('Artikel Test');
+        $this->container = $this->prophesize(ContainerBuilder::class);
+        $this->container->get('sulu_page.structure.factory')->willReturn($this->structureFactory->reveal());
+        $this->container->get('translator')->willReturn($translator->reveal());
+        $this->container->getParameter('sulu_core.locales')->willReturn(['en', 'de']);
+
+        $this->container->setParameter(
+            'sulu_snippet.areas',
+            [
+                'article' => [
+                    'key' => 'article',
+                    'template' => 'test',
+                    'title' => [
+                        'en' => 'Article Test',
+                        'de' => 'Artikel Test',
                     ],
                 ],
             ]

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/DependencyInjection/Compiler/SnippetAreaCompilerPassTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/DependencyInjection/Compiler/SnippetAreaCompilerPassTest.php
@@ -89,6 +89,7 @@ class SnippetAreaCompilerPassTest extends TestCase
             [
                 'article' => [
                     'key' => 'article',
+                    'cache-invalidation' => 'false',
                     'title' => [
                         'en' => 'Article EN',
                     ],
@@ -113,6 +114,7 @@ class SnippetAreaCompilerPassTest extends TestCase
                 'article' => [
                     'key' => 'article',
                     'template' => 'test',
+                    'cache-invalidation' => 'false',
                     'title' => [
                         'en' => 'Article EN',
                         'de' => 'Test DE Article',
@@ -182,6 +184,7 @@ class SnippetAreaCompilerPassTest extends TestCase
             [
                 'article' => [
                     'key' => 'article',
+                    'cache-invalidation' => 'false',
                     'title' => [
                         'sulu_snippet.areas.article.title',
                     ],
@@ -206,6 +209,7 @@ class SnippetAreaCompilerPassTest extends TestCase
                 'article' => [
                     'key' => 'article',
                     'template' => 'test',
+                    'cache-invalidation' => 'false',
                     'title' => [
                         'en' => 'Article Test',
                         'de' => 'Artikel Test',
@@ -226,6 +230,7 @@ class SnippetAreaCompilerPassTest extends TestCase
             [
                 'article' => [
                     'key' => 'article',
+                    'cache-invalidation' => 'false',
                     'title' => [
                         'sulu_snippet.areas.article.title',
                     ],
@@ -250,6 +255,7 @@ class SnippetAreaCompilerPassTest extends TestCase
                 'article' => [
                     'key' => 'article',
                     'template' => 'test',
+                    'cache-invalidation' => 'false',
                     'title' => [
                         'en' => 'sulu_snippet.areas.article.title',
                         'de' => 'sulu_snippet.areas.article.title',

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/DependencyInjection/Compiler/SnippetAreaCompilerPassTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/DependencyInjection/Compiler/SnippetAreaCompilerPassTest.php
@@ -80,6 +80,50 @@ class SnippetAreaCompilerPassTest extends TestCase
         $compiler->process($this->container->reveal());
     }
 
+    public function testWithOnlyOneTranslation(): void
+    {
+        $compiler = new SnippetAreaCompilerPass();
+
+        $structureMetaData = $this->createStructureMetaData(
+            'test',
+            [
+                'article' => [
+                    'key' => 'article',
+                    'title' => [
+                        'en' => 'Article EN',
+                    ],
+                ],
+            ]
+        );
+
+        $this->structureFactory = $this->prophesize(StructureMetadataFactoryInterface::class);
+        $this->structureFactory->getStructures('snippet')->willReturn([$structureMetaData->reveal()]);
+
+        $translator = $this->prophesize(TranslatorInterface::class);
+        $translator->trans()->shouldNotBeCalled();
+
+        $this->container = $this->prophesize(ContainerBuilder::class);
+        $this->container->get('sulu_page.structure.factory')->willReturn($this->structureFactory->reveal());
+        $this->container->get('translator')->shouldNotBeCalled();
+        $this->container->getParameter('sulu_core.locales')->willReturn(['en', 'de']);
+
+        $this->container->setParameter(
+            'sulu_snippet.areas',
+            [
+                'article' => [
+                    'key' => 'article',
+                    'template' => 'test',
+                    'title' => [
+                        'en' => 'Article EN',
+                        'de' => 'Test DE Article',
+                    ],
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $compiler->process($this->container->reveal());
+    }
+
     public function testWithAreas(): void
     {
         $compiler = new SnippetAreaCompilerPass();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #7120 
| License | MIT
| Documentation PR | -

#### What's in this PR?
Adding the option to use a translation key in the snippet area configuration.

#### Why?
Separating the content configuration from the translation to make it easier for external tools to help with translations. 

#### Example Usage
```xml
 <areas>
        <area key="top">
            <meta>
                <title>some.translation.key</title>
            </meta>
        </area>
    </areas>
```