### PR TITLE
Try out jackalope/jackalope-doctrine-dbal/pull/432 xml delete properties performance improvement against sulu

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,12 +108,18 @@
         "twig/twig": "^2.13 || ^3.0",
         "webmozart/assert": "^1.9"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "git@github.com:alexander-schranz/jackalope-doctrine-dbal.git"
+        }
+    ],
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.14",
         "google/cloud-storage": "^1.0",
         "handcraftedinthealps/zendsearch": "^2.0",
         "jackalope/jackalope": "^1.4.5",
-        "jackalope/jackalope-doctrine-dbal": "^1.6",
+        "jackalope/jackalope-doctrine-dbal": "dev-feature/improve-delete-properties-performance ",
         "jangregor/phpstan-prophecy": "^1.0",
         "league/flysystem": "^1.0",
         "league/flysystem-aws-s3-v3": "^1.0.1",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

See  https://github.com/jackalope/jackalope-doctrine-dbal/pull/432

#### Why?

It should improve the deleteProperties handling.
