### PR TITLE
Improve command name consistency

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11511,11 +11511,6 @@ parameters:
 			path: src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
 
 		-
-			message: "#^Property Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\Command\\\\PHPCRCleanupSingleNodeCommand\\:\\:\\$invalidationSubscriber is never read, only written\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
-
-		-
 			message: "#^Variable \\$liveCleanupNode might not be defined\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php

--- a/src/Sulu/Bundle/AdminBundle/Command/ViewDebugCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/ViewDebugCommand.php
@@ -33,7 +33,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * @internal
  */
-#[AsCommand(name: 'sulu:admin:debug-views', description: 'Display current Views for the admin')]
+#[AsCommand(name: 'sulu:admin:debug-view', description: 'Display current Views for the admin')]
 class ViewDebugCommand extends Command
 {
     public function __construct(

--- a/src/Sulu/Bundle/AdminBundle/Command/ViewDebugCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/ViewDebugCommand.php
@@ -33,7 +33,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * @internal
  */
-#[AsCommand(name: 'sulu:debug:admin:views', description: 'Display current Views for the admin')]
+#[AsCommand(name: 'sulu:admin:debug-views', description: 'Display current Views for the admin')]
 class ViewDebugCommand extends Command
 {
     public function __construct(

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
@@ -31,7 +31,7 @@ use Webmozart\Assert\Assert;
 /**
  * @internal
  */
-#[AsCommand(name: 'sulu:phpcr:cleanup')]
+#[AsCommand(name: 'sulu:document:phpcr-cleanup', description: 'Cleanup the PHPCR repository and remove unused properties.')]
 class PHPCRCleanupCommand extends Command
 {
     private OutputInterface $logger;
@@ -42,7 +42,7 @@ class PHPCRCleanupCommand extends Command
         private ServicesResetter $servicesResetter,
         private string $projectDirectory,
     ) {
-        parent::__construct('sulu:phpcr:cleanup');
+        parent::__construct();
     }
 
     protected function configure(): void
@@ -243,7 +243,7 @@ class PHPCRCleanupCommand extends Command
         $process = new Process(\array_filter([
             $php,
             $_SERVER['argv'][0],
-            'sulu:phpcr:cleanup:single-node',
+            PHPCRCleanupSingleNodeCommand::getDefaultName(),
             $uuid,
             $dryRun ? '--dry-run' : null,
             $debug ? '--debug' : null,

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
@@ -25,6 +25,7 @@ use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Event;
 use Sulu\Component\DocumentManager\Events;
 use Sulu\Component\DocumentManager\NamespaceRegistry;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -39,6 +40,7 @@ use Webmozart\Assert\Assert;
 /**
  * @internal
  */
+#[AsCommand(name: 'sulu:document:phpcr-cleanup-single-node', description: 'Cleanup a single PHPCR node and remove unused properties.')]
 class PHPCRCleanupSingleNodeCommand extends Command
 {
     public const IGNORED = 101;
@@ -79,10 +81,9 @@ class PHPCRCleanupSingleNodeCommand extends Command
         NamespaceRegistry $namespaceRegistry,
         private EventDispatcherInterface $documentManagerEventDispatcher,
         private DocumentManagerInterface $documentManager,
-        private InvalidationSubscriber $invalidationSubscriber,
         array $mapping,
     ) {
-        parent::__construct('sulu:phpcr:cleanup:single-node');
+        parent::__construct();
 
         $this->logger = new NullOutput();
 

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/command.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/command.xml
@@ -38,7 +38,6 @@
             <argument type="service" id="sulu_document_manager.namespace_registry" />
             <argument type="service" id="sulu_document_manager.event_dispatcher" />
             <argument type="service" id="sulu_document_manager.document_manager" />
-            <argument type="service" id="sulu_http_cache.event_subscriber.invalidation" />
             <argument>%sulu_document_manager.mapping%</argument>
 
             <tag name="console.command" />


### PR DESCRIPTION
#### What's in this PR?

This MR improves the command names to be more consistent with the other sulu commands.
Sulu commands should follow this naming convention `sulu:<bundle>:command-name`