### PR TITLE
Fix flaky postgres snippet export test

### DIFF
--- a/src/Sulu/Component/Snippet/Export/SnippetExport.php
+++ b/src/Sulu/Component/Snippet/Export/SnippetExport.php
@@ -135,7 +135,7 @@ class SnippetExport extends Export implements SnippetExportInterface
         );
 
         $query = $this->documentManager->createQuery(
-            'SELECT * FROM [nt:unstructured] AS a WHERE ' . \implode(' AND ', $where),
+            'SELECT * FROM [nt:unstructured] AS a WHERE ' . \implode(' AND ', $where) . ' ORDER BY [jcr:path] ASC',
             $this->exportLocale
         );
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix flaky postgres snippet export test.

#### Why?

Should fix https://github.com/sulu/sulu/actions/runs/7875032524/job/21485991140?pr=7177:

```diff

1) Sulu\Bundle\PageBundle\Tests\Functional\Export\SnippetTest::test12Xliff
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
             'name' => 'title'
             'type' => 'text_line'
             'options' => Array (...)
-            'value' => 'ElePHPant2'
+            'value' => 'ElePHPant1'
         )
         'description' => Array (
             'name' => 'description'
             'type' => 'text_editor'
             'options' => Array (...)
-            'value' => 'Elephants are large mammals of the family Elephantidae and the order Proboscidea.2'
+            'value' => 'Elephants are large mammals of the family Elephantidae and the order Proboscidea.1'
         )
     )
 )
```

This mostly happens because of a false sorting. This merge request add sorting like already done in https://github.com/sulu/sulu/pull/7273 for webspace export.
