### PR TITLE
Optimize loading of media for download media action

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
@@ -255,7 +255,7 @@ class MediaStreamController
     protected function getFileVersion($id, $version)
     {
         /** @var MediaInterface $mediaEntity */
-        $mediaEntity = $this->mediaRepository->findMediaById($id);
+        $mediaEntity = $this->mediaRepository->findMediaByIdForRendering($id, null);
 
         if (!$mediaEntity) {
             return null;

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
@@ -102,7 +102,7 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
                 ->where('media.id = :mediaId')
                 ->setParameter('mediaId', $id);
 
-            if ($formatKey !== null) {
+            if (null !== $formatKey) {
                 $queryBuilder
                     ->addSelect('formatOptions')
                     ->leftJoin(

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
@@ -97,20 +97,23 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
             $queryBuilder = $this->createQueryBuilder('media')
                 ->leftJoin('media.files', 'file')
                 ->leftJoin('file.fileVersions', 'fileVersion', Join::WITH, 'file.version = fileVersion.version')
-                ->leftJoin(
-                    'fileVersion.formatOptions',
-                    'formatOptions',
-                    Join::WITH,
-                    'formatOptions.formatKey = :formatKey'
-                )
-                ->setParameter('formatKey', $formatKey)
                 ->addSelect('file')
                 ->addSelect('fileVersion')
-                ->addSelect('formatOptions')
                 ->where('media.id = :mediaId')
                 ->setParameter('mediaId', $id);
 
-            /** @var MediaInterface */
+            if ($formatKey !== null) {
+                $queryBuilder
+                    ->addSelect('formatOptions')
+                    ->leftJoin(
+                        'fileVersion.formatOptions',
+                        'formatOptions',
+                        Join::WITH,
+                        'formatOptions.formatKey = :formatKey'
+                    )
+                    ->setParameter('formatKey', $formatKey);
+            }
+
             return $queryBuilder->getQuery()->getSingleResult();
         } catch (NoResultException $ex) {
             return null;

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
@@ -114,6 +114,7 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
                     ->setParameter('formatKey', $formatKey);
             }
 
+            /** @var MediaInterface */
             return $queryBuilder->getQuery()->getSingleResult();
         } catch (NoResultException $ex) {
             return null;

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepositoryInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepositoryInterface.php
@@ -37,7 +37,7 @@ interface MediaRepositoryInterface extends RepositoryInterface
      * to be able to render the actual media.
      *
      * @param int $id
-     * @param string $formatKey
+     * @param string|null $formatKey
      *
      * @return MediaInterface|null
      */


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Do not join all sub entities for download.

#### Why?

Not required

#### TODO

 - [x] Profile query
 
**Before**

![Bildschirmfoto 2024-02-05 um 12 23 53](https://github.com/sulu/sulu/assets/1698337/27e7e5ac-5a2b-45d6-b45e-0cc1d5391793)


**After**

![Bildschirmfoto 2024-02-05 um 12 24 11](https://github.com/sulu/sulu/assets/1698337/232a347b-0a3e-425f-8e97-57ce1b732336)

---

Memory usage is the same on php side:

![Bildschirmfoto 2024-02-05 um 12 25 18](https://github.com/sulu/sulu/assets/1698337/5d7c5047-0363-4bb0-bbce-a69e4abd981d)

The usage on the mysql side I did not measure but its fine to merge this as we query less and it sure is an optimization.
