### PR TITLE
Replace switch with match where possible

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4056,11 +4056,6 @@ parameters:
 			path: src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
 
 		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\CategoryBundle\\\\Controller\\\\KeywordController\\:\\:deleteAction\\(\\) has parameter \\$id with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
@@ -14171,11 +14166,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
 
 		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Controller\\\\FormatController\\:\\:cgetAction\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Controller/FormatController.php
@@ -14298,11 +14288,6 @@ parameters:
 		-
 			message: "#^Strict comparison using \\=\\=\\= between true and string will always evaluate to false\\.$#"
 			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 2
 			path: src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
 
 		-
@@ -32393,11 +32378,6 @@ parameters:
 		-
 			message: "#^Property Sulu\\\\Bundle\\\\TestBundle\\\\Testing\\\\SuluTestCase\\:\\:\\$workspaceInitialized has no type specified\\.$#"
 			count: 1
-			path: src/Sulu/Bundle/TestBundle/Testing/SuluTestCase.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 2
 			path: src/Sulu/Bundle/TestBundle/Testing/SuluTestCase.php
 
 		-

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Rule/DeviceTypeRule.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Rule/DeviceTypeRule.php
@@ -52,16 +52,12 @@ class DeviceTypeRule implements RuleInterface
             return false;
         }
 
-        switch ($options[static::DEVICE_TYPE]) {
-            case static::SMARTPHONE:
-                return $this->deviceDetector->isSmartphone();
-            case static::TABLET:
-                return $this->deviceDetector->isTablet();
-            case static::DESKTOP:
-                return $this->deviceDetector->isDesktop();
-        }
-
-        return false;
+        return match ($options[static::DEVICE_TYPE]) {
+            static::SMARTPHONE => $this->deviceDetector->isSmartphone(),
+            static::TABLET => $this->deviceDetector->isTablet(),
+            static::DESKTOP => $this->deviceDetector->isDesktop(),
+            default => false,
+        };
     }
 
     public function getName()

--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -162,13 +162,10 @@ class CategoryController extends AbstractRestController implements ClassResource
         $action = $this->getRequestParameter($request, 'action', true);
 
         try {
-            switch ($action) {
-                case 'move':
-                    return $this->move($id, $request);
-                    break;
-                default:
-                    throw new RestException(\sprintf('Unrecognized action: "%s"', $action));
-            }
+            return match ($action) {
+                'move' => $this->move($id, $request),
+                default => throw new RestException(\sprintf('Unrecognized action: "%s"', $action)),
+            };
         } catch (RestException $ex) {
             $view = $this->view($ex->toArray(), 400);
 

--- a/src/Sulu/Bundle/HttpCacheBundle/CacheLifetime/CacheLifetimeResolver.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/CacheLifetime/CacheLifetimeResolver.php
@@ -38,16 +38,11 @@ class CacheLifetimeResolver implements CacheLifetimeResolverInterface
         $cacheLifetimeKey = \sprintf('%s:%s', $type, $value);
 
         if (!\array_key_exists($cacheLifetimeKey, $this->cacheLifetimes)) {
-            switch ($type) {
-                case self::TYPE_EXPRESSION:
-                    $this->cacheLifetimes[$cacheLifetimeKey] = $this->getCacheLifetimeForExpression($value);
-                    break;
-                case self::TYPE_SECONDS:
-                    $this->cacheLifetimes[$cacheLifetimeKey] = (int) $value;
-                    break;
-                default:
-                    $this->cacheLifetimes[$cacheLifetimeKey] = 0;
-            }
+            $this->cacheLifetimes[$cacheLifetimeKey] = match ($type) {
+                self::TYPE_EXPRESSION => $this->getCacheLifetimeForExpression($value),
+                self::TYPE_SECONDS => (int) $value,
+                default => 0,
+            };
         }
 
         return $this->cacheLifetimes[$cacheLifetimeKey];

--- a/src/Sulu/Bundle/MediaBundle/Content/MediaSelectionContainer.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/MediaSelectionContainer.php
@@ -148,20 +148,14 @@ class MediaSelectionContainer implements ArrayableInterface
 
     public function __get($name)
     {
-        switch ($name) {
-            case 'data':
-                return $this->getData();
-            case 'config':
-                return $this->getConfig();
-            case 'ids':
-                return $this->getIds();
-            case 'displayOption':
-                return $this->getDisplayOption();
-            case 'types':
-                return $this->getTypes();
-        }
-
-        return null;
+        return match ($name) {
+            'data' => $this->getData(),
+            'config' => $this->getConfig(),
+            'ids' => $this->getIds(),
+            'displayOption' => $this->getDisplayOption(),
+            'types' => $this->getTypes(),
+            default => null,
+        };
     }
 
     public function __isset($name)

--- a/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
@@ -336,13 +336,10 @@ class CollectionController extends AbstractRestController implements ClassResour
         $action = $this->getRequestParameter($request, 'action', true);
 
         try {
-            switch ($action) {
-                case 'move':
-                    return $this->moveEntity($id, $request);
-                    break;
-                default:
-                    throw new RestException(\sprintf('Unrecognized action: "%s"', $action));
-            }
+            return match ($action) {
+                'move' => $this->moveEntity($id, $request),
+                default => throw new RestException(\sprintf('Unrecognized action: "%s"', $action)),
+            };
         } catch (RestException $ex) {
             $view = $this->view($ex->toArray(), 400);
 

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
@@ -477,16 +477,11 @@ class MediaController extends AbstractMediaController implements
         $action = $this->getRequestParameter($request, 'action', true);
 
         try {
-            switch ($action) {
-                case 'move':
-                    return $this->moveEntity($id, $request);
-                    break;
-                case 'new-version':
-                    return $this->saveEntity($id, $request);
-                    break;
-                default:
-                    throw new RestException(\sprintf('Unrecognized action: "%s"', $action));
-            }
+            return match ($action) {
+                'move' => $this->moveEntity($id, $request),
+                'new-version' => $this->saveEntity($id, $request),
+                default => throw new RestException(\sprintf('Unrecognized action: "%s"', $action)),
+            };
         } catch (RestException $e) {
             $view = $this->view($e->toArray(), 400);
 

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Focus/Focus.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Focus/Focus.php
@@ -68,36 +68,22 @@ class Focus implements FocusInterface
 
             $cropY = 0;
 
-            switch ($x) {
-                case static::FOCUS_LEFT:
-                    $cropX = 0;
-                    break;
-                case static::FOCUS_RIGHT:
-                    $cropX = $imageSize->getWidth() - $width;
-                    break;
-                case static::FOCUS_CENTER:
-                default:
-                    $cropX = ($imageSize->getWidth() - $width) / 2;
-                    break;
-            }
+            $cropX = match ($x) {
+                static::FOCUS_LEFT => 0,
+                static::FOCUS_RIGHT => $imageSize->getWidth() - $width,
+                default => ($imageSize->getWidth() - $width) / 2,
+            };
         } else {
             $width = $imageSize->getWidth();
             $height = (int) \round($width / $targetRatio);
 
             $cropX = 0;
 
-            switch ($y) {
-                case static::FOCUS_TOP:
-                    $cropY = 0;
-                    break;
-                case static::FOCUS_BOTTOM:
-                    $cropY = $imageSize->getHeight() - $height;
-                    break;
-                case static::FOCUS_MIDDLE:
-                default:
-                    $cropY = ($imageSize->getHeight() - $height) / 2;
-                    break;
-            }
+            $cropY = match ($y) {
+                static::FOCUS_TOP => 0,
+                static::FOCUS_BOTTOM => $imageSize->getHeight() - $height,
+                default => ($imageSize->getHeight() - $height) / 2,
+            };
         }
 
         return $image->crop(new Point($cropX, $cropY), new Box($width, $height));

--- a/src/Sulu/Bundle/PageBundle/Controller/ResourcelocatorController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/ResourcelocatorController.php
@@ -44,12 +44,11 @@ class ResourcelocatorController implements ClassResourceInterface
     public function postAction(Request $request)
     {
         $action = $request->query->get('action');
-        switch ($action) {
-            case 'generate':
-                return $this->generateUrlResponse($request);
-        }
 
-        throw new RestException('Unrecognized action: ' . $action);
+        return match ($action) {
+            'generate' => $this->generateUrlResponse($request),
+            default => throw new RestException('Unrecognized action: ' . $action),
+        };
     }
 
     private function generateUrlResponse(Request $request)

--- a/src/Sulu/Bundle/PreviewBundle/UserInterface/Controller/PreviewController.php
+++ b/src/Sulu/Bundle/PreviewBundle/UserInterface/Controller/PreviewController.php
@@ -166,14 +166,10 @@ class PreviewController
     private function getOptionsFromRequest(Request $request): array
     {
         return \array_filter($request->query->all(), function($key) {
-            switch ($key) {
-                case 'id':
-                case 'provider':
-                case 'token':
-                    return false;
-                default:
-                    return true;
-            }
+            return match ($key) {
+                'id', 'provider', 'token' => false,
+                default => true,
+            };
         }, \ARRAY_FILTER_USE_KEY);
     }
 }

--- a/src/Sulu/Bundle/RouteBundle/Controller/RouteController.php
+++ b/src/Sulu/Bundle/RouteBundle/Controller/RouteController.php
@@ -105,12 +105,11 @@ class RouteController extends AbstractRestController implements ClassResourceInt
     public function postAction(Request $request): Response
     {
         $action = $request->query->get('action');
-        switch ($action) {
-            case 'generate':
-                return $this->generateUrlResponse($request);
-        }
 
-        throw new RestException('Unrecognized action: ' . $action);
+        return match ($action) {
+            'generate' => $this->generateUrlResponse($request),
+            default => throw new RestException('Unrecognized action: ' . $action),
+        };
     }
 
     /**

--- a/src/Sulu/Bundle/SecurityBundle/Controller/UserController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/UserController.php
@@ -189,19 +189,12 @@ class UserController extends AbstractRestController implements ClassResourceInte
         $action = $request->get('action');
 
         try {
-            switch ($action) {
-                case 'enable':
-                    $user = $this->userManager->enableUser($id);
-                    break;
-                case 'lock':
-                    $user = $this->userManager->lockUser($id);
-                    break;
-                case 'unlock':
-                    $user = $this->userManager->unlockUser($id);
-                    break;
-                default:
-                    throw new RestException('Unrecognized action: ' . $action);
-            }
+            $user = match ($action) {
+                'enable' => $this->userManager->enableUser($id),
+                'lock' => $this->userManager->lockUser($id),
+                'unlock' => $this->userManager->unlockUser($id),
+                default => throw new RestException('Unrecognized action: ' . $action),
+            };
 
             // prepare view
             $view = $this->view($user, 200);

--- a/src/Sulu/Bundle/TestBundle/Testing/PhpCrInitTrait.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/PhpCrInitTrait.php
@@ -119,18 +119,11 @@ trait PhpCrInitTrait
             );
         }
 
-        switch ($workspace) {
-            case 'live':
-                return static::$kernel->getCommonCacheDir() . '/initial_live.xml';
-
-                break;
-            case 'default':
-                return static::$kernel->getCommonCacheDir() . '/initial.xml';
-
-                break;
-            default:
-                throw new \InvalidArgumentException(\sprintf('Workspace "%s" is not a valid option', $workspace));
-        }
+        return match ($workspace) {
+            'live' => static::$kernel->getCommonCacheDir() . '/initial_live.xml',
+            'default' => static::$kernel->getCommonCacheDir() . '/initial.xml',
+            default => throw new \InvalidArgumentException(\sprintf('Workspace "%s" is not a valid option', $workspace)),
+        };
     }
 
     abstract public static function getContainer(): ContainerInterface;

--- a/src/Sulu/Bundle/TrashBundle/UserInterface/Controller/Admin/TrashItemController.php
+++ b/src/Sulu/Bundle/TrashBundle/UserInterface/Controller/Admin/TrashItemController.php
@@ -269,12 +269,10 @@ class TrashItemController extends AbstractRestController implements ClassResourc
         $action = $this->getRequestParameter($request, 'action', true);
 
         try {
-            switch ($action) {
-                case 'restore':
-                    return $this->restoreTrashItem($id, $request->request->all());
-                default:
-                    throw new RestException(\sprintf('Unrecognized action: "%s"', $action));
-            }
+            return match ($action) {
+                'restore' => $this->restoreTrashItem($id, $request->request->all()),
+                default => throw new RestException(\sprintf('Unrecognized action: "%s"', $action)),
+            };
         } catch (RestException $ex) {
             $view = $this->view($ex->toArray(), 400);
 

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/AnalyticsController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/AnalyticsController.php
@@ -186,23 +186,18 @@ class AnalyticsController extends AbstractRestController implements ClassResourc
             return null;
         }
 
-        switch ($data['type']) {
-            case 'google':
-                return $data['google_key'] ?? null;
-            case 'google_tag_manager':
-                return $data['google_tag_manager_key'] ?? null;
-            case 'matomo':
-                return [
-                    'siteId' => $data['matomo_id'] ?? null,
-                    'url' => $data['matomo_url'] ?? null,
-                ];
-            case 'custom':
-                return [
-                    'position' => $data['custom_position'] ?? null,
-                    'value' => $data['custom_script'] ?? null,
-                ];
-            default:
-                return null;
-        }
+        return match ($data['type']) {
+            'google' => $data['google_key'] ?? null,
+            'google_tag_manager' => $data['google_tag_manager_key'] ?? null,
+            'matomo' => [
+                'siteId' => $data['matomo_id'] ?? null,
+                'url' => $data['matomo_url'] ?? null,
+            ],
+            'custom' => [
+                'position' => $data['custom_position'] ?? null,
+                'value' => $data['custom_script'] ?? null,
+            ],
+            default => null,
+        };
     }
 }

--- a/src/Sulu/Component/Content/Import/WebspaceImport.php
+++ b/src/Sulu/Component/Content/Import/WebspaceImport.php
@@ -422,17 +422,12 @@ class WebspaceImport extends Import implements WebspaceImportInterface
             return;
         }
 
-        switch ($key) {
-            case 'redirectTarget':
-                $value = $this->documentManager->find($value);
-                break;
-            case 'permissions':
-                $value = \json_decode($value, true);
-                break;
-            case 'navigationContexts':
-                $value = \json_decode($value);
-                break;
-        }
+        $value = match ($key) {
+            'redirectTarget' => $this->documentManager->find($value),
+            'permissions' => \json_decode($value, true),
+            'navigationContexts' => \json_decode($value),
+            default => $value,
+        };
 
         return $value;
     }

--- a/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
@@ -290,14 +290,10 @@ class PropertiesXmlParser
             'meta' => $this->loadMeta($xpath, $node),
         ];
 
-        switch ($result['type']) {
-            case 'collection':
-                $result['value'] = $this->loadParams('x:param', $xpath, $node);
-                break;
-            default:
-                $result['value'] = $this->getValueFromXPath('@value', $xpath, $node);
-                break;
-        }
+        $result['value'] = match ($result['type']) {
+            'collection' => $this->loadParams('x:param', $xpath, $node),
+            default => $this->getValueFromXPath('@value', $xpath, $node),
+        };
 
         return $result;
     }

--- a/src/Sulu/Component/DocumentManager/PropertyEncoder.php
+++ b/src/Sulu/Component/DocumentManager/PropertyEncoder.php
@@ -30,20 +30,15 @@ class PropertyEncoder
 
     public function encode($encoding, $name, $locale)
     {
-        switch ($encoding) {
-            case 'system_localized':
-                return $this->localizedSystemName($name, $locale);
-            case 'system':
-                return $this->systemName($name);
-            case 'content_localized':
-                return $this->localizedContentName($name, $locale);
-            case 'content':
-                return $this->contentName($name);
-            default:
-                throw new \InvalidArgumentException(\sprintf(
-                    'Invalid encoding "%s"', $encoding
-                ));
-        }
+        return match ($encoding) {
+            'system_localized' => $this->localizedSystemName($name, $locale),
+            'system' => $this->systemName($name),
+            'content_localized' => $this->localizedContentName($name, $locale),
+            'content' => $this->contentName($name),
+            default => throw new \InvalidArgumentException(\sprintf(
+                'Invalid encoding "%s"', $encoding
+            )),
+        };
     }
 
     /**

--- a/src/Sulu/Component/DocumentManager/Subscriber/Core/MappingSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Core/MappingSubscriber.php
@@ -81,18 +81,11 @@ class MappingSubscriber implements EventSubscriberInterface
                 continue;
             }
 
-            switch ($fieldMapping['type']) {
-                case 'reference':
-                    $this->persistReference($node, $accessor, $fieldName, $locale, $fieldMapping);
-
-                    break;
-                case 'json_array':
-                    $this->persistJsonArray($node, $accessor, $fieldName, $locale, $fieldMapping);
-
-                    break;
-                default:
-                    $this->persistGeneric($node, $accessor, $fieldName, $locale, $fieldMapping);
-            }
+            match ($fieldMapping['type']) {
+                'reference' => $this->persistReference($node, $accessor, $fieldName, $locale, $fieldMapping),
+                'json_array' => $this->persistJsonArray($node, $accessor, $fieldName, $locale, $fieldMapping),
+                default => $this->persistGeneric($node, $accessor, $fieldName, $locale, $fieldMapping),
+            };
         }
     }
 
@@ -195,26 +188,19 @@ class MappingSubscriber implements EventSubscriberInterface
                 continue;
             }
 
-            switch ($fieldMapping['type']) {
-                case 'reference':
-                    $this->hydrateReferenceField(
-                        $node,
-                        $document,
-                        $accessor,
-                        $fieldName,
-                        $locale,
-                        $fieldMapping,
-                        $event->getOptions()
-                    );
-
-                    break;
-                case 'json_array':
-                    $this->hydrateJsonArrayField($node, $accessor, $fieldName, $locale, $fieldMapping);
-
-                    break;
-                default:
-                    $this->hydrateGenericField($node, $accessor, $fieldName, $locale, $fieldMapping);
-            }
+            match ($fieldMapping['type']) {
+                'reference' => $this->hydrateReferenceField(
+                    $node,
+                    $document,
+                    $accessor,
+                    $fieldName,
+                    $locale,
+                    $fieldMapping,
+                    $event->getOptions()
+                ),
+                'json_array' => $this->hydrateJsonArrayField($node, $accessor, $fieldName, $locale, $fieldMapping),
+                default => $this->hydrateGenericField($node, $accessor, $fieldName, $locale, $fieldMapping),
+            };
         }
     }
 

--- a/src/Sulu/Component/Rest/ListBuilder/Expression/Doctrine/DoctrineWhereExpression.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Expression/Doctrine/DoctrineWhereExpression.php
@@ -83,14 +83,11 @@ class DoctrineWhereExpression extends AbstractDoctrineExpression implements Wher
      */
     protected function convertNullComparator($comparator)
     {
-        switch ($comparator) {
-            case ListBuilderInterface::WHERE_COMPARATOR_EQUAL:
-                return 'IS NULL';
-            case ListBuilderInterface::WHERE_COMPARATOR_UNEQUAL:
-                return 'IS NOT NULL';
-            default:
-                return $comparator;
-        }
+        return match ($comparator) {
+            ListBuilderInterface::WHERE_COMPARATOR_EQUAL => 'IS NULL',
+            ListBuilderInterface::WHERE_COMPARATOR_UNEQUAL => 'IS NOT NULL',
+            default => $comparator,
+        };
     }
 
     public function getValue()

--- a/src/Sulu/Component/Rest/ListBuilder/Filter/NumberFilterType.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Filter/NumberFilterType.php
@@ -26,21 +26,14 @@ class NumberFilterType implements FilterTypeInterface
         }
 
         foreach (\array_keys($options) as $operator) {
-            switch ($operator) {
-                case 'eq':
-                    $listBuilderOperator = ListBuilderInterface::WHERE_COMPARATOR_EQUAL;
-                    break;
-                case 'lt':
-                    $listBuilderOperator = ListBuilderInterface::WHERE_COMPARATOR_LESS;
-                    break;
-                case 'gt':
-                    $listBuilderOperator = ListBuilderInterface::WHERE_COMPARATOR_GREATER;
-                    break;
-                default:
-                    throw new InvalidFilterTypeOptionsException(
-                        'The NumberFilterType does not support the "' . $operator . '" operator'
-                    );
-            }
+            $listBuilderOperator = match ($operator) {
+                'eq' => ListBuilderInterface::WHERE_COMPARATOR_EQUAL,
+                'lt' => ListBuilderInterface::WHERE_COMPARATOR_LESS,
+                'gt' => ListBuilderInterface::WHERE_COMPARATOR_GREATER,
+                default => throw new InvalidFilterTypeOptionsException(
+                    'The NumberFilterType does not support the "' . $operator . '" operator'
+                ),
+            };
 
             if (!\is_numeric($options[$operator])) {
                 throw new InvalidFilterTypeOptionsException(

--- a/src/Sulu/Component/Rest/ListBuilder/Filter/TextFilterType.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Filter/TextFilterType.php
@@ -26,15 +26,12 @@ class TextFilterType implements FilterTypeInterface
         }
 
         foreach (\array_keys($options) as $operator) {
-            switch ($operator) {
-                case 'eq':
-                    $listBuilderOperator = ListBuilderInterface::WHERE_COMPARATOR_EQUAL;
-                    break;
-                default:
-                    throw new InvalidFilterTypeOptionsException(
-                        'The TextFilterType does not support the "' . $operator . '" operator'
-                    );
-            }
+            $listBuilderOperator = match ($operator) {
+                'eq' => ListBuilderInterface::WHERE_COMPARATOR_EQUAL,
+                default => throw new InvalidFilterTypeOptionsException(
+                    'The TextFilterType does not support the "' . $operator . '" operator'
+                ),
+            };
 
             $listBuilder->where($fieldDescriptor, $options[$operator], $listBuilderOperator);
         }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/ListXmlLoader.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/ListXmlLoader.php
@@ -73,31 +73,18 @@ class ListXmlLoader
     private function loadPropertyMetadata(\DOMXPath $xpath, \DOMNode $propertyNode)
     {
         $propertyMetadata = null;
-        switch ($propertyNode->nodeName) {
-            case 'concatenation-property':
-                $propertyMetadata = $this->loadConcatenationPropertyMetadata($xpath, $propertyNode);
-                break;
-            case 'identity-property':
-                $propertyMetadata = $this->loadIdentityPropertyMetadata($xpath, $propertyNode);
-                break;
-            case 'group-concat-property':
-                $propertyMetadata = $this->loadGroupConcatPropertyMetadata($xpath, $propertyNode);
-                break;
-            case 'case-property':
-                $propertyMetadata = $this->loadCasePropertyMetadata($xpath, $propertyNode);
-                break;
-            case 'count-property':
-                $propertyMetadata = $this->loadCountPropertyMetadata($xpath, $propertyNode);
-                break;
-            case 'property':
-                $propertyMetadata = $this->loadSinglePropertyMetadata($xpath, $propertyNode);
-                break;
-            default:
-                throw new \InvalidArgumentException(\sprintf(
-                    'The tag "%s" cannot be handled by this loader',
-                    $propertyNode->nodeName
-                ));
-        }
+        $propertyMetadata = match ($propertyNode->nodeName) {
+            'concatenation-property' => $this->loadConcatenationPropertyMetadata($xpath, $propertyNode),
+            'identity-property' => $this->loadIdentityPropertyMetadata($xpath, $propertyNode),
+            'group-concat-property' => $this->loadGroupConcatPropertyMetadata($xpath, $propertyNode),
+            'case-property' => $this->loadCasePropertyMetadata($xpath, $propertyNode),
+            'count-property' => $this->loadCountPropertyMetadata($xpath, $propertyNode),
+            'property' => $this->loadSinglePropertyMetadata($xpath, $propertyNode),
+            default => throw new \InvalidArgumentException(\sprintf(
+                'The tag "%s" cannot be handled by this loader',
+                $propertyNode->nodeName
+            )),
+        };
 
         if (null !== $translation = XmlUtil::getValueFromXPath('@translation', $xpath, $propertyNode)) {
             $propertyMetadata->setTranslation($translation);

--- a/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
+++ b/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
@@ -287,14 +287,11 @@ trait DataProviderRepositoryTrait
      */
     private function appendRelation(QueryBuilder $queryBuilder, $relation, $values, $operator, $alias)
     {
-        switch ($operator) {
-            case 'or':
-                return $this->appendRelationOr($queryBuilder, $relation, $values, $alias);
-            case 'and':
-                return $this->appendRelationAnd($queryBuilder, $relation, $values, $alias);
-        }
-
-        return [];
+        return match ($operator) {
+            'or' => $this->appendRelationOr($queryBuilder, $relation, $values, $alias),
+            'and' => $this->appendRelationAnd($queryBuilder, $relation, $values, $alias),
+            default => [],
+        };
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no  
| New feature? | no  
| BC breaks? | no  
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #7325
| License | MIT
| Documentation PR | -

#### What's in this PR?
Replacing switch statements with match. Powered by rector™.

#### Why?
We want to use all the new features of php 8. This code is less error prone (not able to forget the break).

#### Example Usage
PHP [match](https://www.php.net/manual/en/control-structures.match.php)
