### PR TITLE
Add language package for ckeditor

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
@@ -11,6 +11,7 @@
         "@ckeditor/ckeditor5-engine": "^41.2.1",
         "@ckeditor/ckeditor5-essentials": "^41.2.1",
         "@ckeditor/ckeditor5-heading": "^41.2.1",
+        "@ckeditor/ckeditor5-language": "^41.2.1",
         "@ckeditor/ckeditor5-list": "^41.2.1",
         "@ckeditor/ckeditor5-paragraph": "^41.2.1",
         "@ckeditor/ckeditor5-table": "^41.2.1",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | #7363
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add ckeditor language plugin package. https://ckeditor.com/docs/ckeditor5/latest/features/language.html

#### Why?

So it's possible to add the language plugin to your editor toolbar, for better accessability.