### PR TITLE
Fix routepath on language copy if the parent page only exist in one l…

### DIFF
--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/CopyLocaleSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/CopyLocaleSubscriberTest.php
@@ -14,12 +14,16 @@ namespace Sulu\Component\Content\Tests\Unit\Document\Subscriber;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Bundle\PageBundle\Document\PageDocument;
+use Sulu\Bundle\RouteBundle\Model\RouteInterface;
+use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Document\Structure\StructureInterface;
 use Sulu\Component\Content\Document\Subscriber\CopyLocaleSubscriber;
+use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\Content\Types\ResourceLocator\Strategy\ResourceLocatorStrategyInterface;
 use Sulu\Component\Content\Types\ResourceLocator\Strategy\ResourceLocatorStrategyPoolInterface;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Event\CopyLocaleEvent;
+use Sulu\Component\Route\Document\Behavior\RoutableBehavior;
 
 class CopyLocaleSubscriberTest extends SubscriberTestCase
 {
@@ -123,5 +127,167 @@ class CopyLocaleSubscriberTest extends SubscriberTestCase
         $event->setDestDocument($destDocument->reveal())->shouldBeCalled();
 
         $this->subscriber->handleCopyLocale($event->reveal());
+    }
+
+    public function testHandleCopyLocalePageTreeRoute(): void
+    {
+        /** @var CopyLocaleEvent|ObjectProphecy $event */
+        $event = $this->prophesize(CopyLocaleEvent::class);
+        $event->getLocale()->willReturn('en');
+        $event->getDestLocale()->willReturn('de');
+
+        $structureData = [
+            'foo' => 'bar',
+            'routePath' => [
+                'page' => [
+                    'uuid' => null,
+                    'path' => '',
+                ],
+                'path' => '/overview/new',
+                'suffix' => '/new',
+            ],
+        ];
+
+        /** @var StructureInterface|ObjectProphecy $structure */
+        $structure = $this->prophesize(StructureInterface::class);
+        $structure->toArray()->willReturn($structureData);
+
+        /** @var PageDocument|ObjectProphecy $document */
+        $document = $this->prophesize(PageDocument::class);
+        $document->getStructure()->willReturn($structure->reveal());
+
+        /** @var RoutableBehavior|ObjectProphecy $destDocument */
+        $destDocument = $this->prophesize(RoutableBehavior::class);
+        $routeInterface = $this->prophesize(RouteInterface::class);
+        $destDocument->setRoutePath('/new')->shouldBeCalled();
+        $destDocument->getRoute()->willReturn($routeInterface->reveal());
+
+        $structure = $this->subscriber->checkPageTreeRoute($destDocument->reveal(), $document->reveal(), 'de');
+        $expectedStructure = [
+            'foo' => 'bar',
+            'routePath' => [
+                'page' => [
+                    'uuid' => null,
+                    'path' => '',
+                ],
+                'path' => '/new',
+                'suffix' => '/new',
+            ],
+        ];
+
+        $this->assertSame($expectedStructure, $structure);
+    }
+
+    public function testHandleCopyLocalePageTreeRouteParentNotPublished(): void
+    {
+        /** @var CopyLocaleEvent|ObjectProphecy $event */
+        $event = $this->prophesize(CopyLocaleEvent::class);
+        $event->getLocale()->willReturn('en');
+        $event->getDestLocale()->willReturn('de');
+
+        $structureData = [
+            'foo' => 'bar',
+            'routePath' => [
+                'page' => [
+                    'uuid' => '2ad86c23-04b7-41e0-b2bf-086b7d43d4a2',
+                    'path' => 'overview',
+                ],
+                'path' => '/overview/new',
+                'suffix' => '/new',
+            ],
+        ];
+
+        /** @var StructureInterface|ObjectProphecy $structure */
+        $structure = $this->prophesize(StructureInterface::class);
+        $structure->toArray()->willReturn($structureData);
+
+        /** @var PageDocument|ObjectProphecy $document */
+        $document = $this->prophesize(PageDocument::class);
+
+        $document->getStructure()->willReturn($structure->reveal());
+        $pageDocument = $this->prophesize(PageDocument::class);
+        $pageDocument->getWorkflowStage()->willReturn(WorkflowStage::TEST);
+        $this->documentManager->find('2ad86c23-04b7-41e0-b2bf-086b7d43d4a2', 'de')->willReturn($pageDocument->reveal());
+
+        /** @var RoutableBehavior|ObjectProphecy $destDocument */
+        $destDocument = $this->prophesize(RoutableBehavior::class);
+        $routeInterface = $this->prophesize(RouteInterface::class);
+        $destDocument->setRoutePath('/new')->shouldBeCalled();
+        $destDocument->getRoute()->willReturn($routeInterface->reveal());
+
+        $structure = $this->subscriber->checkPageTreeRoute($destDocument->reveal(), $document->reveal(), 'de');
+        $expectedStructure = [
+            'foo' => 'bar',
+            'routePath' => [
+                'page' => [
+                    'uuid' => null,
+                    'path' => '',
+                ],
+                'path' => '/new',
+                'suffix' => '/new',
+            ],
+        ];
+
+        $this->assertSame($expectedStructure, $structure);
+    }
+
+    public function testHandleCopyLocalePageTreeRouteParent(): void
+    {
+        /** @var CopyLocaleEvent|ObjectProphecy $event */
+        $event = $this->prophesize(CopyLocaleEvent::class);
+        $event->getLocale()->willReturn('en');
+        $event->getDestLocale()->willReturn('de');
+
+        $structureData = [
+            'foo' => 'bar',
+            'routePath' => [
+                'page' => [
+                    'uuid' => '2ad86c23-04b7-41e0-b2bf-086b7d43d4a2',
+                    'path' => '/overview',
+                ],
+                'path' => '/overview/new',
+                'suffix' => '/new',
+            ],
+        ];
+
+        /** @var StructureInterface|ObjectProphecy $structure */
+        $structure = $this->prophesize(StructureInterface::class);
+        $structure->toArray()->willReturn($structureData);
+
+        /** @var PageDocument|ObjectProphecy $document */
+        $document = $this->prophesize(PageDocument::class);
+
+        $document->getStructure()->willReturn($structure->reveal());
+        $pageDocument = $this->prophesize(PageDocument::class);
+        $pageDocument->getWorkflowStage()->willReturn(WorkflowStage::PUBLISHED);
+        $propertyInterface = $this->prophesize(PropertyInterface::class);
+        $propertyInterface->getValue()->willReturn('/overview');
+
+        $structureInterface = $this->prophesize(StructureInterface::class);
+        $structureInterface->getProperty('url')->willReturn($propertyInterface->reveal());
+
+        $pageDocument->getStructure()->willReturn($structureInterface->reveal());
+        $this->documentManager->find('2ad86c23-04b7-41e0-b2bf-086b7d43d4a2', 'de')->willReturn($pageDocument->reveal());
+
+        /** @var RoutableBehavior|ObjectProphecy $destDocument */
+        $destDocument = $this->prophesize(RoutableBehavior::class);
+        $routeInterface = $this->prophesize(RouteInterface::class);
+        $destDocument->setRoutePath('/overview/new')->shouldBeCalled();
+        $destDocument->getRoute()->willReturn($routeInterface->reveal());
+
+        $structure = $this->subscriber->checkPageTreeRoute($destDocument->reveal(), $document->reveal(), 'de');
+        $expectedStructure = [
+            'foo' => 'bar',
+            'routePath' => [
+                'page' => [
+                    'uuid' => '2ad86c23-04b7-41e0-b2bf-086b7d43d4a2',
+                    'path' => '/overview',
+                ],
+                'path' => '/overview/new',
+                'suffix' => '/new',
+            ],
+        ];
+
+        $this->assertSame($expectedStructure, $structure);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes https://github.com/sulu/SuluArticleBundle/issues/661
| License | MIT

#### What's in this PR?

Only add the parent page (page tree route) if it exists in the target language.

#### Why?

Otherwise there will be wrong routes.

