### PR TITLE
Fixing caching of snippets in different locales

### DIFF
--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/content.xml
@@ -23,6 +23,8 @@
         <service id="sulu_snippet.resolver" class="Sulu\Bundle\SnippetBundle\Snippet\SnippetResolver" public="true">
             <argument type="service" id="sulu.content.mapper" />
             <argument type="service" id="sulu_website.resolver.structure" />
+
+            <tag name="kernel.reset" method="reset" />
         </service>
 
         <service id="sulu_snippet.content.single_snippet_selection" class="Sulu\Bundle\SnippetBundle\Content\SingleSnippetSelection">

--- a/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetResolver.php
+++ b/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetResolver.php
@@ -17,11 +17,12 @@ use Sulu\Component\Content\Compat\Structure\SnippetBridge;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Resolves snippets by UUIDs.
  */
-class SnippetResolver implements SnippetResolverInterface
+class SnippetResolver implements SnippetResolverInterface, ResetInterface
 {
     /**
      * @var array<array|StructureInterface>
@@ -32,6 +33,11 @@ class SnippetResolver implements SnippetResolverInterface
         private ContentMapperInterface $contentMapper,
         private StructureResolverInterface $structureResolver
     ) {
+    }
+
+    public function reset(): void
+    {
+        $this->snippetCache = [];
     }
 
     /**

--- a/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetResolver.php
+++ b/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetResolver.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\SnippetBundle\Snippet;
 use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;
 use Sulu\Component\Content\Compat\Structure\SnippetBridge;
+use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 
@@ -22,6 +23,9 @@ use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
  */
 class SnippetResolver implements SnippetResolverInterface
 {
+    /**
+     * @var array<array|StructureInterface>
+     */
     private array $snippetCache = [];
 
     public function __construct(
@@ -30,11 +34,20 @@ class SnippetResolver implements SnippetResolverInterface
     ) {
     }
 
+    /**
+     * @param array<string> $uuids
+     * @param string $webspaceKey
+     * @param string $locale
+     * @param string|null $shadowLocale
+     * @param bool $loadExcerpt
+     *
+     * @return array
+     */
     public function resolve($uuids, $webspaceKey, $locale, $shadowLocale = null, $loadExcerpt = false)
     {
         $snippets = [];
         foreach ($uuids as $uuid) {
-            $cacheKey = sprintf('%s|%s', $locale, $uuid);
+            $cacheKey = \sprintf('%s|%s', $locale, $uuid);
             if (!\array_key_exists($cacheKey, $this->snippetCache)) {
                 try {
                     $snippet = $this->contentMapper->load($uuid, $webspaceKey, $locale);

--- a/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetResolver.php
+++ b/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetResolver.php
@@ -22,27 +22,12 @@ use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
  */
 class SnippetResolver implements SnippetResolverInterface
 {
-    /**
-     * @var array
-     */
-    private $snippetCache = [];
-
-    /**
-     * @var ContentMapperInterface
-     */
-    private $contentMapper;
-
-    /**
-     * @var StructureResolverInterface
-     */
-    private $structureResolver;
+    private array $snippetCache = [];
 
     public function __construct(
-        ContentMapperInterface $contentMapper,
-        StructureResolverInterface $structureResolver
+        private ContentMapperInterface $contentMapper,
+        private StructureResolverInterface $structureResolver
     ) {
-        $this->contentMapper = $contentMapper;
-        $this->structureResolver = $structureResolver;
     }
 
     public function resolve($uuids, $webspaceKey, $locale, $shadowLocale = null, $loadExcerpt = false)

--- a/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetResolver.php
+++ b/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetResolver.php
@@ -34,7 +34,8 @@ class SnippetResolver implements SnippetResolverInterface
     {
         $snippets = [];
         foreach ($uuids as $uuid) {
-            if (!\array_key_exists($uuid, $this->snippetCache)) {
+            $cacheKey = sprintf('%s|%s', $locale, $uuid);
+            if (!\array_key_exists($cacheKey, $this->snippetCache)) {
                 try {
                     $snippet = $this->contentMapper->load($uuid, $webspaceKey, $locale);
                 } catch (DocumentNotFoundException $e) {
@@ -63,10 +64,10 @@ class SnippetResolver implements SnippetResolverInterface
                 $resolved['view']['template'] = $snippet->getKey();
                 $resolved['view']['uuid'] = $snippet->getUuid();
 
-                $this->snippetCache[$uuid] = $resolved;
+                $this->snippetCache[$cacheKey] = $resolved;
             }
 
-            $snippets[] = $this->snippetCache[$uuid];
+            $snippets[] = $this->snippetCache[$cacheKey];
         }
 
         return $snippets;

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
@@ -128,7 +128,7 @@ class SnippetResolverTest extends TestCase
         $contentMapper->load(
             $uuid,
             $webspaceKey,
-            Argument::that( fn ($value) => in_array($value, $locales)),
+            Argument::that(fn ($value) => \in_array($value, $locales)),
         )->shouldBeCalledTimes(\count($locales))->will(
             function($arguments) use ($structures) {
                 return $structures[$arguments[2]];

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
@@ -102,6 +102,55 @@ class SnippetResolverTest extends TestCase
         }
     }
 
+    public function testResolveWithMultipleLocales(): void
+    {
+        $contentMapper = $this->prophesize(ContentMapperInterface::class);
+        $structureResolver = $this->prophesize(StructureResolverInterface::class);
+
+        $uuid = '1234-5678';
+        $webspaceKey = 'sulu_io';
+        $locales = ['en', 'de'];
+
+        $structures = [];
+        foreach ($locales as $locale) {
+            $structure = $this->prophesize(SnippetBridge::class);
+            $structure->getUuid()->willReturn('1234-5678');
+            $structure->getKey()->willReturn('test');
+            $structure->getHasTranslation()->willReturn(true);
+            $structure->setIsShadow(false)->shouldBeCalled();
+            $structure->setShadowBaseLanguage(null)->shouldBeCalled();
+
+            $structures[$locale] = $structure->reveal();
+        }
+
+        $resolver = new SnippetResolver($contentMapper->reveal(), $structureResolver->reveal());
+
+        $contentMapper->load(
+            $uuid,
+            $webspaceKey,
+            Argument::that( fn ($value) => in_array($value, $locales)),
+        )->shouldBeCalledTimes(\count($locales))->will(
+            function($arguments) use ($structures) {
+                return $structures[$arguments[2]];
+            }
+        );
+
+        $structureResolver->resolve($structures['en'], false)
+            ->shouldBeCalledTimes(1)
+            ->willReturn(['content' => ['title' => 'English'], 'view' => ['title' => []]]);
+
+        $structureResolver->resolve($structures['de'], false)
+            ->shouldBeCalledTimes(1)
+            ->willReturn(['content' => ['title' => 'Deutsch'], 'view' => ['title' => []]]);
+
+        $result = $resolver->resolve([$uuid], $webspaceKey, 'en');
+        $result2 = $resolver->resolve([$uuid], $webspaceKey, 'de');
+
+        // Ids are equal but not the entire content
+        $this->assertEquals($result[0]['view']['uuid'], $result2[0]['view']['uuid']);
+        $this->assertNotEquals($result, $result2);
+    }
+
     public function testResolveNotExistingUuid(): void
     {
         $contentMapper = $this->prophesize(ContentMapperInterface::class);

--- a/src/Sulu/Component/Content/Tests/Unit/Types/TextEditorTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Types/TextEditorTest.php
@@ -15,7 +15,6 @@ use PHPCR\NodeInterface;
 use PHPCR\PropertyInterface as NodePropertyInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\MarkupBundle\Markup\MarkupParserInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;

--- a/src/Sulu/Component/Content/Tests/Unit/Types/TextEditorTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Types/TextEditorTest.php
@@ -15,6 +15,7 @@ use PHPCR\NodeInterface;
 use PHPCR\PropertyInterface as NodePropertyInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\MarkupBundle\Markup\MarkupParserInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #7201 
| Related issues/PRs | #7201
| License | MIT
| Documentation PR | -

#### What's in this PR?
Adding the locale to the snippet cache key.

#### Why?
If we only cache snippets by their uuid then, the same snippet in different locales will only return the first requested locale. (more info in the linked issue).
