### PR TITLE
Add visibleCondition for block-setting icons

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -1,14 +1,16 @@
 // @flow
 import equals from 'fast-deep-equal';
 import jsonpointer from 'json-pointer';
+import jexl from 'jexl';
 import React, {Fragment} from 'react';
-import {action, observable, computed, toJS} from 'mobx';
+import {action, computed, observable, toJS} from 'mobx';
 import {observer} from 'mobx-react';
 import BlockCollection from '../../components/BlockCollection';
 import {translate} from '../../utils/Translator';
 import {memoryFormStoreFactory} from '../Form';
 import FormOverlay from '../FormOverlay';
 import snackbarStore from '../../stores/snackbarStore';
+import conditionDataProviderRegistry from '../Form/registries/conditionDataProviderRegistry';
 import blockPreviewTransformerRegistry from './registries/blockPreviewTransformerRegistry';
 import FieldRenderer from './FieldRenderer';
 import type {BlockError, FieldTypeProps, FormStoreInterface} from '../Form/types';
@@ -194,7 +196,7 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
             const blockSettingsTag = schemaEntry.tags.find((tag) => tag.name === SETTINGS_TAG);
 
             if (blockSettingsTag) {
-                iconsMapping[SETTINGS_PREFIX + schemaKey] = blockSettingsTag.attributes.icon;
+                iconsMapping[SETTINGS_PREFIX + schemaKey] = blockSettingsTag.attributes;
             }
 
             return iconsMapping;
@@ -209,12 +211,36 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
         }
 
         return this.value.map((value) => Object.keys(this.iconsMapping).reduce((icons, pointer) => {
-            if (jsonpointer.has(value, pointer) && jsonpointer.get(value, pointer)) {
-                icons.push(this.iconsMapping[pointer]);
+            const visibleCondition = this.iconsMapping[pointer].visibleCondition;
+            if (jsonpointer.has(value, pointer) || visibleCondition !== undefined) {
+                let icon = undefined;
+                if (visibleCondition !== undefined) {
+                    const conditionData = this.getConditionData(value, pointer);
+                    if (jexl.evalSync(visibleCondition, conditionData)){
+                        icon = this.iconsMapping[pointer].icon;
+                    }
+                } else if (jsonpointer.get(value, pointer)) {
+                    icon = this.iconsMapping[pointer].icon;
+                }
+
+                if (icon) {
+                    icons.push(icon);
+                }
             }
 
             return icons;
         }, []));
+    }
+
+    getConditionData(data, dataPath) {
+        const {formInspector} = this.props;
+
+        return conditionDataProviderRegistry.getAll().reduce(
+            function(data, conditionDataProvider) {
+                return {...data, ...conditionDataProvider(data, dataPath, formInspector)};
+            },
+            {...data}
+        );
     }
 
     @action setValue = (value: Object) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -232,7 +232,7 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
         }, []));
     }
 
-    getConditionData(data, dataPath) {
+    getConditionData(data: {[string]: any}, dataPath: ?string) {
         const {formInspector} = this.props;
 
         return conditionDataProviderRegistry.getAll().reduce(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Adds a `visibleCondition` to the `sulu.block_setting_icon` tag. 

#### Why?

Previously the icon was only shown, when the checkbox was set to `true`, this condition makes it more flexible, you can now also render the icon when the checkbox is `false` but other conditions are true.

#### Example Usage

Show the icon only when the page locale is `de` or `en` and the checkbox is true.

```xml

<property name="showInAustria" type="checkbox" visibleCondition="__locale in ['de', 'en']">
        <params>
            <param name="description">
                <meta>
                    <title lang="en">This block will be visible for the Austrian .at domain</title>
                    <title lang="de">Dieser Block wird für die österreichische .at Domain sichtbar sein
                    </title>
                </meta>
            </param>
            <param name="icon" value="su-app-austria"/>
            <param name="label">
                <meta>
                    <title lang="en">Austria (.at)</title>
                    <title lang="de">Österreich (.at)</title>
                </meta>
            </param>
            <param name="skin" value="heading"/>
            <param name="type" value="toggler"/>
            <param name="default_value" value="true"/>
        </params>
        
        <tag name="sulu.block_setting_icon" icon="su-app-austria" visibleCondition="__locale in ['de', 'en'] and settings.showInAustria == true"/>
 </property>

```

#### To Do

- [ ] Create a documentation PR
