### PR TITLE
Avoid bundle deprecation messages by add void return types and mark them as `@internal`

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/SuluAdminBundle.php
+++ b/src/Sulu/Bundle/AdminBundle/SuluAdminBundle.php
@@ -16,12 +16,15 @@ use Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\AddMetadataProviderPass
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+/**
+ * @final
+ */
 class SuluAdminBundle extends Bundle
 {
     /**
-     * @return void
+     * @internal
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/SuluAudienceTargetingBundle.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/SuluAudienceTargetingBundle.php
@@ -23,12 +23,17 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 /**
  * Sulu Audience Targeting Bundle is for managing target groups, their rules and conditions
  * and applying them to certain contents to delivery user specific content.
+ *
+ * @final
  */
 class SuluAudienceTargetingBundle extends Bundle
 {
     use PersistenceBundleTrait;
 
-    public function build(ContainerBuilder $container)
+    /**
+     * @internal
+     */
+    public function build(ContainerBuilder $container): void
     {
         $this->buildPersistence(
             [

--- a/src/Sulu/Bundle/CategoryBundle/SuluCategoryBundle.php
+++ b/src/Sulu/Bundle/CategoryBundle/SuluCategoryBundle.php
@@ -22,12 +22,17 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * Entry point for the SuluCategoryBundle.
+ *
+ * @final
  */
 class SuluCategoryBundle extends Bundle
 {
     use PersistenceBundleTrait;
 
-    public function build(ContainerBuilder $container)
+    /**
+     * @internal
+     */
+    public function build(ContainerBuilder $container): void
     {
         $this->buildPersistence(
             [

--- a/src/Sulu/Bundle/ContactBundle/SuluContactBundle.php
+++ b/src/Sulu/Bundle/ContactBundle/SuluContactBundle.php
@@ -17,11 +17,17 @@ use Sulu\Bundle\PersistenceBundle\PersistenceBundleTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+/**
+ * @final
+ */
 class SuluContactBundle extends Bundle
 {
     use PersistenceBundleTrait;
 
-    public function build(ContainerBuilder $container)
+    /**
+     * @internal
+     */
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/src/Sulu/Bundle/CoreBundle/SuluCoreBundle.php
+++ b/src/Sulu/Bundle/CoreBundle/SuluCoreBundle.php
@@ -23,9 +23,15 @@ use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+/**
+ * @final
+ */
 class SuluCoreBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    /**
+     * @internal
+     */
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/src/Sulu/Bundle/CustomUrlBundle/SuluCustomUrlBundle.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/SuluCustomUrlBundle.php
@@ -18,10 +18,15 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * Integrates custom-urls into sulu.
+ *
+ * @final
  */
 class SuluCustomUrlBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    /**
+     * @internal
+     */
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/src/Sulu/Bundle/DocumentManagerBundle/SuluDocumentManagerBundle.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/SuluDocumentManagerBundle.php
@@ -17,9 +17,15 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+/**
+ * @final
+ */
 class SuluDocumentManagerBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    /**
+     * @internal
+     */
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
         $container->addCompilerPass(new InitializerPass());

--- a/src/Sulu/Bundle/MarkupBundle/SuluMarkupBundle.php
+++ b/src/Sulu/Bundle/MarkupBundle/SuluMarkupBundle.php
@@ -19,10 +19,15 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * Integrates markup into symfony.
+ *
+ * @final
  */
 class SuluMarkupBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    /**
+     * @internal
+     */
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/src/Sulu/Bundle/MediaBundle/SuluMediaBundle.php
+++ b/src/Sulu/Bundle/MediaBundle/SuluMediaBundle.php
@@ -21,11 +21,17 @@ use Sulu\Bundle\PersistenceBundle\PersistenceBundleTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+/**
+ * @final
+ */
 class SuluMediaBundle extends Bundle
 {
     use PersistenceBundleTrait;
 
-    public function build(ContainerBuilder $container)
+    /**
+     * @internal
+     */
+    public function build(ContainerBuilder $container): void
     {
         $this->buildPersistence(
             [

--- a/src/Sulu/Bundle/PageBundle/SuluPageBundle.php
+++ b/src/Sulu/Bundle/PageBundle/SuluPageBundle.php
@@ -20,9 +20,15 @@ use Sulu\Component\Symfony\CompilerPass\TaggedServiceCollectorCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+/**
+ * @final
+ */
 class SuluPageBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    /**
+     * @internal
+     */
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/src/Sulu/Bundle/PersistenceBundle/SuluPersistenceBundle.php
+++ b/src/Sulu/Bundle/PersistenceBundle/SuluPersistenceBundle.php
@@ -16,12 +16,15 @@ use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+/**
+ * @final
+ */
 class SuluPersistenceBundle extends Bundle
 {
     /**
-     * @return void
+     * @internal
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(
             new ActivateResolveTargetEntityResolverPass(),

--- a/src/Sulu/Bundle/PreviewBundle/SuluPreviewBundle.php
+++ b/src/Sulu/Bundle/PreviewBundle/SuluPreviewBundle.php
@@ -21,12 +21,17 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * Integrates preview into symfony.
+ *
+ * @final
  */
 class SuluPreviewBundle extends Bundle
 {
     use PersistenceBundleTrait;
 
-    public function build(ContainerBuilder $container)
+    /**
+     * @internal
+     */
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/src/Sulu/Bundle/RouteBundle/SuluRouteBundle.php
+++ b/src/Sulu/Bundle/RouteBundle/SuluRouteBundle.php
@@ -22,12 +22,14 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * Entry point of sulu-route-bundle.
+ *
+ * @final
  */
 class SuluRouteBundle extends Bundle
 {
     use PersistenceBundleTrait;
 
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/src/Sulu/Bundle/SecurityBundle/SuluSecurityBundle.php
+++ b/src/Sulu/Bundle/SecurityBundle/SuluSecurityBundle.php
@@ -21,11 +21,17 @@ use Sulu\Component\Security\Authorization\AccessControl\AccessControlInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+/**
+ * @final
+ */
 class SuluSecurityBundle extends Bundle
 {
     use PersistenceBundleTrait;
 
-    public function build(ContainerBuilder $container)
+    /**
+     * @internal
+     */
+    public function build(ContainerBuilder $container): void
     {
         $this->buildPersistence(
             [

--- a/src/Sulu/Bundle/SnippetBundle/SuluSnippetBundle.php
+++ b/src/Sulu/Bundle/SnippetBundle/SuluSnippetBundle.php
@@ -16,9 +16,15 @@ use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+/**
+ * @final
+ */
 class SuluSnippetBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    /**
+     * @internal
+     */
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new SnippetAreaCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -1024);
 

--- a/src/Sulu/Bundle/TagBundle/SuluTagBundle.php
+++ b/src/Sulu/Bundle/TagBundle/SuluTagBundle.php
@@ -18,12 +18,17 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * Entry-point of tag-bundle.
+ *
+ * @final
  */
 class SuluTagBundle extends Bundle
 {
     use PersistenceBundleTrait;
 
-    public function build(ContainerBuilder $container)
+    /**
+     * @internal
+     */
+    public function build(ContainerBuilder $container): void
     {
         $this->buildPersistence(
             [

--- a/src/Sulu/Bundle/TestBundle/SuluTestBundle.php
+++ b/src/Sulu/Bundle/TestBundle/SuluTestBundle.php
@@ -17,14 +17,20 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class SuluTestBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    /**
+     * @internal
+     */
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 
         $container->addCompilerPass(new ReplaceTestClientPass());
     }
 
-    public static function getConfigDir()
+    /**
+     * @internal
+     */
+    public static function getConfigDir(): string
     {
         return __DIR__ . '/Resources/app/config';
     }

--- a/src/Sulu/Bundle/WebsiteBundle/SuluWebsiteBundle.php
+++ b/src/Sulu/Bundle/WebsiteBundle/SuluWebsiteBundle.php
@@ -20,11 +20,17 @@ use Sulu\Component\Util\SuluVersionPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+/**
+ * @final
+ */
 class SuluWebsiteBundle extends Bundle
 {
     use PersistenceBundleTrait;
 
-    public function build(ContainerBuilder $container)
+    /**
+     * @internal
+     */
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no 
| BC breaks? | no
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Avoid bundle deprecation messages by add void return types and mark them as `@internal`

#### Why?

The methods should never be used by an application, they are symfony `@internal` and used by symfony dependency injection and never directly called. Currently symfony outputs lot of deprecations when bundle not yet uses `: void`. Adding `: void` is a technical bc break but don't think that somebody ever extended from a bundle class of our side that so think we can still do it.
