### PR TITLE
Added support for doctrine/persistence 3.x to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "doctrine/doctrine-fixtures-bundle": "^3.3 || ^4.0",
         "doctrine/inflector": "^1.4.1 || ^2.0.1",
         "doctrine/orm": "^2.13",
-        "doctrine/persistence": "^2.0",
+        "doctrine/persistence": "^2.0 || ^3.0",
         "doctrine/phpcr-bundle": "^2.2",
         "dragonmantank/cron-expression": "^1.1 || ^2.0 || ^3.0",
         "friendsofphp/proxy-manager-lts": "^1.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Added support for doctrine/persistence 3.x to composer.json

#### Why?

Not enabling lazy ghost objects is deprecated by doctrine's ORM. But lazy ghost objects are not supported by doctrine/persistence v2.x
