### PR TITLE
Add sorting for snippet area / default snippets by title instead of key

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -29866,16 +29866,6 @@ parameters:
 			path: src/Sulu/Bundle/SnippetBundle/Content/SnippetQueryBuilder.php
 
 		-
-			message: "#^Call to an undefined method object\\:\\:getTitle\\(\\)\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SnippetBundle/Controller/SnippetAreaController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getUuid\\(\\)\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SnippetBundle/Controller/SnippetAreaController.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\SnippetBundle\\\\Controller\\\\SnippetAreaController\\:\\:__construct\\(\\) has parameter \\$sulu_snippet_area with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/Controller/SnippetAreaController.php
@@ -29913,11 +29903,6 @@ parameters:
 		-
 			message: "#^Strict comparison using \\=\\=\\= between true and string will always evaluate to false\\.$#"
 			count: 1
-			path: src/Sulu/Bundle/SnippetBundle/Controller/SnippetAreaController.php
-
-		-
-			message: "#^Ternary operator condition is always true\\.$#"
-			count: 4
 			path: src/Sulu/Bundle/SnippetBundle/Controller/SnippetAreaController.php
 
 		-

--- a/src/Sulu/Bundle/SnippetBundle/Controller/SnippetAreaController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/SnippetAreaController.php
@@ -123,8 +123,8 @@ class SnippetAreaController implements ClassResourceInterface
 
                 if ($uuid) {
                     $snippet = $this->documentManager->find($uuid, $this->getUser()->getLocale());
-                    $areaData['defaultUuid'] = $snippet ? $snippet->getUuid() : null;
-                    $areaData['defaultTitle'] = $snippet ? $snippet->getTitle() : null;
+                    $areaData['defaultUuid'] = null;
+                    $areaData['defaultTitle'] = null;
                 }
             }
 
@@ -175,8 +175,8 @@ class SnippetAreaController implements ClassResourceInterface
                 'key' => $key,
                 'template' => $area['template'],
                 'title' => $area['title'],
-                'defaultUuid' => $defaultSnippet ? $defaultSnippet->getUuid() : null,
-                'defaultTitle' => $defaultSnippet ? $defaultSnippet->getTitle() : null,
+                'defaultUuid' => $defaultSnippet->getUuid(),
+                'defaultTitle' => $defaultSnippet->getTitle(),
                 'valid' => true,
             ]
         );

--- a/src/Sulu/Bundle/SnippetBundle/Controller/SnippetAreaController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/SnippetAreaController.php
@@ -135,7 +135,7 @@ class SnippetAreaController implements ClassResourceInterface
 
         $data = [
             '_embedded' => [
-                'areas' => $dataList,
+                'areas' => \array_values($dataList),
             ],
             'total' => \count($dataList),
         ];

--- a/src/Sulu/Bundle/SnippetBundle/Controller/SnippetAreaController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/SnippetAreaController.php
@@ -21,6 +21,7 @@ use Sulu\Component\Rest\RequestParametersTrait;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Sulu\Component\Security\Authorization\SecurityCondition;
+use Sulu\Component\Util\SortUtils;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -130,11 +131,11 @@ class SnippetAreaController implements ClassResourceInterface
             $dataList[$key] = $areaData;
         }
 
-        \ksort($dataList);
+        $dataList = SortUtils::sortLocaleAware($dataList, $this->getUser()->getLocale(), fn ($a) => $a['title']);
 
         $data = [
             '_embedded' => [
-                'areas' => \array_values($dataList),
+                'areas' => $dataList,
             ],
             'total' => \count($dataList),
         ];

--- a/src/Sulu/Component/Util/SortUtils.php
+++ b/src/Sulu/Component/Util/SortUtils.php
@@ -96,4 +96,49 @@ final class SortUtils
 
         return $values;
     }
+
+    /**
+     * Sorts the items of the iterable by a locale aware function.
+     *
+     * The values for comparison are casted to string, before they are compared. The sorted items are returned by a new array.
+     *
+     * If the intl extension is not loaded, the comparison falls back to binary comparison.
+     *
+     * @param iterable<mixed> $list
+     * @param null|callable $getComparableValue callback to get the value from each item that will be compared
+     *
+     * @return mixed[]
+     *
+     * @throws \InvalidArgumentException if the comparison of the values failed
+     */
+    public static function sortLocaleAware(iterable $list, string $locale, ?callable $getComparableValue = null): array
+    {
+        $array = \is_array($list) ? $list : \iterator_to_array($list);
+
+        if (null === $getComparableValue) {
+            $getComparableValue = fn ($item) => $item;
+        }
+
+        // Collator class requires intl extension
+        $collator = \class_exists(\Collator::class) ? new \Collator($locale) : null;
+
+        \usort($array, function(mixed $itemA, mixed $itemB) use ($collator, $getComparableValue) {
+            $valueA = (string) $getComparableValue($itemA);
+            $valueB = (string) $getComparableValue($itemB);
+
+            if ($collator) {
+                $result = $collator->compare($valueA, $valueB);
+            } else {
+                $result = \strcmp($valueA, $valueB);
+            }
+
+            if (false === $result) {
+                throw new \InvalidArgumentException('Comparison of the strings "%s" and "%s" failed.');
+            }
+
+            return $result;
+        });
+
+        return $array;
+    }
 }

--- a/src/Sulu/Component/Util/SortUtils.php
+++ b/src/Sulu/Component/Util/SortUtils.php
@@ -122,7 +122,7 @@ final class SortUtils
         // Collator class requires intl extension
         $collator = \class_exists(\Collator::class) ? new \Collator($locale) : null;
 
-        \usort($array, function(mixed $itemA, mixed $itemB) use ($collator, $getComparableValue) {
+        \uasort($array, function(mixed $itemA, mixed $itemB) use ($collator, $getComparableValue) {
             $valueA = (string) $getComparableValue($itemA);
             $valueB = (string) $getComparableValue($itemB);
 

--- a/src/Sulu/Component/Util/SortUtils.php
+++ b/src/Sulu/Component/Util/SortUtils.php
@@ -104,16 +104,20 @@ final class SortUtils
      *
      * If the intl extension is not loaded, the comparison falls back to binary comparison.
      *
-     * @param iterable<mixed> $list
+     * @template T of mixed
+     * @template TKey of array-key
+     *
+     * @param iterable<TKey, T> $list
      * @param null|callable $getComparableValue callback to get the value from each item that will be compared
      *
-     * @return mixed[]
+     * @return array<TKey, T>
      *
      * @throws \InvalidArgumentException if the comparison of the values failed
      */
     public static function sortLocaleAware(iterable $list, string $locale, ?callable $getComparableValue = null): array
     {
         $array = \is_array($list) ? $list : \iterator_to_array($list);
+        $isList = \array_is_list($array);
 
         if (null === $getComparableValue) {
             $getComparableValue = fn ($item) => $item;
@@ -122,7 +126,9 @@ final class SortUtils
         // Collator class requires intl extension
         $collator = \class_exists(\Collator::class) ? new \Collator($locale) : null;
 
-        \uasort($array, function(mixed $itemA, mixed $itemB) use ($collator, $getComparableValue) {
+        $sortMethod = $isList ? '\usort' : '\uasort';
+
+        $sortMethod($array, function(mixed $itemA, mixed $itemB) use ($collator, $getComparableValue) {
             $valueA = (string) $getComparableValue($itemA);
             $valueB = (string) $getComparableValue($itemB);
 

--- a/src/Sulu/Component/Util/Tests/Unit/SortUtilsTest.php
+++ b/src/Sulu/Component/Util/Tests/Unit/SortUtilsTest.php
@@ -167,6 +167,56 @@ class SortUtilsTest extends TestCase
 
         SortUtils::multisort($collection, 'somefink');
     }
+
+    public function testSortLocaleAwareSimpleArray(): void
+    {
+        $array = ['D', 'A', 'Ê', 'E', 'Ä', 'M'];
+        $result = SortUtils::sortLocaleAware($array, 'de');
+
+        if (!\class_exists(\Collator::class)) {
+            $this->addWarning('Could not test sorting with \\Collator, because intl extension is not loaded');
+
+            $this->assertSame(['A', 'D', 'E', 'M', 'Ä', 'Ê'], $result);
+        } else {
+            $this->assertSame(['A', 'Ä', 'D', 'E', 'Ê', 'M'], $result);
+        }
+    }
+
+    public function testSortLocaleAwareDeepArray(): void
+    {
+        $array = [
+            ['value' => 'D'],
+            ['value' => 'A'],
+            ['value' => 'Ê'],
+            ['value' => 'E'],
+            ['value' => 'Ä'],
+            ['value' => 'M'],
+        ];
+
+        $result = SortUtils::sortLocaleAware($array, 'de', fn ($item) => $item['value']);
+
+        if (!\class_exists(\Collator::class)) {
+            $this->addWarning('Could not test sorting with \\Collator, because intl extension is not loaded');
+
+            $this->assertSame([
+                ['value' => 'A'],
+                ['value' => 'D'],
+                ['value' => 'E'],
+                ['value' => 'M'],
+                ['value' => 'Ä'],
+                ['value' => 'Ê'],
+            ], $result);
+        } else {
+            $this->assertSame([
+                ['value' => 'A'],
+                ['value' => 'Ä'],
+                ['value' => 'D'],
+                ['value' => 'E'],
+                ['value' => 'Ê'],
+                ['value' => 'M'],
+            ], $result);
+        }
+    }
 }
 
 class FoobarTestClass


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | in a way, but only very low break
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Changed the sorting of the snippet areas. They are sorted by title instead of their key (which is not visible in the frontend).

#### Why?

Currently the snippet areas are sorted by their key. But this makes it harder to scan the list for the user because titles may have the wrong order.

#### Note

I am using PHP's `Collate` class for comparing the string. But this is only available if the intl extension is loaded. So I have added a fallback to simple `strcmp` function, because the intl extension is not a requirement by Sulu. 
But I am unsure how to handle this in the unit tests. Is it okay how it is done?