### PR TITLE
[DX] Using the `DocumentManagerInterface` everywhere

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -14,6 +14,12 @@ Removing unused arguments:
 
 - `Sulu\Component\Webspace\Analyzer\Attributes\WebsiteRequestProcessor::__construct` `$contentMapper` (2nd argument) removed
 
+Classes implementing the `DocumentFixtureInterface` have to update the load method signature:
+```diff
+-    public function load(DocumentManager $documentManager): void
++    public function load(DocumentManagerInterface $documentManager): void
+```
+
 ## 2.6.0
 
 ### PHP 8.2 upgrade

--- a/src/Sulu/Bundle/DocumentManagerBundle/DataFixtures/DocumentFixtureInterface.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/DataFixtures/DocumentFixtureInterface.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Bundle\DocumentManagerBundle\DataFixtures;
 
-use Sulu\Component\DocumentManager\DocumentManager;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
 
 interface DocumentFixtureInterface
 {
@@ -23,7 +23,7 @@ interface DocumentFixtureInterface
      *
      * @return void
      */
-    public function load(DocumentManager $documentManager);
+    public function load(DocumentManagerInterface $documentManager);
 
     /**
      * Return an integer by which the order will be determined in

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/DataFixtures/FooFixture.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/DataFixtures/FooFixture.php
@@ -12,11 +12,11 @@
 namespace Sulu\Bundle\DocumentManagerBundle\Tests\Unit\Command\DataFixtures;
 
 use Sulu\Bundle\DocumentManagerBundle\DataFixtures\DocumentFixtureInterface;
-use Sulu\Component\DocumentManager\DocumentManager;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
 
 class FooFixture implements DocumentFixtureInterface
 {
-    public function load(DocumentManager $documentManager): void
+    public function load(DocumentManagerInterface $documentManager): void
     {
         return;
     }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/DataFixtures/GroupBarFixture.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/DataFixtures/GroupBarFixture.php
@@ -13,11 +13,11 @@ namespace Sulu\Bundle\DocumentManagerBundle\Tests\Unit\Command\DataFixtures;
 
 use Sulu\Bundle\DocumentManagerBundle\DataFixtures\DocumentFixtureGroupInterface;
 use Sulu\Bundle\DocumentManagerBundle\DataFixtures\DocumentFixtureInterface;
-use Sulu\Component\DocumentManager\DocumentManager;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
 
 class GroupBarFixture implements DocumentFixtureInterface, DocumentFixtureGroupInterface
 {
-    public function load(DocumentManager $documentManager): void
+    public function load(DocumentManagerInterface $documentManager): void
     {
         return;
     }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/DataFixtures/GroupFooFixture.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/DataFixtures/GroupFooFixture.php
@@ -13,11 +13,11 @@ namespace Sulu\Bundle\DocumentManagerBundle\Tests\Unit\Command\DataFixtures;
 
 use Sulu\Bundle\DocumentManagerBundle\DataFixtures\DocumentFixtureGroupInterface;
 use Sulu\Bundle\DocumentManagerBundle\DataFixtures\DocumentFixtureInterface;
-use Sulu\Component\DocumentManager\DocumentManager;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
 
 class GroupFooFixture implements DocumentFixtureInterface, DocumentFixtureGroupInterface
 {
-    public function load(DocumentManager $documentManager): void
+    public function load(DocumentManagerInterface $documentManager): void
     {
         return;
     }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/DataFixtures/fixtures/BarfooFixture.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/DataFixtures/fixtures/BarfooFixture.php
@@ -12,11 +12,11 @@
 namespace Sulu\Bundle\DocumentManagerBundle\Tests\Unit\DataFixtures\fixtures;
 
 use Sulu\Bundle\DocumentManagerBundle\DataFixtures\DocumentFixtureInterface;
-use Sulu\Component\DocumentManager\DocumentManager;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
 
 class BarfooFixture implements DocumentFixtureInterface
 {
-    public function load(DocumentManager $documentManager): void
+    public function load(DocumentManagerInterface $documentManager): void
     {
     }
 

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/DataFixtures/fixtures/ContainerFixture.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/DataFixtures/fixtures/ContainerFixture.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\DocumentManagerBundle\Tests\Unit\DataFixtures\fixtures;
 
 use Sulu\Bundle\DocumentManagerBundle\DataFixtures\DocumentFixtureInterface;
-use Sulu\Component\DocumentManager\DocumentManager;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -25,7 +25,7 @@ class ContainerFixture implements DocumentFixtureInterface, ContainerAwareInterf
         $this->container = $container;
     }
 
-    public function load(DocumentManager $documentManager): void
+    public function load(DocumentManagerInterface $documentManager): void
     {
     }
 

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/DataFixtures/fixtures/FoobarFixture.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/DataFixtures/fixtures/FoobarFixture.php
@@ -12,11 +12,11 @@
 namespace Sulu\Bundle\DocumentManagerBundle\Tests\Unit\DataFixtures\fixtures;
 
 use Sulu\Bundle\DocumentManagerBundle\DataFixtures\DocumentFixtureInterface;
-use Sulu\Component\DocumentManager\DocumentManager;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
 
 class FoobarFixture implements DocumentFixtureInterface
 {
-    public function load(DocumentManager $documentManager): void
+    public function load(DocumentManagerInterface $documentManager): void
     {
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | yes
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Using the `DocumentManagerInterface` instead of the implementation.

#### Why?
* Making the `DocumentManager` implementation extendable
* Interface is used everywhere else in the code

#### To Do

- [x] Add breaking changes to UPGRADE.md
