### PR TITLE
Replace EntityManager::merge with EntityManager::persist

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/DataFixtures/ORM/LoadDefaultTypes.php
+++ b/src/Sulu/Bundle/ContactBundle/DataFixtures/ORM/LoadDefaultTypes.php
@@ -34,17 +34,17 @@ class LoadDefaultTypes extends AbstractFixture implements OrderedFixtureInterfac
 
         $phoneType1 = new PhoneType();
         $phoneType1->setId(1);
-        $phoneType1 = $manager->merge($phoneType1);
+        $manager->persist($phoneType1);
         $phoneType1->setName('sulu_contact.work');
 
         $phoneType2 = new PhoneType();
         $phoneType2->setId(2);
-        $phoneType2 = $manager->merge($phoneType2);
+        $manager->persist($phoneType2);
         $phoneType2->setName('sulu_contact.private');
 
         $phoneType3 = new PhoneType();
         $phoneType3->setId(3);
-        $phoneType3 = $manager->merge($phoneType3);
+        $manager->persist($phoneType3);
         $phoneType3->setName('sulu_contact.mobile');
 
         // Email types.
@@ -54,14 +54,14 @@ class LoadDefaultTypes extends AbstractFixture implements OrderedFixtureInterfac
 
         $emailType1 = new EmailType();
         $emailType1->setId(1);
-        $emailType1 = $manager->merge($emailType1);
+        $manager->persist($emailType1);
         $emailType1->setName('sulu_contact.work');
 
         $this->addReference('email.type.work', $emailType1);
 
         $emailType2 = new EmailType();
         $emailType2->setId(2);
-        $emailType2 = $manager->merge($emailType2);
+        $manager->persist($emailType2);
         $emailType2->setName('sulu_contact.private');
 
         $this->addReference('email.type.private', $emailType2);
@@ -73,12 +73,12 @@ class LoadDefaultTypes extends AbstractFixture implements OrderedFixtureInterfac
 
         $addressType1 = new AddressType();
         $addressType1->setId(1);
-        $addressType1 = $manager->merge($addressType1);
+        $manager->persist($addressType1);
         $addressType1->setName('sulu_contact.work');
 
         $addressType2 = new AddressType();
         $addressType2->setId(2);
-        $addressType2 = $manager->merge($addressType2);
+        $manager->persist($addressType2);
         $addressType2->setName('sulu_contact.private');
 
         // Url types.
@@ -88,12 +88,12 @@ class LoadDefaultTypes extends AbstractFixture implements OrderedFixtureInterfac
 
         $urlType1 = new UrlType();
         $urlType1->setId(1);
-        $urlType1 = $manager->merge($urlType1);
+        $manager->persist($urlType1);
         $urlType1->setName('sulu_contact.work');
 
         $urlType2 = new UrlType();
         $urlType2->setId(2);
-        $urlType2 = $manager->merge($urlType2);
+        $manager->persist($urlType2);
         $urlType2->setName('sulu_contact.private');
 
         // Fax types.
@@ -103,12 +103,12 @@ class LoadDefaultTypes extends AbstractFixture implements OrderedFixtureInterfac
 
         $faxType1 = new FaxType();
         $faxType1->setId(1);
-        $faxType1 = $manager->merge($faxType1);
+        $manager->persist($faxType1);
         $faxType1->setName('sulu_contact.work');
 
         $faxType2 = new FaxType();
         $faxType2->setId(2);
-        $faxType2 = $manager->merge($faxType2);
+        $manager->persist($faxType2);
         $faxType2->setName('sulu_contact.private');
 
         // Social media profile types.
@@ -118,17 +118,17 @@ class LoadDefaultTypes extends AbstractFixture implements OrderedFixtureInterfac
 
         $socialMediaProfileType1 = new SocialMediaProfileType();
         $socialMediaProfileType1->setId(1);
-        $socialMediaProfileType1 = $manager->merge($socialMediaProfileType1);
+        $manager->persist($socialMediaProfileType1);
         $socialMediaProfileType1->setName('Facebook');
 
         $socialMediaProfileType2 = new SocialMediaProfileType();
         $socialMediaProfileType2->setId(2);
-        $socialMediaProfileType2 = $manager->merge($socialMediaProfileType2);
+        $manager->persist($socialMediaProfileType2);
         $socialMediaProfileType2->setName('Twitter');
 
         $socialMediaProfileType3 = new SocialMediaProfileType();
         $socialMediaProfileType3->setId(3);
-        $socialMediaProfileType3 = $manager->merge($socialMediaProfileType3);
+        $manager->persist($socialMediaProfileType3);
         $socialMediaProfileType3->setName('Instagram');
 
         $manager->flush();

--- a/src/Sulu/Bundle/ContactBundle/DataFixtures/ORM/LoadDefaultTypes.php
+++ b/src/Sulu/Bundle/ContactBundle/DataFixtures/ORM/LoadDefaultTypes.php
@@ -32,37 +32,52 @@ class LoadDefaultTypes extends AbstractFixture implements OrderedFixtureInterfac
         $metadata->setIdGenerator(new AssignedGenerator());
         $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
 
-        $phoneType1 = new PhoneType();
-        $phoneType1->setId(1);
-        $manager->persist($phoneType1);
-        $phoneType1->setName('sulu_contact.work');
+        $phoneType1 = $manager->find(PhoneType::class, 1);
+        if (null === $phoneType1) {
+            $phoneType1 = new PhoneType();
+            $phoneType1->setId(1);
+            $manager->persist($phoneType1);
+            $phoneType1->setName('sulu_contact.work');
+        }
 
-        $phoneType2 = new PhoneType();
-        $phoneType2->setId(2);
-        $manager->persist($phoneType2);
-        $phoneType2->setName('sulu_contact.private');
+        $phoneType2 = $manager->find(PhoneType::class, 2);
+        if (null === $phoneType2) {
+            $phoneType2 = new PhoneType();
+            $phoneType2->setId(2);
+            $manager->persist($phoneType2);
+            $phoneType2->setName('sulu_contact.private');
+        }
 
-        $phoneType3 = new PhoneType();
-        $phoneType3->setId(3);
-        $manager->persist($phoneType3);
-        $phoneType3->setName('sulu_contact.mobile');
+        $phoneType3 = $manager->find(PhoneType::class, 3);
+        if (null === $phoneType3) {
+            $phoneType3 = new PhoneType();
+            $phoneType3->setId(3);
+            $manager->persist($phoneType3);
+            $phoneType3->setName('sulu_contact.mobile');
+        }
 
         // Email types.
         $metadata = $manager->getClassMetaData(EmailType::class);
         $metadata->setIdGenerator(new AssignedGenerator());
         $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
 
-        $emailType1 = new EmailType();
-        $emailType1->setId(1);
-        $manager->persist($emailType1);
-        $emailType1->setName('sulu_contact.work');
+        $emailType1 = $manager->find(EmailType::class, 1);
+        if (null === $emailType1) {
+            $emailType1 = new EmailType();
+            $emailType1->setId(1);
+            $manager->persist($emailType1);
+            $emailType1->setName('sulu_contact.work');
+        }
 
         $this->addReference('email.type.work', $emailType1);
 
-        $emailType2 = new EmailType();
-        $emailType2->setId(2);
-        $manager->persist($emailType2);
-        $emailType2->setName('sulu_contact.private');
+        $emailType2 = $manager->find(EmailType::class, 2);
+        if (null === $emailType2) {
+            $emailType2 = new EmailType();
+            $emailType2->setId(2);
+            $manager->persist($emailType2);
+            $emailType2->setName('sulu_contact.private');
+        }
 
         $this->addReference('email.type.private', $emailType2);
 
@@ -71,65 +86,92 @@ class LoadDefaultTypes extends AbstractFixture implements OrderedFixtureInterfac
         $metadata->setIdGenerator(new AssignedGenerator());
         $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
 
-        $addressType1 = new AddressType();
-        $addressType1->setId(1);
-        $manager->persist($addressType1);
-        $addressType1->setName('sulu_contact.work');
+        $addressType1 = $manager->find(AddressType::class, 1);
+        if (null === $addressType1) {
+            $addressType1 = new AddressType();
+            $addressType1->setId(1);
+            $manager->persist($addressType1);
+            $addressType1->setName('sulu_contact.work');
+        }
 
-        $addressType2 = new AddressType();
-        $addressType2->setId(2);
-        $manager->persist($addressType2);
-        $addressType2->setName('sulu_contact.private');
+        $addressType2 = $manager->find(AddressType::class, 2);
+        if (null === $addressType2) {
+            $addressType2 = new AddressType();
+            $addressType2->setId(2);
+            $manager->persist($addressType2);
+            $addressType2->setName('sulu_contact.private');
+        }
 
         // Url types.
         $metadata = $manager->getClassMetaData(UrlType::class);
         $metadata->setIdGenerator(new AssignedGenerator());
         $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
 
-        $urlType1 = new UrlType();
-        $urlType1->setId(1);
-        $manager->persist($urlType1);
-        $urlType1->setName('sulu_contact.work');
+        $urlType1 = $manager->find(UrlType::class, 1);
+        if (null === $urlType1) {
+            $urlType1 = new UrlType();
+            $urlType1->setId(1);
+            $manager->persist($urlType1);
+            $urlType1->setName('sulu_contact.work');
+        }
 
-        $urlType2 = new UrlType();
-        $urlType2->setId(2);
-        $manager->persist($urlType2);
-        $urlType2->setName('sulu_contact.private');
+        $urlType2 = $manager->find(UrlType::class, 2);
+        if (null === $urlType2) {
+            $urlType2 = new UrlType();
+            $urlType2->setId(2);
+            $manager->persist($urlType2);
+            $urlType2->setName('sulu_contact.private');
+        }
 
         // Fax types.
         $metadata = $manager->getClassMetaData(FaxType::class);
         $metadata->setIdGenerator(new AssignedGenerator());
         $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
 
-        $faxType1 = new FaxType();
-        $faxType1->setId(1);
-        $manager->persist($faxType1);
-        $faxType1->setName('sulu_contact.work');
+        $faxType1 = $manager->find(FaxType::class, 1);
+        if (null === $faxType1) {
+            $faxType1 = new FaxType();
+            $faxType1->setId(1);
+            $manager->persist($faxType1);
+            $faxType1->setName('sulu_contact.work');
+        }
 
-        $faxType2 = new FaxType();
-        $faxType2->setId(2);
-        $manager->persist($faxType2);
-        $faxType2->setName('sulu_contact.private');
+        $faxType2 = $manager->find(FaxType::class, 2);
+        if (null === $faxType2) {
+            $faxType2 = new FaxType();
+            $faxType2->setId(2);
+            $manager->persist($faxType2);
+            $faxType2->setName('sulu_contact.private');
+        }
 
         // Social media profile types.
         $metadata = $manager->getClassMetaData(SocialMediaProfileType::class);
         $metadata->setIdGenerator(new AssignedGenerator());
         $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
 
-        $socialMediaProfileType1 = new SocialMediaProfileType();
-        $socialMediaProfileType1->setId(1);
-        $manager->persist($socialMediaProfileType1);
-        $socialMediaProfileType1->setName('Facebook');
+        $socialMediaProfileType1 = $manager->find(SocialMediaProfileType::class, 1);
+        if (null === $socialMediaProfileType1) {
+            $socialMediaProfileType1 = new SocialMediaProfileType();
+            $socialMediaProfileType1->setId(1);
+            $manager->persist($socialMediaProfileType1);
+            $socialMediaProfileType1->setName('Facebook');
+        }
 
-        $socialMediaProfileType2 = new SocialMediaProfileType();
-        $socialMediaProfileType2->setId(2);
-        $manager->persist($socialMediaProfileType2);
-        $socialMediaProfileType2->setName('Twitter');
+        $socialMediaProfileType2 = $manager->find(SocialMediaProfileType::class, 2);
+        if (null === $socialMediaProfileType2) {
+            $socialMediaProfileType2 = new SocialMediaProfileType();
+            $socialMediaProfileType2->setId(2);
+            $manager->persist($socialMediaProfileType2);
+            $socialMediaProfileType2->setName('Twitter');
+        }
 
-        $socialMediaProfileType3 = new SocialMediaProfileType();
-        $socialMediaProfileType3->setId(3);
-        $manager->persist($socialMediaProfileType3);
-        $socialMediaProfileType3->setName('Instagram');
+        $socialMediaProfileType3 = $manager->find(SocialMediaProfileType::class, 3);
+        if (null === $socialMediaProfileType3) {
+            $socialMediaProfileType3 = new SocialMediaProfileType();
+            $socialMediaProfileType3->setId(3);
+            $manager->persist($socialMediaProfileType3);
+            $socialMediaProfileType3->setName('Instagram');
+        }
 
         $manager->flush();
     }

--- a/src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadCollectionTypes.php
+++ b/src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadCollectionTypes.php
@@ -28,19 +28,25 @@ class LoadCollectionTypes extends AbstractFixture implements OrderedFixtureInter
         $metadata->setIdGenerator(new AssignedGenerator());
         $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
 
-        // create or update collectiontype with id 1
-        $defaultCollectionType = new CollectionType();
-        $defaultCollectionType->setId(1);
-        $manager->persist($defaultCollectionType);
-        $defaultCollectionType->setKey('collection.default');
-        $defaultCollectionType->setName('Default');
+        $defaultCollectionType = $manager->find(CollectionType::class, 1);
+        if (null === $defaultCollectionType) {
+            // create or update collectiontype with id 1
+            $defaultCollectionType = new CollectionType();
+            $defaultCollectionType->setId(1);
+            $manager->persist($defaultCollectionType);
+            $defaultCollectionType->setKey('collection.default');
+            $defaultCollectionType->setName('Default');
+        }
 
-        // create or update collectiontype with id 2
-        $systemCollectionType = new CollectionType();
-        $systemCollectionType->setId(2);
-        $manager->persist($systemCollectionType);
-        $systemCollectionType->setKey(SystemCollectionManagerInterface::COLLECTION_TYPE);
-        $systemCollectionType->setName('System Collections');
+        $systemCollectionType = $manager->find(CollectionType::class, 2);
+        if (null === $systemCollectionType) {
+            // create or update collectiontype with id 2
+            $systemCollectionType = new CollectionType();
+            $systemCollectionType->setId(2);
+            $manager->persist($systemCollectionType);
+            $systemCollectionType->setKey(SystemCollectionManagerInterface::COLLECTION_TYPE);
+            $systemCollectionType->setName('System Collections');
+        }
 
         $manager->flush();
     }

--- a/src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadCollectionTypes.php
+++ b/src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadCollectionTypes.php
@@ -31,14 +31,14 @@ class LoadCollectionTypes extends AbstractFixture implements OrderedFixtureInter
         // create or update collectiontype with id 1
         $defaultCollectionType = new CollectionType();
         $defaultCollectionType->setId(1);
-        $defaultCollectionType = $manager->merge($defaultCollectionType);
+        $manager->persist($defaultCollectionType);
         $defaultCollectionType->setKey('collection.default');
         $defaultCollectionType->setName('Default');
 
         // create or update collectiontype with id 2
         $systemCollectionType = new CollectionType();
         $systemCollectionType->setId(2);
-        $systemCollectionType = $manager->merge($systemCollectionType);
+        $manager->persist($systemCollectionType);
         $systemCollectionType->setKey(SystemCollectionManagerInterface::COLLECTION_TYPE);
         $systemCollectionType->setName('System Collections');
 

--- a/src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadMediaTypes.php
+++ b/src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadMediaTypes.php
@@ -27,25 +27,37 @@ class LoadMediaTypes extends AbstractFixture implements OrderedFixtureInterface
         $metadata->setIdGenerator(new AssignedGenerator());
         $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
 
-        $mediaDocument = new MediaType();
-        $mediaDocument->setId(1);
-        $manager->persist($mediaDocument);
-        $mediaDocument->setName('document');
+        $mediaDocument = $manager->find(MediaType::class, 1);
+        if (null === $mediaDocument) {
+            $mediaDocument = new MediaType();
+            $mediaDocument->setId(1);
+            $manager->persist($mediaDocument);
+            $mediaDocument->setName('document');
+        }
 
-        $mediaImage = new MediaType();
-        $mediaImage->setId(2);
-        $manager->persist($mediaImage);
-        $mediaImage->setName('image');
+        $mediaImage = $manager->find(MediaType::class, 2);
+        if (null === $mediaImage) {
+            $mediaImage = new MediaType();
+            $mediaImage->setId(2);
+            $manager->persist($mediaImage);
+            $mediaImage->setName('image');
+        }
 
-        $mediaVideo = new MediaType();
-        $mediaVideo->setId(3);
-        $manager->persist($mediaVideo);
-        $mediaVideo->setName('video');
+        $mediaVideo = $manager->find(MediaType::class, 3);
+        if (null === $mediaVideo) {
+            $mediaVideo = new MediaType();
+            $mediaVideo->setId(3);
+            $manager->persist($mediaVideo);
+            $mediaVideo->setName('video');
+        }
 
-        $mediaAudio = new MediaType();
-        $mediaAudio->setId(4);
-        $manager->persist($mediaAudio);
-        $mediaAudio->setName('audio');
+        $mediaAudio = $manager->find(MediaType::class, 4);
+        if (null === $mediaAudio) {
+            $mediaAudio = new MediaType();
+            $mediaAudio->setId(4);
+            $manager->persist($mediaAudio);
+            $mediaAudio->setName('audio');
+        }
 
         $manager->flush();
     }

--- a/src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadMediaTypes.php
+++ b/src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadMediaTypes.php
@@ -29,22 +29,22 @@ class LoadMediaTypes extends AbstractFixture implements OrderedFixtureInterface
 
         $mediaDocument = new MediaType();
         $mediaDocument->setId(1);
-        $mediaDocument = $manager->merge($mediaDocument);
+        $manager->persist($mediaDocument);
         $mediaDocument->setName('document');
 
         $mediaImage = new MediaType();
         $mediaImage->setId(2);
-        $mediaImage = $manager->merge($mediaImage);
+        $manager->persist($mediaImage);
         $mediaImage->setName('image');
 
         $mediaVideo = new MediaType();
         $mediaVideo->setId(3);
-        $mediaVideo = $manager->merge($mediaVideo);
+        $manager->persist($mediaVideo);
         $mediaVideo->setName('video');
 
         $mediaAudio = new MediaType();
         $mediaAudio->setId(4);
-        $mediaAudio = $manager->merge($mediaAudio);
+        $manager->persist($mediaAudio);
         $mediaAudio->setName('audio');
 
         $manager->flush();


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #7184
| License | MIT

#### What's in this PR?

EntityManagerInterface::merge() is deprecated, replace the calls with EntityManagerInterface::persist()