### PR TITLE
Add last modified field value to sitemap when exists

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Sitemap/PagesSitemapProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Sitemap/PagesSitemapProvider.php
@@ -80,7 +80,7 @@ class PagesSitemapProvider extends AbstractSitemapProvider
                 $portalInformation->getLocalization()->getLocale(),
                 $portalInformation->getPortalKey(),
                 MappingBuilder::create()
-                    ->addProperties(['changed', 'seo-hideInSitemap'])
+                    ->addProperties(['changed', 'seo-hideInSitemap', 'lastModified'])
                     ->setResolveUrl(true)
                     ->setHydrateGhost(false)
                     ->getMapping()
@@ -126,7 +126,7 @@ class PagesSitemapProvider extends AbstractSitemapProvider
         string $host,
         string $scheme
     ) {
-        $changed = $contentPage['changed'];
+        $changed = $contentPage['lastModified'] ?? $contentPage['changed'];
         if (\is_string($changed)) {
             $changed = new \DateTime($changed);
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | #7238, #7313
| License | MIT

#### What's in this PR?

Adding the last modified field to the sitemap if it's defined.

#### Why?

For better content in the sitemap.
