### PR TITLE
Add missing prophecy trait to CategoryAdminTest

### DIFF
--- a/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Admin/CategoryAdminTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Admin/CategoryAdminTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\CategoryBundle\Tests\Unit\Admin;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\AdminBundle\Admin\View\FormOverlayListViewBuilderInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\FormViewBuilderInterface;
@@ -27,6 +28,8 @@ use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 
 class CategoryAdminTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var ObjectProphecy<ViewBuilderFactoryInterface>
      */


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add missing prophecy trait to CategoryAdminTest.

#### Why?

Avoids a warning inside the CI tests:

```
Sulu\Bundle\CategoryBundle\Tests\Unit\Admin\CategoryAdminTest::testUserHasViewEditAddDeleteRole
PHPUnit\Framework\TestCase::prophesize() is deprecated and will be removed in PHPUnit 10. Please use the trait provided by phpspec/prophecy-ph
```