### PR TITLE
Fix running UnitTests on a machine in a different timezone

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,9 +19,9 @@
     </filter>
 
     <php>
-        <env name="SYMFONY_PHPUNIT_VERSION" value="8.0"/>
         <server name="APP_ENV" value="test" force="true"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <ini name="date.timezone" value="UTC"/>
     </php>
 
     <listeners>

--- a/src/Sulu/Bundle/ActivityBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/ActivityBundle/phpunit.xml.dist
@@ -21,6 +21,7 @@
         <server name="APP_ENV" value="test" force="true"/>
         <env name="KERNEL_CLASS" value="Sulu\Bundle\ActivityBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <ini name="date.timezone" value="UTC"/>
     </php>
 
     <listeners>

--- a/src/Sulu/Bundle/AdminBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/AdminBundle/phpunit.xml.dist
@@ -21,6 +21,7 @@
         <server name="APP_ENV" value="test" force="true"/>
         <env name="KERNEL_CLASS" value="Sulu\Bundle\AdminBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <ini name="date.timezone" value="UTC"/>
     </php>
 
     <listeners>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/phpunit.xml.dist
@@ -21,6 +21,7 @@
         <server name="APP_ENV" value="test" force="true"/>
         <env name="KERNEL_CLASS" value="Sulu\Bundle\AudienceTargetingBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <ini name="date.timezone" value="UTC"/>
     </php>
 
     <listeners>

--- a/src/Sulu/Bundle/CategoryBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/CategoryBundle/phpunit.xml.dist
@@ -21,6 +21,7 @@
         <server name="APP_ENV" value="test" force="true"/>
         <env name="KERNEL_CLASS" value="Sulu\Bundle\CategoryBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <ini name="date.timezone" value="UTC"/>
     </php>
 
     <listeners>

--- a/src/Sulu/Bundle/ContactBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/ContactBundle/phpunit.xml.dist
@@ -21,6 +21,7 @@
         <server name="APP_ENV" value="test" force="true"/>
         <env name="KERNEL_CLASS" value="Sulu\Bundle\ContactBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <ini name="date.timezone" value="UTC"/>
     </php>
 
     <listeners>

--- a/src/Sulu/Bundle/CoreBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/CoreBundle/phpunit.xml.dist
@@ -21,6 +21,7 @@
         <server name="APP_ENV" value="test" force="true"/>
         <env name="KERNEL_CLASS" value="Sulu\Bundle\CoreBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <ini name="date.timezone" value="UTC"/>
     </php>
 
     <listeners>

--- a/src/Sulu/Bundle/CustomUrlBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/CustomUrlBundle/phpunit.xml.dist
@@ -21,6 +21,7 @@
         <server name="APP_ENV" value="test" force="true"/>
         <env name="KERNEL_CLASS" value="Sulu\Bundle\CustomUrlBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <ini name="date.timezone" value="UTC"/>
     </php>
 
     <listeners>

--- a/src/Sulu/Bundle/DocumentManagerBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/DocumentManagerBundle/phpunit.xml.dist
@@ -25,10 +25,10 @@
         <server name="APP_ENV" value="test" force="true"/>
         <env name="KERNEL_CLASS" value="Sulu\Bundle\DocumentManagerBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <ini name="date.timezone" value="UTC"/>
     </php>
 
     <listeners>
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
     </listeners>
 </phpunit>
-

--- a/src/Sulu/Bundle/HttpCacheBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/HttpCacheBundle/phpunit.xml.dist
@@ -20,6 +20,7 @@
     <php>
         <server name="APP_ENV" value="test" force="true"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <ini name="date.timezone" value="UTC"/>
     </php>
 
     <listeners>

--- a/src/Sulu/Bundle/LocationBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/LocationBundle/phpunit.xml.dist
@@ -20,6 +20,7 @@
     <php>
         <server name="APP_ENV" value="test" force="true"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <ini name="date.timezone" value="UTC"/>
     </php>
 
     <listeners>

--- a/src/Sulu/Bundle/MarkupBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/MarkupBundle/phpunit.xml.dist
@@ -20,6 +20,7 @@
     <php>
         <server name="APP_ENV" value="test" force="true"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <ini name="date.timezone" value="UTC"/>
     </php>
 
     <listeners>

--- a/src/Sulu/Bundle/MediaBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/MediaBundle/phpunit.xml.dist
@@ -21,6 +21,7 @@
         <server name="APP_ENV" value="test" force="true"/>
         <env name="KERNEL_CLASS" value="Sulu\Bundle\MediaBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <ini name="date.timezone" value="UTC"/>
     </php>
 
     <listeners>

--- a/src/Sulu/Bundle/PageBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/PageBundle/phpunit.xml.dist
@@ -21,6 +21,7 @@
         <server name="APP_ENV" value="test" force="true"/>
         <env name="KERNEL_CLASS" value="Sulu\Bundle\PageBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <ini name="date.timezone" value="UTC"/>
     </php>
 
     <listeners>

--- a/src/Sulu/Bundle/PersistenceBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/PersistenceBundle/phpunit.xml.dist
@@ -21,6 +21,7 @@
         <server name="APP_ENV" value="test" force="true"/>
         <env name="KERNEL_CLASS" value="Sulu\Bundle\PersistenceBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <ini name="date.timezone" value="UTC"/>
     </php>
 
     <listeners>

--- a/src/Sulu/Bundle/PreviewBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/PreviewBundle/phpunit.xml.dist
@@ -21,6 +21,7 @@
         <server name="APP_ENV" value="test" force="true"/>
         <env name="KERNEL_CLASS" value="Sulu\Bundle\PreviewBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <ini name="date.timezone" value="UTC"/>
     </php>
 
     <listeners>

--- a/src/Sulu/Bundle/RouteBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/RouteBundle/phpunit.xml.dist
@@ -21,6 +21,7 @@
         <server name="APP_ENV" value="test" force="true"/>
         <env name="KERNEL_CLASS" value="Sulu\Bundle\RouteBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <ini name="date.timezone" value="UTC"/>
     </php>
 
     <listeners>

--- a/src/Sulu/Bundle/SearchBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/SearchBundle/phpunit.xml.dist
@@ -26,10 +26,10 @@
         <server name="APP_ENV" value="test" force="true"/>
         <env name="KERNEL_CLASS" value="Sulu\Bundle\SearchBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <ini name="date.timezone" value="UTC"/>
     </php>
 
     <listeners>
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
     </listeners>
 </phpunit>
-

--- a/src/Sulu/Bundle/SecurityBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/SecurityBundle/phpunit.xml.dist
@@ -21,6 +21,7 @@
         <server name="APP_ENV" value="test" force="true"/>
         <env name="KERNEL_CLASS" value="Sulu\Bundle\SecurityBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <ini name="date.timezone" value="UTC"/>
     </php>
 
     <listeners>

--- a/src/Sulu/Bundle/SnippetBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/SnippetBundle/phpunit.xml.dist
@@ -25,6 +25,7 @@
         <server name="APP_ENV" value="test" force="true"/>
         <env name="KERNEL_CLASS" value="Sulu\Bundle\SnippetBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <ini name="date.timezone" value="UTC"/>
     </php>
 
     <listeners>

--- a/src/Sulu/Bundle/TagBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/TagBundle/phpunit.xml.dist
@@ -21,6 +21,7 @@
         <server name="APP_ENV" value="test" force="true"/>
         <env name="KERNEL_CLASS" value="Sulu\Bundle\TagBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <ini name="date.timezone" value="UTC"/>
     </php>
 
     <listeners>

--- a/src/Sulu/Bundle/TrashBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/TrashBundle/phpunit.xml.dist
@@ -21,6 +21,7 @@
         <server name="APP_ENV" value="test" force="true"/>
         <env name="KERNEL_CLASS" value="Sulu\Bundle\TrashBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <ini name="date.timezone" value="UTC"/>
     </php>
 
     <listeners>

--- a/src/Sulu/Bundle/WebsiteBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/WebsiteBundle/phpunit.xml.dist
@@ -21,6 +21,7 @@
         <server name="APP_ENV" value="test" force="true"/>
         <env name="KERNEL_CLASS" value="Sulu\Bundle\WebsiteBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <ini name="date.timezone" value="UTC"/>
     </php>
 
     <listeners>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix running UnitTests in a different timezone.

#### Why?

Running tests in e.g. Europe/Berlin timezone will currently make some tests failing. So we define that the tests run in UTC like it already in the CI the case.
