### PR TITLE
Disable the delete-locale button correctly

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteToolbarAction.js
@@ -176,7 +176,10 @@ export default class DeleteToolbarAction extends AbstractFormToolbarAction {
         const {id} = this.resourceFormStore;
 
         const visibleConditionFulfilled = !visibleCondition || jexl.evalSync(visibleCondition, this.conditionData);
-        const isDisabled = !id || (deleteLocale && jexl.evalSync('contentLocales.length == 1', this.conditionData));
+        const isDisabled = !id || (deleteLocale && jexl.evalSync(
+            'contentLocales && contentLocales|length == 1',
+            this.conditionData
+        ));
 
         if (visibleConditionFulfilled) {
             return {


### PR DESCRIPTION
…lable

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes a jexl condition to disable the delete locale button when only one content-locale is available.

#### Why?

Currently the UI is able to remove the last translation of a page and that lead into a broken node.
