### PR TITLE
Fix PreviewKernel and RefreshCommand compatibility

### DIFF
--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
@@ -15,6 +15,7 @@ namespace Sulu\Bundle\DocumentManagerBundle\Command;
 
 use PHPCR\SessionInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManager;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -30,6 +31,7 @@ use Webmozart\Assert\Assert;
 /**
  * @internal
  */
+#[AsCommand(name: 'sulu:phpcr:cleanup')]
 class PHPCRCleanupCommand extends Command
 {
     private OutputInterface $logger;

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
@@ -116,7 +116,7 @@ class PreviewKernel extends Kernel
     /**
      * @return void
      */
-    protected function build(ContainerBuilder $container)
+    protected function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new RegisterPreviewWebspaceClassPass());
     }

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
@@ -113,9 +113,6 @@ class PreviewKernel extends Kernel
         );
     }
 
-    /**
-     * @return void
-     */
     protected function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new RegisterPreviewWebspaceClassPass());

--- a/src/Sulu/Bundle/ReferenceBundle/UserInterface/Command/RefreshCommand.php
+++ b/src/Sulu/Bundle/ReferenceBundle/UserInterface/Command/RefreshCommand.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\ReferenceBundle\UserInterface\Command;
 
 use Sulu\Bundle\ReferenceBundle\Application\Refresh\ReferenceRefresherInterface;
 use Sulu\Bundle\ReferenceBundle\Domain\Repository\ReferenceRepositoryInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -24,6 +25,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  *
  * @final
  */
+#[AsCommand(name: 'sulu:reference:refresh')]
 class RefreshCommand extends Command
 {
     protected static $defaultName = 'sulu:reference:refresh';


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #7156  <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix PreviewKernel and RefreshCommand compatibility.

#### Why?

On Symfony 7 this two classes currently errors.