### PR TITLE
Upgrade PHP requirement to PHP 8.2

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -63,7 +63,7 @@ jobs:
             - name: Install and configure PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: '8.1'
+                  php-version: '8.2'
                   tools: 'composer:v2'
                   ini-values: memory_limit=-1
                   coverage: none
@@ -130,7 +130,7 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - php-version: '8.0'
+                    - php-version: '8.2'
                       database: mysql-57
                       phpcr-transport: doctrinedbal
                       dependency-versions: 'lowest'
@@ -142,7 +142,7 @@ jobs:
                           DATABASE_CHARSET: utf8mb4
                           DATABASE_COLLATE: utf8mb4_unicode_ci
 
-                    - php-version: '8.1'
+                    - php-version: '8.2'
                       database: mysql-57
                       phpcr-transport: jackrabbit
                       dependency-versions: 'highest'
@@ -154,7 +154,7 @@ jobs:
                           DATABASE_CHARSET: utf8mb4
                           DATABASE_COLLATE: utf8mb4_unicode_ci
 
-                    - php-version: '8.2'
+                    - php-version: '8.3'
                       database: postgres-14
                       phpcr-transport: doctrinedbal
                       dependency-versions: 'highest'
@@ -170,7 +170,7 @@ jobs:
                       database: mysql-80
                       phpcr-transport: doctrinedbal
                       dependency-versions: 'highest'
-                      php-extensions: 'ctype, iconv, mysql, gd'
+                      php-extensions: 'ctype, iconv, mysql, imagick'
                       tools: 'composer:v2'
                       composer-stability: 'dev'
                       env:
@@ -223,9 +223,17 @@ jobs:
 
             - name: Output versions and installed dependencies
               run: |
+                  echo 'PHP Version:'
                   php --version
+                  echo ''
+                  echo 'PHP Modules:'
                   php -m
+                  echo ''
+                  echo 'Composer Info:'
                   composer info
+                  echo ''
+                  echo 'Composer Lock:'
+                  cat composer.lock
 
             - name: Bootstrap test environment
               run: composer bootstrap-test-environment
@@ -253,8 +261,8 @@ jobs:
             - name: Install and configure PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: '8.1'
-                  extensions: 'ctype, iconv, mysql, imagick'
+                  php-version: '8.2'
+                  extensions: 'ctype, iconv, mysql'
                   tools: 'composer:v2'
                   ini-values: memory_limit=-1
                   coverage: none
@@ -263,6 +271,20 @@ jobs:
               uses: ramsey/composer-install@v1
               with:
                   dependency-versions: highest
+
+            - name: Output versions and installed dependencies
+              run: |
+                  echo 'PHP Version:'
+                  php --version
+                  echo ''
+                  echo 'PHP Modules:'
+                  php -m
+                  echo ''
+                  echo 'Composer Info:'
+                  composer info
+                  echo ''
+                  echo 'Composer Lock:'
+                  cat composer.lock
 
             - name: Lint code
               run: composer lint

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -261,7 +261,7 @@ jobs:
             - name: Install and configure PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: '8.2'
+                  php-version: '8.3'
                   extensions: 'ctype, iconv, mysql'
                   tools: 'composer:v2'
                   ini-values: memory_limit=-1

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,11 +4,11 @@
 
 ### PHP 8.2 upgrade
 
-Before you can upgrade to Sulu 2.6 you should make sure your project code and
-dependency are already working with PHP 8.2.
+Before upgrading to Sulu 2.6, ensure that your project's code and dependencies
+are already compatible with PHP 8.2.
 
-We recommend todo the PHP upgrade as seperate step before you are updating to
-Sulu 2.6. This make it easier for you to identify eventueally occuring bugs
+We recommend performing the PHP upgrade as a separate step before updating to
+Sulu 2.6. This will make it easier for you to identify any bugs that may occur
 in the project code with PHP 8.2.
 
 ### DocumentToUuidTransformer return type changed

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,15 @@
 
 ## 2.6.0
 
+### PHP 8.2 upgrade
+
+Before you can upgrade to Sulu 2.6 you should make sure your project code and
+dependency are already working with PHP 8.2.
+
+We recommend todo the PHP upgrade as seperate step before you are updating to
+Sulu 2.6. This make it easier for you to identify eventueally occuring bugs
+in the project code with PHP 8.2.
+
 ### DocumentToUuidTransformer return type changed
 
 For compatibility to Symfony 7 the `DocumentToUuidTransformer` methods return types changed:

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "docs": "https://docs.sulu.io/"
     },
     "require": {
-        "php": "^8.0 || ^8.1",
+        "php": "^8.2 || ^8.3",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-simplexml": "*",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -48811,11 +48811,6 @@ parameters:
 			path: src/Sulu/Component/Rest/ListBuilder/Filter/FilterTypeRegistry.php
 
 		-
-			message: "#^Parameter \\#1 \\$iterator of function iterator_to_array expects Traversable, iterable given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Filter/FilterTypeRegistry.php
-
-		-
 			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Filter\\\\NumberFilterType\\:\\:filter\\(\\) has parameter \\$options with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Rest/ListBuilder/Filter/NumberFilterType.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,6 +10,7 @@ includes:
     - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
 
 parameters:
+    phpVersion: 80200
     paths:
         - .
     level: max


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no 
| BC breaks? | no
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Upgrade PHP requirement to PHP 8.2.

#### Why?

For the maintainance on our side we require the same PHP Version for 2.6 as the current Symfony version. Even the first release of 2.6 is not yet compatible because of some blockers listed in the [Symfony 7 Pull Request](https://github.com/sulu/sulu/pull/7156). We want to prepare as much as possible and keep the maintance of 2.6 which will ending into a LTS when 3.0 as good as possible.

Dependencies which require already PHP 8.2 in there latest version are Symfony and PHPUnit.

#### To Do

- [x] Add breaking changes to UPGRADE.md
