### PR TITLE
Fix parameter type of portal

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1046,7 +1046,7 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Entity/CollaborationRepository.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function array_filter expects callable\\(mixed\\)\\: mixed, Closure\\(Sulu\\\\Bundle\\\\AdminBundle\\\\Entity\\\\Collaboration\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(mixed\\)\\: mixed\\)\\|null, Closure\\(Sulu\\\\Bundle\\\\AdminBundle\\\\Entity\\\\Collaboration\\)\\: bool given\\.$#"
 			count: 2
 			path: src/Sulu/Bundle/AdminBundle/Entity/CollaborationRepository.php
 
@@ -14366,11 +14366,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Collection\\\\Manager\\\\CollectionManager\\:\\:get\\(\\) return type with generic class Doctrine\\\\ORM\\\\Tools\\\\Pagination\\\\Paginator does not specify its types\\: T$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Collection\\\\Manager\\\\CollectionManager\\:\\:get\\(\\) should return Doctrine\\\\ORM\\\\Tools\\\\Pagination\\\\Paginator but returns array\\<int\\<0, max\\>, Sulu\\\\Bundle\\\\MediaBundle\\\\Api\\\\Collection\\>\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
@@ -14537,11 +14532,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Collection\\\\Manager\\\\CollectionManagerInterface\\:\\:get\\(\\) has parameter \\$sortBy with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManagerInterface.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Collection\\\\Manager\\\\CollectionManagerInterface\\:\\:get\\(\\) return type with generic class Doctrine\\\\ORM\\\\Tools\\\\Pagination\\\\Paginator does not specify its types\\: T$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManagerInterface.php
 
@@ -16132,11 +16122,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Entity\\\\MediaRepository\\:\\:findMedia\\(\\) has parameter \\$filter with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Entity\\\\MediaRepository\\:\\:findMedia\\(\\) should return array\\<Sulu\\\\Bundle\\\\MediaBundle\\\\Entity\\\\Media\\> but returns mixed\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
 
@@ -56484,11 +56469,6 @@ parameters:
 			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Manager\\\\Dumper\\\\WebspaceCollectionDumper\\:\\:render\\(\\) has parameter \\$template with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Webspace/Manager/Dumper/WebspaceCollectionDumper.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Manager\\\\WebspaceCollection\\:\\:__construct\\(\\) has parameter \\$webspaces with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
 
 		-
 			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Manager\\\\WebspaceCollection\\:\\:addResource\\(\\) has no return type specified\\.$#"

--- a/src/Sulu/Bundle/MediaBundle/Search/Subscriber/StructureMediaSearchSubscriber.php
+++ b/src/Sulu/Bundle/MediaBundle/Search/Subscriber/StructureMediaSearchSubscriber.php
@@ -117,7 +117,6 @@ class StructureMediaSearchSubscriber implements EventSubscriberInterface
         // new structures will container an instance of MediaSelectionContainer
         if ($data instanceof MediaSelectionContainer) {
             $medias = $data->getData();
-            // old ones an array ...
         } else {
             $ids = [];
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Admin/MediaAdminTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Admin/MediaAdminTest.php
@@ -91,7 +91,8 @@ class MediaAdminTest extends TestCase
         $security2 = new Security();
         $security2->setSystem('Webspace2');
         $webspace2->setSecurity($security2);
-        $this->webspaceManager->getWebspaceCollection()->willReturn(new WebspaceCollection([$webspace1, $webspace2]));
+        $this->webspaceManager->getWebspaceCollection()
+            ->willReturn(new WebspaceCollection(['test-1' => $webspace1, 'test-2' => $webspace2]));
 
         $this->assertEquals(
             [

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Admin/PageAdminTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Admin/PageAdminTest.php
@@ -100,10 +100,8 @@ class PageAdminTest extends TestCase
         $webspace2->setLocalizations([$localization2]);
         $webspace2->setDefaultLocalization($localization2);
 
-        $webspaceCollection = new WebspaceCollection();
-        $webspaceCollection->setWebspaces([$webspace1, $webspace2]);
-
-        $this->webspaceManager->getWebspaceCollection()->willReturn($webspaceCollection);
+        $this->webspaceManager->getWebspaceCollection()
+            ->willReturn(new WebspaceCollection(['test-1' => $webspace1, 'test-2' => $webspace2]));
 
         $admin = new PageAdmin(
             $this->viewBuilderFactory,
@@ -224,8 +222,8 @@ class PageAdminTest extends TestCase
         $webspace2->setSecurity($webspace2Security->reveal());
 
         $this->webspaceManager->getWebspaceCollection()->willReturn(new WebspaceCollection([
-            $webspace1,
-            $webspace2,
+            'webspace-key-1' => $webspace1,
+            'webspace-key-2' => $webspace2,
         ]));
 
         $this->assertEquals(

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Build/NodeOrderBuilderTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Build/NodeOrderBuilderTest.php
@@ -94,7 +94,7 @@ class NodeOrderBuilderTest extends TestCase
     {
         $webspace = new Webspace();
         $webspace->setKey('sulu_io');
-        $this->webspaceManager->getWebspaceCollection()->willReturn(new WebspaceCollection([$webspace]));
+        $this->webspaceManager->getWebspaceCollection()->willReturn(new WebspaceCollection(['sulu_io' => $webspace]));
 
         $this->sessionManager->getContentPath('sulu_io')->willReturn('/cmf/sulu_io/contents');
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Command/MaintainResourceLocatorCommandTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Command/MaintainResourceLocatorCommandTest.php
@@ -106,7 +106,8 @@ class MaintainResourceLocatorCommandTest extends TestCase
         $webspace1->setKey('sulu_io');
         $webspace1->addLocalization(new Localization('de'));
 
-        $this->webspaceManager->getWebspaceCollection()->willReturn(new WebspaceCollection([$webspace1]));
+        $this->webspaceManager->getWebspaceCollection()
+            ->willReturn(new WebspaceCollection(['sulu_io' => $webspace1]));
 
         $this->sessionManager->getContentPath('sulu_io')->willReturn('/cmf/sulu_io/contents');
         $this->sessionManager->getRoutePath('sulu_io', 'de')->willReturn('/cmf/sulu_io/routes/de');

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/DefaultSnippetManagerTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/DefaultSnippetManagerTest.php
@@ -265,7 +265,8 @@ class DefaultSnippetManagerTest extends TestCase
         $webspace2 = new Webspace();
         $webspace2->setKey('test-2');
 
-        $webspaceManager->getWebspaceCollection()->willReturn(new WebspaceCollection([$webspace1, $webspace2]));
+        $webspaceManager->getWebspaceCollection()
+            ->willReturn(new WebspaceCollection(['test-1' => $webspace1, 'test-2' => $webspace2]));
         $settingsManager->loadStringByWildcard('test-1', 'snippets-*')->willReturn(
             ['snippets-test-1' => '123', 'snippets-test-2' => '456']
         );
@@ -299,7 +300,8 @@ class DefaultSnippetManagerTest extends TestCase
         $webspace2 = new Webspace();
         $webspace2->setKey('test-2');
 
-        $webspaceManager->getWebspaceCollection()->willReturn(new WebspaceCollection([$webspace1, $webspace2]));
+        $webspaceManager->getWebspaceCollection()
+            ->willReturn(new WebspaceCollection(['test-1' => $webspace1, 'test-2' => $webspace2]));
         $settingsManager->loadStringByWildcard('test-1', 'snippets-*')->willReturn(
             ['snippets-test-1' => '123', 'snippets-test-2' => '456']
         );
@@ -334,7 +336,8 @@ class DefaultSnippetManagerTest extends TestCase
         $webspace2 = new Webspace();
         $webspace2->setKey('test-2');
 
-        $webspaceManager->getWebspaceCollection()->willReturn(new WebspaceCollection([$webspace1, $webspace2]));
+        $webspaceManager->getWebspaceCollection()
+            ->willReturn(new WebspaceCollection(['test-1' => $webspace1, 'test-2' => $webspace2]));
         $settingsManager->loadStringByWildcard('test-1', 'snippets-*')->willReturn(
             ['snippets-test-1' => '123-123-123']
         );

--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
@@ -78,13 +78,13 @@ class WebspaceCollection implements \IteratorAggregate
     /**
      * Returns the portal with the given index.
      *
-     * @param string $key The index of the portal
+     * @param int|string $key The index of the portal
      *
      * @return Portal|null
      */
     public function getPortal($key)
     {
-        return \array_key_exists($key, $this->portals) ? $this->portals[$key] : null;
+        return $this->portals[$key] ?? null;
     }
 
     /**
@@ -117,13 +117,13 @@ class WebspaceCollection implements \IteratorAggregate
     /**
      * Returns the webspace with the given key.
      *
-     * @param string $key The key of the webspace
+     * @param int|string $key The key of the webspace
      *
      * @return Webspace|null
      */
     public function getWebspace($key)
     {
-        return \array_key_exists($key, $this->webspaces) ? $this->webspaces[$key] : null;
+        return $this->webspaces[$key] ?? null;
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
@@ -26,14 +26,14 @@ class WebspaceCollection implements \IteratorAggregate
     /**
      * All the webspaces in a specific sulu installation.
      *
-     * @var Webspace[]
+     * @var array<string, Webspace>
      */
     private $webspaces;
 
     /**
      * All the portals in a specific sulu installation.
      *
-     * @var Portal[]
+     * @var array<string, Portal>
      */
     private $portals;
 
@@ -52,6 +52,9 @@ class WebspaceCollection implements \IteratorAggregate
      */
     private $resources;
 
+    /**
+     * @param array<string, Webspace> $webspaces
+     */
     public function __construct(array $webspaces = [])
     {
         $this->webspaces = $webspaces;
@@ -78,7 +81,7 @@ class WebspaceCollection implements \IteratorAggregate
     /**
      * Returns the portal with the given index.
      *
-     * @param int|string $key The index of the portal
+     * @param string $key The index of the portal
      *
      * @return Portal|null
      */
@@ -117,7 +120,7 @@ class WebspaceCollection implements \IteratorAggregate
     /**
      * Returns the webspace with the given key.
      *
-     * @param int|string $key The key of the webspace
+     * @param string $key The key of the webspace
      *
      * @return Webspace|null
      */
@@ -172,7 +175,7 @@ class WebspaceCollection implements \IteratorAggregate
     }
 
     /**
-     * @param \Sulu\Component\Webspace\Webspace[] $webspaces
+     * @param array<string, Webspace> $webspaces
      */
     public function setWebspaces($webspaces)
     {
@@ -180,7 +183,7 @@ class WebspaceCollection implements \IteratorAggregate
     }
 
     /**
-     * @return \Sulu\Component\Webspace\Webspace[]
+     * @return array<string, Webspace>
      */
     public function getWebspaces()
     {
@@ -190,7 +193,7 @@ class WebspaceCollection implements \IteratorAggregate
     /**
      * Returns all the portals of this collection.
      *
-     * @return Portal[]
+     * @return array<string, Portal>
      */
     public function getPortals()
     {
@@ -200,7 +203,7 @@ class WebspaceCollection implements \IteratorAggregate
     /**
      * Sets the portals for this collection.
      *
-     * @param Portal[] $portals
+     * @param array<string, Portal> $portals
      */
     public function setPortals($portals)
     {

--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
@@ -119,7 +119,7 @@ class WebspaceCollectionBuilder
                 }
             }
 
-            $this->webspaces[] = $webspace;
+            $this->webspaces[$webspace->getKey()] = $webspace;
 
             $this->buildPortals($webspace);
         }

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
@@ -62,26 +62,28 @@ class WebspaceCollectionBuilderTest extends WebspaceTestCase
 
         $webspaceCollection = $webspaceCollectionBuilder->build();
 
-        $webspaces = $webspaceCollection->getWebspaces();
+        $webspaces = \array_values($webspaceCollection->getWebspaces());
 
         $this->assertCount(2, $webspaces);
 
         $this->assertEquals('Massive Art', $webspaces[0]->getName());
         $this->assertEquals('Sulu CMF', $webspaces[1]->getName());
 
-        $this->assertEquals(2, \count($webspaces[0]->getNavigation()->getContexts()));
+        $navigationContext = $webspaces[0]->getNavigation()->getContexts();
 
-        $this->assertEquals('main', $webspaces[0]->getNavigation()->getContexts()[0]->getKey());
-        $this->assertEquals('Hauptnavigation', $webspaces[0]->getNavigation()->getContexts()[0]->getTitle('de'));
-        $this->assertEquals('Mainnavigation', $webspaces[0]->getNavigation()->getContexts()[0]->getTitle('en'));
-        $this->assertEquals('Main', $webspaces[0]->getNavigation()->getContexts()[0]->getTitle('fr'));
+        $this->assertEquals(2, \count($navigationContext));
 
-        $this->assertEquals('footer', $webspaces[0]->getNavigation()->getContexts()[1]->getKey());
-        $this->assertEquals('Unten', $webspaces[0]->getNavigation()->getContexts()[1]->getTitle('de'));
-        $this->assertEquals('Footer', $webspaces[0]->getNavigation()->getContexts()[1]->getTitle('en'));
-        $this->assertEquals('Footer', $webspaces[0]->getNavigation()->getContexts()[1]->getTitle('fr'));
+        $this->assertEquals('main', $navigationContext[0]->getKey());
+        $this->assertEquals('Hauptnavigation', $navigationContext[0]->getTitle('de'));
+        $this->assertEquals('Mainnavigation', $navigationContext[0]->getTitle('en'));
+        $this->assertEquals('Main', $navigationContext[0]->getTitle('fr'));
 
-        $portals = $webspaceCollection->getPortals();
+        $this->assertEquals('footer', $navigationContext[1]->getKey());
+        $this->assertEquals('Unten', $navigationContext[1]->getTitle('de'));
+        $this->assertEquals('Footer', $navigationContext[1]->getTitle('en'));
+        $this->assertEquals('Footer', $navigationContext[1]->getTitle('fr'));
+
+        $portals = \array_values($webspaceCollection->getPortals());
 
         $this->assertCount(3, $portals);
 
@@ -190,7 +192,7 @@ class WebspaceCollectionBuilderTest extends WebspaceTestCase
 
         $webspaceCollection = $webspaceCollectionBuilder->build();
 
-        $webspace = $webspaceCollection->getWebspaces()[0];
+        $webspace = $webspaceCollection->getWebspaces()['sulu_io'];
         $this->assertEquals('sulu_io', $webspace->getKey());
 
         $dev = $webspace->getPortals()[0]->getEnvironment('dev');
@@ -217,7 +219,7 @@ class WebspaceCollectionBuilderTest extends WebspaceTestCase
 
         $webspaceCollection = $webspaceCollectionBuilder->build();
 
-        $webspace = $webspaceCollection->getWebspaces()[0];
+        $webspace = $webspaceCollection->getWebspaces()['sulu_io'];
         $this->assertEquals('sulu_io', $webspace->getKey());
 
         $dev = $webspace->getPortals()[0]->getEnvironment('dev');

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionTest.php
@@ -33,11 +33,8 @@ class WebspaceCollectionTest extends TestCase
 
     public function setUp(): void
     {
-        $webspaces = [];
         $portals = [];
         $portalInformations = ['prod' => [], 'dev' => []];
-
-        $this->webspaceCollection = new WebspaceCollection();
 
         // first portal
         $portal = new Portal();
@@ -77,6 +74,7 @@ class WebspaceCollectionTest extends TestCase
         $portal->setDefaultLocalization($localizationEnUs);
 
         $webspace = new Webspace();
+        $webspace->setKey('default');
         $webspace->addLocalization($localizationEnUs);
         $webspace->addLocalization($localizationFrCa);
         $segmentSummer = new Segment();
@@ -91,15 +89,11 @@ class WebspaceCollectionTest extends TestCase
         $webspace->addSegment($segmentWinter);
         $webspace->setTheme('portal1theme');
         $webspace->addPortal($portal);
-        $webspace->setKey('default');
         $webspace->setName('Default');
         $webspace->setResourceLocatorStrategy('tree_leaf_edit');
         $webspace->addPortal($portal);
 
         $webspace->setNavigation(new Navigation([new NavigationContext('main', [])]));
-
-        $portals[] = $portal;
-        $webspaces[] = $webspace;
 
         $portalInformations['prod']['www.portal1.com'] = new PortalInformation(
             RequestAnalyzerInterface::MATCH_TYPE_FULL,
@@ -119,8 +113,8 @@ class WebspaceCollectionTest extends TestCase
             $segmentSummer
         );
 
-        $this->webspaceCollection->setWebspaces($webspaces);
-        $this->webspaceCollection->setPortals($portals);
+        $this->webspaceCollection = new WebspaceCollection(['default' => $webspace]);
+        $this->webspaceCollection->setPortals(['portal1' => $portal]);
         $this->webspaceCollection->setPortalInformations($portalInformations);
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | documentation
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
The list of portals in the `WebspaceCollection` is not a Hash therefore using string as a typehint is wrong as no string will yield any results.

#### Why?
Better type annotations are always good.

#### Example Usage
```php
$this->webspaceCollection->getPortal(0); // works
$this->webspaceCollection->getPortal('somePortal'); // doesn't work
```
