### PR TITLE
Remove unused parameter from ReferenceProvider

### DIFF
--- a/src/Sulu/Bundle/DocumentManagerBundle/Reference/Provider/AbstractDocumentReferenceProvider.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Reference/Provider/AbstractDocumentReferenceProvider.php
@@ -44,22 +44,18 @@ abstract class AbstractDocumentReferenceProvider implements DocumentReferencePro
 
     private string $structureType;
 
-    protected string $referenceSecurityContext;
-
     public function __construct(
         ContentTypeManagerInterface $contentTypeManager,
         StructureManagerInterface $structureManager,
         ExtensionManagerInterface $extensionManager,
         ReferenceRepositoryInterface $referenceRepository,
         string $structureType,
-        string $referenceSecurityContext
     ) {
         $this->contentTypeManager = $contentTypeManager;
         $this->structureManager = $structureManager;
         $this->extensionManager = $extensionManager;
         $this->referenceRepository = $referenceRepository;
         $this->structureType = $structureType;
-        $this->referenceSecurityContext = $referenceSecurityContext;
     }
 
     abstract public static function getResourceKey(): string;

--- a/src/Sulu/Bundle/PageBundle/Reference/Provider/PageReferenceProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Reference/Provider/PageReferenceProvider.php
@@ -38,8 +38,7 @@ class PageReferenceProvider extends AbstractDocumentReferenceProvider
             $structureManager,
             $extensionManager,
             $referenceRepository,
-            Structure::TYPE_PAGE,
-            '' // TODO check what we need here
+            Structure::TYPE_PAGE
         );
     }
 

--- a/src/Sulu/Bundle/SnippetBundle/Reference/Provider/SnippetReferenceProvider.php
+++ b/src/Sulu/Bundle/SnippetBundle/Reference/Provider/SnippetReferenceProvider.php
@@ -38,8 +38,7 @@ class SnippetReferenceProvider extends AbstractDocumentReferenceProvider
             $structureManager,
             $extensionManager,
             $referenceRepository,
-            Structure::TYPE_SNIPPET,
-            SnippetAdmin::SECURITY_CONTEXT
+            Structure::TYPE_SNIPPET
         );
     }
 

--- a/src/Sulu/Bundle/SnippetBundle/Reference/Provider/SnippetReferenceProvider.php
+++ b/src/Sulu/Bundle/SnippetBundle/Reference/Provider/SnippetReferenceProvider.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\SnippetBundle\Reference\Provider;
 
 use Sulu\Bundle\DocumentManagerBundle\Reference\Provider\AbstractDocumentReferenceProvider;
 use Sulu\Bundle\ReferenceBundle\Domain\Repository\ReferenceRepositoryInterface;
-use Sulu\Bundle\SnippetBundle\Admin\SnippetAdmin;
 use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Sulu\Component\Content\Compat\Structure;
 use Sulu\Component\Content\Compat\StructureManagerInterface;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

Removes unused parameter from the ReferenceProvider constructor
