### PR TITLE
Add public url to S3 storage for cdn support

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
@@ -232,6 +232,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('path_prefix')->defaultNull()->end()
                         ->scalarNode('version')->defaultValue('latest')->end()
                         ->scalarNode('endpoint')->defaultNull()->end()
+                        ->scalarNode('url')->defaultNull()->end()
                         ->scalarNode('segments')->defaultValue(10)->end()
                         ->arrayNode('arguments')
                             ->scalarPrototype()->end()

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
@@ -232,7 +232,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('path_prefix')->defaultNull()->end()
                         ->scalarNode('version')->defaultValue('latest')->end()
                         ->scalarNode('endpoint')->defaultNull()->end()
-                        ->scalarNode('url')->defaultNull()->end()
+                        ->scalarNode('public_url')->defaultNull()->end()
                         ->scalarNode('segments')->defaultValue(10)->end()
                         ->arrayNode('arguments')
                             ->scalarPrototype()->end()

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/S3Storage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/S3Storage.php
@@ -35,9 +35,9 @@ class S3Storage extends FlysystemStorage
     /**
      * @var string|null
      */
-    private $url;
+    private $publicUrl;
 
-    public function __construct(FilesystemInterface $filesystem, int $segments, ?string $url = null)
+    public function __construct(FilesystemInterface $filesystem, int $segments, ?string $publicUrl = null)
     {
         parent::__construct($filesystem, $segments);
 
@@ -50,7 +50,7 @@ class S3Storage extends FlysystemStorage
         $this->endpoint = (string) $this->adapter->getClient()->getEndpoint();
         $this->bucketName = $this->adapter->getBucket();
 
-        $this->url = null !== $url ? $url : ($this->endpoint . '/' . $this->bucketName);
+        $this->publicUrl = null !== $publicUrl ? $publicUrl : ($this->endpoint . '/' . $this->bucketName);
     }
 
     public function getPath(array $storageOptions): string
@@ -58,7 +58,7 @@ class S3Storage extends FlysystemStorage
         $filePath = $this->getFilePath($storageOptions);
         $path = $this->adapter->applyPathPrefix($filePath);
 
-        return $this->url . '/' . \ltrim($path, '/');
+        return $this->publicUrl . '/' . \ltrim($path, '/');
     }
 
     public function getType(array $storageOptions): string

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/S3Storage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/S3Storage.php
@@ -32,9 +32,11 @@ class S3Storage extends FlysystemStorage
      */
     private $bucketName;
 
-    public function __construct(FilesystemInterface $filesystem, int $segments)
+    private $url;
+
+    public function __construct(FilesystemInterface $filesystem, int $segments, $url)
     {
-        parent::__construct($filesystem, $segments);
+        parent::__construct($filesystem, $segments, $url);
 
         if (!$filesystem instanceof Filesystem || !$filesystem->getAdapter() instanceof AwsS3Adapter) {
             throw new \RuntimeException('This storage can only handle filesystems with "AwsS3Adapter".');
@@ -44,6 +46,8 @@ class S3Storage extends FlysystemStorage
 
         $this->endpoint = (string) $this->adapter->getClient()->getEndpoint();
         $this->bucketName = $this->adapter->getBucket();
+
+        $this->url = $url;
     }
 
     public function getPath(array $storageOptions): string
@@ -51,7 +55,7 @@ class S3Storage extends FlysystemStorage
         $filePath = $this->getFilePath($storageOptions);
         $path = $this->adapter->applyPathPrefix($filePath);
 
-        return $this->endpoint . '/' . $this->bucketName . '/' . \ltrim($path, '/');
+        return ($this->url ?? $this->endpoint . '/' . $this->bucketName) . '/' . \ltrim($path, '/');
     }
 
     public function getType(array $storageOptions): string

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/S3Storage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/S3Storage.php
@@ -36,7 +36,7 @@ class S3Storage extends FlysystemStorage
 
     public function __construct(FilesystemInterface $filesystem, int $segments, $url)
     {
-        parent::__construct($filesystem, $segments, $url);
+        parent::__construct($filesystem, $segments);
 
         if (!$filesystem instanceof Filesystem || !$filesystem->getAdapter() instanceof AwsS3Adapter) {
             throw new \RuntimeException('This storage can only handle filesystems with "AwsS3Adapter".');

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/S3Storage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/S3Storage.php
@@ -50,7 +50,7 @@ class S3Storage extends FlysystemStorage
         $this->endpoint = (string) $this->adapter->getClient()->getEndpoint();
         $this->bucketName = $this->adapter->getBucket();
 
-        $this->url = null !== $url ? $url : $this->endpoint;
+        $this->url = null !== $url ? $url : $this->endpoint . '/' . $this->bucketName;
     }
 
     public function getPath(array $storageOptions): string
@@ -58,7 +58,7 @@ class S3Storage extends FlysystemStorage
         $filePath = $this->getFilePath($storageOptions);
         $path = $this->adapter->applyPathPrefix($filePath);
 
-        return $this->url . '/' . $this->bucketName . '/' . \ltrim($path, '/');
+        return $this->url . '/' . \ltrim($path, '/');
     }
 
     public function getType(array $storageOptions): string

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/S3Storage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/S3Storage.php
@@ -50,7 +50,7 @@ class S3Storage extends FlysystemStorage
         $this->endpoint = (string) $this->adapter->getClient()->getEndpoint();
         $this->bucketName = $this->adapter->getBucket();
 
-        $this->url = null !== $url ? $url : $this->endpoint . '/' . $this->bucketName;
+        $this->url = null !== $url ? $url : ($this->endpoint . '/' . $this->bucketName);
     }
 
     public function getPath(array $storageOptions): string

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/S3Storage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/S3Storage.php
@@ -47,7 +47,7 @@ class S3Storage extends FlysystemStorage
         $this->endpoint = (string) $this->adapter->getClient()->getEndpoint();
         $this->bucketName = $this->adapter->getBucket();
 
-        $this->url = $url;
+        $this->url = null !== $url ? $url : $this->endpoint;
     }
 
     public function getPath(array $storageOptions): string

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/S3Storage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/S3Storage.php
@@ -55,7 +55,7 @@ class S3Storage extends FlysystemStorage
         $filePath = $this->getFilePath($storageOptions);
         $path = $this->adapter->applyPathPrefix($filePath);
 
-        return ($this->url ?? $this->endpoint . '/' . $this->bucketName) . '/' . \ltrim($path, '/');
+        return $this->url . '/' . $this->bucketName . '/' . \ltrim($path, '/');
     }
 
     public function getType(array $storageOptions): string

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/S3Storage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/S3Storage.php
@@ -32,9 +32,12 @@ class S3Storage extends FlysystemStorage
      */
     private $bucketName;
 
+    /**
+     * @var string|null
+     */
     private $url;
 
-    public function __construct(FilesystemInterface $filesystem, int $segments, $url)
+    public function __construct(FilesystemInterface $filesystem, int $segments, ?string $url = null)
     {
         parent::__construct($filesystem, $segments);
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services_storage_s3.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services_storage_s3.xml
@@ -27,6 +27,7 @@
         <service id="sulu_media.storage.s3" class="Sulu\Bundle\MediaBundle\Media\Storage\S3Storage">
             <argument type="service" id="sulu_media.storage.s3.filesystem"/>
             <argument>%sulu_media.media.storage.s3.segments%</argument>
+            <argument type="string">%sulu_media.media.storage.s3.url%</argument>
         </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services_storage_s3.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services_storage_s3.xml
@@ -27,7 +27,7 @@
         <service id="sulu_media.storage.s3" class="Sulu\Bundle\MediaBundle\Media\Storage\S3Storage">
             <argument type="service" id="sulu_media.storage.s3.filesystem"/>
             <argument>%sulu_media.media.storage.s3.segments%</argument>
-            <argument type="string">%sulu_media.media.storage.s3.url%</argument>
+            <argument type="string">%sulu_media.media.storage.s3.public_url%</argument>
         </service>
     </services>
 </container>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | #7293
| License | MIT

#### What's in this PR?

Add the possibility to define a S3 url for public redirect.

#### Why?

Some S3 providers like DigitalOcean or Cloudflare are providing a CDN url and with this update the url can be set in the S3 config.

#### Example Usage

```yaml
sulu_media:
    storage: s3
    storages:
        s3:
            key: 'xxx'
            secret: 'xxx'
            bucket_name: 'bucket-name'
            path_prefix: 'website/sulu'
            region: 'auto'
            endpoint: 'api-endpoint'
            url: 'cdn-url'
```
