### PR TITLE
Allow doctrine orm 2.17.3 (Sulu 2.6)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -154,7 +154,7 @@
     },
     "conflict": {
         "behat/transliterator": "< 1.3.0",
-        "doctrine/orm": "2.10.0 || 2.14.2 || >=2.16.0",
+        "doctrine/orm": "2.10.0 || 2.14.2 || 2.16.0 - 2.17.2",
         "friendsofphp/php-cs-fixer": "3.9.1",
         "gedmo/doctrine-extensions" : "3.7.0",
         "jackalope/jackalope": "< 1.4.5",

--- a/composer.json
+++ b/composer.json
@@ -154,6 +154,7 @@
     },
     "conflict": {
         "behat/transliterator": "< 1.3.0",
+        "doctrine/lexer": ">= 3.0.0",
         "doctrine/orm": "2.10.0 || 2.14.2 || 2.16.0 - 2.17.2",
         "friendsofphp/php-cs-fixer": "3.9.1",
         "gedmo/doctrine-extensions" : "3.7.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes https://github.com/sulu/sulu/issues/7142
| Related issues/PRs | https://github.com/sulu/sulu/pull/7128, https://github.com/sulu/sulu/pull/7141
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Allow doctrine orm 2.17.3.

#### Why?

There seems to be a lot of the issues fixed which we did run into #7142.

This will test https://github.com/sulu/sulu/pull/7255 on 2.6.