### PR TITLE
Fix failing testcase for MediaRepositoryTest testFindMediaDisplayInfo

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
@@ -669,11 +669,16 @@ class MediaRepositoryTest extends SuluTestCase
         $this->assertEquals(2, \count($result));
         $this->assertEquals(5, \count($result[0]));
         $this->assertEquals(5, \count($result[1]));
-        $this->assertEquals($media1->getId(), $result[0]['id']);
-        $this->assertEquals(2, $result[0]['version']);
-        $this->assertEquals('test-1.jpeg', $result[0]['name']);
-        $this->assertEquals('test-1-title', $result[0]['title']);
-        $this->assertEquals('test-1-title', $result[0]['defaultTitle']);
+
+        $resultMedia1 = $result[0];
+        if ($media1->getId() === ($result[1]['id'] ?? null)) { // the order is not fix, we need to find the correct one first
+            $resultMedia1 = $result[1];
+        }
+        $this->assertEquals($media1->getId(), $resultMedia1['id']);
+        $this->assertEquals(2, $resultMedia1['version']);
+        $this->assertEquals('test-1.jpeg', $resultMedia1['name']);
+        $this->assertEquals('test-1-title', $resultMedia1['title']);
+        $this->assertEquals('test-1-title', $resultMedia1['defaultTitle']);
     }
 
     public function testFindMediaDisplayInfoWithIncorrectIds(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix failing testcase for MediaRepositoryTest testFindMediaDisplayInfo.

#### Why?

Test fails currently in the CI. Locally it still works. But think here we not guarantee in which order the requested entities are returned.
