### PR TITLE
Using `tagged_iterator` for RuleCollections

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -7,7 +7,8 @@
 Deprecated compiler passes:
 
 * `Sulu\Bundle\SecurityBundle\DependencyInjection\Compiler\AccessControlProviderPass` -> `tagged_iterator`
-* `Sulu\Bundle\MediaBundle\DependencyInjection\FormatCacheClearerCompilerPass` (sulu_media.format_cache)
+* `Sulu\Bundle\MediaBundle\DependencyInjection\FormatCacheClearerCompilerPass` (`sulu_media.format_cache`)
+* `Sulu\Bundle\AudienceTargetingBundle\DependencyInjection\Compiler\AddRulesPass` -> (`sulu.audience_target_rule`) `tagged_iterator`
 
 ## 2.6.11
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/DependencyInjection/Compiler/AddRulesPass.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/DependencyInjection/Compiler/AddRulesPass.php
@@ -15,6 +15,11 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
+/**
+ * @internal
+ *
+ * @deprecated since version 2.3, to be removed in 3.0. Use a tagged iterator instead.
+ */
 class AddRulesPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/services.xml
@@ -72,7 +72,7 @@
         </service>
         <service id="sulu_audience_targeting.rules_collection"
                  class="Sulu\Bundle\AudienceTargetingBundle\Rule\RuleCollection">
-            <argument type="collection"></argument>
+            <argument type="tagged_iterator" tag="sulu.audience_target_rule" index-by="alias" />
         </service>
         <service id="sulu_audience_targeting.rules.locale"
                  class="Sulu\Bundle\AudienceTargetingBundle\Rule\LocaleRule">

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Rule/RuleCollection.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Rule/RuleCollection.php
@@ -17,13 +17,16 @@ namespace Sulu\Bundle\AudienceTargetingBundle\Rule;
 class RuleCollection implements RuleCollectionInterface
 {
     /**
-     * @var RuleInterface[]
+     * @var array<string, RuleInterface>
      */
     private $rules;
 
-    public function __construct(array $rules)
+    /**
+     * @param iterable<string, RuleInterface> $rules
+     */
+    public function __construct(iterable $rules)
     {
-        $this->rules = $rules;
+        $this->rules = [...$rules];
     }
 
     public function getRule($name)

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Rule/RuleCollectionInterface.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Rule/RuleCollectionInterface.php
@@ -27,7 +27,7 @@ interface RuleCollectionInterface
     /**
      * Returns all available rules.
      *
-     * @return RuleInterface[]
+     * @return array<string, RuleInterface>
      */
     public function getRules();
 }

--- a/src/Sulu/Bundle/AudienceTargetingBundle/SuluAudienceTargetingBundle.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/SuluAudienceTargetingBundle.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\AudienceTargetingBundle;
 
-use Sulu\Bundle\AudienceTargetingBundle\DependencyInjection\Compiler\AddRulesPass;
 use Sulu\Bundle\AudienceTargetingBundle\DependencyInjection\Compiler\DeviceDetectorCachePass;
 use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupConditionInterface;
 use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupInterface;
@@ -46,7 +45,6 @@ class SuluAudienceTargetingBundle extends Bundle
             $container
         );
 
-        $container->addCompilerPass(new AddRulesPass());
         $container->addCompilerPass(new DeviceDetectorCachePass());
     }
 }

--- a/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/TagCompilerPass.php
+++ b/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/TagCompilerPass.php
@@ -40,8 +40,7 @@ class TagCompilerPass implements CompilerPassInterface
         foreach ($container->findTaggedServiceIds(self::TAG_NAME) as $id => $tags) {
             foreach ($tags as $attributes) {
                 $type = $attributes[self::TYPE_ATTRIBUTE];
-                $namespace = \array_key_exists(self::NAMESPACE_ATTRIBUTE, $attributes)
-                    ? $attributes[self::NAMESPACE_ATTRIBUTE] : 'sulu';
+                $namespace = $attributes[self::NAMESPACE_ATTRIBUTE] ?? 'sulu';
                 $tag = $attributes[self::TAG_ATTRIBUTE];
 
                 if (!\array_key_exists($type, $references)) {

--- a/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/TagCompilerPass.php
+++ b/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/TagCompilerPass.php
@@ -40,7 +40,8 @@ class TagCompilerPass implements CompilerPassInterface
         foreach ($container->findTaggedServiceIds(self::TAG_NAME) as $id => $tags) {
             foreach ($tags as $attributes) {
                 $type = $attributes[self::TYPE_ATTRIBUTE];
-                $namespace = $attributes[self::NAMESPACE_ATTRIBUTE] ?? 'sulu';
+                $namespace = \array_key_exists(self::NAMESPACE_ATTRIBUTE, $attributes)
+                    ? $attributes[self::NAMESPACE_ATTRIBUTE] : 'sulu';
                 $tag = $attributes[self::TAG_ATTRIBUTE];
 
                 if (!\array_key_exists($type, $references)) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | -
| Related issues/PRs | #7402 
| License | MIT
| Documentation PR | -
#### What's in this PR?
Using the tagged iterator concept to reduce the amount of code that sulu has to create.

#### Why?
See linked issue.

#### Example Usage
```xml
<argument type="tagged_iterator" tag="testing" />
```

More info on [Symfony Tagged Services](https://gitlab.dev-b24.de/sylius/sylius/-/merge_requests/2094)
