### PR TITLE
Add lastModified field to page settings

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -25716,108 +25716,8 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
 
 		-
-			message: "#^Cannot access offset 'author' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Cannot access offset 'authored' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Cannot access offset 'created' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Cannot access offset 'creator' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Cannot access offset 'extensionsData' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Cannot access offset 'locale' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Cannot access offset 'navigationContexts' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Cannot access offset 'permissions' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Cannot access offset 'redirectExternal' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Cannot access offset 'redirectTargetUuid' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Cannot access offset 'redirectType' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Cannot access offset 'resourceSegment' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Cannot access offset 'shadowLocale' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Cannot access offset 'shadowLocaleEnabled' on mixed\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Cannot access offset 'structureData' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Cannot access offset 'structureType' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Cannot access offset 'suluOrder' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Cannot access offset 'title' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Parameter \\#1 \\$contactId of method Sulu\\\\Bundle\\\\PageBundle\\\\Document\\\\BasePageDocument\\:\\:setAuthor\\(\\) expects int\\|null, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
 			message: "#^Parameter \\#1 \\$data of method Sulu\\\\Component\\\\Content\\\\Document\\\\Structure\\\\StructureInterface\\:\\:bind\\(\\) expects array, mixed given\\.$#"
 			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Parameter \\#1 \\$datetime of class DateTime constructor expects string, mixed given\\.$#"
-			count: 2
 			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
 
 		-
@@ -25827,21 +25727,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$identifier of method Sulu\\\\Component\\\\DocumentManager\\\\DocumentManagerInterface\\:\\:find\\(\\) expects string, mixed given\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Parameter \\#1 \\$locale of method Sulu\\\\Bundle\\\\PageBundle\\\\Document\\\\BasePageDocument\\:\\:setLocale\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Parameter \\#1 \\$navigationContexts of method Sulu\\\\Bundle\\\\PageBundle\\\\Document\\\\BasePageDocument\\:\\:setNavigationContexts\\(\\) expects array, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Parameter \\#1 \\$order of method Sulu\\\\Bundle\\\\PageBundle\\\\Document\\\\BasePageDocument\\:\\:setSuluOrder\\(\\) expects int, mixed given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
 
@@ -25851,57 +25736,7 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
 
 		-
-			message: "#^Parameter \\#1 \\$redirectExternal of method Sulu\\\\Bundle\\\\PageBundle\\\\Document\\\\BasePageDocument\\:\\:setRedirectExternal\\(\\) expects string\\|null, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Parameter \\#1 \\$redirectType of method Sulu\\\\Bundle\\\\PageBundle\\\\Document\\\\BasePageDocument\\:\\:setRedirectType\\(\\) expects int, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Parameter \\#1 \\$resourceSegment of method Sulu\\\\Bundle\\\\PageBundle\\\\Document\\\\BasePageDocument\\:\\:setResourceSegment\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Parameter \\#1 \\$shadowLocale of method Sulu\\\\Bundle\\\\PageBundle\\\\Document\\\\BasePageDocument\\:\\:setShadowLocale\\(\\) expects string\\|null, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Parameter \\#1 \\$shadowLocaleEnabled of method Sulu\\\\Bundle\\\\PageBundle\\\\Document\\\\BasePageDocument\\:\\:setShadowLocaleEnabled\\(\\) expects bool, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Parameter \\#1 \\$structureType of method Sulu\\\\Bundle\\\\PageBundle\\\\Document\\\\BasePageDocument\\:\\:setStructureType\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Parameter \\#1 \\$title of method Sulu\\\\Bundle\\\\PageBundle\\\\Document\\\\BasePageDocument\\:\\:setTitle\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Parameter \\#1 \\$userId of method Sulu\\\\Bundle\\\\PageBundle\\\\Document\\\\BasePageDocument\\:\\:setCreator\\(\\) expects int\\|null, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
 			message: "#^Parameter \\#2 \\$locale of class Sulu\\\\Bundle\\\\PageBundle\\\\Domain\\\\Event\\\\PageTranslationRestoredEvent constructor expects string, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Parameter \\#2 \\$locale of method Sulu\\\\Component\\\\DocumentManager\\\\DocumentManagerInterface\\:\\:find\\(\\) expects string\\|null, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
-
-		-
-			message: "#^Parameter \\#2 \\$locale of method Sulu\\\\Component\\\\DocumentManager\\\\DocumentManagerInterface\\:\\:persist\\(\\) expects string\\|null, mixed given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Trash/PageTrashItemHandler.php
 

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/behaviors.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/behaviors.xml
@@ -44,6 +44,15 @@
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 
+        <service id="sulu_document_manager.suscriber.behavior.last_modified"
+                 class="Sulu\Component\Content\Document\Subscriber\LastModifiedSubscriber">
+            <argument type="service" id="sulu_document_manager.property_encoder" />
+            <argument type="service" id="sulu.repository.user" />
+            <argument type="service" id="sulu_document_manager.metadata_factory" />
+
+            <tag name="sulu_document_manager.event_subscriber" />
+        </service>
+
         <service id="sulu_document_manager.suscriber.behavior.timestamp"
                  class="Sulu\Component\DocumentManager\Subscriber\Behavior\Audit\TimestampSubscriber">
             <argument type="service" id="sulu_document_manager.property_encoder" />

--- a/src/Sulu/Bundle/PageBundle/Document/BasePageDocument.php
+++ b/src/Sulu/Bundle/PageBundle/Document/BasePageDocument.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\PageBundle\Document;
 use Sulu\Component\Content\Document\Behavior\ExtensionBehavior;
 use Sulu\Component\Content\Document\Behavior\LocalizedAuditableBehavior;
 use Sulu\Component\Content\Document\Behavior\LocalizedAuthorBehavior;
+use Sulu\Component\Content\Document\Behavior\LocalizedLastModifiedBehavior;
 use Sulu\Component\Content\Document\Behavior\LocalizedStructureBehavior;
 use Sulu\Component\Content\Document\Behavior\NavigationContextBehavior;
 use Sulu\Component\Content\Document\Behavior\OrderBehavior;
@@ -58,7 +59,8 @@ class BasePageDocument implements
     LocalizedAuditableBehavior,
     LocalizedTitleBehavior,
     VersionBehavior,
-    LocalizedAuthorBehavior
+    LocalizedAuthorBehavior,
+    LocalizedLastModifiedBehavior
 {
     public const RESOURCE_KEY = 'pages';
 
@@ -248,6 +250,13 @@ class BasePageDocument implements
      * @var Version[]
      */
     protected $versions = [];
+
+    /**
+     * Date of lastModified.
+     *
+     * @var \DateTime|null
+     */
+    protected $lastModified;
 
     /**
      * Date of authoring.
@@ -510,6 +519,29 @@ class BasePageDocument implements
     public function setVersions($versions)
     {
         $this->versions = $versions;
+    }
+
+    public function getLastModifiedEnabled()
+    {
+        return null !== $this->lastModified;
+    }
+
+    /**
+     * @return \DateTime|null
+     */
+    public function getLastModified()
+    {
+        return $this->lastModified;
+    }
+
+    /**
+     * @param \DateTime|null $lastModified
+     *
+     * @return void
+     */
+    public function setLastModified($lastModified)
+    {
+        $this->lastModified = $lastModified;
     }
 
     public function getAuthored()

--- a/src/Sulu/Bundle/PageBundle/Form/Type/BasePageDocumentType.php
+++ b/src/Sulu/Bundle/PageBundle/Form/Type/BasePageDocumentType.php
@@ -55,6 +55,13 @@ abstract class BasePageDocumentType extends AbstractStructureBehaviorType
         $builder->add('shadowLocaleEnabled', CheckboxType::class);
         $builder->add('shadowLocale', TextType::class); // TODO: Should be choice of available shadow locales
         $builder->add(
+            'lastModified',
+            DateTimeType::class,
+            [
+                'widget' => 'single_text',
+            ]
+        );
+        $builder->add(
             'authored',
             DateTimeType::class,
             [

--- a/src/Sulu/Bundle/PageBundle/Resources/config/forms/page_settings.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/forms/page_settings.xml
@@ -142,6 +142,21 @@
                 <title>sulu_page.editing_information</title>
             </meta>
             <properties>
+                <property name="lastModifiedEnabled" type="checkbox" colspan="6">
+                    <meta>
+                        <title>sulu_page.last_modified_enabled</title>
+                    </meta>
+
+                    <params>
+                        <param name="type" value="toggler"/>
+                        <param name="default_value" value="false"/>
+                    </params>
+                </property>
+                <property name="lastModified" type="datetime" colspan="6" disabledCondition="!lastModifiedEnabled">
+                    <meta>
+                        <title>sulu_page.last_modified_date</title>
+                    </meta>
+                </property>
                 <property name="authored" type="datetime" colspan="6">
                     <meta>
                         <title>sulu_page.authored_date</title>

--- a/src/Sulu/Bundle/PageBundle/Resources/config/serializer/Document.BasePageDocument.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/serializer/Document.BasePageDocument.xml
@@ -6,6 +6,8 @@
         <property name="creator" type="integer" groups="defaultPage,preview"/>
         <property name="changer" type="integer" groups="defaultPage,preview"/>
         <property name="created" type="DateTime" groups="defaultPage,preview"/>
+        <virtual-property method="getLastModifiedEnabled" name="lastModifiedEnabled" serialized-name="lastModifiedEnabled" groups="defaultPage"/>
+        <property name="lastModified" type="DateTime" groups="defaultPage,preview"/>
         <property name="authored" type="DateTime" groups="defaultPage,preview"/>
         <property name="author" type="integer" groups="defaultPage,preview"/>
         <property name="published" type="DateTime" groups="defaultPage,smallPage,preview"/>

--- a/src/Sulu/Bundle/PageBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/PageBundle/Resources/translations/admin.de.json
@@ -31,6 +31,8 @@
     "sulu_page.editing_information": "Bearbeitungsinformationen",
     "sulu_page.authored_date": "Verfasst am",
     "sulu_page.author": "Autor",
+    "sulu_page.last_modified_enabled": "Aktualisierungsdatum aktivieren",
+    "sulu_page.last_modified_date": "Datum der Aktualisierung",
     "sulu_page.changelog": "Änderungshistorie",
     "sulu_page.text_for_more_link": "Text für weiterführenden Link",
     "sulu_page.icons": "Icons",

--- a/src/Sulu/Bundle/PageBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/PageBundle/Resources/translations/admin.en.json
@@ -31,6 +31,8 @@
     "sulu_page.editing_information": "Editing Information",
     "sulu_page.authored_date": "Authored Date",
     "sulu_page.author": "Author",
+    "sulu_page.last_modified_enabled": "Enable last modified date",
+    "sulu_page.last_modified_date": "Last modified date",
     "sulu_page.changelog": "Changelog",
     "sulu_page.text_for_more_link": "Text for more link",
     "sulu_page.icons": "Icons",

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
@@ -16,6 +16,7 @@ use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Content\ContentTypeManagerInterface;
 use Sulu\Component\Content\Document\Behavior\ExtensionBehavior;
 use Sulu\Component\Content\Document\Behavior\LocalizedAuthorBehavior;
+use Sulu\Component\Content\Document\Behavior\LocalizedLastModifiedBehavior;
 use Sulu\Component\Content\Document\Extension\ExtensionContainer;
 use Sulu\Component\Content\Extension\ExtensionManagerInterface;
 use Sulu\Component\Content\PreResolvableContentTypeInterface;
@@ -105,6 +106,10 @@ class StructureResolver implements StructureResolverInterface
             $data['published'] = $structure->getPublished();
             $data['shadowBaseLocale'] = $structure->getShadowBaseLanguage();
             $data['webspaceKey'] = $structure->getWebspaceKey();
+        }
+
+        if ($document instanceof LocalizedLastModifiedBehavior) {
+            $data['lastModified'] = $document->getLastModifiedEnabled() ? $document->getLastModified() : null;
         }
 
         if ($document instanceof LocalizedAuthorBehavior) {

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Resolver/StructureResolverTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Resolver/StructureResolverTest.php
@@ -23,6 +23,7 @@ use Sulu\Component\Content\ContentTypeInterface;
 use Sulu\Component\Content\ContentTypeManagerInterface;
 use Sulu\Component\Content\Document\Behavior\ExtensionBehavior;
 use Sulu\Component\Content\Document\Behavior\LocalizedAuthorBehavior;
+use Sulu\Component\Content\Document\Behavior\LocalizedLastModifiedBehavior;
 use Sulu\Component\Content\Document\Extension\ExtensionContainer;
 use Sulu\Component\Content\Extension\ExtensionInterface;
 use Sulu\Component\Content\Extension\ExtensionManagerInterface;
@@ -99,12 +100,17 @@ class StructureResolverTest extends TestCase
         $structure->getWebspaceKey()->willReturn('test');
 
         $authored = new \DateTime();
+        $lastModified = new \DateTime();
+        $lastModified->modify('+ 1 day');
 
         $document = $this->prophesize()->willImplement(LocalizedAuthorBehavior::class);
         $document->willImplement(ExtensionBehavior::class);
+        $document->willImplement(LocalizedLastModifiedBehavior::class);
         $structure->getDocument()->willReturn($document->reveal());
         $document->getAuthored()->willReturn($authored);
         $document->getAuthor()->willReturn(1);
+        $document->getLastModifiedEnabled()->willReturn(true);
+        $document->getlastModified()->willReturn($lastModified);
 
         $expected = [
             'extension' => [
@@ -129,6 +135,7 @@ class StructureResolverTest extends TestCase
             'urls' => ['en' => '/description', 'de' => '/beschreibung', 'es' => null],
             'path' => 'test-path',
             'shadowBaseLocale' => 'en',
+            'lastModified' => $lastModified,
             'authored' => $authored,
             'author' => 1,
             'webspaceKey' => 'test',
@@ -167,12 +174,17 @@ class StructureResolverTest extends TestCase
         $structure->getWebspaceKey()->willReturn('test');
 
         $authored = new \DateTime();
+        $lastModified = new \DateTime();
+        $lastModified->modify('+ 1 day');
 
         $document = $this->prophesize()->willImplement(LocalizedAuthorBehavior::class);
         $document->willImplement(ExtensionBehavior::class);
+        $document->willImplement(LocalizedLastModifiedBehavior::class);
         $structure->getDocument()->willReturn($document->reveal());
         $document->getAuthored()->willReturn($authored);
         $document->getAuthor()->willReturn(1);
+        $document->getLastModifiedEnabled()->willReturn(true);
+        $document->getLastModified()->willReturn($lastModified);
 
         $expected = [
             'extension' => [
@@ -194,6 +206,7 @@ class StructureResolverTest extends TestCase
             'template' => 'test',
             'urls' => ['en' => '/description', 'de' => '/beschreibung', 'es' => null],
             'shadowBaseLocale' => 'en',
+            'lastModified' => $lastModified,
             'authored' => $authored,
             'author' => 1,
             'webspaceKey' => 'test',
@@ -239,12 +252,17 @@ class StructureResolverTest extends TestCase
         $structure->getWebspaceKey()->willReturn('test');
 
         $authored = new \DateTime();
+        $lastModified = new \DateTime();
+        $lastModified->modify('+ 1 day');
 
         $document = $this->prophesize()->willImplement(LocalizedAuthorBehavior::class);
         $document->willImplement(ExtensionBehavior::class);
+        $document->willImplement(LocalizedLastModifiedBehavior::class);
         $structure->getDocument()->willReturn($document->reveal());
         $document->getAuthored()->willReturn($authored);
         $document->getAuthor()->willReturn(1);
+        $document->getLastModifiedEnabled()->willReturn(true);
+        $document->getLastModified()->willReturn($lastModified);
 
         $expected = [
             'id' => 'some-uuid',
@@ -264,6 +282,7 @@ class StructureResolverTest extends TestCase
             'urls' => ['en' => '/description', 'de' => '/beschreibung', 'es' => null],
             'path' => 'test-path',
             'shadowBaseLocale' => 'en',
+            'lastModified' => $lastModified,
             'authored' => $authored,
             'author' => 1,
             'webspaceKey' => 'test',
@@ -309,9 +328,12 @@ class StructureResolverTest extends TestCase
 
         $document = $this->prophesize()->willImplement(LocalizedAuthorBehavior::class);
         $document->willImplement(ExtensionBehavior::class);
+        $document->willImplement(LocalizedLastModifiedBehavior::class);
         $structure->getDocument()->willReturn($document->reveal());
         $document->getAuthored()->willReturn($authored);
         $document->getAuthor()->willReturn(1);
+        $document->getLastModifiedEnabled()->willReturn(false);
+        $document->getLastModified()->willReturn(null);
 
         $expected = [
             'extension' => [
@@ -334,6 +356,7 @@ class StructureResolverTest extends TestCase
             'urls' => ['en' => '/description', 'de' => '/beschreibung', 'es' => null],
             'path' => 'test-path',
             'shadowBaseLocale' => 'en',
+            'lastModified' => null,
             'authored' => $authored,
             'author' => 1,
             'webspaceKey' => 'test',

--- a/src/Sulu/Component/Content/Compat/DataNormalizer.php
+++ b/src/Sulu/Component/Content/Compat/DataNormalizer.php
@@ -66,10 +66,16 @@ class DataNormalizer
             'shadowLocaleEnabled' => self::getAndUnsetValue($data, 'shadowOn') ? true : false,
             'parent' => self::getAndUnsetValue($data, 'parent'),
             'workflowStage' => self::getAndUnsetValue($data, 'workflowStage'),
+            'lastModified' => $data['lastModifiedEnabled'] ?? false ? self::getAndUnsetValue($data, 'lastModified') : null,
             'authored' => self::getAndUnsetValue($data, 'authored'),
             'author' => self::getAndUnsetValue($data, 'author'),
             'structure' => $data,
         ];
+
+        // Set to false if lastModifiedEnabled exists but should be null, because if set to null it will be unset.
+        if (\array_key_exists('lastModifiedEnabled', $data) && false === $data['lastModifiedEnabled']) {
+            $normalized['lastModified'] = false;
+        }
 
         foreach ($normalized as $key => $value) {
             if (null === $value) {

--- a/src/Sulu/Component/Content/Document/Behavior/LastModifiedBehavior.php
+++ b/src/Sulu/Component/Content/Document/Behavior/LastModifiedBehavior.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Document\Behavior;
+
+/**
+ * Adds last modified date and toggler.
+ */
+interface LastModifiedBehavior extends LocalizedLastModifiedBehavior
+{
+}

--- a/src/Sulu/Component/Content/Document/Behavior/LocalizedLastModifiedBehavior.php
+++ b/src/Sulu/Component/Content/Document/Behavior/LocalizedLastModifiedBehavior.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Document\Behavior;
+
+/**
+ * Adds last modified date and toggler.
+ */
+interface LocalizedLastModifiedBehavior extends LocalizedBlameBehavior
+{
+    /**
+     * Returns lastModifiedEnabled.
+     *
+     * @return bool
+     */
+    public function getLastModifiedEnabled();
+
+    /**
+     * Returns lastModified-date.
+     *
+     * @return \DateTime|null
+     */
+    public function getLastModified();
+
+    /**
+     * Set lastModified-date.
+     *
+     * @param \DateTime|null $lastModified
+     *
+     * @return void
+     */
+    public function setLastModified($lastModified);
+}

--- a/src/Sulu/Component/Content/Document/Subscriber/LastModifiedSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/LastModifiedSubscriber.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Document\Subscriber;
+
+use Sulu\Component\Content\Document\Behavior\LastModifiedBehavior;
+use Sulu\Component\Content\Document\Behavior\LocalizedLastModifiedBehavior;
+use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\PropertyEncoder;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Handles lastModifiedEnabled and lastModified.
+ */
+class LastModifiedSubscriber implements EventSubscriberInterface
+{
+    public const LAST_MODIFIED_PROPERTY_NAME = 'lastModified';
+
+    /**
+     * @var PropertyEncoder
+     */
+    private $propertyEncoder;
+
+    public function __construct(
+        PropertyEncoder $propertyEncoder,
+    ) {
+        $this->propertyEncoder = $propertyEncoder;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::HYDRATE => 'setLastModifiedOnDocument',
+            Events::PERSIST => 'setLastModifiedOnNode',
+            Events::PUBLISH => 'setLastModifiedOnNode',
+        ];
+    }
+
+    /**
+     * Set isLastModified/lastModified to document on-hydrate.
+     *
+     * @return void
+     */
+    public function setLastModifiedOnDocument(HydrateEvent $event)
+    {
+        $document = $event->getDocument();
+        if (!$document instanceof LocalizedLastModifiedBehavior) {
+            return;
+        }
+
+        $encoding = 'system_localized';
+        if ($document instanceof LastModifiedBehavior) {
+            $encoding = 'system';
+        } elseif (!$event->getLocale()) {
+            return;
+        }
+
+        $node = $event->getNode();
+
+        /** @var \DateTime|null $lastModified */
+        $lastModified = $node->getPropertyValueWithDefault($this->propertyEncoder->encode($encoding, self::LAST_MODIFIED_PROPERTY_NAME, $event->getLocale()), null);
+        $document->setLastModified($lastModified);
+    }
+
+    /**
+     * Set lastModifiedEnabled/lastModified to document on-persist.
+     *
+     * @return void
+     */
+    public function setLastModifiedOnNode(AbstractMappingEvent $event)
+    {
+        $document = $event->getDocument();
+        if (!$document instanceof LocalizedLastModifiedBehavior) {
+            return;
+        }
+
+        $encoding = 'system_localized';
+        if ($document instanceof LastModifiedBehavior) {
+            $encoding = 'system';
+        } elseif (!$event->getLocale()) {
+            return;
+        }
+
+        $node = $event->getNode();
+
+        $node->setProperty(
+            $this->propertyEncoder->encode($encoding, self::LAST_MODIFIED_PROPERTY_NAME, $event->getLocale()),
+            $document->getLastModified(),
+        );
+    }
+}

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -32,6 +32,7 @@ use Sulu\Component\Content\ContentTypeManager;
 use Sulu\Component\Content\ContentTypeManagerInterface;
 use Sulu\Component\Content\Document\Behavior\ExtensionBehavior;
 use Sulu\Component\Content\Document\Behavior\LocalizedAuthorBehavior;
+use Sulu\Component\Content\Document\Behavior\LocalizedLastModifiedBehavior;
 use Sulu\Component\Content\Document\Behavior\OrderBehavior;
 use Sulu\Component\Content\Document\Behavior\RedirectTypeBehavior;
 use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
@@ -806,6 +807,10 @@ class ContentMapper implements ContentMapperInterface
         if (isset($url)) {
             $documentData['url'] = $url;
             $documentData['urls'] = $this->inspector->getLocalizedUrlsForPage($document);
+        }
+
+        if ($document instanceof LocalizedLastModifiedBehavior) {
+            $documentData['lastModified'] = $document->getLastModified();
         }
 
         if ($document instanceof LocalizedAuthorBehavior) {

--- a/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
@@ -62,6 +62,7 @@ class StructureXmlLoader extends AbstractLoader
         'navContexts',
         'shadow-on',
         'shadow-base',
+        'lastModified',
         'author',
         'authored',
         'type',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | https://github.com/sulu/SuluArticleBundle/pull/655
| License | MIT

#### What's in this PR?

Add new updated date field to the settings tab, with a toggler to enable and disable it.

#### Why?

So pages can have a editable update date.

