### PR TITLE
Fix secret parameter in ResettingController

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
@@ -491,7 +491,7 @@ class ResettingController
      */
     private function generateTokenHash(string $token): string
     {
-        return \hash('sha1', $this->secret . $token);
+        return \hash('sha1', $this->secret . '%' . $token);
     }
 
     /**

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -61,7 +61,7 @@
             <argument>%sulu_security.reset_password.mail.template%</argument>
             <argument>%sulu_security.reset_password.mail.token_send_limit%</argument>
             <argument>%sulu_admin.email%</argument>
-            <argument>%kernel.secret%%</argument>
+            <argument>%kernel.secret%</argument>
 
             <tag name="sulu.context" context="admin"/>
         </service>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #7303
| Related issues/PRs | #7303
| License | MIT
| Documentation PR | -

#### What's in this PR?
Fixing the argument for the resetting controller.

#### Why?
The contents of this variable is not really used anywhere, it's used to generate a unique token for the user for resetting the password. Maybe since the secret is not checked anywhere any random information would be good enough.