### PR TITLE
Prevent ui crashes on missing deeplink view

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/registries/resourceViewRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/registries/resourceViewRegistry.js
@@ -27,7 +27,7 @@ class ResourceViewRegistry {
             return false;
         }
 
-        return this.resourceViews[resourceKey].views[view] !== undefined;
+        return this.resourceViews?.[resourceKey]?.views?.[view] !== undefined;
     }
 
     get(view: string, resourceKey: string): string {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Prevents the admin ui crashing when a deeplink is missing.