### PR TITLE
Add field exclusion strategy for SnippetController

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -101,6 +101,11 @@ Additionally, the following packages where upgraded:
 
 This update is also handled normally by the update build command automatically.
 
+### Query parameters in the snippet controller work again
+
+In the previous version the `SnippetController` would return the entire content of the snippet in the `cgetAction`. Now
+it respects the list of fields provided in the query parameter and only returns those.
+
 ### DocumentToUuidTransformer return type changed
 
 For compatibility to Symfony 7 the `DocumentToUuidTransformer` methods return types changed:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -101,11 +101,6 @@ Additionally, the following packages where upgraded:
 
 This update is also handled normally by the update build command automatically.
 
-### Query parameters in the snippet controller work again
-
-In the previous version the `SnippetController` would return the entire content of the snippet in the `cgetAction`. Now
-it respects the list of fields provided in the query parameter and only returns those.
-
 ### DocumentToUuidTransformer return type changed
 
 For compatibility to Symfony 7 the `DocumentToUuidTransformer` methods return types changed:
@@ -132,7 +127,7 @@ Use the newly added `getUrl` method:
 
 ### Static protected $defaultName property of commands removed
 
-As deprecated in Symfony 6.1 the `$defaultName` of Sulu Commands where replaced with the new
+As deprecated in Symfony 6.1 the `$defaultName` of Sulu Commands were replaced with the new
 `Symfony\Component\Console\Attribute\AsCommand` annotation.
 
 ### ListBuilder Doctrine Changes
@@ -198,6 +193,11 @@ sulu_website:
         attributes:
             urls: true
 ```
+
+### Fields Query parameter are now kept in mind for SnippetController
+
+In the previous version the `SnippetController` would return the entire content of the snippet in the `cgetAction`. Now
+it respects the list of fields provided in the query parameter and only returns those.
 
 ## 2.5.12
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -30877,7 +30877,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
-			count: 17
+			count: 18
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
 
 		-

--- a/src/Sulu/Bundle/CoreBundle/Serializer/Exclusion/FieldsExclusionStrategy.php
+++ b/src/Sulu/Bundle/CoreBundle/Serializer/Exclusion/FieldsExclusionStrategy.php
@@ -19,6 +19,8 @@ use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Metadata\PropertyMetadata;
 
 /**
+ * @final
+ *
  * @internal
  */
 class FieldsExclusionStrategy implements ExclusionStrategyInterface

--- a/src/Sulu/Bundle/CoreBundle/Serializer/Exclusion/FieldsExclusionStrategy.php
+++ b/src/Sulu/Bundle/CoreBundle/Serializer/Exclusion/FieldsExclusionStrategy.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sulu\Bundle\CoreBundle\Serializer\Exclusion;
+
+use JMS\Serializer\Context;
+use JMS\Serializer\Exclusion\ExclusionStrategyInterface;
+use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\Metadata\PropertyMetadata;
+
+class FieldsExclusionStrategy implements ExclusionStrategyInterface
+{
+    /** @param array<int, string> $requestedFields */
+    public function __construct(private array $requestedFields)
+    {
+    }
+
+    public function shouldSkipClass(ClassMetadata $metadata, Context $context): bool
+    {
+        return false;
+    }
+
+    public function shouldSkipProperty(PropertyMetadata $property, Context $context): bool
+    {
+        if ($this->requestedFields === []) {
+            return false;
+        }
+
+        return !in_array($property->serializedName, $this->requestedFields, true);
+    }
+}

--- a/src/Sulu/Bundle/CoreBundle/Serializer/Exclusion/FieldsExclusionStrategy.php
+++ b/src/Sulu/Bundle/CoreBundle/Serializer/Exclusion/FieldsExclusionStrategy.php
@@ -18,6 +18,9 @@ use JMS\Serializer\Exclusion\ExclusionStrategyInterface;
 use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Metadata\PropertyMetadata;
 
+/**
+ * @internal
+ */
 class FieldsExclusionStrategy implements ExclusionStrategyInterface
 {
     /** @param array<int, string> $requestedFields */

--- a/src/Sulu/Bundle/CoreBundle/Serializer/Exclusion/FieldsExclusionStrategy.php
+++ b/src/Sulu/Bundle/CoreBundle/Serializer/Exclusion/FieldsExclusionStrategy.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Sulu\Bundle\CoreBundle\Serializer\Exclusion;
 
 use JMS\Serializer\Context;
@@ -23,10 +32,10 @@ class FieldsExclusionStrategy implements ExclusionStrategyInterface
 
     public function shouldSkipProperty(PropertyMetadata $property, Context $context): bool
     {
-        if ($this->requestedFields === []) {
+        if ([] === $this->requestedFields) {
             return false;
         }
 
-        return !in_array($property->serializedName, $this->requestedFields, true);
+        return !\in_array($property->serializedName, $this->requestedFields, true);
     }
 }

--- a/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
@@ -11,10 +11,12 @@
 
 namespace Sulu\Bundle\SnippetBundle\Controller;
 
+use FOS\RestBundle\Context\Context;
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandler;
 use HandcraftedInTheAlps\RestRoutingBundle\Routing\ClassResourceInterface;
 use PHPCR\NodeInterface;
+use Sulu\Bundle\CoreBundle\Serializer\Exclusion\FieldsExclusionStrategy;
 use Sulu\Bundle\PageBundle\Document\PageDocument;
 use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Sulu\Bundle\SnippetBundle\Snippet\DefaultSnippetManagerInterface;
@@ -205,7 +207,16 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
             $total
         );
 
-        return $this->viewHandler->handle(View::create($data));
+        $view = View::create($data);
+
+        $requestedFields = $this->listRestHelper->getFields() ?? [];
+        if ($requestedFields !== []) {
+            $context = new Context();
+            $context->addExclusionStrategy(new FieldsExclusionStrategy($requestedFields));
+            $view->setContext($context);
+        }
+
+        return $this->viewHandler->handle($view);
     }
 
     /**

--- a/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
@@ -210,7 +210,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
         $view = View::create($data);
 
         $requestedFields = $this->listRestHelper->getFields() ?? [];
-        if ($requestedFields !== []) {
+        if ([] !== $requestedFields) {
             $context = new Context();
             $context->addExclusionStrategy(new FieldsExclusionStrategy($requestedFields));
             $view->setContext($context);

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
@@ -297,6 +297,9 @@ class SnippetControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $response);
 
         $result = \json_decode($response->getContent(), true);
+        $this->assertIsArray($result);
+
+        /** @array array<int, array<string, mixed>> $snippetData */
         $snippetData = $result['_embedded']['snippets'];
 
         foreach ($snippetData as $snippet) {

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
@@ -288,6 +288,25 @@ class SnippetControllerTest extends SuluTestCase
         }
     }
 
+    public function testIndexWithFields(): void
+    {
+        $fields = ['id', 'title', 'path'];
+        $this->client->jsonRequest('GET', '/api/snippets?locale=de&fields=' . \implode(',', $fields));
+        $response = $this->client->getResponse();
+
+        $this->assertHttpStatusCode(200, $response);
+
+        $result = \json_decode($response->getContent(), true);
+        $snippetData = $result['_embedded']['snippets'];
+
+        foreach ($snippetData as $snippet) {
+            foreach ($fields as $field) {
+                $this->assertArrayHasKey($field, $snippet);
+            }
+            $this->assertArrayNotHasKey('description', $snippet);
+        }
+    }
+
     public function providePost()
     {
         return [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | fixes #7023
| Related issues/PRs | #7023
| License | MIT
| Documentation PR | -

#### What's in this PR?
Adding code to only serialize fields specified in the request of the snippet controller.

#### Why?
When using the snippet listing by default it also serializes the content which is very slow. This PR adds an exclusion strategy that will not serialize the content anymore.

#### To Do

- [x] Add breaking changes to UPGRADE.md
