### PR TITLE
Allow doctrine orm 2.17.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -144,7 +144,7 @@
     "conflict": {
         "doctrine/dbal": "2.7.0",
         "doctrine/lexer": "1.0.0",
-        "doctrine/orm": "2.10.0 || 2.14.2 || >= 2.16.0",
+        "doctrine/orm": "2.10.0 || 2.14.2 || 2.16.0 - 2.17.2",
         "doctrine/doctrine-cache-bundle": "<1.3.1",
         "friendsofphp/php-cs-fixer": "3.9.1",
         "gedmo/doctrine-extensions" : "3.7.0",

--- a/composer.json
+++ b/composer.json
@@ -143,7 +143,7 @@
     },
     "conflict": {
         "doctrine/dbal": "2.7.0",
-        "doctrine/lexer": "1.0.0",
+        "doctrine/lexer": "1.0.0 || >= 3.0.0",
         "doctrine/orm": "2.10.0 || 2.14.2 || 2.16.0 - 2.17.2",
         "doctrine/doctrine-cache-bundle": "<1.3.1",
         "friendsofphp/php-cs-fixer": "3.9.1",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes https://github.com/sulu/sulu/issues/7142
| Related issues/PRs | https://github.com/sulu/sulu/pull/7128, https://github.com/sulu/sulu/pull/7141
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Allow doctrine orm 2.17.3.

#### Why?

There seems to be the issues fixed which we did run into #7142.

Also currently it can happen that if somebody is on older sulu versions they don't get a new sulu version when they have already a doctrine/orm version installed which is newer then 2.16.0.

/cc @leon-witlif as you created https://github.com/sulu/sulu/pull/7141