### PR TITLE
Add compatibility to Symfony 7 to ActivateResolveTargetEntityResolverPass

### DIFF
--- a/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/Compiler/ActivateResolveTargetEntityResolverPass.php
+++ b/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/Compiler/ActivateResolveTargetEntityResolverPass.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\PersistenceBundle\DependencyInjection\Compiler;
 
+use Doctrine\ORM\Events;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -21,16 +22,27 @@ class ActivateResolveTargetEntityResolverPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        // TODO we should replace the SuluPersistenceBundle with configuring doctrine.orm.resolve_target_entities in the config
+        //      else we need to keep the resolve target entity resolver uptodate ourself.
+
         if (!$container->hasDefinition('doctrine.orm.listeners.resolve_target_entity')) {
             throw new \RuntimeException('Cannot find Doctrine Target Entity Resolver Listener.');
         }
 
         $resolveTargetEntityListener = $container->findDefinition('doctrine.orm.listeners.resolve_target_entity');
 
-        // we need to make sure that the service is added as event subscriber when doctrine bundle is not doing it
-        // when the bundle dont get any config
-        if (!$resolveTargetEntityListener->hasTag('doctrine.event_subscriber')) {
-            $resolveTargetEntityListener->addTag('doctrine.event_subscriber');
+        // we need to make sure that the service is added as event listener when doctrine bundle is not doing it
+        // when the bundle don't get any config
+        if (!$resolveTargetEntityListener->hasTag('doctrine.event_listener') // >= doctrine-bundle 2.10.0
+            && !$resolveTargetEntityListener->hasTag('doctrine.event_subscriber') // < doctrine-bundle 2.10.0
+        ) {
+            // we need to configure these events:
+            //      https://github.com/doctrine/DoctrineBundle/blob/2.10.0/DependencyInjection/DoctrineExtension.php#L598-L600
+            // even when doctrine-bundle < 2.10.0 is used we can use still event_listener as they are supported by our min version of symfony/doctrine-bridge 5.4
+            //      https://github.com/symfony/doctrine-bridge/blob/v5.4.0/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php#L72
+            $resolveTargetEntityListener
+                ->addTag('doctrine.event_listener', ['event' => Events::loadClassMetadata])
+                ->addTag('doctrine.event_listener', ['event' => Events::onClassMetadataNotFound]);
         }
     }
 }

--- a/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/Compiler/ActivateResolveTargetEntityResolverPass.php
+++ b/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/Compiler/ActivateResolveTargetEntityResolverPass.php
@@ -15,6 +15,9 @@ use Doctrine\ORM\Events;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+/**
+ * @internal
+ */
 class ActivateResolveTargetEntityResolverPass implements CompilerPassInterface
 {
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #7156  <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add compatibility to Symfony 7 to ActivateResolveTargetEntityResolverPass.

#### Why?

Prepare Symfony 7 compatibility. The event system is changed from `doctrine.event_subscriber` to `doctrine.event_listener`.

Reproducer: https://github.com/alexander-schranz/symfony-7-reproducer-entity-resolver 