### PR TITLE
Fix new Website Test Kernel methods

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/Kernel.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/Kernel.php
@@ -48,7 +48,7 @@ class Kernel extends SuluTestKernel
 
     public function registerBundles(): iterable
     {
-        $bundles = parent::registerBundles();
+        $bundles = [...parent::registerBundles()];
 
         if ('with_security' === $this->appContext) {
             $bundles[] = new SecurityBundle();
@@ -57,17 +57,11 @@ class Kernel extends SuluTestKernel
         return $bundles;
     }
 
-    /**
-     * @return string
-     */
     public function getCacheDir(): string
     {
         return parent::getCacheDir() . \ltrim('/' . $this->appContext);
     }
 
-    /**
-     * @return string
-     */
     public function getCommonCacheDir(): string
     {
         return parent::getCommonCacheDir() . \ltrim('/' . $this->appContext);

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/Kernel.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/Kernel.php
@@ -60,7 +60,7 @@ class Kernel extends SuluTestKernel
     /**
      * @return string
      */
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         return parent::getCacheDir() . \ltrim('/' . $this->appContext);
     }
@@ -68,7 +68,7 @@ class Kernel extends SuluTestKernel
     /**
      * @return string
      */
-    public function getCommonCacheDir()
+    public function getCommonCacheDir(): string
     {
         return parent::getCommonCacheDir() . \ltrim('/' . $this->appContext);
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix new Website Test Kernel methods.

#### Why?

On 2.4 there where no requirement for return types this fixes the CI after backmerge.