### PR TITLE
Fix LinkType warning when provider is not defined

### DIFF
--- a/src/Sulu/Component/Content/Types/Link.php
+++ b/src/Sulu/Component/Content/Types/Link.php
@@ -71,7 +71,7 @@ class Link extends SimpleContentType
         }
 
         $result = [
-            'provider' => $value['provider'] ?? false,
+            'provider' => $value['provider'] ?? null,
             'locale' => $value['locale'],
         ];
 

--- a/src/Sulu/Component/Content/Types/Link.php
+++ b/src/Sulu/Component/Content/Types/Link.php
@@ -71,7 +71,7 @@ class Link extends SimpleContentType
         }
 
         $result = [
-            'provider' => $value['provider'],
+            'provider' => $value['provider'] ?? false,
             'locale' => $value['locale'],
         ];
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fix warning on undefined array key "provider"

#### Why?

The use of links in blocks within blocks sometimes causes a warning when the link is empty.