### PR TITLE
Refactor SuluBuilder to be compatible with MassiveBuild ContainerAwareInterface for Symfony 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "imagine/imagine": "^1.0",
         "jms/serializer": "^3.16",
         "jms/serializer-bundle": "^3.8 || ^4.0 || ^5.0",
-        "massive/build-bundle": "^0.5",
+        "massive/build-bundle": "^0.5.7",
         "massive/search-bundle": "^2.8.2",
         "matomo/device-detector": "^3.9 || ^4.0.1 || ^5.0 || ^6.0",
         "nyholm/psr7": "^1.3",

--- a/src/Sulu/Bundle/CoreBundle/Build/SuluBuilder.php
+++ b/src/Sulu/Bundle/CoreBundle/Build/SuluBuilder.php
@@ -13,9 +13,9 @@ namespace Sulu\Bundle\CoreBundle\Build;
 
 use Massive\Bundle\BuildBundle\Build\BuilderContext;
 use Massive\Bundle\BuildBundle\Build\BuilderInterface;
+use Massive\Bundle\BuildBundle\ContainerAwareInterface;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no (interface is an alias if symfonys containerawareinterface exists)
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #7156  <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Refactor SuluBuilder to be compatible with MassiveBuild ContainerAwareInterface for Symfony 7.

#### Why?

Prepare Symfony 7 compatibiliy.
