### PR TITLE
Using `tagged_iterator`s for the markup listener

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -13,6 +13,7 @@ Deprecated compiler passes:
 * `Sulu\Bundle\CoreBundle\DependencyInjection\Compiler\RegisterLocalizationProvidersPass` (`sulu.localization_provider`) `tagged_iterator`
 * `Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\AddAdminPass` (`sulu.admin`) `tagged_iterator`
 * `Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\AddMetadataProvider` (`sulu_admin.property_metadata_mapper`) `tagged_locator`
+* `Sulu\Bundle\MarkupBundle\DependencyInjection\CompilerPass\ParserCompilerPass` -> `tagged_locator`
 * `Sulu\Bundle\MediaBundle\DependencyInjection\ImageTransformationCompilerPass` (`sulu_media.image.transformation`) `tagged_locator`
 
 ## 2.6.11

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -24877,12 +24877,6 @@ parameters:
 			path: src/Sulu/Bundle/MarkupBundle/Listener/MarkupListener.php
 
 		-
-			message: '#^Parameter \#1 \$key of function array_key_exists expects int\|string, string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MarkupBundle/Listener/MarkupListener.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\MarkupBundle\\Markup\\HtmlMarkupParser\:\:validate\(\) should return array\<string, string\> but returns array\.$#'
 			identifier: return.type
 			count: 1
@@ -25157,12 +25151,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/MarkupBundle/Tag/TagRegistry.php
-
-		-
-			message: '#^Class Sulu\\Bundle\\MarkupBundle\\Listener\\MarkupListener constructor invoked with 2 parameters, 1 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: src/Sulu/Bundle/MarkupBundle/Tests/Unit/Listener/MarkupListenerTest.php
 
 		-
 			message: '#^Binary operation "\." between ''\<html\>\<body\>'' and mixed results in an error\.$#'

--- a/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/ParserCompilerPass.php
+++ b/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/ParserCompilerPass.php
@@ -17,6 +17,10 @@ use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * Collects all parsers for markup.
+ *
+ * @internal
+ *
+ * @deprecated since version 2.6 and will be removed in 3.0. Use tagged_iterator instead.
  */
 class ParserCompilerPass implements CompilerPassInterface
 {

--- a/src/Sulu/Bundle/MarkupBundle/Listener/MarkupListener.php
+++ b/src/Sulu/Bundle/MarkupBundle/Listener/MarkupListener.php
@@ -22,10 +22,16 @@ use Symfony\Component\HttpKernel\KernelEvents;
 class MarkupListener implements EventSubscriberInterface
 {
     /**
-     * @param array<string, MarkupParserInterface> $markupParser
+     * @var array<string, MarkupParserInterface>
      */
-    public function __construct(private array $markupParser)
+    private array $markupParser;
+
+    /**
+     * @param iterable<string, MarkupParserInterface> $markupParser
+     */
+    public function __construct(iterable $markupParser)
     {
+        $this->markupParser = [...$markupParser];
     }
 
     public static function getSubscribedEvents(): array

--- a/src/Sulu/Bundle/MarkupBundle/Listener/MarkupListener.php
+++ b/src/Sulu/Bundle/MarkupBundle/Listener/MarkupListener.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\MarkupBundle\Listener;
 
+use Psr\Container\ContainerInterface;
 use Sulu\Bundle\MarkupBundle\Markup\MarkupParserInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
@@ -21,17 +22,8 @@ use Symfony\Component\HttpKernel\KernelEvents;
  */
 class MarkupListener implements EventSubscriberInterface
 {
-    /**
-     * @var array<string, MarkupParserInterface>
-     */
-    private array $markupParser;
-
-    /**
-     * @param iterable<string, MarkupParserInterface> $markupParser
-     */
-    public function __construct(iterable $markupParser)
+    public function __construct(private ContainerInterface $markupParser)
     {
-        $this->markupParser = [...$markupParser];
     }
 
     public static function getSubscribedEvents(): array
@@ -46,15 +38,19 @@ class MarkupListener implements EventSubscriberInterface
     {
         $request = $event->getRequest();
         $response = $event->getResponse();
+
+        /** @var string $format */
         $format = $request->getRequestFormat();
+
         $content = $response->getContent();
 
-        if (!$content || !\array_key_exists($format, $this->markupParser)) {
+        if (!$content || !$this->markupParser->has($format)) {
             return;
         }
 
-        $response->setContent(
-            $this->markupParser[$format]->parse($content, $request->getLocale())
-        );
+        /** @var MarkupParserInterface $markupParser */
+        $markupParser = $this->markupParser->get($format);
+
+        $response->setContent($markupParser->parse($content, $request->getLocale()));
     }
 }

--- a/src/Sulu/Bundle/MarkupBundle/Listener/MarkupListener.php
+++ b/src/Sulu/Bundle/MarkupBundle/Listener/MarkupListener.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\MarkupBundle\Listener;
 
-use Psr\Container\ContainerInterface;
 use Sulu\Bundle\MarkupBundle\Markup\MarkupParserInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
@@ -22,8 +21,17 @@ use Symfony\Component\HttpKernel\KernelEvents;
  */
 class MarkupListener implements EventSubscriberInterface
 {
-    public function __construct(private ContainerInterface $markupParser)
+    /**
+     * @var array<string, MarkupParserInterface>
+     */
+    private array $markupParser;
+
+    /**
+     * @param iterable<string, MarkupParserInterface> $parsers
+     */
+    public function __construct(iterable $parsers)
     {
+        $this->markupParser = [...$parsers];
     }
 
     public static function getSubscribedEvents(): array
@@ -44,12 +52,12 @@ class MarkupListener implements EventSubscriberInterface
 
         $content = $response->getContent();
 
-        if (!$content || !$this->markupParser->has($format)) {
+        if (!$content || !\array_key_exists($format, $this->markupParser)) {
             return;
         }
 
         /** @var MarkupParserInterface $markupParser */
-        $markupParser = $this->markupParser->get($format);
+        $markupParser = $this->markupParser[$format];
 
         $response->setContent($markupParser->parse($content, $request->getLocale()));
     }

--- a/src/Sulu/Bundle/MarkupBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MarkupBundle/Resources/config/services.xml
@@ -25,7 +25,7 @@
         </service>
 
         <service id="sulu_markup.response_listener" class="Sulu\Bundle\MarkupBundle\Listener\MarkupListener">
-            <argument type="collection"/>
+            <argument type="tagged_iterator" tag="sulu_markup.parser" index-by="type" />
 
             <tag name="kernel.event_subscriber"/>
         </service>

--- a/src/Sulu/Bundle/MarkupBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MarkupBundle/Resources/config/services.xml
@@ -25,7 +25,7 @@
         </service>
 
         <service id="sulu_markup.response_listener" class="Sulu\Bundle\MarkupBundle\Listener\MarkupListener">
-            <argument type="tagged_iterator" tag="sulu_markup.parser" index-by="type" />
+            <argument type="tagged_locator" tag="sulu_markup.parser" index-by="type" />
 
             <tag name="kernel.event_subscriber"/>
         </service>

--- a/src/Sulu/Bundle/MarkupBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MarkupBundle/Resources/config/services.xml
@@ -25,7 +25,7 @@
         </service>
 
         <service id="sulu_markup.response_listener" class="Sulu\Bundle\MarkupBundle\Listener\MarkupListener">
-            <argument type="tagged_locator" tag="sulu_markup.parser" index-by="type" />
+            <argument type="tagged_iterator" tag="sulu_markup.parser" index-by="type" />
 
             <tag name="kernel.event_subscriber"/>
         </service>

--- a/src/Sulu/Bundle/MarkupBundle/SuluMarkupBundle.php
+++ b/src/Sulu/Bundle/MarkupBundle/SuluMarkupBundle.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\MarkupBundle;
 
-use Sulu\Bundle\MarkupBundle\DependencyInjection\CompilerPass\ParserCompilerPass;
 use Sulu\Bundle\MarkupBundle\DependencyInjection\CompilerPass\TagCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -30,7 +29,6 @@ class SuluMarkupBundle extends Bundle
     {
         parent::build($container);
 
-        $container->addCompilerPass(new ParserCompilerPass());
         $container->addCompilerPass(new TagCompilerPass());
     }
 }

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Listener/MarkupListenerTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Listener/MarkupListenerTest.php
@@ -72,7 +72,7 @@ class MarkupListenerTest extends TestCase
             $this->response->reveal()
         );
 
-        $this->listener = new MarkupListener(['html' => $this->markupParser->reveal()], ['text/html' => 'html']);
+        $this->listener = new MarkupListener(['html' => $this->markupParser->reveal()]);
     }
 
     public function testReplaceMarkup(): void

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Listener/MarkupListenerTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Listener/MarkupListenerTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
-use Psr\Container\ContainerInterface;
 use Sulu\Bundle\MarkupBundle\Listener\MarkupListener;
 use Sulu\Bundle\MarkupBundle\Markup\MarkupParserInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -73,34 +72,7 @@ class MarkupListenerTest extends TestCase
             $this->response->reveal()
         );
 
-        $container = new class([
-            'html' => $this->markupParser->reveal(),
-        ]) implements ContainerInterface {
-            /**
-             * @param array<string,object> $services
-             */
-            public function __construct(private array $services)
-            {
-            }
-
-            /**
-             * @param string $id
-             */
-            public function get($id)
-            {
-                return $this->services[$id];
-            }
-
-            /**
-             * @param string $id
-             */
-            public function has($id): bool
-            {
-                return \array_key_exists($id, $this->services);
-            }
-        };
-
-        $this->listener = new MarkupListener($container);
+        $this->listener = new MarkupListener(['html' => $this->markupParser->reveal()]);
     }
 
     public function testReplaceMarkup(): void

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Listener/MarkupListenerTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Listener/MarkupListenerTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Container\ContainerInterface;
 use Sulu\Bundle\MarkupBundle\Listener\MarkupListener;
 use Sulu\Bundle\MarkupBundle\Markup\MarkupParserInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -72,7 +73,34 @@ class MarkupListenerTest extends TestCase
             $this->response->reveal()
         );
 
-        $this->listener = new MarkupListener(['html' => $this->markupParser->reveal()]);
+        $container = new class([
+            'html' => $this->markupParser->reveal(),
+        ]) implements ContainerInterface {
+            /**
+             * @param array<string,object> $services
+             */
+            public function __construct(private array $services)
+            {
+            }
+
+            /**
+             * @param string $id
+             */
+            public function get($id)
+            {
+                return $this->services[$id];
+            }
+
+            /**
+             * @param string $id
+             */
+            public function has($id): bool
+            {
+                return \array_key_exists($id, $this->services);
+            }
+        };
+
+        $this->listener = new MarkupListener($container);
     }
 
     public function testReplaceMarkup(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | -
| Related issues/PRs | #7402 
| License | MIT
| Documentation PR | -

#### What's in this PR?
Using the tagged iterator concept to reduce the amount of code that sulu has to create.

#### Why?
See linked issue.

#### Example Usage
```xml
<argument type="tagged_iterator" tag="testing" />
```

More info on [Symfony Tagged Services](https://symfony.com/doc/current/service_container/tags.html)

#### To Do

- [x] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md

<!--

Dear Contributors,

Thank you for contributing to the Sulu ecosystem!

We appreciate your effort to improve our project.  
If you need assistance or have questions about your pull request, our team is here to help.  
Please join our Slack channel for support: https://sulu.io/services/support#chat.

Best Regards, 
The Sulu Core Team

-->
