### PR TITLE
Fix Article restore bug with pageTreeRoute if parent page is null by adding a fallback

### DIFF
--- a/src/Sulu/Bundle/RouteBundle/Content/Type/PageTreeRouteContentType.php
+++ b/src/Sulu/Bundle/RouteBundle/Content/Type/PageTreeRouteContentType.php
@@ -118,9 +118,17 @@ class PageTreeRouteContentType extends SimpleContentType
             ];
         }
 
-        $page = $this->getAttribute('page', $value, ['uuid' => null, 'path' => '/']);
+        // Fallback for string value, because the ArticleBundle had a bug where only the route path was saved and not all neccassary values.
+        // https://github.com/sulu/SuluArticleBundle/pull/658
+        $pageDefault = ['uuid' => null, 'path' => '/'];
+        if (\is_array($value)) {
+            $page = $this->getAttribute('page', $value, $pageDefault) ?? $pageDefault;
+            $suffix = $this->getAttribute('suffix', $value);
+        } else {
+            $page = $pageDefault;
+            $suffix = null;
+        }
 
-        $suffix = $this->getAttribute('suffix', $value);
         if (!$suffix) {
             $suffix = $this->generateSuffix($node, $languageCode);
         } else {

--- a/src/Sulu/Bundle/RouteBundle/Tests/Functional/Content/PageTreeRouteContentTypeTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Functional/Content/PageTreeRouteContentTypeTest.php
@@ -231,6 +231,32 @@ class PageTreeRouteContentTypeTest extends TestCase
         );
     }
 
+    public function testWriteString(): void
+    {
+        $value = '/test-page/test-custom-child';
+        $this->property->getValue()->willReturn($value);
+
+        $route = $this->prophesize(RouteInterface::class);
+        $document = $this->prophesize(RoutableBehavior::class);
+        $this->chainRouteGenerator->generate($document->reveal())->willReturn($route->reveal());
+        $this->documentRegistry->getDocumentForNode($this->node->reveal(), $this->locale)
+            ->willReturn($document->reveal());
+
+        $this->node->setProperty($this->propertyName, '/')->shouldBeCalled();
+        $this->node->setProperty($this->propertyName . '-suffix', '/')->shouldBeCalled();
+
+        $this->node->hasProperty($this->propertyName . '-page')->willReturn(false);
+
+        $this->contentType->write(
+            $this->node->reveal(),
+            $this->property->reveal(),
+            1,
+            $this->webspaceKey,
+            $this->locale,
+            null
+        );
+    }
+
     public function testWriteExistingPageRelation(): void
     {
         $value = [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | https://github.com/sulu/SuluArticleBundle/pull/658
| License | MIT

#### What's in this PR?

Add fallback for PageTreeRoute, when there is no parent page (especially for articles)

#### Why?

When an Article with an empty parent page is restored from the trash, the parent page is set to null. But an array with path and uuid is expected.