### PR TITLE
Add stricter checks for correct types in reference handling

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
@@ -256,14 +256,18 @@ class MediaSelectionContentType extends ComplexContentType implements ContentTyp
     public function getReferences(PropertyInterface $property, ReferenceCollectorInterface $referenceCollector, string $propertyPrefix = ''): void
     {
         $data = $property->getValue();
-        if (!\is_array($data) || (!isset($data['ids']) || !\is_array($data['ids']))) {
+        if (!isset($data['ids']) || !\is_array($data['ids'])) {
             return;
         }
 
         foreach ($data['ids'] as $id) {
+            if (!\is_int($id)) {
+                continue;
+            }
+
             $referenceCollector->addReference(
                 MediaInterface::RESOURCE_KEY,
-                $id,
+                (string) $id,
                 $propertyPrefix . $property->getName()
             );
         }

--- a/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
@@ -256,6 +256,11 @@ class MediaSelectionContentType extends ComplexContentType implements ContentTyp
     public function getReferences(PropertyInterface $property, ReferenceCollectorInterface $referenceCollector, string $propertyPrefix = ''): void
     {
         $data = $property->getValue();
+
+        if ($data instanceof MediaSelectionContainer) { // TODO should probably be removed when tests are refactored
+            $data = $data->toArray();
+        }
+
         if (!\is_array($data) || !isset($data['ids']) || !\is_array($data['ids'])) {
             return;
         }

--- a/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
@@ -256,7 +256,7 @@ class MediaSelectionContentType extends ComplexContentType implements ContentTyp
     public function getReferences(PropertyInterface $property, ReferenceCollectorInterface $referenceCollector, string $propertyPrefix = ''): void
     {
         $data = $property->getValue();
-        if (!isset($data['ids']) || !\is_array($data['ids'])) {
+        if (!\is_array($data) || !isset($data['ids']) || !\is_array($data['ids'])) {
             return;
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Content/Types/SingleMediaSelection.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/SingleMediaSelection.php
@@ -193,7 +193,7 @@ class SingleMediaSelection extends SimpleContentType implements PreResolvableCon
     public function getReferences(PropertyInterface $property, ReferenceCollectorInterface $referenceCollector, string $propertyPrefix = ''): void
     {
         $data = $property->getValue();
-        if (!isset($data['id']) || !\is_int($data['id'])) {
+        if (!\is_array($data) || !isset($data['id']) || !\is_int($data['id'])) {
             return;
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Content/Types/SingleMediaSelection.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/SingleMediaSelection.php
@@ -193,13 +193,13 @@ class SingleMediaSelection extends SimpleContentType implements PreResolvableCon
     public function getReferences(PropertyInterface $property, ReferenceCollectorInterface $referenceCollector, string $propertyPrefix = ''): void
     {
         $data = $property->getValue();
-        if (!\is_array($data) || !isset($data['id'])) {
+        if (!isset($data['id']) || !\is_int($data['id'])) {
             return;
         }
 
         $referenceCollector->addReference(
             MediaInterface::RESOURCE_KEY,
-            $data['id'],
+            (string) $data['id'],
             $propertyPrefix . $property->getName()
         );
     }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Content/Types/MediaSelectionContentTypeTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Content/Types/MediaSelectionContentTypeTest.php
@@ -782,17 +782,17 @@ class MediaSelectionContentTypeTest extends TestCase
             new Metadata([]),
             'media_selection',
         );
-        $property->setValue(['ids' => ['123-123-123', '321-321-321']]);
+        $property->setValue(['ids' => [1, 2]]);
 
         $referenceCollector = $this->prophesize(ReferenceCollector::class);
         $referenceCollector->addReference(
             'media',
-            '123-123-123',
+            1,
             'media'
         )->shouldBeCalled();
         $referenceCollector->addReference(
             'media',
-            '321-321-321',
+            2,
             'media'
         )->shouldBeCalled();
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Content/Types/SingleMediaSelectionTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Content/Types/SingleMediaSelectionTest.php
@@ -427,12 +427,12 @@ class SingleMediaSelectionTest extends TestCase
             new Metadata([]),
             'single_media_selection',
         );
-        $property->setValue(['id' => '123-123-123']);
+        $property->setValue(['id' => 1]);
 
         $referenceCollector = $this->prophesize(ReferenceCollector::class);
         $referenceCollector->addReference(
             'media',
-            '123-123-123',
+            1,
             'media'
         )->shouldBeCalled();
 

--- a/src/Sulu/Bundle/SnippetBundle/Content/SingleSnippetSelection.php
+++ b/src/Sulu/Bundle/SnippetBundle/Content/SingleSnippetSelection.php
@@ -152,7 +152,7 @@ class SingleSnippetSelection extends SimpleContentType implements PreResolvableC
     public function getReferences(PropertyInterface $property, ReferenceCollectorInterface $referenceCollector, string $propertyPrefix = ''): void
     {
         $data = $property->getValue();
-        if (null === $data) {
+        if (null === $data || !\is_string($data)) {
             return;
         }
 

--- a/src/Sulu/Bundle/SnippetBundle/Content/SingleSnippetSelection.php
+++ b/src/Sulu/Bundle/SnippetBundle/Content/SingleSnippetSelection.php
@@ -152,7 +152,7 @@ class SingleSnippetSelection extends SimpleContentType implements PreResolvableC
     public function getReferences(PropertyInterface $property, ReferenceCollectorInterface $referenceCollector, string $propertyPrefix = ''): void
     {
         $data = $property->getValue();
-        if (null === $data || !\is_string($data)) {
+        if (!\is_string($data)) {
             return;
         }
 

--- a/src/Sulu/Bundle/SnippetBundle/Content/SnippetContent.php
+++ b/src/Sulu/Bundle/SnippetBundle/Content/SnippetContent.php
@@ -265,6 +265,10 @@ class SnippetContent extends ComplexContentType implements ContentTypeExportInte
         }
 
         foreach ($data as $id) {
+            if (!\is_string($id)) {
+                continue;
+            }
+
             $referenceCollector->addReference(
                 SnippetDocument::RESOURCE_KEY,
                 $id,

--- a/src/Sulu/Component/Content/Tests/Unit/Block/BlockContentTypeTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Block/BlockContentTypeTest.php
@@ -1007,13 +1007,13 @@ class BlockContentTypeTest extends TestCase
                 'type' => 'type1',
                 'media' => [
                     'ids' => [
-                        '123-123-123',
-                        '321-321-321',
+                        1,
+                        2,
                     ],
                 ],
                 'sub-block' => [
                     'type' => 'subType1',
-                    'single_media' => ['id' => '111-111-111'],
+                    'single_media' => ['id' => 3],
                     'settings' => [],
                 ],
                 'settings' => [],
@@ -1022,7 +1022,7 @@ class BlockContentTypeTest extends TestCase
                 'type' => 'type1',
                 'media' => [
                     'ids' => [
-                        '444-444-444',
+                        4,
                     ],
                 ],
                 'sub-block' => [],
@@ -1036,28 +1036,28 @@ class BlockContentTypeTest extends TestCase
         $referenceCollector = $this->prophesize(ReferenceCollectorInterface::class);
         $referenceCollector->addReference(
             'media',
-            '123-123-123',
+            1,
             'block1[0].media'
         )
             ->shouldBeCalled()
             ->willReturn(new Reference());
         $referenceCollector->addReference(
             'media',
-            '321-321-321',
+            2,
             'block1[0].media'
         )
             ->shouldBeCalled()
             ->willReturn(new Reference());
         $referenceCollector->addReference(
             'media',
-            '111-111-111',
+            3,
             'block1[0].sub-block[0].single_media'
         )
             ->shouldBeCalled()
             ->willReturn(new Reference());
         $referenceCollector->addReference(
             'media',
-            '444-444-444',
+            4,
             'block1[1].media'
         )
             ->shouldBeCalled()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add stricter checks for correct types in reference handling.

#### Why?

Avoid any error if the data is not correct.