### PR TITLE
Add array access wrapper for resource-locator-parts

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -28057,7 +28057,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'resourcelocator' on mixed\\.$#"
-			count: 6
+			count: 7
 			path: src/Sulu/Bundle/RouteBundle/Tests/Functional/Controller/RouteControllerTest.php
 
 		-
@@ -28097,7 +28097,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
-			count: 12
+			count: 13
 			path: src/Sulu/Bundle/RouteBundle/Tests/Functional/Controller/RouteControllerTest.php
 
 		-
@@ -57274,4 +57274,3 @@ parameters:
 			message: "#^Property Sulu\\\\Component\\\\Webspace\\\\Webspace\\:\\:\\$theme \\(string\\) does not accept string\\|null\\.$#"
 			count: 1
 			path: src/Sulu/Component/Webspace/Webspace.php
-

--- a/src/Sulu/Bundle/RouteBundle/Controller/RouteController.php
+++ b/src/Sulu/Bundle/RouteBundle/Controller/RouteController.php
@@ -19,6 +19,7 @@ use Sulu\Bundle\RouteBundle\Domain\Event\RouteRemovedEvent;
 use Sulu\Bundle\RouteBundle\Entity\RouteRepositoryInterface;
 use Sulu\Bundle\RouteBundle\Generator\RouteGeneratorInterface;
 use Sulu\Bundle\RouteBundle\Manager\ConflictResolverInterface;
+use Sulu\Bundle\RouteBundle\Model\ResourceLocatorParts;
 use Sulu\Bundle\RouteBundle\Model\RouteInterface;
 use Sulu\Component\Rest\AbstractRestController;
 use Sulu\Component\Rest\Exception\EntityNotFoundException;
@@ -214,7 +215,7 @@ class RouteController extends AbstractRestController implements ClassResourceInt
             $options['route_schema'] = $routeSchema;
             $options['locale'] = $locale;
 
-            $route = $this->routeGenerator->generate($parts, $options);
+            $route = $this->routeGenerator->generate(new ResourceLocatorParts($parts), $options);
 
             if ($this->conflictResolver) {
                 // create temporary route that is not persisted to resolve possible conflicts with existing routes

--- a/src/Sulu/Bundle/RouteBundle/Model/ResourceLocatorParts.php
+++ b/src/Sulu/Bundle/RouteBundle/Model/ResourceLocatorParts.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\RouteBundle\Model;
+
+/**
+ * @extends \ArrayObject<string, mixed>
+ */
+class ResourceLocatorParts extends \ArrayObject
+{
+    /**
+     * @return mixed
+     */
+    public function __get(string $name)
+    {
+        return $this->offsetGet($name);
+    }
+
+    /**
+     * @param mixed[] $arguments
+     *
+     * @return mixed
+     */
+    public function __call(string $name, array $arguments)
+    {
+        return $this->offsetGet(\lcfirst(\substr($name, 3)));
+    }
+}

--- a/src/Sulu/Bundle/RouteBundle/Tests/Functional/Controller/RouteControllerTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Functional/Controller/RouteControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of Sulu.
  *
@@ -44,7 +46,7 @@ class RouteControllerTest extends SuluTestCase
      */
     private $activityRepository;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->client = $this->createAuthenticatedClient();
         $this->entityManager = $this->getEntityManager();
@@ -70,7 +72,7 @@ class RouteControllerTest extends SuluTestCase
         $result = \json_decode($this->client->getResponse()->getContent(), true);
         $this->assertHttpStatusCode(200, $this->client->getResponse());
 
-        $this->assertEquals('/prefix/2019/test', $result['resourcelocator']);
+        $this->assertSame('/prefix/2019/test', $result['resourcelocator']);
     }
 
     public function testGenerateWithConfigFromParameter(): void
@@ -93,7 +95,7 @@ class RouteControllerTest extends SuluTestCase
         $result = \json_decode($this->client->getResponse()->getContent(), true);
         $this->assertHttpStatusCode(200, $this->client->getResponse());
 
-        $this->assertEquals('/2019/custom-part/test', $result['resourcelocator']);
+        $this->assertSame('/2019/custom-part/test', $result['resourcelocator']);
     }
 
     public function testGenerateWithTranslationInSchema(): void
@@ -115,7 +117,7 @@ class RouteControllerTest extends SuluTestCase
 
         $result = \json_decode($this->client->getResponse()->getContent(), true);
         $this->assertHttpStatusCode(200, $this->client->getResponse());
-        $this->assertEquals('/event/tomorrowland', $result['resourcelocator']);
+        $this->assertSame('/event/tomorrowland', $result['resourcelocator']);
 
         // test german translation
         $this->client->jsonRequest(
@@ -134,7 +136,7 @@ class RouteControllerTest extends SuluTestCase
 
         $result = \json_decode($this->client->getResponse()->getContent(), true);
         $this->assertHttpStatusCode(200, $this->client->getResponse());
-        $this->assertEquals('/veranstaltung/tomorrowland', $result['resourcelocator']);
+        $this->assertSame('/veranstaltung/tomorrowland', $result['resourcelocator']);
     }
 
     public function testGenerateWithConflict(): void
@@ -159,7 +161,7 @@ class RouteControllerTest extends SuluTestCase
         $result = \json_decode($this->client->getResponse()->getContent(), true);
         $this->assertHttpStatusCode(200, $this->client->getResponse());
 
-        $this->assertEquals('/prefix/2019/test-1', $result['resourcelocator']);
+        $this->assertSame('/prefix/2019/test-1', $result['resourcelocator']);
     }
 
     public function testGenerateWithConflictSameEntity(): void
@@ -185,7 +187,32 @@ class RouteControllerTest extends SuluTestCase
         $result = \json_decode($this->client->getResponse()->getContent(), true);
         $this->assertHttpStatusCode(200, $this->client->getResponse());
 
-        $this->assertEquals('/prefix/2019/test', $result['resourcelocator']);
+        $this->assertSame('/prefix/2019/test', $result['resourcelocator']);
+    }
+
+    public function testGenerateObjectAccess(): void
+    {
+        $this->client->jsonRequest(
+            'POST',
+            '/api/routes?action=generate',
+            [
+                'locale' => 'de',
+                'resourceKey' => 'event-resource-key',
+                'entityClass' => 'event-class',
+                'routeSchema' => '/prefix/{object.getYear()}/{object.month}/{object["day"]}/{object.getTitle()}',
+                'parts' => [
+                    'title' => 'Christmas Party',
+                    'year' => '2023',
+                    'month' => '12',
+                    'day' => '24',
+                ],
+            ]
+        );
+
+        $result = \json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+
+        $this->assertSame('/prefix/2023/12/24/christmas-party', $result['resourcelocator']);
     }
 
     public function testCGetAction(): void
@@ -217,8 +244,8 @@ class RouteControllerTest extends SuluTestCase
         $this->assertCount(1, $result['_embedded']['routes']);
 
         $items = $result['_embedded']['routes'];
-        $this->assertEquals($routes[0]->getId(), $items[0]['id']);
-        $this->assertEquals($routes[0]->getPath(), $items[0]['path']);
+        $this->assertSame($routes[0]->getId(), $items[0]['id']);
+        $this->assertSame($routes[0]->getPath(), $items[0]['path']);
     }
 
     public function testCGetActionWithEntityClassParameter(): void
@@ -249,8 +276,8 @@ class RouteControllerTest extends SuluTestCase
         $this->assertCount(1, $result['_embedded']['routes']);
 
         $items = $result['_embedded']['routes'];
-        $this->assertEquals($entityRoute1->getId(), $items[0]['id']);
-        $this->assertEquals($entityRoute1->getPath(), $items[0]['path']);
+        $this->assertSame($entityRoute1->getId(), $items[0]['id']);
+        $this->assertSame($entityRoute1->getPath(), $items[0]['path']);
     }
 
     public function testCGetActionNotExistingResourceKey(): void
@@ -306,8 +333,8 @@ class RouteControllerTest extends SuluTestCase
         for ($i = 0; $i < 3; ++$i) {
             $id = $routes[$i]->getId();
 
-            $this->assertEquals($routes[$i]->getId(), $items[$id]['id']);
-            $this->assertEquals($routes[$i]->getPath(), $items[$id]['path']);
+            $this->assertSame($routes[$i]->getId(), $items[$id]['id']);
+            $this->assertSame($routes[$i]->getPath(), $items[$id]['path']);
         }
     }
 
@@ -382,8 +409,8 @@ class RouteControllerTest extends SuluTestCase
         for ($i = 0; $i < 2; ++$i) {
             $id = $routes[$i + 1]->getId();
 
-            $this->assertEquals($routes[$i + 1]->getId(), $items[$id]['id']);
-            $this->assertEquals($routes[$i + 1]->getPath(), $items[$id]['path']);
+            $this->assertSame($routes[$i + 1]->getId(), $items[$id]['id']);
+            $this->assertSame($routes[$i + 1]->getPath(), $items[$id]['path']);
         }
     }
 

--- a/src/Sulu/Bundle/RouteBundle/Tests/Model/ResourceLocatorPartsTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Model/ResourceLocatorPartsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\RouteBundle\Tests\Model;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\RouteBundle\Model\ResourceLocatorParts;
+
+class ResourceLocatorPartsTest extends TestCase
+{
+    public function testGet(): void
+    {
+        $parts = new ResourceLocatorParts(['test' => 'value']);
+        // @phpstan-ignore-next-line
+        $this->assertSame('value', $parts->test);
+    }
+
+    public function testMagicGetter(): void
+    {
+        $parts = new ResourceLocatorParts(['test' => 'value']);
+        // @phpstan-ignore-next-line
+        $this->assertSame('value', $parts->getTest());
+    }
+
+    public function testArrayAccess(): void
+    {
+        $parts = new ResourceLocatorParts(['test' => 'value']);
+        $this->assertSame('value', $parts['test']);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes (but happens only in article-bundle)
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add a wrapper for resource locator parts.

#### Why?

In article-bundle we use `{object.getTitle()}` in the schema.