### PR TITLE
Using the correct function for adding debug info

### DIFF
--- a/src/Sulu/Component/DocumentManager/EventDispatcher/DebugEventDispatcher.php
+++ b/src/Sulu/Component/DocumentManager/EventDispatcher/DebugEventDispatcher.php
@@ -40,7 +40,7 @@ class DebugEventDispatcher extends EventDispatcher
         $this->logger = $logger ?: new NullLogger();
     }
 
-    protected function doDispatch($listeners, $eventName, $event)
+    protected function callListeners(iterable $listeners, string $eventName, object $event)
     {
         $eventStopwatch = $this->stopwatch->start($eventName, 'section');
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | [#7244](https://github.com/sulu/sulu/pull/7239)
| License | MIT
| Documentation PR | -

#### What's in this PR?
Renaming the overridden function.

#### Why?
In Symfony 5 the event dispatcher renamed/removed the function and now this is the replacement for it.