### PR TITLE
Fix DebugEventDispatcher - Fix method naming and add a check if an event should be stoppable

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -46761,22 +46761,12 @@ parameters:
 			path: src/Sulu/Component/DocumentManager/Event/UnpublishEvent.php
 
 		-
-			message: "#^Method Sulu\\\\Component\\\\DocumentManager\\\\EventDispatcher\\\\DebugEventDispatcher\\:\\:doDispatch\\(\\) has no return type specified\\.$#"
+			message: "#^Call to an undefined method object\\:\\:getDebugMessage\\(\\)\\.$#"
 			count: 1
 			path: src/Sulu/Component/DocumentManager/EventDispatcher/DebugEventDispatcher.php
 
 		-
-			message: "#^Method Sulu\\\\Component\\\\DocumentManager\\\\EventDispatcher\\\\DebugEventDispatcher\\:\\:doDispatch\\(\\) has parameter \\$event with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/DocumentManager/EventDispatcher/DebugEventDispatcher.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\DocumentManager\\\\EventDispatcher\\\\DebugEventDispatcher\\:\\:doDispatch\\(\\) has parameter \\$eventName with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/DocumentManager/EventDispatcher/DebugEventDispatcher.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\DocumentManager\\\\EventDispatcher\\\\DebugEventDispatcher\\:\\:doDispatch\\(\\) has parameter \\$listeners with no type specified\\.$#"
+			message: "#^Cannot use array destructuring on callable\\.$#"
 			count: 1
 			path: src/Sulu/Component/DocumentManager/EventDispatcher/DebugEventDispatcher.php
 

--- a/src/Sulu/Component/DocumentManager/EventDispatcher/DebugEventDispatcher.php
+++ b/src/Sulu/Component/DocumentManager/EventDispatcher/DebugEventDispatcher.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Component\DocumentManager\EventDispatcher;
 
+use Psr\EventDispatcher\StoppableEventInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -40,11 +41,16 @@ class DebugEventDispatcher extends EventDispatcher
         $this->logger = $logger ?: new NullLogger();
     }
 
-    protected function doDispatch($listeners, $eventName, $event)
+    protected function callListeners($listeners, $eventName, $event)
     {
         $eventStopwatch = $this->stopwatch->start($eventName, 'section');
+        $stoppable = $event instanceof StoppableEventInterface;
 
         foreach ($listeners as $listener) {
+            if ($stoppable && $event->isPropagationStopped()) {
+                break;
+            }
+
             list($listenerInstance, $methodName) = $listener;
             $className = \get_class($listenerInstance);
             $name = $this->getDebugClassName($className);
@@ -59,10 +65,6 @@ class DebugEventDispatcher extends EventDispatcher
 
             if ($listenerStopwatch->isStarted()) {
                 $listenerStopwatch->stop();
-            }
-
-            if ($event->isPropagationStopped()) {
-                break;
             }
         }
 

--- a/src/Sulu/Component/DocumentManager/EventDispatcher/DebugEventDispatcher.php
+++ b/src/Sulu/Component/DocumentManager/EventDispatcher/DebugEventDispatcher.php
@@ -41,7 +41,7 @@ class DebugEventDispatcher extends EventDispatcher
         $this->logger = $logger ?: new NullLogger();
     }
 
-    protected function callListeners($listeners, $eventName, $event)
+    protected function callListeners(iterable $listeners, string $eventName, object $event)
     {
         $eventStopwatch = $this->stopwatch->start($eventName, 'section');
         $stoppable = $event instanceof StoppableEventInterface;

--- a/src/Sulu/Component/DocumentManager/EventDispatcher/DebugEventDispatcher.php
+++ b/src/Sulu/Component/DocumentManager/EventDispatcher/DebugEventDispatcher.php
@@ -41,7 +41,7 @@ class DebugEventDispatcher extends EventDispatcher
         $this->logger = $logger ?: new NullLogger();
     }
 
-    protected function callListeners(iterable $listeners, string $eventName, object $event)
+    protected function callListeners(iterable $listeners, string $eventName, object $event): void
     {
         $eventStopwatch = $this->stopwatch->start($eventName, 'section');
         $stoppable = $event instanceof StoppableEventInterface;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/EventDispatcher/DebugEventDispatcherTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/EventDispatcher/DebugEventDispatcherTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sulu\Component\DocumentManager\Tests\Unit\EventDispatcher;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Sulu\Component\DocumentManager\Event\AbstractDocumentEvent;
+use Sulu\Component\DocumentManager\EventDispatcher\DebugEventDispatcher;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+final class DebugEventDispatcherTest extends TestCase
+{
+    public const TEST = 'test';
+    protected DebugEventDispatcher $dispatcher;
+    protected array $logOut = [];
+
+    protected function setUp(): void
+    {
+        $this->dispatcher = new DebugEventDispatcher(new Stopwatch(), new class($this->logOut) extends AbstractLogger {
+            public function __construct(protected array &$logOutput)
+            {
+            }
+
+            public function log($level, $message, array $context = []): void
+            {
+                $this->logOutput[] = $message;
+            }
+        });
+        $this->dispatcher->addListener(self::TEST, [$this, 'listenerMock']);
+    }
+
+    public function listenerMock($event, $eventName, $ref)
+    {
+    }
+
+    public function testDebugLogWritten(): void
+    {
+        $this->dispatcher->dispatch(new class() extends AbstractDocumentEvent {
+            public function __construct()
+            {
+                parent::__construct(new \stdClass());
+            }
+        }, self::TEST);
+        $this->assertCount(1, $this->logOut);
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/EventDispatcher/DebugEventDispatcherTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/EventDispatcher/DebugEventDispatcherTest.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Sulu\Component\DocumentManager\Tests\Unit\EventDispatcher;
 
 use PHPUnit\Framework\TestCase;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/EventDispatcher/DebugEventDispatcherTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/EventDispatcher/DebugEventDispatcherTest.php
@@ -22,12 +22,23 @@ use Symfony\Component\Stopwatch\Stopwatch;
 final class DebugEventDispatcherTest extends TestCase
 {
     public const TEST = 'test';
-    protected DebugEventDispatcher $dispatcher;
-    protected array $logOut = [];
+
+    /**
+     * @var DebugEventDispatcher
+     */
+    protected $dispatcher;
+
+    /**
+     * @var array<string>
+     */
+    protected $logOut = [];
 
     protected function setUp(): void
     {
         $this->dispatcher = new DebugEventDispatcher(new Stopwatch(), new class($this->logOut) extends AbstractLogger {
+            /**
+             * @param array<string> $logOutput
+             */
             public function __construct(protected array &$logOutput)
             {
             }
@@ -36,12 +47,22 @@ final class DebugEventDispatcherTest extends TestCase
             {
                 $this->logOutput[] = $message;
             }
+
+            /**
+             * @param object $event
+             * @param string $eventName
+             * @param mixed $ref
+             */
+            public function listenerMock($event, $eventName, $ref): void
+            {
+            }
         });
-        $this->dispatcher->addListener(self::TEST, [$this, 'listenerMock']);
+        $this->dispatcher->addListener(self::TEST, [$this->dispatcher, 'listenerMock']);
     }
 
-    public function listenerMock($event, $eventName, $ref)
+    protected function tearDown(): void
     {
+        $this->logOut = [];
     }
 
     public function testDebugLogWritten(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no 
| License | MIT


#### What's in this PR?

- The method doDispatch() is renamed to callListeners()
- A check if an event should be stoppable (as done in the base class) has been added
- the isPropagationStopped check is done before calling the listener (as done in the base class) to prevent behavioural differences between the original and this debug dispatcher.

#### Why?

The DebugEventDispatcher relies on overriding doDispatch() which has been removed from the symfony base class EventDispatcher, thus it never got called anymore anyway. 


