### PR TITLE
Refactor phpunit dataprovider to be static

### DIFF
--- a/src/Sulu/Bundle/ActivityBundle/Tests/Functional/UserInterface/Controller/ActivityControllerTest.php
+++ b/src/Sulu/Bundle/ActivityBundle/Tests/Functional/UserInterface/Controller/ActivityControllerTest.php
@@ -87,7 +87,7 @@ class ActivityControllerTest extends SuluTestCase
     /**
      * @return \Generator<mixed[]>
      */
-    public function provideCgetAction(): \Generator
+    public static function provideCgetAction(): \Generator
     {
         yield [
             [],

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormOverlayListViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormOverlayListViewBuilderTest.php
@@ -51,7 +51,7 @@ class FormOverlayListViewBuilderTest extends TestCase
             ->getView();
     }
 
-    public function provideBuildFormOverlayListView()
+    public static function provideBuildFormOverlayListView()
     {
         return [
             [

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormViewBuilderTest.php
@@ -37,7 +37,7 @@ class FormViewBuilderTest extends TestCase
             ->getView();
     }
 
-    public function provideBuildFormView()
+    public static function provideBuildFormView()
     {
         return [
             [

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ListViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ListViewBuilderTest.php
@@ -52,7 +52,7 @@ class ListViewBuilderTest extends TestCase
             ->getView();
     }
 
-    public function provideBuildListView()
+    public static function provideBuildListView()
     {
         return [
             [

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/PreviewFormViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/PreviewFormViewBuilderTest.php
@@ -37,7 +37,7 @@ class PreviewFormViewBuilderTest extends TestCase
             ->getView();
     }
 
-    public function provideBuildPreviewFormView()
+    public static function provideBuildPreviewFormView()
     {
         return [
             [

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ResourceTabViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ResourceTabViewBuilderTest.php
@@ -34,7 +34,7 @@ class ResourceTabViewBuilderTest extends TestCase
             ->getView();
     }
 
-    public function provideBuildResourceTabView()
+    public static function provideBuildResourceTabView()
     {
         return [
             [

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/TabViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/TabViewBuilderTest.php
@@ -23,7 +23,7 @@ class TabViewBuilderTest extends TestCase
         $this->assertNotSame($viewBuilder->getView(), $viewBuilder->getView());
     }
 
-    public function provideBuildTabView()
+    public static function provideBuildTabView()
     {
         return [
             [

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ViewBuilderTest.php
@@ -17,7 +17,7 @@ use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilder;
 
 class ViewBuilderTest extends TestCase
 {
-    public function provideBuildView()
+    public static function provideBuildView()
     {
         return [
             [

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
@@ -342,7 +342,7 @@ class AdminControllerTest extends TestCase
         $this->adminController->metadataAction('form', 'pages', $request);
     }
 
-    public function provideTranslationsAction()
+    public static function provideTranslationsAction()
     {
         return [
             [

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Entity/CollaborationRepositoryTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Entity/CollaborationRepositoryTest.php
@@ -99,7 +99,7 @@ class CollaborationRepositoryTest extends TestCase
         $this->assertNull($result);
     }
 
-    public function provideUpdate()
+    public static function provideUpdate()
     {
         return [
             [

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/ArrayMetadataTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/ArrayMetadataTest.php
@@ -18,7 +18,7 @@ use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
 
 class ArrayMetadataTest extends TestCase
 {
-    public function provideToJsonSchema()
+    public static function provideToJsonSchema()
     {
         return [
             [

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/ConstMetadataTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/ConstMetadataTest.php
@@ -16,7 +16,7 @@ use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\ConstMetadata;
 
 class ConstMetadataTest extends TestCase
 {
-    public function provideToJsonSchema()
+    public static function provideToJsonSchema()
     {
         return [
             ['Homepage', ['const' => 'Homepage']],

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/PropertyMetadataTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/PropertyMetadataTest.php
@@ -18,7 +18,7 @@ use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\StringMetadata;
 
 class PropertyMetadataTest extends TestCase
 {
-    public function provideGetter()
+    public static function provideGetter()
     {
         return [
             ['title', true],
@@ -36,7 +36,7 @@ class PropertyMetadataTest extends TestCase
         $this->assertEquals($mandatory, $property->isMandatory());
     }
 
-    public function provideToJsonSchema()
+    public static function provideToJsonSchema()
     {
         return [
             ['title', false, null, null],

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Controller/TargetGroupEvaluationControllerTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Controller/TargetGroupEvaluationControllerTest.php
@@ -82,7 +82,7 @@ class TargetGroupEvaluationControllerTest extends TestCase
         $this->assertEquals($targetGroupId, $response->headers->get($header));
     }
 
-    public function provideTargetGroup()
+    public static function provideTargetGroup()
     {
         $targetGroup1 = new TargetGroup();
 
@@ -128,7 +128,7 @@ class TargetGroupEvaluationControllerTest extends TestCase
         $targetGroupEvaluationController->targetGroupHitAction();
     }
 
-    public function provideTargetGroupHit()
+    public static function provideTargetGroupHit()
     {
         $oldTargetGroup1 = new TargetGroup();
         self::setPrivateProperty($oldTargetGroup1, 'id', 1);

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
@@ -141,7 +141,7 @@ class TargetGroupSubscriberTest extends TestCase
         $targetGroupSubscriber->setTargetGroup($event);
     }
 
-    public function provideSetTargetGroupFromHeader()
+    public static function provideSetTargetGroupFromHeader()
     {
         return [
             ['X-Sulu-Target-Group', '1', '1'],
@@ -209,7 +209,7 @@ class TargetGroupSubscriberTest extends TestCase
         $targetGroupSubscriber->setTargetGroup($event);
     }
 
-    public function provideSetTargetGroupFromCookie()
+    public static function provideSetTargetGroupFromCookie()
     {
         return [
             ['sulu-visitor-target-group', 'visitor-session', '1', true, null, '1', false],
@@ -253,7 +253,7 @@ class TargetGroupSubscriberTest extends TestCase
         $this->assertCount(0, $request->headers->all());
     }
 
-    public function provideSetTargetGroupFromEvaluation()
+    public static function provideSetTargetGroupFromEvaluation()
     {
         $targetGroup1 = new TargetGroup();
         self::setPrivateProperty($targetGroup1, 'id', 1);
@@ -328,7 +328,7 @@ class TargetGroupSubscriberTest extends TestCase
         $this->assertEquals($varyHeaders, $response->getVary());
     }
 
-    public function provideAddVaryHeader()
+    public static function provideAddVaryHeader()
     {
         return [
             ['/_target_group', '/test', true, 'X-Sulu-Target-Group-Hash', ['X-Sulu-Target-Group-Hash']],
@@ -381,7 +381,7 @@ class TargetGroupSubscriberTest extends TestCase
         }
     }
 
-    public function provideAddSetCookieHeader()
+    public static function provideAddSetCookieHeader()
     {
         return [
             ['sulu-visitor-target-group', 'visitor-session', false, '/_target_group_hit', null],
@@ -441,7 +441,7 @@ class TargetGroupSubscriberTest extends TestCase
         $this->assertEquals('<body><script></script></body>', $response->getContent());
     }
 
-    public function provideAddTargetGroupHitScript()
+    public static function provideAddTargetGroupHitScript()
     {
         return [
             ['/_target_group_hit', 'X-Forwarded-URL', 'X-Fowarded-Referer', 'X-Forwarded-UUID', 'some-uuid'],

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Request/ForwardedUrlRequestProcessorTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Request/ForwardedUrlRequestProcessorTest.php
@@ -33,7 +33,7 @@ class ForwardedUrlRequestProcessorTest extends TestCase
         $this->assertEquals($path, $requestAttributes->getAttribute('path'));
     }
 
-    public function provideProcess()
+    public static function provideProcess()
     {
         return [
             ['X-Forwarded-Url', 'http://127.0.0.1:8000/en/test', '127.0.0.1', 8000, '/en/test'],

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/BrowserRuleTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/BrowserRuleTest.php
@@ -53,7 +53,7 @@ class BrowserRuleTest extends TestCase
         $this->assertEquals($result, $this->browserRule->evaluate($options));
     }
 
-    public function provideEvaluate()
+    public static function provideEvaluate()
     {
         return [
             ['CH', ['browser' => 'Chrome'], true],

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/DeviceTypeRuleTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/DeviceTypeRuleTest.php
@@ -56,7 +56,7 @@ class DeviceTypeRuleTest extends TestCase
         $this->assertSame($result, $this->deviceTypeRule->evaluate($options));
     }
 
-    public function provideEvaluate()
+    public static function provideEvaluate()
     {
         return [
             [null, ['device_type' => DeviceTypeRule::DESKTOP], false],

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/LocaleRuleTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/LocaleRuleTest.php
@@ -62,7 +62,7 @@ class LocaleRuleTest extends TestCase
         $this->assertEquals($result, $this->localeRule->evaluate($options));
     }
 
-    public function provideEvaluationData()
+    public static function provideEvaluationData()
     {
         return [
             [['de'], ['locale' => 'de'], true],

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/OperatingSystemRuleTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/OperatingSystemRuleTest.php
@@ -53,7 +53,7 @@ class OperatingSystemRuleTest extends TestCase
         $this->assertEquals($result, $this->operatingSystemRule->evaluate($options));
     }
 
-    public function provideEvaluate()
+    public static function provideEvaluate()
     {
         return [
             ['LIN', ['os' => 'GNU/Linux'], true],

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/QueryStringRuleTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/QueryStringRuleTest.php
@@ -52,7 +52,7 @@ class QueryStringRuleTest extends TestCase
         $this->assertEquals($result, $queryStringRule->evaluate($options));
     }
 
-    public function provideEvaluate()
+    public static function provideEvaluate()
     {
         return [
             [

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/ReferrerRuleTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/ReferrerRuleTest.php
@@ -61,7 +61,7 @@ class ReferrerRuleTest extends TestCase
         $this->assertEquals($result, $referrerRule->evaluate($options));
     }
 
-    public function provideEvaluationData()
+    public static function provideEvaluationData()
     {
         return [
             [null, 'https://www.google.com/test', ['referrer' => 'https://www.google.com/*'], true],

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/TargetGroupEvaluatorTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/TargetGroupEvaluatorTest.php
@@ -99,7 +99,7 @@ class TargetGroupEvaluatorTest extends TestCase
         $this->assertEquals($evaluatedTargetGroup, $this->targetGroupEvaluator->evaluate($frequency, $currentTargetGroup));
     }
 
-    public function provideEvaluationData()
+    public static function provideEvaluationData()
     {
         $targetGroup1 = new TargetGroup();
 

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Category/KeywordManagerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Category/KeywordManagerTest.php
@@ -30,7 +30,7 @@ class KeywordManagerTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function provideSaveData()
+    public static function provideSaveData()
     {
         return [
             [],
@@ -154,7 +154,7 @@ class KeywordManagerTest extends TestCase
         $this->assertEquals($keyword->reveal(), $result);
     }
 
-    public function provideDeleteData()
+    public static function provideDeleteData()
     {
         return [
             [],

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Twig/CategoryTwigExtensionTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Twig/CategoryTwigExtensionTest.php
@@ -76,7 +76,7 @@ class CategoryTwigExtensionTest extends TestCase
     /**
      * @return array<array{0:array<mixed>, 1?:string, 2?:string, 3?:int}>
      */
-    public function getProvider(): array
+    public static function getProvider(): array
     {
         return [
             [[]],
@@ -135,7 +135,7 @@ class CategoryTwigExtensionTest extends TestCase
     /**
      * @return array<array{string, string, string, string}>
      */
-    public function appendProvider(): array
+    public static function appendProvider(): array
     {
         return [
             ['c', '/test', '1,2', '1,2,3'],
@@ -207,7 +207,7 @@ class CategoryTwigExtensionTest extends TestCase
     /**
      * @return array<array{string, string, string, string}>
      */
-    public function setProvider(): array
+    public static function setProvider(): array
     {
         return [
             ['c', '/test', '1,2', '3'],
@@ -253,7 +253,7 @@ class CategoryTwigExtensionTest extends TestCase
     }
 
     /** @return array<array{string, string, string}> */
-    public function clearProvider(): array
+    public static function clearProvider(): array
     {
         return [
             ['c', '/test', '1,2'],

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/CacheInvalidationListenerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/CacheInvalidationListenerTest.php
@@ -45,7 +45,7 @@ class CacheInvalidationListenerTest extends TestCase
         $this->listener = new CacheInvalidationListener($this->cacheManager->reveal());
     }
 
-    public function provideData()
+    public static function provideData()
     {
         return [
             [ContactInterface::class, 'contact'],
@@ -123,7 +123,7 @@ class CacheInvalidationListenerTest extends TestCase
         $this->listener->preRemove($eventArgs->reveal());
     }
 
-    public function provideDataWithTagsAndCategories()
+    public static function provideDataWithTagsAndCategories()
     {
         return [
             [ContactInterface::class, 'contact'],

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/CustomerIdConverterTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/CustomerIdConverterTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class CustomerIdConverterTest extends TestCase
 {
-    public function convertIdsToGroupedIdsProvider()
+    public static function convertIdsToGroupedIdsProvider()
     {
         return [
             [[], [], []],
@@ -40,7 +40,7 @@ class CustomerIdConverterTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function convertGroupedIdsToIdsProvider()
+    public static function convertGroupedIdsToIdsProvider()
     {
         return [
             [[], []],

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/IndexComparatorTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/IndexComparatorTest.php
@@ -18,7 +18,7 @@ class IndexComparatorTest extends TestCase
     /**
      * @return array
      */
-    public function usortProvider()
+    public static function usortProvider()
     {
         return [
             [[5, 4, 3, 1, 2], [1, 2, 3, 4, 5], [1, 2, 3, 4, 5], []],

--- a/src/Sulu/Bundle/CoreBundle/Tests/Unit/DependencyInjection/Compiler/ListBuilderMetadataProviderCompilerPassTest.php
+++ b/src/Sulu/Bundle/CoreBundle/Tests/Unit/DependencyInjection/Compiler/ListBuilderMetadataProviderCompilerPassTest.php
@@ -23,7 +23,7 @@ class ListBuilderMetadataProviderCompilerPassTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function dataProcessProvider()
+    public static function dataProcessProvider()
     {
         return [
             [false],

--- a/src/Sulu/Bundle/CoreBundle/Tests/Unit/DependencyInjection/Compiler/RemoveForeignContextServicesPassTest.php
+++ b/src/Sulu/Bundle/CoreBundle/Tests/Unit/DependencyInjection/Compiler/RemoveForeignContextServicesPassTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\Definition;
 
 class RemoveForeignContextServicesPassTest extends AbstractCompilerPassTestCase
 {
-    public function provideWebsiteServices()
+    public static function provideWebsiteServices()
     {
         return [
             [

--- a/src/Sulu/Bundle/CoreBundle/Tests/Unit/ReplacerXmlLoaderTest.php
+++ b/src/Sulu/Bundle/CoreBundle/Tests/Unit/ReplacerXmlLoaderTest.php
@@ -49,7 +49,7 @@ class ReplacerXmlLoaderTest extends TestCase
         );
     }
 
-    public function examplesDataProvider()
+    public static function examplesDataProvider()
     {
         return [
             ['default', ' ', '-'],

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Functional/Controller/CustomUrlControllerTest.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Functional/Controller/CustomUrlControllerTest.php
@@ -57,7 +57,7 @@ class CustomUrlControllerTest extends SuluTestCase
         $this->contentDocument = $this->documentManager->find('/cmf/sulu_io/contents', 'en');
     }
 
-    public function postProvider()
+    public static function postProvider()
     {
         return [
             [
@@ -168,7 +168,7 @@ class CustomUrlControllerTest extends SuluTestCase
         return $responseData['id'];
     }
 
-    public function postMultipleProvider()
+    public static function postMultipleProvider()
     {
         return [
             [
@@ -271,7 +271,7 @@ class CustomUrlControllerTest extends SuluTestCase
         $this->testPost($data, $url, $statusCode, $restErrorCode);
     }
 
-    public function putProvider()
+    public static function putProvider()
     {
         return [
             [
@@ -558,7 +558,7 @@ class CustomUrlControllerTest extends SuluTestCase
         return $responseData['id'];
     }
 
-    public function getProvider()
+    public static function getProvider()
     {
         return [
             [
@@ -620,7 +620,7 @@ class CustomUrlControllerTest extends SuluTestCase
         $this->assertEquals('sulu_io', $responseData['webspace']);
     }
 
-    public function cgetProvider()
+    public static function cgetProvider()
     {
         return [
             [

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Functional/Controller/CustomUrlRouteControllerTest.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Functional/Controller/CustomUrlRouteControllerTest.php
@@ -35,7 +35,7 @@ class CustomUrlRouteControllerTest extends SuluTestCase
             ->find('/cmf/sulu_io/contents', 'en');
     }
 
-    public function cdeleteRoutesProvider()
+    public static function cdeleteRoutesProvider()
     {
         return [
             [

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/Request/CustomUrlRequestProcessorTest.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/Request/CustomUrlRequestProcessorTest.php
@@ -32,7 +32,7 @@ class CustomUrlRequestProcessorTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function dataProvider()
+    public static function dataProvider()
     {
         return [
             ['sulu.io', '/test', null, 'sulu.io/test', false],

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Bridge/DocumentInspectorTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Bridge/DocumentInspectorTest.php
@@ -135,7 +135,7 @@ class DocumentInspectorTest extends TestCase
         $this->assertEquals($expectedWebspace, $webspace);
     }
 
-    public function provideGetWebspace()
+    public static function provideGetWebspace()
     {
         return [
             ['/cmf/sulu_io/content/articles/article-one', 'sulu_io'],
@@ -284,7 +284,7 @@ class DocumentInspectorTest extends TestCase
         $this->assertEquals($expectedWebspace, $webspace);
     }
 
-    public function provideWebspace()
+    public static function provideWebspace()
     {
         return [
             [

--- a/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/CacheLifetime/CacheLifetimeEnhancerTest.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/CacheLifetime/CacheLifetimeEnhancerTest.php
@@ -93,7 +93,7 @@ class CacheLifetimeEnhancerTest extends TestCase
         );
     }
 
-    public function provideCacheLifeTime()
+    public static function provideCacheLifeTime()
     {
         return [
             [50, null, 50],

--- a/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/CacheLifetime/CacheLifetimeRequestStoreTest.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/CacheLifetime/CacheLifetimeRequestStoreTest.php
@@ -38,7 +38,7 @@ class CacheLifetimeRequestStoreTest extends TestCase
         $this->cacheLifetimeRequestStore = new CacheLifetimeRequestStore($this->requestStack->reveal());
     }
 
-    public function provideSetCacheLifetime()
+    public static function provideSetCacheLifetime()
     {
         return [
             [null, 200, 200],

--- a/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/EventSubscriber/InvalidationSubscriberTest.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/EventSubscriber/InvalidationSubscriberTest.php
@@ -120,7 +120,7 @@ class InvalidationSubscriberTest extends TestCase
         );
     }
 
-    public function provideRequest()
+    public static function provideRequest()
     {
         return [
             [false, 'http'],

--- a/src/Sulu/Bundle/LocationBundle/Tests/Unit/Content/Types/LocationContentTypeTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Unit/Content/Types/LocationContentTypeTest.php
@@ -47,7 +47,7 @@ class LocationContentTypeTest extends TestCase
             ->with($data);
     }
 
-    public function provideRead()
+    public static function provideRead()
     {
         return [
             [

--- a/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/Service/GoogleGeolocatorTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/Service/GoogleGeolocatorTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 
 class GoogleGeolocatorTest extends TestCase
 {
-    public function provideLocate()
+    public static function provideLocate()
     {
         return [
             [

--- a/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/Service/NominatimGeolocatorTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/Service/NominatimGeolocatorTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 
 class NominatimGeolocatorTest extends TestCase
 {
-    public function provideLocate()
+    public static function provideLocate()
     {
         return [
             [

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlTagExtractorTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlTagExtractorTest.php
@@ -16,7 +16,7 @@ use Sulu\Bundle\MarkupBundle\Markup\HtmlTagExtractor;
 
 class HtmlTagExtractorTest extends TestCase
 {
-    public function provideTags()
+    public static function provideTags()
     {
         return [
             ['<sulu-tag/>', 'tag', []],
@@ -50,7 +50,7 @@ class HtmlTagExtractorTest extends TestCase
         $this->assertEquals($result[0]->getTags()[$tag], $attributes);
     }
 
-    public function provideMultipleTags()
+    public static function provideMultipleTags()
     {
         $tags = [
             '<sulu-tag/>',

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
@@ -69,7 +69,7 @@ class LinkTagTest extends TestCase
     /**
      * @return mixed[]
      */
-    public function provideParseData(): array
+    public static function provideParseData(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/CollectionRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/CollectionRepositoryTest.php
@@ -146,7 +146,7 @@ class CollectionRepositoryTest extends SuluTestCase
         }
     }
 
-    public function provideTreeData()
+    public static function provideTreeData()
     {
         return [
             [0, [0, 1, 12, 15, 20]],

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
@@ -642,7 +642,7 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
         }
     }
 
-    public function provideFindByFiltersWithAudienceTargeting()
+    public static function provideFindByFiltersWithAudienceTargeting()
     {
         return [
             [null, [0, 1, 2, 3]],

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/SearchIntegration/SearchIntegrationTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/SearchIntegration/SearchIntegrationTest.php
@@ -62,7 +62,7 @@ class SearchIntegrationTest extends SuluTestCase
     /**
      * @return array<array{string, class-string<\Throwable>|null}>
      */
-    public function provideIndex(): array
+    public static function provideIndex(): array
     {
         return [
             ['sulu-100x100', null],

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/EventListener/CacheInvalidationListenerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/EventListener/CacheInvalidationListenerTest.php
@@ -47,7 +47,7 @@ class CacheInvalidationListenerTest extends TestCase
         $this->listener = new CacheInvalidationListener($this->cacheManager->reveal());
     }
 
-    public function provideFunctionName()
+    public static function provideFunctionName()
     {
         return [
             ['postPersist'],

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Focus/FocusTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Focus/FocusTest.php
@@ -45,7 +45,7 @@ class FocusTest extends TestCase
         $this->focus->focus($image->reveal(), $x, $y, $width, $height);
     }
 
-    public function provideFocus()
+    public static function provideFocus()
     {
         return [
             [800, 800, 0, 0, 400, 400, 0, 0, 800, 800],

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
@@ -534,7 +534,7 @@ class MediaManagerTest extends TestCase
         ];
     }
 
-    public function provideSpecialCharacterFileName()
+    public static function provideSpecialCharacterFileName()
     {
         return [
             ['aäüßa', 'aäüßa', 'aaeuesa', ''],
@@ -542,7 +542,7 @@ class MediaManagerTest extends TestCase
         ];
     }
 
-    public function provideSpecialCharacterUrl()
+    public static function provideSpecialCharacterUrl()
     {
         return [
             [1, 'aäüßa.mp4', 2, '/download/1/media/a%C3%A4%C3%BC%C3%9Fa.mp4?v=2'],

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Mapper/ContentMapperSnippetTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Mapper/ContentMapperSnippetTest.php
@@ -164,7 +164,7 @@ class ContentMapperSnippetTest extends SuluTestCase
         }
     }
 
-    public function provideRemoveSnippetWithReferencesDereference()
+    public static function provideRemoveSnippetWithReferencesDereference()
     {
         return [
             [true],

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Markup/LinkTagTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Markup/LinkTagTest.php
@@ -122,7 +122,7 @@ class LinkTagTest extends TestCase
         $this->linkTag = new LinkTag($this->linkProviderPool);
     }
 
-    public function provideParseDataDefaultProvider()
+    public static function provideParseDataDefaultProvider()
     {
         return [
             [

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/ContentRepositoryTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/ContentRepositoryTest.php
@@ -1017,7 +1017,7 @@ class ContentRepositoryTest extends SuluTestCase
         );
     }
 
-    public function provideWebspaceKeys()
+    public static function provideWebspaceKeys()
     {
         return [['sulu_io'], ['test_io']];
     }

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/SinglePageSelectionTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/SinglePageSelectionTest.php
@@ -49,7 +49,7 @@ class SinglePageSelectionTest extends TestCase
         $this->type = new SinglePageSelection($this->referenceStore->reveal());
     }
 
-    public function providePreResolve()
+    public static function providePreResolve()
     {
         return [
             [

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Rule/PageRuleTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Rule/PageRuleTest.php
@@ -131,7 +131,7 @@ class PageRuleTest extends TestCase
         $this->assertEquals($result, $pageRule->evaluate(['page' => $uuidRule]));
     }
 
-    public function provideEvaluate()
+    public static function provideEvaluate()
     {
         return [
             ['X-Forwarded-UUID', 'some-uuid', 'X-Forwarded-URL', null, null, null, null, 'some-uuid', true, true],

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
@@ -113,7 +113,7 @@ class PreviewRendererTest extends TestCase
         );
     }
 
-    public function portalDataProvider()
+    public static function portalDataProvider()
     {
         return [
             [

--- a/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/SearchControllerTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/SearchControllerTest.php
@@ -58,7 +58,7 @@ class SearchControllerTest extends SuluTestCase
         $this->indexProducts();
     }
 
-    public function provideSearch()
+    public static function provideSearch()
     {
         return [
             [

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Controller/PermissionControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Controller/PermissionControllerTest.php
@@ -84,7 +84,7 @@ class PermissionControllerTest extends TestCase
         );
     }
 
-    public function providePermissionData()
+    public static function providePermissionData()
     {
         return [
             [
@@ -160,7 +160,7 @@ class PermissionControllerTest extends TestCase
         $this->permissionController->cputAction($request);
     }
 
-    public function provideWrongPermissionData()
+    public static function provideWrongPermissionData()
     {
         return [
             [null, null, null],

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/PermissionInheritanceSubscriberTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/PermissionInheritanceSubscriberTest.php
@@ -47,7 +47,7 @@ class PermissionInheritanceSubscriberTest extends TestCase
         );
     }
 
-    public function providePostPersist()
+    public static function providePostPersist()
     {
         return [
             [5, 1, [1 => ['view' => true]]],

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/ContentOnPageTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/ContentOnPageTest.php
@@ -72,7 +72,7 @@ class ContentOnPageTest extends BaseFunctionalTestCase
         $this->documentManager->flush();
     }
 
-    public function provideSaveSnippetPage()
+    public static function provideSaveSnippetPage()
     {
         return [
             [

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
@@ -95,7 +95,7 @@ class SnippetControllerTest extends SuluTestCase
         $this->assertEquals($this->hotel1->getUuid(), $result['id']);
     }
 
-    public function provideGet()
+    public static function provideGet()
     {
         return [
             [
@@ -203,7 +203,7 @@ class SnippetControllerTest extends SuluTestCase
         $this->assertEquals($this->hotel1->getUuid(), $result['id']);
     }
 
-    public function provideIndex()
+    public static function provideIndex()
     {
         return [
             [
@@ -288,7 +288,7 @@ class SnippetControllerTest extends SuluTestCase
         }
     }
 
-    public function providePost()
+    public static function providePost()
     {
         return [
             [

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Snippet/SnippetRepositoryTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Snippet/SnippetRepositoryTest.php
@@ -44,7 +44,7 @@ class SnippetRepositoryTest extends BaseFunctionalTestCase
         $this->phpcrSession = $this->getContainer()->get('doctrine_phpcr')->getConnection();
     }
 
-    public function provideGetSnippets()
+    public static function provideGetSnippets()
     {
         return [
             [
@@ -83,7 +83,7 @@ class SnippetRepositoryTest extends BaseFunctionalTestCase
         }
     }
 
-    public function provideGetSnippetsByUuids()
+    public static function provideGetSnippetsByUuids()
     {
         return [
             [

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
@@ -51,7 +51,7 @@ class SnippetAdminTest extends TestCase
         $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
     }
 
-    public function provideConfigureViews()
+    public static function provideConfigureViews()
     {
         return [
             [['en' => 'en', 'de' => 'de', 'fr' => 'fr']],

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SnippetDataProviderTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SnippetDataProviderTest.php
@@ -242,7 +242,7 @@ class SnippetDataProviderTest extends TestCase
         $this->assertEquals($hasNextPage, $dataProviderResult->getHasNextPage());
     }
 
-    public function provideResolveDataItems()
+    public static function provideResolveDataItems()
     {
         return [
             [['excluded' => null], [], ['webspaceKey' => 'sulu', 'locale' => 'de'], null, 1, null, [], false],
@@ -372,7 +372,7 @@ class SnippetDataProviderTest extends TestCase
         $this->assertEquals(false, $dataProviderResult->getHasNextPage());
     }
 
-    public function provideResolveExcludeDuplicates()
+    public static function provideResolveExcludeDuplicates()
     {
         return [
             [

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/DefaultSnippetManagerTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/DefaultSnippetManagerTest.php
@@ -60,7 +60,7 @@ class DefaultSnippetManagerTest extends TestCase
         ],
     ];
 
-    public function saveDataProvider()
+    public static function saveDataProvider()
     {
         return [
             ['sulu_io', 'de', 'test', 'test', '123-123-123'],
@@ -162,7 +162,7 @@ class DefaultSnippetManagerTest extends TestCase
         $manager->remove('sulu_io', 'test');
     }
 
-    public function loadDataProvider()
+    public static function loadDataProvider()
     {
         return [
             ['sulu_io', 'de', 'test', '123-123-123'],

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
@@ -26,7 +26,7 @@ class SnippetResolverTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function dataProvider()
+    public static function dataProvider()
     {
         return [
             [[]],

--- a/src/Sulu/Bundle/TagBundle/Tests/Unit/Twig/TagTwigExtensionTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Unit/Twig/TagTwigExtensionTest.php
@@ -42,7 +42,7 @@ class TagTwigExtensionTest extends TestCase
         return new Memoize(new ArrayCache(), 0);
     }
 
-    public function getProvider()
+    public static function getProvider()
     {
         return [
             [[]],
@@ -82,7 +82,7 @@ class TagTwigExtensionTest extends TestCase
         $this->assertEquals($tagData, $tagExtension->getTagsFunction());
     }
 
-    public function appendProvider()
+    public static function appendProvider()
     {
         return [
             ['t', '/test', 'Sulu,Core', 'Sulu,Core,Test'],
@@ -125,7 +125,7 @@ class TagTwigExtensionTest extends TestCase
         $this->assertEquals($url . '?' . $tagsParameter . '=' . \urlencode($expected), $result);
     }
 
-    public function setProvider()
+    public static function setProvider()
     {
         return [
             ['t', '/test', 'Sulu,Core', 'Test'],
@@ -168,7 +168,7 @@ class TagTwigExtensionTest extends TestCase
         $this->assertEquals($url . '?' . $tagsParameter . '=' . \urlencode($expected), $result);
     }
 
-    public function clearProvider()
+    public static function clearProvider()
     {
         return [
             ['t', '/test', 'Sulu,Core'],

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Analytics/AnalyticsManagerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Analytics/AnalyticsManagerTest.php
@@ -127,7 +127,7 @@ class AnalyticsManagerTest extends BaseFunctional
         $this->assertEquals('www.sulu.io/{localization}', $domains[0]);
     }
 
-    public function dataProvider()
+    public static function dataProvider()
     {
         return [
             [

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Controller/RedirectControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Controller/RedirectControllerTest.php
@@ -53,7 +53,7 @@ class RedirectControllerTest extends TestCase
         return $request->reveal();
     }
 
-    public function provideRedirectAction()
+    public static function provideRedirectAction()
     {
         return [
             ['http://sulu.lo/articles?foo=bar', 'sulu.lo', 'sulu.lo/en', 'http://sulu.lo/en/articles?foo=bar'],
@@ -87,7 +87,7 @@ class RedirectControllerTest extends TestCase
         $this->assertEquals($expectedTargetUrl, $response->getTargetUrl());
     }
 
-    public function provideRedirectWebspaceAction()
+    public static function provideRedirectWebspaceAction()
     {
         return [
             ['sulu.lo/de', 'http://sulu.lo', 'http://sulu.lo/de'],
@@ -110,7 +110,7 @@ class RedirectControllerTest extends TestCase
         $this->assertEquals($expectedTargetUrl, $response->getTargetUrl());
     }
 
-    public function provideRedirectToRouteAction()
+    public static function provideRedirectToRouteAction()
     {
         return [
             ['', 410],

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/AppendAnalyticsListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/AppendAnalyticsListenerTest.php
@@ -32,7 +32,7 @@ class AppendAnalyticsListenerTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function formatProvider()
+    public static function formatProvider()
     {
         return [['json'], ['xml']];
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/SegmentCacheListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/SegmentCacheListenerTest.php
@@ -33,7 +33,7 @@ class SegmentCacheListenerTests extends TestCase
         $this->segmentCacheListener = new SegmentCacheListener();
     }
 
-    public function providePreHandleCookieValue()
+    public static function providePreHandleCookieValue()
     {
         return [
             ['s'],
@@ -55,7 +55,7 @@ class SegmentCacheListenerTests extends TestCase
         $this->assertEquals($cookieValue, $request->headers->get('X-Sulu-Segment'));
     }
 
-    public function providePostHandleVary()
+    public static function providePostHandleVary()
     {
         return [
             ['X-Something', 60, 120, 120],

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/SegmentSubscriberTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/SegmentSubscriberTest.php
@@ -68,7 +68,7 @@ class SegmentSubscriberTest extends TestCase
         $this->assertEquals([], $response->getVary());
     }
 
-    public function provideAddCookieHeader()
+    public static function provideAddCookieHeader()
     {
         return [
             [['s', 'w'], 's', 's', 'w', null, 0],

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RedirectExceptionSubscriberTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RedirectExceptionSubscriberTest.php
@@ -498,7 +498,7 @@ class RedirectExceptionSubscriberTest extends TestCase
     /**
      * @return mixed[]
      */
-    public function provideResolveData(): array
+    public static function provideResolveData(): array
     {
         return [
             ['http://sulu.lo/articles?foo=bar', 'sulu.lo', 'sulu.lo/en', 'http://sulu.lo/en/articles?foo=bar'],

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/NavigationTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/NavigationTwigExtensionTest.php
@@ -24,7 +24,7 @@ class NavigationTwigExtensionTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function activeElementProvider()
+    public static function activeElementProvider()
     {
         return [
             [false, '/', '/news/item'],

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/Seo/SeoTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/Seo/SeoTwigExtensionTest.php
@@ -152,7 +152,7 @@ class SeoTwigExtensionTest extends TestCase
         $this->seoTwigExtension->renderSeoTags([], [], [], null);
     }
 
-    public function provideSeoData()
+    public static function provideSeoData()
     {
         return [
             [

--- a/src/Sulu/Component/Cache/Tests/Unit/Cache/DataCacheTest.php
+++ b/src/Sulu/Component/Cache/Tests/Unit/Cache/DataCacheTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class DataCacheTest extends TestCase
 {
-    public function provideIsFreshData()
+    public static function provideIsFreshData()
     {
         $tmpFile = \tempnam(\sys_get_temp_dir(), 'sulu-test');
 

--- a/src/Sulu/Component/Category/Tests/Unit/Request/CategoryRequestHandlerTest.php
+++ b/src/Sulu/Component/Category/Tests/Unit/Request/CategoryRequestHandlerTest.php
@@ -22,7 +22,7 @@ class CategoryRequestHandlerTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function getProvider()
+    public static function getProvider()
     {
         return [
             ['c', '', []],
@@ -53,7 +53,7 @@ class CategoryRequestHandlerTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function appendProvider()
+    public static function appendProvider()
     {
         return [
             ['c', '/test', '1,2', '1,2,3'],
@@ -89,7 +89,7 @@ class CategoryRequestHandlerTest extends TestCase
         $this->assertEquals($url . '?' . $parameter . '=' . \urlencode($expected), $result);
     }
 
-    public function removeSingleProvider()
+    public static function removeSingleProvider()
     {
         return [
             ['c', '/test', '1,2,3', '1,2'],
@@ -125,7 +125,7 @@ class CategoryRequestHandlerTest extends TestCase
         $this->assertEquals($url . '?' . $parameter . '=' . \urlencode($expected), $result);
     }
 
-    public function toggleProvider()
+    public static function toggleProvider()
     {
         return [
             ['c', '/test', '1,2', '1,2,3'],
@@ -161,7 +161,7 @@ class CategoryRequestHandlerTest extends TestCase
         $this->assertEquals($url . '?' . $parameter . '=' . \urlencode($expected), $result);
     }
 
-    public function setProvider()
+    public static function setProvider()
     {
         return [
             ['c', '/test', '1,2', '3'],
@@ -197,7 +197,7 @@ class CategoryRequestHandlerTest extends TestCase
         $this->assertEquals($url . '?' . $parameter . '=' . \urlencode($expected), $result);
     }
 
-    public function removeProvider()
+    public static function removeProvider()
     {
         return [
             ['c', '/test', '1,2'],

--- a/src/Sulu/Component/Content/Tests/Unit/Block/BlockPropertyTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Block/BlockPropertyTest.php
@@ -46,7 +46,7 @@ class BlockPropertyTest extends TestCase
         $blockProperty->setValue($data);
     }
 
-    public function provideIsMultiple()
+    public static function provideIsMultiple()
     {
         return [
             [null, null, true],
@@ -81,7 +81,7 @@ class BlockPropertyTest extends TestCase
         $blockProperty->doSetValue($value);
     }
 
-    public function provideSetInvalidValue(): array
+    public static function provideSetInvalidValue(): array
     {
         return [
             'invalid int' => [10, 'Expected block configuration but got "int" at property: "block"'],

--- a/src/Sulu/Component/Content/Tests/Unit/Compat/PropertyTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Compat/PropertyTest.php
@@ -16,7 +16,7 @@ use Sulu\Component\Content\Compat\Property;
 
 class PropertyTest extends TestCase
 {
-    public function provideIsMultipleTest()
+    public static function provideIsMultipleTest()
     {
         return [
             [0, 1, true],

--- a/src/Sulu/Component/Content/Tests/Unit/ContentTypeManagerTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/ContentTypeManagerTest.php
@@ -53,7 +53,7 @@ class ContentTypeManagerTest extends TestCase
         $this->manager->get('invalid.alias');
     }
 
-    public function provideHas()
+    public static function provideHas()
     {
         return [
             ['content_1.alias', true],

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Structure/PropertyValueTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Structure/PropertyValueTest.php
@@ -16,7 +16,7 @@ use Sulu\Component\Content\Document\Structure\PropertyValue;
 
 class PropertyValueTest extends TestCase
 {
-    public function provideOffsetSetData()
+    public static function provideOffsetSetData()
     {
         return [
             [[], 'foo', 'bar', ['foo' => 'bar']],

--- a/src/Sulu/Component/Content/Tests/Unit/Extension/ExtensionManagerTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Extension/ExtensionManagerTest.php
@@ -56,7 +56,7 @@ class ExtensionManagerTest extends TestCase
         };
     }
 
-    public function addProvider()
+    public static function addProvider()
     {
         $instances = [
             self::createExtension('test1'),
@@ -93,7 +93,7 @@ class ExtensionManagerTest extends TestCase
         $this->assertEquals($expected, $manager->getExtensions($type));
     }
 
-    public function hasProvider()
+    public static function hasProvider()
     {
         $instances = [
             self::createExtension('test1'),
@@ -139,7 +139,7 @@ class ExtensionManagerTest extends TestCase
         $this->assertEquals($expected, $manager->hasExtension($type, $name));
     }
 
-    public function getProvider()
+    public static function getProvider()
     {
         $instances = [
             self::createExtension('test1'),
@@ -179,7 +179,7 @@ class ExtensionManagerTest extends TestCase
         $this->assertEquals($expected, $manager->getExtension($type, $name));
     }
 
-    public function getExceptionProvider()
+    public static function getExceptionProvider()
     {
         $instances = [
             self::createExtension('test1'),

--- a/src/Sulu/Component/Content/Tests/Unit/Mapper/Translation/MultipleTranslatedPropertiesTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Mapper/Translation/MultipleTranslatedPropertiesTest.php
@@ -32,7 +32,7 @@ class MultipleTranslatedPropertiesTest extends TestCase
         );
     }
 
-    public function provideGetName()
+    public static function provideGetName()
     {
         return [
             [Structure::TYPE_PAGE, 'foobar', 'i18n:de-foobar'],

--- a/src/Sulu/Component/Content/Tests/Unit/SmartContent/Orm/BaseDataProviderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/SmartContent/Orm/BaseDataProviderTest.php
@@ -46,7 +46,7 @@ class BaseDataProviderTest extends TestCase
         $this->assertEquals([], $provider->getDefaultPropertyParameter());
     }
 
-    public function configurationProvider()
+    public static function configurationProvider()
     {
         return [
             [true, true, true, true, true, []],
@@ -114,7 +114,7 @@ class BaseDataProviderTest extends TestCase
         $this->assertNull($provider->resolveDatasource('', [], []));
     }
 
-    public function filtersProvider()
+    public static function filtersProvider()
     {
         return [
             [

--- a/src/Sulu/Component/Content/Tests/Unit/Types/Block/ScheduleBlockVisitorTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Types/Block/ScheduleBlockVisitorTest.php
@@ -65,7 +65,7 @@ class ScheduleBlockVisitorTest extends TestCase
         $this->assertEquals($blockPropertyType, $this->scheduleBlockVisitor->visit($blockPropertyType));
     }
 
-    public function provideVisit()
+    public static function provideVisit()
     {
         return [
             [

--- a/src/Sulu/Component/CustomUrl/Tests/Functional/Generator/GeneratorTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Functional/Generator/GeneratorTest.php
@@ -19,7 +19,7 @@ use Sulu\Component\Webspace\Url\Replacer;
 
 class GeneratorTest extends TestCase
 {
-    public function provideGenerateData()
+    public static function provideGenerateData()
     {
         $locales = [new Localization('de', 'at'), new Localization('en')];
 

--- a/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/CustomUrlRouteProviderTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/CustomUrlRouteProviderTest.php
@@ -28,7 +28,7 @@ class CustomUrlRouteProviderTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function dataProvider()
+    public static function dataProvider()
     {
         return [
             ['sulu.io', '/test', null, 'sulu.io/test', false],

--- a/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/Enhancers/ContentEnhancerTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/Enhancers/ContentEnhancerTest.php
@@ -28,7 +28,7 @@ class ContentEnhancerTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function enhanceProvider()
+    public static function enhanceProvider()
     {
         return [
             [

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Slugifier/NodeNameSlugifierTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Slugifier/NodeNameSlugifierTest.php
@@ -44,7 +44,7 @@ class NodeNameSlugifierTest extends TestCase
         $this->assertEquals('test-article', $this->nodeNameSlugifier->slugify('Test article'));
     }
 
-    public function provide10eData()
+    public static function provide10eData()
     {
         return [
             ['10e', '10-e'],

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
@@ -82,7 +82,7 @@ class FindSubscriberTest extends TestCase
         $this->doTestFind(['type' => null]);
     }
 
-    public function provideFindWithTypeOrClass()
+    public static function provideFindWithTypeOrClass()
     {
         return [
             ['alias', 'page', false],

--- a/src/Sulu/Component/Hash/Tests/AuditableHasherTest.php
+++ b/src/Sulu/Component/Hash/Tests/AuditableHasherTest.php
@@ -51,7 +51,7 @@ class AuditableHasherTest extends TestCase
         $this->assertSame($this->hasher->hash($object->reveal()), $this->hasher->hash($object->reveal()));
     }
 
-    public function provideDifferentObjects()
+    public static function provideDifferentObjects()
     {
         return [
             [1, 2, new \DateTime('2016-02-05'), new \DateTime('2016-02-04')],

--- a/src/Sulu/Component/Hash/Tests/RequestHashCheckerTest.php
+++ b/src/Sulu/Component/Hash/Tests/RequestHashCheckerTest.php
@@ -39,7 +39,7 @@ class RequestHashCheckerTest extends TestCase
         $this->requestHashChecker = new RequestHashChecker($this->hasher->reveal());
     }
 
-    public function provideCheckHash()
+    public static function provideCheckHash()
     {
         return [
             ['false', 'hash', 'hash', true],

--- a/src/Sulu/Component/Localization/Tests/Unit/LocalizationTest.php
+++ b/src/Sulu/Component/Localization/Tests/Unit/LocalizationTest.php
@@ -51,7 +51,7 @@ class LocalizationTest extends TestCase
         $this->assertEquals('de_AT', $this->localization->getLocale(Localization::LCID));
     }
 
-    public function formatProvider()
+    public static function formatProvider()
     {
         return [
             [Localization::UNDERSCORE],

--- a/src/Sulu/Component/Media/Tests/Unit/SystemCollections/SystemCollectionManagerTest.php
+++ b/src/Sulu/Component/Media/Tests/Unit/SystemCollections/SystemCollectionManagerTest.php
@@ -27,7 +27,7 @@ class SystemCollectionManagerTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function configProvider()
+    public static function configProvider()
     {
         return [
             // existing 1 namespace / 1 collection
@@ -291,7 +291,7 @@ class SystemCollectionManagerTest extends TestCase
         ];
     }
 
-    public function getProvider()
+    public static function getProvider()
     {
         return [
             [
@@ -313,7 +313,7 @@ class SystemCollectionManagerTest extends TestCase
         ];
     }
 
-    public function isProvider()
+    public static function isProvider()
     {
         return [
             [

--- a/src/Sulu/Component/PHPCR/Tests/Unit/PathCleanupTest.php
+++ b/src/Sulu/Component/PHPCR/Tests/Unit/PathCleanupTest.php
@@ -62,7 +62,7 @@ class PathCleanupTest extends TestCase
         $this->assertEquals($b, $clean);
     }
 
-    public function cleanupProvider()
+    public static function cleanupProvider()
     {
         return [
             ['-/aSDf     asdf/äöü-/hello: world\'s', '/asdf-asdf/aeoeue/hello-world-s', 'de'],

--- a/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/OrderByTraitTest.php
+++ b/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/OrderByTraitTest.php
@@ -50,7 +50,7 @@ class OrderByTraitTest extends TestCase
         $this->addOrderByFunction->setAccessible(true);
     }
 
-    public function orderByProvider()
+    public static function orderByProvider()
     {
         return [
             ['user', ['firstName' => 'ASC'], ['user.firstName' => 'ASC']],

--- a/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
+++ b/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
@@ -87,7 +87,7 @@ class TimestampableSubscriberTest extends TestCase
         $this->subscriber->loadClassMetadata($this->loadClassMetadataEvent->reveal());
     }
 
-    public function provideOnPreUpdate()
+    public static function provideOnPreUpdate()
     {
         return [
             [null],

--- a/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/UserBlameSubscriberTest.php
+++ b/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/UserBlameSubscriberTest.php
@@ -126,7 +126,7 @@ class UserBlameSubscriberTest extends TestCase
         $this->subscriber->loadClassMetadata($this->loadClassMetadataEvent->reveal());
     }
 
-    public function provideLifecycle()
+    public static function provideLifecycle()
     {
         return [
             // new entity no user set

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/EncodeAliasTraitTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/EncodeAliasTraitTest.php
@@ -26,7 +26,7 @@ class EncodeAliasTraitTest extends TestCase
         $this->encodeAlias = $this->getMockForTrait(EncodeAliasTrait::class);
     }
 
-    public function encodeAliasDataProvider()
+    public static function encodeAliasDataProvider()
     {
         return [
             [

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/FieldDescriptor/DoctrineCaseFieldDescriptorTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/FieldDescriptor/DoctrineCaseFieldDescriptorTest.php
@@ -18,7 +18,7 @@ use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineJoinDescrip
 
 class DoctrineCaseFieldDescriptorTest extends TestCase
 {
-    public function dataProvider()
+    public static function dataProvider()
     {
         return [
             [

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineWhereExpressionTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineWhereExpressionTest.php
@@ -64,7 +64,7 @@ class DoctrineWhereExpressionTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
-    public function nullProvider()
+    public static function nullProvider()
     {
         return [
             [ListBuilderInterface::WHERE_COMPARATOR_EQUAL, 'IS NULL'],
@@ -103,7 +103,7 @@ class DoctrineWhereExpressionTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
-    public function andOrProvider()
+    public static function andOrProvider()
     {
         return [
             ['and'],

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/BooleanFilterTypeTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/BooleanFilterTypeTest.php
@@ -39,7 +39,7 @@ class BooleanFilterTypeTest extends TestCase
         $this->listBuilder = $this->prophesize(ListBuilderInterface::class);
     }
 
-    public function provideFilter()
+    public static function provideFilter()
     {
         return [
             ['active', 'true', true],

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/DateFilterTypeTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/DateFilterTypeTest.php
@@ -39,7 +39,7 @@ class DateFilterTypeTest extends TestCase
         $this->listBuilder = $this->prophesize(ListBuilderInterface::class);
     }
 
-    public function provideFilter()
+    public static function provideFilter()
     {
         return [
             ['created', ['from' => '2020-02-05 00:00', 'to' => '2020-02-07 00:00'], ['2020-02-05 00:00:00', '2020-02-07 23:59:59']],
@@ -65,7 +65,7 @@ class DateFilterTypeTest extends TestCase
             ->shouldBeCalled();
     }
 
-    public function provideFilterFromOnly()
+    public static function provideFilterFromOnly()
     {
         return [
             ['created', ['from' => '2020-02-05 00:00'], '2020-02-05 00:00:00'],
@@ -86,7 +86,7 @@ class DateFilterTypeTest extends TestCase
             ->shouldBeCalled();
     }
 
-    public function provideFilterToOnly()
+    public static function provideFilterToOnly()
     {
         return [
             ['created', ['to' => '2020-02-05'], '2020-02-05 23:59:59'],
@@ -108,7 +108,7 @@ class DateFilterTypeTest extends TestCase
             ->shouldBeCalled();
     }
 
-    public function provideFilterWithInvalidOptions()
+    public static function provideFilterWithInvalidOptions()
     {
         return [
             [[]],

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/DateTimeFilterTypeTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/DateTimeFilterTypeTest.php
@@ -39,7 +39,7 @@ class DateTimeFilterTypeTest extends TestCase
         $this->listBuilder = $this->prophesize(ListBuilderInterface::class);
     }
 
-    public function provideFilter()
+    public static function provideFilter()
     {
         return [
             ['created', ['from' => '2020-02-05 12:15', 'to' => '2020-02-07 13:15'], ['2020-02-05 12:15:00', '2020-02-07 13:15:59']],
@@ -65,7 +65,7 @@ class DateTimeFilterTypeTest extends TestCase
             ->shouldBeCalled();
     }
 
-    public function provideFilterFromOnly()
+    public static function provideFilterFromOnly()
     {
         return [
             ['created', ['from' => '2020-02-05 12:15'], '2020-02-05 12:15:00'],
@@ -87,7 +87,7 @@ class DateTimeFilterTypeTest extends TestCase
             ->shouldBeCalled();
     }
 
-    public function provideFilterToOnly()
+    public static function provideFilterToOnly()
     {
         return [
             ['created', ['to' => '2020-02-05 12:15'], '2020-02-05 12:15:59'],
@@ -109,7 +109,7 @@ class DateTimeFilterTypeTest extends TestCase
             ->shouldBeCalled();
     }
 
-    public function provideFilterWithInvalidOptions()
+    public static function provideFilterWithInvalidOptions()
     {
         return [
             [[]],

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/NumberFilterTypeTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/NumberFilterTypeTest.php
@@ -39,7 +39,7 @@ class NumberFilterTypeTest extends TestCase
         $this->listBuilder = $this->prophesize(ListBuilderInterface::class);
     }
 
-    public function provideFilter()
+    public static function provideFilter()
     {
         return [
             ['price', ['eq' => 6], '=', 6],
@@ -59,7 +59,7 @@ class NumberFilterTypeTest extends TestCase
         $this->listBuilder->where($fieldDescriptor->reveal(), $expectedValue, $expectedOperator)->shouldBeCalled();
     }
 
-    public function provideFilterWithInvalidOptions()
+    public static function provideFilterWithInvalidOptions()
     {
         return [
             [''],

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/SelectFilterTypeTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/SelectFilterTypeTest.php
@@ -39,7 +39,7 @@ class SelectFilterTypeTest extends TestCase
         $this->listBuilder = $this->prophesize(ListBuilderInterface::class);
     }
 
-    public function provideFilter()
+    public static function provideFilter()
     {
         return [
             ['type', 'overview,homepage', ['overview', 'homepage']],

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/SelectionFilterTypeTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/SelectionFilterTypeTest.php
@@ -39,7 +39,7 @@ class SelectionFilterTypeTest extends TestCase
         $this->listBuilder = $this->prophesize(ListBuilderInterface::class);
     }
 
-    public function provideFilter()
+    public static function provideFilter()
     {
         return [
             ['accountIds', '1,2,3', [1, 2, 3]],

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/TextFilterTypeTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Filter/TextFilterTypeTest.php
@@ -39,7 +39,7 @@ class TextFilterTypeTest extends TestCase
         $this->listBuilder = $this->prophesize(ListBuilderInterface::class);
     }
 
-    public function provideFilter()
+    public static function provideFilter()
     {
         return [
             ['firstName', ['eq' => 'Max'], '=', 'Max'],

--- a/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/AccessControlManagerTest.php
+++ b/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/AccessControlManagerTest.php
@@ -642,7 +642,7 @@ class AccessControlManagerTest extends TestCase
         );
     }
 
-    public function provideUserPermission()
+    public static function provideUserPermission()
     {
         return [
             [

--- a/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/PhpcrAccessControlProviderTest.php
+++ b/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/PhpcrAccessControlProviderTest.php
@@ -152,7 +152,7 @@ class PhpcrAccessControlProviderTest extends TestCase
         $this->assertEquals($this->phpcrAccessControlProvider->supports($type), $supported);
     }
 
-    public function provideSupport()
+    public static function provideSupport()
     {
         return [
             [BasePageDocument::class, true],

--- a/src/Sulu/Component/SmartContent/Tests/Unit/BuilderTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/BuilderTest.php
@@ -17,7 +17,7 @@ use Sulu\Component\SmartContent\Configuration\Builder;
 
 class BuilderTest extends TestCase
 {
-    public function provideBoolean()
+    public static function provideBoolean()
     {
         return [[true], [false]];
     }

--- a/src/Sulu/Component/SmartContent/Tests/Unit/ContentTypeTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/ContentTypeTest.php
@@ -598,7 +598,7 @@ class ContentTypeTest extends TestCase
         $this->assertEquals([1, 2, 3, 4, 5], $pageData);
     }
 
-    public function pageProvider()
+    public static function pageProvider()
     {
         return [
             // first page page-size 3 (one page more to check available pages)

--- a/src/Sulu/Component/Tag/Tests/Unit/Request/TagRequestHandlerTest.php
+++ b/src/Sulu/Component/Tag/Tests/Unit/Request/TagRequestHandlerTest.php
@@ -22,7 +22,7 @@ class TagRequestHandlerTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function getProvider()
+    public static function getProvider()
     {
         return [
             ['t', '', []],
@@ -53,7 +53,7 @@ class TagRequestHandlerTest extends TestCase
         $this->assertEquals($expected, $tags);
     }
 
-    public function appendProvider()
+    public static function appendProvider()
     {
         return [
             ['t', '/test', 'Sulu,Core', 'Sulu,Core,Test'],
@@ -87,7 +87,7 @@ class TagRequestHandlerTest extends TestCase
         $this->assertEquals($url . '?' . $tagsParameter . '=' . \urlencode($expected), $result);
     }
 
-    public function setProvider()
+    public static function setProvider()
     {
         return [
             ['t', '/test', 'Sulu,Core', 'Test'],
@@ -121,7 +121,7 @@ class TagRequestHandlerTest extends TestCase
         $this->assertEquals($url . '?' . $tagsParameter . '=' . \urlencode($expected), $result);
     }
 
-    public function removeProvider()
+    public static function removeProvider()
     {
         return [
             ['t', '/test', 'Sulu,Core'],

--- a/src/Sulu/Component/Util/Tests/Unit/ArrayUtilsTest.php
+++ b/src/Sulu/Component/Util/Tests/Unit/ArrayUtilsTest.php
@@ -16,7 +16,7 @@ use Sulu\Component\Util\ArrayUtils;
 
 class ArrayUtilsTest extends TestCase
 {
-    public function provideData()
+    public static function provideData()
     {
         return [
             [

--- a/src/Sulu/Component/Util/Tests/Unit/SortUtilsTest.php
+++ b/src/Sulu/Component/Util/Tests/Unit/SortUtilsTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 
 class SortUtilsTest extends TestCase
 {
-    public function provideSortObjects()
+    public static function provideSortObjects()
     {
         return [
             // ascending

--- a/src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
+++ b/src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
@@ -152,7 +152,7 @@ class SuluNodeHelperTest extends TestCase
         ], $localizedValues);
     }
 
-    public function provideExtractWebspaceFromPath()
+    public static function provideExtractWebspaceFromPath()
     {
         return [
             ['/cmf/sulu_io/content/articles/article-one', 'sulu_io'],
@@ -174,7 +174,7 @@ class SuluNodeHelperTest extends TestCase
         $this->assertEquals($expected, $res);
     }
 
-    public function provideExtractSnippetTypeFromPath()
+    public static function provideExtractSnippetTypeFromPath()
     {
         return [
             ['/cmf/snippets/foobar/snippet1', 'foobar'],
@@ -200,7 +200,7 @@ class SuluNodeHelperTest extends TestCase
         $this->assertEquals($expected, $res);
     }
 
-    public function provideGetStructureTypeForNode()
+    public static function provideGetStructureTypeForNode()
     {
         return [
             ['sulu:snippet', 'snippet'],
@@ -223,7 +223,7 @@ class SuluNodeHelperTest extends TestCase
         $this->assertEquals($expected, $this->helper->getStructureTypeForNode($this->node));
     }
 
-    public function provideHasSuluNodeType()
+    public static function provideHasSuluNodeType()
     {
         return [
             ['sulu:snippet', true],

--- a/src/Sulu/Component/Util/Tests/Unit/TextUtilsTest.php
+++ b/src/Sulu/Component/Util/Tests/Unit/TextUtilsTest.php
@@ -16,7 +16,7 @@ use Sulu\Component\Util\TextUtils;
 
 class TextUtilsTest extends TestCase
 {
-    public function provideTruncate()
+    public static function provideTruncate()
     {
         return [
             ['Hello', 10, null, 'Hello'],

--- a/src/Sulu/Component/Util/Tests/Unit/WildcardUrlUtilTest.php
+++ b/src/Sulu/Component/Util/Tests/Unit/WildcardUrlUtilTest.php
@@ -16,7 +16,7 @@ use Sulu\Component\Util\WildcardUrlUtil;
 
 class WildcardUrlUtilTest extends TestCase
 {
-    public function provideMatchData()
+    public static function provideMatchData()
     {
         return [
             ['*.sulu.lo', '1.sulu.lo', true],
@@ -37,7 +37,7 @@ class WildcardUrlUtilTest extends TestCase
         $this->assertEquals($expected, WildcardUrlUtil::match($url, $portalUrl));
     }
 
-    public function provideResolveData()
+    public static function provideResolveData()
     {
         return [
             ['*.sulu.lo', '1.sulu.lo', '1.sulu.lo'],

--- a/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
@@ -81,7 +81,7 @@ class RequestAnalyzerTest extends TestCase
         $this->webspaceManager->getPortalInformations(Argument::any())->willReturn([]);
     }
 
-    public function provideAnalyze()
+    public static function provideAnalyze()
     {
         return [
             [
@@ -115,7 +115,7 @@ class RequestAnalyzerTest extends TestCase
         ];
     }
 
-    public function provideAnalyzeWithFormat()
+    public static function provideAnalyzeWithFormat()
     {
         return [
             [

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/AdminRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/AdminRequestProcessorTest.php
@@ -24,7 +24,7 @@ class AdminRequestProcessorTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function provideData()
+    public static function provideData()
     {
         return [
             [],

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
@@ -194,7 +194,7 @@ class PortalInformationRequestProcessorTest extends TestCase
         $this->assertTrue($this->portalInformationRequestProcessor->validate(new RequestAttributes()));
     }
 
-    public function provideProcess()
+    public static function provideProcess()
     {
         return [
             [
@@ -236,7 +236,7 @@ class PortalInformationRequestProcessorTest extends TestCase
         ];
     }
 
-    public function provideProcessWithFormat()
+    public static function provideProcessWithFormat()
     {
         return [
             [

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/RequestAttributesTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/RequestAttributesTest.php
@@ -16,7 +16,7 @@ use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
 
 class RequestAttributesTest extends TestCase
 {
-    public function provideData()
+    public static function provideData()
     {
         return [
             [['test1' => 1], 'test1', null, 1],

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/SegmentRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/SegmentRequestProcessorTest.php
@@ -80,7 +80,7 @@ class SegmentRequestProcessorTest extends TestCase
         $this->assertNull($attributes->getAttribute('segment'));
     }
 
-    public function provideProcessWithDefaultSegmentValue()
+    public static function provideProcessWithDefaultSegmentValue()
     {
         return [
             [null, 's', 's'],

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/UrlRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/UrlRequestProcessorTest.php
@@ -41,7 +41,7 @@ class UrlRequestProcessorTest extends TestCase
         $this->assertEquals($path, $requestAttributes->getAttribute('path'));
     }
 
-    public function provideProcess()
+    public static function provideProcess()
     {
         return [
             ['http://127.0.0.1:8000/en/test', '127.0.0.1', 8000, '/en/test'],

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/RequestAnalyzerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/RequestAnalyzerTest.php
@@ -185,7 +185,7 @@ class RequestAnalyzerTest extends TestCase
         $this->assertEquals('https', $requestAnalyzer->getAttribute('scheme'));
     }
 
-    public function provideGetter()
+    public static function provideGetter()
     {
         $localization = new Localization('de', 'at');
 

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
@@ -487,7 +487,7 @@ class WebspaceManagerTest extends WebspaceTestCase
     /**
      * @return array<array{string, bool}>
      */
-    public function provideFindPortalInformationByUrl()
+    public static function provideFindPortalInformationByUrl()
     {
         return [
             ['dan.lo/de-asd/test/test', false],

--- a/src/Sulu/Component/Webspace/Tests/Unit/PortalInformationTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/PortalInformationTest.php
@@ -54,7 +54,7 @@ class PortalInformationTest extends TestCase
     /**
      * @return array<array{string, string, ?string}>
      */
-    public function provideUrl()
+    public static function provideUrl()
     {
         return [
             ['sulu.lo', 'sulu.lo', null],

--- a/src/Sulu/Component/Webspace/Tests/Unit/Settings/SettingsManagerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Settings/SettingsManagerTest.php
@@ -79,7 +79,7 @@ class SettingsManagerTest extends TestCase
         $this->settingsManager->save($webspaceKey, $key, $data);
     }
 
-    public function removeDataProvider()
+    public static function removeDataProvider()
     {
         return [
             ['sulu_io', 'test-1'],
@@ -118,7 +118,7 @@ class SettingsManagerTest extends TestCase
         $this->assertEquals($data, $result);
     }
 
-    public function loadStringDataProvider()
+    public static function loadStringDataProvider()
     {
         return [
             ['sulu_io', 'test-1', '123-123-123', true],

--- a/src/Sulu/Component/Webspace/Tests/Unit/UrlTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/UrlTest.php
@@ -16,7 +16,7 @@ use Sulu\Component\Webspace\Url;
 
 class UrlTest extends TestCase
 {
-    public function provideIsValidLocale()
+    public static function provideIsValidLocale()
     {
         return [
             ['de', 'at', 'de', 'at', true],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #7339
| License | MIT
| Documentation PR | -

#### What's in this PR?
Making the dataproviers for phpunit static.

#### Why?
In PhpUnit 10 you can't have non static dataproviders (which should be possible after #7412 was merged).

#### Example Usage
-

<!--

Dear Contributors,

Thank you for contributing to the Sulu ecosystem!

We appreciate your effort to improve our project.  
If you need assistance or have questions about your pull request, our team is here to help.  
Please join our Slack channel for support: https://sulu.io/services/support#chat.

Best Regards, 
The Sulu Core Team

-->
