### PR TITLE
Add focus for search fields

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/Search.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/Search.js
@@ -76,18 +76,20 @@ class Search extends React.Component<Props> {
 
     render() {
         return (
-            <Input
-                collapsed={this.collapsed}
-                icon="su-search"
-                onBlur={this.handleBlur}
-                onChange={this.handleChange}
-                onClearClick={this.handleClearClick}
-                onIconClick={this.handleIconClick}
-                onKeyPress={this.handleKeyPress}
-                placeholder={translate('sulu_admin.list_search_placeholder')}
-                skin="dark"
-                value={this.value}
-            />
+            <label aria-label={translate('sulu_admin.list_search_placeholder')}>
+                <Input
+                    collapsed={this.collapsed}
+                    icon="su-search"
+                    onBlur={this.handleBlur}
+                    onChange={this.handleChange}
+                    onClearClick={this.handleClearClick}
+                    onIconClick={this.handleIconClick}
+                    onKeyPress={this.handleKeyPress}
+                    placeholder={translate('sulu_admin.list_search_placeholder')}
+                    skin="dark"
+                    value={this.value}
+                />
+            </label>
         );
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/__snapshots__/List.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/__snapshots__/List.test.js.snap
@@ -10,25 +10,29 @@ exports[`Do not render Loader instead of Adapter if no page count is given 1`] =
     <div
       class="toolbarLeft"
     >
-      <div
-        class="input dark left collapsed hasAppendIcon"
+      <label
+        aria-label="sulu_admin.list_search_placeholder"
       >
         <div
-          class="prependedContainer dark collapsed"
+          class="input dark left collapsed hasAppendIcon"
         >
-          <span
-            aria-label="su-search"
-            class="su-search clickable icon dark iconClickable collapsed"
-            role="button"
-            tabindex="0"
+          <div
+            class="prependedContainer dark collapsed"
+          >
+            <span
+              aria-label="su-search"
+              class="su-search clickable icon dark iconClickable collapsed"
+              role="button"
+              tabindex="0"
+            />
+          </div>
+          <input
+            placeholder="sulu_admin.list_search_placeholder"
+            type="text"
+            value=""
           />
         </div>
-        <input
-          placeholder="sulu_admin.list_search_placeholder"
-          type="text"
-          value=""
-        />
-      </div>
+      </label>
     </div>
     <div
       class="toolbarRight"
@@ -54,25 +58,29 @@ exports[`Render Loader instead of Adapter if nothing was loaded yet 1`] = `
     <div
       class="toolbarLeft"
     >
-      <div
-        class="input dark left collapsed hasAppendIcon"
+      <label
+        aria-label="sulu_admin.list_search_placeholder"
       >
         <div
-          class="prependedContainer dark collapsed"
+          class="input dark left collapsed hasAppendIcon"
         >
-          <span
-            aria-label="su-search"
-            class="su-search clickable icon dark iconClickable collapsed"
-            role="button"
-            tabindex="0"
+          <div
+            class="prependedContainer dark collapsed"
+          >
+            <span
+              aria-label="su-search"
+              class="su-search clickable icon dark iconClickable collapsed"
+              role="button"
+              tabindex="0"
+            />
+          </div>
+          <input
+            placeholder="sulu_admin.list_search_placeholder"
+            type="text"
+            value=""
           />
         </div>
-        <input
-          placeholder="sulu_admin.list_search_placeholder"
-          type="text"
-          value=""
-        />
-      </div>
+      </label>
     </div>
     <div
       class="toolbarRight"
@@ -125,25 +133,29 @@ exports[`Render the adapter in disabled state 1`] = `
     <div
       class="toolbarLeft"
     >
-      <div
-        class="input dark left collapsed hasAppendIcon"
+      <label
+        aria-label="sulu_admin.list_search_placeholder"
       >
         <div
-          class="prependedContainer dark collapsed"
+          class="input dark left collapsed hasAppendIcon"
         >
-          <span
-            aria-label="su-search"
-            class="su-search clickable icon dark iconClickable collapsed"
-            role="button"
-            tabindex="0"
+          <div
+            class="prependedContainer dark collapsed"
+          >
+            <span
+              aria-label="su-search"
+              class="su-search clickable icon dark iconClickable collapsed"
+              role="button"
+              tabindex="0"
+            />
+          </div>
+          <input
+            placeholder="sulu_admin.list_search_placeholder"
+            type="text"
+            value=""
           />
         </div>
-        <input
-          placeholder="sulu_admin.list_search_placeholder"
-          type="text"
-          value=""
-        />
-      </div>
+      </label>
     </div>
     <div
       class="toolbarRight"
@@ -206,25 +218,29 @@ exports[`Render the adapter with filters 1`] = `
     <div
       class="toolbarLeft"
     >
-      <div
-        class="input dark left collapsed hasAppendIcon"
+      <label
+        aria-label="sulu_admin.list_search_placeholder"
       >
         <div
-          class="prependedContainer dark collapsed"
+          class="input dark left collapsed hasAppendIcon"
         >
-          <span
-            aria-label="su-search"
-            class="su-search clickable icon dark iconClickable collapsed"
-            role="button"
-            tabindex="0"
+          <div
+            class="prependedContainer dark collapsed"
+          >
+            <span
+              aria-label="su-search"
+              class="su-search clickable icon dark iconClickable collapsed"
+              role="button"
+              tabindex="0"
+            />
+          </div>
+          <input
+            placeholder="sulu_admin.list_search_placeholder"
+            type="text"
+            value=""
           />
         </div>
-        <input
-          placeholder="sulu_admin.list_search_placeholder"
-          type="text"
-          value=""
-        />
-      </div>
+      </label>
       <div
         class="fieldFilter"
       >
@@ -306,25 +322,29 @@ exports[`Render the adapter with filters but filterable disabled 1`] = `
     <div
       class="toolbarLeft"
     >
-      <div
-        class="input dark left collapsed hasAppendIcon"
+      <label
+        aria-label="sulu_admin.list_search_placeholder"
       >
         <div
-          class="prependedContainer dark collapsed"
+          class="input dark left collapsed hasAppendIcon"
         >
-          <span
-            aria-label="su-search"
-            class="su-search clickable icon dark iconClickable collapsed"
-            role="button"
-            tabindex="0"
+          <div
+            class="prependedContainer dark collapsed"
+          >
+            <span
+              aria-label="su-search"
+              class="su-search clickable icon dark iconClickable collapsed"
+              role="button"
+              tabindex="0"
+            />
+          </div>
+          <input
+            placeholder="sulu_admin.list_search_placeholder"
+            type="text"
+            value=""
           />
         </div>
-        <input
-          placeholder="sulu_admin.list_search_placeholder"
-          type="text"
-          value=""
-        />
-      </div>
+      </label>
     </div>
     <div
       class="toolbarRight"
@@ -350,25 +370,29 @@ exports[`Render toolbar with with search field and actions 1`] = `
     <div
       class="toolbarLeft"
     >
-      <div
-        class="input dark left collapsed hasAppendIcon"
+      <label
+        aria-label="sulu_admin.list_search_placeholder"
       >
         <div
-          class="prependedContainer dark collapsed"
+          class="input dark left collapsed hasAppendIcon"
         >
-          <span
-            aria-label="su-search"
-            class="su-search clickable icon dark iconClickable collapsed"
-            role="button"
-            tabindex="0"
+          <div
+            class="prependedContainer dark collapsed"
+          >
+            <span
+              aria-label="su-search"
+              class="su-search clickable icon dark iconClickable collapsed"
+              role="button"
+              tabindex="0"
+            />
+          </div>
+          <input
+            placeholder="sulu_admin.list_search_placeholder"
+            type="text"
+            value=""
           />
         </div>
-        <input
-          placeholder="sulu_admin.list_search_placeholder"
-          type="text"
-          value=""
-        />
-      </div>
+      </label>
     </div>
     <div
       class="toolbarRight"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/__snapshots__/Search.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/__snapshots__/Search.test.js.snap
@@ -1,77 +1,89 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`The component should expand the input when clicking on icon 1`] = `
-<div
-  class="input dark left hasAppendIcon"
+<label
+  aria-label="sulu_admin.list_search_placeholder"
 >
   <div
-    class="prependedContainer dark"
+    class="input dark left hasAppendIcon"
   >
-    <span
-      aria-label="su-search"
-      class="su-search clickable icon dark iconClickable"
-      role="button"
-      tabindex="0"
+    <div
+      class="prependedContainer dark"
+    >
+      <span
+        aria-label="su-search"
+        class="su-search clickable icon dark iconClickable"
+        role="button"
+        tabindex="0"
+      />
+    </div>
+    <input
+      placeholder="sulu_admin.list_search_placeholder"
+      type="text"
+      value=""
     />
   </div>
-  <input
-    placeholder="sulu_admin.list_search_placeholder"
-    type="text"
-    value=""
-  />
-</div>
+</label>
 `;
 
 exports[`The component should render collapsed 1`] = `
-<div
-  class="input dark left collapsed hasAppendIcon"
+<label
+  aria-label="sulu_admin.list_search_placeholder"
 >
   <div
-    class="prependedContainer dark collapsed"
+    class="input dark left collapsed hasAppendIcon"
   >
-    <span
-      aria-label="su-search"
-      class="su-search clickable icon dark iconClickable collapsed"
-      role="button"
-      tabindex="0"
+    <div
+      class="prependedContainer dark collapsed"
+    >
+      <span
+        aria-label="su-search"
+        class="su-search clickable icon dark iconClickable collapsed"
+        role="button"
+        tabindex="0"
+      />
+    </div>
+    <input
+      placeholder="sulu_admin.list_search_placeholder"
+      type="text"
+      value=""
     />
   </div>
-  <input
-    placeholder="sulu_admin.list_search_placeholder"
-    type="text"
-    value=""
-  />
-</div>
+</label>
 `;
 
 exports[`The component should render not collapsed when value is given 1`] = `
-<div
-  class="input dark left hasAppendIcon"
+<label
+  aria-label="sulu_admin.list_search_placeholder"
 >
   <div
-    class="prependedContainer dark"
+    class="input dark left hasAppendIcon"
   >
-    <span
-      aria-label="su-search"
-      class="su-search clickable icon dark iconClickable"
-      role="button"
-      tabindex="0"
+    <div
+      class="prependedContainer dark"
+    >
+      <span
+        aria-label="su-search"
+        class="su-search clickable icon dark iconClickable"
+        role="button"
+        tabindex="0"
+      />
+    </div>
+    <input
+      placeholder="sulu_admin.list_search_placeholder"
+      type="text"
+      value="search-string"
     />
+    <div
+      class="appendContainer"
+    >
+      <span
+        aria-label="su-times"
+        class="su-times clickable icon dark iconClickable"
+        role="button"
+        tabindex="0"
+      />
+    </div>
   </div>
-  <input
-    placeholder="sulu_admin.list_search_placeholder"
-    type="text"
-    value="search-string"
-  />
-  <div
-    class="appendContainer"
-  >
-    <span
-      aria-label="su-times"
-      class="su-times clickable icon dark iconClickable"
-      role="button"
-      tabindex="0"
-    />
-  </div>
-</div>
+</label>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
@@ -296,24 +296,26 @@ exports[`Should render the list with a title 1`] = `
       <div
         class="toolbarLeft"
       >
-        <div
-          class="input dark left collapsed hasAppendIcon"
-        >
+        <label>
           <div
-            class="prependedContainer dark collapsed"
+            class="input dark left collapsed hasAppendIcon"
           >
-            <span
-              aria-label="su-search"
-              class="su-search clickable icon dark iconClickable collapsed"
-              role="button"
-              tabindex="0"
+            <div
+              class="prependedContainer dark collapsed"
+            >
+              <span
+                aria-label="su-search"
+                class="su-search clickable icon dark iconClickable collapsed"
+                role="button"
+                tabindex="0"
+              />
+            </div>
+            <input
+              type="text"
+              value=""
             />
           </div>
-          <input
-            type="text"
-            value=""
-          />
-        </div>
+        </label>
       </div>
       <div
         class="toolbarRight"
@@ -581,24 +583,26 @@ exports[`Should render the list with nodes of given ListItemActions 1`] = `
       <div
         class="toolbarLeft"
       >
-        <div
-          class="input dark left collapsed hasAppendIcon"
-        >
+        <label>
           <div
-            class="prependedContainer dark collapsed"
+            class="input dark left collapsed hasAppendIcon"
           >
-            <span
-              aria-label="su-search"
-              class="su-search clickable icon dark iconClickable collapsed"
-              role="button"
-              tabindex="0"
+            <div
+              class="prependedContainer dark collapsed"
+            >
+              <span
+                aria-label="su-search"
+                class="su-search clickable icon dark iconClickable collapsed"
+                role="button"
+                tabindex="0"
+              />
+            </div>
+            <input
+              type="text"
+              value=""
             />
           </div>
-          <input
-            type="text"
-            value=""
-          />
-        </div>
+        </label>
       </div>
       <div
         class="toolbarRight"
@@ -912,24 +916,26 @@ exports[`Should render the list with nodes of given ToolbarActions 1`] = `
       <div
         class="toolbarLeft"
       >
-        <div
-          class="input dark left collapsed hasAppendIcon"
-        >
+        <label>
           <div
-            class="prependedContainer dark collapsed"
+            class="input dark left collapsed hasAppendIcon"
           >
-            <span
-              aria-label="su-search"
-              class="su-search clickable icon dark iconClickable collapsed"
-              role="button"
-              tabindex="0"
+            <div
+              class="prependedContainer dark collapsed"
+            >
+              <span
+                aria-label="su-search"
+                class="su-search clickable icon dark iconClickable collapsed"
+                role="button"
+                tabindex="0"
+              />
+            </div>
+            <input
+              type="text"
+              value=""
             />
           </div>
-          <input
-            type="text"
-            value=""
-          />
-        </div>
+        </label>
       </div>
       <div
         class="toolbarRight"
@@ -1201,24 +1207,26 @@ exports[`Should render the list with the correct resourceKey 1`] = `
       <div
         class="toolbarLeft"
       >
-        <div
-          class="input dark left collapsed hasAppendIcon"
-        >
+        <label>
           <div
-            class="prependedContainer dark collapsed"
+            class="input dark left collapsed hasAppendIcon"
           >
-            <span
-              aria-label="su-search"
-              class="su-search clickable icon dark iconClickable collapsed"
-              role="button"
-              tabindex="0"
+            <div
+              class="prependedContainer dark collapsed"
+            >
+              <span
+                aria-label="su-search"
+                class="su-search clickable icon dark iconClickable collapsed"
+                role="button"
+                tabindex="0"
+              />
+            </div>
+            <input
+              type="text"
+              value=""
             />
           </div>
-          <input
-            type="text"
-            value=""
-          />
-        </div>
+        </label>
       </div>
       <div
         class="toolbarRight"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
@@ -246,25 +246,29 @@ exports[`Render the MediaCollection 1`] = `
       <div
         class="toolbarLeft"
       >
-        <div
-          class="input dark left collapsed hasAppendIcon"
+        <label
+          aria-label="sulu_admin.list_search_placeholder"
         >
           <div
-            class="prependedContainer dark collapsed"
+            class="input dark left collapsed hasAppendIcon"
           >
-            <span
-              aria-label="su-search"
-              class="su-search clickable icon dark iconClickable collapsed"
-              role="button"
-              tabindex="0"
+            <div
+              class="prependedContainer dark collapsed"
+            >
+              <span
+                aria-label="su-search"
+                class="su-search clickable icon dark iconClickable collapsed"
+                role="button"
+                tabindex="0"
+              />
+            </div>
+            <input
+              placeholder="sulu_admin.list_search_placeholder"
+              type="text"
+              value=""
             />
           </div>
-          <input
-            placeholder="sulu_admin.list_search_placeholder"
-            type="text"
-            value=""
-          />
-        </div>
+        </label>
       </div>
       <div
         class="toolbarRight"
@@ -816,25 +820,29 @@ exports[`Render the MediaCollection for all media 1`] = `
       <div
         class="toolbarLeft"
       >
-        <div
-          class="input dark left collapsed hasAppendIcon"
+        <label
+          aria-label="sulu_admin.list_search_placeholder"
         >
           <div
-            class="prependedContainer dark collapsed"
+            class="input dark left collapsed hasAppendIcon"
           >
-            <span
-              aria-label="su-search"
-              class="su-search clickable icon dark iconClickable collapsed"
-              role="button"
-              tabindex="0"
+            <div
+              class="prependedContainer dark collapsed"
+            >
+              <span
+                aria-label="su-search"
+                class="su-search clickable icon dark iconClickable collapsed"
+                role="button"
+                tabindex="0"
+              />
+            </div>
+            <input
+              placeholder="sulu_admin.list_search_placeholder"
+              type="text"
+              value=""
             />
           </div>
-          <input
-            placeholder="sulu_admin.list_search_placeholder"
-            type="text"
-            value=""
-          />
-        </div>
+        </label>
       </div>
       <div
         class="toolbarRight"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
@@ -280,25 +280,29 @@ Array [
                   <div
                     class="toolbarLeft"
                   >
-                    <div
-                      class="input dark left collapsed hasAppendIcon"
+                    <label
+                      aria-label="sulu_admin.list_search_placeholder"
                     >
                       <div
-                        class="prependedContainer dark collapsed"
+                        class="input dark left collapsed hasAppendIcon"
                       >
-                        <span
-                          aria-label="su-search"
-                          class="su-search clickable icon dark iconClickable collapsed"
-                          role="button"
-                          tabindex="0"
+                        <div
+                          class="prependedContainer dark collapsed"
+                        >
+                          <span
+                            aria-label="su-search"
+                            class="su-search clickable icon dark iconClickable collapsed"
+                            role="button"
+                            tabindex="0"
+                          />
+                        </div>
+                        <input
+                          placeholder="sulu_admin.list_search_placeholder"
+                          type="text"
+                          value=""
                         />
                       </div>
-                      <input
-                        placeholder="sulu_admin.list_search_placeholder"
-                        type="text"
-                        value=""
-                      />
-                    </div>
+                    </label>
                   </div>
                   <div
                     class="toolbarRight"
@@ -976,25 +980,29 @@ Array [
                   <div
                     class="toolbarLeft"
                   >
-                    <div
-                      class="input dark left collapsed hasAppendIcon"
+                    <label
+                      aria-label="sulu_admin.list_search_placeholder"
                     >
                       <div
-                        class="prependedContainer dark collapsed"
+                        class="input dark left collapsed hasAppendIcon"
                       >
-                        <span
-                          aria-label="su-search"
-                          class="su-search clickable icon dark iconClickable collapsed"
-                          role="button"
-                          tabindex="0"
+                        <div
+                          class="prependedContainer dark collapsed"
+                        >
+                          <span
+                            aria-label="su-search"
+                            class="su-search clickable icon dark iconClickable collapsed"
+                            role="button"
+                            tabindex="0"
+                          />
+                        </div>
+                        <input
+                          placeholder="sulu_admin.list_search_placeholder"
+                          type="text"
+                          value=""
                         />
                       </div>
-                      <input
-                        placeholder="sulu_admin.list_search_placeholder"
-                        type="text"
-                        value=""
-                      />
-                    </div>
+                    </label>
                   </div>
                   <div
                     class="toolbarRight"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/__snapshots__/MediaOverview.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/__snapshots__/MediaOverview.test.js.snap
@@ -252,25 +252,29 @@ exports[`Render a simple MediaOverview 1`] = `
       <div
         class="toolbarLeft"
       >
-        <div
-          class="input dark left collapsed hasAppendIcon"
+        <label
+          aria-label="sulu_admin.list_search_placeholder"
         >
           <div
-            class="prependedContainer dark collapsed"
+            class="input dark left collapsed hasAppendIcon"
           >
-            <span
-              aria-label="su-search"
-              class="su-search clickable icon dark iconClickable collapsed"
-              role="button"
-              tabindex="0"
+            <div
+              class="prependedContainer dark collapsed"
+            >
+              <span
+                aria-label="su-search"
+                class="su-search clickable icon dark iconClickable collapsed"
+                role="button"
+                tabindex="0"
+              />
+            </div>
+            <input
+              placeholder="sulu_admin.list_search_placeholder"
+              type="text"
+              value=""
             />
           </div>
-          <input
-            placeholder="sulu_admin.list_search_placeholder"
-            type="text"
-            value=""
-          />
-        </div>
+        </label>
       </div>
       <div
         class="toolbarRight"

--- a/src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/SearchField.js
+++ b/src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/SearchField.js
@@ -117,6 +117,7 @@ class SearchField extends React.Component<Props> {
                     </ArrowMenu>
                     <div className={searchFieldStyles.inputContainer}>
                         <input
+                            autoFocus={true}
                             className={searchFieldStyles.input}
                             onChange={this.handleQueryChange}
                             onKeyPress={this.handleQueryKeyPress}

--- a/src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/tests/__snapshots__/SearchField.test.js.snap
+++ b/src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/tests/__snapshots__/SearchField.test.js.snap
@@ -23,6 +23,7 @@ Array [
       class="inputContainer"
     >
       <input
+        autofocus=""
         class="input"
         value="Test"
       />
@@ -71,6 +72,7 @@ Array [
       class="inputContainer"
     >
       <input
+        autofocus=""
         class="input"
         value=""
       />


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Focus for Search fields. For example to focus when clicking on the Search icon on the list views. And auto focus search input on search page.

#### Why?

For better user experience.
