### PR TITLE
Fix TextEditor in 2.6 Edit and Remove of Links do not work and buttons jumps

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
@@ -29,7 +29,6 @@ $textEditorUnpublishedLinkColor: $gold;
         --ck-z-default: 0;
 
         /* focus */
-        --ck-focus-ring: $textEditorAccentColor;
         --ck-focus-outer-shadow: var(--ck-color-base-border);
 
         /* shadows */

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/ExternalLinkPlugin/ExternalLinkPlugin.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/ExternalLinkPlugin/ExternalLinkPlugin.js
@@ -163,10 +163,6 @@ export default class ExternalLinkPlugin extends Plugin {
                 });
             }
         });
-
-        this.listenTo(view.document, 'blur', () => {
-            this.hideBalloon();
-        });
     }
 
     hideBalloon() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/InternalLinkPlugin/InternalLinkPlugin.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/InternalLinkPlugin/InternalLinkPlugin.js
@@ -234,10 +234,6 @@ export default class InternalLinkPlugin extends Plugin {
                 });
             }
         });
-
-        this.listenTo(view.document, 'blur', () => {
-            this.hideBalloon();
-        });
     }
 
     hideBalloon() {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | #7355
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT

#### What's in this PR?

Remove blur listener for Internal- and ExternalLinkPlugin, so the edit/delete button are working again.
Removed "--ck-focus-ring: $textEditorAccentColor" variable to fix jumping issue and enhance usability. 

#### Why?

To fix button issue and enhance usability.

