### PR TITLE
Fix issue with SnippetResolver on PHP 7.2

### DIFF
--- a/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetResolver.php
+++ b/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetResolver.php
@@ -27,12 +27,26 @@ class SnippetResolver implements SnippetResolverInterface, ResetInterface
     /**
      * @var array<array|StructureInterface>
      */
-    private array $snippetCache = [];
+    private $snippetCache = [];
+
+    /**
+     * @var ContentMapperInterface
+     */
+    private $contentMapper;
+
+    /**
+     * @var StructureResolverInterface
+     */
+    private $structureResolver;
+
+
 
     public function __construct(
-        private ContentMapperInterface $contentMapper,
-        private StructureResolverInterface $structureResolver
+        ContentMapperInterface $contentMapper,
+        StructureResolverInterface $structureResolver
     ) {
+        $this->contentMapper = $contentMapper;
+        $this->structureResolver = $structureResolver;
     }
 
     public function reset(): void

--- a/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetResolver.php
+++ b/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetResolver.php
@@ -39,8 +39,6 @@ class SnippetResolver implements SnippetResolverInterface, ResetInterface
      */
     private $structureResolver;
 
-
-
     public function __construct(
         ContentMapperInterface $contentMapper,
         StructureResolverInterface $structureResolver

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
@@ -128,7 +128,7 @@ class SnippetResolverTest extends TestCase
         $contentMapper->load(
             $uuid,
             $webspaceKey,
-            Argument::that(function ($value) use ($locales) { return \in_array($value, $locales); })
+            Argument::that(function($value) use ($locales) { return \in_array($value, $locales); })
         )->shouldBeCalledTimes(\count($locales))->will(
             function($arguments) use ($structures) {
                 return $structures[$arguments[2]];

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
@@ -128,7 +128,7 @@ class SnippetResolverTest extends TestCase
         $contentMapper->load(
             $uuid,
             $webspaceKey,
-            Argument::that(fn ($value) => \in_array($value, $locales)),
+            Argument::that(function ($value) use ($locales) { return \in_array($value, $locales); })
         )->shouldBeCalledTimes(\count($locales))->will(
             function($arguments) use ($structures) {
                 return $structures[$arguments[2]];


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix issue with SnippetResolver on PHP 7.2.

#### Why?

CI is currently failing after backmerge a bugfix.
