### PR TITLE
Fixes ReactCircularProgressbar props

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CircularProgressbar/CircularProgressbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CircularProgressbar/CircularProgressbar.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import {computed} from 'mobx';
 import {CircularProgressbar as ReactCircularProgressbar} from 'react-circular-progressbar';
 import circularProgressbarStyles from './circularProgressbar.scss';
 
@@ -16,21 +17,18 @@ export default class CircularProgressbar extends React.PureComponent<Props> {
         size: 100,
     };
 
-    handlePercentageText = (percentage: number) => {
-        const {hidePercentageText} = this.props;
+    @computed get percentageText() {
+        const { hidePercentageText, percentage } = this.props;
 
         if (hidePercentageText) {
             return null;
         }
 
         return `${percentage}%`;
-    };
+    }
 
     render() {
-        const {
-            size,
-            percentage,
-        } = this.props;
+        const { size, percentage } = this.props;
         const sizeStyle = {
             width: size,
             height: size,
@@ -47,8 +45,8 @@ export default class CircularProgressbar extends React.PureComponent<Props> {
                         text: circularProgressbarStyles.text,
                         background: circularProgressbarStyles.background,
                     }}
-                    percentage={percentage}
-                    textForPercentage={this.handlePercentageText} // eslint-disable-line react/jsx-handler-names
+                    text={this.percentageText}
+                    value={percentage}
                 />
             </div>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CircularProgressbar/CircularProgressbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CircularProgressbar/CircularProgressbar.js
@@ -18,7 +18,7 @@ export default class CircularProgressbar extends React.PureComponent<Props> {
     };
 
     @computed get percentageText() {
-        const { hidePercentageText, percentage } = this.props;
+        const {hidePercentageText, percentage} = this.props;
 
         if (hidePercentageText) {
             return null;
@@ -28,7 +28,7 @@ export default class CircularProgressbar extends React.PureComponent<Props> {
     }
 
     render() {
-        const { size, percentage } = this.props;
+        const {size, percentage} = this.props;
         const sizeStyle = {
             width: size,
             height: size,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CircularProgressbar/tests/__snapshots__/CircularProgressbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CircularProgressbar/tests/__snapshots__/CircularProgressbar.test.js.snap
@@ -37,8 +37,15 @@ exports[`Render a CircularProgressbar 1`] = `
     "
         fill-opacity="0"
         stroke-width="8"
-        style="stroke-dasharray: 289.02652413026095px 289.02652413026095px; stroke-dashoffset: NaNpx;"
+        style="stroke-dasharray: 289.02652413026095px 289.02652413026095px; stroke-dashoffset: 115.61060965210439px;"
       />
+      <text
+        class="text"
+        x="50"
+        y="50"
+      >
+        60%
+      </text>
     </svg>
   </div>
 </div>
@@ -81,8 +88,15 @@ exports[`Render a CircularProgressbar in a different size 1`] = `
     "
         fill-opacity="0"
         stroke-width="8"
-        style="stroke-dasharray: 289.02652413026095px 289.02652413026095px; stroke-dashoffset: NaNpx;"
+        style="stroke-dasharray: 289.02652413026095px 289.02652413026095px; stroke-dashoffset: 115.61060965210439px;"
       />
+      <text
+        class="text"
+        x="50"
+        y="50"
+      >
+        60%
+      </text>
     </svg>
   </div>
 </div>
@@ -125,7 +139,7 @@ exports[`Render a CircularProgressbar without the progress info in the center 1`
     "
         fill-opacity="0"
         stroke-width="8"
-        style="stroke-dasharray: 289.02652413026095px 289.02652413026095px; stroke-dashoffset: NaNpx;"
+        style="stroke-dasharray: 289.02652413026095px 289.02652413026095px; stroke-dashoffset: 115.61060965210439px;"
       />
     </svg>
   </div>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/tests/__snapshots__/SingleMediaDropzone.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/tests/__snapshots__/SingleMediaDropzone.test.js.snap
@@ -113,8 +113,15 @@ exports[`Render a SingleMediaDropzone while uploading 1`] = `
     "
           fill-opacity="0"
           stroke-width="8"
-          style="stroke-dasharray:289.02652413026095px 289.02652413026095px;stroke-dashoffset:NaNpx"
+          style="stroke-dasharray:289.02652413026095px 289.02652413026095px;stroke-dashoffset:144.51326206513048px"
         />
+        <text
+          class="text"
+          x="50"
+          y="50"
+        >
+          50%
+        </text>
       </svg>
     </div>
   </div>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no 
| Fixed tickets | fixes #7376
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

This PR upgrades the props passed to `ReactCircularProgressbar` to revive the former style and behaviour (currently broken)

#### Why?

A progress-bar that always displays full progress is useless and should either be fixed or removed from UI library.
