### PR TITLE
Validate Texteditor content only for string type

### DIFF
--- a/src/Sulu/Component/Content/Types/TextEditor.php
+++ b/src/Sulu/Component/Content/Types/TextEditor.php
@@ -45,7 +45,7 @@ class TextEditor extends SimpleContentType
     public function read(NodeInterface $node, PropertyInterface $property, $webspaceKey, $languageCode, $segmentKey)
     {
         $value = $node->getPropertyValueWithDefault($property->getName(), $this->defaultValue);
-        $property->setValue($this->validate($value, $languageCode));
+        $property->setValue(\is_string($value) ? $this->validate($value, $languageCode) : null);
 
         return $value;
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| BC breaks? | yes (no exception is thrown anymore)
| Fixed tickets | fixes #7140
| License | MIT

#### What's in this PR?

See the discussion in #7140: Due to some template changes (and not having written proper migrations), a page could not be deleted because the MarkupBundle could not parse the content anymore as it was not of type string. Thanks to Alex' suggestion, this PR will only validate Texteditor content if the content is of type string.

#### Why?

Because uncaught errors are not nice :) And in our specific case, the uncaught error did not allow us to delete the page in question.

