### PR TITLE
Add routeAttributes to preview conditions

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/PreviewForm/PreviewForm.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/PreviewForm/PreviewForm.js
@@ -1,5 +1,6 @@
 // @flow
 import jexl from 'jexl';
+import {toJS} from 'mobx';
 import withSidebar from '../../containers/Sidebar/withSidebar';
 import Form from '../Form';
 
@@ -13,7 +14,11 @@ export default withSidebar(Form, function() {
             },
         },
     } = this.props;
-    const enablePreview = !previewCondition || jexl.evalSync(previewCondition, this.resourceFormStore.data);
+    const previewData = {
+        __routeAttributes: this.props.router.attributes,
+        ...toJS(this.resourceFormStore.data),
+    };
+    const enablePreview = !previewCondition || jexl.evalSync(previewCondition, previewData);
 
     const {
         resourceFormStore: {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no
| BC breaks? | no 
| Deprecations? | no
| Related issues/PRs | required for https://github.com/sulu/SuluArticleBundle/pull/656
| License | MIT

#### What's in this PR?

Adds `routeAttributes` to the preview data that is used for jexl conditions. This allows more flexibility with conditions.

#### Example Usage

see https://github.com/sulu/SuluArticleBundle/pull/656