### PR TITLE
Fix inconsistent container width for lists with pagination

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/Pagination.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/Pagination.js
@@ -140,7 +140,7 @@ class Pagination extends React.Component<Props> {
         const {children, loading, totalPages, currentLimit} = this.props;
 
         return (
-            <section className={paginationStyles.resultsContainer}>
+            <section>
                 {children}
                 <nav className={paginationStyles.pagination}>
                     <span className={paginationStyles.display}>{translate('sulu_admin.per_page')}:</span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/pagination.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/pagination.scss
@@ -29,8 +29,3 @@ $buttonActiveColor: $blueZodiac;
     margin-right: 20px;
     width: 50px;
 }
-
-.resultsContainer {
-    width: 100%;
-    max-width: 820px;
-}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/tests/__snapshots__/Pagination.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/tests/__snapshots__/Pagination.test.js.snap
@@ -2,9 +2,7 @@
 
 exports[`Render disabled next link if current page is last page 1`] = `
 <div>
-  <section
-    class="resultsContainer"
-  >
+  <section>
     <p>
       Test
     </p>
@@ -115,9 +113,7 @@ exports[`Render disabled next link if current page is last page 1`] = `
 
 exports[`Render disabled previous link current page is first page 1`] = `
 <div>
-  <section
-    class="resultsContainer"
-  >
+  <section>
     <p>
       Test
     </p>
@@ -228,9 +224,7 @@ exports[`Render disabled previous link current page is first page 1`] = `
 
 exports[`Render pagination with loader 1`] = `
 <div>
-  <section
-    class="resultsContainer"
-  >
+  <section>
     <p>
       Test
     </p>
@@ -352,9 +346,7 @@ exports[`Render pagination with loader 1`] = `
 
 exports[`Render pagination with page numbers 1`] = `
 <div>
-  <section
-    class="resultsContainer"
-  >
+  <section>
     <p>
       Test
     </p>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/FolderAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/FolderAdapter.test.js.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Render a basic Folder list with data 1`] = `
-<section
-  class="resultsContainer"
->
+<section>
   <ul
     class="folderList"
   >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TableAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TableAdapter.test.js.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Render column with ascending sort icon 1`] = `
-<section
-  class="resultsContainer"
->
+<section>
   <div
     class="tableContainer dark"
   >
@@ -175,9 +173,7 @@ exports[`Render column with ascending sort icon 1`] = `
 `;
 
 exports[`Render column with descending sort icon 1`] = `
-<section
-  class="resultsContainer"
->
+<section>
   <div
     class="tableContainer dark"
   >
@@ -349,9 +345,7 @@ exports[`Render column with descending sort icon 1`] = `
 `;
 
 exports[`Render data with all different visibility types schema 1`] = `
-<section
-  class="resultsContainer"
->
+<section>
   <div
     class="tableContainer dark"
   >
@@ -536,9 +530,7 @@ exports[`Render data with all different visibility types schema 1`] = `
 `;
 
 exports[`Render data with pencil button and given itemActions when onItemEdit callback is passed 1`] = `
-<section
-  class="resultsContainer"
->
+<section>
   <div
     class="tableContainer dark hasButtons"
   >
@@ -827,9 +819,7 @@ exports[`Render data with pencil button and given itemActions when onItemEdit ca
 `;
 
 exports[`Render data with pencil button when onItemEdit callback is passed 1`] = `
-<section
-  class="resultsContainer"
->
+<section>
   <div
     class="tableContainer dark hasButtons"
   >
@@ -1034,9 +1024,7 @@ exports[`Render data with pencil button when onItemEdit callback is passed 1`] =
 `;
 
 exports[`Render data with schema 1`] = `
-<section
-  class="resultsContainer"
->
+<section>
   <div
     class="tableContainer dark"
   >
@@ -1343,9 +1331,7 @@ exports[`Render data with schema 1`] = `
 `;
 
 exports[`Render data with schema and selections 1`] = `
-<section
-  class="resultsContainer"
->
+<section>
   <div
     class="tableContainer dark"
   >
@@ -1623,9 +1609,7 @@ exports[`Render data with schema and selections 1`] = `
 `;
 
 exports[`Render data with schema in different order 1`] = `
-<section
-  class="resultsContainer"
->
+<section>
   <div
     class="tableContainer dark"
   >
@@ -1787,9 +1771,7 @@ exports[`Render data with schema in different order 1`] = `
 `;
 
 exports[`Render data with schema not containing all fields 1`] = `
-<section
-  class="resultsContainer"
->
+<section>
   <div
     class="tableContainer dark"
   >
@@ -1912,9 +1894,7 @@ exports[`Render data with schema not containing all fields 1`] = `
 `;
 
 exports[`Render data with shrunken cell 1`] = `
-<section
-  class="resultsContainer"
->
+<section>
   <div
     class="tableContainer dark"
   >
@@ -2177,9 +2157,7 @@ exports[`Render data with shrunken cell 1`] = `
 `;
 
 exports[`Render data with skin 1`] = `
-<section
-  class="resultsContainer"
->
+<section>
   <div
     class="tableContainer light"
   >
@@ -2312,9 +2290,7 @@ exports[`Render data with skin 1`] = `
 `;
 
 exports[`Render data without header 1`] = `
-<section
-  class="resultsContainer"
->
+<section>
   <div
     class="tableContainer dark"
   >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
@@ -340,9 +340,7 @@ exports[`Should render the list with a title 1`] = `
     <div
       class="list"
     >
-      <section
-        class="resultsContainer"
-      >
+      <section>
         <div
           class="tableContainer dark"
         >
@@ -629,9 +627,7 @@ exports[`Should render the list with nodes of given ListItemActions 1`] = `
     <div
       class="list"
     >
-      <section
-        class="resultsContainer"
-      >
+      <section>
         <div
           class="tableContainer dark hasButtons"
         >
@@ -964,9 +960,7 @@ exports[`Should render the list with nodes of given ToolbarActions 1`] = `
     <div
       class="list"
     >
-      <section
-        class="resultsContainer"
-      >
+      <section>
         <div
           class="tableContainer dark"
         >
@@ -1257,9 +1251,7 @@ exports[`Should render the list with the correct resourceKey 1`] = `
     <div
       class="list"
     >
-      <section
-        class="resultsContainer"
-      >
+      <section>
         <div
           class="tableContainer dark"
         >

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
@@ -69,9 +69,7 @@ exports[`Render the MediaCollection 1`] = `
       <div
         class="list"
       >
-        <section
-          class="resultsContainer"
-        >
+        <section>
           <ul
             class="folderList"
           >
@@ -644,9 +642,7 @@ exports[`Render the MediaCollection for all media 1`] = `
       <div
         class="list"
       >
-        <section
-          class="resultsContainer"
-        >
+        <section>
           <ul
             class="folderList"
           >

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
@@ -103,9 +103,7 @@ Array [
                   <div
                     class="list"
                   >
-                    <section
-                      class="resultsContainer"
-                    >
+                    <section>
                       <ul
                         class="folderList"
                       >
@@ -804,9 +802,7 @@ Array [
                   <div
                     class="list"
                   >
-                    <section
-                      class="resultsContainer"
-                    >
+                    <section>
                       <ul
                         class="folderList"
                       >

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/__snapshots__/MediaOverview.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/__snapshots__/MediaOverview.test.js.snap
@@ -75,9 +75,7 @@ exports[`Render a simple MediaOverview 1`] = `
       <div
         class="list"
       >
-        <section
-          class="resultsContainer"
-        >
+        <section>
           <ul
             class="folderList"
           >

--- a/src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/Search.js
+++ b/src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/Search.js
@@ -12,6 +12,7 @@ import indexStore from './stores/indexStore';
 import SearchField from './SearchField';
 import SearchResult from './SearchResult';
 import searchStyles from './search.scss';
+import searchResultStyles from './searchResult.scss';
 import type {Index} from './types';
 
 type Props = {|
@@ -127,16 +128,18 @@ class Search extends React.Component<Props> {
                     </div>
                 }
                 {!searchStore.loading && searchStore.result.length > 0 &&
-                    <Pagination
-                        currentLimit={searchStore.limit}
-                        currentPage={searchStore.page}
-                        loading={searchStore.loading}
-                        onLimitChange={this.handleLimitChange}
-                        onPageChange={this.handlePageChange}
-                        totalPages={searchStore.pages}
-                    >
-                        {results}
-                    </Pagination>
+                    <div className={searchResultStyles.searchResultsOuterContainer}>
+                        <Pagination
+                            currentLimit={searchStore.limit}
+                            currentPage={searchStore.page}
+                            loading={searchStore.loading}
+                            onLimitChange={this.handleLimitChange}
+                            onPageChange={this.handlePageChange}
+                            totalPages={searchStore.pages}
+                        >
+                            {results}
+                        </Pagination>
+                    </div>
                 }
             </div>
         );

--- a/src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/searchResult.scss
+++ b/src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/searchResult.scss
@@ -19,6 +19,11 @@ $searchResultIconBackgroundColor: $concrete;
     cursor: pointer;
 }
 
+.search-results-outer-container {
+    width: 100%;
+    max-width: 820px;
+}
+
 .image-container,
 .image,
 .icon {

--- a/src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/tests/__snapshots__/Search.test.js.snap
+++ b/src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/tests/__snapshots__/Search.test.js.snap
@@ -223,190 +223,192 @@ exports[`Render search results 1`] = `
   >
     sulu_search.search_hint
   </p>
-  <section
-    class="resultsContainer"
+  <div
+    class="searchResultsOuterContainer"
   >
-    <div
-      class="searchResult"
-      role="button"
-    >
+    <section>
       <div
-        class="imageContainer"
-      >
-        <img
-          class="image"
-          src="/image.jgp"
-        />
-      </div>
-      <div
-        class="resultContainer"
+        class="searchResult"
+        role="button"
       >
         <div
-          class="resource"
+          class="imageContainer"
         >
-          Page
-        </div>
-        <div
-          class="titleContainer"
-        >
-          <div
-            class="title"
-          >
-            Test1
-          </div>
-          <div
-            class="locale"
-          >
-             (de)
-          </div>
-        </div>
-        <div
-          class="description"
-        >
-          something
-
-        </div>
-      </div>
-    </div>
-    <div
-      class="searchResult"
-      role="button"
-    >
-      <div
-        class="imageContainer"
-      >
-        <div
-          class="icon"
-        >
-          <span
-            aria-label="su-contact"
-            class="su-contact"
+          <img
+            class="image"
+            src="/image.jgp"
           />
         </div>
-      </div>
-      <div
-        class="resultContainer"
-      >
         <div
-          class="resource"
-        >
-          Contact
-        </div>
-        <div
-          class="titleContainer"
+          class="resultContainer"
         >
           <div
-            class="title"
+            class="resource"
           >
-            Max Mustermann
+            Page
+          </div>
+          <div
+            class="titleContainer"
+          >
+            <div
+              class="title"
+            >
+              Test1
+            </div>
+            <div
+              class="locale"
+            >
+               (de)
+            </div>
+          </div>
+          <div
+            class="description"
+          >
+            something
+
+          </div>
+        </div>
+      </div>
+      <div
+        class="searchResult"
+        role="button"
+      >
+        <div
+          class="imageContainer"
+        >
+          <div
+            class="icon"
+          >
+            <span
+              aria-label="su-contact"
+              class="su-contact"
+            />
           </div>
         </div>
         <div
-          class="description"
+          class="resultContainer"
         >
-          something 2
-
-        </div>
-      </div>
-    </div>
-    <nav
-      class="pagination"
-    >
-      <span
-        class="display"
-      >
-        sulu_admin.per_page:
-      </span>
-      <span>
-        <div
-          class="select"
-          role="none"
-        >
-          <button
-            class="displayValue dark"
-            type="button"
+          <div
+            class="resource"
+          >
+            Contact
+          </div>
+          <div
+            class="titleContainer"
           >
             <div
-              aria-label="sulu_admin.please_choose"
-              class="croppedText"
-              title="sulu_admin.please_choose"
+              class="title"
+            >
+              Max Mustermann
+            </div>
+          </div>
+          <div
+            class="description"
+          >
+            something 2
+
+          </div>
+        </div>
+      </div>
+      <nav
+        class="pagination"
+      >
+        <span
+          class="display"
+        >
+          sulu_admin.per_page:
+        </span>
+        <span>
+          <div
+            class="select"
+            role="none"
+          >
+            <button
+              class="displayValue dark"
+              type="button"
             >
               <div
-                aria-hidden="true"
-                class="front"
+                aria-label="sulu_admin.please_choose"
+                class="croppedText"
+                title="sulu_admin.please_choose"
               >
-                sulu_admin.p
+                <div
+                  aria-hidden="true"
+                  class="front"
+                >
+                  sulu_admin.p
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="back"
+                >
+                  <span>
+                    lease_choose
+                  </span>
+                </div>
+                <div
+                  class="whole"
+                >
+                  sulu_admin.please_choose
+                </div>
               </div>
-              <div
-                aria-hidden="true"
-                class="back"
-              >
-                <span>
-                  lease_choose
-                </span>
-              </div>
-              <div
-                class="whole"
-              >
-                sulu_admin.please_choose
-              </div>
-            </div>
+              <span
+                aria-label="su-angle-down"
+                class="su-angle-down toggle"
+              />
+            </button>
+          </div>
+        </span>
+        <div
+          class="loader"
+        />
+        <span>
+          sulu_admin.page:
+        </span>
+        <span
+          class="inputContainer"
+        >
+          <div
+            class="input dark center"
+          >
+            <input
+              inputmode="numeric"
+              type="text"
+              value=""
+            />
+          </div>
+        </span>
+        <span
+          class="display"
+        >
+          sulu_admin.of 
+        </span>
+        <div
+          class="buttonGroup"
+        >
+          <button
+            class="button icon button"
+            disabled=""
+            type="button"
+          >
             <span
-              aria-label="su-angle-down"
-              class="su-angle-down toggle"
+              aria-label="su-angle-left"
+              class="su-angle-left buttonIcon"
+            />
+          </button>
+          <button
+            class="button icon button"
+            disabled=""
+            type="button"
+          >
+            <span
+              aria-label="su-angle-right"
+              class="su-angle-right buttonIcon"
             />
           </button>
         </div>
-      </span>
-      <div
-        class="loader"
-      />
-      <span>
-        sulu_admin.page:
-      </span>
-      <span
-        class="inputContainer"
-      >
-        <div
-          class="input dark center"
-        >
-          <input
-            inputmode="numeric"
-            type="text"
-            value=""
-          />
-        </div>
-      </span>
-      <span
-        class="display"
-      >
-        sulu_admin.of 
-      </span>
-      <div
-        class="buttonGroup"
-      >
-        <button
-          class="button icon button"
-          disabled=""
-          type="button"
-        >
-          <span
-            aria-label="su-angle-left"
-            class="su-angle-left buttonIcon"
-          />
-        </button>
-        <button
-          class="button icon button"
-          disabled=""
-          type="button"
-        >
-          <span
-            aria-label="su-angle-right"
-            class="su-angle-right buttonIcon"
-          />
-        </button>
-      </div>
-    </nav>
-  </section>
+      </nav>
+    </section>
+  </div>
 </div>
 `;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #7389 
| Related issues/PRs | #7228
| License | MIT
| Documentation PR | --

#### What's in this PR?

Moves the pagination styles introduced in #7228 from [`Pagination`](https://github.com/sulu/sulu/blob/9ae2daafbc7221b601b32ddba583b755ef258d1e/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/Pagination.js) to [`Search`](https://github.com/sulu/sulu/blob/9ae2daafbc7221b601b32ddba583b755ef258d1e/src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/Search.js).

#### Why?

Limiting width of the search results container inadvertently broke the container width for all lists with pagination. That led to lists being a variable width instead of automatically expanding to 100%.