### PR TITLE
Prepare compatibility to Symfony 7

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -109,9 +109,9 @@ Additionally, the following packages where upgraded:
 
 This update is also handled normally by the update build command automatically.
 
-### DocumentToUuidTransformer return type changed
+### Different return type changed for preparing Symfony 7 compatibility
 
-For compatibility to Symfony 7 the `DocumentToUuidTransformer` methods return types changed:
+The `DocumentToUuidTransformer` methods return types changed:
 
 ```diff
 -    public function transform($document)
@@ -120,6 +120,51 @@ For compatibility to Symfony 7 the `DocumentToUuidTransformer` methods return ty
 -    public function reverseTransform($uuid)
 +    public function reverseTransform($uuid): ?object
 ```
+
+The `User` methods return types changed:
+
+```diff
+-    public function eraseCredentials()
++    public function eraseCredentials(): void
+```
+
+The `AuthenticationEntryPoint` methods return types changed:
+
+```diff
+-    public function start(Request $request, ?AuthenticationException $authException = null)
++    public function start(Request $request, ?AuthenticationException $authException = null): Response
+```
+
+The `UserProvider` and `TestUserProvider` methods return types changed:
+
+```diff
+-    public function refreshUser()
++    public function refreshUser(): UserInterface
+
+-    public function supportsClass()
++    public function supportsClass(): bool
+```
+
+The `SecurityContextVoter` and `TestVoter` methods return types changed:
+
+```diff
+-    public function vote(TokenInterface $token, $object, array $attributes)
++    public function vote(TokenInterface $token, $object, array $attributes): int
+```
+
+### Replace Symfony Security class
+
+The `Symfony\Component\Security\Core\Security` deprecated class was replaced by
+`Symfony\Bundle\SecurityBundle\Security` for preparing Symfony 7 compatibility:
+
+ - `Sulu/Bundle/ActivityBundle/Application/Subscriber/SetDomainEventUserSubscriber`
+ - `Sulu/Bundle/PageBundle/EventListener/PageRemoveSubscriber`
+ - `Sulu/Bundle/SecurityBundle/Metadata/TwoFactorFormMetadataVisitor`
+ - `Sulu/Bundle/SecurityBundle/Security/AuthenticationHandler`
+ - `Sulu/Bundle/TrashBundle/Infrastructure/Doctrine/Repository/TrashItemRepository`
+ - `Sulu/Component/Content/Mapper/ContentMapper`
+ - `Sulu/Component/Media/SmartContent/MediaDataProvider`
+ - `Sulu/Component/Security/Authorization/AccessControl/AccessControlManager`
 
 ### Admin JS ResourceRouteRegistry getDetailUrl and getListUrl deprecated
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -109,9 +109,9 @@ Additionally, the following packages where upgraded:
 
 This update is also handled normally by the update build command automatically.
 
-### Different return type changed for preparing Symfony 7 compatibility
+### Return type adjustments to prepare Symfony 7 compatibility
 
-The `DocumentToUuidTransformer` methods return types changed:
+Return type changes in `DocumentToUuidTransformer`:
 
 ```diff
 -    public function transform($document)
@@ -121,21 +121,21 @@ The `DocumentToUuidTransformer` methods return types changed:
 +    public function reverseTransform($uuid): ?object
 ```
 
-The `User` methods return types changed:
+Return type changes in `User`:
 
 ```diff
 -    public function eraseCredentials()
 +    public function eraseCredentials(): void
 ```
 
-The `AuthenticationEntryPoint` methods return types changed:
+Return type changes in `AuthenticationEntryPoint`:
 
 ```diff
 -    public function start(Request $request, ?AuthenticationException $authException = null)
 +    public function start(Request $request, ?AuthenticationException $authException = null): Response
 ```
 
-The `UserProvider` and `TestUserProvider` methods return types changed:
+Return type changes in `UserProvider` and `TestUserProvider`:
 
 ```diff
 -    public function refreshUser()
@@ -145,14 +145,14 @@ The `UserProvider` and `TestUserProvider` methods return types changed:
 +    public function supportsClass(): bool
 ```
 
-The `SecurityContextVoter` and `TestVoter` methods return types changed:
+Return type changes in `SecurityContextVoter` and `TestVoter`:
 
 ```diff
 -    public function vote(TokenInterface $token, $object, array $attributes)
 +    public function vote(TokenInterface $token, $object, array $attributes): int
 ```
 
-Different internal `Warmer` has be changed:
+Return type changes in the internal `Warmer`:
 
 ```diff
 -    public function warmUp($cacheDir)
@@ -162,7 +162,7 @@ Different internal `Warmer` has be changed:
 +    public function isOptional(): bool
 ```
 
-Different internal `Loader` has be changed:
+Return type changes in `Loader`:
 
 ```diff
 -    public function load($resource, $type = null)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -152,6 +152,27 @@ The `SecurityContextVoter` and `TestVoter` methods return types changed:
 +    public function vote(TokenInterface $token, $object, array $attributes): int
 ```
 
+Different internal `Warmer` has be changed:
+
+```diff
+-    public function warmUp($cacheDir)
++    public function warmUp($cacheDir, ?string $buildDir = null): array
+
+-    public function isOptional()
++    public function isOptional(): bool
+```
+
+Different internal `Loader` has be changed:
+
+```diff
+-    public function load($resource, $type = null)
++    public function load($resource, $type = null): mixed
+
+
+-    public function supports($resource, $type = null)
++    public function supports($resource, $type = null): bool
+```
+
 ### Replace Symfony Security class
 
 The `Symfony\Component\Security\Core\Security` deprecated class was replaced by

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1181,11 +1181,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\Metadata\\\\FormMetadata\\\\StructureFormMetadataLoader\\:\\:warmUp\\(\\) should return array\\<string\\> but return statement is missing\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
-
-		-
 			message: "#^Parameter \\#1 \\$data of function unserialize expects string, string\\|false given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
@@ -1262,11 +1257,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\Metadata\\\\FormMetadata\\\\XmlFormMetadataLoader\\:\\:getMetadata\\(\\) should return Sulu\\\\Bundle\\\\AdminBundle\\\\Metadata\\\\MetadataInterface\\|null but returns mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\Metadata\\\\FormMetadata\\\\XmlFormMetadataLoader\\:\\:warmUp\\(\\) should return array\\<string\\> but return statement is missing\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
 
@@ -33581,11 +33571,6 @@ parameters:
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Application/AppCache.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Tests\\\\Application\\\\AppCache\\:\\:registerContainerConfiguration\\(\\) with return type void returns mixed but should not return anything\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Tests/Application/AppCache.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Tests\\\\Application\\\\AppCache\\:\\:serialize\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Application/AppCache.php
@@ -47081,6 +47066,11 @@ parameters:
 			path: src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
 
 		-
+			message: "#^Parameter \\#6 \\$security of class Sulu\\\\Component\\\\Media\\\\SmartContent\\\\MediaDataProvider constructor expects Symfony\\\\Component\\\\Security\\\\Core\\\\Security\\|null, object given\\.$#"
+			count: 1
+			path: src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
+
+		-
 			message: "#^Method Sulu\\\\Component\\\\Media\\\\Tests\\\\Unit\\\\SystemCollections\\\\SystemCollectionManagerTest\\:\\:appendExistingCollection\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Media/Tests/Unit/SystemCollections/SystemCollectionManagerTest.php
@@ -50562,6 +50552,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$user of method Sulu\\\\Component\\\\Security\\\\Authorization\\\\AccessControl\\\\AccessControlManager\\:\\:getUserPermissions\\(\\) expects Sulu\\\\Component\\\\Security\\\\Authentication\\\\UserInterface\\|null, string given\\.$#"
+			count: 1
+			path: src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/AccessControlManagerTest.php
+
+		-
+			message: "#^Parameter \\#7 \\$security of class Sulu\\\\Component\\\\Security\\\\Authorization\\\\AccessControl\\\\AccessControlManager constructor expects Symfony\\\\Component\\\\Security\\\\Core\\\\Security\\|null, object given\\.$#"
 			count: 1
 			path: src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/AccessControlManagerTest.php
 

--- a/src/Sulu/Bundle/ActivityBundle/Application/Subscriber/SetDomainEventUserSubscriber.php
+++ b/src/Sulu/Bundle/ActivityBundle/Application/Subscriber/SetDomainEventUserSubscriber.php
@@ -14,17 +14,18 @@ namespace Sulu\Bundle\ActivityBundle\Application\Subscriber;
 use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
+use Symfony\Bundle\SecurityBundle\Security;
 
 class SetDomainEventUserSubscriber implements EventSubscriberInterface
 {
     /**
-     * @var Security|null
+     * @var SymfonyCoreSecurity|Security|null
      */
     private $security;
 
     public function __construct(
-        ?Security $security
+        Security|SymfonyCoreSecurity|null $security
     ) {
         $this->security = $security;
     }

--- a/src/Sulu/Bundle/ActivityBundle/Application/Subscriber/SetDomainEventUserSubscriber.php
+++ b/src/Sulu/Bundle/ActivityBundle/Application/Subscriber/SetDomainEventUserSubscriber.php
@@ -13,9 +13,9 @@ namespace Sulu\Bundle\ActivityBundle\Application\Subscriber;
 
 use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
 use Sulu\Component\Security\Authentication\UserInterface;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
-use Symfony\Bundle\SecurityBundle\Security;
 
 class SetDomainEventUserSubscriber implements EventSubscriberInterface
 {

--- a/src/Sulu/Bundle/ActivityBundle/Tests/Unit/Application/Subscriber/SetDomainEventUserSubscriberTest.php
+++ b/src/Sulu/Bundle/ActivityBundle/Tests/Unit/Application/Subscriber/SetDomainEventUserSubscriberTest.php
@@ -18,20 +18,25 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\ActivityBundle\Application\Subscriber\SetDomainEventUserSubscriber;
 use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
 use Sulu\Component\Security\Authentication\UserInterface;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
+use Symfony\Bundle\SecurityBundle\Security;
 
 class SetDomainEventUserSubscriberTest extends TestCase
 {
     use ProphecyTrait;
 
     /**
-     * @var ObjectProphecy<Security>
+     * @var ObjectProphecy<Security|SymfonyCoreSecurity>
      */
     private $security;
 
     public function setUp(): void
     {
-        $this->security = $this->prophesize(Security::class);
+        $this->security = $this->prophesize(
+            \class_exists(Security::class)
+                ? Security::class
+                : SymfonyCoreSecurity::class
+        );
     }
 
     public function testSetDomainEventUser(): void

--- a/src/Sulu/Bundle/ActivityBundle/Tests/Unit/Application/Subscriber/SetDomainEventUserSubscriberTest.php
+++ b/src/Sulu/Bundle/ActivityBundle/Tests/Unit/Application/Subscriber/SetDomainEventUserSubscriberTest.php
@@ -18,8 +18,8 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\ActivityBundle\Application\Subscriber\SetDomainEventUserSubscriber;
 use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
 use Sulu\Component\Security\Authentication\UserInterface;
-use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
 
 class SetDomainEventUserSubscriberTest extends TestCase
 {

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
@@ -148,6 +148,8 @@ class StructureFormMetadataLoader implements FormMetadataLoaderInterface, CacheW
                 );
             }
         }
+
+        return [];
     }
 
     /**

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
@@ -117,7 +117,7 @@ class StructureFormMetadataLoader implements FormMetadataLoaderInterface, CacheW
         return $form;
     }
 
-    public function warmUp($cacheDir)
+    public function warmUp($cacheDir, ?string $buildDir = null): array
     {
         $structuresMetadataByTypes = [];
         foreach ($this->structureMetadataFactory->getStructureTypes() as $structureType) {
@@ -227,7 +227,7 @@ class StructureFormMetadataLoader implements FormMetadataLoaderInterface, CacheW
         }
     }
 
-    public function isOptional()
+    public function isOptional(): bool
     {
         return false;
     }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
@@ -77,7 +77,7 @@ class XmlFormMetadataLoader implements FormMetadataLoaderInterface, CacheWarmerI
         return $form;
     }
 
-    public function warmUp($cacheDir)
+    public function warmUp($cacheDir, ?string $buildDir = null): array
     {
         $formFinder = (new Finder())->in($this->formDirectories)->name('*.xml');
         $formsMetadataCollection = [];
@@ -130,7 +130,7 @@ class XmlFormMetadataLoader implements FormMetadataLoaderInterface, CacheWarmerI
         }
     }
 
-    public function isOptional()
+    public function isOptional(): bool
     {
         return false;
     }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
@@ -108,6 +108,8 @@ class XmlFormMetadataLoader implements FormMetadataLoaderInterface, CacheWarmerI
                 );
             }
         }
+
+        return [];
     }
 
     /**

--- a/src/Sulu/Bundle/CoreBundle/Cache/StructureWarmer.php
+++ b/src/Sulu/Bundle/CoreBundle/Cache/StructureWarmer.php
@@ -35,7 +35,7 @@ class StructureWarmer implements CacheWarmerInterface
      *
      * {@inheritdoc}
      */
-    public function warmUp($cacheDir)
+    public function warmUp($cacheDir, ?string $buildDir = null): array
     {
         // warmup the pages
         $this->structureManager->getStructures(Structure::TYPE_PAGE);
@@ -51,7 +51,7 @@ class StructureWarmer implements CacheWarmerInterface
      *
      * {@inheritdoc}
      */
-    public function isOptional()
+    public function isOptional(): bool
     {
         return true;
     }

--- a/src/Sulu/Bundle/CoreBundle/DataFixtures/ReplacerXmlLoader.php
+++ b/src/Sulu/Bundle/CoreBundle/DataFixtures/ReplacerXmlLoader.php
@@ -22,7 +22,7 @@ class ReplacerXmlLoader extends FileLoader
     /**
      * @param string $resource
      */
-    public function load($resource, $type = null)
+    public function load($resource, $type = null): mixed
     {
         $path = $this->getLocator()->locate($resource);
 
@@ -30,7 +30,7 @@ class ReplacerXmlLoader extends FileLoader
         return $this->parseXml($path);
     }
 
-    public function supports($resource, $type = null)
+    public function supports($resource, $type = null): bool
     {
         return 'xml' === \pathinfo($resource, \PATHINFO_EXTENSION);
     }

--- a/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Compiler/RegisterListenersPass.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Compiler/RegisterListenersPass.php
@@ -219,7 +219,7 @@ class ExtractingEventDispatcher extends EventDispatcher implements EventSubscrib
     public static $aliases = [];
     public static $subscriber;
 
-    public function addListener(string $eventName, $listener, int $priority = 0)
+    public function addListener(string $eventName, $listener, int $priority = 0): void
     {
         $this->listeners[] = [$eventName, $listener[1], $priority];
     }

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/BaseXmlFormatLoader.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/BaseXmlFormatLoader.php
@@ -67,7 +67,7 @@ abstract class BaseXmlFormatLoader extends FileLoader
      *
      * @return array The formats array for the given resource
      */
-    public function load($resource, $type = null)
+    public function load($resource, $type = null): mixed
     {
         $path = $this->getLocator()->locate($resource);
 
@@ -82,7 +82,7 @@ abstract class BaseXmlFormatLoader extends FileLoader
      *
      * @return bool true if this class supports the given resource, false otherwise
      */
-    public function supports($resource, $type = null)
+    public function supports($resource, $type = null): bool
     {
         if (!\is_string($resource) || 'xml' !== \pathinfo($resource, \PATHINFO_EXTENSION)) {
             return false;

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader10.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader10.php
@@ -24,7 +24,7 @@ class XmlFormatLoader10 extends BaseXmlFormatLoader
 
     public const SCHEME_PATH = '/schema/formats/formats-1.0.xsd';
 
-    public function load($resource, $type = null)
+    public function load($resource, $type = null): mixed
     {
         @trigger_deprecation(
             'sulu/sulu',

--- a/src/Sulu/Bundle/PageBundle/EventListener/PageRemoveSubscriber.php
+++ b/src/Sulu/Bundle/PageBundle/EventListener/PageRemoveSubscriber.php
@@ -29,7 +29,8 @@ use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authorization\AccessControl\AccessControlRepositoryInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
+use Symfony\Bundle\SecurityBundle\Security;
 
 class PageRemoveSubscriber implements EventSubscriberInterface
 {
@@ -51,7 +52,7 @@ class PageRemoveSubscriber implements EventSubscriberInterface
     private $systemStore;
 
     /**
-     * @var Security|null
+     * @var Security|SymfonyCoreSecurity|null
      */
     private $security;
 
@@ -67,7 +68,7 @@ class PageRemoveSubscriber implements EventSubscriberInterface
         SessionManagerInterface $sessionManager,
         AccessControlRepositoryInterface $accessControlRepository,
         SystemStoreInterface $systemStore,
-        ?Security $security,
+        Security|SymfonyCoreSecurity|null $security,
         array $permissions
     ) {
         $this->sessionManager = $sessionManager;

--- a/src/Sulu/Bundle/PageBundle/EventListener/PageRemoveSubscriber.php
+++ b/src/Sulu/Bundle/PageBundle/EventListener/PageRemoveSubscriber.php
@@ -28,9 +28,9 @@ use Sulu\Component\Rest\Exception\InsufficientDescendantPermissionsException;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authorization\AccessControl\AccessControlRepositoryInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
-use Symfony\Bundle\SecurityBundle\Security;
 
 class PageRemoveSubscriber implements EventSubscriberInterface
 {

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
@@ -27,7 +27,7 @@ class PreviewKernel extends Kernel
      */
     private $projectDir;
 
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         parent::registerContainerConfiguration($loader);
 

--- a/src/Sulu/Bundle/ReferenceBundle/Infrastructure/Symfony/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/ReferenceBundle/Infrastructure/Symfony/DependencyInjection/Configuration.php
@@ -23,7 +23,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sulu_reference');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/Sulu/Bundle/ReferenceBundle/UserInterface/Command/RefreshCommand.php
+++ b/src/Sulu/Bundle/ReferenceBundle/UserInterface/Command/RefreshCommand.php
@@ -45,7 +45,7 @@ class RefreshCommand extends Command
         $this->addArgument('resource-key', InputArgument::OPTIONAL, 'The resource key which should be refreshed');
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $resourceKeyFilter = $input->getArgument('resource-key');
 

--- a/src/Sulu/Bundle/SecurityBundle/Entity/User.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/User.php
@@ -313,7 +313,7 @@ class User extends ApiEntity implements UserInterface, EquatableInterface, Audit
     /**
      * Removes the password of the user.
      */
-    public function eraseCredentials()
+    public function eraseCredentials(): void
     {
     }
 

--- a/src/Sulu/Bundle/SecurityBundle/Metadata/TwoFactorFormMetadataVisitor.php
+++ b/src/Sulu/Bundle/SecurityBundle/Metadata/TwoFactorFormMetadataVisitor.php
@@ -16,7 +16,8 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataVisitorInterface;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Bundle\SecurityBundle\Entity\User;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
+use Symfony\Bundle\SecurityBundle\Security;
 
 /**
  * @internal
@@ -30,7 +31,7 @@ class TwoFactorFormMetadataVisitor implements FormMetadataVisitorInterface
 
     private ?string $twoFactorForcePattern;
 
-    private ?Security $security;
+    private Security|SymfonyCoreSecurity|null $security;
 
     /**
      * @param string[] $twoFactorMethods
@@ -38,7 +39,7 @@ class TwoFactorFormMetadataVisitor implements FormMetadataVisitorInterface
     public function __construct(
         array $twoFactorMethods,
         ?string $twoFactorForcePattern,
-        ?Security $security
+        Security|SymfonyCoreSecurity|null $security
     ) {
         $this->twoFactorMethods = $twoFactorMethods;
         $this->twoFactorForcePattern = $twoFactorForcePattern;

--- a/src/Sulu/Bundle/SecurityBundle/Metadata/TwoFactorFormMetadataVisitor.php
+++ b/src/Sulu/Bundle/SecurityBundle/Metadata/TwoFactorFormMetadataVisitor.php
@@ -16,8 +16,8 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataVisitorInterface;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Bundle\SecurityBundle\Entity\User;
-use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
 
 /**
  * @internal

--- a/src/Sulu/Bundle/SecurityBundle/Security/AuthenticationEntryPoint.php
+++ b/src/Sulu/Bundle/SecurityBundle/Security/AuthenticationEntryPoint.php
@@ -22,7 +22,7 @@ use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface
  */
 class AuthenticationEntryPoint implements AuthenticationEntryPointInterface
 {
-    public function start(Request $request, ?AuthenticationException $authException = null)
+    public function start(Request $request, ?AuthenticationException $authException = null): Response
     {
         return new Response('', 401);
     }

--- a/src/Sulu/Bundle/SecurityBundle/Security/AuthenticationHandler.php
+++ b/src/Sulu/Bundle/SecurityBundle/Security/AuthenticationHandler.php
@@ -19,9 +19,11 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
 /**
  * Called after a user gets authenticated at the admin firewall
@@ -109,7 +111,14 @@ class AuthenticationHandler implements AuthenticationSuccessHandlerInterface, Au
         } else {
             // if form login
             // set authentication exception to session
-            $request->getSession()->set(Security::AUTHENTICATION_ERROR, $exception);
+            $request->getSession()->set(
+                \class_exists(SecurityRequestAttributes::class)
+                     ? SecurityRequestAttributes::AUTHENTICATION_ERROR
+                     : (\class_exists(Security::class)
+                        ? Security::AUTHENTICATION_ERROR // BC layer to Symfony <=6.4
+                        : SymfonyCoreSecurity::AUTHENTICATION_ERROR), // BC layer to Symfony <=5.4
+                $exception
+            );
             $response = new RedirectResponse($this->router->generate('sulu_admin'));
         }
 

--- a/src/Sulu/Bundle/SecurityBundle/Security/AuthenticationHandler.php
+++ b/src/Sulu/Bundle/SecurityBundle/Security/AuthenticationHandler.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\SecurityBundle\Security;
 
 use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,7 +21,6 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
 use Symfony\Component\Security\Http\SecurityRequestAttributes;

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Security/AuthenticationHandlerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Security/AuthenticationHandlerTest.php
@@ -58,6 +58,7 @@ class AuthenticationHandlerTest extends TestCase
     public function setUp(): void
     {
         $this->exception = $this->prophesize(AuthenticationException::class);
+        $this->exception->getMessageKey()->willReturn('error');
         $this->request = $this->prophesize(Request::class);
         $this->token = $this->prophesize(TokenInterface::class);
         $this->user = $this->prophesize(UserInterface::class);

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Security/AuthenticationHandlerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Security/AuthenticationHandlerTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Component\Security\Authentication\UserInterface;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -23,7 +24,6 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
 class AuthenticationHandlerTest extends TestCase

--- a/src/Sulu/Bundle/SecurityBundle/User/UserProvider.php
+++ b/src/Sulu/Bundle/SecurityBundle/User/UserProvider.php
@@ -45,7 +45,7 @@ class UserProvider implements UserProviderInterface
     }
 
     /**
-     * For Symfony <= 5.4
+     * For Symfony <= 5.4.
      *
      * @return UserInterface
      */

--- a/src/Sulu/Bundle/SecurityBundle/User/UserProvider.php
+++ b/src/Sulu/Bundle/SecurityBundle/User/UserProvider.php
@@ -45,6 +45,8 @@ class UserProvider implements UserProviderInterface
     }
 
     /**
+     * For Symfony <= 5.4
+     *
      * @return UserInterface
      */
     public function loadUserByUsername($username)
@@ -84,7 +86,7 @@ class UserProvider implements UserProviderInterface
         throw new UserNotFoundException($exceptionMessage, 0);
     }
 
-    public function refreshUser(BaseUserInterface $user)
+    public function refreshUser(BaseUserInterface $user): UserInterface
     {
         $class = \get_class($user);
         if (!$this->supportsClass($class)) {
@@ -109,7 +111,7 @@ class UserProvider implements UserProviderInterface
         return $user;
     }
 
-    public function supportsClass($class)
+    public function supportsClass($class): bool
     {
         return \is_subclass_of($class, UserInterface::class);
     }

--- a/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
+++ b/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
@@ -132,9 +132,6 @@ class SuluTestKernel extends SuluKernel
         return $this->projectDir;
     }
 
-    /**
-     * @return void
-     */
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(SuluTestBundle::getConfigDir() . '/config.php');

--- a/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
+++ b/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
@@ -135,7 +135,7 @@ class SuluTestKernel extends SuluKernel
     /**
      * @return void
      */
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(SuluTestBundle::getConfigDir() . '/config.php');
 

--- a/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
@@ -158,7 +158,7 @@ class TestUserProvider implements UserProviderInterface, ResetInterface
      *
      * @throws UnsupportedUserException if the account is not supported
      */
-    public function refreshUser(UserInterface $user)
+    public function refreshUser(UserInterface $user): UserInterface
     {
         if (self::TEST_USER_USERNAME === $user->getUserIdentifier()) {
             return $this->getUser();
@@ -174,7 +174,7 @@ class TestUserProvider implements UserProviderInterface, ResetInterface
      *
      * @return bool
      */
-    public function supportsClass($class)
+    public function supportsClass($class): bool
     {
         return $this->userProvider->supportsClass($class);
     }

--- a/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
@@ -154,8 +154,6 @@ class TestUserProvider implements UserProviderInterface, ResetInterface
      * object can just be merged into some internal array of users / identity
      * map.
      *
-     * @return UserInterface
-     *
      * @throws UnsupportedUserException if the account is not supported
      */
     public function refreshUser(UserInterface $user): UserInterface
@@ -171,8 +169,6 @@ class TestUserProvider implements UserProviderInterface, ResetInterface
      * Whether this provider supports the given user class.
      *
      * @param string $class
-     *
-     * @return bool
      */
     public function supportsClass($class): bool
     {

--- a/src/Sulu/Bundle/TestBundle/Testing/TestVoter.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/TestVoter.php
@@ -56,7 +56,7 @@ class TestVoter implements VoterInterface
      *
      * @return int either ACCESS_GRANTED, ACCESS_ABSTAIN, or ACCESS_DENIED
      */
-    public function vote(TokenInterface $token, $object, array $attributes)
+    public function vote(TokenInterface $token, $object, array $attributes): int
     {
         $user = $token->getUser();
 

--- a/src/Sulu/Bundle/TrashBundle/Infrastructure/Doctrine/Repository/TrashItemRepository.php
+++ b/src/Sulu/Bundle/TrashBundle/Infrastructure/Doctrine/Repository/TrashItemRepository.php
@@ -19,8 +19,8 @@ use Sulu\Bundle\TrashBundle\Domain\Exception\TrashItemNotFoundException;
 use Sulu\Bundle\TrashBundle\Domain\Model\TrashItemInterface;
 use Sulu\Bundle\TrashBundle\Domain\Repository\TrashItemRepositoryInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
-use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
 
 final class TrashItemRepository implements TrashItemRepositoryInterface
 {

--- a/src/Sulu/Bundle/TrashBundle/Infrastructure/Doctrine/Repository/TrashItemRepository.php
+++ b/src/Sulu/Bundle/TrashBundle/Infrastructure/Doctrine/Repository/TrashItemRepository.php
@@ -19,7 +19,8 @@ use Sulu\Bundle\TrashBundle\Domain\Exception\TrashItemNotFoundException;
 use Sulu\Bundle\TrashBundle\Domain\Model\TrashItemInterface;
 use Sulu\Bundle\TrashBundle\Domain\Repository\TrashItemRepositoryInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
+use Symfony\Bundle\SecurityBundle\Security;
 
 final class TrashItemRepository implements TrashItemRepositoryInterface
 {
@@ -29,7 +30,7 @@ final class TrashItemRepository implements TrashItemRepositoryInterface
     private $entityManager;
 
     /**
-     * @var Security|null
+     * @var Security|SymfonyCoreSecurity|null
      */
     private $security;
 
@@ -38,7 +39,7 @@ final class TrashItemRepository implements TrashItemRepositoryInterface
      */
     private $entityRepository;
 
-    public function __construct(EntityManagerInterface $entityManager, ?Security $security)
+    public function __construct(EntityManagerInterface $entityManager, Security|SymfonyCoreSecurity|null $security)
     {
         $this->entityManager = $entityManager;
         $this->security = $security;

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/PortalLoader.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/PortalLoader.php
@@ -49,7 +49,7 @@ class PortalLoader extends FileLoader
     /**
      * @param string $resource
      */
-    public function load($resource, $type = null)
+    public function load($resource, $type = null): mixed
     {
         $collection = new RouteCollection();
 
@@ -80,7 +80,7 @@ class PortalLoader extends FileLoader
         return $collection;
     }
 
-    public function supports($resource, $type = null)
+    public function supports($resource, $type = null): bool
     {
         return 'portal' === $type;
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/AppCache.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/AppCache.php
@@ -39,9 +39,9 @@ class AppCache extends SuluHttpCache implements KernelInterface
         return $this->kernel->registerBundles();
     }
 
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
-        return $this->kernel->registerContainerConfiguration($loader);
+        $this->kernel->registerContainerConfiguration($loader);
     }
 
     public function boot()

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -63,7 +63,8 @@ use Sulu\Component\Security\Authorization\AccessControl\AccessControlManagerInte
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
+use Symfony\Bundle\SecurityBundle\Security;
 
 /**
  * Maps content nodes to phpcr nodes with content types and provides utility function to handle content nodes.
@@ -148,7 +149,7 @@ class ContentMapper implements ContentMapperInterface
     private $permissions;
 
     /**
-     * @var ?Security
+     * @var ?Security|SymfonyCoreSecurity
      */
     private $security;
 
@@ -167,7 +168,7 @@ class ContentMapper implements ContentMapperInterface
         NamespaceRegistry $namespaceRegistry,
         AccessControlManagerInterface $accessControlManager,
         $permissions,
-        ?Security $security = null
+        Security|SymfonyCoreSecurity|null $security = null
     ) {
         $this->contentTypeManager = $contentTypeManager;
         $this->structureManager = $structureManager;

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -149,7 +149,7 @@ class ContentMapper implements ContentMapperInterface
     private $permissions;
 
     /**
-     * @var ?Security|SymfonyCoreSecurity
+     * @var Security|SymfonyCoreSecurity|null
      */
     private $security;
 

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -61,10 +61,10 @@ use Sulu\Component\DocumentManager\NamespaceRegistry;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
 use Sulu\Component\Security\Authorization\AccessControl\AccessControlManagerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
-use Symfony\Bundle\SecurityBundle\Security;
 
 /**
  * Maps content nodes to phpcr nodes with content types and provides utility function to handle content nodes.

--- a/src/Sulu/Component/Content/Metadata/Loader/AbstractLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/AbstractLoader.php
@@ -45,7 +45,7 @@ abstract class AbstractLoader implements LoaderInterface
     /**
      * @param string $resource
      */
-    public function load($resource, $type = null)
+    public function load($resource, $type = null): mixed
     {
         $schemaPath = __DIR__ . $this->schemaPath;
 
@@ -179,17 +179,17 @@ abstract class AbstractLoader implements LoaderInterface
         return $result;
     }
 
-    public function supports($resource, $type = null)
+    public function supports($resource, $type = null): bool
     {
         throw new FeatureNotImplementedException();
     }
 
-    public function getResolver()
+    public function getResolver(): LoaderResolverInterface
     {
         throw new FeatureNotImplementedException();
     }
 
-    public function setResolver(LoaderResolverInterface $resolver)
+    public function setResolver(LoaderResolverInterface $resolver): void
     {
         throw new FeatureNotImplementedException();
     }

--- a/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
@@ -138,7 +138,7 @@ class StructureXmlLoader extends AbstractLoader
     /**
      * @param string $resource
      */
-    public function load($resource, $type = null)
+    public function load($resource, $type = null): StructureMetadata
     {
         if (null === $type) {
             $type = 'page';

--- a/src/Sulu/Component/Content/Tests/Unit/SmartContent/Orm/BaseDataProviderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/SmartContent/Orm/BaseDataProviderTest.php
@@ -395,7 +395,7 @@ class BaseDataProviderTest extends TestCase
 
         $serializer = $this->prophesize(ArraySerializerInterface::class);
 
-        $security = $this->prophesize(Security::class);
+        $security = $this->prophesize(\class_exists(Security::class) ? Security::class : SymfonyCoreSecurity::class);
         $security->getUser()->willReturn($user->reveal());
 
         $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);

--- a/src/Sulu/Component/Content/Tests/Unit/SmartContent/Orm/BaseDataProviderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/SmartContent/Orm/BaseDataProviderTest.php
@@ -26,7 +26,8 @@ use Sulu\Component\SmartContent\ResourceItemInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Security as WebspaceSecurity;
 use Sulu\Component\Webspace\Webspace;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
+use Symfony\Bundle\SecurityBundle\Security;
 
 class BaseDataProviderTest extends TestCase
 {
@@ -351,7 +352,7 @@ class BaseDataProviderTest extends TestCase
 
         $serializer = $this->prophesize(ArraySerializerInterface::class);
 
-        $security = $this->prophesize(Security::class);
+        $security = $this->prophesize(\class_exists(Security::class) ? Security::class : SymfonyCoreSecurity::class);
         $security->getUser()->willReturn($user->reveal());
 
         $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);

--- a/src/Sulu/Component/Content/Tests/Unit/SmartContent/Orm/BaseDataProviderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/SmartContent/Orm/BaseDataProviderTest.php
@@ -26,8 +26,8 @@ use Sulu\Component\SmartContent\ResourceItemInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Security as WebspaceSecurity;
 use Sulu\Component\Webspace\Webspace;
-use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
 
 class BaseDataProviderTest extends TestCase
 {

--- a/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
+++ b/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
@@ -23,9 +23,9 @@ use Sulu\Component\SmartContent\DatasourceItem;
 use Sulu\Component\SmartContent\Orm\BaseDataProvider;
 use Sulu\Component\SmartContent\Orm\DataProviderRepositoryInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**

--- a/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
+++ b/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
@@ -24,7 +24,8 @@ use Sulu\Component\SmartContent\Orm\BaseDataProvider;
 use Sulu\Component\SmartContent\Orm\DataProviderRepositoryInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -63,7 +64,7 @@ class MediaDataProvider extends BaseDataProvider
         ArraySerializerInterface $serializer,
         RequestStack $requestStack,
         ReferenceStoreInterface $referenceStore,
-        ?Security $security,
+        Security|SymfonyCoreSecurity|null $security,
         RequestAnalyzerInterface $requestAnalyzer,
         $permissions,
         bool $hasAudienceTargeting = false,

--- a/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
+++ b/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
@@ -76,7 +76,7 @@ class MediaDataProviderTest extends TestCase
     private $mediaDataProvider;
 
     /**
-     * @var ObjectProphecy<Security>
+     * @var ObjectProphecy<Security|SymfonyCoreSecurity>
      */
     private $security;
 

--- a/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
+++ b/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
@@ -36,9 +36,9 @@ use Sulu\Component\SmartContent\Orm\DataProviderRepositoryInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Security as WebspaceSecurity;
 use Sulu\Component\Webspace\Webspace;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class MediaDataProviderTest extends TestCase

--- a/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
+++ b/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
@@ -37,7 +37,8 @@ use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Security as WebspaceSecurity;
 use Sulu\Component\Webspace\Webspace;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class MediaDataProviderTest extends TestCase
@@ -91,7 +92,7 @@ class MediaDataProviderTest extends TestCase
         $this->serializer = $this->prophesize(ArraySerializerInterface::class);
         $this->requestStack = $this->prophesize(RequestStack::class);
         $this->referenceStore = $this->prophesize(ReferenceStoreInterface::class);
-        $this->security = $this->prophesize(Security::class);
+        $this->security = $this->prophesize(\class_exists(Security::class) ? Security::class : SymfonyCoreSecurity::class);
         $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
 
         $this->mediaDataProvider = new MediaDataProvider(

--- a/src/Sulu/Component/PHPCR/PathCleanup.php
+++ b/src/Sulu/Component/PHPCR/PathCleanup.php
@@ -54,8 +54,13 @@ class PathCleanup implements PathCleanupInterface
             $slugger = new AsciiSlugger();
         }
 
-        if (\method_exists($slugger, 'withEmoji')) {
-            $slugger = $slugger->withEmoji();
+        if (\method_exists($slugger, 'withEmoji')) { // BC Layer <= Symfony 6.3
+            if (
+                !\method_exists(\Symfony\Component\String\AbstractUnicodeString::class, 'localeUpper') // BC Layer <= Symfony 7.0
+                || \class_exists(\Symfony\Component\Emoji\EmojiTransliterator::class) // Symfony >= 7.1 requires symfony/emoji
+            ) {
+                $slugger = $slugger->withEmoji();
+            }
         }
 
         $this->replacers = $replacers;

--- a/src/Sulu/Component/PHPCR/Tests/Unit/PathCleanupTest.php
+++ b/src/Sulu/Component/PHPCR/Tests/Unit/PathCleanupTest.php
@@ -31,7 +31,10 @@ class PathCleanupTest extends TestCase
     protected function setUp(): void
     {
         $slugger = new AsciiSlugger();
-        $this->hasEmojiSupport = \method_exists($slugger, 'withEmoji');
+        $this->hasEmojiSupport = \method_exists($slugger, 'withEmoji') && (
+            !\method_exists(\Symfony\Component\String\AbstractUnicodeString::class, 'localeUpper') // BC Layer <= Symfony 7.0
+            || \class_exists(\Symfony\Component\Emoji\EmojiTransliterator::class) // Symfony >= 7.1 requires symfony/emoji
+        );
 
         $this->cleaner = new PathCleanup(
             [

--- a/src/Sulu/Component/Rest/ContextAwareNormalizerInterface.php
+++ b/src/Sulu/Component/Rest/ContextAwareNormalizerInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Sulu\Component\Rest;
 
 use Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface as SymfonyContextAwareNormalizerInterface;

--- a/src/Sulu/Component/Rest/ContextAwareNormalizerInterface.php
+++ b/src/Sulu/Component/Rest/ContextAwareNormalizerInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Sulu\Component\Rest;
+
+use Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface as SymfonyContextAwareNormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+if (\class_exists(SymfonyContextAwareNormalizerInterface::class)) {
+    // BC Layer for Symfony <= 6.4: https://github.com/symfony/symfony/blob/7.1/UPGRADE-7.0.md#serializer
+    interface ContextAwareNormalizerInterface extends SymfonyContextAwareNormalizerInterface
+    {
+    }
+} else {
+    interface ContextAwareNormalizerInterface extends NormalizerInterface
+    {
+    }
+}

--- a/src/Sulu/Component/Rest/FlattenExceptionNormalizer.php
+++ b/src/Sulu/Component/Rest/FlattenExceptionNormalizer.php
@@ -15,7 +15,6 @@ use Sulu\Component\Rest\Exception\ReferencingResourcesFoundExceptionInterface;
 use Sulu\Component\Rest\Exception\RemoveDependantResourcesFoundExceptionInterface;
 use Sulu\Component\Rest\Exception\TranslationErrorMessageExceptionInterface;
 use Symfony\Component\ErrorHandler\Exception\FlattenException;
-use Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 

--- a/src/Sulu/Component/Rest/FlattenExceptionNormalizer.php
+++ b/src/Sulu/Component/Rest/FlattenExceptionNormalizer.php
@@ -54,7 +54,7 @@ class FlattenExceptionNormalizer implements ContextAwareNormalizerInterface
     /**
      * @return array<int|string, mixed>
      */
-    public function normalize($exception, $format = null, array $context = [])
+    public function normalize($exception, $format = null, array $context = []): array
     {
         /** @var array<int|string, mixed> $data */
         $data = $this->decoratedNormalizer->normalize($exception, $format, $context);

--- a/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
@@ -68,7 +68,7 @@ class AccessControlManager implements AccessControlManagerInterface
     private $accessControlRepository;
 
     /**
-     * @var Security|null
+     * @var Security|SymfonyCoreSecurity|null
      */
     private $security;
 

--- a/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
@@ -22,9 +22,10 @@ use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCondition;
 use Sulu\Component\Security\Event\PermissionUpdateEvent;
 use Sulu\Component\Security\Event\SecurityEvents;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
-use Symfony\Bundle\SecurityBundle\Security;
+
 /**
  * An implementation of the AccessControlManagerInterface, which supports registering AccessControlProvider. All method
  * calls are delegated to the AccessControlProvider supporting the given type.

--- a/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
@@ -23,8 +23,8 @@ use Sulu\Component\Security\Authorization\SecurityCondition;
 use Sulu\Component\Security\Event\PermissionUpdateEvent;
 use Sulu\Component\Security\Event\SecurityEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Security\Core\Security;
-
+use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
+use Symfony\Bundle\SecurityBundle\Security;
 /**
  * An implementation of the AccessControlManagerInterface, which supports registering AccessControlProvider. All method
  * calls are delegated to the AccessControlProvider supporting the given type.
@@ -86,7 +86,7 @@ class AccessControlManager implements AccessControlManagerInterface
         iterable $descendantProviders,
         RoleRepositoryInterface $roleRepository,
         AccessControlRepositoryInterface $accessControlRepository,
-        ?Security $security,
+        Security|SymfonyCoreSecurity|null $security,
         array $permissions
     ) {
         $this->maskConverter = $maskConverter;

--- a/src/Sulu/Component/Security/Authorization/SecurityContextVoter.php
+++ b/src/Sulu/Component/Security/Authorization/SecurityContextVoter.php
@@ -49,7 +49,7 @@ class SecurityContextVoter implements VoterInterface
         return SecurityCondition::class === $class || \is_subclass_of($class, SecurityCondition::class);
     }
 
-    public function vote(TokenInterface $token, $object, array $attributes)
+    public function vote(TokenInterface $token, $object, array $attributes): int
     {
         /** @var User $user */
         $user = $token->getUser();

--- a/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/AccessControlManagerTest.php
+++ b/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/AccessControlManagerTest.php
@@ -84,7 +84,7 @@ class AccessControlManagerTest extends TestCase
     private $accessControlRepository;
 
     /**
-     * @var ObjectProphecy<Security>
+     * @var ObjectProphecy<Security|SymfonyCoreSecurity>
      */
     private $security;
 

--- a/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/AccessControlManagerTest.php
+++ b/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/AccessControlManagerTest.php
@@ -34,9 +34,9 @@ use Sulu\Component\Security\Authorization\MaskConverterInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCondition;
 use Sulu\Component\Security\Event\PermissionUpdateEvent;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
-use Symfony\Bundle\SecurityBundle\Security;
 
 class AccessControlManagerTest extends TestCase
 {

--- a/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/AccessControlManagerTest.php
+++ b/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/AccessControlManagerTest.php
@@ -35,7 +35,8 @@ use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCondition;
 use Sulu\Component\Security\Event\PermissionUpdateEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
+use Symfony\Bundle\SecurityBundle\Security;
 
 class AccessControlManagerTest extends TestCase
 {
@@ -112,7 +113,7 @@ class AccessControlManagerTest extends TestCase
         $this->systemStore = $this->prophesize(SystemStoreInterface::class);
         $this->roleRepository = $this->prophesize(RoleRepositoryInterface::class);
         $this->accessControlRepository = $this->prophesize(AccessControlRepositoryInterface::class);
-        $this->security = $this->prophesize(Security::class);
+        $this->security = $this->prophesize(\class_exists(Security::class) ? Security::class : SymfonyCoreSecurity::class);
         $this->user = $this->prophesize(UserInterface::class);
 
         $this->security->getUser()->willReturn($this->user->reveal());

--- a/src/Sulu/Component/SmartContent/Orm/BaseDataProvider.php
+++ b/src/Sulu/Component/SmartContent/Orm/BaseDataProvider.php
@@ -64,7 +64,7 @@ abstract class BaseDataProvider implements DataProviderInterface
     private $referenceStore;
 
     /**
-     * @var ?Security|SymfonyCoreSecurity
+     * @var Security|SymfonyCoreSecurity|null
      */
     private $security;
 

--- a/src/Sulu/Component/SmartContent/Orm/BaseDataProvider.php
+++ b/src/Sulu/Component/SmartContent/Orm/BaseDataProvider.php
@@ -25,8 +25,8 @@ use Sulu\Component\SmartContent\DataProviderInterface;
 use Sulu\Component\SmartContent\DataProviderResult;
 use Sulu\Component\SmartContent\ItemInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
-use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
 
 /**
  * Provides basic functionality for contact and account providers.

--- a/src/Sulu/Component/SmartContent/Orm/BaseDataProvider.php
+++ b/src/Sulu/Component/SmartContent/Orm/BaseDataProvider.php
@@ -25,7 +25,8 @@ use Sulu\Component\SmartContent\DataProviderInterface;
 use Sulu\Component\SmartContent\DataProviderResult;
 use Sulu\Component\SmartContent\ItemInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
+use Symfony\Bundle\SecurityBundle\Security;
 
 /**
  * Provides basic functionality for contact and account providers.
@@ -63,7 +64,7 @@ abstract class BaseDataProvider implements DataProviderInterface
     private $referenceStore;
 
     /**
-     * @var ?Security
+     * @var ?Security|SymfonyCoreSecurity
      */
     private $security;
 
@@ -81,7 +82,7 @@ abstract class BaseDataProvider implements DataProviderInterface
         DataProviderRepositoryInterface $repository,
         ArraySerializerInterface $serializer,
         ?ReferenceStoreInterface $referenceStore = null,
-        ?Security $security = null,
+        Security|SymfonyCoreSecurity|null $security = null,
         ?RequestAnalyzerInterface $requestAnalyzer = null,
         $permissions = null
     ) {

--- a/src/Sulu/Component/Webspace/Loader/BaseXmlFileLoader.php
+++ b/src/Sulu/Component/Webspace/Loader/BaseXmlFileLoader.php
@@ -25,7 +25,7 @@ abstract class BaseXmlFileLoader extends FileLoader
 
     public const SCHEMA_URI = '';
 
-    public function supports($resource, $type = null)
+    public function supports($resource, $type = null): bool
     {
         if (!\is_string($resource) || 'xml' !== \pathinfo($resource, \PATHINFO_EXTENSION)) {
             return false;

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
@@ -68,7 +68,7 @@ class XmlFileLoader10 extends BaseXmlFileLoader
      *
      * @return Webspace The webspace object for the given resource
      */
-    public function load($resource, $type = null)
+    public function load($resource, $type = null): Webspace
     {
         $path = $this->getLocator()->locate($resource);
 
@@ -84,7 +84,7 @@ class XmlFileLoader10 extends BaseXmlFileLoader
      *
      * @return bool true if this class supports the given resource, false otherwise
      */
-    public function supports($resource, $type = null)
+    public function supports($resource, $type = null): bool
     {
         return parent::supports($resource, $type);
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no
| BC breaks? | yes
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7156/
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Prepare compatibility to Symfony 7.

#### Why?

As discussed we will already cherry pick the required changes into 2.6 to prepare as much as possible for Symfony 7 compatibility.

Cherry pick bc breaks from https://github.com/sulu/sulu/pull/7156/

Most of them should effect no projects so we are fine to add the return types as I don't think a lot of projects ever did come into contact with this more internal services.

#### To Do

- [x] Add breaking changes to UPGRADE.md
