### PR TITLE
Fix removing of defaultMeta of a FileVersion removes also the whole FileVersion entity

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersion.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersion.orm.xml
@@ -35,7 +35,7 @@
 
         <one-to-one field="defaultMeta" target-entity="Sulu\Bundle\MediaBundle\Entity\FileVersionMeta">
             <cascade>
-                <cascade-all />
+                <cascade-persist />
             </cascade>
 
             <join-column name="idFileVersionsMetaDefault" referenced-column-name="id" nullable="true" on-delete="CASCADE" />

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersion.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersion.orm.xml
@@ -38,7 +38,7 @@
                 <cascade-persist />
             </cascade>
 
-            <join-column name="idFileVersionsMetaDefault" referenced-column-name="id" nullable="true" on-delete="CASCADE" />
+            <join-column name="idFileVersionsMetaDefault" referenced-column-name="id" nullable="true" on-delete="SET NULL" /><!-- why this should on-delete="RESTRICT" to avoid remove defaultMeta because of the nature of databases we need to use here SET NULL else the FileVersion is never deleteable -->
         </one-to-one>
         <one-to-many field="contentLanguages" target-entity="Sulu\Bundle\MediaBundle\Entity\FileVersionContentLanguage" mapped-by="fileVersion">
             <cascade>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #7266 
| Related issues/PRs | NO
| License | MIT

#### What's in this PR?

Don't cascade to delete FireVersion when FileVersionMeta is deleted.