### PR TITLE
Configuration of CKEditor 5 powered by and fix some small UI issues

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/CKEditor5.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/CKEditor5.js
@@ -158,8 +158,10 @@ export default class CKEditor5 extends React.Component<Props> {
                 poweredBy: {
                     position: 'inside',
                     side: 'right',
-                    label: ''
-                }
+                    label: '',
+                    verticalOffset: 2,
+                    horizontalOffset: 3,
+                },
             },
         };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/CKEditor5.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/CKEditor5.js
@@ -154,6 +154,13 @@ export default class CKEditor5 extends React.Component<Props> {
                     'mergeTableCells',
                 ],
             },
+            ui: {
+                poweredBy: {
+                    position: 'inside',
+                    side: 'right',
+                    label: ''
+                }
+            },
         };
 
         ClassicEditor

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
@@ -28,6 +28,10 @@ $textEditorUnpublishedLinkColor: $gold;
         /* z-index */
         --ck-z-default: 0;
 
+        /* focus */
+        --ck-focus-ring: $textEditorAccentColor;
+        --ck-focus-outer-shadow: var(--ck-color-base-border);
+
         /* shadows */
         --ck-color-shadow-inner: none;
         --ck-color-shadow-drop: none;
@@ -49,6 +53,7 @@ $textEditorUnpublishedLinkColor: $gold;
         --ck-color-button-default-hover-background: var(--ck-color-button-default-background);
         --ck-color-button-default-active-background: var(--ck-color-button-default-background);
         --ck-color-button-on-background: $textEditorDarkBackgroundColor;
+        --ck-color-button-on-color: inherit;
         --ck-color-button-on-hover-background: var(--ck-color-button-on-background);
         --ck-color-button-on-active-background: var(--ck-color-button-on-background);
         --ck-color-split-button-hover-background: transparent;
@@ -168,6 +173,10 @@ $textEditorUnpublishedLinkColor: $gold;
         }
     }
 
+    .ck.ck-balloon-panel.ck-powered-by-balloon {
+        background: transparent !important;
+    }
+
     .ck.ck-editor {
         .ck.ck-toolbar__separator {
             background: none;
@@ -178,6 +187,11 @@ $textEditorUnpublishedLinkColor: $gold;
             border-color: $textEditorBackgroundColor !important;
             line-height: 20px;
             min-height: 100px;
+            padding-bottom: 5px;
+
+            &.ck-focused {
+                border: 1px solid $textEditorBackgroundColor !important;
+            }
         }
 
         .ck-widget.table {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no
| BC breaks? | no 
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Configuration of CKEditor 5 powered by.

Default:

<img width="950" alt="Bildschirmfoto 2024-03-25 um 14 31 35" src="https://github.com/sulu/sulu/assets/1698337/5add1982-3678-4319-9c04-6e6558af6a3f">

Suggestion:

![ckeditor_powerd_by](https://github.com/sulu/sulu/assets/1698337/4aee9cb6-7520-431c-9748-49b8565a63c2)

Updated edited some spacing here to avoid overlapping:

![Bildschirmfoto 2024-03-25 um 16 05 55](https://github.com/sulu/sulu/assets/1698337/32c0696c-b3c3-4811-8363-c73913c70f6b)

Typo 3 seems to have a similar implementation:

![typo3_ckeditor](https://github.com/sulu/sulu/assets/1698337/5b813d32-1544-498f-ae43-3b447addd542)



#### Why?

https://ckeditor.com/docs/ckeditor5/latest/support/licensing/managing-ckeditor-logo.html