### PR TITLE
Add typehint to S3StorageTest class for Symfony 7 compatibility

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Media/Storage/S3StorageTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Media/Storage/S3StorageTest.php
@@ -24,6 +24,12 @@ class S3StorageTest extends SuluTestCase
         static::$class = S3Kernel::class;
     }
 
+    protected function tearDown(): void
+    {
+        static::$class = null;
+        parent::tearDown();
+    }
+
     public function testSave(): void
     {
         $kernel = self::bootKernel();

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Media/Storage/S3StorageTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Media/Storage/S3StorageTest.php
@@ -19,7 +19,7 @@ use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
 class S3StorageTest extends SuluTestCase
 {
-    protected static function setUp(): void
+    protected function setUp(): void
     {
         static::$class = S3Kernel::class;
     }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Media/Storage/S3StorageTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Media/Storage/S3StorageTest.php
@@ -19,7 +19,7 @@ use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
 class S3StorageTest extends SuluTestCase
 {
-    protected static function setUp(): svoid
+    protected static function setUp(): void
     {
         static::$class = S3Kernel::class;
     }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Media/Storage/S3StorageTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Media/Storage/S3StorageTest.php
@@ -19,9 +19,9 @@ use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
 class S3StorageTest extends SuluTestCase
 {
-    protected static function getKernelClass(): string
+    protected static function setUp(): svoid
     {
-        return S3Kernel::class;
+        static::$class = S3Kernel::class;
     }
 
     public function testSave(): void

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Media/Storage/S3StorageTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Media/Storage/S3StorageTest.php
@@ -19,10 +19,7 @@ use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
 class S3StorageTest extends SuluTestCase
 {
-    /**
-     * @var string
-     */
-    protected static $class = S3Kernel::class;
+    protected static ?string $class = S3Kernel::class;
 
     protected static function getKernelClass(): string
     {

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Media/Storage/S3StorageTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Media/Storage/S3StorageTest.php
@@ -19,8 +19,6 @@ use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
 class S3StorageTest extends SuluTestCase
 {
-    protected static ?string $class = S3Kernel::class;
-
     protected static function getKernelClass(): string
     {
         return S3Kernel::class;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #7156 
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add typehint to S3StorageTest class for Symfony 7 compatibility

#### Why?

Symfony 7 added the same typehint.