### PR TITLE
Refactor ParameterBag to HeaderBag in Core Tests

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -34341,18 +34341,8 @@ parameters:
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Controller/RedirectControllerTest.php
 
 		-
-			message: "#^Property Symfony\\\\Component\\\\HttpFoundation\\\\Request\\:\\:\\$query \\(Symfony\\\\Component\\\\HttpFoundation\\\\InputBag\\<string\\>\\) does not accept Symfony\\\\Component\\\\HttpFoundation\\\\ParameterBag\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Controller/RedirectControllerTest.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Tests\\\\Unit\\\\EventListener\\\\AppendAnalyticsListenerTest\\:\\:formatProvider\\(\\) has no return type specified\\.$#"
 			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/AppendAnalyticsListenerTest.php
-
-		-
-			message: "#^Property Symfony\\\\Component\\\\HttpFoundation\\\\Response\\:\\:\\$headers \\(Symfony\\\\Component\\\\HttpFoundation\\\\ResponseHeaderBag\\) does not accept Symfony\\\\Component\\\\HttpFoundation\\\\ParameterBag\\.$#"
-			count: 8
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/AppendAnalyticsListenerTest.php
 
 		-

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Controller/RedirectControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Controller/RedirectControllerTest.php
@@ -16,6 +16,7 @@ use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Bundle\WebsiteBundle\Controller\RedirectController;
 use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
+use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -143,15 +144,12 @@ class RedirectControllerTest extends TestCase
             \array_merge($attributesData, ['route' => $route, 'permanent' => $permanent])
         );
 
-        $query = $this->prophesize(ParameterBag::class);
-        $query->all()->willReturn($queryData);
-
         $router = $this->prophesize(RouterInterface::class);
         $router->generate($route, \array_merge($attributesData, $queryData), UrlGeneratorInterface::ABSOLUTE_URL)->willReturn('/test-route');
 
         $request = $this->prophesize(Request::class);
         $request->reveal()->attributes = $attributes->reveal();
-        $request->reveal()->query = $query->reveal();
+        $request->reveal()->query = new InputBag([]);
 
         $response = $this->controller->redirectToRouteAction($request->reveal(), $route, $permanent);
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/AppendAnalyticsListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/AppendAnalyticsListenerTest.php
@@ -20,9 +20,9 @@ use Sulu\Bundle\WebsiteBundle\EventListener\AppendAnalyticsListener;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\PortalInformation;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
-use Symfony\Component\HttpFoundation\HeaderBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Twig\Environment;
@@ -57,7 +57,7 @@ class AppendAnalyticsListenerTest extends TestCase
         $request = $this->prophesize(Request::class);
         $request->getRequestFormat()->willReturn($format);
         $response = $this->prophesize(Response::class);
-        $response->reveal()->headers = new HeaderBag(['Content-Type' => 'text/plain']);
+        $response->reveal()->headers = new ResponseHeaderBag(['Content-Type' => 'text/plain']);
         $response->getContent()->shouldNotBeCalled();
         $requestAnalyzer->getPortalInformation()->shouldNotBeCalled();
         $event = $this->createResponseEvent($request->reveal(), $response->reveal());
@@ -84,7 +84,7 @@ class AppendAnalyticsListenerTest extends TestCase
         $request = $this->prophesize(Request::class);
         $request->getRequestFormat()->willReturn('html');
         $response = $this->prophesize(BinaryFileResponse::class);
-        $response->reveal()->headers = new HeaderBag(['Content-Type' => 'text/html']);
+        $response->reveal()->headers = new ResponseHeaderBag(['Content-Type' => 'text/html']);
         $response->getContent()->willReturn(false)->shouldBeCalled();
         $requestAnalyzer->getPortalInformation()->shouldNotBeCalled();
         $event = $this->createResponseEvent($request->reveal(), $response->reveal());
@@ -125,7 +125,7 @@ class AppendAnalyticsListenerTest extends TestCase
         $request = $this->prophesize(Request::class);
         $request->getRequestFormat()->willReturn('html');
         $response = $this->prophesize(Response::class);
-        $response->reveal()->headers = new HeaderBag(['Content-Type' => 'text/html']);
+        $response->reveal()->headers = new ResponseHeaderBag(['Content-Type' => 'text/html']);
         $event = $this->createResponseEvent($request->reveal(), $response->reveal());
 
         $loader = $this->prophesize(FilesystemLoader::class);
@@ -183,7 +183,7 @@ class AppendAnalyticsListenerTest extends TestCase
         $request->getHost()->willReturn('1.sulu.lo');
         $request->getRequestUri()->willReturn('/2');
         $response = $this->prophesize(Response::class);
-        $response->reveal()->headers = new HeaderBag(['Content-Type' => 'text/html']);
+        $response->reveal()->headers = new ResponseHeaderBag(['Content-Type' => 'text/html']);
         $event = $this->createResponseEvent($request->reveal(), $response->reveal());
 
         $loader = $this->prophesize(FilesystemLoader::class);
@@ -237,7 +237,7 @@ class AppendAnalyticsListenerTest extends TestCase
 
         $response = $this->prophesize(Response::class);
         $response->getContent()->willReturn('<html><head><title>Test</title></head><body><h1>Title</h1></body></html>');
-        $response->reveal()->headers = new HeaderBag(['Content-Type' => 'text/html']);
+        $response->reveal()->headers = new ResponseHeaderBag(['Content-Type' => 'text/html']);
         $response->setContent(Argument::cetera())
             ->shouldNotBeCalled();
 
@@ -282,7 +282,7 @@ class AppendAnalyticsListenerTest extends TestCase
         $request = $this->prophesize(Request::class);
         $request->getRequestFormat()->willReturn('html');
         $response = $this->prophesize(Response::class);
-        $response->reveal()->headers = new HeaderBag(['Content-Type' => 'text/html']);
+        $response->reveal()->headers = new ResponseHeaderBag(['Content-Type' => 'text/html']);
         $event = $this->createResponseEvent($request->reveal(), $response->reveal());
 
         $loader = $this->prophesize(FilesystemLoader::class);
@@ -341,7 +341,7 @@ class AppendAnalyticsListenerTest extends TestCase
         $request = $this->prophesize(Request::class);
         $request->getRequestFormat()->willReturn('html');
         $response = $this->prophesize(Response::class);
-        $response->reveal()->headers = new HeaderBag(['Content-Type' => 'text/html']);
+        $response->reveal()->headers = new ResponseHeaderBag(['Content-Type' => 'text/html']);
         $event = $this->createResponseEvent($request->reveal(), $response->reveal());
 
         $loader = $this->prophesize(FilesystemLoader::class);
@@ -400,7 +400,7 @@ class AppendAnalyticsListenerTest extends TestCase
         $request = $this->prophesize(Request::class);
         $request->getRequestFormat()->willReturn('html');
         $response = $this->prophesize(Response::class);
-        $response->reveal()->headers = new HeaderBag(['Content-Type' => 'text/html']);
+        $response->reveal()->headers = new ResponseHeaderBag(['Content-Type' => 'text/html']);
         $event = $this->createResponseEvent($request->reveal(), $response->reveal());
 
         $loader = $this->prophesize(FilesystemLoader::class);

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/AppendAnalyticsListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/AppendAnalyticsListenerTest.php
@@ -20,6 +20,7 @@ use Sulu\Bundle\WebsiteBundle\EventListener\AppendAnalyticsListener;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\PortalInformation;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\HeaderBag;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -57,7 +58,7 @@ class AppendAnalyticsListenerTest extends TestCase
         $request = $this->prophesize(Request::class);
         $request->getRequestFormat()->willReturn($format);
         $response = $this->prophesize(Response::class);
-        $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/plain']);
+        $response->reveal()->headers = new HeaderBag(['Content-Type' => 'text/plain']);
         $response->getContent()->shouldNotBeCalled();
         $requestAnalyzer->getPortalInformation()->shouldNotBeCalled();
         $event = $this->createResponseEvent($request->reveal(), $response->reveal());
@@ -84,7 +85,7 @@ class AppendAnalyticsListenerTest extends TestCase
         $request = $this->prophesize(Request::class);
         $request->getRequestFormat()->willReturn('html');
         $response = $this->prophesize(BinaryFileResponse::class);
-        $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/html']);
+        $response->reveal()->headers = new HeaderBag(['Content-Type' => 'text/html']);
         $response->getContent()->willReturn(false)->shouldBeCalled();
         $requestAnalyzer->getPortalInformation()->shouldNotBeCalled();
         $event = $this->createResponseEvent($request->reveal(), $response->reveal());
@@ -125,7 +126,7 @@ class AppendAnalyticsListenerTest extends TestCase
         $request = $this->prophesize(Request::class);
         $request->getRequestFormat()->willReturn('html');
         $response = $this->prophesize(Response::class);
-        $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/html']);
+        $response->reveal()->headers = new HeaderBag(['Content-Type' => 'text/html']);
         $event = $this->createResponseEvent($request->reveal(), $response->reveal());
 
         $loader = $this->prophesize(FilesystemLoader::class);
@@ -183,7 +184,7 @@ class AppendAnalyticsListenerTest extends TestCase
         $request->getHost()->willReturn('1.sulu.lo');
         $request->getRequestUri()->willReturn('/2');
         $response = $this->prophesize(Response::class);
-        $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/html']);
+        $response->reveal()->headers = new HeaderBag(['Content-Type' => 'text/html']);
         $event = $this->createResponseEvent($request->reveal(), $response->reveal());
 
         $loader = $this->prophesize(FilesystemLoader::class);
@@ -237,7 +238,7 @@ class AppendAnalyticsListenerTest extends TestCase
 
         $response = $this->prophesize(Response::class);
         $response->getContent()->willReturn('<html><head><title>Test</title></head><body><h1>Title</h1></body></html>');
-        $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/html']);
+        $response->reveal()->headers = new HeaderBag(['Content-Type' => 'text/html']);
         $response->setContent(Argument::cetera())
             ->shouldNotBeCalled();
 
@@ -282,7 +283,7 @@ class AppendAnalyticsListenerTest extends TestCase
         $request = $this->prophesize(Request::class);
         $request->getRequestFormat()->willReturn('html');
         $response = $this->prophesize(Response::class);
-        $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/html']);
+        $response->reveal()->headers = new HeaderBag(['Content-Type' => 'text/html']);
         $event = $this->createResponseEvent($request->reveal(), $response->reveal());
 
         $loader = $this->prophesize(FilesystemLoader::class);
@@ -341,7 +342,7 @@ class AppendAnalyticsListenerTest extends TestCase
         $request = $this->prophesize(Request::class);
         $request->getRequestFormat()->willReturn('html');
         $response = $this->prophesize(Response::class);
-        $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/html']);
+        $response->reveal()->headers = new HeaderBag(['Content-Type' => 'text/html']);
         $event = $this->createResponseEvent($request->reveal(), $response->reveal());
 
         $loader = $this->prophesize(FilesystemLoader::class);
@@ -400,7 +401,7 @@ class AppendAnalyticsListenerTest extends TestCase
         $request = $this->prophesize(Request::class);
         $request->getRequestFormat()->willReturn('html');
         $response = $this->prophesize(Response::class);
-        $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/html']);
+        $response->reveal()->headers = new HeaderBag(['Content-Type' => 'text/html']);
         $event = $this->createResponseEvent($request->reveal(), $response->reveal());
 
         $loader = $this->prophesize(FilesystemLoader::class);

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/AppendAnalyticsListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/AppendAnalyticsListenerTest.php
@@ -21,7 +21,6 @@ use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\PortalInformation;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\HeaderBag;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | -
| Related issues/PRs | #7156  #7382
| License | MIT
| Documentation PR | -

#### What's in this PR?
Using the `HeaderBag` instead of the generic bag.

#### Why?
Symfony 7 :tada: 
