### PR TITLE
Fix domain with dash in single sign on configuration

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Configuration.php
@@ -71,6 +71,7 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->arrayNode('providers')
                             ->useAttributeAsKey('domain')
+                            ->normalizeKeys(false)
                             ->arrayPrototype()
                                 ->children()
                                     ->scalarNode('dsn')


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes https://github.com/sulu/sulu-docs/pull/797 Thx @tic984  for report
| Related issues/PRs | #7262 
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix domain with dash in single sign on configuration.

#### Why?

Symfony normalize Yaml, XML config keys with `-` always to `_` when not explicit defined. The `normalizeKeys(false)` avoid this: https://symfony.com/doc/current/components/config/definition.html#array-node-options
