### PR TITLE
Cancel CI tasks after 30 minutes

### DIFF
--- a/.github/workflows/crowdin-upload.yaml
+++ b/.github/workflows/crowdin-upload.yaml
@@ -9,12 +9,17 @@ jobs:
     upload_sources:
         name: Upload Sources
         runs-on: ubuntu-18.04
+        timeout-minutes: 30
+
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v4
+
             - name: Merge all translation files
               run: jq -s '.|add' src/Sulu/Bundle/*/Resources/translations/admin.*.json > admin.en.json
+
             - name: Download Crowdin CLI
               run: curl "https://downloads.crowdin.com/cli/v3/crowdin-cli.zip" --output crowdin-cli.zip && unzip crowdin-cli.zip
+
             - name: Upload translations to crowdin
               env:
                   CROWDIN_TOKEN: ${{ secrets.CrowdinToken }}

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -16,6 +16,7 @@ jobs:
     js-css:
         name: "Node ${{ matrix.node-version }}"
         runs-on: ubuntu-latest
+        timeout-minutes: 30
 
         strategy:
             fail-fast: false
@@ -81,6 +82,7 @@ jobs:
     js-lint:
         name: "Node Lint"
         runs-on: ubuntu-latest
+        timeout-minutes: 30
 
         env:
             COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -117,6 +119,7 @@ jobs:
     php:
         name: "PHP ${{ matrix.php-version }} (${{ matrix.database }}, ${{ matrix.phpcr-transport }}, ${{ matrix.dependency-versions }})"
         runs-on: ubuntu-latest
+        timeout-minutes: 30
 
         env:
             APP_ENV: test
@@ -238,6 +241,7 @@ jobs:
     php-lint:
         name: "PHP Lint"
         runs-on: ubuntu-latest
+        timeout-minutes: 30
 
         env:
             APP_ENV: test

--- a/.github/workflows/trigger-styleguide-build.yaml
+++ b/.github/workflows/trigger-styleguide-build.yaml
@@ -10,6 +10,8 @@ jobs:
     trigger-styleguide-build:
         name: Trigger styleguide build
         runs-on: ubuntu-latest
+        timeout-minutes: 30
+
         steps:
             - name: Trigger styleguide build
               uses: benc-uk/workflow-dispatch@v1


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Cancel CI tasks after 30 minutes.

#### Why?

Sometimes tasks run into a timeout and the default timeout is 6 hours which isn't something which make sense to block a CI runner that long.
