### PR TITLE
Add support for NPM 8, 9, 10 and PNPM 8, remove support for NPM 6

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -21,10 +21,11 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - node-version: '14'
+                    - node-version: '18'
                       styleguide: false
-                    - node-version: '16'
-                      npm-version: '6'
+                      npm-version: '8'
+                    - node-version: '20'
+                      npm-version: '10'
                       styleguide: true
 
         env:
@@ -92,7 +93,7 @@ jobs:
             - name: Install and configure Node
               uses: actions/setup-node@v2-beta
               with:
-                  node-version: '14'
+                  node-version: '20'
 
             - name: Assert error when using yarn
               run: tests/js/check-yarn-warning.sh

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# unfortunately, npm 7 tries to resolve the dependency tree before validating the "engines" section of the
+# package.json. to display a helpful message instead of a confusing dependency tree error when using npm 7, we enable
+# the "legacy-peer-deps" setting: https://github.com/sulu/skeleton/issues/133#issuecomment-907271497
+legacy-peer-deps=true

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -13,9 +13,10 @@ in the project code with PHP 8.2.
 
 ### Custom Admin Builds npm version changed
 
-Sulu 2.6 now supports [npm 8, 9, 10](https://nodejs.org/en/download) and even
-[pnpm 8](https://pnpm.io/) or [bun 1](https://bun.sh/) to be used for custom admin
-builds. To support this new versions we were required to drop support for NPM 6.
+Sulu 2.6 now supports [npm 8, 9, and 10](https://nodejs.org/en/download), 
+as well as [pnpm 8](https://pnpm.io/) or [bun 1](https://bun.sh/) for custom 
+admin builds. With the introduction of these new versions, it is necessary 
+to drop the support for npm 6.
 
 ### DocumentToUuidTransformer return type changed
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -11,6 +11,12 @@ We recommend performing the PHP upgrade as a separate step before updating to
 Sulu 2.6. This will make it easier for you to identify any bugs that may occur
 in the project code with PHP 8.2.
 
+### Custom Admin Builds npm version changed
+
+Sulu 2.6 now supports [npm 8, 9, 10](https://nodejs.org/en/download) and even
+[pnpm 8](https://pnpm.io/) or [bun 1](https://bun.sh/) to be used for custom admin
+builds. To support this new versions we were required to drop support for NPM 6.
+
 ### DocumentToUuidTransformer return type changed
 
 For compatibility to Symfony 7 the `DocumentToUuidTransformer` methods return types changed:

--- a/preinstall.js
+++ b/preinstall.js
@@ -1,6 +1,7 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 
 if (process.env.npm_execpath.indexOf('npm') === -1
+    && process.env.npm_execpath.indexOf('pnpm') === -1 // @experimental supported
     && process.env.npm_execpath.indexOf('bun') === -1 // @experimental supported
 ) {
     throw new Error('\x1b[31mYou must use "npm install", yarn is not supported\x1b[0m');

--- a/src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php
@@ -349,7 +349,9 @@ class UpdateBuildCommand extends Command
     {
         $filesToCleanup = [
             'package-lock.json',
+            'bun.lockb',
             'yarn.lock',
+            'pnpm-lock.yaml',
             'node_modules',
         ];
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | https://github.com/sulu/skeleton/pull/235, https://github.com/sulu/skeleton/issues/88
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

See https://github.com/sulu/skeleton/pull/235

#### Why?

Node 16 is going for end of life: https://nodejs.org/en/about/previous-releases

#### Example Usage

```php
rm -rf ./**/node_modules/
rm -rf ./**/package-lock.json

cd assets/admin
npm -g i npm@10

npm install
npm run build
```

```php
rm -rf ./**/node_modules/
rm -rf ./**/package-lock.json
rm -rf ./**/pnpm-lock.yaml

cd assets/admin
curl -fsSL https://get.pnpm.io/install.sh | sh -

pnpm install
pnpm run build
```

#### BC Breaks/Deprecations

No support for NPM 6 / symlinked local packages.

#### Disadvantages

No watch task over vendor package developments as install requires `install-links=true` which ends not longer uses symlinks. Instead a tarball is created and install, but it installs correctly dependencies of local dependencies. Which does not work for `file:` packages.