### PR TITLE
Add types to Symfony Configuration classes

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3346,16 +3346,6 @@ parameters:
 			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/AudienceTargetingCacheListenerTest.php
 
 		-
-			message: "#^Offset 0 does not exist on array\\{\\}\\.$#"
-			count: 3
-			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/AudienceTargetingCacheListenerTest.php
-
-		-
-			message: "#^Offset 1 does not exist on array\\{\\}\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/AudienceTargetingCacheListenerTest.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Tests\\\\Unit\\\\TargetGroupSubscriberTest\\:\\:provideAddSetCookieHeader\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
@@ -43653,6 +43643,11 @@ parameters:
 		-
 			message: "#^Method Sulu\\\\Component\\\\Content\\\\Query\\\\ListToTreeConverter\\:\\:toArray\\(\\) has parameter \\$tree with no type specified\\.$#"
 			count: 1
+			path: src/Sulu/Component/Content/Query/ListToTreeConverter.php
+
+		-
+			message: "#^Offset 'children' does not exist on array\\{\\}\\.$#"
+			count: 2
 			path: src/Sulu/Component/Content/Query/ListToTreeConverter.php
 
 		-

--- a/src/Sulu/Bundle/ActivityBundle/Infrastructure/Symfony/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/ActivityBundle/Infrastructure/Symfony/DependencyInjection/Configuration.php
@@ -18,7 +18,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sulu_activity');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Configuration.php
@@ -31,7 +31,7 @@ class Configuration implements ConfigurationInterface
         $this->debug = $debug;
     }
 
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sulu_admin');
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/DependencyInjection/Configuration.php
@@ -29,7 +29,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sulu_audience_targeting');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/Sulu/Bundle/CategoryBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/CategoryBundle/DependencyInjection/Configuration.php
@@ -22,7 +22,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sulu_category');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/Sulu/Bundle/ContactBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/ContactBundle/DependencyInjection/Configuration.php
@@ -24,7 +24,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sulu_contact');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -22,7 +22,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sulu_core');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Configuration.php
@@ -16,7 +16,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sulu_document_manager');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/Configuration.php
@@ -29,7 +29,7 @@ class Configuration implements ConfigurationInterface
         $this->debug = $debug;
     }
 
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sulu_http_cache');
         $root = $treeBuilder->getRootNode();

--- a/src/Sulu/Bundle/LocationBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/LocationBundle/DependencyInjection/Configuration.php
@@ -16,7 +16,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sulu_location');
         $treeBuilder->getRootNode()

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
@@ -26,7 +26,7 @@ class Configuration implements ConfigurationInterface
 
     public const STORAGE_AZURE_BLOB = 'azure_blob';
 
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sulu_media');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/Sulu/Bundle/PageBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/PageBundle/DependencyInjection/Configuration.php
@@ -16,7 +16,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sulu_page');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/Configuration.php
@@ -19,7 +19,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sulu_persistence');
 

--- a/src/Sulu/Bundle/PreviewBundle/Infrastructure/Symfony/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/PreviewBundle/Infrastructure/Symfony/DependencyInjection/Configuration.php
@@ -19,7 +19,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sulu_preview');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/Sulu/Bundle/RouteBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/RouteBundle/DependencyInjection/Configuration.php
@@ -22,7 +22,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sulu_route');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/Sulu/Bundle/RouteBundle/PageTree/PageTreeRepository.php
+++ b/src/Sulu/Bundle/RouteBundle/PageTree/PageTreeRepository.php
@@ -137,6 +137,7 @@ class PageTreeRepository implements PageTreeUpdaterInterface, PageTreeMoverInter
         $node->setProperty($propertyName . '-page', $parentDocument->getUuid());
         $node->setProperty($propertyName . '-page-path', $resourceSegment);
 
+        /** @var string|null $suffix */
         $suffix = $node->getPropertyValueWithDefault($propertyName . '-suffix', null);
         if ($suffix) {
             $path = \rtrim($resourceSegment, '/') . '/' . \ltrim($suffix, '/');

--- a/src/Sulu/Bundle/SearchBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/SearchBundle/DependencyInjection/Configuration.php
@@ -16,7 +16,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sulu_search');
         $treeBuilder->getRootNode()

--- a/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Configuration.php
@@ -20,7 +20,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sulu_security');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/Sulu/Bundle/SnippetBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/SnippetBundle/DependencyInjection/Configuration.php
@@ -16,7 +16,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sulu_snippet');
         $treeBuilder->getRootNode()

--- a/src/Sulu/Bundle/TagBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/TagBundle/DependencyInjection/Configuration.php
@@ -21,7 +21,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sulu_tag');
         $treeBuilder->getRootNode()

--- a/src/Sulu/Bundle/TestBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/TestBundle/DependencyInjection/Configuration.php
@@ -21,7 +21,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sulu_test');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/Sulu/Bundle/TrashBundle/Infrastructure/Symfony/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/TrashBundle/Infrastructure/Symfony/DependencyInjection/Configuration.php
@@ -20,7 +20,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sulu_trash');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Configuration.php
@@ -24,7 +24,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sulu_website');
         $rootNode = $treeBuilder->getRootNode();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | (fixing some of them yes)
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Adding return types to the configuration builder classes.

#### Why?

In Symfony 6 not having this type is deprecated and it can't hurt in 5.4 either. This is not a BC break as Return Type narrowing (the implementation of an interface can have a narrower return type than the interface implementing it) was introduced in 7.4 and not returning a `TreeBuilder` crashes the application anyways.

![image](https://github.com/sulu/sulu/assets/14860264/1504430c-5f07-45e3-b071-bd90bb8d3669)
