### PR TITLE
Fix condition provider crashing of the admin when no parent is found

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/conditionDataProviders/parentConditionDataProvider.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/conditionDataProviders/parentConditionDataProvider.js
@@ -13,6 +13,12 @@ export default function(data: Object, dataPath: ?string): {[string]: any} {
 
     do {
         parentDataPath = parentDataPath.substring(0, parentDataPath.lastIndexOf('/'));
+
+        if (!jsonpointer.has(data, parentDataPath)) {
+            currentConditionData.__parent = null;
+            break;
+        }
+
         const evaluatedData = jsonpointer.get(data, parentDataPath);
 
         if (isArrayLike(evaluatedData)) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/conditionDataProviders/parentConditionDataProvider.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/conditionDataProviders/parentConditionDataProvider.test.js
@@ -19,6 +19,18 @@ test('Return parent for first block', () => {
     expect(parentConditionDataProvider(data, '/blocks/0/title')).toEqual({__parent: {title: 'Block title 1'}});
 });
 
+test('Return null for not existing path', () => {
+    const data = {
+        title: 'Title',
+        blocks: [
+            {title: 'Block title 1'},
+            {title: 'Block title 2'},
+        ],
+    };
+
+    expect(parentConditionDataProvider(data, '/not/existing/path')).toEqual({__parent: null});
+});
+
 test('Return parent for second block', () => {
     const data = {
         title: 'Title',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

When adding a new block the `settings` array is undefined, this MR prevents the admin from completely crashing in this case.

#### Why?

Admin ui should never crash completely due to JS errors
