### PR TITLE
Set "sulu_document_manager.path_segment_registry" service public

### DIFF
--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/core.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/core.xml
@@ -77,7 +77,7 @@
         </service>
 
         <!-- Utilities -->
-        <service id="sulu_document_manager.path_segment_registry" class="Sulu\Component\DocumentManager\PathSegmentRegistry">
+        <service id="sulu_document_manager.path_segment_registry" class="Sulu\Component\DocumentManager\PathSegmentRegistry" public="true">
             <argument>%sulu_document_manager.segments%</argument>
         </service>
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This pr set the "sulu_document_manager.path_segment_registry"  service public

#### Why?

When using phpcr migrations, a specific one get this service via the container (using `container->get`).
See: https://github.com/sulu/sulu/blob/347f0957917f9ac5e91b96fa4d668abe1e12fb6d/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201504271608.php#L57

Therefore, the service *MUST* be public to avoid crititcal errors such as
```
The "sulu_document_manager.path_segment_registry" service or alias has been
removed or inlined when the container was compiled. You should either make
it public, or stop using the container directly and use dependency injecti
on instead.

