### PR TITLE
Migrate missing PHPCR migration to new ContainerAwareInterface

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version202404051600.php
+++ b/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version202404051600.php
@@ -13,10 +13,10 @@ namespace Sulu\Bundle\PageBundle;
 
 use PHPCR\Migrations\VersionInterface;
 use PHPCR\NodeInterface;
+use PHPCR\PhpcrMigrationsBundle\ContainerAwareInterface;
 use PHPCR\SessionInterface;
 use Sulu\Component\Content\Document\Subscriber\ShadowCopyPropertiesSubscriber;
 use Sulu\Component\Webspace\Webspace;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class Version202404051600 implements VersionInterface, ContainerAwareInterface


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | part of #7156  <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Migrate missing PHPCR migration to new ContainerAwareInterface.

#### Why?

Some tests on Symfony 7 failing this way, https://github.com/sulu/skeleton/pull/246.