### PR TITLE
Refactor phpunit dataprovider to be static

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -36,11 +36,6 @@ parameters:
 			path: src/Sulu/Bundle/ActivityBundle/Tests/Functional/UserInterface/Controller/ActivityControllerTest.php
 
 		-
-			message: "#^Unsafe call to private method Sulu\\\\Bundle\\\\ActivityBundle\\\\Tests\\\\Functional\\\\UserInterface\\\\Controller\\\\ActivityControllerTest\\:\\:createActivity\\(\\) through static\\:\\:\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ActivityBundle/Tests/Functional/UserInterface/Controller/ActivityControllerTest.php
-
-		-
 			message: "#^Unsafe call to private method Sulu\\\\Bundle\\\\ActivityBundle\\\\Tests\\\\Functional\\\\UserInterface\\\\Controller\\\\ActivityControllerTest\\:\\:setUpUserRole\\(\\) through static\\:\\:\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ActivityBundle/Tests/Functional/UserInterface/Controller/ActivityControllerTest.php
@@ -53597,11 +53592,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Tests\\\\Unit\\\\EnvironmentTest\\:\\:addUrlProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/EnvironmentTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Tests\\\\Unit\\\\EnvironmentTest\\:\\:getUrl\\(\\) has parameter \\$toArrayResult with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Component/Webspace/Tests/Unit/EnvironmentTest.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -42131,41 +42131,6 @@ parameters:
 			path: src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/FallbackLocalizationSubscriberTest.php
 
 		-
-			message: "#^Cannot call method willReturn\\(\\) on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/PHPCR/SuluNodeTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Content\\\\Tests\\\\Unit\\\\Document\\\\Subscriber\\\\PHPCR\\\\SuluNodeTest\\:\\:provideDelegateData\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/PHPCR/SuluNodeTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Content\\\\Tests\\\\Unit\\\\Document\\\\Subscriber\\\\PHPCR\\\\SuluNodeTest\\:\\:testDelegate\\(\\) has parameter \\$arguments with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/PHPCR/SuluNodeTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Content\\\\Tests\\\\Unit\\\\Document\\\\Subscriber\\\\PHPCR\\\\SuluNodeTest\\:\\:testDelegate\\(\\) has parameter \\$functionName with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/PHPCR/SuluNodeTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Content\\\\Tests\\\\Unit\\\\Document\\\\Subscriber\\\\PHPCR\\\\SuluNodeTest\\:\\:testDelegate\\(\\) has parameter \\$returnValue with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/PHPCR/SuluNodeTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$callback of function call_user_func_array expects callable\\(\\)\\: mixed, array\\{Prophecy\\\\Prophecy\\\\ObjectProphecy\\<PHPCR\\\\NodeInterface\\>, mixed\\} given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/PHPCR/SuluNodeTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$callback of function call_user_func_array expects callable\\(\\)\\: mixed, array\\{Sulu\\\\Component\\\\Content\\\\Document\\\\Subscriber\\\\PHPCR\\\\SuluNode, mixed\\} given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/PHPCR/SuluNodeTest.php
-
-		-
 			message: "#^Class Sulu\\\\Component\\\\Content\\\\Document\\\\Subscriber\\\\RedirectTypeSubscriber does not have a constructor and must be instantiated without any parameters\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/RedirectTypeSubscriberTest.php

--- a/src/Sulu/Bundle/ActivityBundle/Tests/Functional/UserInterface/Controller/ActivityControllerTest.php
+++ b/src/Sulu/Bundle/ActivityBundle/Tests/Functional/UserInterface/Controller/ActivityControllerTest.php
@@ -50,7 +50,7 @@ class ActivityControllerTest extends SuluTestCase
                         $resourceSecurityObjectType = null !== $objectSecurity ? SecuredEntityInterface::class : null;
                         $resourceSecurityObjectId = null !== $objectSecurity ? $resourceId : null;
 
-                        static::createActivity(
+                        self::createActivity(
                             $resourceKey,
                             $resourceId,
                             $resourceLocale,

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/PHPCR/SuluNodeTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/PHPCR/SuluNodeTest.php
@@ -502,7 +502,7 @@ class SuluNodeTest extends TestCase
 
         $suluNode = new SuluNode($node->reveal());
 
-        $this->assertSame($nodes, $suluNode->getSharedSet());
+        $this->assertSame($nodes, [...$suluNode->getSharedSet()]);
     }
 
     public function testRemoveSharedSet(): void

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/PHPCR/SuluNodeTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/PHPCR/SuluNodeTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\Content\Tests\Unit\Document\Subscriber\PHPCR;
 
 use PHPCR\ItemVisitorInterface;
 use PHPCR\NodeInterface;
+use PHPCR\NodeType\NodeTypeInterface;
 use PHPCR\PropertyInterface;
 use PHPCR\PropertyType;
 use PHPCR\SessionInterface;
@@ -24,74 +25,544 @@ class SuluNodeTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function provideDelegateData()
+    public function testGetPath(): void
     {
-        return [
-            ['getPath', '/test'],
-            ['getName', 'test'],
-            ['getAncestor', [$this->prophesize(NodeInterface::class)->reveal()], [1]],
-            ['getParent', $this->prophesize(NodeInterface::class)->reveal()],
-            ['getDepth', 1],
-            ['getSession', $this->prophesize(SessionInterface::class)->reveal()],
-            ['isNode', true],
-            ['isNew', true],
-            ['isModified', true],
-            ['isSame', false, [$this->prophesize(NodeInterface::class)->reveal()]],
-            ['accept', null, [$this->prophesize(ItemVisitorInterface::class)->reveal()]],
-            ['revert', null],
-            ['remove', null],
-            ['addNode', $this->prophesize(NodeInterface::class)->reveal(), ['test-1', 'sulu:content']],
-            ['addNodeAutoNamed', $this->prophesize(NodeInterface::class)->reveal(), ['test-1', 'sulu:content']],
-            ['orderBefore', null, ['test-1', 'test-2']],
-            ['rename', null, ['test-1']],
-            ['getNode', $this->prophesize(NodeInterface::class)->reveal(), ['test-1']],
-            ['getNodes', [$this->prophesize(NodeInterface::class)->reveal()], ['test-*', 'sulu:*']],
-            ['getNodeNames', ['test-1'], ['test-*', 'sulu:*']],
-            ['getProperty', $this->prophesize(PropertyInterface::class)->reveal(), ['test-1']],
-            ['getPropertyValue', 'test-1', ['test-1', PropertyType::TYPENAME_DATE]],
-            ['getPropertyValueWithDefault', 'test-1', ['test-1', null]],
-            ['getProperties', [$this->prophesize(PropertyInterface::class)->reveal()], ['test-*']],
-            ['getPropertiesValues', ['test-1'], ['test-*', false]],
-            ['getPrimaryItem', 'sulu:content'],
-            ['getIdentifier', '123-123-123'],
-            ['getIndex', 1],
-            ['getReferences', [$this->prophesize(NodeInterface::class)->reveal()], ['sulu:content']],
-            ['getWeakReferences', [$this->prophesize(NodeInterface::class)->reveal()], ['sulu:content']],
-            ['hasNode', true, ['test-1']],
-            ['hasProperty', true, ['test-1']],
-            ['hasNodes', true],
-            ['hasProperties', true],
-            ['getPrimaryNodeType', 'sulu:content'],
-            ['getMixinNodeTypes', ['sulu:content']],
-            ['isNodeType', true, ['sulu:content']],
-            ['setPrimaryType', null, ['sulu:content']],
-            ['addMixin', null, ['sulu:content']],
-            ['removeMixin', null, ['sulu:content']],
-            ['setMixins', null, [['sulu:content']]],
-            ['update', null, ['default']],
-            ['getCorrespondingNodePath', '/test-1', ['default']],
-            ['getSharedSet', [$this->prophesize(NodeInterface::class)->reveal()]],
-            ['removeSharedSet', null],
-            ['removeShare', null],
-            ['isCheckedOut', true],
-            ['isLocked', true],
-            ['followLifecycleTransition', null, ['test-1']],
-            ['getAllowedLifecycleTransitions', ['test-1']],
-        ];
-    }
-
-    /**
-     * @dataProvider provideDelegateData
-     */
-    public function testDelegate($functionName, $returnValue, $arguments = []): void
-    {
+        $path = '/test';
         $node = $this->prophesize(NodeInterface::class);
-
-        \call_user_func_array([$node, $functionName], $arguments)->willReturn($returnValue);
+        $node->getPath()->willReturn($path);
 
         $suluNode = new SuluNode($node->reveal());
 
-        $this->assertEquals($returnValue, \call_user_func_array([$suluNode, $functionName], $arguments));
+        $this->assertEquals($path, $suluNode->getPath());
+    }
+
+    public function testGetName(): void
+    {
+        $name = '/test';
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getName()->willReturn($name);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals($name, $suluNode->getName());
+    }
+
+    public function testGetAncestor(): void
+    {
+        $ancestor = $this->prophesize(NodeInterface::class)->reveal();
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getAncestor(1)->willReturn($ancestor);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals($ancestor, $suluNode->getAncestor(1));
+    }
+
+    public function testGetParent(): void
+    {
+        $parent = $this->prophesize(NodeInterface::class)->reveal();
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getParent()->willReturn($parent);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals($parent, $suluNode->getParent());
+    }
+
+    public function testGetDepth(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getDepth()->willReturn(1);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals(1, $suluNode->getDepth());
+    }
+
+    public function testGetSession(): void
+    {
+        $session = $this->prophesize(SessionInterface::class)->reveal();
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getSession()->willReturn($session);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals($session, $suluNode->getSession());
+    }
+
+    public function testIsNode(): void
+    {
+        $returnValue = true;
+        $node = $this->prophesize(NodeInterface::class);
+        $node->isNode()->willReturn($returnValue);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals($returnValue, $suluNode->isNode());
+    }
+
+    public function testIsNew(): void
+    {
+        $returnValue = true;
+        $node = $this->prophesize(NodeInterface::class);
+        $node->isNew()->willReturn($returnValue);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals($returnValue, $suluNode->isNew());
+    }
+
+    public function testIsModified(): void
+    {
+        $returnValue = true;
+        $node = $this->prophesize(NodeInterface::class);
+        $node->isModified()->willReturn($returnValue);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals($returnValue, $suluNode->isModified());
+    }
+
+    public function testIsSame(): void
+    {
+        $returnValue = false;
+        $otherNode = $this->prophesize(NodeInterface::class)->reveal();
+        $node = $this->prophesize(NodeInterface::class);
+        $node->isSame($otherNode)->willReturn($returnValue);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals($returnValue, $suluNode->isSame($otherNode));
+    }
+
+    public function testAccept(): void
+    {
+        $visitor = $this->prophesize(ItemVisitorInterface::class)->reveal();
+        $node = $this->prophesize(NodeInterface::class);
+        $node->accept($visitor)->shouldBeCalled();
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $suluNode->accept($visitor);
+    }
+
+    public function testRevert(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->revert()->shouldBeCalled();
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $suluNode->revert();
+    }
+
+    public function testRemove(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->remove()->shouldBeCalled();
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $suluNode->remove();
+    }
+
+    public function testAddNode(): void
+    {
+        $newNode = $this->prophesize(NodeInterface::class)->reveal();
+        $node = $this->prophesize(NodeInterface::class);
+        $node->addNode('test-1', 'sulu:content')->willReturn($newNode);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals($newNode, $suluNode->addNode('test-1', 'sulu:content'));
+    }
+
+    public function testAddNodeAutoNamed(): void
+    {
+        $newNode = $this->prophesize(NodeInterface::class)->reveal();
+        $node = $this->prophesize(NodeInterface::class);
+        $node->addNodeAutoNamed('test-1', 'sulu:content')->willReturn($newNode);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals($newNode, $suluNode->addNodeAutoNamed('test-1', 'sulu:content'));
+    }
+
+    public function testOrderBefore(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->orderBefore('test-1', 'test-2')->shouldBeCalled();
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $suluNode->orderBefore('test-1', 'test-2');
+    }
+
+    public function testRename(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->rename('test-1')->shouldBeCalled();
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $suluNode->rename('test-1');
+    }
+
+    public function testGetNode(): void
+    {
+        $otherNode = $this->prophesize(NodeInterface::class)->reveal();
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getNode('test-1')->willReturn($otherNode);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals($otherNode, $suluNode->getNode('test-1'));
+    }
+
+    public function testGetNodes(): void
+    {
+        $otherNodes = [$this->prophesize(NodeInterface::class)->reveal()];
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getNodes('test-*', null)->willReturn($otherNodes);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals($otherNodes, $suluNode->getNodes('test-*'));
+    }
+
+    public function testGetNodeNames(): void
+    {
+        $otherNodes = ['test-1'];
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getNodeNames('test-*', null)->willReturn($otherNodes);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals($otherNodes, $suluNode->getNodeNames('test-*'));
+    }
+
+    public function testGetProperty(): void
+    {
+        $property = $this->prophesize(PropertyInterface::class)->reveal();
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getProperty('test-1')->willReturn($property);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals($property, $suluNode->getProperty('test-1'));
+    }
+
+    public function testGetProperties(): void
+    {
+        $property = [
+            $this->prophesize(PropertyInterface::class)->reveal(),
+        ];
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getProperties('test-*')->willReturn($property);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals($property, $suluNode->getProperties('test-*'));
+    }
+
+    public function testGetPropertiesValues(): void
+    {
+        $values = [
+            'test-1' => 'Some value',
+        ];
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getPropertiesValues('test-*', false)->willReturn($values);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals($values, $suluNode->getPropertiesValues('test-*', false));
+    }
+
+    public function testGetPropertyValue(): void
+    {
+        $value = 'Some value';
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getPropertyValue('test-1', PropertyType::DATE)->willReturn($value);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals($value, $suluNode->getPropertyValue('test-1', PropertyType::DATE));
+    }
+
+    public function testGetPropertyValueWithoutType(): void
+    {
+        $value = 'Some value';
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getPropertyValue('test-1', PropertyType::UNDEFINED)->willReturn($value);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals($value, $suluNode->getPropertyValue('test-1'));
+    }
+
+    public function testGetPropertyValueWithDefault(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getPropertyValueWithDefault('test-1', 'Default')->willReturn('Default');
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals('Default', $suluNode->getPropertyValueWithDefault('test-1', 'Default'));
+    }
+
+    public function testGetPrimaryItem(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getPrimaryItem()->willReturn('sulu:content');
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals('sulu:content', $suluNode->getPrimaryItem());
+    }
+
+    public function testGetIdentifier(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getIdentifier()->willReturn('123-123-123');
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals('123-123-123', $suluNode->getIdentifier());
+    }
+
+    public function testGetIndex(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getIndex()->willReturn(1);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals(1, $suluNode->getIndex());
+    }
+
+    public function testGetReferences(): void
+    {
+        $referencedNodes = [$this->prophesize(NodeInterface::class)->reveal()];
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getReferences('sulu:content')->willReturn($referencedNodes);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals($referencedNodes, $suluNode->getReferences('sulu:content'));
+    }
+
+    public function testGetWeakReferences(): void
+    {
+        $referencedNodes = [$this->prophesize(NodeInterface::class)->reveal()];
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getWeakReferences('sulu:content')->willReturn($referencedNodes);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals($referencedNodes, $suluNode->getWeakReferences('sulu:content'));
+    }
+
+    public function testHasNode(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->hasNode('test-1')->willReturn(true);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertTrue($suluNode->hasNode('test-1'));
+    }
+
+    public function testHasProperty(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->hasProperty('test-1')->willReturn(true);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertTrue($suluNode->hasProperty('test-1'));
+    }
+
+    public function testHasNodes(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->hasNodes()->willReturn(true);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertTrue($suluNode->hasNodes());
+    }
+
+    public function testHasProperties(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->hasProperties()->willReturn(true);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertTrue($suluNode->hasProperties());
+    }
+
+    public function testGetPrimaryNodeType(): void
+    {
+        $nodeType = $this->prophesize(NodeTypeInterface::class)->reveal();
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getPrimaryNodeType()->willReturn($nodeType);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertSame($nodeType, $suluNode->getPrimaryNodeType());
+    }
+
+    public function testGetMixinNodeTypes(): void
+    {
+        $nodeTypes = [$this->prophesize(NodeTypeInterface::class)->reveal()];
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getMixinNodeTypes()->willReturn($nodeTypes);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertSame($nodeTypes, $suluNode->getMixinNodeTypes());
+    }
+
+    public function testIsNodeType(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->isNodeType('sulu:content')->willReturn(true);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertTrue($suluNode->isNodeType('sulu:content'));
+    }
+
+    public function testSetPrimaryType(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->setPrimaryType('sulu:content')->shouldBeCalled();
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $suluNode->setPrimaryType('sulu:content');
+    }
+
+    public function testAddMixin(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->addMixin('sulu:content')->shouldBeCalled();
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $suluNode->addMixin('sulu:content');
+    }
+
+    public function testRemoveMixin(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->removeMixin('sulu:content')->shouldBeCalled();
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $suluNode->removeMixin('sulu:content');
+    }
+
+    public function testSetMixins(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->setMixins(['sulu:content'])->shouldBeCalled();
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $suluNode->setMixins(['sulu:content']);
+    }
+
+    public function testUpdate(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->update('default')->shouldBeCalled();
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $suluNode->update('default');
+    }
+
+    public function testGetCorrespondingNodePath(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getCorrespondingNodePath('default')->willReturn('/test-1');
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertSame('/test-1', $suluNode->getCorrespondingNodePath('default'));
+    }
+
+    public function testGetSharedSet(): void
+    {
+        $nodes = [];
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getSharedSet()->willReturn($nodes);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertSame($nodes, $suluNode->getSharedSet());
+    }
+
+    public function testRemoveSharedSet(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->removeSharedSet()->shouldBeCalled();
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $suluNode->removeSharedSet();
+    }
+
+    public function testRemoveShare(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->removeShare()->shouldBeCalled();
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $suluNode->removeShare();
+    }
+
+    public function testIsCheckedOut(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->isCheckedOut()->willReturn(true);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertTrue($suluNode->isCheckedOut());
+    }
+
+    public function testIsLocked(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->isLocked()->willReturn(true);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertTrue($suluNode->isLocked());
+    }
+
+    public function testFollowLifecycleTransition(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->followLifecycleTransition('test-1')->shouldBeCalled();
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $suluNode->followLifecycleTransition('test-1');
+    }
+
+    public function testGetAllowedLifecycleTransitions(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getAllowedLifecycleTransitions()->willReturn(['test-1']);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertSame(['test-1'], $suluNode->getAllowedLifecycleTransitions());
     }
 
     public function testGetIterator(): void

--- a/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
+++ b/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
@@ -31,7 +31,6 @@ use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Media\SmartContent\MediaDataItem;
 use Sulu\Component\Media\SmartContent\MediaDataProvider;
-use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Serializer\ArraySerializerInterface;
 use Sulu\Component\SmartContent\ArrayAccessItem;
 use Sulu\Component\SmartContent\Configuration\ProviderConfigurationInterface;

--- a/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
+++ b/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
@@ -25,6 +25,7 @@ use Sulu\Bundle\MediaBundle\Entity\FileVersion;
 use Sulu\Bundle\MediaBundle\Entity\FileVersionMeta;
 use Sulu\Bundle\MediaBundle\Entity\Media as MediaEntity;
 use Sulu\Bundle\MediaBundle\Entity\MediaType;
+use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
@@ -354,7 +355,7 @@ class MediaDataProviderTest extends TestCase
             self::createMedia(3, 'Test-3'),
         ];
 
-        $user = $this->prophesize(UserInterface::class);
+        $user = new User();
 
         $resourceItems = [];
         foreach ($medias as $media) {
@@ -362,7 +363,7 @@ class MediaDataProviderTest extends TestCase
         }
 
         return [
-            [['dataSource' => 42, 'tags' => [1]], null, 1, 3, $medias, false, $user->reveal(), $resourceItems],
+            [['dataSource' => 42, 'tags' => [1]], null, 1, 3, $medias, false, $user, $resourceItems],
             [['dataSource' => 42, 'tags' => [1]], null, 1, 2, $medias, true, null, \array_slice($resourceItems, 0, 2)],
             [['dataSource' => 42, 'tags' => [1]], 5, 1, 2, $medias, true, null, \array_slice($resourceItems, 0, 2)],
             [['dataSource' => 42, 'tags' => [1]], 1, 1, 2, \array_slice($medias, 0, 1), false, null, \array_slice($resourceItems, 0, 1)],

--- a/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/DoctrineAccessControlProviderTest.php
+++ b/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/DoctrineAccessControlProviderTest.php
@@ -315,13 +315,12 @@ class DoctrineAccessControlProviderTest extends TestCase
         $this->assertSame($supported, $this->doctrineAccessControlProvider->supports($type));
     }
 
-    public function provideSupport()
+    public static function provideSupport()
     {
-        $securedEntity = $this->prophesize(SecuredEntityInterface::class);
 
         return [
             [\stdClass::class, false],
-            [\get_class($securedEntity->reveal()), true],
+            [SecuredEntityInterface::class, true],
         ];
     }
 }

--- a/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/DoctrineAccessControlProviderTest.php
+++ b/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/DoctrineAccessControlProviderTest.php
@@ -317,7 +317,6 @@ class DoctrineAccessControlProviderTest extends TestCase
 
     public static function provideSupport()
     {
-
         return [
             [\stdClass::class, false],
             [SecuredEntityInterface::class, true],

--- a/src/Sulu/Component/SmartContent/Tests/Unit/DataProviderPoolTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/DataProviderPoolTest.php
@@ -13,8 +13,13 @@ namespace Sulu\Component\SmartContent\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Component\SmartContent\Configuration\ProviderConfiguration;
+use Sulu\Component\SmartContent\Configuration\ProviderConfigurationInterface;
 use Sulu\Component\SmartContent\DataProviderInterface;
 use Sulu\Component\SmartContent\DataProviderPool;
+use Sulu\Component\SmartContent\DataProviderResult;
+use Sulu\Component\SmartContent\DatasourceItem;
+use Sulu\Component\SmartContent\DatasourceItemInterface;
 use Sulu\Component\SmartContent\Exception\DataProviderAliasAlreadyExistsException;
 use Sulu\Component\SmartContent\Exception\DataProviderNotExistsException;
 
@@ -22,48 +27,96 @@ class DataProviderPoolTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function addProvider()
+    public static function createDataProvider(): DataProviderInterface {
+        return new class () implements DataProviderInterface {
+            public function getConfiguration(): ProviderConfigurationInterface {
+                return new ProviderConfiguration();
+            }
+
+            public function getDefaultPropertyParameter(): array {
+                return [];
+            }
+
+            /**
+             * @inheritdoc
+             */
+            public function resolveDataItems(
+                array $filters,
+                array $propertyParameter,
+                array $options = [],
+                $limit = null,
+                $page = 1,
+                $pageSize = null
+            ): DataProviderResult {
+                return new DataProviderResult([], false);
+            }
+
+            /**
+             * @inheritdoc
+             */
+            public function resolveResourceItems(
+                array $filters,
+                array $propertyParameter,
+                array $options = [],
+                $limit = null,
+                $page = 1,
+                $pageSize = null
+            ) : DataProviderResult {
+                return new DataProviderResult([], false);
+            }
+
+            public function resolveDatasource(
+                $datasource,
+                array $propertyParameter,
+                array $options,
+            ): DatasourceItemInterface {
+                return new DatasourceItem('', '', '', '');
+            }
+        };
+    }
+
+    public static function addProvider()
     {
         $pool1 = new DataProviderPool(true);
         $pool2 = new DataProviderPool(true);
 
-        $provider1 = $this->prophesize(DataProviderInterface::class);
-        $provider2 = $this->prophesize(DataProviderInterface::class);
-        $provider3 = $this->prophesize(DataProviderInterface::class);
+        $provider1 = self::createDataProvider();
+        $provider2 = self::createDataProvider();
+        $provider3 = self::createDataProvider();
 
-        $pool2->add('test-1', $provider1->reveal());
+        $pool2->add('test-1', $provider1);
 
         return [
             [
                 $pool1,
                 [
-                    ['alias' => 'test', 'provider' => $provider1->reveal()],
+                    ['alias' => 'test', 'provider' => $provider1],
                 ],
                 [
-                    'test' => $provider1->reveal(),
+                    'test' => $provider1,
                 ],
             ],
             [
                 $pool1,
                 [
-                    ['alias' => 'test', 'provider' => $provider1->reveal()],
-                    ['alias' => 'test', 'provider' => $provider2->reveal()],
+                    ['alias' => 'test', 'provider' => $provider1],
+                    ['alias' => 'test', 'provider' => $provider2],
                 ],
                 [
-                    'test' => $provider1->reveal(),
+                    'test' => $provider1,
                 ],
                 DataProviderAliasAlreadyExistsException::class,
             ],
             [
                 $pool2,
                 [
-                    ['alias' => 'test-2', 'provider' => $provider2->reveal()],
-                    ['alias' => 'test-3', 'provider' => $provider3->reveal()],
+                    ['alias' => 'test-2', 'provider' => $provider2],
+                    ['alias' => 'test-3', 'provider' => $provider3],
                 ],
                 [
-                    'test-1' => $provider1->reveal(),
-                    'test-2' => $provider2->reveal(),
-                    'test-3' => $provider3->reveal(),
+                    'test-1' => $provider1,
+                    'test-2' => $provider2,
+                    'test-3' => $provider3,
                 ],
             ],
         ];
@@ -85,23 +138,15 @@ class DataProviderPoolTest extends TestCase
         $this->assertEquals($expectedProviders, $pool->getAll());
     }
 
-    public function existsProvider()
+    public static function existsProvider()
     {
         $pool = new DataProviderPool(true);
-        $provider = $this->prophesize(DataProviderInterface::class);
-        $pool->add('test', $provider->reveal());
+        $provider = self::createDataProvider();
+        $pool->add('test', $provider);
 
         return [
-            [
-                $pool,
-                'test',
-                true,
-            ],
-            [
-                $pool,
-                'test-1',
-                false,
-            ],
+            [ $pool, 'test', true ],
+            [ $pool, 'test-1', false ],
         ];
     }
 
@@ -113,17 +158,17 @@ class DataProviderPoolTest extends TestCase
         $this->assertEquals($expected, $pool->exists($alias));
     }
 
-    public function getProvider()
+    public static function getProvider()
     {
         $pool = new DataProviderPool(true);
-        $provider = $this->prophesize(DataProviderInterface::class);
+        $provider = self::createDataProvider();
         $pool->add('test', $provider->reveal());
 
         return [
             [
                 $pool,
                 'test',
-                $provider->reveal(),
+                $provider,
             ],
             [
                 $pool,
@@ -150,17 +195,17 @@ class DataProviderPoolTest extends TestCase
     {
         $pool1 = new DataProviderPool(true);
         $pool2 = new DataProviderPool(true);
-        $provider1 = $this->prophesize(DataProviderInterface::class);
-        $provider2 = $this->prophesize(DataProviderInterface::class);
-        $pool1->add('test-1', $provider1->reveal());
-        $pool1->add('test-2', $provider2->reveal());
+        $provider1 = self::createDataProvider();
+        $provider2 = self::createDataProvider();
+        $pool1->add('test-1', $provider1);
+        $pool1->add('test-2', $provider2);
 
         return [
             [
                 $pool1,
                 [
-                    'test-1' => $provider1->reveal(),
-                    'test-2' => $provider2->reveal(),
+                    'test-1' => $provider1,
+                    'test-2' => $provider2,
                 ],
             ],
             [

--- a/src/Sulu/Component/SmartContent/Tests/Unit/DataProviderPoolTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/DataProviderPoolTest.php
@@ -27,19 +27,19 @@ class DataProviderPoolTest extends TestCase
 {
     use ProphecyTrait;
 
-    public static function createDataProvider(): DataProviderInterface {
+    public static function createDataProvider(): DataProviderInterface
+    {
         return new class () implements DataProviderInterface {
-            public function getConfiguration(): ProviderConfigurationInterface {
+            public function getConfiguration(): ProviderConfigurationInterface
+            {
                 return new ProviderConfiguration();
             }
 
-            public function getDefaultPropertyParameter(): array {
+            public function getDefaultPropertyParameter(): array
+            {
                 return [];
             }
 
-            /**
-             * @inheritdoc
-             */
             public function resolveDataItems(
                 array $filters,
                 array $propertyParameter,
@@ -51,9 +51,6 @@ class DataProviderPoolTest extends TestCase
                 return new DataProviderResult([], false);
             }
 
-            /**
-             * @inheritdoc
-             */
             public function resolveResourceItems(
                 array $filters,
                 array $propertyParameter,
@@ -61,7 +58,7 @@ class DataProviderPoolTest extends TestCase
                 $limit = null,
                 $page = 1,
                 $pageSize = null
-            ) : DataProviderResult {
+            ): DataProviderResult {
                 return new DataProviderResult([], false);
             }
 
@@ -141,12 +138,11 @@ class DataProviderPoolTest extends TestCase
     public static function existsProvider()
     {
         $pool = new DataProviderPool(true);
-        $provider = self::createDataProvider();
-        $pool->add('test', $provider);
+        $pool->add('test', self::createDataProvider());
 
         return [
-            [ $pool, 'test', true ],
-            [ $pool, 'test-1', false ],
+            [$pool, 'test', true],
+            [$pool, 'test-1', false],
         ];
     }
 
@@ -162,7 +158,7 @@ class DataProviderPoolTest extends TestCase
     {
         $pool = new DataProviderPool(true);
         $provider = self::createDataProvider();
-        $pool->add('test', $provider->reveal());
+        $pool->add('test', $provider);
 
         return [
             [

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/WebsiteRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/WebsiteRequestProcessorTest.php
@@ -209,7 +209,8 @@ class WebsiteRequestProcessorTest extends TestCase
 
     public function provideValidateData()
     {
-        $portalInformation = $this->prophesize(PortalInformation::class);
+        $portalInformationReflection = new \ReflectionClass(PortalInformation::class);
+        $portalInformation = $portalInformationReflection->newInstanceWithoutConstructor();
 
         $webspace = new Webspace();
         $webspace->setKey('sulu');

--- a/src/Sulu/Component/Webspace/Tests/Unit/EnvironmentTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/EnvironmentTest.php
@@ -12,7 +12,6 @@
 namespace Sulu\Component\Webspace\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Component\Webspace\Environment;
 use Sulu\Component\Webspace\Url;
@@ -26,35 +25,44 @@ class EnvironmentTest extends TestCase
         $expected = [
             'type' => 'foo',
             'urls' => [
-                ['test'],
-            ],
+                0 => [
+                    'url' => 'test',
+                    'language' => null,
+                    'country' => null,
+                    'segment' => null,
+                    'redirect' => null,
+                    'main' => true,
+                    'environment' => null,
+                ]
+            ]
         ];
+        $url = new Url('test', 'test');
 
         $environment = new Environment();
 
-        $environment->addUrl($this->getUrl(['test']));
+        $environment->addUrl($url);
         $environment->setType($expected['type']);
 
         $this->assertEquals($expected, $environment->toArray());
     }
 
-    public function addUrlProvider()
+    public static function addUrlProvider()
     {
         $urls = [
             // case 0
-            $this->getUrl([], false),
+            $this->getUrl(false),
             // case 1
-            $this->getUrl([], true),
+            $this->getUrl(true),
             // case 2
-            $this->getUrl([], true),
-            $this->getUrl([], false),
+            $this->getUrl(true),
+            $this->getUrl(false),
             // case 3
-            $this->getUrl([], false),
-            $this->getUrl([], true),
+            $this->getUrl(false),
+            $this->getUrl(true),
             // case 4
-            $this->getUrl([], false),
-            $this->getUrl([], true),
-            $this->getUrl([], false),
+            $this->getUrl(false),
+            $this->getUrl(true),
+            $this->getUrl(false),
         ];
 
         return [
@@ -92,18 +100,12 @@ class EnvironmentTest extends TestCase
      *
      * @return Url
      */
-    private function getUrl($toArrayResult, $isMain = false)
+    private static function getUrl($isMain = false)
     {
-        $url = $this->prophesize(Url::class);
-        $url->isMain()->willReturn($isMain);
-        $url->setMain(Argument::any())->will(
-            function($args) use ($url) {
-                $url->isMain()->willReturn($args[0]);
-            }
-        );
-        $url->toArray()->willReturn($toArrayResult);
-        $url->setEnvironment(Argument::any())->willReturn(true);
+        $url = new Url('test', 'test');
+        $url->setMain($isMain);
 
-        return $url->reveal();
+        return $url;
     }
+
 }

--- a/src/Sulu/Component/Webspace/Tests/Unit/EnvironmentTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/EnvironmentTest.php
@@ -33,8 +33,8 @@ class EnvironmentTest extends TestCase
                     'redirect' => null,
                     'main' => true,
                     'environment' => null,
-                ]
-            ]
+                ],
+            ],
         ];
         $url = new Url('test', 'test');
 
@@ -50,19 +50,19 @@ class EnvironmentTest extends TestCase
     {
         $urls = [
             // case 0
-            $this->getUrl(false),
+            self::getUrl(false),
             // case 1
-            $this->getUrl(true),
+            self::getUrl(true),
             // case 2
-            $this->getUrl(true),
-            $this->getUrl(false),
+            self::getUrl(true),
+            self::getUrl(false),
             // case 3
-            $this->getUrl(false),
-            $this->getUrl(true),
+            self::getUrl(false),
+            self::getUrl(true),
             // case 4
-            $this->getUrl(false),
-            $this->getUrl(true),
-            $this->getUrl(false),
+            self::getUrl(false),
+            self::getUrl(true),
+            self::getUrl(false),
         ];
 
         return [
@@ -95,7 +95,6 @@ class EnvironmentTest extends TestCase
     /**
      * Return url with given to-array result.
      *
-     * @param array $toArrayResult
      * @param bool $isMain
      *
      * @return Url
@@ -107,5 +106,4 @@ class EnvironmentTest extends TestCase
 
         return $url;
     }
-
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #6988 
| License | MIT
| Documentation PR | -

#### What's in this PR?
Fixing more dataproviders.

### Todo
- [ ] src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/PHPCR/SuluNodeTest.php