### PR TITLE
Add Friends Of Sulu to InfoCommand

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Command/InfoCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/InfoCommand.php
@@ -81,6 +81,7 @@ class InfoCommand extends Command
  - Sulu Slack Channel: <href=https://sulu.io/services-and-support#chat>https://sulu.io/services-and-support#chat</>
  - Symfony Slack Channel: <href=https://symfony.com/community>https://symfony.com/community</>
  - Doctrine Slack Channel: <href=https://www.doctrine-project.org/community/index.html>https://www.doctrine-project.org/community/index.html</>
+ - FriendsOfSulu: <href=https://github.com/FriendsOfSulu>https://github.com/FriendsOfSulu</>
 
 ---
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

Add the FriendsOfSulu page to the Community section of Cummunity in InfoCommand

#### Why?

 that new people can be aware of community projects when installing Sulu.
