### PR TITLE
Limit symlink-dir version to <6.0 in symlink-vendor-directory.js

### DIFF
--- a/symlink-vendor-directory.js
+++ b/symlink-vendor-directory.js
@@ -33,7 +33,7 @@ if (
         && path.basename(path.dirname(process.cwd())) === 'assets'
     )
 ) {
-    exec('npx symlink-dir ' + from + ' ' + to, (error) => {
+    exec('npx "symlink-dir@<6.0" ' + from + ' ' + to, (error) => {
         if (error) {
             throw new Error('Error occured while creating symlink: ' + error);
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -


#### What's in this PR?

The [symlink-dir](https://www.npmjs.com/package/symlink-dir) package is required in the `symlink-vendor-directory.js`. Version 6.0 was just released and it requires node >= 18.12. But node 18 comes with npm 9, which is currently not supported by Sulu.

By the limititation of symlink-dir's version to something lower than 6.0 we make sure that npx does not load an incompatible version.

#### Why?

Running `cd assets/admin/ && npm install` to build the admin frontend fails with the following error:

> $ npm install
> > sulu-skeleton@ preinstall /srv/htdocs/sulu/assets/admin
> > node ../../vendor/sulu/sulu/preinstall.js
> 
> /srv/htdocs/sulu/vendor/sulu/sulu/symlink-vendor-directory.js:38
>             throw new Error('Error occured while creating symlink: ' + error);
>             ^
> 
> Error: Error occured while creating symlink: Error: Command failed: npx symlink-dir ../../vendor node_modules/@sulu/vendor
> npm ERR! code ENOTSUP
> npm ERR! notsup Unsupported engine for symlink-dir@6.0.0: wanted: {"node":">=18.12"} (current: {"node":"14.21.3","npm":"6.14.18"})
> npm ERR! notsup Not compatible with your version of node/npm: symlink-dir@6.0.0
> npm ERR! notsup Not compatible with your version of node/npm: symlink-dir@6.0.0
> npm ERR! notsup Required: {"node":">=18.12"}
> npm ERR! notsup Actual:   {"npm":"6.14.18","node":"14.21.3"}
> 
> npm ERR! A complete log of this run can be found in:
> npm ERR!     /home/stollr/.npm/_logs/2024-04-11T14_29_09_259Z-debug.log
> Install for [ 'symlink-dir@<7.0' ] failed with code 1
> 
>     at /srv/htdocs/sulu/vendor/sulu/sulu/symlink-vendor-directory.js:38:19
>     at ChildProcess.exithandler (child_process.js:390:5)
>     at ChildProcess.emit (events.js:400:28)
>     at maybeClose (internal/child_process.js:1088:16)
>     at Socket.<anonymous> (internal/child_process.js:446:11)
>     at Socket.emit (events.js:400:28)
>     at Pipe.<anonymous> (net.js:686:12)
> npm ERR! code ELIFECYCLE
> npm ERR! errno 1
> npm ERR! sulu-skeleton@ preinstall: `node ../../vendor/sulu/sulu/preinstall.js`
> npm ERR! Exit status 1
> npm ERR! 
> npm ERR! Failed at the sulu-skeleton@ preinstall script.
> npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
> 
