### PR TITLE
Add Symfony 7 compatibility to VersionRouteLoader and ContainerExpressionLanguageProvider

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -173,6 +173,13 @@ Return type changes in `Loader`:
 +    public function supports($resource, $type = null): bool
 ```
 
+Return type changes in `ExpressionLanguageProvider`:
+
+```diff
+-    public function getFunctions()
++    public function getFunctions(): array
+```
+
 ### Replace Symfony Security class
 
 The `Symfony\Component\Security\Core\Security` deprecated class was replaced by

--- a/src/Sulu/Bundle/CoreBundle/ExpressionLanguage/ContainerExpressionLanguageProvider.php
+++ b/src/Sulu/Bundle/CoreBundle/ExpressionLanguage/ContainerExpressionLanguageProvider.php
@@ -27,7 +27,7 @@ class ContainerExpressionLanguageProvider implements ExpressionFunctionProviderI
         $this->container = $container;
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new ExpressionFunction(

--- a/src/Sulu/Bundle/DocumentManagerBundle/Routing/Loader/VersionRouteLoader.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Routing/Loader/VersionRouteLoader.php
@@ -35,7 +35,7 @@ class VersionRouteLoader extends Loader
     /**
      * @param string $resource
      */
-    public function load($resource, $type = null)
+    public function load($resource, $type = null): mixed
     {
         if (!$this->enabled) {
             return new RouteCollection();
@@ -44,7 +44,7 @@ class VersionRouteLoader extends Loader
         return $this->import($resource, 'rest');
     }
 
-    public function supports($resource, $type = null)
+    public function supports($resource, $type = null): bool
     {
         return 'versioning_rest' === $type;
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? |  yes
| BC breaks? | yes
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #7156
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add Symfony 7 compatibility to VersionRouteLoader and ContainerExpressionLanguageProvider

#### Why?

Required for support Symfony 7 in future.
