### PR TITLE
Fix segmentKey typehint in ContentTypeInterface

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2326,11 +2326,6 @@ parameters:
 			path: src/Sulu/Bundle/AudienceTargetingBundle/Content/Types/TargetGroupSelection.php
 
 		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Content\\\\Types\\\\TargetGroupSelection\\:\\:write\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/AudienceTargetingBundle/Content/Types/TargetGroupSelection.php
-
-		-
 			message: "#^Call to an undefined method Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Entity\\\\TargetGroupRepositoryInterface\\:\\:findById\\(\\)\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/AudienceTargetingBundle/Controller/TargetGroupController.php
@@ -3276,21 +3271,6 @@ parameters:
 			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Functional/Entity/TargetGroupRepositoryTest.php
 
 		-
-			message: "#^Parameter \\#5 \\$segmentKey of method Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Content\\\\Types\\\\TargetGroupSelection\\:\\:read\\(\\) expects string, null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Content/Types/TargetGroupSelectionTest.php
-
-		-
-			message: "#^Parameter \\#5 \\$segmentKey of method Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Content\\\\Types\\\\TargetGroupSelection\\:\\:remove\\(\\) expects string, null given\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Content/Types/TargetGroupSelectionTest.php
-
-		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Content\\\\Types\\\\TargetGroupSelection\\:\\:write\\(\\) expects string, null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Content/Types/TargetGroupSelectionTest.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Tests\\\\Unit\\\\TargetGroupEvaluationControllerTest\\:\\:provideTargetGroup\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Controller/TargetGroupEvaluationControllerTest.php
@@ -4182,11 +4162,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/CategoryBundle/Content/Types/CategorySelection.php
-
-		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Bundle\\\\CategoryBundle\\\\Content\\\\Types\\\\CategorySelection\\:\\:write\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/CategoryBundle/Content/Types/CategorySelection.php
 
@@ -8067,11 +8042,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Content/Types/ContactAccountSelection.php
-
-		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Bundle\\\\ContactBundle\\\\Content\\\\Types\\\\ContactAccountSelection\\:\\:write\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Content/Types/ContactAccountSelection.php
 
@@ -13241,11 +13211,6 @@ parameters:
 			path: src/Sulu/Bundle/LocationBundle/Content/Types/LocationContentType.php
 
 		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Bundle\\\\LocationBundle\\\\Content\\\\Types\\\\LocationContentType\\:\\:write\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/LocationBundle/Content/Types/LocationContentType.php
-
-		-
 			message: "#^Parameter \\#1 \\$query of method Sulu\\\\Bundle\\\\LocationBundle\\\\Geolocator\\\\GeolocatorInterface\\:\\:locate\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/LocationBundle/Controller/GeolocatorController.php
@@ -14786,11 +14751,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Content/Types/ImageMapContentType.php
 
 		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Bundle\\\\MediaBundle\\\\Content\\\\Types\\\\ImageMapContentType\\:\\:doWrite\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Content/Types/ImageMapContentType.php
-
-		-
 			message: "#^Access to an undefined property object\\:\\:\\$max\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
@@ -14871,11 +14831,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
 
 		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Bundle\\\\MediaBundle\\\\Content\\\\Types\\\\MediaSelectionContentType\\:\\:write\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
-
-		-
 			message: "#^Property Sulu\\\\Bundle\\\\MediaBundle\\\\Content\\\\Types\\\\MediaSelectionContentType\\:\\:\\$permissions type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
@@ -14922,11 +14877,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$name of class Sulu\\\\Bundle\\\\AdminBundle\\\\Metadata\\\\SchemaMetadata\\\\PropertyMetadata constructor expects string, float\\|int\\|string given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Content/Types/SingleMediaSelection.php
-
-		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Component\\\\Content\\\\SimpleContentType\\:\\:write\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Content/Types/SingleMediaSelection.php
 
@@ -20636,16 +20586,6 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Content/Structure/ExcerptStructureExtension.php
 
 		-
-			message: "#^Parameter \\#5 \\$segmentKey of method Sulu\\\\Component\\\\Content\\\\ContentTypeInterface\\:\\:read\\(\\) expects string, null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Content/Structure/ExcerptStructureExtension.php
-
-		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Component\\\\Content\\\\ContentTypeInterface\\:\\:write\\(\\) expects string, null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Content/Structure/ExcerptStructureExtension.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\PageBundle\\\\Content\\\\Structure\\\\ExcerptValueContainer\\:\\:__construct\\(\\) has parameter \\$data with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Content/Structure/ExcerptValueContainer.php
@@ -20851,11 +20791,6 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Content/Types/PageSelection.php
 
 		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Bundle\\\\PageBundle\\\\Content\\\\Types\\\\PageSelection\\:\\:write\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Content/Types/PageSelection.php
-
-		-
 			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Content\\\\Types\\\\PageSelection\\:\\:\\$enabledTwigAttributes type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Content/Types/PageSelection.php
@@ -20912,11 +20847,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Content/Types/Select.php
-
-		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Component\\\\Content\\\\SimpleContentType\\:\\:write\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Content/Types/Select.php
 
@@ -26201,16 +26131,6 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/ResourceLocatorTest.php
 
 		-
-			message: "#^Parameter \\#5 \\$segmentKey of method Sulu\\\\Component\\\\Content\\\\SimpleContentType\\:\\:read\\(\\) expects string, null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/ResourceLocatorTest.php
-
-		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Component\\\\Content\\\\SimpleContentType\\:\\:write\\(\\) expects string, null given\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/ResourceLocatorTest.php
-
-		-
 			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\ResourceLocator\\\\ResourceLocatorTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManager\\) does not accept Doctrine\\\\Persistence\\\\ObjectManager\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/ResourceLocatorTest.php
@@ -26661,28 +26581,8 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/DateTest.php
 
 		-
-			message: "#^Parameter \\#5 \\$segmentKey of method Sulu\\\\Bundle\\\\PageBundle\\\\Content\\\\Types\\\\Date\\:\\:read\\(\\) expects string, null given\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/DateTest.php
-
-		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Bundle\\\\PageBundle\\\\Content\\\\Types\\\\Date\\:\\:write\\(\\) expects string, null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/DateTest.php
-
-		-
 			message: "#^Method Prophecy\\\\Prophecy\\\\MethodProphecy\\:\\:shouldBeCalled\\(\\) invoked with 1 parameter, 0 required\\.$#"
 			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/DateTimeTest.php
-
-		-
-			message: "#^Parameter \\#5 \\$segmentKey of method Sulu\\\\Bundle\\\\PageBundle\\\\Content\\\\Types\\\\DateTime\\:\\:read\\(\\) expects string, null given\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/DateTimeTest.php
-
-		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Bundle\\\\PageBundle\\\\Content\\\\Types\\\\DateTime\\:\\:write\\(\\) expects string, null given\\.$#"
-			count: 2
 			path: src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/DateTimeTest.php
 
 		-
@@ -26696,29 +26596,9 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/EmailTest.php
 
 		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Bundle\\\\PageBundle\\\\Content\\\\Types\\\\PageSelection\\:\\:write\\(\\) expects string, null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/PageSelectionTest.php
-
-		-
 			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Unit\\\\Content\\\\Types\\\\PageSelectionTest\\:\\:\\$logger is never read, only written\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/PageSelectionTest.php
-
-		-
-			message: "#^Parameter \\#5 \\$segmentKey of method Sulu\\\\Bundle\\\\PageBundle\\\\Content\\\\Types\\\\SegmentSelect\\:\\:read\\(\\) expects string, null given\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/SegmentSelectTest.php
-
-		-
-			message: "#^Parameter \\#5 \\$segmentKey of method Sulu\\\\Bundle\\\\PageBundle\\\\Content\\\\Types\\\\SegmentSelect\\:\\:remove\\(\\) expects string, null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/SegmentSelectTest.php
-
-		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Bundle\\\\PageBundle\\\\Content\\\\Types\\\\SegmentSelect\\:\\:write\\(\\) expects string, null given\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/SegmentSelectTest.php
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Unit\\\\Content\\\\Types\\\\SinglePageSelectionTest\\:\\:providePreResolve\\(\\) has no return type specified\\.$#"
@@ -28444,16 +28324,6 @@ parameters:
 			message: "#^Method Sulu\\\\Bundle\\\\RouteBundle\\\\SuluRouteBundle\\:\\:build\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/RouteBundle/SuluRouteBundle.php
-
-		-
-			message: "#^Parameter \\#5 \\$segmentKey of method Sulu\\\\Bundle\\\\RouteBundle\\\\Content\\\\Type\\\\PageTreeRouteContentType\\:\\:read\\(\\) expects string, null given\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/RouteBundle/Tests/Functional/Content/PageTreeRouteContentTypeTest.php
-
-		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Bundle\\\\RouteBundle\\\\Content\\\\Type\\\\PageTreeRouteContentType\\:\\:write\\(\\) expects string, null given\\.$#"
-			count: 4
-			path: src/Sulu/Bundle/RouteBundle/Tests/Functional/Content/PageTreeRouteContentTypeTest.php
 
 		-
 			message: "#^Cannot access offset '_embedded' on mixed\\.$#"
@@ -31921,11 +31791,6 @@ parameters:
 			path: src/Sulu/Bundle/SnippetBundle/Content/SnippetContent.php
 
 		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Bundle\\\\SnippetBundle\\\\Content\\\\SnippetContent\\:\\:write\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SnippetBundle/Content/SnippetContent.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\SnippetBundle\\\\Content\\\\SnippetDataProvider\\:\\:decorateDataItems\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/Content/SnippetDataProvider.php
@@ -32663,21 +32528,6 @@ parameters:
 		-
 			message: "#^Parameter \\#2 \\$haystack of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertCount\\(\\) expects Countable\\|iterable, mixed given\\.$#"
 			count: 11
-			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/SnippetContentTest.php
-
-		-
-			message: "#^Parameter \\#5 \\$segmentKey of method Sulu\\\\Bundle\\\\SnippetBundle\\\\Content\\\\SnippetContent\\:\\:read\\(\\) expects string, null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/SnippetContentTest.php
-
-		-
-			message: "#^Parameter \\#5 \\$segmentKey of method Sulu\\\\Bundle\\\\SnippetBundle\\\\Content\\\\SnippetContent\\:\\:remove\\(\\) expects string, null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/SnippetContentTest.php
-
-		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Bundle\\\\SnippetBundle\\\\Content\\\\SnippetContent\\:\\:write\\(\\) expects string, null given\\.$#"
-			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/SnippetContentTest.php
 
 		-
@@ -33592,11 +33442,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/TagBundle/Content/Types/TagSelection.php
-
-		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Bundle\\\\TagBundle\\\\Content\\\\Types\\\\TagSelection\\:\\:write\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/TagBundle/Content/Types/TagSelection.php
 
@@ -36306,16 +36151,6 @@ parameters:
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Navigation/NavigationMapperTest.php
 
 		-
-			message: "#^Parameter \\#5 \\$segmentKey of method Sulu\\\\Component\\\\Content\\\\ContentTypeInterface\\:\\:read\\(\\) expects string, null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Navigation/NavigationMapperTest.php
-
-		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Component\\\\Content\\\\ContentTypeInterface\\:\\:write\\(\\) expects string, null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Navigation/NavigationMapperTest.php
-
-		-
 			message: "#^Property Sulu\\\\Bundle\\\\WebsiteBundle\\\\Tests\\\\Functional\\\\Navigation\\\\NavigationMapperTest\\:\\:\\$homeDocument has no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Navigation/NavigationMapperTest.php
@@ -36762,16 +36597,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#3 \\$userId of method Sulu\\\\Component\\\\Content\\\\ContentTypeInterface\\:\\:write\\(\\) expects int, null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapGeneratorTest.php
-
-		-
-			message: "#^Parameter \\#5 \\$segmentKey of method Sulu\\\\Component\\\\Content\\\\ContentTypeInterface\\:\\:read\\(\\) expects string, null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapGeneratorTest.php
-
-		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Component\\\\Content\\\\ContentTypeInterface\\:\\:write\\(\\) expects string, null given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapGeneratorTest.php
 
@@ -39836,11 +39661,6 @@ parameters:
 			path: src/Sulu/Component/Content/Document/Structure/ManagedStructure.php
 
 		-
-			message: "#^Parameter \\#5 \\$segmentKey of method Sulu\\\\Component\\\\Content\\\\ContentTypeInterface\\:\\:read\\(\\) expects string, null given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Document/Structure/ManagedStructure.php
-
-		-
 			message: "#^Property Sulu\\\\Component\\\\Content\\\\Document\\\\Structure\\\\ManagedStructure\\:\\:\\$document \\(Sulu\\\\Component\\\\Content\\\\Document\\\\Behavior\\\\StructureBehavior\\) does not accept object\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Document/Structure/ManagedStructure.php
@@ -40967,11 +40787,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#4 \\$ignoreRequired of method Sulu\\\\Component\\\\Content\\\\Document\\\\Subscriber\\\\StructureSubscriber\\:\\:mapContentToNode\\(\\) expects bool, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
-
-		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Component\\\\Content\\\\ContentTypeInterface\\:\\:write\\(\\) expects string, null given\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
 
@@ -44146,11 +43961,6 @@ parameters:
 			path: src/Sulu/Component/Content/SimpleContentType.php
 
 		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Component\\\\Content\\\\SimpleContentType\\:\\:write\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/SimpleContentType.php
-
-		-
 			message: "#^Method Sulu\\\\Component\\\\Content\\\\SmartContent\\\\ContentDataItem\\:\\:__construct\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/SmartContent/ContentDataItem.php
@@ -45551,29 +45361,9 @@ parameters:
 			path: src/Sulu/Component/Content/Tests/Unit/Types/NumberTest.php
 
 		-
-			message: "#^Parameter \\#5 \\$segmentKey of method Sulu\\\\Component\\\\Content\\\\Types\\\\Number\\:\\:read\\(\\) expects string, null given\\.$#"
-			count: 2
-			path: src/Sulu/Component/Content/Tests/Unit/Types/NumberTest.php
-
-		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Component\\\\Content\\\\Types\\\\Number\\:\\:write\\(\\) expects string, null given\\.$#"
-			count: 3
-			path: src/Sulu/Component/Content/Tests/Unit/Types/NumberTest.php
-
-		-
 			message: "#^Property Sulu\\\\Component\\\\Content\\\\Tests\\\\Unit\\\\Types\\\\NumberTest\\:\\:\\$template is never written, only read\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Tests/Unit/Types/NumberTest.php
-
-		-
-			message: "#^Parameter \\#5 \\$segmentKey of method Sulu\\\\Component\\\\Content\\\\Types\\\\TextEditor\\:\\:read\\(\\) expects string, null given\\.$#"
-			count: 2
-			path: src/Sulu/Component/Content/Tests/Unit/Types/TextEditorTest.php
-
-		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Component\\\\Content\\\\Types\\\\TextEditor\\:\\:write\\(\\) expects string, null given\\.$#"
-			count: 2
-			path: src/Sulu/Component/Content/Tests/Unit/Types/TextEditorTest.php
 
 		-
 			message: "#^Method Sulu\\\\Component\\\\Content\\\\Types\\\\Block\\\\ScheduleBlockVisitor\\:\\:matchWeekday\\(\\) has no return type specified\\.$#"
@@ -45711,11 +45501,6 @@ parameters:
 			path: src/Sulu/Component/Content/Types/BlockContentType.php
 
 		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Component\\\\Content\\\\Types\\\\BlockContentType\\:\\:doWrite\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Types/BlockContentType.php
-
-		-
 			message: "#^Property Sulu\\\\Component\\\\Content\\\\Types\\\\BlockContentType\\:\\:\\$blockVisitors \\(array\\<Sulu\\\\Component\\\\Content\\\\Types\\\\Block\\\\BlockVisitorInterface\\>\\) does not accept iterable\\|null\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Types/BlockContentType.php
@@ -45742,11 +45527,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Types/Link.php
-
-		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Component\\\\Content\\\\SimpleContentType\\:\\:write\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Types/Link.php
 
@@ -45921,11 +45701,6 @@ parameters:
 			path: src/Sulu/Component/Content/Types/ResourceLocator/Strategy/TreeLeafEditStrategy.php
 
 		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Component\\\\Content\\\\ContentTypeInterface\\:\\:write\\(\\) expects string, null given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Types/ResourceLocator/Strategy/TreeLeafEditStrategy.php
-
-		-
 			message: "#^Method Sulu\\\\Component\\\\Content\\\\Types\\\\TextEditor\\:\\:__construct\\(\\) has parameter \\$markupNamespace with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Types/TextEditor.php
@@ -45952,11 +45727,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$content of method Sulu\\\\Component\\\\Content\\\\Types\\\\TextEditor\\:\\:removeValidation\\(\\) expects string, int\\|string given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Types/TextEditor.php
-
-		-
-			message: "#^Parameter \\#1 \\$content of method Sulu\\\\Component\\\\Content\\\\Types\\\\TextEditor\\:\\:validate\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Types/TextEditor.php
 
@@ -54537,11 +54307,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$value of class Sulu\\\\Component\\\\Content\\\\Compat\\\\PropertyParameter constructor expects array\\|bool\\|string, null given\\.$#"
-			count: 1
-			path: src/Sulu/Component/SmartContent/ContentType.php
-
-		-
-			message: "#^Parameter \\#6 \\$segmentKey of method Sulu\\\\Component\\\\SmartContent\\\\ContentType\\:\\:write\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Sulu/Component/SmartContent/ContentType.php
 

--- a/src/Sulu/Bundle/MediaBundle/Content/Types/ImageMapContentType.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/ImageMapContentType.php
@@ -162,7 +162,7 @@ class ImageMapContentType extends ComplexContentType implements ContentTypeExpor
      * @param string $userId
      * @param string $webspaceKey
      * @param string $languageCode
-     * @param string $segmentKey
+     * @param string|null $segmentKey
      * @param bool $isImport
      *
      * @throws UnexpectedPropertyType

--- a/src/Sulu/Component/Content/ContentTypeInterface.php
+++ b/src/Sulu/Component/Content/ContentTypeInterface.php
@@ -24,7 +24,7 @@ interface ContentTypeInterface
      *
      * @param string $webspaceKey
      * @param string $languageCode
-     * @param string $segmentKey
+     * @param string|null $segmentKey
      */
     public function read(
         NodeInterface $node,
@@ -39,7 +39,7 @@ interface ContentTypeInterface
      *
      * @param string $webspaceKey
      * @param string $languageCode
-     * @param string $segmentKey
+     * @param string|null $segmentKey
      */
     public function hasValue(
         NodeInterface $node,
@@ -55,7 +55,7 @@ interface ContentTypeInterface
      * @param int $userId
      * @param string $webspaceKey
      * @param string $languageCode
-     * @param string $segmentKey
+     * @param string|null $segmentKey
      */
     public function write(
         NodeInterface $node,
@@ -71,7 +71,7 @@ interface ContentTypeInterface
      *
      * @param string $webspaceKey
      * @param string $languageCode
-     * @param string $segmentKey
+     * @param string|null $segmentKey
      */
     public function remove(
         NodeInterface $node,

--- a/src/Sulu/Component/Content/Types/BlockContentType.php
+++ b/src/Sulu/Component/Content/Types/BlockContentType.php
@@ -199,7 +199,7 @@ class BlockContentType extends ComplexContentType implements ContentTypeExportIn
      * @param string $userId
      * @param string $webspaceKey
      * @param string $languageCode
-     * @param string $segmentKey
+     * @param string|null $segmentKey
      * @param bool $isImport
      *
      * @throws UnexpectedPropertyType


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix segmentKey typehint in ContentTypeInterface.

#### Why?

Stumbled over this in https://github.com/sulu/sulu/pull/7216.