### PR TITLE
Fix preview issues with null token and slow requests

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
@@ -170,6 +170,10 @@ class Preview extends React.Component<Props> {
         this.dataDisposer = reaction(
             () => toJS(formStore.data),
             (data) => {
+                if (this.iframeRef === null && !this.previewWindow) {
+                    return;
+                }
+
                 this.updatePreview(data);
             }
         );
@@ -185,14 +189,14 @@ class Preview extends React.Component<Props> {
 
         this.localeDisposer = reaction(
             () => toJS(formStore.locale),
-            () => {
-                this.previewStore.restart();
+            (locale) => {
+                this.previewStore.restart(locale);
             }
         );
     };
 
     updatePreview = debounce((data: Object) => {
-        if (this.shouldUpdateFormStore) {
+        if (this.shouldUpdateFormStore && !!this.previewStore.token) {
             const {previewStore} = this;
             previewStore.update(data).then(this.setContent);
         }

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/stores/PreviewStore.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/stores/PreviewStore.js
@@ -1,5 +1,5 @@
 // @flow
-import {action, computed, observable} from 'mobx';
+import {action, computed, observable, toJS} from 'mobx';
 import {Requester} from 'sulu-admin-bundle/services';
 import {buildQueryString, transformDateForUrl} from 'sulu-admin-bundle/utils';
 import type {IObservableValue} from 'mobx/lib/mobx';
@@ -14,7 +14,7 @@ export default class PreviewStore {
 
     resourceKey: string;
     id: ?string | number;
-    locale: ?IObservableValue<string>;
+    @observable locale: ?string;
     @observable webspace: string;
     @observable segment: ?string;
     @observable targetGroup: number = -1;
@@ -30,8 +30,8 @@ export default class PreviewStore {
         segment: ?string
     ) {
         // keep backwards compatibility to previous versions where locale was passed as string
-        if (typeof locale === 'string') {
-            locale = observable.box(locale);
+        if (typeof locale !== 'string') {
+            locale = toJS(locale);
         }
         this.resourceKey = resourceKey;
         this.id = id;
@@ -89,8 +89,15 @@ export default class PreviewStore {
         });
     }
 
-    restart(): Promise<string> {
-        return this.stop().then(() => this.start());
+    @action restart(locale: ?string): Promise<string> {
+        return this.stop().then(
+            () => {
+                if (locale) {
+                    this.locale = locale;
+                }
+
+                return this.start();
+            });
     }
 
     update(data: Object): Promise<string> {

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/Preview.test.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/Preview.test.js
@@ -349,6 +349,7 @@ test('React and update preview when data is changed', () => {
     previewStore.start.mockReturnValue(startPromise);
     previewStore.update.mockReturnValue(updatePromise);
     previewStore.starting = false;
+    previewStore.token = '123-123-123';
 
     preview.instance().handleStartClick();
 
@@ -356,6 +357,7 @@ test('React and update preview when data is changed', () => {
 
     return startPromise.then(() => {
         preview.update();
+        previewStore.token = '123-123-123';
         expect(previewStore.update).toBeCalledWith({title: 'New Test'});
 
         expect(preview.render()).toMatchSnapshot();
@@ -393,6 +395,7 @@ test('React and update preview in external window when data is changed', () => {
     previewStore.start.mockReturnValue(startPromise);
     previewStore.update.mockReturnValue(updatePromise);
     previewStore.starting = false;
+    previewStore.token = '123-123-123';
 
     preview.instance().handleStartClick();
     preview.update();
@@ -566,6 +569,7 @@ test('Change target group in PreviewStore when selection of target group has cha
     const previewStore = preview.instance().previewStore;
     previewStore.start.mockReturnValue(startPromise);
     previewStore.starting = false;
+    previewStore.token = '123-123-123';
 
     preview.instance().handleStartClick();
 

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/stores/PreviewStore.test.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/stores/PreviewStore.test.js
@@ -245,8 +245,6 @@ test('Should request server on restart preview with new locale', () => {
     const previewStore = new PreviewStore('pages', '123-123-123', locale, 'sulu_io');
     previewStore.start();
 
-    locale.set('de');
-
     // $FlowFixMe
     Requester.post = jest.fn();
     const startPromise = Promise.resolve({token: '123-123-123'});
@@ -254,7 +252,7 @@ test('Should request server on restart preview with new locale', () => {
     Requester.post.mockReturnValueOnce(stopPromise);
     Requester.post.mockReturnValueOnce(startPromise);
 
-    return previewStore.restart().then(() => {
+    return previewStore.restart('de').then(() => {
         expect(Requester.post).toBeCalledWith('/stop');
         expect(Requester.post).toBeCalledWith('/start?provider=pages&id=123-123-123&locale=de');
     });


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Adds adjustments to the preview react component to prevent generating urls with the token being `null`.

#### Why?

This problem occures in a customer project when switching locales.