### PR TITLE
Add experimental support for bun

### DIFF
--- a/preinstall.js
+++ b/preinstall.js
@@ -1,6 +1,8 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 
-if (process.env.npm_execpath.indexOf('npm') === -1) {
+if (process.env.npm_execpath.indexOf('npm') === -1
+    && process.env.npm_execpath.indexOf('bun') === -1 // @experimental supported
+) {
     throw new Error('\x1b[31mYou must use "npm install", yarn is not supported\x1b[0m');
 }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add experimental support for bun.

#### Why?

As an alternative to `npm@6`. Alternative to #6566 also see https://github.com/sulu/skeleton/issues/88.

#### Example Usage

```bash
bun run preinstall

bun install

bun run build
```

preinstall is currently required to run manually see: # currently required see https://github.com/oven-sh/bun/issues/4914. But it can be run with every npm version.

#### To Do

- [x] Create a documentation PR (https://docs.sulu.io/en/latest/cookbook/build-admin-frontend.html#solution-3-build-manually-locally)
