### PR TITLE
Add compatibility to Symfony 7 DataTransformer in DocumentToUuidTransformer

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,18 @@
 
 ## 2.6.0
 
+### DocumentToUuidTransformer return type changed
+
+For compatibility to Symfony 7 the `DocumentToUuidTransformer` methods return types changed:
+
+```diff
+-    public function transform($document)
++    public function transform($document): ?string
+
+-    public function reverseTransform($uuid)
++    public function reverseTransform($uuid): ?object
+```
+
 ### Admin JS ResourceRouteRegistry getDetailUrl and getListUrl deprecated
 
 The `getDetailUrl` and `getListUrl` methods of the `routeRegistry` were deprecated.  

--- a/src/Sulu/Component/Content/Form/DataTransformer/DocumentToUuidTransformer.php
+++ b/src/Sulu/Component/Content/Form/DataTransformer/DocumentToUuidTransformer.php
@@ -52,7 +52,7 @@ class DocumentToUuidTransformer implements DataTransformerInterface
     public function reverseTransform($uuid): ?object
     {
         if (!$uuid) {
-            return;
+            return null;
         }
 
         if (!UUIDHelper::isUuid($uuid)) {

--- a/src/Sulu/Component/Content/Form/DataTransformer/DocumentToUuidTransformer.php
+++ b/src/Sulu/Component/Content/Form/DataTransformer/DocumentToUuidTransformer.php
@@ -17,6 +17,9 @@ use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 
+/**
+ * @final
+ */
 class DocumentToUuidTransformer implements DataTransformerInterface
 {
     /**
@@ -29,10 +32,10 @@ class DocumentToUuidTransformer implements DataTransformerInterface
         $this->documentManager = $documentManager;
     }
 
-    public function transform($document)
+    public function transform($document): ?string
     {
         if (null === $document) {
-            return;
+            return null;
         }
 
         // TODO: Use the document inspector instead of the UUID behavior
@@ -46,7 +49,7 @@ class DocumentToUuidTransformer implements DataTransformerInterface
         return $document->getUuid();
     }
 
-    public function reverseTransform($uuid)
+    public function reverseTransform($uuid): ?object
     {
         if (!$uuid) {
             return;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs |  https://github.com/sulu/sulu/pull/7156
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Change of return types of DocumentToUuidTransformer.

#### Why?

Prepare Support for Symfony 7 for Sulu 2.6, see error on https://github.com/sulu/sulu/pull/7156.