### PR TITLE
Add phpcr cleanup command

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11491,6 +11491,31 @@ parameters:
 			path: src/Sulu/Bundle/DocumentManagerBundle/Command/FixturesLoadCommand.php
 
 		-
+			message: "#^In method \"Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\Command\\\\PHPCRCleanupSingleNodeCommand\\:\\:execute\", caught \"Exception\" must be rethrown\\. Either catch a more specific exception or add a \"throw\" clause in the \"catch\" block to propagate the exception\\. More info\\: http\\://bit\\.ly/failloud$#"
+			count: 1
+			path: src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
+
+		-
+			message: "#^Method Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\Command\\\\PHPCRCleanupSingleNodeCommand\\:\\:cleanupNode\\(\\) has parameter \\$writtenProperties with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
+
+		-
+			message: "#^Method Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\Command\\\\PHPCRCleanupSingleNodeCommand\\:\\:getLocales\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
+
+		-
+			message: "#^Property Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\Command\\\\PHPCRCleanupSingleNodeCommand\\:\\:\\$invalidationSubscriber is never read, only written\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
+
+		-
+			message: "#^Variable \\$liveCleanupNode might not be defined\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
+
+		-
 			message: "#^Cannot use array destructuring on array\\<callable\\>\\|\\(callable\\)\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/DocumentManagerBundle/Command/SubscriberDebugCommand.php
@@ -37979,6 +38004,26 @@ parameters:
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, Iterator\\<string, PHPCR\\\\NodeInterface\\> given\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Document/Subscriber/OrderSubscriber.php
+
+		-
+			message: "#^Call to an undefined method PHPCR\\\\NodeInterface\\:\\:getIterator\\(\\)\\.$#"
+			count: 1
+			path: src/Sulu/Component/Content/Document/Subscriber/PHPCR/CleanupNode.php
+
+		-
+			message: "#^Class Sulu\\\\Component\\\\Content\\\\Document\\\\Subscriber\\\\PHPCR\\\\CleanupNode implements generic interface IteratorAggregate but does not specify its types\\: TKey, TValue$#"
+			count: 1
+			path: src/Sulu/Component/Content/Document/Subscriber/PHPCR/CleanupNode.php
+
+		-
+			message: "#^Method Sulu\\\\Component\\\\Content\\\\Document\\\\Subscriber\\\\PHPCR\\\\CleanupNode\\:\\:getWrittenPropertyKeys\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Sulu/Component/Content/Document/Subscriber/PHPCR/CleanupNode.php
+
+		-
+			message: "#^Property Sulu\\\\Component\\\\Content\\\\Document\\\\Subscriber\\\\PHPCR\\\\CleanupNode\\:\\:\\$writtenProperties type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Sulu/Component/Content/Document/Subscriber/PHPCR/CleanupNode.php
 
 		-
 			message: "#^Class Sulu\\\\Component\\\\Content\\\\Document\\\\Subscriber\\\\PHPCR\\\\SuluNode implements generic interface IteratorAggregate but does not specify its types\\: TKey, TValue$#"

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
@@ -23,6 +23,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
+use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\PhpProcess;
 use Symfony\Component\Process\Process;
 
@@ -228,13 +229,17 @@ class PHPCRCleanupCommand extends Command
 
     protected function createProcess(string $uuid, bool $dryRun, bool $debug): Process
     {
-        $process = new PhpProcess(\implode(' ', \array_filter([
+        $executableFinder = new PhpExecutableFinder();
+        $php = $executableFinder->find(false);
+
+        $process = new Process(\array_filter([
+            $php,
             $_SERVER['argv'][0],
             'sulu:phpcr:cleanup:single-node',
             $uuid,
             $dryRun ? '--dry-run' : null,
             $debug ? '--debug' : null,
-        ])));
+        ]));
 
         $process->setTimeout(120);
 

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
@@ -24,18 +24,10 @@ use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
 use Symfony\Component\Process\PhpExecutableFinder;
-use Symfony\Component\Process\PhpProcess;
 use Symfony\Component\Process\Process;
 
-/**
- * TODO:
- * * Snippets
- * * Articles
- */
 class PHPCRCleanupCommand extends Command
 {
-    protected static $defaultName = 'sulu:phpcr:cleanup';
-
     private OutputInterface $logger;
 
     public function __construct(
@@ -44,7 +36,7 @@ class PHPCRCleanupCommand extends Command
         private ServicesResetter $servicesResetter,
         private string $projectDirectory,
     ) {
-        parent::__construct();
+        parent::__construct('sulu:phpcr:cleanup');
     }
 
     protected function configure(): void

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
@@ -125,6 +125,7 @@ class PHPCRCleanupCommand extends Command
         }
 
         $wheres[] = 'page.[jcr:path] LIKE "/cmf/snippets/%/%"';
+        $wheres[] = 'page.[jcr:path] LIKE "/cmf/articles/%/%/%"';
 
         $sql2 = \sprintf(
             'SELECT [jcr:uuid] FROM [nt:unstructured] AS page WHERE %s',

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
@@ -23,6 +23,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
+use Symfony\Component\Process\PhpProcess;
 use Symfony\Component\Process\Process;
 
 /**
@@ -227,14 +228,13 @@ class PHPCRCleanupCommand extends Command
 
     protected function createProcess(string $uuid, bool $dryRun, bool $debug): Process
     {
-        $process = new Process(\array_filter([
-            $_SERVER['PHP_BINARY'],
+        $process = new PhpProcess(\implode(' ', \array_filter([
             $_SERVER['argv'][0],
             'sulu:phpcr:cleanup:single-node',
             $uuid,
             $dryRun ? '--dry-run' : null,
             $debug ? '--debug' : null,
-        ]));
+        ])));
 
         $process->setTimeout(120);
 

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
@@ -192,11 +192,15 @@ class PHPCRCleanupCommand extends Command
         $progressBar->finish();
         $io->success('Cleanup process finished');
 
-        $io->section('Following nodes are errored');
-        $io->listing($erroredUuids);
+        if (0 < \count($erroredUuids)) {
+            $io->section('Following nodes are errored');
+            $io->listing($erroredUuids);
+        }
 
-        $io->section('Following nodes are ignored');
-        $io->listing($ignoredUuids);
+        if (0 < \count($ignoredUuids)) {
+            $io->section('Following nodes are ignored');
+            $io->listing($ignoredUuids);
+        }
 
         return self::SUCCESS;
     }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
@@ -13,17 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\DocumentManagerBundle\Command;
 
-use PHPCR\NodeInterface;
 use PHPCR\SessionInterface;
-use Sulu\Bundle\HttpCacheBundle\EventSubscriber\InvalidationSubscriber;
-use Sulu\Component\Content\Document\Behavior\WorkflowStageBehavior;
-use Sulu\Component\Content\Document\Subscriber\PHPCR\CleanupNode;
-use Sulu\Component\Content\Document\WorkflowStage;
-use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
-use Sulu\Component\DocumentManager\DocumentManagerInterface;
-use Sulu\Component\DocumentManager\Event;
-use Sulu\Component\DocumentManager\Events;
-use Sulu\Component\DocumentManager\NamespaceRegistry;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -31,53 +21,21 @@ use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
+use Symfony\Component\Process\Process;
 
 class PHPCRCleanupCommand extends Command
 {
-    /**
-     * @var string[]
-     */
-    public const WHITELIST = [
-        'state',
-        'published',
-        'created',
-        'creator',
-        'changed',
-        'changer',
-    ];
-
     protected static $defaultName = 'sulu:phpcr:cleanup';
-
-    private array $aliasMapping = [];
-
-    private string $languagePrefix;
-
-    /**
-     * @var array<string, OptionsResolver>
-     */
-    private array $optionsResolvers = [];
 
     private OutputInterface $logger;
 
     public function __construct(
-        private SessionInterface $liveSession,
         private SessionInterface $session,
-        NamespaceRegistry $namespaceRegistry,
-        private EventDispatcherInterface $documentManagerEventDispatcher,
-        private DocumentManagerInterface $documentManager,
-        private StructureMetadataFactoryInterface $structureMetaDataFactory,
-        private InvalidationSubscriber $invalidationSubscriber,
+        private ServicesResetter $servicesResetter,
         private string $projectDirectory,
-        array $mapping,
     ) {
         parent::__construct();
-
-        $this->languagePrefix = $namespaceRegistry->getPrefix('system_localized');
-        foreach ($mapping as $item) {
-            $this->aliasMapping[$item['phpcr_type']] = $item['alias'];
-        }
     }
 
     protected function configure(): void
@@ -88,6 +46,7 @@ class PHPCRCleanupCommand extends Command
         $this->addOption('dry-run', null, InputOption::VALUE_NONE, 'Do not make any changes to the repository.');
         $this->addOption('debug', null, InputOption::VALUE_NONE, 'Write debug information to a file.');
         $this->addOption('debug-file', null, InputOption::VALUE_REQUIRED, 'Write debug information to a file.', $defaultDebugFile);
+        $this->addOption('processes', 'p', InputOption::VALUE_REQUIRED, 'Number of parallel processes.', 5);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -101,7 +60,11 @@ class PHPCRCleanupCommand extends Command
         if (!$dryRun) {
             $io->warning('This command will remove properties from the PHPCR repository. Make sure to have a backup before running this command.');
             if (!$input->getOption('force')) {
-                $answer = $io->ask('Do you want to continue [y/n]', null, function ($value) {
+                $answer = $io->ask('Do you want to continue [y/n]', null, function (?string $value) {
+                    if (null === $value) {
+                        return false;
+                    }
+
                     $value = \strtolower($value);
                     if (!\in_array($value, ['y', 'n'], true)) {
                         throw new \RuntimeException('You need to enter "y" to continue or "n" to abort.');
@@ -139,7 +102,7 @@ class PHPCRCleanupCommand extends Command
         $io->writeln('Debug: ' . ($debug ? 'enabled' : 'disabled'));
 
         $this->logger = new NullOutput();
-        if ($input->getOption('debug')) {
+        if ($debug) {
             $debugFile = $input->getOption('debug-file');
             $io->writeln('Debug file: ' . $debugFile);
 
@@ -150,84 +113,75 @@ class PHPCRCleanupCommand extends Command
         $io->newLine();
 
         $queryManager = $this->session->getWorkspace()->getQueryManager();
-        $rows = $queryManager->createQuery('SELECT * FROM [nt:unstructured]', 'JCR-SQL2')->execute();
+        $rows = $queryManager->createQuery('SELECT [jcr:uuid] FROM [nt:unstructured] AS page WHERE ISDESCENDANTNODE(page, "/cmf") AND page.[jcr:path] LIKE "/cmf/%/%"  AND NOT page.[jcr:path] LIKE "/cmf/%/routes/%" AND NOT page.[jcr:path] LIKE "/cmf/%/routes" AND NOT page.[jcr:path] LIKE "/cmf/%/custom-urls/%" AND NOT page.[jcr:path] LIKE "/cmf/%/custom-urls"', 'JCR-SQL2')->execute();
+
+        $uuids = \array_map(static fn ($row) => $row->getValue('jcr:uuid'), \iterator_to_array($rows->getRows()));
+        unset($rows);
 
         $stats = [
             'nodes' => 0,
             'ignoredNodes' => 0,
+            'erroredNodes' => 0,
+            'documents' => 0,
             'properties' => 0,
             'removedProperties' => 0,
         ];
 
         $io->section('Running cleanup process ...');
-        $progressBar = $io->createProgressBar();
-        $progressBar->setFormat("Nodes: %nodes%\nIngored: %ignoredNodes%\nProperties: %properties%\nRemoved properties: %removedProperties%\n\n");
+        $progressBar = $io->createProgressBar(\count($uuids));
+        $progressBar->setFormat("Nodes: %nodes%\nIgnored: %ignoredNodes%\nErrored: %erroredNodes%\nDocuments: %documents%\nProperties: %properties%\nRemoved properties: %removedProperties%\n\n%current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s%\n\n");
 
         $progressBar->setMessage((string) $stats['nodes'], 'nodes');
         $progressBar->setMessage((string) $stats['ignoredNodes'], 'ignoredNodes');
+        $progressBar->setMessage((string) $stats['erroredNodes'], 'erroredNodes');
+        $progressBar->setMessage((string) $stats['documents'], 'documents');
         $progressBar->setMessage((string) $stats['properties'], 'properties');
         $progressBar->setMessage((string) $stats['removedProperties'], 'removedProperties');
 
         $progressBar->start();
 
-        foreach ($rows->getNodes() as $node) {
-            $alias = $this->getAliasForNode($node);
-            if (null === $alias || !$this->structureMetaDataFactory->hasStructuresFor($alias)) {
-                continue;
+        $chunks = \array_chunk($uuids, (int) $input->getOption('processes'));
+        foreach ($chunks as $chunk) {
+            $processes = [];
+            foreach ($chunk as $uuid) {
+                $processes[$uuid] = $this->createProcess($uuid, $dryRun, $debug);
+                $processes[$uuid]->start();
             }
 
-            ++$stats['nodes'];
-
-            foreach ($this->getLocales($node) as $locale) {
-                if (!$node->hasProperty($this->languagePrefix . ':' . $locale . '-template')) {
-                    continue;
-                }
-
-                $document = $this->documentManager->find($node->getIdentifier(), $locale);
-
-                $workflowStage = WorkflowStage::TEST;
-                if ($document instanceof WorkflowStageBehavior) {
-                    $workflowStage = $document->getWorkflowStage();
-                }
-
-                try {
-                    $defaultCleanupNode = new CleanupNode(clone $node);
-                    $this->persist($document, $defaultCleanupNode, $locale);
-
-                    $liveCleanupNode = new CleanupNode(clone $node);
-                    if (WorkflowStage::PUBLISHED === $workflowStage) {
-                        $this->publish($document, $liveCleanupNode, $locale);
-                    }
-
-                    $this->documentManager->clear();
-                } catch (\Exception $e) {
+            foreach ($processes as $uuid => $process) {
+                ++$stats['nodes'];
+                $status = $process->wait();
+                if (PHPCRCleanupSingleNodeCommand::IGNORED === $status) {
                     ++$stats['ignoredNodes'];
 
                     continue;
                 }
+                if (0 !== $status) {
+                    ++$stats['erroredNodes'];
 
-                $writtenProperties = $defaultCleanupNode->getWrittenPropertyKeys();
-                foreach ($this->cleanupNode($node, $locale, $writtenProperties, $dryRun) as $result) {
-                    ++$stats['properties'];
-                    $stats['removedProperties'] += $result ? 1 : 0;
+                    continue;
                 }
 
-                $liveNode = $this->liveSession->getNode($node->getPath());
-                $writtenProperties = $liveCleanupNode->getWrittenPropertyKeys();
-                foreach ($this->cleanupNode($liveNode, $locale, $writtenProperties, $dryRun) as $result) {
-                    ++$stats['properties'];
-                    $stats['removedProperties'] += $result ? 1 : 0;
-                }
+                $output = $process->getOutput();
+                \preg_match('/Documents: (\d+)/', $output, $matches);
+                $stats['documents'] += (int) ($matches[1] ?? 0);
+                \preg_match('/Removed properties: (\d+)/', $output, $matches);
+                $stats['removedProperties'] += (int) ($matches[1] ?? 0);
+                \preg_match('/Total properties: (\d+)/', $output, $matches);
+                $stats['properties'] += (int) ($matches[1] ?? 0);
 
-                $this->session->save();
-                $this->documentManager->clear();
+                $this->logger->writeln($output);
+
+                $progressBar->setMessage((string) $stats['nodes'], 'nodes');
+                $progressBar->setMessage((string) $stats['ignoredNodes'], 'ignoredNodes');
+                $progressBar->setMessage((string) $stats['erroredNodes'], 'erroredNodes');
+                $progressBar->setMessage((string) $stats['documents'], 'documents');
+                $progressBar->setMessage((string) $stats['properties'], 'properties');
+                $progressBar->setMessage((string) $stats['removedProperties'], 'removedProperties');
+                $progressBar->advance();
             }
 
-            $progressBar->setMessage((string) $stats['nodes'], 'nodes');
-            $progressBar->setMessage((string) $stats['ignoredNodes'], 'ignoredNodes');
-            $progressBar->setMessage((string) $stats['properties'], 'properties');
-            $progressBar->setMessage((string) $stats['removedProperties'], 'removedProperties');
-            $progressBar->advance();
+            $this->servicesResetter->reset();
         }
 
         $progressBar->finish();
@@ -236,103 +190,15 @@ class PHPCRCleanupCommand extends Command
         return self::SUCCESS;
     }
 
-    private function persist($document, CleanupNode $cleanupNode, string $locale): void
+    protected function createProcess(string $uuid, bool $dryRun, bool $debug): Process
     {
-        $options = $this->getOptionsResolver(Events::PERSIST)->resolve();
-        $event = new Event\PersistEvent($document, $locale, $options);
-        $event->setNode($cleanupNode);
-        $this->documentManagerEventDispatcher->dispatch($event, Events::PERSIST);
-    }
-
-    private function publish($document, CleanupNode $cleanupNode, string $locale): void
-    {
-        $this->invalidationSubscriber->deactivate();
-        $options = $this->getOptionsResolver(Events::PUBLISH)->resolve();
-        $event = new Event\PublishEvent($document, $locale, $options);
-        $event->setNode($cleanupNode);
-        $this->documentManagerEventDispatcher->dispatch($event, Events::PUBLISH);
-        $this->invalidationSubscriber->activate();
-    }
-
-    private function cleanupNode(NodeInterface $node, string $locale, array $writtenProperties, bool $dryRun): \Generator
-    {
-        $this->logger->writeln(\sprintf("# Cleaning up node \"%s\" for locale \"%s\" in workspace \"%s\"\n", $node->getPath(), $locale, $node->getSession()->getWorkspace()->getName()));
-
-        $whiteList = \array_map(fn ($property) => $this->languagePrefix . ':' . $locale . '-' . $property, self::WHITELIST);
-        $this->logger->writeln(\sprintf("Whitelisted:\n* %s\n", \implode("\n* ", $whiteList)));
-        $this->logger->writeln(\sprintf("Written:\n* %s\n", \implode("\n* ", $writtenProperties)));
-
-        $removedProperties = [];
-        foreach ($node->getProperties() as $property) {
-            if (!\str_starts_with($property->getName(), $this->languagePrefix . ':' . $locale)) {
-                yield false;
-
-                continue;
-            }
-
-            if (\in_array($property->getName(), $writtenProperties, true)
-                || \in_array($property->getName(), $whiteList, true)
-            ) {
-                yield false;
-
-                continue;
-            }
-
-            $removedProperties[] = $property->getName();
-            if (!$dryRun) {
-                $property->remove();
-            }
-
-            yield true;
-        }
-
-        $this->logger->writeln(\sprintf("Removed:\n* %s\n", \implode("\n* ", $removedProperties)));
-    }
-
-    private function getOptionsResolver(string $eventName): OptionsResolver
-    {
-        if (isset($this->optionsResolvers[$eventName])) {
-            return $this->optionsResolvers[$eventName];
-        }
-
-        $resolver = new OptionsResolver();
-        $resolver->setDefault('locale', null);
-
-        $event = new Event\ConfigureOptionsEvent($resolver);
-        $this->documentManagerEventDispatcher->dispatch($event, Events::CONFIGURE_OPTIONS);
-
-        $this->optionsResolvers[$eventName] = $resolver;
-
-        return $resolver;
-    }
-
-    private function getLocales(NodeInterface $node)
-    {
-        $locales = [];
-
-        foreach ($node->getProperties() as $property) {
-            \preg_match(
-                \sprintf('/^%s:([a-zA-Z_]*?)-.*/', $this->languagePrefix),
-                $property->getName(),
-                $matches,
-            );
-
-            if ($matches) {
-                $locales[$matches[1]] = $matches[1];
-            }
-        }
-
-        return \array_values(\array_unique($locales));
-    }
-
-    private function getAliasForNode(NodeInterface $node): ?string
-    {
-        foreach ($node->getMixinNodeTypes() as $mixinNodeType) {
-            if (isset($this->aliasMapping[$mixinNodeType->getName()])) {
-                return $this->aliasMapping[$mixinNodeType->getName()];
-            }
-        }
-
-        return null;
+        return new Process(\array_filter([
+            $_SERVER['PHP_BINARY'],
+            $_SERVER['argv'][0],
+            'sulu:phpcr:cleanup:single-node',
+            $uuid,
+            $dryRun ? '--dry-run' : null,
+            $debug ? '--debug' : null,
+        ]));
     }
 }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
@@ -61,7 +61,7 @@ class PHPCRCleanupCommand extends Command
         if (!$dryRun) {
             $io->warning('This command will remove properties from the PHPCR repository. Make sure to have a backup before running this command.');
             if (!$input->getOption('force')) {
-                $answer = $io->ask('Do you want to continue [y/n]', null, function (?string $value) {
+                $answer = $io->ask('Do you want to continue [y/n]', null, function(?string $value) {
                     if (null === $value) {
                         return false;
                     }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
@@ -1,0 +1,338 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\DocumentManagerBundle\Command;
+
+use PHPCR\NodeInterface;
+use PHPCR\SessionInterface;
+use Sulu\Bundle\HttpCacheBundle\EventSubscriber\InvalidationSubscriber;
+use Sulu\Component\Content\Document\Behavior\WorkflowStageBehavior;
+use Sulu\Component\Content\Document\Subscriber\PHPCR\CleanupNode;
+use Sulu\Component\Content\Document\WorkflowStage;
+use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Sulu\Component\DocumentManager\Event;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\NamespaceRegistry;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class PHPCRCleanupCommand extends Command
+{
+    /**
+     * @var string[]
+     */
+    public const WHITELIST = [
+        'state',
+        'published',
+        'created',
+        'creator',
+        'changed',
+        'changer',
+    ];
+
+    protected static $defaultName = 'sulu:phpcr:cleanup';
+
+    private array $aliasMapping = [];
+
+    private string $languagePrefix;
+
+    /**
+     * @var array<string, OptionsResolver>
+     */
+    private array $optionsResolvers = [];
+
+    private OutputInterface $logger;
+
+    public function __construct(
+        private SessionInterface $liveSession,
+        private SessionInterface $session,
+        NamespaceRegistry $namespaceRegistry,
+        private EventDispatcherInterface $documentManagerEventDispatcher,
+        private DocumentManagerInterface $documentManager,
+        private StructureMetadataFactoryInterface $structureMetaDataFactory,
+        private InvalidationSubscriber $invalidationSubscriber,
+        private string $projectDirectory,
+        array $mapping,
+    ) {
+        parent::__construct();
+
+        $this->languagePrefix = $namespaceRegistry->getPrefix('system_localized');
+        foreach ($mapping as $item) {
+            $this->aliasMapping[$item['phpcr_type']] = $item['alias'];
+        }
+    }
+
+    protected function configure(): void
+    {
+        $defaultDebugFile = \sprintf('%s/var/%s_phpcr-cleanup.md', $this->projectDirectory, \date('Y-m-d-H-i-s'));
+
+        $this->addOption('force', 'f', InputOption::VALUE_NONE, 'Do not ask for confirmation.');
+        $this->addOption('dry-run', null, InputOption::VALUE_NONE, 'Do not make any changes to the repository.');
+        $this->addOption('debug', null, InputOption::VALUE_NONE, 'Write debug information to a file.');
+        $this->addOption('debug-file', null, InputOption::VALUE_REQUIRED, 'Write debug information to a file.', $defaultDebugFile);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $io->title('PHPCR Cleanup');
+
+        $dryRun = $input->getOption('dry-run');
+
+        if (!$dryRun) {
+            $io->warning('This command will remove properties from the PHPCR repository. Make sure to have a backup before running this command.');
+            if (!$input->getOption('force')) {
+                $answer = $io->ask('Do you want to continue [y/n]', null, function ($value) {
+                    $value = \strtolower($value);
+                    if (!\in_array($value, ['y', 'n'], true)) {
+                        throw new \RuntimeException('You need to enter "y" to continue or "n" to abort.');
+                    }
+
+                    return 'y' === $value;
+                });
+
+                if (!$answer) {
+                    $io->warning('You have aborted the command');
+
+                    return self::SUCCESS;
+                }
+            } else {
+                $io->writeln('The command will wait for 5 seconds before starting');
+                $progressBar = $io->createProgressBar(5);
+                $progressBar->start();
+                for ($i = 0; $i < 5; ++$i) {
+                    $progressBar->advance();
+                    \sleep(1);
+                }
+                $progressBar->finish();
+
+                $io->newLine();
+                $io->newLine();
+                $io->newLine();
+            }
+        }
+
+        $io->section('Initiating cleanup process ...');
+        $io->writeln('Project directory: ' . $this->projectDirectory);
+        $io->writeln('Dry-run: ' . ($dryRun ? 'enabled' : 'disabled'));
+
+        $debug = $input->getOption('debug');
+        $io->writeln('Debug: ' . ($debug ? 'enabled' : 'disabled'));
+
+        $this->logger = new NullOutput();
+        if ($input->getOption('debug')) {
+            $debugFile = $input->getOption('debug-file');
+            $io->writeln('Debug file: ' . $debugFile);
+
+            $this->logger = new StreamOutput(\fopen($debugFile, 'w'));
+        }
+
+        $io->newLine();
+        $io->newLine();
+
+        $queryManager = $this->session->getWorkspace()->getQueryManager();
+        $rows = $queryManager->createQuery('SELECT * FROM [nt:unstructured]', 'JCR-SQL2')->execute();
+
+        $stats = [
+            'nodes' => 0,
+            'ignoredNodes' => 0,
+            'properties' => 0,
+            'removedProperties' => 0,
+        ];
+
+        $io->section('Running cleanup process ...');
+        $progressBar = $io->createProgressBar();
+        $progressBar->setFormat("Nodes: %nodes%\nIngored: %ignoredNodes%\nProperties: %properties%\nRemoved properties: %removedProperties%\n\n");
+
+        $progressBar->setMessage((string) $stats['nodes'], 'nodes');
+        $progressBar->setMessage((string) $stats['ignoredNodes'], 'ignoredNodes');
+        $progressBar->setMessage((string) $stats['properties'], 'properties');
+        $progressBar->setMessage((string) $stats['removedProperties'], 'removedProperties');
+
+        $progressBar->start();
+
+        foreach ($rows->getNodes() as $node) {
+            $alias = $this->getAliasForNode($node);
+            if (null === $alias || !$this->structureMetaDataFactory->hasStructuresFor($alias)) {
+                continue;
+            }
+
+            ++$stats['nodes'];
+
+            foreach ($this->getLocales($node) as $locale) {
+                if (!$node->hasProperty($this->languagePrefix . ':' . $locale . '-template')) {
+                    continue;
+                }
+
+                $document = $this->documentManager->find($node->getIdentifier(), $locale);
+
+                $workflowStage = WorkflowStage::TEST;
+                if ($document instanceof WorkflowStageBehavior) {
+                    $workflowStage = $document->getWorkflowStage();
+                }
+
+                try {
+                    $defaultCleanupNode = new CleanupNode(clone $node);
+                    $this->persist($document, $defaultCleanupNode, $locale);
+
+                    $liveCleanupNode = new CleanupNode(clone $node);
+                    if (WorkflowStage::PUBLISHED === $workflowStage) {
+                        $this->publish($document, $liveCleanupNode, $locale);
+                    }
+
+                    $this->documentManager->clear();
+                } catch (\Exception $e) {
+                    ++$stats['ignoredNodes'];
+
+                    continue;
+                }
+
+                $writtenProperties = $defaultCleanupNode->getWrittenPropertyKeys();
+                foreach ($this->cleanupNode($node, $locale, $writtenProperties, $dryRun) as $result) {
+                    ++$stats['properties'];
+                    $stats['removedProperties'] += $result ? 1 : 0;
+                }
+
+                $liveNode = $this->liveSession->getNode($node->getPath());
+                $writtenProperties = $liveCleanupNode->getWrittenPropertyKeys();
+                foreach ($this->cleanupNode($liveNode, $locale, $writtenProperties, $dryRun) as $result) {
+                    ++$stats['properties'];
+                    $stats['removedProperties'] += $result ? 1 : 0;
+                }
+
+                $this->session->save();
+                $this->documentManager->clear();
+            }
+
+            $progressBar->setMessage((string) $stats['nodes'], 'nodes');
+            $progressBar->setMessage((string) $stats['ignoredNodes'], 'ignoredNodes');
+            $progressBar->setMessage((string) $stats['properties'], 'properties');
+            $progressBar->setMessage((string) $stats['removedProperties'], 'removedProperties');
+            $progressBar->advance();
+        }
+
+        $progressBar->finish();
+        $io->success('Cleanup process finished');
+
+        return self::SUCCESS;
+    }
+
+    private function persist($document, CleanupNode $cleanupNode, string $locale): void
+    {
+        $options = $this->getOptionsResolver(Events::PERSIST)->resolve();
+        $event = new Event\PersistEvent($document, $locale, $options);
+        $event->setNode($cleanupNode);
+        $this->documentManagerEventDispatcher->dispatch($event, Events::PERSIST);
+    }
+
+    private function publish($document, CleanupNode $cleanupNode, string $locale): void
+    {
+        $this->invalidationSubscriber->deactivate();
+        $options = $this->getOptionsResolver(Events::PUBLISH)->resolve();
+        $event = new Event\PublishEvent($document, $locale, $options);
+        $event->setNode($cleanupNode);
+        $this->documentManagerEventDispatcher->dispatch($event, Events::PUBLISH);
+        $this->invalidationSubscriber->activate();
+    }
+
+    private function cleanupNode(NodeInterface $node, string $locale, array $writtenProperties, bool $dryRun): \Generator
+    {
+        $this->logger->writeln(\sprintf("# Cleaning up node \"%s\" for locale \"%s\" in workspace \"%s\"\n", $node->getPath(), $locale, $node->getSession()->getWorkspace()->getName()));
+
+        $whiteList = \array_map(fn ($property) => $this->languagePrefix . ':' . $locale . '-' . $property, self::WHITELIST);
+        $this->logger->writeln(\sprintf("Whitelisted:\n* %s\n", \implode("\n* ", $whiteList)));
+        $this->logger->writeln(\sprintf("Written:\n* %s\n", \implode("\n* ", $writtenProperties)));
+
+        $removedProperties = [];
+        foreach ($node->getProperties() as $property) {
+            if (!\str_starts_with($property->getName(), $this->languagePrefix . ':' . $locale)) {
+                yield false;
+
+                continue;
+            }
+
+            if (\in_array($property->getName(), $writtenProperties, true)
+                || \in_array($property->getName(), $whiteList, true)
+            ) {
+                yield false;
+
+                continue;
+            }
+
+            $removedProperties[] = $property->getName();
+            if (!$dryRun) {
+                $property->remove();
+            }
+
+            yield true;
+        }
+
+        $this->logger->writeln(\sprintf("Removed:\n* %s\n", \implode("\n* ", $removedProperties)));
+    }
+
+    private function getOptionsResolver(string $eventName): OptionsResolver
+    {
+        if (isset($this->optionsResolvers[$eventName])) {
+            return $this->optionsResolvers[$eventName];
+        }
+
+        $resolver = new OptionsResolver();
+        $resolver->setDefault('locale', null);
+
+        $event = new Event\ConfigureOptionsEvent($resolver);
+        $this->documentManagerEventDispatcher->dispatch($event, Events::CONFIGURE_OPTIONS);
+
+        $this->optionsResolvers[$eventName] = $resolver;
+
+        return $resolver;
+    }
+
+    private function getLocales(NodeInterface $node)
+    {
+        $locales = [];
+
+        foreach ($node->getProperties() as $property) {
+            \preg_match(
+                \sprintf('/^%s:([a-zA-Z_]*?)-.*/', $this->languagePrefix),
+                $property->getName(),
+                $matches,
+            );
+
+            if ($matches) {
+                $locales[$matches[1]] = $matches[1];
+            }
+        }
+
+        return \array_values(\array_unique($locales));
+    }
+
+    private function getAliasForNode(NodeInterface $node): ?string
+    {
+        foreach ($node->getMixinNodeTypes() as $mixinNodeType) {
+            if (isset($this->aliasMapping[$mixinNodeType->getName()])) {
+                return $this->aliasMapping[$mixinNodeType->getName()];
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
@@ -27,6 +27,9 @@ use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 use Webmozart\Assert\Assert;
 
+/**
+ * @internal
+ */
 class PHPCRCleanupCommand extends Command
 {
     private OutputInterface $logger;

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
@@ -36,6 +36,9 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Webmozart\Assert\Assert;
 
+/**
+ * @internal
+ */
 class PHPCRCleanupSingleNodeCommand extends Command
 {
     public const IGNORED = 101;

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\DocumentManagerBundle\Command;
+
+use PHPCR\NodeInterface;
+use PHPCR\SessionInterface;
+use Sulu\Bundle\HttpCacheBundle\EventSubscriber\InvalidationSubscriber;
+use Sulu\Component\Content\Document\Behavior\WorkflowStageBehavior;
+use Sulu\Component\Content\Document\Subscriber\PHPCR\CleanupNode;
+use Sulu\Component\Content\Document\WorkflowStage;
+use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Sulu\Component\DocumentManager\Event;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\NamespaceRegistry;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class PHPCRCleanupSingleNodeCommand extends Command
+{
+    public const IGNORED = 101;
+
+    /**
+     * @var string[]
+     */
+    public const WHITELIST = [
+        'state',
+        'published',
+        'created',
+        'creator',
+        'changed',
+        'changer',
+    ];
+
+    protected static $defaultName = 'sulu:phpcr:cleanup:single-node';
+
+    private string $languagePrefix;
+
+    private array $aliasMapping = [];
+
+    /**
+     * @var array<string, OptionsResolver>
+     */
+    private array $optionsResolvers = [];
+
+    private OutputInterface $logger;
+
+    public function __construct(
+        private SessionInterface $liveSession,
+        private SessionInterface $session,
+        private StructureMetadataFactoryInterface $structureMetaDataFactory,
+        NamespaceRegistry $namespaceRegistry,
+        private EventDispatcherInterface $documentManagerEventDispatcher,
+        private DocumentManagerInterface $documentManager,
+        private InvalidationSubscriber $invalidationSubscriber,
+        array $mapping,
+    ) {
+        parent::__construct();
+
+        $this->logger = new NullOutput();
+
+        $this->languagePrefix = $namespaceRegistry->getPrefix('system_localized');
+        foreach ($mapping as $item) {
+            $this->aliasMapping[$item['phpcr_type']] = $item['alias'];
+        }
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('node', InputArgument::REQUIRED, 'Node identifier to cleanup.');
+        $this->addOption('dry-run', null, InputOption::VALUE_NONE, 'Do not make any changes to the repository.');
+        $this->addOption('debug', null, InputOption::VALUE_NONE, 'Write debug information to a file.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $debug = $input->getOption('debug');
+        if ($debug) {
+            $this->logger = $output;
+        }
+
+        $io = new SymfonyStyle($input, $output);
+
+        $dryRun = $input->getOption('dry-run');
+        $uuid = $input->getArgument('node');
+
+        $stats = [
+            'documents' => 0,
+            'properties' => 0,
+            'removedProperties' => 0,
+        ];
+
+        $node = $this->session->getNodeByIdentifier($uuid);
+        $alias = $this->getAliasForNode($node);
+        if (null === $alias || !$this->structureMetaDataFactory->hasStructuresFor($alias)) {
+            return self::IGNORED;
+        }
+
+        $locales = $this->getLocales($node);
+        if (0 === \count($locales)) {
+            return self::IGNORED;
+        }
+
+        foreach ($locales as $locale) {
+            ++$stats['documents'];
+
+            $document = $this->documentManager->find($uuid, $locale);
+
+            $workflowStage = WorkflowStage::TEST;
+            if ($document instanceof WorkflowStageBehavior) {
+                $workflowStage = $document->getWorkflowStage();
+            }
+
+            try {
+                $node = $this->session->getNodeByIdentifier($document->getUuid());
+                $defaultCleanupNode = new CleanupNode(clone $node);
+                $this->persist($document, $defaultCleanupNode, $locale);
+
+                $liveNode = $this->liveSession->getNodeByIdentifier($document->getUuid());
+                $liveCleanupNode = new CleanupNode(clone $liveNode);
+                if (WorkflowStage::PUBLISHED === $workflowStage) {
+                    $this->publish($document, $liveCleanupNode, $locale);
+                }
+
+                $this->documentManager->clear();
+            } catch (\Exception $e) {
+                return self::INVALID;
+            }
+
+            $writtenProperties = $defaultCleanupNode->getWrittenPropertyKeys();
+            foreach ($this->cleanupNode($node, $locale, $writtenProperties, $dryRun) as $result) {
+                ++$stats['properties'];
+                $stats['removedProperties'] += $result ? 1 : 0;
+            }
+
+            $liveNode = $this->liveSession->getNode($node->getPath());
+            $writtenProperties = $liveCleanupNode->getWrittenPropertyKeys();
+            foreach ($this->cleanupNode($liveNode, $locale, $writtenProperties, $dryRun) as $result) {
+                ++$stats['properties'];
+                $stats['removedProperties'] += $result ? 1 : 0;
+            }
+
+            if (!$dryRun) {
+                $this->session->save();
+                $this->liveSession->save();
+            }
+
+            $this->documentManager->clear();
+        }
+
+        $io->success(\sprintf(
+            'Cleaned up node "%s"',
+            $node->getPath(),
+        ));
+
+        $io->listing([
+            'Documents: ' . $stats['documents'],
+            'Removed properties: ' . $stats['removedProperties'],
+            'Total properties: ' . $stats['properties'],
+        ]);
+
+        return self::SUCCESS;
+    }
+
+    private function persist($document, CleanupNode $cleanupNode, string $locale): void
+    {
+        $options = $this->getOptionsResolver(Events::PERSIST)->resolve();
+        $event = new Event\PersistEvent($document, $locale, $options);
+        $event->setNode($cleanupNode);
+        $this->documentManagerEventDispatcher->dispatch($event, Events::PERSIST);
+    }
+
+    private function publish($document, CleanupNode $cleanupNode, string $locale): void
+    {
+        $this->invalidationSubscriber->deactivate();
+        $options = $this->getOptionsResolver(Events::PUBLISH)->resolve();
+        $event = new Event\PublishEvent($document, $locale, $options);
+        $event->setNode($cleanupNode);
+        $this->documentManagerEventDispatcher->dispatch($event, Events::PUBLISH);
+        $this->invalidationSubscriber->activate();
+    }
+
+    private function cleanupNode(NodeInterface $node, string $locale, array $writtenProperties, bool $dryRun): \Generator
+    {
+        $this->logger->writeln(\sprintf("# Cleaning up node \"%s\" for locale \"%s\" in workspace \"%s\"\n", $node->getPath(), $locale, $node->getSession()->getWorkspace()->getName()));
+
+        $whiteList = \array_map(fn ($property) => $this->languagePrefix . ':' . $locale . '-' . $property, self::WHITELIST);
+
+        $removedProperties = [];
+        foreach ($node->getProperties() as $property) {
+            if (!\str_starts_with($property->getName(), $this->languagePrefix . ':' . $locale . '-')) {
+                yield false;
+
+                continue;
+            }
+
+            if (\in_array($property->getName(), $writtenProperties, true)
+                || \in_array($property->getName(), $whiteList, true)
+            ) {
+                yield false;
+
+                continue;
+            }
+
+            $removedProperties[] = $property->getName();
+            if (!$dryRun) {
+                $property->remove();
+            }
+
+            yield true;
+        }
+
+        $this->logger->writeln(\sprintf("Removed:\n* %s\n", \implode("\n* ", $removedProperties)));
+    }
+
+    private function getOptionsResolver(string $eventName): OptionsResolver
+    {
+        if (isset($this->optionsResolvers[$eventName])) {
+            return $this->optionsResolvers[$eventName];
+        }
+
+        $resolver = new OptionsResolver();
+        $resolver->setDefault('locale', null);
+
+        $event = new Event\ConfigureOptionsEvent($resolver);
+        $this->documentManagerEventDispatcher->dispatch($event, Events::CONFIGURE_OPTIONS);
+
+        $this->optionsResolvers[$eventName] = $resolver;
+
+        return $resolver;
+    }
+
+    private function getLocales(NodeInterface $node): array
+    {
+        $locales = [];
+
+        foreach ($node->getProperties() as $property) {
+            \preg_match(
+                \sprintf('/^%s:([a-zA-Z_]*?)-template/', $this->languagePrefix),
+                $property->getName(),
+                $matches,
+            );
+
+            if ($matches) {
+                $locales[$matches[1]] = $matches[1];
+            }
+        }
+
+        return \array_values(\array_unique($locales));
+    }
+
+    private function getAliasForNode(NodeInterface $node): ?string
+    {
+        foreach ($node->getMixinNodeTypes() as $mixinNodeType) {
+            if (isset($this->aliasMapping[$mixinNodeType->getName()])) {
+                return $this->aliasMapping[$mixinNodeType->getName()];
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
@@ -259,7 +259,7 @@ class PHPCRCleanupSingleNodeCommand extends Command
 
         foreach ($node->getProperties() as $property) {
             \preg_match(
-                \sprintf('/^%s:([a-zA-Z_]*?)-template/', $this->languagePrefix),
+                \sprintf('/^%s:([a-zA-Z_]*?)-(template|title)/', $this->languagePrefix),
                 $property->getName(),
                 $matches,
             );

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
@@ -50,8 +50,6 @@ class PHPCRCleanupSingleNodeCommand extends Command
         'changer',
     ];
 
-    protected static $defaultName = 'sulu:phpcr:cleanup:single-node';
-
     private string $languagePrefix;
 
     private array $aliasMapping = [];
@@ -73,7 +71,7 @@ class PHPCRCleanupSingleNodeCommand extends Command
         private InvalidationSubscriber $invalidationSubscriber,
         array $mapping,
     ) {
-        parent::__construct();
+        parent::__construct('sulu:phpcr:cleanup:single-node');
 
         $this->logger = new NullOutput();
 
@@ -269,7 +267,7 @@ class PHPCRCleanupSingleNodeCommand extends Command
             }
         }
 
-        return \array_values(\array_unique($locales));
+        return \array_keys($locales);
     }
 
     private function getAliasForNode(NodeInterface $node): ?string

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/command.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/command.xml
@@ -23,7 +23,7 @@
         </service>
 
         <service id="sulu_document_manager.command.phpcr_cleanup" class="Sulu\Bundle\DocumentManagerBundle\Command\PHPCRCleanupCommand">
-            <argument type="service" id="doctrine_phpcr.live_session" />
+            <argument type="service" id="doctrine_phpcr.default_session" />
             <argument type="service" id="sulu_core.webspace.webspace_manager" />
             <argument type="service" id="services_resetter" />
             <argument>%kernel.project_dir%</argument>

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/command.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/command.xml
@@ -24,6 +24,7 @@
 
         <service id="sulu_document_manager.command.phpcr_cleanup" class="Sulu\Bundle\DocumentManagerBundle\Command\PHPCRCleanupCommand">
             <argument type="service" id="doctrine_phpcr.live_session" />
+            <argument type="service" id="sulu_core.webspace.webspace_manager" />
             <argument type="service" id="services_resetter" />
             <argument>%kernel.project_dir%</argument>
 

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/command.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/command.xml
@@ -21,5 +21,19 @@
 
             <tag name="console.command" />
         </service>
+
+        <service id="sulu_document_manager.command.phpcr_cleanup" class="Sulu\Bundle\DocumentManagerBundle\Command\PHPCRCleanupCommand">
+            <argument type="service" id="doctrine_phpcr.live_session" />
+            <argument type="service" id="doctrine_phpcr.default_session" />
+            <argument type="service" id="sulu_document_manager.namespace_registry" />
+            <argument type="service" id="sulu_document_manager.event_dispatcher.standard" />
+            <argument type="service" id="sulu_document_manager.document_manager" />
+            <argument type="service" id="sulu_page.structure.factory" />
+            <argument type="service" id="sulu_http_cache.event_subscriber.invalidation" />
+            <argument>%kernel.project_dir%</argument>
+            <argument>%sulu_document_manager.mapping%</argument>
+
+            <tag name="console.command" />
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/command.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/command.xml
@@ -26,7 +26,7 @@
             <argument type="service" id="doctrine_phpcr.live_session" />
             <argument type="service" id="doctrine_phpcr.default_session" />
             <argument type="service" id="sulu_document_manager.namespace_registry" />
-            <argument type="service" id="sulu_document_manager.event_dispatcher.standard" />
+            <argument type="service" id="sulu_document_manager.event_dispatcher" />
             <argument type="service" id="sulu_document_manager.document_manager" />
             <argument type="service" id="sulu_page.structure.factory" />
             <argument type="service" id="sulu_http_cache.event_subscriber.invalidation" />

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/command.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/command.xml
@@ -24,13 +24,20 @@
 
         <service id="sulu_document_manager.command.phpcr_cleanup" class="Sulu\Bundle\DocumentManagerBundle\Command\PHPCRCleanupCommand">
             <argument type="service" id="doctrine_phpcr.live_session" />
+            <argument type="service" id="services_resetter" />
+            <argument>%kernel.project_dir%</argument>
+
+            <tag name="console.command" />
+        </service>
+
+        <service id="sulu_document_manager.command.phpcr_cleanup_single_node" class="Sulu\Bundle\DocumentManagerBundle\Command\PHPCRCleanupSingleNodeCommand">
+            <argument type="service" id="doctrine_phpcr.live_session" />
             <argument type="service" id="doctrine_phpcr.default_session" />
+            <argument type="service" id="sulu_page.structure.factory" />
             <argument type="service" id="sulu_document_manager.namespace_registry" />
             <argument type="service" id="sulu_document_manager.event_dispatcher" />
             <argument type="service" id="sulu_document_manager.document_manager" />
-            <argument type="service" id="sulu_page.structure.factory" />
             <argument type="service" id="sulu_http_cache.event_subscriber.invalidation" />
-            <argument>%kernel.project_dir%</argument>
             <argument>%sulu_document_manager.mapping%</argument>
 
             <tag name="console.command" />

--- a/src/Sulu/Bundle/HttpCacheBundle/EventSubscriber/InvalidationSubscriber.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/EventSubscriber/InvalidationSubscriber.php
@@ -81,6 +81,11 @@ class InvalidationSubscriber implements EventSubscriberInterface
     private $environment;
 
     /**
+     * @var bool
+     */
+    private $activated = true;
+
+    /**
      * @param string $environment - kernel envionment, dev, prod, etc
      */
     public function __construct(
@@ -103,6 +108,16 @@ class InvalidationSubscriber implements EventSubscriberInterface
         $this->environment = $environment;
     }
 
+    public function deactivate(): void
+    {
+        $this->activated = false;
+    }
+
+    public function activate(): void
+    {
+        $this->activated = true;
+    }
+
     public static function getSubscribedEvents()
     {
         return [
@@ -120,6 +135,10 @@ class InvalidationSubscriber implements EventSubscriberInterface
      */
     public function invalidateDocumentBeforePublishing(PublishEvent $event)
     {
+        if (false === $this->activated) {
+            return;
+        }
+
         $document = $event->getDocument();
 
         if ($document instanceof StructureBehavior) {
@@ -145,6 +164,10 @@ class InvalidationSubscriber implements EventSubscriberInterface
      */
     public function invalidateDocumentBeforeUnpublishing(UnpublishEvent $event)
     {
+        if (false === $this->activated) {
+            return;
+        }
+
         $document = $event->getDocument();
 
         if ($document instanceof StructureBehavior) {
@@ -166,6 +189,10 @@ class InvalidationSubscriber implements EventSubscriberInterface
      */
     public function invalidateDocumentBeforeRemoving(RemoveEvent $event)
     {
+        if (false === $this->activated) {
+            return;
+        }
+
         $document = $event->getDocument();
 
         if ($document instanceof StructureBehavior) {
@@ -186,6 +213,10 @@ class InvalidationSubscriber implements EventSubscriberInterface
      */
     public function invalidateDocumentBeforeRemovingLocale(RemoveLocaleEvent $event)
     {
+        if (false === $this->activated) {
+            return;
+        }
+
         $document = $event->getDocument();
 
         if ($document instanceof StructureBehavior) {

--- a/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/EventSubscriber/InvalidationSubscriberTest.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/EventSubscriber/InvalidationSubscriberTest.php
@@ -160,6 +160,7 @@ class InvalidationSubscriberTest extends TestCase
 
         $event = $this->prophesize(PublishEvent::class);
         $event->getDocument()->willReturn($document);
+        $event->getOption(InvalidationSubscriber::HTTP_CACHE_INVALIDATION_OPTION, true)->willReturn(true);
 
         $structureMetadata = $this->prophesize(StructureMetadata::class);
         $this->documentInspector->getStructureMetadata($document)->willReturn($structureMetadata);
@@ -216,6 +217,7 @@ class InvalidationSubscriberTest extends TestCase
 
         $event = $this->prophesize(PublishEvent::class);
         $event->getDocument()->willReturn($document);
+        $event->getOption(InvalidationSubscriber::HTTP_CACHE_INVALIDATION_OPTION, true)->willReturn(true);
 
         $structureMetadata = $this->prophesize(StructureMetadata::class);
         $this->documentInspector->getStructureMetadata($document)->willReturn($structureMetadata);
@@ -252,6 +254,7 @@ class InvalidationSubscriberTest extends TestCase
 
         $event = $this->prophesize(PublishEvent::class);
         $event->getDocument()->willReturn($document);
+        $event->getOption(InvalidationSubscriber::HTTP_CACHE_INVALIDATION_OPTION, true)->willReturn(true);
 
         $structureMetadata = $this->prophesize(StructureMetadata::class);
         $this->documentInspector->getStructureMetadata($document)->willReturn($structureMetadata);
@@ -274,6 +277,7 @@ class InvalidationSubscriberTest extends TestCase
         $document = new \stdClass();
         $event = $this->prophesize(PublishEvent::class);
         $event->getDocument()->willReturn($document);
+        $event->getOption(InvalidationSubscriber::HTTP_CACHE_INVALIDATION_OPTION, true)->willReturn(true);
 
         $this->cacheManager->invalidatePath(Argument::any())->shouldNotBeCalled();
 
@@ -309,6 +313,7 @@ class InvalidationSubscriberTest extends TestCase
 
         $event = $this->prophesize(UnpublishEvent::class);
         $event->getDocument()->willReturn($document);
+        $event->getOption(InvalidationSubscriber::HTTP_CACHE_INVALIDATION_OPTION, true)->willReturn(true);
 
         $structureMetadata = $this->prophesize(StructureMetadata::class);
         $this->documentInspector->getStructureMetadata($document)->willReturn($structureMetadata);
@@ -362,6 +367,7 @@ class InvalidationSubscriberTest extends TestCase
 
         $event = $this->prophesize(UnpublishEvent::class);
         $event->getDocument()->willReturn($document);
+        $event->getOption(InvalidationSubscriber::HTTP_CACHE_INVALIDATION_OPTION, true)->willReturn(true);
 
         $structureMetadata = $this->prophesize(StructureMetadata::class);
         $this->documentInspector->getStructureMetadata($document)->willReturn($structureMetadata);
@@ -384,6 +390,7 @@ class InvalidationSubscriberTest extends TestCase
         $document = new \stdClass();
         $event = $this->prophesize(PublishEvent::class);
         $event->getDocument()->willReturn($document);
+        $event->getOption(InvalidationSubscriber::HTTP_CACHE_INVALIDATION_OPTION, true)->willReturn(true);
 
         $this->cacheManager->invalidatePath(Argument::any())->shouldNotBeCalled();
 
@@ -421,6 +428,7 @@ class InvalidationSubscriberTest extends TestCase
 
         $event = $this->prophesize(RemoveEvent::class);
         $event->getDocument()->willReturn($document);
+        $event->getOption(InvalidationSubscriber::HTTP_CACHE_INVALIDATION_OPTION, true)->willReturn(true);
 
         $structureMetadata = $this->prophesize(StructureMetadata::class);
         $this->documentInspector->getStructureMetadata($document)->willReturn($structureMetadata);
@@ -512,6 +520,7 @@ class InvalidationSubscriberTest extends TestCase
         $event = $this->prophesize(RemoveLocaleEvent::class);
         $event->getDocument()->willReturn($document);
         $event->getLocale()->willReturn('en');
+        $event->getOption(InvalidationSubscriber::HTTP_CACHE_INVALIDATION_OPTION, true)->willReturn(true);
 
         $structureMetadata = $this->prophesize(StructureMetadata::class);
         $this->documentInspector->getStructureMetadata($document)->willReturn($structureMetadata);
@@ -567,6 +576,7 @@ class InvalidationSubscriberTest extends TestCase
         $document->getWebspaceName()->willReturn('sulu')->shouldBeCalled();
         $this->documentInspector->getPublishedLocales($document->reveal())->willReturn(['de']);
         $event->getDocument()->willReturn($document->reveal());
+        $event->getOption(InvalidationSubscriber::HTTP_CACHE_INVALIDATION_OPTION, true)->willReturn(true);
 
         $this->resourceLocatorStrategy->loadByContentUuid(Argument::cetera())
             ->willThrow(ResourceLocatorNotFoundException::class)->shouldBeCalled();
@@ -580,9 +590,50 @@ class InvalidationSubscriberTest extends TestCase
         $document = new \stdClass();
         $event = $this->prophesize(RemoveEvent::class);
         $event->getDocument()->willReturn($document);
+        $event->getOption(InvalidationSubscriber::HTTP_CACHE_INVALIDATION_OPTION, true)->willReturn(true);
 
         $this->cacheManager->invalidatePath(Argument::any())->shouldNotBeCalled();
 
         $this->invalidationSubscriber->invalidateDocumentBeforeRemoving($event->reveal());
+    }
+
+    public function testInvalidateDocumentBeforePublishingNoInvalidation(): void
+    {
+        $event = $this->prophesize(PublishEvent::class);
+        $event->getOption(InvalidationSubscriber::HTTP_CACHE_INVALIDATION_OPTION, true)->willReturn(false);
+
+        $this->cacheManager->invalidatePath(Argument::any())->shouldNotBeCalled();
+
+        $this->invalidationSubscriber->invalidateDocumentBeforePublishing($event->reveal());
+    }
+
+    public function testInvalidateDocumentBeforeUnpublishingNoInvalidation(): void
+    {
+        $event = $this->prophesize(UnpublishEvent::class);
+        $event->getOption(InvalidationSubscriber::HTTP_CACHE_INVALIDATION_OPTION, true)->willReturn(false);
+
+        $this->cacheManager->invalidatePath(Argument::any())->shouldNotBeCalled();
+
+        $this->invalidationSubscriber->invalidateDocumentBeforeUnpublishing($event->reveal());
+    }
+
+    public function testInvalidateDocumentBeforeRemovingNoInvalidation(): void
+    {
+        $event = $this->prophesize(RemoveEvent::class);
+        $event->getOption(InvalidationSubscriber::HTTP_CACHE_INVALIDATION_OPTION, true)->willReturn(false);
+
+        $this->cacheManager->invalidatePath(Argument::any())->shouldNotBeCalled();
+
+        $this->invalidationSubscriber->invalidateDocumentBeforeRemoving($event->reveal());
+    }
+
+    public function testInvalidateDocumentBeforeRemovingLocaleNoInvalidation(): void
+    {
+        $event = $this->prophesize(RemoveLocaleEvent::class);
+        $event->getOption(InvalidationSubscriber::HTTP_CACHE_INVALIDATION_OPTION, true)->willReturn(false);
+
+        $this->cacheManager->invalidatePath(Argument::any())->shouldNotBeCalled();
+
+        $this->invalidationSubscriber->invalidateDocumentBeforeRemovingLocale($event->reveal());
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Document/Subscriber/PublishSubscriber.php
+++ b/src/Sulu/Bundle/PageBundle/Document/Subscriber/PublishSubscriber.php
@@ -170,6 +170,8 @@ class PublishSubscriber implements EventSubscriberInterface
      */
     public function setNodeFromPublicWorkspaceForPublishing(PublishEvent $event)
     {
+        // if the node is already set by another subscriber or to the event directly, we don't need to do anything.
+        // One possible reason is the phpcr-cleanup command, which sets the node directly to the event.
         if ($event->hasNode()) {
             return;
         }

--- a/src/Sulu/Bundle/PageBundle/Document/Subscriber/PublishSubscriber.php
+++ b/src/Sulu/Bundle/PageBundle/Document/Subscriber/PublishSubscriber.php
@@ -170,6 +170,10 @@ class PublishSubscriber implements EventSubscriberInterface
      */
     public function setNodeFromPublicWorkspaceForPublishing(PublishEvent $event)
     {
+        if ($event->getNode()) {
+            return;
+        }
+
         $this->setNodeFromPublicWorkspace($event);
     }
 

--- a/src/Sulu/Bundle/PageBundle/Document/Subscriber/PublishSubscriber.php
+++ b/src/Sulu/Bundle/PageBundle/Document/Subscriber/PublishSubscriber.php
@@ -170,7 +170,7 @@ class PublishSubscriber implements EventSubscriberInterface
      */
     public function setNodeFromPublicWorkspaceForPublishing(PublishEvent $event)
     {
-        if ($event->getNode()) {
+        if ($event->hasNode()) {
             return;
         }
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Document/Subscriber/PublishSubscriberTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Document/Subscriber/PublishSubscriberTest.php
@@ -380,11 +380,28 @@ class PublishSubscriberTest extends TestCase
         $document->getPath()->willReturn('/cmf/sulu');
 
         $event = $this->prophesize(PublishEvent::class);
+        $event->hasNode()->willReturn(false);
         $event->getDocument()->willReturn($document->reveal());
 
         $this->liveSession->getNode('/cmf/sulu')->willReturn($this->node->reveal());
 
         $event->setNode($this->node->reveal())->shouldBeCalled();
+
+        $this->publishSubscriber->setNodeFromPublicWorkspaceForPublishing($event->reveal());
+    }
+
+    public function testSetNodeFromPublicWorkspaceForPublishingAlreadySet(): void
+    {
+        $document = $this->prophesize(PathBehavior::class);
+        $document->getPath()->willReturn('/cmf/sulu');
+
+        $event = $this->prophesize(PublishEvent::class);
+        $event->hasNode()->willReturn(true);
+        $event->getDocument()->willReturn($document->reveal());
+
+        $this->liveSession->getNode('/cmf/sulu')->shouldNotBeCalled();
+
+        $event->setNode(Argument::any())->shouldNotBeCalled();
 
         $this->publishSubscriber->setNodeFromPublicWorkspaceForPublishing($event->reveal());
     }

--- a/src/Sulu/Bundle/RouteBundle/Content/Type/PageTreeRouteContentType.php
+++ b/src/Sulu/Bundle/RouteBundle/Content/Type/PageTreeRouteContentType.php
@@ -144,18 +144,22 @@ class PageTreeRouteContentType extends SimpleContentType
         $node->setProperty($propertyName . '-suffix', $suffix);
 
         $pagePropertyName = $propertyName . '-page';
-        if ($node->hasProperty($pagePropertyName)) {
-            $node->getProperty($pagePropertyName)->remove();
-        }
-
+        $pagePathPropertyName = $pagePropertyName . '-path';
         if (!$page['uuid']) {
+            if ($node->hasProperty($pagePropertyName)) {
+                $node->getProperty($pagePropertyName)->remove();
+            }
+            if ($node->hasProperty($pagePathPropertyName)) {
+                $node->getProperty($pagePathPropertyName)->remove();
+            }
+
             // no parent-page given
 
             return;
         }
 
         $node->setProperty($pagePropertyName, $page['uuid']);
-        $node->setProperty($pagePropertyName . '-path', $page['path']);
+        $node->setProperty($pagePathPropertyName, $page['path']);
     }
 
     public function getContentData(PropertyInterface $property)

--- a/src/Sulu/Bundle/RouteBundle/Tests/Functional/Content/PageTreeRouteContentTypeTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Functional/Content/PageTreeRouteContentTypeTest.php
@@ -249,6 +249,7 @@ class PageTreeRouteContentTypeTest extends TestCase
         $this->node->setProperty($this->propertyName . '-suffix', '/')->shouldBeCalled();
 
         $this->node->hasProperty($this->propertyName . '-page')->willReturn(false);
+        $this->node->hasProperty($this->propertyName . '-page-path')->willReturn(false);
 
         $this->contentType->write(
             $this->node->reveal(),
@@ -275,14 +276,10 @@ class PageTreeRouteContentTypeTest extends TestCase
 
         $this->node->setProperty($this->propertyName, $value['path'])->shouldBeCalled();
         $this->node->setProperty($this->propertyName . '-suffix', $value['suffix'])->shouldBeCalled();
-        $this->node->setProperty($this->propertyName . '-page', $value['page']['uuid'])
-            ->shouldBeCalled();
+        $this->node->setProperty($this->propertyName . '-page', $value['page']['uuid'])->shouldBeCalled();
         $this->node->setProperty($this->propertyName . '-page-path', $value['page']['path'])->shouldBeCalled();
 
-        $pageProperty = $this->prophesize(\PHPCR\PropertyInterface::class);
-        $pageProperty->remove()->shouldBeCalled();
         $this->node->hasProperty($this->propertyName . '-page')->willReturn(true);
-        $this->node->getProperty($this->propertyName . '-page')->willReturn($pageProperty->reveal());
 
         $this->contentType->write(
             $this->node->reveal(),
@@ -328,11 +325,6 @@ class PageTreeRouteContentTypeTest extends TestCase
             ->shouldBeCalled();
         $this->node->setProperty($this->propertyName . '-page-path', $value['page']['path'])->shouldBeCalled();
 
-        $pageProperty = $this->prophesize(\PHPCR\PropertyInterface::class);
-        $pageProperty->remove()->shouldBeCalled();
-        $this->node->hasProperty($this->propertyName . '-page')->willReturn(true);
-        $this->node->getProperty($this->propertyName . '-page')->willReturn($pageProperty->reveal());
-
         $this->contentType->write(
             $this->node->reveal(),
             $this->property->reveal(),
@@ -377,10 +369,52 @@ class PageTreeRouteContentTypeTest extends TestCase
             ->shouldBeCalled();
         $this->node->setProperty($this->propertyName . '-page-path', $value['page']['path'])->shouldBeCalled();
 
+        $this->node->hasProperty($this->propertyName . '-page')->willReturn(true);
+
+        $this->contentType->write(
+            $this->node->reveal(),
+            $this->property->reveal(),
+            1,
+            $this->webspaceKey,
+            $this->locale,
+            null
+        );
+    }
+
+    public function testWriteNoParentPage(): void
+    {
+        $route = $this->prophesize(RouteInterface::class);
+        $route->getPath()->willReturn('/');
+        $route->setPath('/')->shouldBeCalled();
+
+        $this->routeRepository->createNew()->willReturn($route);
+        $this->conflictResolver->resolve($route)->shouldBeCalled()->willReturn($route);
+
+        $document = $this->prophesize(RoutableBehavior::class);
+        $this->chainRouteGenerator->generate($document->reveal())->willReturn($route->reveal());
+        $this->documentRegistry->getDocumentForNode($this->node->reveal(), $this->locale)
+            ->willReturn($document->reveal());
+
+        $value = [
+            'page' => [
+                'uuid' => null,
+                'path' => null,
+            ],
+        ];
+
+        $this->node->setProperty($this->propertyName, '/')->shouldBeCalled();
+        $this->node->setProperty($this->propertyName . '-suffix', '/')->shouldBeCalled();
+
         $pageProperty = $this->prophesize(\PHPCR\PropertyInterface::class);
         $pageProperty->remove()->shouldBeCalled();
+        $pagePathProperty = $this->prophesize(\PHPCR\PropertyInterface::class);
+        $pagePathProperty->remove()->shouldBeCalled();
         $this->node->hasProperty($this->propertyName . '-page')->willReturn(true);
         $this->node->getProperty($this->propertyName . '-page')->willReturn($pageProperty->reveal());
+        $this->node->hasProperty($this->propertyName . '-page-path')->willReturn(true);
+        $this->node->getProperty($this->propertyName . '-page-path')->willReturn($pagePathProperty->reveal());
+
+        $this->property->getValue()->willReturn($value);
 
         $this->contentType->write(
             $this->node->reveal(),

--- a/src/Sulu/Component/Content/Document/Subscriber/PHPCR/CleanupNode.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/PHPCR/CleanupNode.php
@@ -297,6 +297,7 @@ class CleanupNode implements \IteratorAggregate, NodeInterface
         return $this->node->getAllowedLifecycleTransitions();
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->node->getIterator();

--- a/src/Sulu/Component/Content/Document/Subscriber/PHPCR/CleanupNode.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/PHPCR/CleanupNode.php
@@ -133,7 +133,7 @@ class CleanupNode implements \IteratorAggregate, NodeInterface
         return $this->node->getProperty($relPath);
     }
 
-    public function getPropertyValue($name, $type = PropertyType::UNDEFINED)
+    public function getPropertyValue($name, $type = null)
     {
         return $this->node->getPropertyValue($name, $type);
     }

--- a/src/Sulu/Component/Content/Document/Subscriber/PHPCR/CleanupNode.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/PHPCR/CleanupNode.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Sulu\Component\Content\Document\Subscriber\PHPCR;
 
 use PHPCR\ItemInterface;
@@ -18,7 +27,7 @@ class CleanupNode implements \IteratorAggregate, NodeInterface
 
     public function getWrittenPropertyKeys()
     {
-        return array_keys($this->writtenProperties);
+        return \array_keys($this->writtenProperties);
     }
 
     public function getPath()

--- a/src/Sulu/Component/Content/Document/Subscriber/PHPCR/CleanupNode.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/PHPCR/CleanupNode.php
@@ -1,0 +1,295 @@
+<?php
+
+namespace Sulu\Component\Content\Document\Subscriber\PHPCR;
+
+use PHPCR\ItemInterface;
+use PHPCR\ItemVisitorInterface;
+use PHPCR\NodeInterface;
+use PHPCR\PropertyType;
+
+class CleanupNode implements \IteratorAggregate, NodeInterface
+{
+    private array $writtenProperties = [];
+
+    public function __construct(
+        private NodeInterface $node,
+    ) {
+    }
+
+    public function getWrittenPropertyKeys()
+    {
+        return array_keys($this->writtenProperties);
+    }
+
+    public function getPath()
+    {
+        return $this->node->getPath();
+    }
+
+    public function getName()
+    {
+        return $this->node->getName();
+    }
+
+    public function getAncestor($depth)
+    {
+        return $this->node->getAncestor($depth);
+    }
+
+    public function getParent()
+    {
+        return $this->node->getParent();
+    }
+
+    public function getDepth()
+    {
+        return $this->node->getDepth();
+    }
+
+    public function getSession()
+    {
+        return $this->node->getSession();
+    }
+
+    public function isNode()
+    {
+        return $this->node->isNode();
+    }
+
+    public function isNew()
+    {
+        return $this->node->isNew();
+    }
+
+    public function isModified()
+    {
+        return $this->node->isModified();
+    }
+
+    public function isSame(ItemInterface $otherItem)
+    {
+        return $this->node->isSame($otherItem);
+    }
+
+    public function accept(ItemVisitorInterface $visitor)
+    {
+        $this->node->accept($visitor);
+    }
+
+    public function revert()
+    {
+        $this->node->revert();
+    }
+
+    public function remove()
+    {
+        $this->node->remove();
+    }
+
+    public function addNode($relPath, $primaryNodeTypeName = null)
+    {
+        return $this->node->addNode($relPath, $primaryNodeTypeName);
+    }
+
+    public function addNodeAutoNamed($nameHint = null, $primaryNodeTypeName = null)
+    {
+        return $this->node->addNodeAutoNamed($nameHint, $primaryNodeTypeName);
+    }
+
+    public function orderBefore($srcChildRelPath, $destChildRelPath)
+    {
+        $this->node->orderBefore($srcChildRelPath, $destChildRelPath);
+    }
+
+    public function rename($newName)
+    {
+        $this->node->rename($newName);
+    }
+
+    public function setProperty($name, $value, $type = PropertyType::UNDEFINED)
+    {
+        $this->writtenProperties[$name] = ['value' => $value, 'type' => $type];
+
+        return $this->node->setProperty($name, $value, $type);
+    }
+
+    public function getNode($relPath)
+    {
+        return $this->node->getNode($relPath);
+    }
+
+    public function getNodes($nameFilter = null, $typeFilter = null)
+    {
+        return $this->node->getNodes($nameFilter, $typeFilter);
+    }
+
+    public function getNodeNames($nameFilter = null, $typeFilter = null)
+    {
+        return $this->node->getNodeNames($nameFilter, $typeFilter);
+    }
+
+    public function getProperty($relPath)
+    {
+        return $this->node->getProperty($relPath);
+    }
+
+    public function getPropertyValue($name, $type = PropertyType::UNDEFINED)
+    {
+        return $this->node->getPropertyValue($name, $type);
+    }
+
+    public function getPropertyValueWithDefault($relPath, $defaultValue)
+    {
+        return $this->node->getPropertyValueWithDefault($relPath, $defaultValue);
+    }
+
+    public function getProperties($nameFilter = null)
+    {
+        return $this->node->getProperties($nameFilter);
+    }
+
+    public function getPropertiesValues($nameFilter = null, $dereference = true)
+    {
+        return $this->node->getPropertiesValues($nameFilter, $dereference);
+    }
+
+    public function getPrimaryItem()
+    {
+        return $this->node->getPrimaryItem();
+    }
+
+    public function getIdentifier()
+    {
+        return $this->node->getIdentifier();
+    }
+
+    public function getIndex()
+    {
+        return $this->node->getIndex();
+    }
+
+    public function getReferences($name = null)
+    {
+        return $this->node->getReferences($name);
+    }
+
+    public function getWeakReferences($name = null)
+    {
+        return $this->node->getWeakReferences($name);
+    }
+
+    public function hasNode($relPath)
+    {
+        return $this->node->hasNode($relPath);
+    }
+
+    public function hasProperty($relPath)
+    {
+        return $this->node->hasProperty($relPath);
+    }
+
+    public function hasNodes()
+    {
+        return $this->node->hasNodes();
+    }
+
+    public function hasProperties()
+    {
+        return $this->node->hasProperties();
+    }
+
+    public function getPrimaryNodeType()
+    {
+        return $this->node->getPrimaryNodeType();
+    }
+
+    public function getMixinNodeTypes()
+    {
+        return $this->node->getMixinNodeTypes();
+    }
+
+    public function isNodeType($nodeTypeName)
+    {
+        return $this->node->isNodeType($nodeTypeName);
+    }
+
+    public function setPrimaryType($nodeTypeName)
+    {
+        $this->node->setPrimaryType($nodeTypeName);
+    }
+
+    public function addMixin($mixinName)
+    {
+        $this->node->addMixin($mixinName);
+    }
+
+    public function removeMixin($mixinName)
+    {
+        $this->node->removeMixin($mixinName);
+    }
+
+    public function setMixins(array $mixinNames)
+    {
+        $this->node->setMixins($mixinNames);
+    }
+
+    public function canAddMixin($mixinName)
+    {
+        return $this->node->canAddMixin($mixinName);
+    }
+
+    public function getDefinition()
+    {
+        return $this->node->getDefinition();
+    }
+
+    public function update($srcWorkspace)
+    {
+        $this->node->update($srcWorkspace);
+    }
+
+    public function getCorrespondingNodePath($workspaceName)
+    {
+        return $this->node->getCorrespondingNodePath($workspaceName);
+    }
+
+    public function getSharedSet()
+    {
+        return $this->node->getSharedSet();
+    }
+
+    public function removeSharedSet()
+    {
+        $this->node->removeSharedSet();
+    }
+
+    public function removeShare()
+    {
+        $this->node->removeShare();
+    }
+
+    public function isCheckedOut()
+    {
+        return $this->node->isCheckedOut();
+    }
+
+    public function isLocked()
+    {
+        return $this->node->isLocked();
+    }
+
+    public function followLifecycleTransition($transition)
+    {
+        $this->node->followLifecycleTransition($transition);
+    }
+
+    public function getAllowedLifecycleTransitions()
+    {
+        return $this->node->getAllowedLifecycleTransitions();
+    }
+
+    public function getIterator()
+    {
+        return $this->node->getIterator();
+    }
+}

--- a/src/Sulu/Component/Content/Document/Subscriber/ShadowCopyPropertiesSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ShadowCopyPropertiesSubscriber.php
@@ -83,7 +83,7 @@ class ShadowCopyPropertiesSubscriber implements EventSubscriberInterface
 
         foreach ($node->getProperties(self::SHADOW_BASE_PROPERTY) as $name => $property) {
             $locale = $this->getLocale($name);
-            if ($node->getPropertyValueWithDefault(sprintf(self::SHADOW_ON_PROPERTY, $locale), false)
+            if ($node->getPropertyValueWithDefault(\sprintf(self::SHADOW_ON_PROPERTY, $locale), false)
                 && $property->getValue() === $document->getLocale()
             ) {
                 $locale = $this->getLocale($property->getName());

--- a/src/Sulu/Component/Content/Document/Subscriber/ShadowCopyPropertiesSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ShadowCopyPropertiesSubscriber.php
@@ -26,6 +26,8 @@ class ShadowCopyPropertiesSubscriber implements EventSubscriberInterface
 {
     public const SHADOW_BASE_PROPERTY = 'i18n:*-shadow-base';
 
+    public const SHADOW_ON_PROPERTY = 'i18n:%s-shadow-on';
+
     public const TAGS_PROPERTY = 'i18n:%s-excerpt-tags';
 
     public const CATEGORIES_PROPERTY = 'i18n:%s-excerpt-categories';
@@ -79,8 +81,11 @@ class ShadowCopyPropertiesSubscriber implements EventSubscriberInterface
         $categories = $this->getCategories($node, $document->getLocale());
         $navigationContext = $this->getNavigationContext($node, $document->getLocale());
 
-        foreach ($node->getProperties(self::SHADOW_BASE_PROPERTY) as $property) {
-            if ($property->getValue() === $document->getLocale()) {
+        foreach ($node->getProperties(self::SHADOW_BASE_PROPERTY) as $name => $property) {
+            $locale = $this->getLocale($name);
+            if ($node->getPropertyValueWithDefault(sprintf(self::SHADOW_ON_PROPERTY, $locale), false)
+                && $property->getValue() === $document->getLocale()
+            ) {
                 $locale = $this->getLocale($property->getName());
 
                 $node->setProperty(\sprintf(self::TAGS_PROPERTY, $locale), $tags);

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/ShadowCopyPropertiesSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/ShadowCopyPropertiesSubscriberTest.php
@@ -52,6 +52,8 @@ class ShadowCopyPropertiesSubscriberTest extends SubscriberTestCase
 
         $this->document->getLocale()->willReturn('en');
 
+        $this->node->getPropertyValueWithDefault('i18n:de-shadow-on', false)->willReturn(true);
+
         $this->node->getPropertyValueWithDefault('i18n:en-excerpt-tags', [])->willReturn([1, 2, 3]);
         $this->node->getPropertyValueWithDefault('i18n:en-excerpt-categories', [])->willReturn([3, 2, 1]);
         $this->node->getPropertyValueWithDefault('i18n:en-navContexts', [])->willReturn(['main']);
@@ -60,7 +62,30 @@ class ShadowCopyPropertiesSubscriberTest extends SubscriberTestCase
         $this->node->setProperty('i18n:de-excerpt-categories', [3, 2, 1])->shouldBeCalled();
         $this->node->setProperty('i18n:de-navContexts', ['main'])->shouldBeCalled();
 
-        $this->node->getProperties('i18n:*-shadow-base')->willReturn([$property->reveal()]);
+        $this->node->getProperties('i18n:*-shadow-base')->willReturn(['i18n:de-shadow-base' => $property->reveal()]);
+
+        $this->subscriber->copyToShadows($this->document->reveal(), $this->node->reveal());
+    }
+
+    public function testCopyToShadowsNoShadow(): void
+    {
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getName()->willReturn('i18n:de-shadow-base');
+        $property->getValue()->willReturn('en');
+
+        $this->document->getLocale()->willReturn('en');
+
+        $this->node->getPropertyValueWithDefault('i18n:de-shadow-on', false)->willReturn(false);
+
+        $this->node->getPropertyValueWithDefault('i18n:en-excerpt-tags', [])->willReturn([1, 2, 3]);
+        $this->node->getPropertyValueWithDefault('i18n:en-excerpt-categories', [])->willReturn([3, 2, 1]);
+        $this->node->getPropertyValueWithDefault('i18n:en-navContexts', [])->willReturn(['main']);
+
+        $this->node->setProperty('i18n:de-excerpt-tags', [1, 2, 3])->shouldNotBeCalled();
+        $this->node->setProperty('i18n:de-excerpt-categories', [3, 2, 1])->shouldNotBeCalled();
+        $this->node->setProperty('i18n:de-navContexts', ['main'])->shouldNotBeCalled();
+
+        $this->node->getProperties('i18n:*-shadow-base')->willReturn(['i18n:de-shadow-base' => $property->reveal()]);
 
         $this->subscriber->copyToShadows($this->document->reveal(), $this->node->reveal());
     }
@@ -77,6 +102,9 @@ class ShadowCopyPropertiesSubscriberTest extends SubscriberTestCase
 
         $this->document->getLocale()->willReturn('en');
 
+        $this->node->getPropertyValueWithDefault('i18n:de-shadow-on', false)->willReturn(true);
+        $this->node->getPropertyValueWithDefault('i18n:en_us-shadow-on', false)->willReturn(true);
+
         $this->node->getPropertyValueWithDefault('i18n:en-excerpt-tags', [])->willReturn([1, 2, 3]);
         $this->node->getPropertyValueWithDefault('i18n:en-excerpt-categories', [])->willReturn([3, 2, 1]);
         $this->node->getPropertyValueWithDefault('i18n:en-navContexts', [])->willReturn(['main']);
@@ -89,7 +117,7 @@ class ShadowCopyPropertiesSubscriberTest extends SubscriberTestCase
         $this->node->setProperty('i18n:en_us-excerpt-categories', [3, 2, 1])->shouldBeCalled();
         $this->node->setProperty('i18n:en_us-navContexts', ['main'])->shouldBeCalled();
 
-        $this->node->getProperties('i18n:*-shadow-base')->willReturn([$property1->reveal(), $property2->reveal()]);
+        $this->node->getProperties('i18n:*-shadow-base')->willReturn(['i18n:de-shadow-base' => $property1->reveal(), 'i18n:en_us-shadow-base' => $property2->reveal()]);
 
         $this->subscriber->copyToShadows($this->document->reveal(), $this->node->reveal());
     }
@@ -124,32 +152,6 @@ class ShadowCopyPropertiesSubscriberTest extends SubscriberTestCase
         $this->node->setProperty('i18n:de-excerpt-tags', [1, 2, 3])->shouldBeCalled();
         $this->node->setProperty('i18n:de-excerpt-categories', [3, 2, 1])->shouldBeCalled();
         $this->node->setProperty('i18n:de-navContexts', ['main'])->shouldBeCalled();
-
-        $this->persistEvent->getDocument()->willReturn($this->document->reveal());
-        $this->persistEvent->getNode()->willReturn($this->node->reveal());
-
-        $this->subscriber->copyShadowProperties($this->persistEvent->reveal());
-    }
-
-    public function testHandlePersistNotShadow(): void
-    {
-        $this->document->isShadowLocaleEnabled()->willReturn(false);
-
-        $property = $this->prophesize(PropertyInterface::class);
-        $property->getName()->willReturn('i18n:de-shadow-base');
-        $property->getValue()->willReturn('en');
-
-        $this->document->getLocale()->willReturn('en');
-
-        $this->node->getPropertyValueWithDefault('i18n:en-excerpt-tags', [])->willReturn([1, 2, 3]);
-        $this->node->getPropertyValueWithDefault('i18n:en-excerpt-categories', [])->willReturn([3, 2, 1]);
-        $this->node->getPropertyValueWithDefault('i18n:en-navContexts', [])->willReturn(['main']);
-
-        $this->node->setProperty('i18n:de-excerpt-tags', [1, 2, 3])->shouldBeCalled();
-        $this->node->setProperty('i18n:de-excerpt-categories', [3, 2, 1])->shouldBeCalled();
-        $this->node->setProperty('i18n:de-navContexts', ['main'])->shouldBeCalled();
-
-        $this->node->getProperties('i18n:*-shadow-base')->willReturn([$property->reveal()]);
 
         $this->persistEvent->getDocument()->willReturn($this->document->reveal());
         $this->persistEvent->getNode()->willReturn($this->node->reveal());

--- a/src/Sulu/Component/CustomUrl/Document/Subscriber/InvalidationSubscriber.php
+++ b/src/Sulu/Component/CustomUrl/Document/Subscriber/InvalidationSubscriber.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of Sulu.
  *
@@ -37,7 +35,7 @@ class InvalidationSubscriber implements EventSubscriberInterface
     private $customUrlManager;
 
     /**
-     * @var CacheManager|null
+     * @var null|CacheManager
      */
     private $cacheManager;
 
@@ -124,7 +122,7 @@ class InvalidationSubscriber implements EventSubscriberInterface
 
         $url = PathHelper::relativizePath(
             $routeDocument->getPath(),
-            $this->customUrlManager->getRoutesPath($this->documentInspector->getWebspace($routeDocument)),
+            $this->customUrlManager->getRoutesPath($this->documentInspector->getWebspace($routeDocument))
         );
 
         $this->cacheManager->invalidatePath($this->getUrlWithScheme($url));

--- a/src/Sulu/Component/CustomUrl/Document/Subscriber/InvalidationSubscriber.php
+++ b/src/Sulu/Component/CustomUrl/Document/Subscriber/InvalidationSubscriber.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of Sulu.
  *
@@ -35,7 +37,7 @@ class InvalidationSubscriber implements EventSubscriberInterface
     private $customUrlManager;
 
     /**
-     * @var null|CacheManager
+     * @var CacheManager|null
      */
     private $cacheManager;
 
@@ -122,7 +124,7 @@ class InvalidationSubscriber implements EventSubscriberInterface
 
         $url = PathHelper::relativizePath(
             $routeDocument->getPath(),
-            $this->customUrlManager->getRoutesPath($this->documentInspector->getWebspace($routeDocument))
+            $this->customUrlManager->getRoutesPath($this->documentInspector->getWebspace($routeDocument)),
         );
 
         $this->cacheManager->invalidatePath($this->getUrlWithScheme($url));


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no yes
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | replaces #7043 
| License | MIT
| Documentation PR | sulu/sulu-docs#791

#### What's in this PR?

This PR add a new command `sulu:phpcr:cleanup` to cleanup the phpcr repository.

#### Why?

This is needed to keep the repository clean.

#### Example Usage

```bash
bin/console sulu:phpcr:cleanup --force
```

#### To Do

- [x] Create a documentation PR
- [x] Use also publish event and the live session to cleanup the live node
- [x] Test with different languages, blocks and image_maps
- [x] Test with audience-targeting and segmentation
- [x] Refactor to use StreamOutput with a file handle
- [x] Guard the node with:
  * Check the alias and if the structure manager has metadata for the alias (see https://github.com/mamazu/sulu/pull/2/files#diff-fd6471db309389445b7798ca7915fa5cd47010b1d91336a145f60e36276abb93R77-R80)
  * Check if language has a template 
  * Ignore nodes which could not be persisted (and or published)
- [x] Add summary of the cleanup (stats and ignored nodes) to the debug-file at the top
- [x] Feedback from @mamazu
