### PR TITLE
Fix page_tree_route suffix

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26576,11 +26576,6 @@ parameters:
 			path: src/Sulu/Bundle/RouteBundle/Document/Subscriber/RoutableSubscriber.php
 
 		-
-			message: "#^Thrown exceptions in a catch block must bundle the previous exception \\(see throw statement line 246\\)\\. More info\\: http\\://bit\\.ly/bundleexception$#"
-			count: 1
-			path: src/Sulu/Bundle/RouteBundle/Document/Subscriber/RoutableSubscriber.php
-
-		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/RouteBundle/Document/Subscriber/RoutableSubscriber.php


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #662
| License | MIT

#### What's in this PR?

Content type page_tree_route, saves wrong "routepath-suffix" if there are multiple pages/articles with the same route.

#### Why?

The routePath was updated correctly but not the routepath-suffix which is displayed in the sulu admin was wrong.

#### Example

If you have a page "overview" and create an page with "page_tree_route" and select "overview"  as parent page and name the page "test". The routePath is "/overview/test" and the routepath-suffix is "/test". If you do that again the routePath is "/overview/test-1" and the routepath-suffix was still "/test". Now the routepath-suffix is "/test-1" and displayed correctly in the sulu admin.
