### PR TITLE
Restart preview always when the locale is changed

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
@@ -163,6 +163,13 @@ class Preview extends React.Component<Props> {
             formStore,
         } = this.props;
 
+        this.localeDisposer = reaction(
+            () => toJS(formStore.locale),
+            (locale) => {
+                this.previewStore.restart(locale);
+            }
+        );
+
         if (previewStore.resourceKey !== formStore.resourceKey) {
             return;
         }
@@ -184,13 +191,6 @@ class Preview extends React.Component<Props> {
                 if (formStore.type) {
                     previewStore.updateContext(toJS(formStore.type), toJS(formStore.data)).then(this.setContent);
                 }
-            }
-        );
-
-        this.localeDisposer = reaction(
-            () => toJS(formStore.locale),
-            (locale) => {
-                this.previewStore.restart(locale);
             }
         );
     };


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

Always enables the `reaction` to observe the locale to restart the previewstore.

#### Why?

Switching the locale when [(previewStore.resourceKey !== formStore.resourceKey)](https://github.com/sulu/sulu/pull/7315/files#diff-9d86ad8a804f9170856f574d2c4ca3e0e8d4688b0b9082679c249b38f4e2861fR173) is true, does not update the preview.
