### PR TITLE
Updating to phpunit 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ yarn.lock
 .phpunit
 phpunit.xml
 .phpunit.result.cache
+.phpunit.cache
 
 # IDEs
 /.idea

--- a/composer.json
+++ b/composer.json
@@ -133,7 +133,7 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "phpstan/phpstan-symfony": "^1.0",
         "phpstan/phpstan-webmozart-assert": "^1.0",
-        "phpunit/phpunit": "^9.5.20",
+        "phpunit/phpunit": "^10.5",
         "psr/event-dispatcher": "^1.0",
         "rector/rector": "^1.1",
         "scheb/2fa-backup-code": "^6.0 || ^7.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16776,11 +16776,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createCollection\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createCollection\\(\\) has parameter \\$name with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,19 +5,17 @@
          colors="true"
          failOnIncomplete="true"
          failOnWarning="true"
-         failOnRisky="true"
->
-    <coverage>
+         failOnRisky="true">
+    <source>
         <include>
             <directory>./src/Sulu/Component/</directory>
         </include>
-
         <exclude>
             <directory>./tests</directory>
             <directory>./vendor</directory>
             <directory>./*/Tests</directory>
         </exclude>
-    </coverage>
+    </source>
 
     <testsuites>
         <testsuite name="components">

--- a/src/Sulu/Bundle/ActivityBundle/Tests/Functional/UserInterface/Controller/ActivityControllerTest.php
+++ b/src/Sulu/Bundle/ActivityBundle/Tests/Functional/UserInterface/Controller/ActivityControllerTest.php
@@ -131,10 +131,9 @@ class ActivityControllerTest extends SuluTestCase
     }
 
     /**
-     * @dataProvider provideCgetAction
-     *
      * @param mixed[] $parameters
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideCgetAction')]
     public function testCgetAction(array $parameters, int $expectedTotal): void
     {
         $urlParameters = \array_merge(

--- a/src/Sulu/Bundle/ActivityBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/ActivityBundle/phpunit.xml.dist
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="../TestBundle/Resources/app/bootstrap.php"
-         colors="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage>
+    bootstrap="../TestBundle/Resources/app/bootstrap.php"
+    colors="true"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+    <source>
         <include>
             <directory>./</directory>
         </include>
-
         <exclude>
             <directory>./Tests</directory>
             <directory>./vendor</directory>
         </exclude>
-    </coverage>
+    </source>
 
     <testsuites>
         <testsuite name="SuluActivityBundle Test Suite">

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormOverlayListViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormOverlayListViewBuilderTest.php
@@ -83,9 +83,7 @@ class FormOverlayListViewBuilderTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideBuildFormOverlayListView
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideBuildFormOverlayListView')]
     public function testBuildFormOverlayListView(
         string $name,
         string $path,

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormViewBuilderTest.php
@@ -107,9 +107,7 @@ class FormViewBuilderTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideBuildFormView
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideBuildFormView')]
     public function testBuildFormView(
         string $name,
         string $path,

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ListViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ListViewBuilderTest.php
@@ -82,9 +82,7 @@ class ListViewBuilderTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideBuildListView
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideBuildListView')]
     public function testBuildListView(
         string $name,
         string $path,

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/PreviewFormViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/PreviewFormViewBuilderTest.php
@@ -77,9 +77,7 @@ class PreviewFormViewBuilderTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideBuildPreviewFormView
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideBuildPreviewFormView')]
     public function testBuildPreviewFormView(
         string $name,
         string $path,

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ResourceTabViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ResourceTabViewBuilderTest.php
@@ -80,9 +80,7 @@ class ResourceTabViewBuilderTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideBuildResourceTabView
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideBuildResourceTabView')]
     public function testBuildResourceTabView(
         string $name,
         string $path,

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/TabViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/TabViewBuilderTest.php
@@ -53,9 +53,7 @@ class TabViewBuilderTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideBuildTabView
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideBuildTabView')]
     public function testBuildTabView(
         string $name,
         string $path,

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ViewBuilderTest.php
@@ -41,9 +41,7 @@ class ViewBuilderTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideBuildView
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideBuildView')]
     public function testBuildTabView(
         string $name,
         string $path,

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
@@ -372,9 +372,7 @@ class AdminControllerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideTranslationsAction
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideTranslationsAction')]
     public function testTranslationsAction($locale, $translations, $fallbackTranslations, $resultTranslations): void
     {
         $request = new Request(['locale' => $locale]);

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Entity/CollaborationRepositoryTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Entity/CollaborationRepositoryTest.php
@@ -131,9 +131,7 @@ class CollaborationRepositoryTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideUpdate
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideUpdate')]
     public function testUpdate(
         $threshold,
         $collaborationId1,

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/ArrayMetadataTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/ArrayMetadataTest.php
@@ -50,9 +50,7 @@ class ArrayMetadataTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideToJsonSchema
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideToJsonSchema')]
     public function testToJsonSchema($schemaMetadata, $minItems, $maxItems, $uniqueItems, $expectedSchema): void
     {
         $property = new ArrayMetadata($schemaMetadata, $minItems, $maxItems, $uniqueItems);

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/ConstMetadataTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/ConstMetadataTest.php
@@ -25,9 +25,7 @@ class ConstMetadataTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideToJsonSchema
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideToJsonSchema')]
     public function testToJsonSchema($const, $expectedSchema): void
     {
         $property = new ConstMetadata($const);

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/PropertyMetadataTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/PropertyMetadataTest.php
@@ -26,9 +26,7 @@ class PropertyMetadataTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideGetter
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideGetter')]
     public function testGetter($name, $mandatory): void
     {
         $property = new PropertyMetadata($name, $mandatory);
@@ -47,9 +45,7 @@ class PropertyMetadataTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideToJsonSchema
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideToJsonSchema')]
     public function testToJsonSchema($name, $mandatory, $schemaMetadata, $expectedSchema): void
     {
         $property = new PropertyMetadata($name, $mandatory, $schemaMetadata);

--- a/src/Sulu/Bundle/AdminBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/AdminBundle/phpunit.xml.dist
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../TestBundle/Resources/app/bootstrap.php"
-         colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    bootstrap="../TestBundle/Resources/app/bootstrap.php"
+    colors="true"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+    <source>
         <include>
             <directory>./</directory>
         </include>
-
         <exclude>
             <directory>./Tests</directory>
             <directory>./vendor</directory>
         </exclude>
-    </coverage>
+    </source>
 
     <testsuites>
         <testsuite name="Sulu AdminBundle Test Suite">

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Functional/CachingTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Functional/CachingTest.php
@@ -69,9 +69,7 @@ class CachingTest extends SuluTestCase
         return [$client, $cookieJar];
     }
 
-    /**
-     * @depends testFirstRequestIsACacheMiss
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testFirstRequestIsACacheMiss')]
     public function testSecondRequestIsACacheHit($arguments)
     {
         list($client, $cookieJar) = $arguments;
@@ -86,9 +84,7 @@ class CachingTest extends SuluTestCase
         return [$client, $cookieJar];
     }
 
-    /**
-     * @depends testSecondRequestIsACacheHit
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testSecondRequestIsACacheHit')]
     public function testRequestFromOtherClientIsACacheMiss($arguments)
     {
         list($client, $cookieJar) = $arguments;
@@ -108,9 +104,7 @@ class CachingTest extends SuluTestCase
         return [$client, $cookieJar];
     }
 
-    /**
-     * @depends testRequestFromOtherClientIsACacheMiss
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testRequestFromOtherClientIsACacheMiss')]
     public function testRequestWithoutSessionCookieTriggersNoRules($arguments)
     {
         /** @var KernelBrowser $client */
@@ -133,9 +127,7 @@ class CachingTest extends SuluTestCase
         return [$client, $cookieJar];
     }
 
-    /**
-     * @depends testRequestWithoutSessionCookieTriggersNoRules
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testRequestWithoutSessionCookieTriggersNoRules')]
     public function testRequestWithoutSessionCookieTriggersARule($arguments): void
     {
         /** @var KernelBrowser $client */

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Controller/TargetGroupEvaluationControllerTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Controller/TargetGroupEvaluationControllerTest.php
@@ -51,9 +51,7 @@ class TargetGroupEvaluationControllerTest extends TestCase
         $this->targetGroupStore = $this->prophesize(TargetGroupStoreInterface::class);
     }
 
-    /**
-     * @dataProvider provideTargetGroup
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideTargetGroup')]
     public function testTargetGroupAction($header, $currentTargetGroup, $targetGroup, $targetGroupId): void
     {
         if ($currentTargetGroup) {
@@ -101,9 +99,7 @@ class TargetGroupEvaluationControllerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideTargetGroupHit
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideTargetGroupHit')]
     public function testTargetGroupHitAction($oldTargetGroup, $newTargetGroup, $newTargetGroupId): void
     {
         $this->targetGroupRepository->find($oldTargetGroup->getId())->willReturn($oldTargetGroup);

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
@@ -103,9 +103,7 @@ class TargetGroupSubscriberTest extends TestCase
         $targetGroupSubscriber->setTargetGroup($event);
     }
 
-    /**
-     * @dataProvider provideSetTargetGroupFromHeader
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideSetTargetGroupFromHeader')]
     public function testSetTargetGroupFromHeader(
         $targetGroupHeader,
         $headerTargetGroup,
@@ -150,9 +148,7 @@ class TargetGroupSubscriberTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideSetTargetGroupFromCookie
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideSetTargetGroupFromCookie')]
     public function testSetTargetGroupFromCookie(
         $targetGroupCookie,
         $visitorSessionCookie,
@@ -219,9 +215,7 @@ class TargetGroupSubscriberTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideSetTargetGroupFromEvaluation
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideSetTargetGroupFromEvaluation')]
     public function testSetTargetGroupFromEvaluation($evaluatedTargetGroup, $result): void
     {
         $targetGroupSubscriber = new TargetGroupSubscriber(
@@ -297,9 +291,7 @@ class TargetGroupSubscriberTest extends TestCase
         $targetGroupSubscriber->setTargetGroup($event);
     }
 
-    /**
-     * @dataProvider provideAddVaryHeader
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideAddVaryHeader')]
     public function testAddVaryHeader($targetGroupUrl, $requestUrl, $hasInfluencedContent, $header, $varyHeaders): void
     {
         $targetGroupSubscriber = new TargetGroupSubscriber(
@@ -348,9 +340,7 @@ class TargetGroupSubscriberTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideAddSetCookieHeader
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideAddSetCookieHeader')]
     public function testAddSetCookieHeader(string $targetGroupCookie, string $visitorSession, bool $hasChanged, string $url, ?int $cookieValue): void
     {
         $targetGroupSubscriber = new TargetGroupSubscriber(
@@ -409,9 +399,7 @@ class TargetGroupSubscriberTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideAddTargetGroupHitScript
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideAddTargetGroupHitScript')]
     public function testAddTargetGroupHitScript(
         string $targetGroupHitUrl,
         string $forwardedUrlHeader,

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Request/ForwardedUrlRequestProcessorTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Request/ForwardedUrlRequestProcessorTest.php
@@ -18,9 +18,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 class ForwardedUrlRequestProcessorTest extends TestCase
 {
-    /**
-     * @dataProvider provideProcess
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideProcess')]
     public function testProcess($urlHeader, $url, $host, $port, $path): void
     {
         $forwardedUrlRequestProcessor = new ForwardedUrlRequestProcessor($urlHeader);

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/BrowserRuleTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/BrowserRuleTest.php
@@ -44,9 +44,7 @@ class BrowserRuleTest extends TestCase
         $this->browserRule = new BrowserRule($this->deviceDetector->reveal(), $this->translator->reveal());
     }
 
-    /**
-     * @dataProvider provideEvaluate
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideEvaluate')]
     public function testEvaluate($browserShortName, $options, $result): void
     {
         $this->deviceDetector->getClient('short_name')->willReturn($browserShortName);

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/DeviceTypeRuleTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/DeviceTypeRuleTest.php
@@ -44,9 +44,7 @@ class DeviceTypeRuleTest extends TestCase
         $this->deviceTypeRule = new DeviceTypeRule($this->deviceDetector->reveal(), $this->translator->reveal());
     }
 
-    /**
-     * @dataProvider provideEvaluate
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideEvaluate')]
     public function testEvaluate($deviceType, $options, $result): void
     {
         $this->deviceDetector->isDesktop()->willReturn(DeviceTypeRule::DESKTOP === $deviceType);

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/LocaleRuleTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/LocaleRuleTest.php
@@ -53,9 +53,7 @@ class LocaleRuleTest extends TestCase
         $this->localeRule = new LocaleRule($this->requestStack->reveal(), $this->translator->reveal());
     }
 
-    /**
-     * @dataProvider provideEvaluationData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideEvaluationData')]
     public function testEvaluate($languages, $options, $result): void
     {
         $this->request->getLanguages()->willReturn($languages);

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/OperatingSystemRuleTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/OperatingSystemRuleTest.php
@@ -44,9 +44,7 @@ class OperatingSystemRuleTest extends TestCase
         $this->operatingSystemRule = new OperatingSystemRule($this->deviceDetector->reveal(), $this->translator->reveal());
     }
 
-    /**
-     * @dataProvider provideEvaluate
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideEvaluate')]
     public function testEvaluate($operatingSystemShortName, $options, $result): void
     {
         $this->deviceDetector->getOs('short_name')->willReturn($operatingSystemShortName);

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/QueryStringRuleTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/QueryStringRuleTest.php
@@ -39,9 +39,7 @@ class QueryStringRuleTest extends TestCase
         $this->translator = $this->prophesize(TranslatorInterface::class);
     }
 
-    /**
-     * @dataProvider provideEvaluate
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideEvaluate')]
     public function testEvaluate($url, $urlHeader, $urlHeaderValue, $options, $result): void
     {
         $queryStringRule = new QueryStringRule($this->requestStack->reveal(), $this->translator->reveal(), $urlHeader);

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/ReferrerRuleTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/ReferrerRuleTest.php
@@ -39,9 +39,7 @@ class ReferrerRuleTest extends TestCase
         $this->translator = $this->prophesize(TranslatorInterface::class);
     }
 
-    /**
-     * @dataProvider provideEvaluationData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideEvaluationData')]
     public function testEvaluate($referrerHeader, $referrer, $options, $result): void
     {
         $referrerRule = new ReferrerRule($this->requestStack->reveal(), $this->translator->reveal(), $referrerHeader);

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/TargetGroupEvaluatorTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/TargetGroupEvaluatorTest.php
@@ -63,9 +63,8 @@ class TargetGroupEvaluatorTest extends TestCase
     /**
      * @param array<TargetGroup> $targetGroups
      * @param array<string, string[]> $ruleWhitelists
-     *
-     * @dataProvider provideEvaluationData
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideEvaluationData')]
     public function testEvaluate(
         array $targetGroups,
         array $ruleWhitelists,

--- a/src/Sulu/Bundle/AudienceTargetingBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/phpunit.xml.dist
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="../TestBundle/Resources/app/bootstrap.php"
-         colors="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage>
+    bootstrap="../TestBundle/Resources/app/bootstrap.php"
+    colors="true"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+    <source>
         <include>
             <directory>./</directory>
         </include>
-
         <exclude>
             <directory>./Tests</directory>
             <directory>./vendor</directory>
         </exclude>
-    </coverage>
+    </source>
 
     <testsuites>
         <testsuite name="SuluAudienceTargeting Test Suite">

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Category/KeywordManagerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Category/KeywordManagerTest.php
@@ -40,9 +40,7 @@ class KeywordManagerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideSaveData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideSaveData')]
     public function testSave($exists = false, $has = false, $keywordString = 'Test', $locale = 'de'): void
     {
         $repository = $this->prophesize(KeywordRepositoryInterface::class);
@@ -162,9 +160,7 @@ class KeywordManagerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideDeleteData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideDeleteData')]
     public function testDelete($referenced = false, $keywordString = 'Test', $locale = 'de'): void
     {
         $repository = $this->prophesize(KeywordRepositoryInterface::class);

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Twig/CategoryTwigExtensionTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Twig/CategoryTwigExtensionTest.php
@@ -101,9 +101,8 @@ class CategoryTwigExtensionTest extends TestCase
 
     /**
      * @param array<array{id:int, name: string}> $categoryData
-     *
-     * @dataProvider getProvider
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getProvider')]
     public function testGet(array $categoryData, string $locale = 'en', ?string $parent = null, ?int $depth = null): void
     {
         $categoryEntities = [];
@@ -173,9 +172,7 @@ class CategoryTwigExtensionTest extends TestCase
         $this->assertSame([], $result);
     }
 
-    /**
-     * @dataProvider appendProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('appendProvider')]
     public function testAppendUrl(string $parameter, string $url, string $string, string $expected): void
     {
         $category = ['id' => 3, 'name' => 'test'];
@@ -221,9 +218,7 @@ class CategoryTwigExtensionTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider setProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('setProvider')]
     public function testSetUrl(string $parameter, string $url, string $string, string $expected): void
     {
         $category = ['id' => 3, 'name' => 'test'];
@@ -265,9 +260,7 @@ class CategoryTwigExtensionTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider clearProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('clearProvider')]
     public function testClearUrl(string $parameter, string $url, string $string): void
     {
         $manager = $this->prophesize(CategoryManagerInterface::class);

--- a/src/Sulu/Bundle/CategoryBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/CategoryBundle/phpunit.xml.dist
@@ -2,17 +2,16 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="../TestBundle/Resources/app/bootstrap.php"
          colors="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage>
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+    <source>
         <include>
             <directory>./</directory>
         </include>
-
         <exclude>
             <directory>./Tests</directory>
             <directory>./vendor</directory>
         </exclude>
-    </coverage>
+    </source>
 
     <testsuites>
         <testsuite name="SuluCategoryBundle Test Suite">

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/CacheInvalidationListenerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/CacheInvalidationListenerTest.php
@@ -54,9 +54,7 @@ class CacheInvalidationListenerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
     public function testPostPersist($class, $alias): void
     {
         $entity = $this->prophesize($class);
@@ -77,9 +75,7 @@ class CacheInvalidationListenerTest extends TestCase
         $this->listener->postPersist($eventArgs->reveal());
     }
 
-    /**
-     * @dataProvider provideData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
     public function testPostUpdate($class, $alias): void
     {
         $entity = $this->prophesize($class);
@@ -100,9 +96,7 @@ class CacheInvalidationListenerTest extends TestCase
         $this->listener->postUpdate($eventArgs->reveal());
     }
 
-    /**
-     * @dataProvider provideData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
     public function testPreRemove($class, $alias): void
     {
         $entity = $this->prophesize($class);
@@ -131,9 +125,7 @@ class CacheInvalidationListenerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideDataWithTagsAndCategories
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataWithTagsAndCategories')]
     public function testPersistUpdateWithTagsAndCategories($class, $alias): void
     {
         $entity = $this->prophesize($class);
@@ -161,9 +153,7 @@ class CacheInvalidationListenerTest extends TestCase
         $this->listener->postPersist($eventArgs->reveal());
     }
 
-    /**
-     * @dataProvider provideDataWithTagsAndCategories
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataWithTagsAndCategories')]
     public function testPostUpdateWithTagsAndCategories($class, $alias): void
     {
         $entity = $this->prophesize($class);
@@ -191,9 +181,7 @@ class CacheInvalidationListenerTest extends TestCase
         $this->listener->postUpdate($eventArgs->reveal());
     }
 
-    /**
-     * @dataProvider provideDataWithTagsAndCategories
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataWithTagsAndCategories')]
     public function testPreRemoveUpdateWithTagsAndCategories($class, $alias): void
     {
         $entity = $this->prophesize($class);

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/CustomerIdConverterTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/CustomerIdConverterTest.php
@@ -29,9 +29,7 @@ class CustomerIdConverterTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider convertIdsToGroupedIdsProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('convertIdsToGroupedIdsProvider')]
     public function testConvertIdsToGroupedIds(array $ids, array $default, $expected): void
     {
         $converter = new CustomerIdConverter();
@@ -53,9 +51,7 @@ class CustomerIdConverterTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider convertGroupedIdsToIdsProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('convertGroupedIdsToIdsProvider')]
     public function testConvertGroupedIdsToIds(array $groupedIds, array $expected): void
     {
         $converter = new CustomerIdConverter();

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/IndexComparatorTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/IndexComparatorTest.php
@@ -36,9 +36,7 @@ class IndexComparatorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider usortProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('usortProvider')]
     public function testUsortCallback(array $array, array $ids, $startsWith, $contains): void
     {
         $comparator = new IndexComparator();

--- a/src/Sulu/Bundle/ContactBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/ContactBundle/phpunit.xml.dist
@@ -2,8 +2,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="../TestBundle/Resources/app/bootstrap.php"
          colors="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage>
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+    <source>
         <include>
             <directory>./</directory>
         </include>
@@ -12,7 +12,7 @@
             <directory>./Tests</directory>
             <directory>./vendor</directory>
         </exclude>
-    </coverage>
+    </source>
 
     <testsuites>
         <testsuite name="SuluContactBundle Test Suite">

--- a/src/Sulu/Bundle/CoreBundle/Tests/Unit/DependencyInjection/Compiler/ListBuilderMetadataProviderCompilerPassTest.php
+++ b/src/Sulu/Bundle/CoreBundle/Tests/Unit/DependencyInjection/Compiler/ListBuilderMetadataProviderCompilerPassTest.php
@@ -33,9 +33,7 @@ class ListBuilderMetadataProviderCompilerPassTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider dataProcessProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProcessProvider')]
     public function testProcess($hasDefinition, $taggedServices = []): void
     {
         $definition = $this->prophesize(Definition::class);

--- a/src/Sulu/Bundle/CoreBundle/Tests/Unit/DependencyInjection/Compiler/RemoveForeignContextServicesPassTest.php
+++ b/src/Sulu/Bundle/CoreBundle/Tests/Unit/DependencyInjection/Compiler/RemoveForeignContextServicesPassTest.php
@@ -36,9 +36,7 @@ class RemoveForeignContextServicesPassTest extends AbstractCompilerPassTestCase
         $container->addCompilerPass(new RemoveForeignContextServicesPass());
     }
 
-    /**
-     * @dataProvider provideWebsiteServices
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideWebsiteServices')]
     public function testRemoveWebsiteServices($services): void
     {
         $this->setParameter('sulu.context', 'website');

--- a/src/Sulu/Bundle/CoreBundle/Tests/Unit/ReplacerXmlLoaderTest.php
+++ b/src/Sulu/Bundle/CoreBundle/Tests/Unit/ReplacerXmlLoaderTest.php
@@ -72,9 +72,7 @@ class ReplacerXmlLoaderTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider examplesDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('examplesDataProvider')]
     public function testRealFile($locale, $from, $to): void
     {
         $filename = 'replacers.xml';

--- a/src/Sulu/Bundle/CoreBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/CoreBundle/phpunit.xml.dist
@@ -2,8 +2,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="../TestBundle/Resources/app/bootstrap.php"
          colors="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage>
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+    <source>
         <include>
             <directory>./</directory>
         </include>
@@ -12,7 +12,7 @@
             <directory>./Tests</directory>
             <directory>./vendor</directory>
         </exclude>
-    </coverage>
+    </source>
 
     <testsuites>
         <testsuite name="Sulu CoreBundle Test Suite">

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Functional/Controller/CustomUrlControllerTest.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Functional/Controller/CustomUrlControllerTest.php
@@ -124,9 +124,7 @@ class CustomUrlControllerTest extends SuluTestCase
         ];
     }
 
-    /**
-     * @dataProvider postProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('postProvider')]
     public function testPost($data, $url, $statusCode = 200, $restErrorCode = null)
     {
         // content document is not there in provider
@@ -262,9 +260,7 @@ class CustomUrlControllerTest extends SuluTestCase
         ];
     }
 
-    /**
-     * @dataProvider postMultipleProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('postMultipleProvider')]
     public function testPostMultiple($before, $data, $beforeUrl, $url, $statusCode = 200, $restErrorCode = null): void
     {
         $this->testPost($before, $beforeUrl);
@@ -510,9 +506,7 @@ class CustomUrlControllerTest extends SuluTestCase
         ];
     }
 
-    /**
-     * @dataProvider putProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('putProvider')]
     public function testPut(array $before, $data, $url, $statusCode = 200, $restErrorCode = null)
     {
         foreach ($before as $beforeUrl => $beforeData) {
@@ -579,9 +573,7 @@ class CustomUrlControllerTest extends SuluTestCase
         ];
     }
 
-    /**
-     * @dataProvider getProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getProvider')]
     public function testGet($data, $url): void
     {
         // content document is not there in provider
@@ -654,9 +646,7 @@ class CustomUrlControllerTest extends SuluTestCase
         ];
     }
 
-    /**
-     * @dataProvider cgetProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('cgetProvider')]
     public function testCGet($items): void
     {
         foreach ($items as $url => $data) {
@@ -693,9 +683,7 @@ class CustomUrlControllerTest extends SuluTestCase
         }
     }
 
-    /**
-     * @dataProvider getProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getProvider')]
     public function testDelete($data, $url): void
     {
         $uuid = $this->testPost($data, $url);
@@ -715,9 +703,7 @@ class CustomUrlControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(404, $response);
     }
 
-    /**
-     * @dataProvider cgetProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('cgetProvider')]
     public function testCDelete($items): void
     {
         $uuid = $this->testPost(

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Functional/Controller/CustomUrlRouteControllerTest.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Functional/Controller/CustomUrlRouteControllerTest.php
@@ -103,9 +103,7 @@ class CustomUrlRouteControllerTest extends SuluTestCase
         ];
     }
 
-    /**
-     * @dataProvider cdeleteRoutesProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('cdeleteRoutesProvider')]
     public function testCDeleteRoutes(
         array $before,
         $data,

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/Request/CustomUrlRequestProcessorTest.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/Request/CustomUrlRequestProcessorTest.php
@@ -50,9 +50,7 @@ class CustomUrlRequestProcessorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider dataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
     public function testProcess(
         $host,
         $pathInfo,

--- a/src/Sulu/Bundle/CustomUrlBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/CustomUrlBundle/phpunit.xml.dist
@@ -2,8 +2,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="../TestBundle/Resources/app/bootstrap.php"
          colors="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage>
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+    <source>
         <include>
             <directory>./</directory>
         </include>
@@ -12,7 +12,7 @@
             <directory>./Tests</directory>
             <directory>./vendor</directory>
         </exclude>
-    </coverage>
+    </source>
 
     <testsuites>
         <testsuite name="SuluCustomUrl Test Suite">

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Bridge/DocumentInspectorTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Bridge/DocumentInspectorTest.php
@@ -122,9 +122,8 @@ class DocumentInspectorTest extends TestCase
 
     /**
      * It should return the webspace for the given document.
-     *
-     * @dataProvider provideGetWebspace
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideGetWebspace')]
     public function testGetWebspace($path, $expectedWebspace): void
     {
         $this->documentRegistry->getNodeForDocument($this->document)->willReturn($this->node->reveal());
@@ -271,9 +270,8 @@ class DocumentInspectorTest extends TestCase
 
     /**
      * It should return the webspace name for a given node.
-     *
-     * @dataProvider provideWebspace
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideWebspace')]
     public function testWebspace($path, $expectedWebspace): void
     {
         $this->documentRegistry->getNodeForDocument($this->document)->willReturn($this->node->reveal());

--- a/src/Sulu/Bundle/DocumentManagerBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/DocumentManagerBundle/phpunit.xml.dist
@@ -3,18 +3,18 @@
          colors="true"
          bootstrap="../TestBundle/Resources/app/bootstrap.php"
          processIsolation="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage includeUncoveredFiles="true">
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+    <source>
         <include>
-            <directory>.</directory>
+            <directory>./</directory>
         </include>
 
         <exclude>
-            <directory>Resources/</directory>
-            <directory>Tests/</directory>
-            <directory>vendor/</directory>
+            <directory>./Resources</directory>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
         </exclude>
-    </coverage>
+    </source>
 
     <testsuites>
         <testsuite name="Sulu DocumentManager Bundle">

--- a/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/CacheLifetime/CacheLifetimeEnhancerTest.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/CacheLifetime/CacheLifetimeEnhancerTest.php
@@ -104,9 +104,7 @@ class CacheLifetimeEnhancerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideCacheLifeTime
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideCacheLifeTime')]
     public function testEnhance(int $cacheLifetime, ?int $requestCacheLifetime, int $expectedCacheLifetime): void
     {
         $this->page->getCacheLifeTime()->willReturn(

--- a/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/CacheLifetime/CacheLifetimeRequestStoreTest.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/CacheLifetime/CacheLifetimeRequestStoreTest.php
@@ -48,9 +48,7 @@ class CacheLifetimeRequestStoreTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideSetCacheLifetime
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideSetCacheLifetime')]
     public function testSetCacheLifetime($previousCacheLifetime, $newCacheLifetime, $expectedCacheLifetime): void
     {
         $request = new Request([], [], $previousCacheLifetime ? ['_cacheLifetime' => $previousCacheLifetime] : []);

--- a/src/Sulu/Bundle/HttpCacheBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/HttpCacheBundle/phpunit.xml.dist
@@ -2,16 +2,17 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="../TestBundle/Resources/app/bootstrap.php"
          colors="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage>
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+    <source>
         <include>
             <directory>./</directory>
         </include>
+
         <exclude>
             <directory>./Tests</directory>
             <directory>./vendor</directory>
         </exclude>
-    </coverage>
+    </source>
 
     <testsuites>
         <testsuite name="SuluHttpCacheBundle Test Suite">

--- a/src/Sulu/Bundle/LocationBundle/Tests/Unit/Content/Types/LocationContentTypeTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Unit/Content/Types/LocationContentTypeTest.php
@@ -56,9 +56,7 @@ class LocationContentTypeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideRead
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideRead')]
     public function testRead($data): void
     {
         $this->initReadTest($data);
@@ -81,9 +79,7 @@ class LocationContentTypeTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider provideRead
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideRead')]
     public function testWrite($data): void
     {
         $this->suluProperty->expects($this->once())

--- a/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/Service/GoogleGeolocatorTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/Service/GoogleGeolocatorTest.php
@@ -59,9 +59,7 @@ class GoogleGeolocatorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideLocate
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideLocate')]
     public function testLocate($query, $expectedCount, $expectationMap): void
     {
         $fixtureName = __DIR__ . '/google-responses/' . \md5($query) . '.json';
@@ -113,9 +111,8 @@ class GoogleGeolocatorTest extends TestCase
 
     /**
      * Test if BC is maintained and guzzle client still works.
-     *
-     * @dataProvider provideLocate
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideLocate')]
     public function testLegacyGuzzleLocate($query, $expectedCount, $expectationMap): void
     {
         if (!\class_exists(Client::class)) {

--- a/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/Service/MapquestGeolocatorTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/Service/MapquestGeolocatorTest.php
@@ -44,9 +44,8 @@ class MapquestGeolocatorTest extends TestCase
 
     /**
      * @param array<mixed> $expectationMap
-     *
-     * @dataProvider provideLocate
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideLocate')]
     public function testLocate(string $query, int $expectedCount, array $expectationMap): void
     {
         $fixtureName = __DIR__ . '/mapquest-responses/' . \md5($query) . '.json';

--- a/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/Service/NominatimGeolocatorTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/Service/NominatimGeolocatorTest.php
@@ -45,9 +45,8 @@ class NominatimGeolocatorTest extends TestCase
 
     /**
      * Test if BC is maintained and guzzle client still works.
-     *
-     * @dataProvider provideLocate
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideLocate')]
     public function testGuzzleLocate($query, $expectedCount, $expectationMap): void
     {
         $fixtureName = __DIR__ . '/responses/' . \md5($query) . '.json';
@@ -71,9 +70,7 @@ class NominatimGeolocatorTest extends TestCase
         }
     }
 
-    /**
-     * @dataProvider provideLocate
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideLocate')]
     public function testLocate($query, $expectedCount, $expectationMap): void
     {
         $fixtureName = __DIR__ . '/responses/' . \md5($query) . '.json';

--- a/src/Sulu/Bundle/LocationBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/LocationBundle/phpunit.xml.dist
@@ -2,8 +2,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="../TestBundle/Resources/app/bootstrap.php"
          colors="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage>
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+    <source>
         <include>
             <directory>./</directory>
         </include>
@@ -12,7 +12,7 @@
             <directory>./Tests</directory>
             <directory>./vendor</directory>
         </exclude>
-    </coverage>
+    </source>
 
     <testsuites>
         <testsuite name="SuluLocationBundle Test Suite">

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlTagExtractorTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlTagExtractorTest.php
@@ -35,9 +35,7 @@ class HtmlTagExtractorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideTags
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideTags')]
     public function testExtract($tag, $tagName, array $attributes): void
     {
         $html = '<html><body>' . $tag . '</body></html>';
@@ -74,9 +72,7 @@ class HtmlTagExtractorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideMultipleTags
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideMultipleTags')]
     public function testExtractAll($html, array $counts): void
     {
         $extractor = new HtmlTagExtractor('sulu');
@@ -88,9 +84,7 @@ class HtmlTagExtractorTest extends TestCase
         }
     }
 
-    /**
-     * @dataProvider provideMultipleTags
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideMultipleTags')]
     public function testCount($html, array $counts, $count): void
     {
         $extractor = new HtmlTagExtractor('sulu');

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
@@ -219,9 +219,7 @@ class LinkTagTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideParseData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideParseData')]
     public function testParseAll($tag, $attributes, $items, $expected): void
     {
         $uuid = \preg_split('/[#?]/', $attributes['href'], 2);

--- a/src/Sulu/Bundle/MarkupBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/MarkupBundle/phpunit.xml.dist
@@ -2,8 +2,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="../TestBundle/Resources/app/bootstrap.php"
          colors="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage>
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+    <source>
         <include>
             <directory>./</directory>
         </include>
@@ -12,7 +12,7 @@
             <directory>./Tests</directory>
             <directory>./vendor</directory>
         </exclude>
-    </coverage>
+    </source>
 
     <testsuites>
         <testsuite name="SuluMarkupBundle Test Suite">

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
@@ -1035,9 +1035,7 @@ class MediaControllerTest extends SuluTestCase
         $this->assertNotNull($response->id);
     }
 
-    /**
-     * @group postWithoutDetails
-     */
+    #[\PHPUnit\Framework\Attributes\Group('postWithoutDetails')]
     public function testPostWithoutExtension(): void
     {
         $imagePath = $this->getImagePath();

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaStreamControllerWebsiteSecuredTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaStreamControllerWebsiteSecuredTest.php
@@ -26,9 +26,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 
-/**
- * @runTestsInSeparateProcesses else we get a conflict with the WebspaceCollectionClass already exists error.
- */
+#[\PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses]
 class MediaStreamControllerWebsiteSecuredTest extends WebsiteTestCase
 {
     /**
@@ -56,11 +54,7 @@ class MediaStreamControllerWebsiteSecuredTest extends WebsiteTestCase
         $mediaTypes->load($this->getEntityManager());
     }
 
-    /**
-     * @runInSeparateProcess
-     *
-     * @preserveGlobalState disabled
-     */
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
     public function testDownloadWithCollectionPermissions(): void
     {
         $filePath = $this->createMediaFile('test.jpg');

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/CollectionRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/CollectionRepositoryTest.php
@@ -159,9 +159,7 @@ class CollectionRepositoryTest extends SuluTestCase
         ];
     }
 
-    /**
-     * @dataProvider provideTreeData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideTreeData')]
     public function testTree($index, $expectedIndexes): void
     {
         $expected = [];

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
@@ -126,7 +126,7 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
         $this->em->flush();
     }
 
-    private function createCollection($name, $parent = null)
+    private function createCollection($name, $parent = null): Collection
     {
         $collection = new Collection();
         $collectionType = new CollectionType();
@@ -605,8 +605,6 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
     }
 
     /**
-     * @dataProvider findByProvider
-     *
      * @param array{
      *     dataSource: mixed,
      *     tags?: array<int>,
@@ -630,6 +628,7 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
      * @param array<int> $tags
      * @param array<string, mixed> $options
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('findByProvider')]
     public function testFindByFilters($filters, $page, $pageSize, $limit, $expected, $tags = [], $options = []): void
     {
         foreach ($this->collectionData as $collection) {
@@ -714,10 +713,9 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
     }
 
     /**
-     * @dataProvider provideFindByFiltersWithAudienceTargeting
-     *
      * @param int[] $expectedIndexes
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFindByFiltersWithAudienceTargeting')]
     public function testFindByFiltersWithAudienceTargeting(?int $targetGroupIndex, array $expectedIndexes): void
     {
         /** @var TargetGroupInterface[] $targetGroups */

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/SearchIntegration/SearchIntegrationTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/SearchIntegration/SearchIntegrationTest.php
@@ -71,10 +71,9 @@ class SearchIntegrationTest extends SuluTestCase
     }
 
     /**
-     * @dataProvider provideIndex
-     *
      * @param class-string<\Throwable> $expectException
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideIndex')]
     public function testIndex(string $format, ?string $expectException): void
     {
         $mediaSelectionContainer = $this->prophesize(MediaSelectionContainer::class);

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/EventListener/CacheInvalidationListenerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/EventListener/CacheInvalidationListenerTest.php
@@ -59,9 +59,7 @@ class CacheInvalidationListenerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideFunctionName
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFunctionName')]
     public function testPostUpdate($functionName): void
     {
         $entity = $this->prophesize(MediaInterface::class);
@@ -75,9 +73,7 @@ class CacheInvalidationListenerTest extends TestCase
         $this->listener->{$functionName}($eventArgs->reveal());
     }
 
-    /**
-     * @dataProvider provideFunctionName
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFunctionName')]
     public function testPostUpdateFile($functionName): void
     {
         $media = $this->prophesize(MediaInterface::class);
@@ -93,9 +89,7 @@ class CacheInvalidationListenerTest extends TestCase
         $this->listener->{$functionName}($eventArgs->reveal());
     }
 
-    /**
-     * @dataProvider provideFunctionName
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFunctionName')]
     public function testPostUpdateFileVersion($functionName): void
     {
         $media = $this->prophesize(MediaInterface::class);
@@ -127,9 +121,7 @@ class CacheInvalidationListenerTest extends TestCase
         $this->listener->{$functionName}($eventArgs->reveal());
     }
 
-    /**
-     * @dataProvider provideFunctionName
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFunctionName')]
     public function testPostUpdateFileVersionMeta($functionName): void
     {
         $media = $this->prophesize(MediaInterface::class);
@@ -151,9 +143,7 @@ class CacheInvalidationListenerTest extends TestCase
         $this->listener->{$functionName}($eventArgs->reveal());
     }
 
-    /**
-     * @dataProvider provideFunctionName
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFunctionName')]
     public function testPostUpdateOther($functionName): void
     {
         $entity = $this->prophesize(\stdClass::class);

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Focus/FocusTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Focus/FocusTest.php
@@ -32,9 +32,7 @@ class FocusTest extends TestCase
         $this->focus = new Focus();
     }
 
-    /**
-     * @dataProvider provideFocus
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFocus')]
     public function testFocus($imageWidth, $imageHeight, $x, $y, $width, $height, $cropX, $cropY, $cropWidth, $cropHeight): void
     {
         $image = $this->prophesize(ImageInterface::class);

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/ImagineImageConverterTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/ImagineImageConverterTest.php
@@ -310,9 +310,7 @@ class ImagineImageConverterTest extends TestCase
         $this->assertEquals('jpg', $this->imagineImageConverter->getSupportedOutputImageFormats('image/ico')[0]);
     }
 
-    /**
-     * @dataProvider getSimpleExtensionsByMimeTypes
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getSimpleExtensionsByMimeTypes')]
     public function testSupportedOutputFormatsWithSimpleValidMimeType(string $mimeType, string $extension): void
     {
         $result = \array_unique([
@@ -335,19 +333,16 @@ class ImagineImageConverterTest extends TestCase
         yield ['image/avif', 'avif'];
     }
 
-    /**
-     * @dataProvider getSvgMimeTypes
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getSvgMimeTypes')]
     public function testSupportedOutputFormatsWithValidSvgMimeType(string $mimeType): void
     {
         $this->assertEquals('svg', $this->imagineImageConverter->getSupportedOutputImageFormats($mimeType)[0]);
     }
 
     /**
-     * @dataProvider getSvgMimeTypes
-     *
      * @throws \ReflectionException
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getSvgMimeTypes')]
     public function testSupportedOutputFormatsWithValidSvgMimeTypeWithoutSvhImagine(string $mimeType): void
     {
         $reflection = new \ReflectionClass($this->imagineImageConverter);

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
@@ -194,12 +194,11 @@ class MediaManagerTest extends TestCase
     }
 
     /**
-     * @dataProvider provideGetByIds
-     *
      * @param int[] $ids
      * @param Media[] $media
      * @param Media[] $result
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideGetByIds')]
     public function testGetByIds(array $ids, ?SuluUserInterface $user, ?int $permissions, array $media, array $result): void
     {
         /** @var TokenInterface|ObjectProphecy $token */
@@ -345,9 +344,7 @@ class MediaManagerTest extends TestCase
         $this->mediaManager->delete(1, true);
     }
 
-    /**
-     * @dataProvider provideSpecialCharacterFileName
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideSpecialCharacterFileName')]
     public function testSpecialCharacterFileName(string $fileName, string $cleanUpArgument, string $cleanUpResult, string $extension): void
     {
         /** @var UploadedFile|ObjectProphecy $uploadedFile */
@@ -377,9 +374,7 @@ class MediaManagerTest extends TestCase
         $this->assertEquals($fileName, $media->getName());
     }
 
-    /**
-     * @dataProvider provideSpecialCharacterUrl
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideSpecialCharacterUrl')]
     public function testSpecialCharacterUrl(int $id, string $filename, int $version, string $expected): void
     {
         $this->assertEquals($expected, $this->mediaManager->getUrl($id, $filename, $version));

--- a/src/Sulu/Bundle/MediaBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/MediaBundle/phpunit.xml.dist
@@ -2,8 +2,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="../TestBundle/Resources/app/bootstrap.php"
          colors="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage>
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+    <source>
         <include>
             <directory>./</directory>
         </include>
@@ -12,7 +12,7 @@
             <directory>./Tests</directory>
             <directory>./vendor</directory>
         </exclude>
-    </coverage>
+    </source>
 
     <testsuites>
         <testsuite name="SuluMediaBundle Test Suite">

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Compat/StructureBridgeSerializationTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Compat/StructureBridgeSerializationTest.php
@@ -85,9 +85,7 @@ class StructureBridgeSerializationTest extends SuluTestCase
         return $data;
     }
 
-    /**
-     * @depends testSerialize
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testSerialize')]
     public function testDeserialize($data): void
     {
         $result = $this->serializer->deserialize(

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Document/PageDocumentSerializationTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Document/PageDocumentSerializationTest.php
@@ -85,9 +85,8 @@ class PageDocumentSerializationTest extends SuluTestCase
 
     /**
      * It can deserialize content that contains objects.
-     *
-     * @depends testSerialization
      */
+    #[\PHPUnit\Framework\Attributes\Depends('testSerialization')]
     public function testDeserialization($data): void
     {
         $page = $this->serializer->deserialize($data, PageDocument::class, 'json');

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Mapper/ContentMapperSnippetTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Mapper/ContentMapperSnippetTest.php
@@ -172,9 +172,7 @@ class ContentMapperSnippetTest extends SuluTestCase
         ];
     }
 
-    /**
-     * @dataProvider provideRemoveSnippetWithReferencesDereference
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideRemoveSnippetWithReferencesDereference')]
     public function testRemoveSnippetWithReferencesDereference($multiple = false): void
     {
         $document = $this->documentManager->create('page');

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Markup/LinkTagTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Markup/LinkTagTest.php
@@ -158,9 +158,7 @@ class LinkTagTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideParseDataDefaultProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideParseDataDefaultProvider')]
     public function testParseAllDefaultProvider($tag, $attributes, $expected): void
     {
         $content = $this->createContent('123-123-123', 'Pagetitle', '/test');

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/ContentRepositoryTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/ContentRepositoryTest.php
@@ -1022,9 +1022,7 @@ class ContentRepositoryTest extends SuluTestCase
         return [['sulu_io'], ['test_io']];
     }
 
-    /**
-     * @dataProvider provideWebspaceKeys
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideWebspaceKeys')]
     public function testFindParentsWithSiblingsByUuid($webspaceKey): void
     {
         $role1 = $this->createRole('Role 1', 'Sulu');

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/SinglePageSelectionTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/SinglePageSelectionTest.php
@@ -67,9 +67,7 @@ class SinglePageSelectionTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider providePreResolve
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('providePreResolve')]
     public function testPreResolve($propertyValue, $expected): void
     {
         $this->property->getValue()->willReturn($propertyValue);

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Rule/PageRuleTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Rule/PageRuleTest.php
@@ -58,9 +58,7 @@ class PageRuleTest extends TestCase
         $this->resourceLocatorStrategyPool = $this->prophesize(ResourceLocatorStrategyPoolInterface::class);
     }
 
-    /**
-     * @dataProvider provideEvaluate
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideEvaluate')]
     public function testEvaluate(
         $uuidHeader,
         $uuidValue,

--- a/src/Sulu/Bundle/PageBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/PageBundle/phpunit.xml.dist
@@ -2,8 +2,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="../TestBundle/Resources/app/bootstrap.php"
          colors="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage>
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+    <source>
         <include>
             <directory>./</directory>
         </include>
@@ -12,7 +12,7 @@
             <directory>./Tests</directory>
             <directory>./vendor</directory>
         </exclude>
-    </coverage>
+    </source>
 
     <testsuites>
         <testsuite name="SuluPageBundle Test Suite">

--- a/src/Sulu/Bundle/PersistenceBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/PersistenceBundle/phpunit.xml.dist
@@ -2,8 +2,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="../TestBundle/Resources/app/bootstrap.php"
          colors="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage>
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+    <source>
         <include>
             <directory>./</directory>
         </include>
@@ -12,7 +12,7 @@
             <directory>./Tests</directory>
             <directory>./vendor</directory>
         </exclude>
-    </coverage>
+    </source>
 
     <testsuites>
         <testsuite name="SuluPersistenceBundle Test Suite">

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
@@ -136,9 +136,7 @@ class PreviewRendererTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider portalDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('portalDataProvider')]
     public function testRender($scheme, $portalUrl): void
     {
         $object = $this->prophesize(\stdClass::class);

--- a/src/Sulu/Bundle/PreviewBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/PreviewBundle/phpunit.xml.dist
@@ -2,8 +2,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="../TestBundle/Resources/app/bootstrap.php"
          colors="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage>
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+    <source>
         <include>
             <directory>./</directory>
         </include>
@@ -12,7 +12,7 @@
             <directory>./Tests</directory>
             <directory>./vendor</directory>
         </exclude>
-    </coverage>
+    </source>
 
     <testsuites>
         <testsuite name="SuluPreviewBundle Test Suite">

--- a/src/Sulu/Bundle/ReferenceBundle/Tests/Functional/Infrastructure/Doctrine/Repository/ReferenceRepositoryTest.php
+++ b/src/Sulu/Bundle/ReferenceBundle/Tests/Functional/Infrastructure/Doctrine/Repository/ReferenceRepositoryTest.php
@@ -118,9 +118,7 @@ class ReferenceRepositoryTest extends SuluTestCase
         $this->assertSame($referenceId, $reference->getId());
     }
 
-    /**
-     * @dataProvider filterProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('filterProvider')]
     public function testFindOneByFilter(string $filterKey): void
     {
         self::purgeDatabase();
@@ -138,9 +136,7 @@ class ReferenceRepositoryTest extends SuluTestCase
         $this->assertSame($referenceId, $reference->getId());
     }
 
-    /**
-     * @dataProvider filterProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('filterProvider')]
     public function testGetOneByFilter(string $filterKey): void
     {
         self::purgeDatabase();
@@ -159,9 +155,7 @@ class ReferenceRepositoryTest extends SuluTestCase
         $this->assertSame($referenceId, $reference->getId());
     }
 
-    /**
-     * @dataProvider filterProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('filterProvider')]
     public function testFindFlatFilter(string $filterKey): void
     {
         self::purgeDatabase();

--- a/src/Sulu/Bundle/ReferenceBundle/Tests/Functional/UserInterface/Controller/Admin/ReferenceControllerTest.php
+++ b/src/Sulu/Bundle/ReferenceBundle/Tests/Functional/UserInterface/Controller/Admin/ReferenceControllerTest.php
@@ -45,9 +45,7 @@ class ReferenceControllerTest extends SuluTestCase
         );
     }
 
-    /**
-     * @dataProvider dataCgetActionFiltersAndFields
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataCgetActionFiltersAndFields')]
     public function testCgetActionFiltersAndFields(string $url): void
     {
         $client = $this->createAuthenticatedClient();

--- a/src/Sulu/Bundle/ReferenceBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/ReferenceBundle/phpunit.xml.dist
@@ -1,29 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="../TestBundle/Resources/app/bootstrap.php"
-         colors="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage>
+    bootstrap="../TestBundle/Resources/app/bootstrap.php"
+    colors="true"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+    <source>
         <include>
             <directory>./</directory>
         </include>
-
         <exclude>
             <directory>./Tests</directory>
             <directory>./vendor</directory>
         </exclude>
-    </coverage>
+    </source>
+
     <testsuites>
         <testsuite name="SuluReferenceBundle Test Suite">
             <directory suffix="Test.php">./Tests</directory>
         </testsuite>
     </testsuites>
+
     <php>
         <server name="APP_ENV" value="test" force="true"/>
         <env name="KERNEL_CLASS" value="Sulu\Bundle\ReferenceBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/RouteBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/RouteBundle/phpunit.xml.dist
@@ -2,8 +2,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="../TestBundle/Resources/app/bootstrap.php"
          colors="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage>
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+    <source>
         <include>
             <directory>./</directory>
         </include>
@@ -12,7 +12,7 @@
             <directory>./Tests</directory>
             <directory>./vendor</directory>
         </exclude>
-    </coverage>
+    </source>
 
     <testsuites>
         <testsuite name="SuluRouteBundle Test Suite">

--- a/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/SearchControllerTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/SearchControllerTest.php
@@ -198,9 +198,7 @@ class SearchControllerTest extends SuluTestCase
         ];
     }
 
-    /**
-     * @dataProvider provideSearch
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideSearch')]
     public function testSearch($params, $expectedResult): void
     {
         foreach ($expectedResult['_embedded']['result'] as &$hitResult) {

--- a/src/Sulu/Bundle/SearchBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/SearchBundle/phpunit.xml.dist
@@ -3,18 +3,17 @@
          colors="true"
          bootstrap="../TestBundle/Resources/app/bootstrap.php"
          processIsolation="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage includeUncoveredFiles="true">
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+    <source>
         <include>
-            <directory>.</directory>
+            <directory>./</directory>
         </include>
 
         <exclude>
-            <directory>Resources/</directory>
-            <directory>Tests/</directory>
-            <directory>vendor/</directory>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
         </exclude>
-    </coverage>
+    </source>
 
     <testsuites>
         <testsuite name="Sulu Search Bundle">

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Controller/PermissionControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Controller/PermissionControllerTest.php
@@ -103,9 +103,7 @@ class PermissionControllerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider providePermissionData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('providePermissionData')]
     public function testGetAction($id, $resourceKey, $permissions): void
     {
         $request = new Request(['id' => $id, 'resourceKey' => $resourceKey]);
@@ -123,9 +121,7 @@ class PermissionControllerTest extends TestCase
         $this->permissionController->cgetAction($request);
     }
 
-    /**
-     * @dataProvider providePermissionData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('providePermissionData')]
     public function testPutAction($id, $resourceKey, $permissions): void
     {
         $request = new Request(
@@ -170,9 +166,7 @@ class PermissionControllerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideWrongPermissionData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideWrongPermissionData')]
     public function testPutActionWithWrongData($id, $class, $permissions): void
     {
         $request = new Request(

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/PermissionInheritanceSubscriberTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/PermissionInheritanceSubscriberTest.php
@@ -55,9 +55,7 @@ class PermissionInheritanceSubscriberTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider providePostPersist
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('providePostPersist')]
     public function testPostPersist($id, $parentId, $permissions): void
     {
         $entity = $this->prophesize(PermissionInheritanceInterface::class);

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/SuluSecurityListenerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/SuluSecurityListenerTest.php
@@ -172,9 +172,7 @@ class SuluSecurityListenerTest extends TestCase
         $this->securityChecker->checkPermission('sulu.media.collection', Argument::cetera());
     }
 
-    /**
-     * @dataProvider provideMethodActionMapping
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideMethodActionMapping')]
     public function testMethodPermissionMapping($method, $action, $permission): void
     {
         $request = Request::create('/', $method, ['id' => '1']);
@@ -194,9 +192,7 @@ class SuluSecurityListenerTest extends TestCase
             ->shouldHaveBeenCalled();
     }
 
-    /**
-     * @dataProvider provideInvokeMethodActionMapping
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideInvokeMethodActionMapping')]
     public function testCallableControllerPermission($method, $permission): void
     {
         $request = Request::create('/', $method, ['id' => '1']);

--- a/src/Sulu/Bundle/SecurityBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/SecurityBundle/phpunit.xml.dist
@@ -2,8 +2,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="../TestBundle/Resources/app/bootstrap.php"
          colors="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage>
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+    <source>
         <include>
             <directory>./</directory>
         </include>
@@ -12,7 +12,7 @@
             <directory>./Tests</directory>
             <directory>./vendor</directory>
         </exclude>
-    </coverage>
+    </source>
 
     <testsuites>
         <testsuite name="SuluSecurityBundle Test Suite">

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/ContentOnPageTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/ContentOnPageTest.php
@@ -98,9 +98,7 @@ class ContentOnPageTest extends BaseFunctionalTestCase
         ];
     }
 
-    /**
-     * @dataProvider provideSaveSnippetPage
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideSaveSnippetPage')]
     public function testSaveLoadSnippetPage($webspaceKey, $templateKey, $locale, $data): void
     {
         foreach ($data['hotels'] as &$varName) {

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetAreaControllerTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetAreaControllerTest.php
@@ -98,9 +98,7 @@ class SnippetAreaControllerTest extends BaseFunctionalTestCase
         $this->assertEquals(null, $data[2]['defaultUuid']);
     }
 
-    /**
-     * @depends testPutDefault
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPutDefault')]
     public function testDeleteDefault(): void
     {
         $this->client->jsonRequest(

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
@@ -79,9 +79,7 @@ class SnippetControllerTest extends SuluTestCase
         $this->loadFixtures();
     }
 
-    /**
-     * @dataProvider provideGet
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideGet')]
     public function testGet($locale, $expected): void
     {
         $this->client->jsonRequest('GET', '/api/snippets/' . $this->hotel1->getUuid() . '?locale=' . $locale);
@@ -264,9 +262,7 @@ class SnippetControllerTest extends SuluTestCase
         ];
     }
 
-    /**
-     * @dataProvider provideIndex
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideIndex')]
     public function testIndex($params, $expectedResultCount): void
     {
         $params = \array_merge([
@@ -332,9 +328,7 @@ class SnippetControllerTest extends SuluTestCase
         ];
     }
 
-    /**
-     * @dataProvider providePost
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('providePost')]
     public function testPost($params, $data): void
     {
         $params = \array_merge([
@@ -370,9 +364,7 @@ class SnippetControllerTest extends SuluTestCase
         $this->assertNotNull($activity);
     }
 
-    /**
-     * @dataProvider providePost
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('providePost')]
     public function testPostPublished($params, $data): void
     {
         $params = \array_merge([

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Snippet/SnippetRepositoryTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Snippet/SnippetRepositoryTest.php
@@ -71,9 +71,7 @@ class SnippetRepositoryTest extends BaseFunctionalTestCase
         ];
     }
 
-    /**
-     * @dataProvider provideGetSnippets
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideGetSnippets')]
     public function testGetSnippets($type, $offset, $limit, $search, $expectedCount): void
     {
         $snippets = $this->snippetRepository->getSnippets('de', $type, $offset, $limit, $search);
@@ -101,9 +99,7 @@ class SnippetRepositoryTest extends BaseFunctionalTestCase
         ];
     }
 
-    /**
-     * @dataProvider provideGetSnippetsByUuids
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideGetSnippetsByUuids')]
     public function testGetSnippetsByUuids($snippets, $languageCode, $expectedCount): void
     {
         $uuids = [];

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
@@ -76,9 +76,7 @@ class SnippetAdminTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideConfigureViews
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideConfigureViews')]
     public function testConfigureViews($locales): void
     {
         $snippetAdmin = new SnippetAdmin(

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SnippetDataProviderTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SnippetDataProviderTest.php
@@ -190,9 +190,7 @@ class SnippetDataProviderTest extends TestCase
         $this->assertSame('translated-template-2', $configuration->getTypes()[1]->getName());
     }
 
-    /**
-     * @dataProvider provideResolveDataItems
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideResolveDataItems')]
     public function testResolveDataItems(
         $filters,
         $propertyParameter,
@@ -289,9 +287,7 @@ class SnippetDataProviderTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideResolveDataItems
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideResolveDataItems')]
     public function testResolveResourceItems(
         $filters,
         $propertyParameter,
@@ -329,9 +325,7 @@ class SnippetDataProviderTest extends TestCase
         $this->assertEquals($hasNextPage, $dataProviderResult->getHasNextPage());
     }
 
-    /**
-     * @dataProvider provideResolveExcludeDuplicates
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideResolveExcludeDuplicates')]
     public function testResolveResourceItemsExcludeDuplicates($filters, $uuids): void
     {
         $options = ['webspaceKey' => 'sulu', 'locale' => 'de'];

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/DefaultSnippetManagerTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/DefaultSnippetManagerTest.php
@@ -78,9 +78,7 @@ class DefaultSnippetManagerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider saveDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('saveDataProvider')]
     public function testSave(
         $webspaceKey,
         $locale,
@@ -172,9 +170,7 @@ class DefaultSnippetManagerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider loadDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('loadDataProvider')]
     public function testLoad($webspaceKey, $locale, $type, $uuid, $exists = true, $sameType = true): void
     {
         $settingsManager = $this->prophesize(SettingsManagerInterface::class);

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
@@ -44,9 +44,7 @@ class SnippetResolverTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider dataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
     public function testResolve($uuids, $webspaceKey = 'sulu_io', $locale = 'de'): void
     {
         $contentMapper = $this->prophesize(ContentMapperInterface::class);

--- a/src/Sulu/Bundle/SnippetBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/SnippetBundle/phpunit.xml.dist
@@ -2,18 +2,18 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          colors="true"
          bootstrap="../TestBundle/Resources/app/bootstrap.php"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage includeUncoveredFiles="true">
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+    <source>
         <include>
-            <directory>.</directory>
+            <directory>./</directory>
         </include>
 
         <exclude>
-            <directory>Resources/</directory>
-            <directory>Tests/</directory>
-            <directory>vendor/</directory>
+            <directory>./Resources</directory>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
         </exclude>
-    </coverage>
+    </source>
 
     <testsuites>
         <testsuite name="SuluSnippetBundle Test Suite">

--- a/src/Sulu/Bundle/TagBundle/Tests/Unit/Twig/TagTwigExtensionTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Unit/Twig/TagTwigExtensionTest.php
@@ -52,9 +52,7 @@ class TagTwigExtensionTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider getProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getProvider')]
     public function testGetTags($tagData): void
     {
         $tags = [];
@@ -94,9 +92,7 @@ class TagTwigExtensionTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider appendProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('appendProvider')]
     public function testAppendTagUrl($tagsParameter, $url, $tagsString, $expected): void
     {
         $tag = ['name' => 'Test'];
@@ -137,9 +133,7 @@ class TagTwigExtensionTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider setProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('setProvider')]
     public function testSetTagUrl($tagsParameter, $url, $tagsString, $expected): void
     {
         $tag = ['name' => 'Test'];
@@ -180,9 +174,7 @@ class TagTwigExtensionTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider clearProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('clearProvider')]
     public function testClearTagUrl($tagsParameter, $url, $tagsString): void
     {
         $tagManager = $this->prophesize(TagManagerInterface::class);

--- a/src/Sulu/Bundle/TagBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/TagBundle/phpunit.xml.dist
@@ -2,8 +2,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="../TestBundle/Resources/app/bootstrap.php"
          colors="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage>
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+    <source>
         <include>
             <directory>./</directory>
         </include>
@@ -12,7 +12,7 @@
             <directory>./Tests</directory>
             <directory>./vendor</directory>
         </exclude>
-    </coverage>
+    </source>
 
     <testsuites>
         <testsuite name="SuluTagBundle Test Suite">

--- a/src/Sulu/Bundle/TrashBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/TrashBundle/phpunit.xml.dist
@@ -1,23 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="../TestBundle/Resources/app/bootstrap.php"
-         colors="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage>
+    bootstrap="../TestBundle/Resources/app/bootstrap.php"
+    colors="true"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+    <source>
         <include>
             <directory>./</directory>
         </include>
-
         <exclude>
             <directory>./Tests</directory>
             <directory>./vendor</directory>
         </exclude>
-    </coverage>
+    </source>
+
     <testsuites>
         <testsuite name="SuluTrashBundle Test Suite">
             <directory suffix="Test.php">./Tests</directory>
         </testsuite>
     </testsuites>
+
     <php>
         <server name="APP_ENV" value="test" force="true"/>
         <env name="KERNEL_CLASS" value="Sulu\Bundle\TrashBundle\Tests\Application\Kernel"/>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Analytics/AnalyticsManagerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Analytics/AnalyticsManagerTest.php
@@ -168,9 +168,7 @@ class AnalyticsManagerTest extends BaseFunctional
         ];
     }
 
-    /**
-     * @dataProvider dataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
     public function testCreate($webspaceKey, array $data): void
     {
         $result = $this->analyticsManager->create($webspaceKey, $data);
@@ -211,9 +209,7 @@ class AnalyticsManagerTest extends BaseFunctional
         );
     }
 
-    /**
-     * @dataProvider dataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
     public function testUpdate($webspaceKey, array $data): void
     {
         $id = $this->entities[0]->getId();

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/CachingTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/CachingTest.php
@@ -50,9 +50,7 @@ class CachingTest extends SuluTestCase
         return [$client, $cookieJar];
     }
 
-    /**
-     * @depends testFirstRequestIsACacheMiss
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testFirstRequestIsACacheMiss')]
     public function testSecondRequestIsACacheHit($arguments)
     {
         list($client, $cookieJar) = $arguments;
@@ -67,9 +65,7 @@ class CachingTest extends SuluTestCase
         return [$client, $cookieJar];
     }
 
-    /**
-     * @depends testSecondRequestIsACacheHit
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testSecondRequestIsACacheHit')]
     public function testSwitchSegmentIsACacheMiss($arguments)
     {
         list($client, $cookieJar) = $arguments;
@@ -93,9 +89,7 @@ class CachingTest extends SuluTestCase
         return [$client, $cookieJar];
     }
 
-    /**
-     * @depends testSwitchSegmentIsACacheMiss
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testSwitchSegmentIsACacheMiss')]
     public function testSwitchedSegmentIsACachHit($arguments)
     {
         list($client, $cookieJar) = $arguments;
@@ -109,9 +103,7 @@ class CachingTest extends SuluTestCase
         return [$client, $cookieJar];
     }
 
-    /**
-     * @depends testSwitchedSegmentIsACachHit
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testSwitchedSegmentIsACachHit')]
     public function testSwitchSegmentBackIsACacheHit($arguments)
     {
         list($client, $cookieJar) = $arguments;

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/EventListener/SecurityListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/EventListener/SecurityListenerTest.php
@@ -22,9 +22,7 @@ use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
 use Sulu\Component\Content\Document\WorkflowStage;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
-/**
- * @runTestsInSeparateProcesses This is necessary because the kernel is booted with different configurations.
- */
+#[\PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses]
 class SecurityListenerTest extends SuluTestCase
 {
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Controller/ExceptionControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Controller/ExceptionControllerTest.php
@@ -87,9 +87,7 @@ class ExceptionControllerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideShowAction
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideShowAction')]
     public function testShowActionFormat($retrievedFormat, $templateAvailable, $expectExceptionFormat): void
     {
         $request = new Request();
@@ -146,9 +144,7 @@ class ExceptionControllerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideShowActionErrorTemplate
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideShowActionErrorTemplate')]
     public function testShowActionErrorTemplate($templates, $errorCode, $expectedTemplate): void
     {
         $request = new Request();

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Controller/RedirectControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Controller/RedirectControllerTest.php
@@ -74,9 +74,7 @@ class RedirectControllerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideRedirectAction
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideRedirectAction')]
     public function testRedirectAction($requestUri, $portalUrl, $redirectUrl, $expectedTargetUrl, $prefix = ''): void
     {
         $request = $this->getRequestMock($requestUri, $portalUrl, $redirectUrl, $prefix);
@@ -97,9 +95,7 @@ class RedirectControllerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideRedirectWebspaceAction
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideRedirectWebspaceAction')]
     public function testRedirectWebspaceAction($uri, $redirectUri, $expectedTargetUrl): void
     {
         $request = $this->getRequestMock($redirectUri, null, $uri);
@@ -125,9 +121,7 @@ class RedirectControllerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideRedirectToRouteAction
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideRedirectToRouteAction')]
     public function testRedirectToRouteAction(
         $route,
         $statusCode = 301,

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/AppendAnalyticsListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/AppendAnalyticsListenerTest.php
@@ -38,10 +38,9 @@ class AppendAnalyticsListenerTest extends TestCase
     }
 
     /**
-     * @dataProvider formatProvider
-     *
      * @param string $format
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('formatProvider')]
     public function testAppendFormatNoEffect($format): void
     {
         $engine = $this->prophesize(Environment::class);

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/SegmentCacheListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/SegmentCacheListenerTest.php
@@ -45,9 +45,7 @@ class SegmentCacheListenerTest extends TestCase
         yield [null];
     }
 
-    /**
-     * @dataProvider providePreHandleCookieValue
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('providePreHandleCookieValue')]
     public function testPreHandleCookieValue(?string $cookieValue): void
     {
         $request = new Request([], [], [], ['_ss' => $cookieValue]);
@@ -75,9 +73,7 @@ class SegmentCacheListenerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider providePostHandleVary
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('providePostHandleVary')]
     public function testPostHandleWithVary(?string $header, int $maxAge, int $sharedMaxAge, int $expectedMaxAge): void
     {
         $request = new Request();

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/SegmentSubscriberTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/SegmentSubscriberTest.php
@@ -78,9 +78,7 @@ class SegmentSubscriberTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideAddCookieHeader
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideAddCookieHeader')]
     public function testAddCookieHeader(
         $segmentKeys,
         $cookieSegmentKey,

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RedirectExceptionSubscriberTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RedirectExceptionSubscriberTest.php
@@ -540,9 +540,7 @@ class RedirectExceptionSubscriberTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideResolveData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideResolveData')]
     public function testRedirectPartialMatchResolve(
         $requestUri,
         $portalUrl,

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/NavigationTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/NavigationTwigExtensionTest.php
@@ -40,9 +40,7 @@ class NavigationTwigExtensionTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider activeElementProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('activeElementProvider')]
     public function testActiveElement($expected, $requestPath, $itemPath): void
     {
         $extension = new NavigationTwigExtension(

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/Seo/SeoTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/Seo/SeoTwigExtensionTest.php
@@ -83,9 +83,7 @@ class SeoTwigExtensionTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider provideSeoData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideSeoData')]
     public function testRenderSeoTags(
         $seoExtension,
         $content,

--- a/src/Sulu/Bundle/WebsiteBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/WebsiteBundle/phpunit.xml.dist
@@ -2,8 +2,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="../TestBundle/Resources/app/bootstrap.php"
          colors="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage>
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+    <source>
         <include>
             <directory>./</directory>
         </include>
@@ -12,7 +12,7 @@
             <directory>./Tests</directory>
             <directory>./vendor</directory>
         </exclude>
-    </coverage>
+    </source>
 
     <testsuites>
         <testsuite name="SuluWebsiteBundle Test Suite">

--- a/src/Sulu/Component/Cache/Tests/Unit/Cache/DataCacheTest.php
+++ b/src/Sulu/Component/Cache/Tests/Unit/Cache/DataCacheTest.php
@@ -28,9 +28,7 @@ class DataCacheTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideIsFreshData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideIsFreshData')]
     public function testIsFresh($file, $createFile, $expected): void
     {
         $filesystem = new Filesystem();
@@ -57,9 +55,7 @@ class DataCacheTest extends TestCase
         return $cache;
     }
 
-    /**
-     * @depends testWrite
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testWrite')]
     public function testRead(CacheInterface $cache): void
     {
         $this->assertEquals(['test' => 'test'], $cache->read());

--- a/src/Sulu/Component/Category/Tests/Unit/Request/CategoryRequestHandlerTest.php
+++ b/src/Sulu/Component/Category/Tests/Unit/Request/CategoryRequestHandlerTest.php
@@ -34,9 +34,7 @@ class CategoryRequestHandlerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider getProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getProvider')]
     public function testGet($parameter, $queryString, $expected): void
     {
         $requestStack = $this->prophesize(RequestStack::class);
@@ -67,9 +65,7 @@ class CategoryRequestHandlerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider appendProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('appendProvider')]
     public function testAppendToUrl($parameter, $url, $queryString, $expected): void
     {
         $category = ['id' => 3, 'name' => 'test'];
@@ -103,9 +99,7 @@ class CategoryRequestHandlerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider removeSingleProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('removeSingleProvider')]
     public function testRemoveSingleFromUrl($parameter, $url, $queryString, $expected): void
     {
         $category = ['id' => 3, 'name' => 'test'];
@@ -139,9 +133,7 @@ class CategoryRequestHandlerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider toggleProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('toggleProvider')]
     public function testToggleToUrl($parameter, $url, $queryString, $expected): void
     {
         $category = ['id' => 3, 'name' => 'test'];
@@ -175,9 +167,7 @@ class CategoryRequestHandlerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider setProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('setProvider')]
     public function testSetToUrl($parameter, $url, $queryString, $expected): void
     {
         $category = ['id' => 3, 'name' => 'test'];
@@ -210,9 +200,7 @@ class CategoryRequestHandlerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider removeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('removeProvider')]
     public function testRemoveFromUrl($parameter, $url, $queryString): void
     {
         $requestStack = $this->prophesize(RequestStack::class);

--- a/src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
+++ b/src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
@@ -115,8 +115,6 @@ class AccountDataProviderTest extends TestCase
     }
 
     /**
-     * @dataProvider dataItemsDataProvider
-     *
      * @param array{
      *     tags: string[],
      * } $filters
@@ -127,6 +125,7 @@ class AccountDataProviderTest extends TestCase
      * @param bool $hasNextPage
      * @param AccountDataItem[] $items
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataItemsDataProvider')]
     public function testResolveDataItems($filters, $limit, $page, $pageSize, $repositoryResult, $hasNextPage, $items): void
     {
         $this->dataProviderRepository->findByFilters(
@@ -190,8 +189,6 @@ class AccountDataProviderTest extends TestCase
     }
 
     /**
-     * @dataProvider resourceItemsDataProvider
-     *
      * @param array{
      *      tags: string[],
      *  } $filters
@@ -202,6 +199,7 @@ class AccountDataProviderTest extends TestCase
      * @param bool $hasNextPage
      * @param AccountDataItem[] $items
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('resourceItemsDataProvider')]
     public function testResolveResourceItems(
         $filters,
         $limit,

--- a/src/Sulu/Component/Contact/Tests/Unit/SmartContent/ContactDataProviderTest.php
+++ b/src/Sulu/Component/Contact/Tests/Unit/SmartContent/ContactDataProviderTest.php
@@ -101,9 +101,7 @@ class ContactDataProviderTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider dataItemsDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataItemsDataProvider')]
     public function testResolveDataItems($filters, $limit, $page, $pageSize, $repositoryResult, $hasNextPage, $items): void
     {
         $this->dataProviderRepository->findByFilters(
@@ -181,9 +179,7 @@ class ContactDataProviderTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider resourceItemsDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('resourceItemsDataProvider')]
     public function testResolveResourceItems(
         $filters,
         $limit,

--- a/src/Sulu/Component/Content/Tests/Unit/Block/BlockPropertyTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Block/BlockPropertyTest.php
@@ -59,9 +59,7 @@ class BlockPropertyTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideIsMultiple
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideIsMultiple')]
     public function testGetIsMultiple($minOccurs, $maxOccurs, $result): void
     {
         $blockProperty = new BlockProperty('block', [], 'test', false, false, $maxOccurs, $minOccurs);
@@ -69,9 +67,7 @@ class BlockPropertyTest extends TestCase
         $this->assertEquals($result, $blockProperty->getIsMultiple());
     }
 
-    /**
-     * @dataProvider provideSetInvalidValue
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideSetInvalidValue')]
     public function testSetInvalidValue($value, string $message): void
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/src/Sulu/Component/Content/Tests/Unit/Compat/PropertyTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Compat/PropertyTest.php
@@ -30,9 +30,7 @@ class PropertyTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideIsMultipleTest
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideIsMultipleTest')]
     public function testIsMultipleTest($minOccurs, $maxOccurs, $result): void
     {
         $property = new Property('test', [], 'text_line', false, true, $maxOccurs, $minOccurs);

--- a/src/Sulu/Component/Content/Tests/Unit/Compat/Structure/LegacyPropertyFactoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Compat/Structure/LegacyPropertyFactoryTest.php
@@ -165,9 +165,8 @@ class LegacyPropertyFactoryTest extends TestCase
 
     /**
      * It should create a translated property.
-     *
-     * @depends testCreateProperty
      */
+    #[\PHPUnit\Framework\Attributes\Depends('testCreateProperty')]
     public function testCreateTranslated(): void
     {
         $this->setUpProperty($this->property1);
@@ -180,10 +179,9 @@ class LegacyPropertyFactoryTest extends TestCase
     /**
      * It should create a section property.
      *
-     * @depends testCreateProperty
-     *
      * @param ObjectProphecy<PropertyMetadata> $property
      */
+    #[\PHPUnit\Framework\Attributes\Depends('testCreateProperty')]
     public function testCreateSection(ObjectProphecy $property): void
     {
         $name = 'foo';
@@ -214,10 +212,9 @@ class LegacyPropertyFactoryTest extends TestCase
     /**
      * It should create a block property.
      *
-     * @depends testCreateProperty
-     *
      * @param ObjectProphecy<PropertyMetadata> $property
      */
+    #[\PHPUnit\Framework\Attributes\Depends('testCreateProperty')]
     public function testCreateBlock(ObjectProphecy $property): void
     {
         $this->setUpProperty($this->block);
@@ -256,10 +253,9 @@ class LegacyPropertyFactoryTest extends TestCase
     /**
      * It should create a block property.
      *
-     * @depends testCreateProperty
-     *
      * @param ObjectProphecy<PropertyMetadata> $property
      */
+    #[\PHPUnit\Framework\Attributes\Depends('testCreateProperty')]
     public function testCreateBlockWithGlobalBlock(ObjectProphecy $property): void
     {
         $this->setUpProperty($this->block);
@@ -291,9 +287,8 @@ class LegacyPropertyFactoryTest extends TestCase
 
     /**
      * It should create a block property.
-     *
-     * @depends testCreateProperty
      */
+    #[\PHPUnit\Framework\Attributes\Depends('testCreateProperty')]
     public function testCreatePropertyWithTypes($child): void
     {
         $this->setUpProperty($this->property2);

--- a/src/Sulu/Component/Content/Tests/Unit/ContentTypeManagerTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/ContentTypeManagerTest.php
@@ -61,9 +61,7 @@ class ContentTypeManagerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideHas
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideHas')]
     public function testHas($alias, $expected): void
     {
         $res = $this->manager->has($alias);

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Structure/PropertyValueTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Structure/PropertyValueTest.php
@@ -26,9 +26,7 @@ class PropertyValueTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideOffsetSetData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideOffsetSetData')]
     public function testOffsetSet($value, $setName, $setValue, $expected): void
     {
         $propertyValue = new PropertyValue('test', $value);

--- a/src/Sulu/Component/Content/Tests/Unit/Extension/ExtensionManagerTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Extension/ExtensionManagerTest.php
@@ -85,9 +85,8 @@ class ExtensionManagerTest extends TestCase
      *     type: string,
      * }> $extensions
      * @param array<string, ExtensionInterface> $expected
-     *
-     * @dataProvider addProvider
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('addProvider')]
     public function testAdd(array $extensions, string $type, array $expected): void
     {
         $manager = new ExtensionManager();
@@ -136,9 +135,8 @@ class ExtensionManagerTest extends TestCase
      *     instance: ExtensionInterface,
      *     type: string,
      * }> $extensions
-     *
-     * @dataProvider hasProvider
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('hasProvider')]
     public function testHas(array $extensions, string $type, string $name, bool $expected): void
     {
         $manager = new ExtensionManager();
@@ -187,9 +185,7 @@ class ExtensionManagerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider getProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getProvider')]
     public function testGet($extensions, $type, $name, $expected): void
     {
         $manager = new ExtensionManager();
@@ -244,9 +240,8 @@ class ExtensionManagerTest extends TestCase
      *      type: string,
      * }> $extensions
      * @param class-string<\Throwable> $exxceptionName
-     *
-     * @dataProvider getExceptionProvider
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getExceptionProvider')]
     public function testGetException($extensions, string $type, string $name, string $exxceptionName): void
     {
         $this->expectException($exxceptionName);

--- a/src/Sulu/Component/Content/Tests/Unit/Mapper/Translation/MultipleTranslatedPropertiesTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Mapper/Translation/MultipleTranslatedPropertiesTest.php
@@ -41,9 +41,7 @@ class MultipleTranslatedPropertiesTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideGetName
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideGetName')]
     public function testGetName($structureType, $name, $expectedName): void
     {
         $this->properties->setLanguage('de');

--- a/src/Sulu/Component/Content/Tests/Unit/SmartContent/Orm/BaseDataProviderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/SmartContent/Orm/BaseDataProviderTest.php
@@ -59,9 +59,7 @@ class BaseDataProviderTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider configurationProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('configurationProvider')]
     public function testInitConfiguration($tags, $categories, $limit, $presentAs, $paginated, $sorting): void
     {
         $repository = $this->prophesize(DataProviderRepositoryInterface::class);
@@ -201,9 +199,7 @@ class BaseDataProviderTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider filtersProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('filtersProvider')]
     public function testResolveFilters(
         array $filters,
         $limit,
@@ -236,9 +232,7 @@ class BaseDataProviderTest extends TestCase
         $this->assertEquals($hasNextPage, $result[1]);
     }
 
-    /**
-     * @dataProvider filtersProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('filtersProvider')]
     public function testResolveDataItems(
         array $filters,
         $limit,
@@ -277,9 +271,7 @@ class BaseDataProviderTest extends TestCase
         $this->assertEquals($items, $result->getItems());
     }
 
-    /**
-     * @dataProvider filtersProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('filtersProvider')]
     public function testResolveResourceItems(
         array $filters,
         $limit,
@@ -429,9 +421,7 @@ class BaseDataProviderTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider filtersProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('filtersProvider')]
     public function testResolveResourceItemsWithReferenceStore(
         array $filters,
         $limit,

--- a/src/Sulu/Component/Content/Tests/Unit/Types/Block/ScheduleBlockVisitorTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Types/Block/ScheduleBlockVisitorTest.php
@@ -416,8 +416,7 @@ class ScheduleBlockVisitorTest extends TestCase
         ];
     }
 
-    /** @dataProvider provideVisit
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideVisit')]
     public function testVisit($settings, $now, $skip, $requestCacheLifetimes): void
     {
         $nowDateTime = new \DateTime($now);

--- a/src/Sulu/Component/CustomUrl/Tests/Functional/Generator/GeneratorTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Functional/Generator/GeneratorTest.php
@@ -134,9 +134,8 @@ class GeneratorTest extends TestCase
     /**
      * @param array<string> $domainParts
      * @param class-string<\Throwable>|null $exception
-     *
-     * @dataProvider provideGenerateData
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideGenerateData')]
     public function testGenerate(
         string $baseDomain,
         array $domainParts,

--- a/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/CustomUrlRouteProviderTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/CustomUrlRouteProviderTest.php
@@ -46,9 +46,7 @@ class CustomUrlRouteProviderTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider dataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
     public function testGetRouteCollectionForRequest(
         $host,
         $pathInfo,

--- a/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/Enhancers/ContentEnhancerTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/Enhancers/ContentEnhancerTest.php
@@ -46,9 +46,7 @@ class ContentEnhancerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider enhanceProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('enhanceProvider')]
     public function testEnhance($redirect, $target): void
     {
         $webspace = $this->prophesize(Webspace::class);

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentRegistryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentRegistryTest.php
@@ -56,9 +56,8 @@ class DocumentRegistryTest extends TestCase
 
     /**
      * It should deregister a given document.
-     *
-     * @depends testRegisterDocument
      */
+    #[\PHPUnit\Framework\Attributes\Depends('testRegisterDocument')]
     public function testDeregisterDocument(): void
     {
         $this->registry->registerDocument($this->document, $this->node->reveal(), 'fr');
@@ -78,9 +77,8 @@ class DocumentRegistryTest extends TestCase
 
     /**
      * It should return the PHPCR node for a registered document.
-     *
-     * @depends testRegisterDocument
      */
+    #[\PHPUnit\Framework\Attributes\Depends('testRegisterDocument')]
     public function testGetNodeForDocument(): void
     {
         $this->registry->registerDocument($this->document, $this->node->reveal(), 'fr');
@@ -113,9 +111,8 @@ class DocumentRegistryTest extends TestCase
 
     /**
      * It should return a document for a mangaed node.
-     *
-     * @depends testRegisterDocument
      */
+    #[\PHPUnit\Framework\Attributes\Depends('testRegisterDocument')]
     public function testGetDocumentForNode(): void
     {
         $this->registry->registerDocument($this->document, $this->node->reveal(), 'fr');

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/ProxyFactoryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/ProxyFactoryTest.php
@@ -150,9 +150,8 @@ class ProxyFactoryTest extends TestCase
 
     /**
      * It should lazy load the proxy.
-     *
-     * @depends testCreateProxy
      */
+    #[\PHPUnit\Framework\Attributes\Depends('testCreateProxy')]
     public function testHydrateLazyProxy($result): void
     {
         list($dispatcher, $proxy) = $result;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Slugifier/NodeNameSlugifierTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Slugifier/NodeNameSlugifierTest.php
@@ -63,9 +63,7 @@ class NodeNameSlugifierTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provide10eData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provide10eData')]
     public function testSlugify10e($actual, $expected): void
     {
         $this->slugifier->slugify($actual)->willReturn($actual);

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
@@ -93,9 +93,8 @@ class FindSubscriberTest extends TestCase
 
     /**
      * It should find existing document of specified type or class.
-     *
-     * @dataProvider provideFindWithTypeOrClass
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFindWithTypeOrClass')]
     public function testFindWithTypeOrClass($type, $typeOrClass, $shouldThrow): void
     {
         if ($shouldThrow) {

--- a/src/Sulu/Component/Hash/Tests/AuditableHasherTest.php
+++ b/src/Sulu/Component/Hash/Tests/AuditableHasherTest.php
@@ -60,9 +60,7 @@ class AuditableHasherTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideDifferentObjects
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideDifferentObjects')]
     public function testHashDifferentObject($changer1, $changer2, $changed1, $changed2): void
     {
         /** @var AuditableInterface $object1 */

--- a/src/Sulu/Component/Hash/Tests/RequestHashCheckerTest.php
+++ b/src/Sulu/Component/Hash/Tests/RequestHashCheckerTest.php
@@ -52,9 +52,7 @@ class RequestHashCheckerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideCheckHash
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideCheckHash')]
     public function testCheckHash($force, $givenHash, $realHash, $valid): void
     {
         $request = new Request(['force' => $force], $givenHash ? ['_hash' => $givenHash] : []);

--- a/src/Sulu/Component/Localization/Tests/Unit/LocalizationTest.php
+++ b/src/Sulu/Component/Localization/Tests/Unit/LocalizationTest.php
@@ -61,9 +61,7 @@ class LocalizationTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider formatProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('formatProvider')]
     public function testCreateFromString($format): void
     {
         $localization = Localization::createFromString($format, $format);

--- a/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
+++ b/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
@@ -262,9 +262,7 @@ class MediaDataProviderTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider dataItemsDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataItemsDataProvider')]
     public function testResolveDataItems($filters, $limit, $page, $pageSize, $repositoryResult, $hasNextPage, $items): void
     {
         $this->dataProviderRepository
@@ -370,9 +368,7 @@ class MediaDataProviderTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider resourceItemsDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('resourceItemsDataProvider')]
     public function testResolveResourceItems(
         $filters,
         $limit,

--- a/src/Sulu/Component/Media/Tests/Unit/SystemCollections/SystemCollectionManagerTest.php
+++ b/src/Sulu/Component/Media/Tests/Unit/SystemCollections/SystemCollectionManagerTest.php
@@ -339,9 +339,7 @@ class SystemCollectionManagerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider configProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('configProvider')]
     public function testWarmUp($config, $existingCollections, $notExistingCollections, $data): void
     {
         $tokenStorage = $this->getTokenStorage();
@@ -366,9 +364,7 @@ class SystemCollectionManagerTest extends TestCase
         $manager->warmUp();
     }
 
-    /**
-     * @dataProvider getProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getProvider')]
     public function testGetSystemCollection($data, $key, $expected, $exception = null): void
     {
         if (null !== $exception) {
@@ -398,9 +394,7 @@ class SystemCollectionManagerTest extends TestCase
         }
     }
 
-    /**
-     * @dataProvider isProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('isProvider')]
     public function testIsSystemCollection($data, $id, $expected): void
     {
         $tokenStorage = $this->getTokenStorage();

--- a/src/Sulu/Component/PHPCR/Tests/Unit/PathCleanupTest.php
+++ b/src/Sulu/Component/PHPCR/Tests/Unit/PathCleanupTest.php
@@ -61,9 +61,7 @@ class PathCleanupTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider cleanupProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('cleanupProvider')]
     public function testCleanup(string $a, string $b, string $locale): void
     {
         $clean = $this->cleaner->cleanup($a, $locale);
@@ -101,9 +99,7 @@ class PathCleanupTest extends TestCase
         $this->assertFalse($this->cleaner->validate('/asdf.xml'));
     }
 
-    /**
-     * @dataProvider emojiCleanupProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('emojiCleanupProvider')]
     public function testEmojiCleanup(string $a, string $b, string $locale): void
     {
         if (!$this->hasEmojiSupport) {

--- a/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/OrderByTraitTest.php
+++ b/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/OrderByTraitTest.php
@@ -60,9 +60,7 @@ class OrderByTraitTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider orderByProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('orderByProvider')]
     public function testAddOrderBy($alias, $orderBy, $expectedOrderBy): void
     {
         if (0 === \count($expectedOrderBy)) {

--- a/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
+++ b/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
@@ -95,9 +95,7 @@ class TimestampableSubscriberTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideOnPreUpdate
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideOnPreUpdate')]
     public function testOnPreUpdate($created): void
     {
         $entity = $this->timestampableObject->reveal();

--- a/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/UserBlameSubscriberTest.php
+++ b/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/UserBlameSubscriberTest.php
@@ -210,9 +210,8 @@ class UserBlameSubscriberTest extends TestCase
     /**
      * @param $changeset The changeset for the entity
      * @param $expectedFields List of filds which should be updated/set
-     *
-     * @dataProvider provideLifecycle
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideLifecycle')]
     public function testOnFlush($changeset, $expectedFields, $insert = true): void
     {
         $entity = $this->userBlameObject->reveal();
@@ -257,9 +256,8 @@ class UserBlameSubscriberTest extends TestCase
 
     /**
      * @param $changeset The changeset for the entity
-     *
-     * @dataProvider provideLifecycle
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideLifecycle')]
     public function testOnFlushOtherUser($changeset): void
     {
         $symfonyUser = $this->prophesize(SymfonyUserInterface::class);

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/EncodeAliasTraitTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/EncodeAliasTraitTest.php
@@ -44,9 +44,7 @@ class EncodeAliasTraitTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider encodeAliasDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('encodeAliasDataProvider')]
     public function testEncodeAlias($value, $expected): void
     {
         $method = new \ReflectionMethod(\get_class($this->encodeAlias), 'encodeAlias');

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/FieldDescriptor/DoctrineCaseFieldDescriptorTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/FieldDescriptor/DoctrineCaseFieldDescriptorTest.php
@@ -122,9 +122,7 @@ class DoctrineCaseFieldDescriptorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider dataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
     public function testComplete($name, $case1, $case2, $select, $joins, $search): void
     {
         $fieldDescriptor = new DoctrineCaseFieldDescriptor($name, $case1, $case2);

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineWhereExpressionTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineWhereExpressionTest.php
@@ -72,9 +72,7 @@ class DoctrineWhereExpressionTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider nullProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('nullProvider')]
     public function testGetStatementNullValue($comparator, $expected): void
     {
         $fieldDescriptor = new DoctrineFieldDescriptor('name', 'name', self::$entityName);
@@ -111,9 +109,7 @@ class DoctrineWhereExpressionTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider andOrProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('andOrProvider')]
     public function testGetStatementAndOr($comparator): void
     {
         $value = [1, 2, 3];

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/BooleanFilterTypeTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/BooleanFilterTypeTest.php
@@ -47,9 +47,7 @@ class BooleanFilterTypeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideFilter
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFilter')]
     public function testFilter($fieldName, $value, $expected): void
     {
         $fieldDescriptor = $this->prophesize(FieldDescriptor::class);

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/DateFilterTypeTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/DateFilterTypeTest.php
@@ -47,9 +47,7 @@ class DateFilterTypeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideFilter
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFilter')]
     public function testFilter($fieldName, $value, $expected): void
     {
         $fieldDescriptor = $this->prophesize(FieldDescriptor::class);
@@ -73,9 +71,7 @@ class DateFilterTypeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideFilterFromOnly
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFilterFromOnly')]
     public function testFilterFromOnly($fieldName, $value, $expected): void
     {
         $fieldDescriptor = $this->prophesize(FieldDescriptor::class);
@@ -94,9 +90,7 @@ class DateFilterTypeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideFilterToOnly
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFilterToOnly')]
     public function testFilterToOnly($fieldName, $value, $expected): void
     {
         $fieldDescriptor = $this->prophesize(FieldDescriptor::class);
@@ -116,9 +110,7 @@ class DateFilterTypeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideFilterWithInvalidOptions
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFilterWithInvalidOptions')]
     public function testFilterWithInvalidOptions($value): void
     {
         $this->expectException(InvalidFilterTypeOptionsException::class);

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/DateTimeFilterTypeTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/DateTimeFilterTypeTest.php
@@ -47,9 +47,7 @@ class DateTimeFilterTypeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideFilter
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFilter')]
     public function testFilter($fieldName, $value, $expected): void
     {
         $fieldDescriptor = $this->prophesize(FieldDescriptor::class);
@@ -73,9 +71,7 @@ class DateTimeFilterTypeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideFilterFromOnly
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFilterFromOnly')]
     public function testFilterFromOnly($fieldName, $value, $expected): void
     {
         $fieldDescriptor = $this->prophesize(FieldDescriptor::class);
@@ -95,9 +91,7 @@ class DateTimeFilterTypeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideFilterToOnly
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFilterToOnly')]
     public function testFilterToOnly($fieldName, $value, $expected): void
     {
         $fieldDescriptor = $this->prophesize(FieldDescriptor::class);
@@ -117,9 +111,7 @@ class DateTimeFilterTypeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideFilterWithInvalidOptions
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFilterWithInvalidOptions')]
     public function testFilterWithInvalidOptions($value): void
     {
         $this->expectException(InvalidFilterTypeOptionsException::class);

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/NumberFilterTypeTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/NumberFilterTypeTest.php
@@ -48,9 +48,7 @@ class NumberFilterTypeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideFilter
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFilter')]
     public function testFilter($fieldName, $value, $expectedOperator, $expectedValue): void
     {
         $fieldDescriptor = $this->prophesize(FieldDescriptor::class);
@@ -68,9 +66,7 @@ class NumberFilterTypeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideFilterWithInvalidOptions
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFilterWithInvalidOptions')]
     public function testFilterWithInvalidOptions($options): void
     {
         $this->expectException(InvalidFilterTypeOptionsException::class);

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/SelectFilterTypeTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/SelectFilterTypeTest.php
@@ -47,9 +47,7 @@ class SelectFilterTypeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideFilter
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFilter')]
     public function testFilter($fieldName, $value, $expected): void
     {
         $fieldDescriptor = $this->prophesize(FieldDescriptor::class);

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/SelectionFilterTypeTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/SelectionFilterTypeTest.php
@@ -47,9 +47,7 @@ class SelectionFilterTypeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideFilter
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFilter')]
     public function testFilter($fieldName, $value, $expected): void
     {
         $fieldDescriptor = $this->prophesize(FieldDescriptor::class);

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/TextFilterTypeTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/TextFilterTypeTest.php
@@ -47,9 +47,7 @@ class TextFilterTypeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideFilter
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFilter')]
     public function testFilter($fieldName, $value, $expectedOperator, $expectedValue): void
     {
         $fieldDescriptor = $this->prophesize(FieldDescriptor::class);

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/ListRestHelperTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/ListRestHelperTest.php
@@ -145,9 +145,7 @@ class ListRestHelperTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider dataFieldsProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataFieldsProvider')]
     public function testGetFields($request, $expected): void
     {
         $this->requestStack->getCurrentRequest()->willReturn($request);

--- a/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/AccessControlManagerTest.php
+++ b/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/AccessControlManagerTest.php
@@ -304,9 +304,7 @@ class AccessControlManagerTest extends TestCase
         $this->assertNull($this->accessControlManager->getPermissions(\stdClass::class, '1'));
     }
 
-    /**
-     * @dataProvider provideUserPermission
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideUserPermission')]
     public function testGetUserPermissions(
         $rolePermissions,
         $securityContextPermissions,

--- a/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/DoctrineAccessControlProviderTest.php
+++ b/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/DoctrineAccessControlProviderTest.php
@@ -307,9 +307,7 @@ class DoctrineAccessControlProviderTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider provideSupport
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideSupport')]
     public function testSupport(string $type, bool $supported): void
     {
         $this->assertSame($supported, $this->doctrineAccessControlProvider->supports($type));

--- a/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/PhpcrAccessControlProviderTest.php
+++ b/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/PhpcrAccessControlProviderTest.php
@@ -144,9 +144,7 @@ class PhpcrAccessControlProviderTest extends TestCase
         $this->assertEquals([], $this->phpcrAccessControlProvider->getPermissions('Acme\Document', '1'));
     }
 
-    /**
-     * @dataProvider provideSupport
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideSupport')]
     public function testSupport($type, $supported): void
     {
         $this->assertEquals($this->phpcrAccessControlProvider->supports($type), $supported);

--- a/src/Sulu/Component/SmartContent/Tests/Unit/BuilderTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/BuilderTest.php
@@ -22,9 +22,7 @@ class BuilderTest extends TestCase
         return [[true], [false]];
     }
 
-    /**
-     * @dataProvider provideBoolean
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideBoolean')]
     public function testTags($enable): void
     {
         $builder = Builder::create();
@@ -42,9 +40,7 @@ class BuilderTest extends TestCase
         $this->assertFalse($configuration->hasPagination());
     }
 
-    /**
-     * @dataProvider provideBoolean
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideBoolean')]
     public function testCategories($enable): void
     {
         $builder = Builder::create();
@@ -62,9 +58,7 @@ class BuilderTest extends TestCase
         $this->assertFalse($configuration->hasPagination());
     }
 
-    /**
-     * @dataProvider provideBoolean
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideBoolean')]
     public function testLimit($enable): void
     {
         $builder = Builder::create();
@@ -82,9 +76,7 @@ class BuilderTest extends TestCase
         $this->assertFalse($configuration->hasPagination());
     }
 
-    /**
-     * @dataProvider provideBoolean
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideBoolean')]
     public function testPresentAs($enable): void
     {
         $builder = Builder::create();
@@ -102,9 +94,7 @@ class BuilderTest extends TestCase
         $this->assertFalse($configuration->hasPagination());
     }
 
-    /**
-     * @dataProvider provideBoolean
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideBoolean')]
     public function testPagination($enable): void
     {
         $builder = Builder::create();

--- a/src/Sulu/Component/SmartContent/Tests/Unit/ContentTypeTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/ContentTypeTest.php
@@ -616,9 +616,7 @@ class ContentTypeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider pageProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('pageProvider')]
     public function testGetContentDataPagedLimit(
         $page,
         $pageSize,
@@ -734,9 +732,7 @@ class ContentTypeTest extends TestCase
         $this->assertEquals($expectedData, $pageData);
     }
 
-    /**
-     * @dataProvider pageProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('pageProvider')]
     public function testGetViewDataPagedLimit(
         $page,
         $pageSize,

--- a/src/Sulu/Component/SmartContent/Tests/Unit/DataProviderPoolTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/DataProviderPoolTest.php
@@ -128,12 +128,11 @@ class DataProviderPoolTest extends TestCase
     }
 
     /**
-     * @dataProvider addProvider
-     *
      * @param array<array{alias: string, provider: DataProviderInterface}> $providers
      * @param array<string, DataProviderInterface> $expectedProviders
      * @param class-string<\Throwable>|null $exceptionName
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('addProvider')]
     public function testAdd(DataProviderPool $pool, array $providers, array $expectedProviders, ?string $exceptionName = null): void
     {
         if ($exceptionName) {
@@ -158,9 +157,7 @@ class DataProviderPoolTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider existsProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('existsProvider')]
     public function testExists(DataProviderPool $pool, string $alias, bool $expected): void
     {
         $this->assertEquals($expected, $pool->exists($alias));
@@ -188,10 +185,9 @@ class DataProviderPoolTest extends TestCase
     }
 
     /**
-     * @dataProvider getProvider
-     *
      * @param class-string<\Throwable>|null $exceptionName
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getProvider')]
     public function testGet(DataProviderPool $pool, string $alias, ?DataProviderInterface $expectedProvider, ?string $exceptionName = null): void
     {
         if ($exceptionName) {
@@ -232,10 +228,9 @@ class DataProviderPoolTest extends TestCase
     }
 
     /**
-     * @dataProvider getAllProvider
-     *
      * @param array<string, DataProviderInterface> $expectedProviders
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAllProvider')]
     public function testGetAll(DataProviderPool $pool, array $expectedProviders): void
     {
         $this->assertEquals($expectedProviders, $pool->getAll());

--- a/src/Sulu/Component/Tag/Tests/Unit/Request/TagRequestHandlerTest.php
+++ b/src/Sulu/Component/Tag/Tests/Unit/Request/TagRequestHandlerTest.php
@@ -34,9 +34,7 @@ class TagRequestHandlerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider getProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getProvider')]
     public function testGetTagsProvider($tagsParameter, $tagsString, $expected): void
     {
         $requestStack = $this->prophesize(RequestStack::class);
@@ -65,9 +63,7 @@ class TagRequestHandlerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider appendProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('appendProvider')]
     public function testAppendTagToUrl($tagsParameter, $url, $tagsString, $expected): void
     {
         $tag = ['name' => 'Test'];
@@ -99,9 +95,7 @@ class TagRequestHandlerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider setProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('setProvider')]
     public function testSetTagToUrl($tagsParameter, $url, $tagsString, $expected): void
     {
         $tag = ['name' => 'Test'];
@@ -133,9 +127,7 @@ class TagRequestHandlerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider removeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('removeProvider')]
     public function testRemoveTagsFromUrl($tagsParameter, $url, $tagsString): void
     {
         $requestStack = $this->prophesize(RequestStack::class);

--- a/src/Sulu/Component/Util/Tests/Unit/ArrayUtilsTest.php
+++ b/src/Sulu/Component/Util/Tests/Unit/ArrayUtilsTest.php
@@ -55,9 +55,7 @@ class ArrayUtilsTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
     public function testFilter($collection, $expression, $expected, $context = []): void
     {
         $this->assertEquals($expected, ArrayUtils::filter($collection, $expression, $context));

--- a/src/Sulu/Component/Util/Tests/Unit/SortUtilsTest.php
+++ b/src/Sulu/Component/Util/Tests/Unit/SortUtilsTest.php
@@ -129,9 +129,7 @@ class SortUtilsTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideSortObjects
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideSortObjects')]
     public function testSortObjects($data, $methodName, $direction, $checkField, $expectedOrder): void
     {
         $accessor = PropertyAccess::createPropertyAccessor();
@@ -174,8 +172,6 @@ class SortUtilsTest extends TestCase
         $result = SortUtils::sortLocaleAware($array, 'de');
 
         if (!\class_exists(\Collator::class)) {
-            $this->addWarning('Could not test sorting with \\Collator, because intl extension is not loaded');
-
             $this->assertSame(['A', 'D', 'E', 'M', 'Ä', 'Ê'], $result);
         } else {
             $this->assertSame(['A', 'Ä', 'D', 'E', 'Ê', 'M'], $result);
@@ -196,8 +192,6 @@ class SortUtilsTest extends TestCase
         $result = SortUtils::sortLocaleAware($array, 'de', fn ($item) => $item['value']);
 
         if (!\class_exists(\Collator::class)) {
-            $this->addWarning('Could not test sorting with \\Collator, because intl extension is not loaded');
-
             $this->assertSame([
                 ['value' => 'A'],
                 ['value' => 'D'],

--- a/src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
+++ b/src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
@@ -164,9 +164,7 @@ class SuluNodeHelperTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideExtractWebspaceFromPath
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideExtractWebspaceFromPath')]
     public function testExtractWebspaceFromPath($path, $expected): void
     {
         $res = $this->helper->extractWebspaceFromPath($path);
@@ -186,9 +184,7 @@ class SuluNodeHelperTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideExtractSnippetTypeFromPath
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideExtractSnippetTypeFromPath')]
     public function testExtractSnippetTypeFromPath($path, $expected, $valid = true): void
     {
         if (false === $valid) {
@@ -209,9 +205,7 @@ class SuluNodeHelperTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideGetStructureTypeForNode
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideGetStructureTypeForNode')]
     public function testGetStructureTypeForNode($nodeType, $expected): void
     {
         $this->node->expects($this->any())
@@ -233,9 +227,7 @@ class SuluNodeHelperTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideHasSuluNodeType
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideHasSuluNodeType')]
     public function testHasSuluNodeType($nodeTypes, $expected): void
     {
         $this->node->expects($this->any())

--- a/src/Sulu/Component/Util/Tests/Unit/TextUtilsTest.php
+++ b/src/Sulu/Component/Util/Tests/Unit/TextUtilsTest.php
@@ -31,9 +31,7 @@ class TextUtilsTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideTruncate
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideTruncate')]
     public function testTruncate($text, $length, $suffix, $expected): void
     {
         $res = TextUtils::truncate($text, $length, $suffix);

--- a/src/Sulu/Component/Util/Tests/Unit/WildcardUrlUtilTest.php
+++ b/src/Sulu/Component/Util/Tests/Unit/WildcardUrlUtilTest.php
@@ -29,9 +29,7 @@ class WildcardUrlUtilTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideMatchData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideMatchData')]
     public function testMatch($portalUrl, $url, $expected): void
     {
         $this->assertEquals($expected, WildcardUrlUtil::match($url, $portalUrl));
@@ -51,9 +49,7 @@ class WildcardUrlUtilTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideResolveData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideResolveData')]
     public function testResolve($portalUrl, $url, $expected): void
     {
         $this->assertEquals($expected, WildcardUrlUtil::resolve($url, $portalUrl));

--- a/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
@@ -181,9 +181,7 @@ class RequestAnalyzerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideAnalyze
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideAnalyze')]
     public function testAnalyze($config, $expected = []): void
     {
         $webspace = new Webspace();
@@ -222,9 +220,7 @@ class RequestAnalyzerTest extends TestCase
         $this->assertEquals($expected['resource_locator_prefix'], $this->requestAnalyzer->getResourceLocatorPrefix());
     }
 
-    /**
-     * @dataProvider provideAnalyzeWithFormat
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideAnalyzeWithFormat')]
     public function testAnalyzeWithFormat($config, $expected = []): void
     {
         $webspace = new Webspace();
@@ -282,9 +278,7 @@ class RequestAnalyzerTest extends TestCase
         $this->requestAnalyzer->validate($request);
     }
 
-    /**
-     * @dataProvider provideAnalyze
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideAnalyze')]
     public function testAnalyzeCurrentRequest($config, $expected = []): void
     {
         $webspace = new Webspace();

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/AdminRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/AdminRequestProcessorTest.php
@@ -38,9 +38,7 @@ class AdminRequestProcessorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
     public function testProcess(array $expected = [], $webspaceKey = null, $locale = null, $language = null): void
     {
         $webspaceManager = $this->prophesize(WebspaceManagerInterface::class);

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
@@ -33,9 +33,7 @@ class PortalInformationRequestProcessorTest extends TestCase
         $this->portalInformationRequestProcessor = new PortalInformationRequestProcessor();
     }
 
-    /**
-     * @dataProvider provideProcess
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideProcess')]
     public function testProcess($config, $expected = []): void
     {
         $webspace = new Webspace();
@@ -85,9 +83,7 @@ class PortalInformationRequestProcessorTest extends TestCase
         $this->assertEquals($expected['url_expression'], $attributes->getAttribute('urlExpression'));
     }
 
-    /**
-     * @dataProvider provideProcess
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideProcess')]
     public function testProcessWithoutLocaliziation($config, $expected = []): void
     {
         $webspace = new Webspace();
@@ -136,9 +132,7 @@ class PortalInformationRequestProcessorTest extends TestCase
         $this->assertEquals($expected['url_expression'], $attributes->getAttribute('urlExpression'));
     }
 
-    /**
-     * @dataProvider provideProcessWithFormat
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideProcessWithFormat')]
     public function testProcessWithFormat($config, $expected = []): void
     {
         $webspace = new Webspace();

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/RequestAttributesTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/RequestAttributesTest.php
@@ -28,9 +28,7 @@ class RequestAttributesTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
     public function testGetAttribute(array $attributes, $name, $default, $expected): void
     {
         $instance = new RequestAttributes($attributes);

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/SegmentRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/SegmentRequestProcessorTest.php
@@ -90,9 +90,7 @@ class SegmentRequestProcessorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideProcessWithDefaultSegmentValue
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideProcessWithDefaultSegmentValue')]
     public function testProcessWithDefaultSegmentValue($cookieSegmentKey, $defaultSegmentKey, $expectedSegmentKey): void
     {
         $request = new Request();

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/UrlRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/UrlRequestProcessorTest.php
@@ -28,9 +28,7 @@ class UrlRequestProcessorTest extends TestCase
         $this->urlRequestProcessor = new UrlRequestProcessor();
     }
 
-    /**
-     * @dataProvider provideProcess
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideProcess')]
     public function testProcess($url, $host, $port, $path): void
     {
         $request = Request::create($url);

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/WebsiteRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/WebsiteRequestProcessorTest.php
@@ -249,9 +249,8 @@ class WebsiteRequestProcessorTest extends TestCase
 
     /**
      * @param PortalInformation[] $portalInformations
-     *
-     * @dataProvider provideValidateData
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideValidateData')]
     public function testValidate($attributes, $exception = null, $message = '', $portalInformations = []): void
     {
         if (null !== $exception) {

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/RequestAnalyzerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/RequestAnalyzerTest.php
@@ -213,9 +213,7 @@ class RequestAnalyzerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideGetter
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideGetter')]
     public function testGetter(array $attributes, $method, $expected): void
     {
         $provider = $this->prophesize(RequestProcessorInterface::class);

--- a/src/Sulu/Component/Webspace/Tests/Unit/EnvironmentTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/EnvironmentTest.php
@@ -76,9 +76,7 @@ class EnvironmentTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider addUrlProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('addUrlProvider')]
     public function testAddUrl(array $urls, Url $expectedMainUrl): void
     {
         $environment = new Environment();

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
@@ -495,10 +495,9 @@ class WebspaceManagerTest extends WebspaceTestCase
     }
 
     /**
-     * @dataProvider provideFindPortalInformationByUrl
-     *
      * @param bool $shouldFind
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFindPortalInformationByUrl')]
     public function testFindPortalInformationByUrlWithInvalidSuffix(string $url, $shouldFind): void
     {
         $portalInformation = $this->webspaceManager->findPortalInformationByUrl($url, 'dev');

--- a/src/Sulu/Component/Webspace/Tests/Unit/PortalInformationTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/PortalInformationTest.php
@@ -63,9 +63,7 @@ class PortalInformationTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideUrl
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideUrl')]
     public function testGetHostAndPrefix($url, $host, $prefix): void
     {
         $this->portalInformation->setUrl($url);

--- a/src/Sulu/Component/Webspace/Tests/Unit/Settings/SettingsManagerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Settings/SettingsManagerTest.php
@@ -65,9 +65,8 @@ class SettingsManagerTest extends TestCase
 
     /**
      * @param array<string, string>|null|NodeInterface $data
-     *
-     * @dataProvider dataProvider
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
     public function testSave(string $webspaceKey, string $key, array|NodeInterface|null $data): void
     {
         $this->deprecatedSessionManager->getWebspacePath($webspaceKey)->willReturn('/cmf/' . $webspaceKey);
@@ -99,9 +98,8 @@ class SettingsManagerTest extends TestCase
 
     /**
      * @param array<string, string>|null|NodeInterface $data
-     *
-     * @dataProvider dataProvider
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
     public function testLoad(string $webspaceKey, string $key, array|NodeInterface|null $data): void
     {
         $node = $this->prophesize(NodeInterface::class);
@@ -123,9 +121,7 @@ class SettingsManagerTest extends TestCase
         yield ['sulu_io', 'test-1', '123-123-123', false];
     }
 
-    /**
-     * @dataProvider loadStringDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('loadStringDataProvider')]
     public function testLoadString(string $webspaceKey, string $key, string $data, bool $exists): void
     {
         $node = $this->prophesize(NodeInterface::class);

--- a/src/Sulu/Component/Webspace/Tests/Unit/UrlTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/UrlTest.php
@@ -29,9 +29,7 @@ class UrlTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideIsValidLocale
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideIsValidLocale')]
     public function testIsValidLocale($urlLanguage, $urlCountry, $testLanguage, $testCountry, $result): void
     {
         $url = new Url();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | closes #6988 
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Updating phpunit to version 10 and fixing the tests

* Updating the dependency in the `composer.json`
* Running rector to upgrade the tests (it's using attributes instead of annotations now)
* Fixing the problems with the dataprovider functions being static now (mostly)

#### Why?
It's always a good idea to have an up to date testing library.

#### To Do

- [ ] Fix the tests
