### PR TITLE
Fix PreviewKernel compatibility for Projects overwritten the build method

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
@@ -130,5 +130,6 @@ class PreviewKernel extends Kernel
     protected function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new RegisterPreviewWebspaceClassPass());
+        parent::build($container);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #7332 / #7356
| License | MIT
| Documentation PR | -

#### What's in this PR?

Call the parent build function in the PreviewKernel.

#### Why?

We have our own build function in our project Kernel and use Sulu.
With the advent of the PR 7356 the PreviewKernel overwrites our build function in App/Kernel of our project.
This is the place we registered our own Extension.

However because the PreviewKernel now overwrites this function using composer install does no longer work in our project. The reason is that the cache:clear steps fails because a configuration key in our project can no longer be identified due to the not registered Extension.

Please note that I don't have a FrankenPHP setup and therefore cannot verify how this PR affects the issue #7332.