### PR TITLE
Using the `Localization` constructor

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -45766,31 +45766,6 @@ parameters:
 			path: src/Sulu/Component/CustomUrl/Tests/Functional/Generator/GeneratorTest.php
 
 		-
-			message: "#^Method Sulu\\\\Component\\\\CustomUrl\\\\Tests\\\\Functional\\\\Generator\\\\GeneratorTest\\:\\:testGenerate\\(\\) has parameter \\$baseDomain with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/CustomUrl/Tests/Functional/Generator/GeneratorTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\CustomUrl\\\\Tests\\\\Functional\\\\Generator\\\\GeneratorTest\\:\\:testGenerate\\(\\) has parameter \\$domainParts with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/CustomUrl/Tests/Functional/Generator/GeneratorTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\CustomUrl\\\\Tests\\\\Functional\\\\Generator\\\\GeneratorTest\\:\\:testGenerate\\(\\) has parameter \\$exception with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/CustomUrl/Tests/Functional/Generator/GeneratorTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\CustomUrl\\\\Tests\\\\Functional\\\\Generator\\\\GeneratorTest\\:\\:testGenerate\\(\\) has parameter \\$expected with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/CustomUrl/Tests/Functional/Generator/GeneratorTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\CustomUrl\\\\Tests\\\\Functional\\\\Generator\\\\GeneratorTest\\:\\:testGenerate\\(\\) has parameter \\$locales with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/CustomUrl/Tests/Functional/Generator/GeneratorTest.php
-
-		-
 			message: "#^Method Sulu\\\\Component\\\\CustomUrl\\\\Tests\\\\Unit\\\\Manager\\\\CustomUrlManagerTest\\:\\:getMapping\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/CustomUrl/Tests/Unit/Manager/Manager/CustomUrlManagerTest.php
@@ -55131,11 +55106,6 @@ parameters:
 			path: src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
 
 		-
-			message: "#^Parameter \\#1 \\$language of method Sulu\\\\Component\\\\Localization\\\\Localization\\:\\:setLanguage\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
-
-		-
 			message: "#^Parameter \\#1 \\$localizationNode of method Sulu\\\\Component\\\\Webspace\\\\Loader\\\\XmlFileLoader10\\:\\:generateLocalizationFromNode\\(\\) expects DOMElement, DOMNode given\\.$#"
 			count: 3
 			path: src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
@@ -56428,26 +56398,6 @@ parameters:
 		-
 			message: "#^Cannot call method getLocale\\(\\) on Sulu\\\\Component\\\\Localization\\\\Localization\\|null\\.$#"
 			count: 4
-			path: src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Tests\\\\Unit\\\\WebspaceTest\\:\\:getLocalization\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Tests\\\\Unit\\\\WebspaceTest\\:\\:getLocalization\\(\\) has parameter \\$country with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Tests\\\\Unit\\\\WebspaceTest\\:\\:getLocalization\\(\\) has parameter \\$language with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Tests\\\\Unit\\\\WebspaceTest\\:\\:getLocalization\\(\\) has parameter \\$shadow with no type specified\\.$#"
-			count: 1
 			path: src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
 
 		-

--- a/src/Sulu/Bundle/SearchBundle/Tests/Unit/Controller/WebsiteSearchControllerTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Unit/Controller/WebsiteSearchControllerTest.php
@@ -80,14 +80,11 @@ class WebsiteSearchControllerTest extends TestCase
     {
         $request = new Request(['q' => 'Test']);
 
-        $localization = new Localization();
-        $localization->setLanguage('en');
-
         $webspace = new Webspace();
         $webspace->setKey('sulu');
         $webspace->addTemplate('search', 'search');
 
-        $this->requestAnalyzer->getCurrentLocalization()->willReturn($localization);
+        $this->requestAnalyzer->getCurrentLocalization()->willReturn(new Localization('en'));
         $this->requestAnalyzer->getWebspace()->willReturn($webspace);
 
         $searchQueryBuilder = $this->prophesize(SearchQueryBuilder::class);
@@ -125,14 +122,11 @@ class WebsiteSearchControllerTest extends TestCase
 
         $request = new Request(['q' => 'Test']);
 
-        $localization = new Localization();
-        $localization->setLanguage('en');
-
         $webspace = new Webspace();
         $webspace->setKey('sulu');
         $webspace->addTemplate('search', 'search');
 
-        $this->requestAnalyzer->getCurrentLocalization()->willReturn($localization);
+        $this->requestAnalyzer->getCurrentLocalization()->willReturn(new Localization('en'));
         $this->requestAnalyzer->getWebspace()->willReturn($webspace);
 
         $searchQueryBuilder = $this->prophesize(SearchQueryBuilder::class);

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Resolver/RequestAnalyzerResolverTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Resolver/RequestAnalyzerResolverTest.php
@@ -56,28 +56,19 @@ class RequestAnalyzerResolverTest extends TestCase
     {
         if (null === $this->webspaceManager) {
             $webspace = new Webspace();
-            $en = new Localization();
-            $en->setLanguage('en');
-            $en_us = new Localization();
-            $en_us->setLanguage('en');
-            $en_us->setCountry('us');
+            $en = new Localization('en');
+            $en_us = new Localization('en', 'us');
             $en_us->setParent($en);
             $en->addChild($en_us);
 
-            $de = new Localization();
-            $de->setLanguage('de');
-            $de_at = new Localization();
-            $de_at->setLanguage('de');
-            $de_at->setCountry('at');
+            $de = new Localization('de');
+            $de_at = new Localization('de', 'at');
             $de_at->setParent($de);
             $de->addChild($de_at);
 
-            $es = new Localization();
-            $es->setLanguage('es');
-
             $webspace->addLocalization($en);
             $webspace->addLocalization($de);
-            $webspace->addLocalization($es);
+            $webspace->addLocalization(new Localization('es'));
 
             $this->webspaceManager = $this->prophesize('Sulu\Component\Webspace\Manager\WebspaceManagerInterface');
             $this->webspaceManager->findWebspaceByKey('sulu_io')->willReturn($webspace);
@@ -93,14 +84,9 @@ class RequestAnalyzerResolverTest extends TestCase
         $portal = new Portal();
         $portal->setKey('sulu_io_portal');
         $portal->setName('Sulu Portal');
-        $locale = new Localization();
-        $locale->setLanguage('de');
+        $locale = new Localization('de');
         $locale->setDefault(true);
         $portal->addLocalization($locale);
-
-        $localization = new Localization();
-        $localization->setLanguage('de');
-        $localization->setCountry('at');
 
         $segment = new Segment();
         $segment->setKey('s');
@@ -111,7 +97,7 @@ class RequestAnalyzerResolverTest extends TestCase
 
         $requestAnalyzer = $this->prophesize(RequestAnalyzer::class);
         $requestAnalyzer->getWebspace()->willReturn($webspace);
-        $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
+        $requestAnalyzer->getCurrentLocalization()->willReturn(new Localization('de', 'at'));
         $requestAnalyzer->getPortalUrl()->willReturn('sulu.io/de');
         $requestAnalyzer->getResourceLocatorPrefix()->willReturn('/de');
         $requestAnalyzer->getResourceLocator()->willReturn('/search');

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/ContentRouteProviderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/ContentRouteProviderTest.php
@@ -101,9 +101,6 @@ class ContentRouteProviderTest extends TestCase
 
     public function testStateTest(): void
     {
-        $localization = new Localization();
-        $localization->setLanguage('de');
-
         $portal = new Portal();
         $portal->setKey('portal');
         $webspace = new Webspace();
@@ -128,9 +125,7 @@ class ContentRouteProviderTest extends TestCase
     {
         $attributes = $this->prophesize(RequestAttributes::class);
 
-        $localization = new Localization();
-        $localization->setLanguage('de');
-        $attributes->getAttribute('localization', null)->willReturn($localization);
+        $attributes->getAttribute('localization', null)->willReturn(new Localization('de'));
 
         $portal = new Portal();
         $portal->setKey('portal');
@@ -193,9 +188,7 @@ class ContentRouteProviderTest extends TestCase
     {
         $attributes = $this->prophesize(RequestAttributes::class);
 
-        $localization = new Localization();
-        $localization->setLanguage('de');
-        $attributes->getAttribute('localization', null)->willReturn($localization);
+        $attributes->getAttribute('localization', null)->willReturn(new Localization('de'));
 
         $portal = new Portal();
         $portal->setKey('portal');
@@ -276,9 +269,7 @@ class ContentRouteProviderTest extends TestCase
     {
         $attributes = $this->prophesize(RequestAttributes::class);
 
-        $localization = new Localization();
-        $localization->setLanguage('de');
-        $attributes->getAttribute('localization', null)->willReturn($localization);
+        $attributes->getAttribute('localization', null)->willReturn(new Localization('de'));
 
         $portal = new Portal();
         $portal->setKey('portal');
@@ -352,9 +343,7 @@ class ContentRouteProviderTest extends TestCase
     {
         $attributes = $this->prophesize(RequestAttributes::class);
 
-        $localization = new Localization();
-        $localization->setLanguage('de');
-        $attributes->getAttribute('localization', null)->willReturn($localization);
+        $attributes->getAttribute('localization', null)->willReturn(new Localization('de'));
 
         $portal = new Portal();
         $portal->setKey('portal');
@@ -417,9 +406,7 @@ class ContentRouteProviderTest extends TestCase
     {
         $attributes = $this->prophesize(RequestAttributes::class);
 
-        $localization = new Localization();
-        $localization->setLanguage('de');
-        $attributes->getAttribute('localization', null)->willReturn($localization);
+        $attributes->getAttribute('localization', null)->willReturn(new Localization('de'));
 
         $portal = new Portal();
         $portal->setKey('portal');
@@ -485,9 +472,6 @@ class ContentRouteProviderTest extends TestCase
 
     public function testGetCollectionForRequestWithMissingStructure(): void
     {
-        $localization = new Localization();
-        $localization->setLanguage('de');
-
         $portal = new Portal();
         $portal->setKey('portal');
         $webspace = new Webspace();
@@ -523,9 +507,7 @@ class ContentRouteProviderTest extends TestCase
     {
         $attributes = $this->prophesize(RequestAttributes::class);
 
-        $localization = new Localization();
-        $localization->setLanguage('de');
-        $attributes->getAttribute('localization', null)->willReturn($localization);
+        $attributes->getAttribute('localization', null)->willReturn(new Localization('de'));
 
         $portal = new Portal();
         $portal->setKey('portal');
@@ -603,9 +585,6 @@ class ContentRouteProviderTest extends TestCase
 
     public function testGetCollectionForNotExistingRequest(): void
     {
-        $localization = new Localization();
-        $localization->setLanguage('de');
-
         $portal = new Portal();
         $portal->setKey('portal');
         $webspace = new Webspace();

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/PortalLoaderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/PortalLoaderTest.php
@@ -62,11 +62,7 @@ class PortalLoaderTest extends TestCase
         );
         $this->portalLoader->setResolver($this->loaderResolver->reveal());
 
-        $de = new Localization();
-        $de->setLanguage('de');
-        $en = new Localization();
-        $en->setLanguage('en');
-        $this->localizations = [$de, $en];
+        $this->localizations = [new Localization('de'), new Localization('en')];
     }
 
     public function testLoad(): void

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RedirectExceptionSubscriberTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RedirectExceptionSubscriberTest.php
@@ -234,9 +234,7 @@ class RedirectExceptionSubscriberTest extends TestCase
         $this->attributes->getAttribute('redirect', null)->willReturn(null);
         $this->attributes->getAttribute('portalUrl', null)->willReturn(null);
 
-        $localization = new Localization();
-        $localization->setLanguage('de');
-        $this->defaultLocaleProvider->getDefaultLocale()->willReturn($localization);
+        $this->defaultLocaleProvider->getDefaultLocale()->willReturn(new Localization('de'));
 
         $this->router->matchRequest(Argument::type(Request::class))->willReturn(
             $this->prophesize(Route::class)->reveal()
@@ -266,9 +264,7 @@ class RedirectExceptionSubscriberTest extends TestCase
         $this->attributes->getAttribute('redirect', null)->willReturn(null);
         $this->attributes->getAttribute('portalUrl', null)->willReturn(null);
 
-        $localization = new Localization();
-        $localization->setLanguage('de');
-        $this->defaultLocaleProvider->getDefaultLocale()->willReturn($localization);
+        $this->defaultLocaleProvider->getDefaultLocale()->willReturn(new Localization('de'));
 
         $this->router->matchRequest(Argument::type(Request::class))->willReturn(
             $this->prophesize(Route::class)->reveal()
@@ -298,9 +294,7 @@ class RedirectExceptionSubscriberTest extends TestCase
         $this->attributes->getAttribute('redirect', null)->willReturn('sulu.lo/de');
         $this->attributes->getAttribute('portalUrl', null)->willReturn('sulu.lo/de/');
 
-        $localization = new Localization();
-        $localization->setLanguage('de');
-        $this->defaultLocaleProvider->getDefaultLocale()->willReturn($localization);
+        $this->defaultLocaleProvider->getDefaultLocale()->willReturn(new Localization('de'));
 
         $this->urlReplacer->replaceCountry(Argument::cetera())->shouldBeCalled()->willReturn('sulu.lo/de');
         $this->urlReplacer->replaceLanguage(Argument::cetera())->shouldBeCalled()->willReturn('sulu.lo/de');
@@ -334,9 +328,7 @@ class RedirectExceptionSubscriberTest extends TestCase
         $this->attributes->getAttribute('redirect', null)->willReturn('sulu.lo/de');
         $this->attributes->getAttribute('portalUrl', null)->willReturn('sulu.lo/de/');
 
-        $localization = new Localization();
-        $localization->setLanguage('de');
-        $this->defaultLocaleProvider->getDefaultLocale()->willReturn($localization);
+        $this->defaultLocaleProvider->getDefaultLocale()->willReturn(new Localization('de'));
 
         $this->urlReplacer->replaceCountry(Argument::cetera())->shouldBeCalled()->willReturn('sulu.lo/de');
         $this->urlReplacer->replaceLanguage(Argument::cetera())->shouldBeCalled()->willReturn('sulu.lo/de');

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapGeneratorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapGeneratorTest.php
@@ -148,14 +148,7 @@ class SitemapGeneratorTest extends SuluTestCase
         $this->webspace = new Webspace();
         $this->webspace->setKey('test_io');
 
-        $local1 = new Localization();
-        $local1->setLanguage('en');
-
-        $local2 = new Localization();
-        $local2->setLanguage('en');
-        $local2->setCountry('us');
-
-        $this->webspace->setLocalizations([$local1, $local2]);
+        $this->webspace->setLocalizations([new Localization('en'), new Localization('en', 'us')]);
         $this->webspace->setName('Default');
 
         $this->webspace->addDefaultTemplate('page', 'default');

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/ContentTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/ContentTwigExtensionTest.php
@@ -126,14 +126,10 @@ class ContentTwigExtensionTest extends TestCase
         $this->webspace->getKey()
             ->willReturn('sulu_test');
 
-        $locale = new Localization();
-        $locale->setCountry('us');
-        $locale->setLanguage('en');
-
         $this->webspaceManager->findWebspaceByKey('sulu_test')->willReturn($this->webspace->reveal());
 
         $this->requestAnalyzer->getWebspace()->willReturn($this->webspace->reveal());
-        $this->requestAnalyzer->getCurrentLocalization()->willReturn($locale);
+        $this->requestAnalyzer->getCurrentLocalization()->willReturn(new Localization('en', 'us'));
 
         $this->sessionManager->getSession()->willReturn($this->session->reveal());
         $this->sessionManager->getContentNode('sulu_test')->willReturn($this->startPageNode->reveal());

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/MetaTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/MetaTwigExtensionTest.php
@@ -46,8 +46,7 @@ class MetaTwigExtensionTest extends TestCase
         $webspace = new Webspace();
         $webspace->setKey('sulu_test');
 
-        $locale = new Localization();
-        $locale->setLanguage('en');
+        $locale = new Localization('en');
 
         $this->portal = new Portal();
         $this->portal->setDefaultLocalization($locale);
@@ -99,10 +98,7 @@ class MetaTwigExtensionTest extends TestCase
      */
     public function testGetAlternateLinksDifferentDefaultLocale(): void
     {
-        $locale = new Localization();
-        $locale->setLanguage('de');
-
-        $this->portal->setXDefaultLocalization($locale);
+        $this->portal->setXDefaultLocalization(new Localization('de'));
 
         $extension = new MetaTwigExtension(
             $this->requestAnalyzer->reveal(),

--- a/src/Sulu/Component/CustomUrl/Tests/Functional/Generator/GeneratorTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Functional/Generator/GeneratorTest.php
@@ -21,11 +21,7 @@ class GeneratorTest extends TestCase
 {
     public function provideGenerateData()
     {
-        $locales = [new Localization(), new Localization()];
-
-        $locales[0]->setLanguage('de');
-        $locales[0]->setCountry('at');
-        $locales[1]->setLanguage('en');
+        $locales = [new Localization('de', 'at'), new Localization('en')];
 
         return [
             [
@@ -136,16 +132,24 @@ class GeneratorTest extends TestCase
     }
 
     /**
+     * @param array<string> $domainParts
+     * @param class-string<\Throwable>|null $exception
+     *
      * @dataProvider provideGenerateData
      */
-    public function testGenerate($baseDomain, $domainParts, $locales, $expected, $exception = null): void
-    {
+    public function testGenerate(
+        string $baseDomain,
+        array $domainParts,
+        ?Localization $locale,
+        ?string $expected,
+        ?string $exception = null
+    ): void {
         if ($exception) {
             self::expectException($exception);
         }
 
         $generator = new Generator(new Replacer());
-        $result = $generator->generate($baseDomain, $domainParts, $locales);
+        $result = $generator->generate($baseDomain, $domainParts, $locale);
 
         if (null === $expected) {
             return;

--- a/src/Sulu/Component/Localization/Localization.php
+++ b/src/Sulu/Component/Localization/Localization.php
@@ -45,8 +45,7 @@ class Localization implements \JsonSerializable, ArrayableInterface
 
         $parts = \explode($delimiter, $locale);
 
-        $localization = new self();
-        $localization->setLanguage(\strtolower($parts[0]));
+        $localization = new self(\strtolower($parts[0]));
         if (\count($parts) > 1) {
             $localization->setCountry(\strtolower($parts[1]));
         }

--- a/src/Sulu/Component/Localization/Localization.php
+++ b/src/Sulu/Component/Localization/Localization.php
@@ -87,7 +87,7 @@ class Localization implements \JsonSerializable, ArrayableInterface
      *
      * @Groups({"frontend", "Default"})
      */
-    private $children;
+    private $children = [];
 
     /**
      * The parent localization.
@@ -374,11 +374,9 @@ class Localization implements \JsonSerializable, ArrayableInterface
     public function getAllLocalizations()
     {
         $localizations = [];
-        if (null !== $this->getChildren() && \count($this->getChildren()) > 0) {
-            foreach ($this->getChildren() as $child) {
-                $localizations[] = $child;
-                $localizations = \array_merge($localizations, $child->getAllLocalizations());
-            }
+        foreach ($this->getChildren() as $child) {
+            $localizations[] = $child;
+            $localizations = \array_merge($localizations, $child->getAllLocalizations());
         }
 
         return $localizations;

--- a/src/Sulu/Component/Localization/Provider/LocalizationProvider.php
+++ b/src/Sulu/Component/Localization/Provider/LocalizationProvider.php
@@ -54,8 +54,7 @@ class LocalizationProvider implements LocalizationProviderInterface
     {
         $parts = \explode('_', $locale);
 
-        $localization = new Localization();
-        $localization->setLanguage($parts[0]);
+        $localization = new Localization($parts[0]);
         if (\count($parts) > 1) {
             $localization->setCountry($parts[1]);
         }

--- a/src/Sulu/Component/Localization/Tests/Unit/Manager/LocalizationManagerTest.php
+++ b/src/Sulu/Component/Localization/Tests/Unit/Manager/LocalizationManagerTest.php
@@ -32,12 +32,9 @@ class LocalizationManagerTest extends TestCase
 
     public function testGetAllLocalizations(): void
     {
-        $localization1 = new Localization();
-        $localization1->setLanguage('de');
-        $localization2 = new Localization();
-        $localization2->setLanguage('en');
-        $localization3 = new Localization();
-        $localization3->setLanguage('fr');
+        $localization1 = new Localization('de');
+        $localization2 = new Localization('en');
+        $localization3 = new Localization('fr');
 
         $this->addLocalizationProvider([$localization1, $localization2]);
         $this->addLocalizationProvider([$localization3]);
@@ -52,10 +49,8 @@ class LocalizationManagerTest extends TestCase
 
     public function testGetAllLocalizationsWithSameLocalizations(): void
     {
-        $localization1 = new Localization();
-        $localization1->setLanguage('de');
-        $localization2 = new Localization();
-        $localization2->setLanguage('en');
+        $localization1 = new Localization('de');
+        $localization2 = new Localization('en');
 
         $this->addLocalizationProvider([$localization1, $localization2]);
         $this->addLocalizationProvider([$localization2]);

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
@@ -230,8 +230,7 @@ class XmlFileLoader10 extends BaseXmlFileLoader
      */
     protected function generateLocalizationFromNode(\DOMElement $localizationNode, $flat = false, $parent = null)
     {
-        $localization = new Localization();
-        $localization->setLanguage($localizationNode->attributes->getNamedItem('language')->nodeValue);
+        $localization = new Localization($localizationNode->attributes->getNamedItem('language')->nodeValue);
 
         // set parent if given
         if ($parent) {

--- a/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
+++ b/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
@@ -41,9 +41,7 @@ class {{ cache_class }} extends {{ base_class }}
 {% endif %}
 {% for localization in webspace.localizations %}
         // add localization to webspace
-        $localization0 = new Localization();
-        $localization0->setLanguage('{{ localization.language }}');
-        $localization0->setCountry('{{ localization.country }}');
+        $localization0 = new Localization('{{ localization.language }}', '{{ localization.country }}');
         $localization0->setShadow('{{ (localization.shadow) }}');
         $localization0->setDefault({{ localization.default ? 'true' : 'false' }});
         $localization0->setXDefault('{{ localization.xDefault }}');
@@ -92,9 +90,7 @@ class {{ cache_class }} extends {{ base_class }}
 {% for localization in portal.localizations %}
 
         // add localization
-        $localization = new Localization();
-        $localization->setLanguage('{{ localization.language }}');
-        $localization->setCountry('{{ localization.country }}');
+        $localization = new Localization('{{ localization.language }}', '{{ localization.country }}');
         $localization->setDefault('{{ localization.default }}');
         $localization->setXDefault('{{ localization.xDefault }}');
         $portal->addLocalization($localization);
@@ -194,9 +190,7 @@ class {{ cache_class }} extends {{ base_class }}
 
 {% macro create_localizations(localization, count, parent, webspace) %}{% import _self as self %}
     // parent id {{ parent }}
-    $localization{{ count }} = new Localization();
-    $localization{{ count }}->setLanguage('{{ localization.language }}');
-    $localization{{ count }}->setCountry('{{ localization.country }}');
+    $localization{{ count }} = new Localization('{{ localization.language }}', '{{ localization.country }}');
     $localization{{ count }}->setShadow('{{ (localization.shadow) }}');
     $localization{{ count }}->setParent($localization{{ parent }});
     $localization{{ count }}->setDefault('{{ localization.default }}');

--- a/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
@@ -188,15 +188,11 @@ class RequestAnalyzerTest extends TestCase
         $portal = new Portal();
         $portal->setKey('sulu');
 
-        $localization = new Localization();
-        $localization->setCountry('at');
-        $localization->setLanguage('de');
-
         $portalInformation = new PortalInformation(
             $config['match_type'],
             $webspace,
             $portal,
-            $localization,
+            new Localization('de', 'at'),
             $config['portal_url'],
             null,
             $config['redirect']
@@ -233,15 +229,11 @@ class RequestAnalyzerTest extends TestCase
         $portal = new Portal();
         $portal->setKey('sulu');
 
-        $localization = new Localization();
-        $localization->setCountry('at');
-        $localization->setLanguage('de');
-
         $portalInformation = new PortalInformation(
             $config['match_type'],
             $webspace,
             $portal,
-            $localization,
+            new Localization('de', 'at'),
             $config['portal_url'],
             null,
             $config['redirect']
@@ -297,15 +289,11 @@ class RequestAnalyzerTest extends TestCase
         $portal = new Portal();
         $portal->setKey('sulu');
 
-        $localization = new Localization();
-        $localization->setCountry('at');
-        $localization->setLanguage('de');
-
         $portalInformation = new PortalInformation(
             $config['match_type'],
             $webspace,
             $portal,
-            $localization,
+            new Localization('de', 'at'),
             $config['portal_url'],
             null,
             $config['redirect']

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
@@ -44,9 +44,7 @@ class PortalInformationRequestProcessorTest extends TestCase
         $portal = new Portal();
         $portal->setKey('sulu');
 
-        $localization = new Localization();
-        $localization->setCountry('at');
-        $localization->setLanguage('de');
+        $localization = new Localization('de', 'at');
 
         $portalInformation = new PortalInformation(
             $config['match_type'],
@@ -95,13 +93,9 @@ class PortalInformationRequestProcessorTest extends TestCase
         $webspace = new Webspace();
         $webspace->setKey('sulu');
 
-        $defaultLocalization = new Localization();
-        $defaultLocalization->setCountry('ch');
-        $defaultLocalization->setLanguage('it');
-
         $portal = new Portal();
         $portal->setKey('sulu');
-        $portal->setDefaultLocalization($defaultLocalization);
+        $portal->setDefaultLocalization(new Localization('it', 'ch'));
 
         $portalInformation = new PortalInformation(
             $config['match_type'],
@@ -153,9 +147,7 @@ class PortalInformationRequestProcessorTest extends TestCase
         $portal = new Portal();
         $portal->setKey('sulu');
 
-        $localization = new Localization();
-        $localization->setCountry('at');
-        $localization->setLanguage('de');
+        $localization = new Localization('de', 'at');
 
         $portalInformation = new PortalInformation(
             $config['match_type'],

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/WebsiteRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/WebsiteRequestProcessorTest.php
@@ -63,9 +63,7 @@ class WebsiteRequestProcessorTest extends TestCase
         $portal = new Portal();
         $portal->setKey('sulu');
 
-        $localization = new Localization();
-        $localization->setCountry('at');
-        $localization->setLanguage('de');
+        $localization = new Localization('de', 'at');
 
         $portalInformation1 = new PortalInformation(
             RequestAnalyzerInterface::MATCH_TYPE_FULL,
@@ -116,9 +114,7 @@ class WebsiteRequestProcessorTest extends TestCase
         $portal = new Portal();
         $portal->setKey('sulu');
 
-        $localization = new Localization();
-        $localization->setCountry('at');
-        $localization->setLanguage('de');
+        $localization = new Localization('de', 'at');
 
         $portalInformation1 = new PortalInformation(
             RequestAnalyzerInterface::MATCH_TYPE_FULL,
@@ -168,9 +164,7 @@ class WebsiteRequestProcessorTest extends TestCase
         $portal = new Portal();
         $portal->setKey('sulu');
 
-        $localization = new Localization();
-        $localization->setCountry('at');
-        $localization->setLanguage('de');
+        $localization = new Localization('de', 'at');
 
         $portalInformation1 = new PortalInformation(
             RequestAnalyzerInterface::MATCH_TYPE_FULL,
@@ -220,9 +214,7 @@ class WebsiteRequestProcessorTest extends TestCase
         $portal = new Portal();
         $portal->setKey('sulu');
 
-        $localization = new Localization();
-        $localization->setCountry('at');
-        $localization->setLanguage('de');
+        $localization = new Localization('de', 'at');
 
         return [
             [['portalInformation' => $portalInformation]],

--- a/src/Sulu/Component/Webspace/Tests/Unit/Document/Initializer/WebspaceInitializerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Document/Initializer/WebspaceInitializerTest.php
@@ -96,19 +96,13 @@ class WebspaceInitializerTest extends TestCase
         $webspace1 = new Webspace();
         $webspace1->setKey('webspace1');
         $webspace1->setTheme('theme1');
-        $localization1_1 = new Localization();
-        $localization1_1->setLanguage('de');
-        $localization1_2 = new Localization();
-        $localization1_2->setLanguage('en');
-        $webspace1->setLocalizations([$localization1_1, $localization1_2]);
+        $webspace1->setLocalizations([new Localization('de'), new Localization('en')]);
 
         /** @var Webspace $webspace2 */
         $webspace2 = new Webspace();
         $webspace2->setKey('webspace2');
         $webspace2->setTheme('theme1');
-        $localization2_1 = new Localization();
-        $localization2_1->setLanguage('de');
-        $webspace2->setLocalizations([$localization2_1]);
+        $webspace2->setLocalizations([new Localization('de')]);
 
         $this->webspaceCollection->getIterator()->willReturn(
             new \ArrayIterator([$webspace1, $webspace2])

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionTest.php
@@ -54,20 +54,15 @@ class WebspaceCollectionTest extends TestCase
         $environment->addUrl($url);
         $portal->addEnvironment($environment);
 
-        $localizationEnUs = new Localization();
-        $localizationEnUs->setCountry('us');
-        $localizationEnUs->setLanguage('en');
+        $localizationEnUs = new Localization('en', 'us');
         $localizationEnUs->setShadow('auto');
         $localizationEnUs->setDefault(true);
-        $localizationEnCa = new Localization();
-        $localizationEnCa->setCountry('ca');
-        $localizationEnCa->setLanguage('en');
+        $localizationEnCa = new Localization('en', 'ca');
         $localizationEnCa->setDefault(false);
         $localizationEnUs->addChild($localizationEnCa);
-        $localizationFrCa = new Localization();
-        $localizationFrCa->setCountry('ca');
-        $localizationFrCa->setLanguage('fr');
+        $localizationFrCa = new Localization('fr', 'ca');
         $localizationFrCa->setDefault(false);
+
         $portal->addLocalization($localizationEnUs);
         $portal->addLocalization($localizationEnCa);
         $portal->addLocalization($localizationFrCa);

--- a/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
@@ -97,8 +97,7 @@ class WebspaceTest extends TestCase
         $portal->setEnvironments([]);
         $webspace->addPortal($portal);
 
-        $localization = new Localization();
-        $localization->setLanguage($expected['localizations'][0]['language']);
+        $localization = new Localization($expected['localizations'][0]['language']);
         $portal->addLocalization($localization);
         $webspace->addLocalization($localization);
 
@@ -110,28 +109,18 @@ class WebspaceTest extends TestCase
         $this->assertEquals($expected, $webspace->toArray());
     }
 
-    private function getLocalization($language, $country = '', $shadow = null)
-    {
-        $locale = new Localization();
-        $locale->setLanguage($language);
-        $locale->setCountry($country);
-        $locale->setShadow($shadow);
-
-        return $locale;
-    }
-
     public function testFindLocalization(): void
     {
         $webspace = new Webspace();
 
-        $localeDe = $this->getLocalization('de');
-        $localeDeAt = $this->getLocalization('de', 'at');
-        $localeDeCh = $this->getLocalization('de', 'ch');
+        $localeDe = new Localization('de');
+        $localeDeAt = new Localization('de', 'at');
+        $localeDeCh = new Localization('de', 'ch');
 
         $localeDe->addChild($localeDeAt);
         $localeDe->addChild($localeDeCh);
 
-        $localeEn = $this->getLocalization('en');
+        $localeEn = new Localization('en');
 
         $webspace->addLocalization($localeDe);
         $webspace->addLocalization($localeEn);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | Partial of #3132 
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?
Replacing the calls of `Localization::setLanguage` and `Localization::setCountry` with it's respective constructor versions.

#### Why?
* The code is denser (see more deletions than insertions)
* In the future we can make phpstan lie less:
```php
$localization = new Localization();
$localization->getLanguage(); // According to phpstan string but actually null
```
* We could also make the object immutable because changing the localization would mean changing the object and not the properties of the object.

#### Example Usage
Before:
```php
$localization = new Localization();
$localization->setLanguage('de');
$localization->setCountry('at');
```

Now:
```php
$localization = new Localization('de', 'at');
```

#### To Do

- [x] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md
