### PR TITLE
Add View Debug Command for SuluAdmin

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -531,6 +531,71 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php
 
 		-
+			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\Command\\\\ViewDebugCommand\\:\\:default\\(\\) has parameter \\$tableRows with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Command/ViewDebugCommand.php
+
+		-
+			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\Command\\\\ViewDebugCommand\\:\\:default\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Command/ViewDebugCommand.php
+
+		-
+			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\Command\\\\ViewDebugCommand\\:\\:findViewNameContaining\\(\\) has parameter \\$views with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Command/ViewDebugCommand.php
+
+		-
+			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\Command\\\\ViewDebugCommand\\:\\:findViewNameContaining\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Command/ViewDebugCommand.php
+
+		-
+			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\Command\\\\ViewDebugCommand\\:\\:handleFormView\\(\\) has parameter \\$tableRows with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Command/ViewDebugCommand.php
+
+		-
+			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\Command\\\\ViewDebugCommand\\:\\:handleFormView\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Command/ViewDebugCommand.php
+
+		-
+			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\Command\\\\ViewDebugCommand\\:\\:handleList\\(\\) has parameter \\$tableRows with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Command/ViewDebugCommand.php
+
+		-
+			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\Command\\\\ViewDebugCommand\\:\\:handleList\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Command/ViewDebugCommand.php
+
+		-
+			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\Command\\\\ViewDebugCommand\\:\\:handleResourceTab\\(\\) has parameter \\$tableRows with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Command/ViewDebugCommand.php
+
+		-
+			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\Command\\\\ViewDebugCommand\\:\\:handleResourceTab\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Command/ViewDebugCommand.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Command/ViewDebugCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$name of method Sulu\\\\Bundle\\\\AdminBundle\\\\Admin\\\\View\\\\ViewRegistry\\:\\:findViewByName\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Command/ViewDebugCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Command/ViewDebugCommand.php
+
+		-
 			message: "#^Binary operation \"\\*\" between string and 1000 results in an error\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -15367,6 +15432,16 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\FormatLoader\\\\BaseXmlFormatLoader\\:\\:setGlobalOptions\\(\\) has parameter \\$globalOptions with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/MediaBundle/Media/FormatLoader/BaseXmlFormatLoader.php
+
+		-
+			message: "#^Parameter \\#1 \\$file of method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\FormatLoader\\\\BaseXmlFormatLoader\\:\\:parseXml\\(\\) expects string, array\\|string given\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/MediaBundle/Media/FormatLoader/BaseXmlFormatLoader.php
+
+		-
+			message: "#^Parameter \\#1 \\$file of static method Symfony\\\\Component\\\\Config\\\\Util\\\\XmlUtils\\:\\:loadFile\\(\\) expects string, array\\|string given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Media/FormatLoader/BaseXmlFormatLoader.php
 
@@ -39846,6 +39921,11 @@ parameters:
 			path: src/Sulu/Component/Content/Metadata/Factory/StructureMetadataFactory.php
 
 		-
+			message: "#^Parameter \\#1 \\$resource of class Symfony\\\\Component\\\\Config\\\\Resource\\\\FileResource constructor expects string, array\\|string given\\.$#"
+			count: 1
+			path: src/Sulu/Component/Content/Metadata/Factory/StructureMetadataFactory.php
+
+		-
 			message: "#^Parameter \\#1 \\$type of method Sulu\\\\Component\\\\Content\\\\Metadata\\\\Factory\\\\StructureMetadataFactory\\:\\:assertExists\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Metadata/Factory/StructureMetadataFactory.php
@@ -52782,6 +52862,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$country of method Sulu\\\\Component\\\\Localization\\\\Localization\\:\\:setCountry\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
+
+		-
+			message: "#^Parameter \\#1 \\$file of method Sulu\\\\Component\\\\Webspace\\\\Loader\\\\XmlFileLoader10\\:\\:parseXml\\(\\) expects string, array\\|string given\\.$#"
 			count: 1
 			path: src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15436,16 +15436,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Media/FormatLoader/BaseXmlFormatLoader.php
 
 		-
-			message: "#^Parameter \\#1 \\$file of method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\FormatLoader\\\\BaseXmlFormatLoader\\:\\:parseXml\\(\\) expects string, array\\|string given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Media/FormatLoader/BaseXmlFormatLoader.php
-
-		-
-			message: "#^Parameter \\#1 \\$file of static method Symfony\\\\Component\\\\Config\\\\Util\\\\XmlUtils\\:\\:loadFile\\(\\) expects string, array\\|string given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Media/FormatLoader/BaseXmlFormatLoader.php
-
-		-
 			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Media/FormatLoader/BaseXmlFormatLoader.php
@@ -39921,11 +39911,6 @@ parameters:
 			path: src/Sulu/Component/Content/Metadata/Factory/StructureMetadataFactory.php
 
 		-
-			message: "#^Parameter \\#1 \\$resource of class Symfony\\\\Component\\\\Config\\\\Resource\\\\FileResource constructor expects string, array\\|string given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Metadata/Factory/StructureMetadataFactory.php
-
-		-
 			message: "#^Parameter \\#1 \\$type of method Sulu\\\\Component\\\\Content\\\\Metadata\\\\Factory\\\\StructureMetadataFactory\\:\\:assertExists\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Metadata/Factory/StructureMetadataFactory.php
@@ -52862,11 +52847,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$country of method Sulu\\\\Component\\\\Localization\\\\Localization\\:\\:setCountry\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
-
-		-
-			message: "#^Parameter \\#1 \\$file of method Sulu\\\\Component\\\\Webspace\\\\Loader\\\\XmlFileLoader10\\:\\:parseXml\\(\\) expects string, array\\|string given\\.$#"
 			count: 1
 			path: src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
 

--- a/src/Sulu/Bundle/AdminBundle/Command/ViewDebugCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/ViewDebugCommand.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Sulu\Bundle\AdminBundle\Command;
 
 use Sulu\Bundle\AdminBundle\Admin\View\DropdownToolbarAction;
@@ -26,8 +35,7 @@ class ViewDebugCommand extends Command
 {
     public function __construct(
         private ViewRegistry $viewRegistry,
-    )
-    {
+    ) {
         parent::__construct();
     }
 
@@ -154,5 +162,4 @@ class ViewDebugCommand extends Command
     {
         return $tableRows;
     }
-
 }

--- a/src/Sulu/Bundle/AdminBundle/Command/ViewDebugCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/ViewDebugCommand.php
@@ -51,7 +51,7 @@ class ViewDebugCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
         $views = $this->viewRegistry->getViews();
-        $name = $input->getArgument('name');
+        $name = (string) $input->getArgument('name');
 
         $view = null;
         if ($name) {
@@ -124,7 +124,7 @@ class ViewDebugCommand extends Command
         return $tableRows;
     }
 
-    private function handleList(View $view, array $tableRows)
+    private function handleList(View $view, array $tableRows): array
     {
         $tableRows[] = ['resourceKey', $view->getOption('resourceKey')];
         $tableRows[] = ['listKey', $view->getOption('listKey')];

--- a/src/Sulu/Bundle/AdminBundle/Command/ViewDebugCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/ViewDebugCommand.php
@@ -30,6 +30,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+/**
+ * @internal
+ */
 #[AsCommand(name: 'sulu:debug:admin:views', description: 'Display current Views for the admin')]
 class ViewDebugCommand extends Command
 {

--- a/src/Sulu/Bundle/AdminBundle/Command/ViewDebugCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/ViewDebugCommand.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sulu\Bundle\AdminBundle\Command;
+
+use Sulu\Bundle\AdminBundle\Admin\View\DropdownToolbarAction;
+use Sulu\Bundle\AdminBundle\Admin\View\FormOverlayListViewBuilder;
+use Sulu\Bundle\AdminBundle\Admin\View\FormViewBuilder;
+use Sulu\Bundle\AdminBundle\Admin\View\ListViewBuilder;
+use Sulu\Bundle\AdminBundle\Admin\View\PreviewFormViewBuilder;
+use Sulu\Bundle\AdminBundle\Admin\View\ResourceTabViewBuilder;
+use Sulu\Bundle\AdminBundle\Admin\View\View;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewRegistry;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(name: 'sulu:debug:admin:views', description: 'Display current Views for the admin')]
+class ViewDebugCommand extends Command
+{
+    public function __construct(
+        private ViewRegistry $viewRegistry,
+    )
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setDefinition([
+                new InputArgument('name', InputArgument::OPTIONAL, 'A view name'),
+            ]);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $views = $this->viewRegistry->getViews();
+        $name = $input->getArgument('name');
+
+        $view = null;
+        if ($name) {
+            $matchingViews = $this->findViewNameContaining($name, $views);
+            $default = 1 === \count($matchingViews) ? $matchingViews[0] : null;
+
+            if ($default !== $name) {
+                $name = $io->choice('Select one of the matching Views', $matchingViews, $default);
+            }
+            $view = $this->viewRegistry->findViewByName($name);
+
+            if (!$view) {
+                throw new InvalidArgumentException(\sprintf('The View "%s" does not exist.', $name));
+            }
+
+            $tableRows = [];
+            $tableRows[] = ['Name', $view->getName()];
+            $tableRows[] = ['Type', $view->getType()];
+            $tableRows[] = ['Path', $view->getPath()];
+
+            $tableRows = match ($view->getType()) {
+                ResourceTabViewBuilder::TYPE => $this->handleResourceTab($view, $tableRows),
+                ListViewBuilder::TYPE, FormOverlayListViewBuilder::TYPE => $this->handleList($view, $tableRows),
+                FormViewBuilder::TYPE, PreviewFormViewBuilder::TYPE => $this->handleFormView($view, $tableRows),
+                default => $this->default($view, $tableRows)
+            };
+
+            $table = new Table($output);
+            $table
+                ->setHeaders(['Property', 'Value'])
+                ->setRows($tableRows);
+            $table->render();
+
+            return Command::SUCCESS;
+        }
+
+        $tableRows = [];
+        foreach ($views as $view) {
+            $row = [$view->getName(), $view->getType(), $view->getPath()];
+            $tableRows[] = $row;
+        }
+
+        $table = new Table($output);
+        $table
+            ->setHeaders(['Name', 'Type', 'Path'])
+            ->setRows($tableRows);
+        $table->render();
+
+        return Command::SUCCESS;
+    }
+
+    private function findViewNameContaining(string $name, array $views): array
+    {
+        $foundViewsNames = [];
+        foreach ($views as $view) {
+            if (false !== \stripos($view->getName(), $name)) {
+                $foundViewsNames[] = $view->getName();
+            }
+        }
+
+        return $foundViewsNames;
+    }
+
+    private function handleResourceTab(View $view, array $tableRows): array
+    {
+        $tableRows[] = ['resourceKey', $view->getOption('resourceKey')];
+        $tableRows[] = ['backView', $view->getOption('backView')];
+        $tableRows[] = ['titleProperty', $view->getOption('titleProperty')];
+
+        return $tableRows;
+    }
+
+    private function handleList(View $view, array $tableRows)
+    {
+        $tableRows[] = ['resourceKey', $view->getOption('resourceKey')];
+        $tableRows[] = ['listKey', $view->getOption('listKey')];
+        $adapters = \implode('', $view->getOption('adapters'));
+        $tableRows[] = ['adapters', $adapters];
+
+        $tableRows[] = ['addView', $view->getOption('addView')];
+        $tableRows[] = ['editView', $view->getOption('editView')];
+
+        $tableRows[] = ['toolbarActions', ''];
+        foreach ($view->getOption('toolbarActions') as $action) {
+            $tableRows[] = ['', $action->getType()];
+        }
+
+        return $tableRows;
+    }
+
+    private function handleFormView(View $view, array $tableRows): array
+    {
+        $tableRows[] = ['resourceKey', $view->getOption('resourceKey')];
+        $tableRows[] = ['formKey', $view->getOption('formKey')];
+        $tableRows[] = ['tabTitle', $view->getOption('tabTitle')];
+        $tableRows[] = ['editView', $view->getOption('editView')];
+
+        $tableRows[] = ['toolbarActions', ''];
+        /** @var DropdownToolbarAction $action */
+        foreach ($view->getOption('toolbarActions') as $action) {
+            $tableRows[] = ['', $action->getType()];
+        }
+
+        return $tableRows;
+    }
+
+    private function default(View $view, array $tableRows): array
+    {
+        return $tableRows;
+    }
+
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
-        <parameter key="sulu_admin.admin_controller.class">Sulu\Bundle\AdminBundle\Controller\AdminController
-        </parameter>
+        <parameter key="sulu_admin.admin_controller.class">Sulu\Bundle\AdminBundle\Controller\AdminController</parameter>
         <parameter key="sulu_admin.admin_pool.class">Sulu\Bundle\AdminBundle\Admin\AdminPool</parameter>
     </parameters>
 
@@ -20,10 +18,10 @@
             <argument type="service" id="sulu_admin.view_registry"/>
             <argument type="service" id="sulu_admin.navigation_registry"/>
             <argument type="service" id="sulu_admin.field_type_option_registry"/>
-            <argument type="service" id="sulu_contact.contact_manager"/>
-            <argument type="service" id="sulu_page.smart_content.data_provider_pool"/>
+            <argument type="service" id="sulu_contact.contact_manager" />
+            <argument type="service" id="sulu_page.smart_content.data_provider_pool" />
             <argument type="service" id="sulu_markup.link_tag.provider_pool"/>
-            <argument type="service" id="sulu.core.localization_manager"/>
+            <argument type="service" id="sulu.core.localization_manager" />
             <argument>%kernel.environment%</argument>
             <argument>%sulu.version%</argument>
             <argument>%app.version%</argument>
@@ -58,23 +56,23 @@
             <argument type="tagged" tag="sulu_admin.typed_form_metadata_visitor"/>
             <argument>%sulu_core.fallback_locale%</argument>
 
-            <tag name="sulu_admin.metadata_provider" type="form"/>
+            <tag name="sulu_admin.metadata_provider" type="form" />
         </service>
 
         <service
             id="sulu_admin.expression_form_metadata_visitor"
             class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\ExpressionFormMetadataVisitor"
         >
-            <argument type="service" id="sulu_core.expression_language"/>
-            <tag name="sulu_admin.form_metadata_visitor"/>
-            <tag name="sulu_admin.typed_form_metadata_visitor"/>
+            <argument type="service" id="sulu_core.expression_language" />
+            <tag name="sulu_admin.form_metadata_visitor" />
+            <tag name="sulu_admin.typed_form_metadata_visitor" />
         </service>
 
         <service
             id="sulu_admin.tag_filter_typed_form_metadata_visitor"
             class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TagFilterTypedFormMetadataVisitor"
         >
-            <tag name="sulu_admin.typed_form_metadata_visitor"/>
+            <tag name="sulu_admin.typed_form_metadata_visitor" />
         </service>
 
         <service
@@ -87,7 +85,7 @@
             <argument>%sulu.cache_dir%/forms</argument>
             <argument>%kernel.debug%</argument>
             <tag name="sulu_admin.form_metadata_loader"/>
-            <tag name="kernel.cache_warmer"/>
+            <tag name="kernel.cache_warmer" />
         </service>
 
         <service
@@ -97,26 +95,25 @@
             <argument type="tagged" tag="sulu_admin.list_metadata_loader"/>
             <argument type="tagged" tag="sulu_admin.list_metadata_visitor"/>
 
-            <tag name="sulu_admin.metadata_provider" type="list"/>
+            <tag name="sulu_admin.metadata_provider" type="list" />
         </service>
 
         <service
             id="sulu_admin.xml_list_metadata_loader"
             class="Sulu\Bundle\AdminBundle\Metadata\ListMetadata\XmlListMetadataLoader"
         >
-            <argument type="service" id="sulu_core.list_builder.field_descriptor_factory"/>
+            <argument type="service" id="sulu_core.list_builder.field_descriptor_factory" />
             <argument type="service" id="translator.default"/>
             <tag name="sulu_admin.list_metadata_loader"/>
         </service>
 
-        <service id="sulu_admin.view_builder_factory" class="Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactory"/>
+        <service id="sulu_admin.view_builder_factory" class="Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactory" />
         <service
             id="Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface"
             alias="sulu_admin.view_builder_factory"
         />
 
-        <service id="sulu_admin.form_metadata.form_xml_loader"
-                 class="Sulu\Bundle\AdminBundle\FormMetadata\FormXmlLoader">
+        <service id="sulu_admin.form_metadata.form_xml_loader" class="Sulu\Bundle\AdminBundle\FormMetadata\FormXmlLoader">
             <argument type="service" id="sulu_page.structure.properties_xml_parser"/>
             <argument type="service" id="sulu_page.structure.schema_xml_parser"/>
             <argument>%sulu_core.locales%</argument>
@@ -158,8 +155,7 @@
             <argument type="service" id="sulu_admin.property_metadata_mapper_registry"/>
         </service>
 
-        <service id="sulu_admin.structure_form_metadata_loader"
-                 class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\StructureFormMetadataLoader" lazy="true">
+        <service id="sulu_admin.structure_form_metadata_loader" class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\StructureFormMetadataLoader" lazy="true">
             <argument type="service" id="sulu_page.structure.factory"/>
             <argument type="service" id="sulu_admin.form_metadata.form_metadata_mapper"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
@@ -169,7 +165,7 @@
             <argument>%sulu.cache_dir%/form-structures</argument>
             <argument>%kernel.debug%</argument>
             <tag name="sulu_admin.form_metadata_loader"/>
-            <tag name="kernel.cache_warmer" priority="512"/>
+            <tag name="kernel.cache_warmer" priority="512" />
         </service>
 
         <service id="sulu_admin.view_registry" class="Sulu\Bundle\AdminBundle\Admin\View\ViewRegistry">
@@ -178,8 +174,7 @@
             <tag name="sulu.context" context="admin"/>
         </service>
 
-        <service id="sulu_admin.navigation_registry"
-                 class="Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationRegistry">
+        <service id="sulu_admin.navigation_registry" class="Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationRegistry">
             <argument type="service" id="translator"/>
             <argument type="service" id="sulu_admin.admin_pool"/>
             <argument type="service" id="sulu_admin.view_registry"/>
@@ -197,8 +192,8 @@
             class="Sulu\Bundle\AdminBundle\Controller\CollaborationController"
             public="true"
         >
-            <argument type="service" id="security.token_storage"/>
-            <argument type="service" id="sulu_admin.collaboration_repository"/>
+            <argument type="service" id="security.token_storage" />
+            <argument type="service" id="sulu_admin.collaboration_repository" />
             <argument type="service" id="fos_rest.view_handler"/>
             <argument>%kernel.secret%</argument>
             <tag name="sulu.context" context="admin"/>
@@ -217,21 +212,21 @@
         </service>
 
         <service id="sulu_admin.dropdown_toolbar_action_subscriber"
-                 class="Sulu\Bundle\AdminBundle\Serializer\Subscriber\DropdownToolbarActionSubscriber"
+            class="Sulu\Bundle\AdminBundle\Serializer\Subscriber\DropdownToolbarActionSubscriber"
         >
             <argument type="service" id="translator"/>
             <tag name="jms_serializer.event_subscriber"/>
         </service>
 
         <service id="sulu_admin.save_with_form_dialog_toolbar_action_subscriber"
-                 class="Sulu\Bundle\AdminBundle\Serializer\Subscriber\SaveWithFormDialogToolbarActionSubscriber"
+            class="Sulu\Bundle\AdminBundle\Serializer\Subscriber\SaveWithFormDialogToolbarActionSubscriber"
         >
             <argument type="service" id="translator"/>
             <tag name="jms_serializer.event_subscriber"/>
         </service>
 
         <service id="sulu_admin.toggler_toolbar_action_subscriber"
-                 class="Sulu\Bundle\AdminBundle\Serializer\Subscriber\TogglerToolbarActionSubscriber"
+            class="Sulu\Bundle\AdminBundle\Serializer\Subscriber\TogglerToolbarActionSubscriber"
         >
             <argument type="service" id="translator"/>
             <tag name="jms_serializer.event_subscriber"/>
@@ -246,7 +241,7 @@
         </service>
 
         <service id="sulu_admin.update_build_command" class="Sulu\Bundle\AdminBundle\Command\UpdateBuildCommand">
-            <argument type="service" id="http_client"/>
+            <argument type="service" id="http_client" />
             <argument>%kernel.project_dir%</argument>
             <argument>%sulu.version%</argument>
             <tag name="console.command"/>
@@ -261,8 +256,8 @@
             id="sulu_admin.download_language_command"
             class="Sulu\Bundle\AdminBundle\Command\DownloadLanguageCommand"
         >
-            <argument type="service" id="sulu_admin.http_client"/>
-            <argument type="service" id="filesystem"/>
+            <argument type="service" id="sulu_admin.http_client" />
+            <argument type="service" id="filesystem" />
             <argument>%kernel.project_dir%</argument>
             <argument>%sulu_core.locales%</argument>
             <tag name="console.command"/>

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -268,6 +268,7 @@
             class="Sulu\Bundle\AdminBundle\Command\ViewDebugCommand"
         >
             <argument type="service" id="sulu_admin.view_registry"/>
+            <tag name="sulu.context" context="admin"/>
             <tag name="console.command"/>
         </service>
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
-        <parameter key="sulu_admin.admin_controller.class">Sulu\Bundle\AdminBundle\Controller\AdminController</parameter>
+        <parameter key="sulu_admin.admin_controller.class">Sulu\Bundle\AdminBundle\Controller\AdminController
+        </parameter>
         <parameter key="sulu_admin.admin_pool.class">Sulu\Bundle\AdminBundle\Admin\AdminPool</parameter>
     </parameters>
 
@@ -18,10 +20,10 @@
             <argument type="service" id="sulu_admin.view_registry"/>
             <argument type="service" id="sulu_admin.navigation_registry"/>
             <argument type="service" id="sulu_admin.field_type_option_registry"/>
-            <argument type="service" id="sulu_contact.contact_manager" />
-            <argument type="service" id="sulu_page.smart_content.data_provider_pool" />
+            <argument type="service" id="sulu_contact.contact_manager"/>
+            <argument type="service" id="sulu_page.smart_content.data_provider_pool"/>
             <argument type="service" id="sulu_markup.link_tag.provider_pool"/>
-            <argument type="service" id="sulu.core.localization_manager" />
+            <argument type="service" id="sulu.core.localization_manager"/>
             <argument>%kernel.environment%</argument>
             <argument>%sulu.version%</argument>
             <argument>%app.version%</argument>
@@ -56,23 +58,23 @@
             <argument type="tagged" tag="sulu_admin.typed_form_metadata_visitor"/>
             <argument>%sulu_core.fallback_locale%</argument>
 
-            <tag name="sulu_admin.metadata_provider" type="form" />
+            <tag name="sulu_admin.metadata_provider" type="form"/>
         </service>
 
         <service
             id="sulu_admin.expression_form_metadata_visitor"
             class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\ExpressionFormMetadataVisitor"
         >
-            <argument type="service" id="sulu_core.expression_language" />
-            <tag name="sulu_admin.form_metadata_visitor" />
-            <tag name="sulu_admin.typed_form_metadata_visitor" />
+            <argument type="service" id="sulu_core.expression_language"/>
+            <tag name="sulu_admin.form_metadata_visitor"/>
+            <tag name="sulu_admin.typed_form_metadata_visitor"/>
         </service>
 
         <service
             id="sulu_admin.tag_filter_typed_form_metadata_visitor"
             class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TagFilterTypedFormMetadataVisitor"
         >
-            <tag name="sulu_admin.typed_form_metadata_visitor" />
+            <tag name="sulu_admin.typed_form_metadata_visitor"/>
         </service>
 
         <service
@@ -85,7 +87,7 @@
             <argument>%sulu.cache_dir%/forms</argument>
             <argument>%kernel.debug%</argument>
             <tag name="sulu_admin.form_metadata_loader"/>
-            <tag name="kernel.cache_warmer" />
+            <tag name="kernel.cache_warmer"/>
         </service>
 
         <service
@@ -95,25 +97,26 @@
             <argument type="tagged" tag="sulu_admin.list_metadata_loader"/>
             <argument type="tagged" tag="sulu_admin.list_metadata_visitor"/>
 
-            <tag name="sulu_admin.metadata_provider" type="list" />
+            <tag name="sulu_admin.metadata_provider" type="list"/>
         </service>
 
         <service
             id="sulu_admin.xml_list_metadata_loader"
             class="Sulu\Bundle\AdminBundle\Metadata\ListMetadata\XmlListMetadataLoader"
         >
-            <argument type="service" id="sulu_core.list_builder.field_descriptor_factory" />
+            <argument type="service" id="sulu_core.list_builder.field_descriptor_factory"/>
             <argument type="service" id="translator.default"/>
             <tag name="sulu_admin.list_metadata_loader"/>
         </service>
 
-        <service id="sulu_admin.view_builder_factory" class="Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactory" />
+        <service id="sulu_admin.view_builder_factory" class="Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactory"/>
         <service
             id="Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface"
             alias="sulu_admin.view_builder_factory"
         />
 
-        <service id="sulu_admin.form_metadata.form_xml_loader" class="Sulu\Bundle\AdminBundle\FormMetadata\FormXmlLoader">
+        <service id="sulu_admin.form_metadata.form_xml_loader"
+                 class="Sulu\Bundle\AdminBundle\FormMetadata\FormXmlLoader">
             <argument type="service" id="sulu_page.structure.properties_xml_parser"/>
             <argument type="service" id="sulu_page.structure.schema_xml_parser"/>
             <argument>%sulu_core.locales%</argument>
@@ -155,7 +158,8 @@
             <argument type="service" id="sulu_admin.property_metadata_mapper_registry"/>
         </service>
 
-        <service id="sulu_admin.structure_form_metadata_loader" class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\StructureFormMetadataLoader" lazy="true">
+        <service id="sulu_admin.structure_form_metadata_loader"
+                 class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\StructureFormMetadataLoader" lazy="true">
             <argument type="service" id="sulu_page.structure.factory"/>
             <argument type="service" id="sulu_admin.form_metadata.form_metadata_mapper"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
@@ -165,7 +169,7 @@
             <argument>%sulu.cache_dir%/form-structures</argument>
             <argument>%kernel.debug%</argument>
             <tag name="sulu_admin.form_metadata_loader"/>
-            <tag name="kernel.cache_warmer" priority="512" />
+            <tag name="kernel.cache_warmer" priority="512"/>
         </service>
 
         <service id="sulu_admin.view_registry" class="Sulu\Bundle\AdminBundle\Admin\View\ViewRegistry">
@@ -174,7 +178,8 @@
             <tag name="sulu.context" context="admin"/>
         </service>
 
-        <service id="sulu_admin.navigation_registry" class="Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationRegistry">
+        <service id="sulu_admin.navigation_registry"
+                 class="Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationRegistry">
             <argument type="service" id="translator"/>
             <argument type="service" id="sulu_admin.admin_pool"/>
             <argument type="service" id="sulu_admin.view_registry"/>
@@ -192,8 +197,8 @@
             class="Sulu\Bundle\AdminBundle\Controller\CollaborationController"
             public="true"
         >
-            <argument type="service" id="security.token_storage" />
-            <argument type="service" id="sulu_admin.collaboration_repository" />
+            <argument type="service" id="security.token_storage"/>
+            <argument type="service" id="sulu_admin.collaboration_repository"/>
             <argument type="service" id="fos_rest.view_handler"/>
             <argument>%kernel.secret%</argument>
             <tag name="sulu.context" context="admin"/>
@@ -212,21 +217,21 @@
         </service>
 
         <service id="sulu_admin.dropdown_toolbar_action_subscriber"
-            class="Sulu\Bundle\AdminBundle\Serializer\Subscriber\DropdownToolbarActionSubscriber"
+                 class="Sulu\Bundle\AdminBundle\Serializer\Subscriber\DropdownToolbarActionSubscriber"
         >
             <argument type="service" id="translator"/>
             <tag name="jms_serializer.event_subscriber"/>
         </service>
 
         <service id="sulu_admin.save_with_form_dialog_toolbar_action_subscriber"
-            class="Sulu\Bundle\AdminBundle\Serializer\Subscriber\SaveWithFormDialogToolbarActionSubscriber"
+                 class="Sulu\Bundle\AdminBundle\Serializer\Subscriber\SaveWithFormDialogToolbarActionSubscriber"
         >
             <argument type="service" id="translator"/>
             <tag name="jms_serializer.event_subscriber"/>
         </service>
 
         <service id="sulu_admin.toggler_toolbar_action_subscriber"
-            class="Sulu\Bundle\AdminBundle\Serializer\Subscriber\TogglerToolbarActionSubscriber"
+                 class="Sulu\Bundle\AdminBundle\Serializer\Subscriber\TogglerToolbarActionSubscriber"
         >
             <argument type="service" id="translator"/>
             <tag name="jms_serializer.event_subscriber"/>
@@ -241,7 +246,7 @@
         </service>
 
         <service id="sulu_admin.update_build_command" class="Sulu\Bundle\AdminBundle\Command\UpdateBuildCommand">
-            <argument type="service" id="http_client" />
+            <argument type="service" id="http_client"/>
             <argument>%kernel.project_dir%</argument>
             <argument>%sulu.version%</argument>
             <tag name="console.command"/>
@@ -256,10 +261,18 @@
             id="sulu_admin.download_language_command"
             class="Sulu\Bundle\AdminBundle\Command\DownloadLanguageCommand"
         >
-            <argument type="service" id="sulu_admin.http_client" />
-            <argument type="service" id="filesystem" />
+            <argument type="service" id="sulu_admin.http_client"/>
+            <argument type="service" id="filesystem"/>
             <argument>%kernel.project_dir%</argument>
             <argument>%sulu_core.locales%</argument>
+            <tag name="console.command"/>
+        </service>
+
+        <service
+            id="sulu_admin.debug_view_command"
+            class="Sulu\Bundle\AdminBundle\Command\ViewDebugCommand"
+        >
+            <argument type="service" id="sulu_admin.view_registry"/>
             <tag name="console.command"/>
         </service>
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Related issues/PRs | #7267
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

brings a command for debug Sulu Admin Views

`bin/console sulu:debug:admin:view`

or single Views

`bin/console sulu:debug:admin:view sulu_page.page_edit_form.setting`

#### Why?

Missing

#### To Do

- [ ] Create a documentation PR hint in Extend Sulu Admin
