### PR TITLE
Change behaviour of SymfonyExpressionTokenProviderTest testResolveWithInvalidSyntax to throw Exception instead 

### DIFF
--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/SymfonyExpressionTokenProviderTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/SymfonyExpressionTokenProviderTest.php
@@ -130,15 +130,16 @@ class SymfonyExpressionTokenProviderTest extends TestCase
         );
     }
 
-    public function testResolveNotExists(): void
+    public function testResolveWithInvalidSyntax(): void
     {
         $this->expectException(CannotEvaluateTokenException::class);
+
         $translator = $this->prophesize(Translator::class);
         $translator->getLocale()->willReturn('en');
         $translator->setLocale('en')->shouldBeCalled();
         $entity = new \stdClass();
         $provider = new SymfonyExpressionTokenProvider($translator->reveal());
-        $provider->provide($entity, 'object.title');
+        $provider->provide($entity, 'object:title');
     }
 
     public function testResolveTranslationAddResource(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #6988 
| License | MIT
| Documentation PR | -

#### What's in this PR?
Fixing a phpunit test to really throw an exception and not be testing PhpUnit behaviour

#### Why?
In PhpUnit < 10 every warning in a test is converted to an exception. However this means that the code behaves differently when run inside of PhpUnit and outside.

The code that has changed had the following behavior: If the property on the object does not exist it should throw an exception. However outside of phpunit (and in phpunit 10+) this will only trigger a warning of "Undefined property". So we either have to change the test to cause the parser to fail with an exception (like in this PR) or we change the ExpressionTokenProvider to fail hard if a property does not exist (would be a BC break though). 
