### PR TITLE
Add anchor-field to MediaLinkTypeOverlay

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/overlays/MediaLinkTypeOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/overlays/MediaLinkTypeOverlay.js
@@ -29,7 +29,7 @@ export default class MediaLinkTypeOverlay extends React.Component<LinkTypeOverla
             open,
             title,
             target,
-            anchor
+            anchor,
         } = this.props;
 
         if (typeof href === 'string') {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/overlays/MediaLinkTypeOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/overlays/MediaLinkTypeOverlay.js
@@ -18,7 +18,19 @@ export default class MediaLinkTypeOverlay extends React.Component<LinkTypeOverla
     };
 
     render() {
-        const {href, locale, onCancel, onConfirm, onTitleChange, onTargetChange, onAnchorChange, open, title, target, anchor} = this.props;
+        const {
+            href,
+            locale,
+            onCancel,
+            onConfirm,
+            onTitleChange,
+            onTargetChange,
+            onAnchorChange,
+            open,
+            title,
+            target,
+            anchor
+        } = this.props;
 
         if (typeof href === 'string') {
             throw new Error('The id of a media should always be a number!');

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/overlays/MediaLinkTypeOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/overlays/MediaLinkTypeOverlay.js
@@ -18,7 +18,7 @@ export default class MediaLinkTypeOverlay extends React.Component<LinkTypeOverla
     };
 
     render() {
-        const {href, locale, onCancel, onConfirm, onTitleChange, onTargetChange, open, title, target} = this.props;
+        const {href, locale, onCancel, onConfirm, onTitleChange, onTargetChange, onAnchorChange, open, title, target, anchor} = this.props;
 
         if (typeof href === 'string') {
             throw new Error('The id of a media should always be a number!');
@@ -41,6 +41,12 @@ export default class MediaLinkTypeOverlay extends React.Component<LinkTypeOverla
                             value={{displayOption: undefined, id: href}}
                         />
                     </Form.Field>
+
+                    {!!onAnchorChange &&
+                        <Form.Field label={translate('sulu_admin.link_anchor')}>
+                            <Input onChange={onAnchorChange} value={anchor} />
+                        </Form.Field>
+                    }
 
                     {!!onTargetChange &&
                         <Form.Field label={translate('sulu_admin.link_target')} required={true}>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/tests/overlays/MediaLinkTypeOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/tests/overlays/MediaLinkTypeOverlay.test.js
@@ -38,6 +38,21 @@ test('Render overlay with invalid href type', () => {
     )).toThrow('The id of a media should always be a number!');
 });
 
+test('Render overlay with anchor enabled', () => {
+    const mediaLinkTypeOverlay = mount(
+        <MediaLinkTypeOverlay
+            href={undefined}
+            onCancel={jest.fn()}
+            onConfirm={jest.fn()}
+            onHrefChange={jest.fn()}
+            onAnchorChange={jest.fn()}
+            open={true}
+        />
+    );
+
+    expect(mediaLinkTypeOverlay.find('Form').render()).toMatchSnapshot();
+});
+
 test('Render overlay with target enabled', () => {
     const mediaLinkTypeOverlay = mount(
         <MediaLinkTypeOverlay

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/tests/overlays/MediaLinkTypeOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/tests/overlays/MediaLinkTypeOverlay.test.js
@@ -42,10 +42,10 @@ test('Render overlay with anchor enabled', () => {
     const mediaLinkTypeOverlay = mount(
         <MediaLinkTypeOverlay
             href={undefined}
+            onAnchorChange={jest.fn()}
             onCancel={jest.fn()}
             onConfirm={jest.fn()}
             onHrefChange={jest.fn()}
-            onAnchorChange={jest.fn()}
             open={true}
         />
     );

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/tests/overlays/__snapshots__/MediaLinkTypeOverlay.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/tests/overlays/__snapshots__/MediaLinkTypeOverlay.test.js.snap
@@ -1,5 +1,82 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Render overlay with anchor enabled 1`] = `
+<div
+  class="grid grid"
+>
+  <div
+    class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
+  >
+    <div
+      class="field"
+    >
+      <label
+        class="label"
+      >
+        sulu_admin.link_url *
+      </label>
+      <div
+        class="singleItemSelection"
+      >
+        <button
+          class="button left"
+          type="button"
+        >
+          <span
+            aria-label="su-image"
+            class="su-image icon"
+          />
+        </button>
+        <div
+          class="itemContainer"
+        >
+          <div
+            class="item clickable"
+            role="button"
+          >
+            <div
+              class="empty"
+            >
+              sulu_media.select_media_singular
+            </div>
+          </div>
+        </div>
+      </div>
+      <div>
+        single media selection overlay
+      </div>
+      <div
+        class="errorLabel"
+      />
+    </div>
+  </div>
+  <div
+    class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
+  >
+    <div
+      class="field"
+    >
+      <label
+        class="label"
+      >
+        sulu_admin.link_anchor
+      </label>
+      <div
+        class="input default left"
+      >
+        <input
+          type="text"
+          value=""
+        />
+      </div>
+      <div
+        class="errorLabel"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Render overlay with minimal config 1`] = `
 <div
   class="grid grid"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | sort of
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #7082
| Related issues/PRs | #7082
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

This PR adds an anchor field to the MediaLinkTypeOverlay (as a copy from the internal link overlay, that already has one).

#### Why?

As discussed in https://github.com/sulu/sulu/issues/7082 at least for PDF-media an URL fragment can be very useful (to jump to a specific page with `#page=12`). 

#### Example Usage

Links to a media files (mainly PDF files) can now get an anchor like `page=12` within the overlay form (just like links to pages) that is appended to the link's URL like `...longdocument.pdf#page=12`.

I didn't find any documentation for the link overlays, so there is no documentation PR,

#### To Do

Nothing from my point of view. Update: Added a test to cover that field.
