### PR TITLE
Tests should crash on non zero exit code

### DIFF
--- a/bin/runtests
+++ b/bin/runtests
@@ -135,13 +135,10 @@ function exec_cmd($cmdLine, $echo = true, $checkForError = true)
         write($out);
     });
 
-    if ($checkForError && $process->getExitCode() !== 0) {
-        write_error(sprintf(
-            'Could not execute command "%s", got exit code "%s": %s',
-            $cmdLine,
-            $process->getExitCode(),
-            $process->getErrorOutput()
-        ));
+    if ($checkForError) {
+        $process->mustRun();
+    } else {
+        $process->run();
     }
 
     return $process;

--- a/bin/runtests
+++ b/bin/runtests
@@ -284,16 +284,7 @@ function get_phpunit_path()
 
 function init_bundle()
 {
-    if (!$console = get_test_console_path()) {
-        return;
-    }
-
-    $process = exec_cmd(sprintf(
-        PHP_BINARY . ' %s %s',
-        $console,
-        'debug:container doctrine.orm.entity_manager'
-    ), false, false);
-
+    $process = exec_sf_cmd('debug:container doctrine.orm.entity_manager', false, false);
     // bundle does not use Doctrine ORM
     if ($process->getExitCode() !== 0) {
         return;
@@ -301,20 +292,12 @@ function init_bundle()
 
     write_info('Doctrine ORM detected, updating the schema for the bundle.');
 
-    $process = exec_sf_cmd(sprintf(
-        PHP_BINARY . ' %s %s',
-        $console,
-        ' doctrine:schema:update --force'
-    ));
+    $process = exec_sf_cmd('doctrine:schema:update --force');
     if ($process->getExitCode() !== 0) {
         exit($process->getExitCode());
     }
 
-    $process = exec_cmd(sprintf(
-        PHP_BINARY . ' %s %s',
-        $console,
-        ' sulu:document:initialize --purge --force --ansi'
-    ));
+    $process = exec_sf_cmd('sulu:document:initialize --purge --force --ansi');
     if ($process->getExitCode() !== 0) {
         exit($process->getExitCode());
     }

--- a/bin/runtests
+++ b/bin/runtests
@@ -293,14 +293,8 @@ function init_bundle()
     write_info('Doctrine ORM detected, updating the schema for the bundle.');
 
     $process = exec_sf_cmd('doctrine:schema:update --force');
-    if ($process->getExitCode() !== 0) {
-        exit($process->getExitCode());
-    }
 
     $process = exec_sf_cmd('sulu:document:initialize --purge --force --ansi');
-    if ($process->getExitCode() !== 0) {
-        exit($process->getExitCode());
-    }
 }
 
 function is_everything_ok()

--- a/bin/runtests
+++ b/bin/runtests
@@ -135,10 +135,13 @@ function exec_cmd($cmdLine, $echo = true, $checkForError = true)
         write($out);
     });
 
-    if ($checkForError) {
-        $process->mustRun();
-    } else {
-        $process->run();
+    if ($checkForError && $process->getExitCode() !== 0) {
+        write_error(sprintf(
+            'Could not execute command "%s", got exit code "%s": %s',
+            $cmdLine,
+            $process->getExitCode(),
+            $process->getErrorOutput()
+        ));
     }
 
     return $process;
@@ -220,9 +223,12 @@ function init_dbal()
     );
 
     write_info('Updating schema');
-    exec_sf_cmd(
+    $process = exec_sf_cmd(
         'doctrine:schema:update --force'
     );
+    if ($process->getExitCode() !== 0) {
+        exit($process->getExitCode());
+    }
 }
 
 function run_bundle_tests(\SplFileInfo $phpunitFile)
@@ -295,17 +301,23 @@ function init_bundle()
 
     write_info('Doctrine ORM detected, updating the schema for the bundle.');
 
-    exec_cmd(sprintf(
+    $process = exec_sf_cmd(sprintf(
         PHP_BINARY . ' %s %s',
         $console,
         ' doctrine:schema:update --force'
     ));
+    if ($process->getExitCode() !== 0) {
+        exit($process->getExitCode());
+    }
 
-    exec_cmd(sprintf(
+    $process = exec_cmd(sprintf(
         PHP_BINARY . ' %s %s',
         $console,
         ' sulu:document:initialize --purge --force --ansi'
     ));
+    if ($process->getExitCode() !== 0) {
+        exit($process->getExitCode());
+    }
 }
 
 function is_everything_ok()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #6834
| License | MIT
| Documentation PR | -

#### What's in this PR?
This adds the function that the tests crash when one of the steps exists with a non-zero exit code.

#### Why?
Currently the tests just ignore the exit code and continue running which then causes issues further down the suite. This should make the tests easier to debug as the errors are reported earlier and closer to the source.
