### PR TITLE
TaggedServiceCollectorCompilerPass -> `tagged_iterator`

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -9,6 +9,7 @@ Deprecated compiler passes:
 * `Sulu\Bundle\SecurityBundle\DependencyInjection\Compiler\AccessControlProviderPass` -> `tagged_iterator`
 * `Sulu\Bundle\MediaBundle\DependencyInjection\FormatCacheClearerCompilerPass` (`sulu_media.format_cache`)
 * `Sulu\Bundle\AudienceTargetingBundle\DependencyInjection\Compiler\AddRulesPass` -> (`sulu.audience_target_rule`) `tagged_iterator`
+* `Sulu\Component\Symfony\CompilerPass\TaggedServiceCollectorCompilerPass` -> `tagged_iterator`
 
 ## 2.6.11
 

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
@@ -111,7 +111,7 @@
         <!-- rlp strategies -->
         <service id="sulu.content.resource_locator.strategy_pool"
                  class="Sulu\Component\Content\Types\ResourceLocator\Strategy\ResourceLocatorStrategyPool">
-            <argument type="collection"/>
+            <argument type="tagged_iterator" tag="sulu.resource_locator.strategy" index-by="alias" />
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
         </service>
         <service id="sulu.content.resource_locator.strategy.tree_generator"

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/request_analyzer.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/request_analyzer.xml
@@ -6,7 +6,7 @@
         <service id="sulu_core.webspace.request_analyzer"
                  class="Sulu\Component\Webspace\Analyzer\RequestAnalyzer" public="true">
             <argument type="service" id="request_stack"/>
-            <argument type="collection"/>
+            <argument type="tagged_iterator" tag="sulu.request_attributes" />
         </service>
         <service id="Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface" alias="sulu_core.webspace.request_analyzer" />
 

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/webspace.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/webspace.xml
@@ -64,7 +64,7 @@
         </service>
 
         <service id="sulu_core.webspace.url_provider" class="Sulu\Component\Webspace\Url\WebspaceUrlChainProvider">
-            <argument type="collection"/>
+            <argument type="tagged_iterator" tag="sulu.webspace.url_provider"/>
         </service>
 
         <service id="sulu_core.webspace.url_provider.default" class="Sulu\Component\Webspace\Url\WebspaceUrlProvider">

--- a/src/Sulu/Bundle/CoreBundle/SuluCoreBundle.php
+++ b/src/Sulu/Bundle/CoreBundle/SuluCoreBundle.php
@@ -17,7 +17,6 @@ use Sulu\Bundle\CoreBundle\DependencyInjection\Compiler\RegisterContentTypesComp
 use Sulu\Bundle\CoreBundle\DependencyInjection\Compiler\RegisterLocalizationProvidersPass;
 use Sulu\Bundle\CoreBundle\DependencyInjection\Compiler\RemoveForeignContextServicesPass;
 use Sulu\Bundle\CoreBundle\DependencyInjection\Compiler\ReplacersCompilerPass;
-use Sulu\Component\Symfony\CompilerPass\TaggedServiceCollectorCompilerPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -39,20 +38,6 @@ class SuluCoreBundle extends Bundle
         $container->addCompilerPass(new RemoveForeignContextServicesPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 99);
         $container->addCompilerPass(new ReplacersCompilerPass(__DIR__ . '/DataFixtures/replacers.xml'));
         $container->addCompilerPass(new ListBuilderMetadataProviderCompilerPass());
-        $container->addCompilerPass(
-            new TaggedServiceCollectorCompilerPass('sulu_core.webspace.request_analyzer', 'sulu.request_attributes', 1)
-        );
         $container->addCompilerPass(new CsvHandlerCompilerPass());
-        $container->addCompilerPass(
-            new TaggedServiceCollectorCompilerPass('sulu_core.webspace.url_provider', 'sulu.webspace.url_provider')
-        );
-        $container->addCompilerPass(
-            new TaggedServiceCollectorCompilerPass(
-                'sulu.content.resource_locator.strategy_pool',
-                'sulu.resource_locator.strategy',
-                0,
-                'alias'
-            )
-        );
     }
 }

--- a/src/Sulu/Bundle/MarkupBundle/Markup/DelegatingTagExtractor.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/DelegatingTagExtractor.php
@@ -17,9 +17,9 @@ namespace Sulu\Bundle\MarkupBundle\Markup;
 class DelegatingTagExtractor implements TagExtractorInterface
 {
     /**
-     * @param array<TagExtractorInterface> $pool
+     * @param iterable<TagExtractorInterface> $pool
      */
-    public function __construct(private array $pool)
+    public function __construct(private iterable $pool)
     {
     }
 

--- a/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkProviderPool.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkProviderPool.php
@@ -17,16 +17,16 @@ namespace Sulu\Bundle\MarkupBundle\Markup\Link;
 class LinkProviderPool implements LinkProviderPoolInterface
 {
     /**
-     * @var LinkProviderInterface[]
+     * @var array<string, LinkProviderInterface>
      */
     private $providers;
 
     /**
-     * @param LinkProviderInterface[] $providers
+     * @param iterable<string, LinkProviderInterface> $providers
      */
-    public function __construct(array $providers)
+    public function __construct(iterable $providers)
     {
-        $this->providers = $providers;
+        $this->providers = [...$providers];
     }
 
     public function getProvider($name)

--- a/src/Sulu/Bundle/MarkupBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MarkupBundle/Resources/config/services.xml
@@ -14,7 +14,7 @@
 
         <service id="sulu_markup.parser.delegating_html_extractor"
                  class="Sulu\Bundle\MarkupBundle\Markup\DelegatingTagExtractor">
-            <argument type="collection"/>
+            <argument type="tagged_iterator" tag="sulu_markup.parser.html_extractor" />
         </service>
 
         <service id="sulu_markup.parser" class="Sulu\Bundle\MarkupBundle\Markup\HtmlMarkupParser">
@@ -40,7 +40,7 @@
 
         <service id="sulu_markup.link_tag.provider_pool"
                  class="Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderPool">
-            <argument type="collection"/>
+            <argument type="tagged_iterator" tag="sulu.link.provider" index-by="alias" />
         </service>
 
         <service id="sulu_markup.link_tag" class="Sulu\Bundle\MarkupBundle\Markup\LinkTag">

--- a/src/Sulu/Bundle/MarkupBundle/SuluMarkupBundle.php
+++ b/src/Sulu/Bundle/MarkupBundle/SuluMarkupBundle.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\MarkupBundle;
 
 use Sulu\Bundle\MarkupBundle\DependencyInjection\CompilerPass\ParserCompilerPass;
 use Sulu\Bundle\MarkupBundle\DependencyInjection\CompilerPass\TagCompilerPass;
-use Sulu\Component\Symfony\CompilerPass\TaggedServiceCollectorCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -33,19 +32,5 @@ class SuluMarkupBundle extends Bundle
 
         $container->addCompilerPass(new ParserCompilerPass());
         $container->addCompilerPass(new TagCompilerPass());
-        $container->addCompilerPass(
-            new TaggedServiceCollectorCompilerPass(
-                'sulu_markup.parser.delegating_html_extractor',
-                'sulu_markup.parser.html_extractor'
-            )
-        );
-        $container->addCompilerPass(
-            new TaggedServiceCollectorCompilerPass(
-                'sulu_markup.link_tag.provider_pool',
-                'sulu.link.provider',
-                0,
-                'alias'
-            )
-        );
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Resources/config/teaser.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/teaser.xml
@@ -5,7 +5,7 @@
         <!-- provider -->
         <service id="sulu_page.teaser.provider_pool"
                  class="Sulu\Bundle\PageBundle\Teaser\Provider\TeaserProviderPool">
-            <argument type="collection"/>
+            <argument type="tagged_iterator" tag="sulu.teaser.provider" index-by="alias" />
         </service>
 
         <!-- content provider -->

--- a/src/Sulu/Bundle/PageBundle/SuluPageBundle.php
+++ b/src/Sulu/Bundle/PageBundle/SuluPageBundle.php
@@ -16,7 +16,6 @@ use Sulu\Bundle\PageBundle\DependencyInjection\Compiler\SmartContentDataProvider
 use Sulu\Bundle\PageBundle\DependencyInjection\Compiler\StructureExtensionCompilerPass;
 use Sulu\Bundle\PageBundle\DependencyInjection\Compiler\VersioningCompilerPass;
 use Sulu\Bundle\PageBundle\DependencyInjection\Compiler\WebspacesPass;
-use Sulu\Component\Symfony\CompilerPass\TaggedServiceCollectorCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -37,13 +36,5 @@ class SuluPageBundle extends Bundle
         $container->addCompilerPass(new WebspacesPass());
         $container->addCompilerPass(new StructureExtensionCompilerPass());
         $container->addCompilerPass(new VersioningCompilerPass());
-        $container->addCompilerPass(
-            new TaggedServiceCollectorCompilerPass(
-                'sulu_page.teaser.provider_pool',
-                'sulu.teaser.provider',
-                0,
-                'alias'
-            )
-        );
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Teaser/Provider/TeaserProviderPool.php
+++ b/src/Sulu/Bundle/PageBundle/Teaser/Provider/TeaserProviderPool.php
@@ -17,10 +17,16 @@ namespace Sulu\Bundle\PageBundle\Teaser\Provider;
 class TeaserProviderPool implements TeaserProviderPoolInterface
 {
     /**
-     * @param TeaserProviderInterface[] $providers
+     * @var array<string, TeaserProviderInterface>
      */
-    public function __construct(private array $providers)
+    private $providers;
+
+    /**
+     * @param iterable<string, TeaserProviderInterface> $providers
+     */
+    public function __construct(iterable $providers)
     {
+        $this->providers = [...$providers];
     }
 
     public function getProvider($name)

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Object/PreviewObjectProviderRegistry.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Object/PreviewObjectProviderRegistry.php
@@ -16,10 +16,16 @@ use Sulu\Bundle\PreviewBundle\Preview\Exception\ProviderNotFoundException;
 class PreviewObjectProviderRegistry implements PreviewObjectProviderRegistryInterface
 {
     /**
-     * @param PreviewObjectProviderInterface[] $previewObjectProviders
+     * @var array<string, PreviewObjectProviderInterface>
      */
-    public function __construct(private array $previewObjectProviders)
+    private $previewObjectProviders;
+
+    /**
+     * @param iterable<string, PreviewObjectProviderInterface> $previewObjectProviders
+     */
+    public function __construct(iterable $previewObjectProviders)
     {
+        $this->previewObjectProviders = [...$previewObjectProviders];
     }
 
     public function getPreviewObjectProviders(): array

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/services.xml
@@ -51,7 +51,7 @@
         </service>
 
         <service id="sulu_preview.preview_object_provider_registry" class="Sulu\Bundle\PreviewBundle\Preview\Object\PreviewObjectProviderRegistry">
-            <argument type="collection"/>
+            <argument type="tagged_iterator" tag="sulu_preview.object_provider" index-by="provider-key" />
         </service>
 
         <service id="sulu_preview.preview_link_repository" class="Sulu\Bundle\PreviewBundle\Infrastructure\Doctrine\Repository\PreviewLinkRepository">

--- a/src/Sulu/Bundle/PreviewBundle/SuluPreviewBundle.php
+++ b/src/Sulu/Bundle/PreviewBundle/SuluPreviewBundle.php
@@ -14,7 +14,6 @@ namespace Sulu\Bundle\PreviewBundle;
 use Sulu\Bundle\PersistenceBundle\PersistenceBundleTrait;
 use Sulu\Bundle\PreviewBundle\Domain\Model\PreviewLinkInterface;
 use Sulu\Bundle\PreviewBundle\Infrastructure\Symfony\DependencyInjection\SuluPreviewExtension;
-use Sulu\Component\Symfony\CompilerPass\TaggedServiceCollectorCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -40,15 +39,6 @@ class SuluPreviewBundle extends Bundle
                 PreviewLinkInterface::class => 'sulu.model.preview_link.class',
             ],
             $container
-        );
-
-        $container->addCompilerPass(
-            new TaggedServiceCollectorCompilerPass(
-                'sulu_preview.preview_object_provider_registry',
-                'sulu_preview.object_provider',
-                0,
-                'provider-key'
-            )
         );
     }
 

--- a/src/Sulu/Bundle/RouteBundle/Resources/config/routing.xml
+++ b/src/Sulu/Bundle/RouteBundle/Resources/config/routing.xml
@@ -10,7 +10,7 @@
     <services>
         <!-- route-defaults -->
         <service id="sulu_route.routing.defaults_provider" class="Sulu\Bundle\RouteBundle\Routing\Defaults\RouteDefaultsProvider">
-            <argument type="collection">%sulu_route.routing.defaults_provider%</argument>
+            <argument type="tagged_iterator" tag="sulu_route.defaults_provider" />
         </service>
 
         <!-- router -->

--- a/src/Sulu/Bundle/RouteBundle/Routing/Defaults/RouteDefaultsProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Routing/Defaults/RouteDefaultsProvider.php
@@ -17,14 +17,14 @@ namespace Sulu\Bundle\RouteBundle\Routing\Defaults;
 class RouteDefaultsProvider implements RouteDefaultsProviderInterface
 {
     /**
-     * @var RouteDefaultsProviderInterface[]
+     * @var array<string, RouteDefaultsProviderInterface>
      */
     private $defaultsProviderMap = [];
 
     /**
-     * @param RouteDefaultsProviderInterface[] $defaultsProvider
+     * @param iterable<RouteDefaultsProviderInterface> $defaultsProvider
      */
-    public function __construct(private array $defaultsProvider)
+    public function __construct(private iterable $defaultsProvider)
     {
     }
 
@@ -47,6 +47,9 @@ class RouteDefaultsProvider implements RouteDefaultsProviderInterface
         return null !== $this->getDefaultProvider($entityClass);
     }
 
+    /**
+     * @param string $entityClass
+     */
     private function getDefaultProvider($entityClass)
     {
         if (\array_key_exists($entityClass, $this->defaultsProviderMap)) {

--- a/src/Sulu/Bundle/RouteBundle/SuluRouteBundle.php
+++ b/src/Sulu/Bundle/RouteBundle/SuluRouteBundle.php
@@ -15,7 +15,6 @@ use Sulu\Bundle\PersistenceBundle\PersistenceBundleTrait;
 use Sulu\Bundle\RouteBundle\DependencyInjection\RouteGeneratorCompilerPass;
 use Sulu\Bundle\RouteBundle\Model\RouteInterface;
 use Sulu\Component\Route\RouteDefaultOptionsCompilerPass;
-use Sulu\Component\Symfony\CompilerPass\TaggedServiceCollectorCompilerPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -36,9 +35,6 @@ class SuluRouteBundle extends Bundle
         $container->addCompilerPass(new RouteGeneratorCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -1024);
         $container->addCompilerPass(
             new RouteDefaultOptionsCompilerPass('sulu_route.routing.provider', 5)
-        );
-        $container->addCompilerPass(
-            new TaggedServiceCollectorCompilerPass('sulu_route.routing.defaults_provider', 'sulu_route.defaults_provider')
         );
 
         $this->buildPersistence(

--- a/src/Sulu/Bundle/WebsiteBundle/ReferenceStore/ReferenceStorePool.php
+++ b/src/Sulu/Bundle/WebsiteBundle/ReferenceStore/ReferenceStorePool.php
@@ -17,16 +17,16 @@ namespace Sulu\Bundle\WebsiteBundle\ReferenceStore;
 class ReferenceStorePool implements ReferenceStorePoolInterface
 {
     /**
-     * @var ReferenceStoreInterface[]
+     * @var array<string, ReferenceStoreInterface>
      */
     private $stores = [];
 
     /**
-     * @param ReferenceStoreInterface[] $stores
+     * @param iterable<string, ReferenceStoreInterface> $stores
      */
-    public function __construct(array $stores)
+    public function __construct(iterable $stores)
     {
-        $this->stores = $stores;
+        $this->stores = [...$stores];
     }
 
     public function getStores()

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -310,7 +310,7 @@
         <!-- reference-store -->
         <service id="sulu_website.reference_store_pool"
                  class="Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStorePool">
-            <argument type="collection"/>
+            <argument type="tagged_iterator" tag="sulu_website.reference_store" index-by="alias" />
         </service>
 
         <service id="sulu_website.webspace_reference_store"

--- a/src/Sulu/Bundle/WebsiteBundle/SuluWebsiteBundle.php
+++ b/src/Sulu/Bundle/WebsiteBundle/SuluWebsiteBundle.php
@@ -15,7 +15,6 @@ use Sulu\Bundle\PersistenceBundle\PersistenceBundleTrait;
 use Sulu\Bundle\WebsiteBundle\DependencyInjection\Compiler\DeregisterDefaultRouteListenerCompilerPass;
 use Sulu\Bundle\WebsiteBundle\Entity\AnalyticsInterface;
 use Sulu\Component\Route\RouteDefaultOptionsCompilerPass;
-use Sulu\Component\Symfony\CompilerPass\TaggedServiceCollectorCompilerPass;
 use Sulu\Component\Util\SuluVersionPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -38,15 +37,6 @@ class SuluWebsiteBundle extends Bundle
         $container->addCompilerPass(new DeregisterDefaultRouteListenerCompilerPass());
         $container->addCompilerPass(
             new RouteDefaultOptionsCompilerPass('sulu_website.provider.content', 7)
-        );
-
-        $container->addCompilerPass(
-            new TaggedServiceCollectorCompilerPass(
-                'sulu_website.reference_store_pool',
-                'sulu_website.reference_store',
-                0,
-                'alias'
-            )
         );
 
         $this->buildPersistence(

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/ResourceLocatorStrategyPool.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/ResourceLocatorStrategyPool.php
@@ -19,10 +19,16 @@ use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 class ResourceLocatorStrategyPool implements ResourceLocatorStrategyPoolInterface
 {
     /**
-     * @param ResourceLocatorStrategyInterface[] $strategies
+     * @var array<string, ResourceLocatorStrategyInterface>
      */
-    public function __construct(private array $strategies, private WebspaceManagerInterface $webspaceManager)
+    private $strategies;
+
+    /**
+     * @param iterable<string, ResourceLocatorStrategyInterface> $strategies
+     */
+    public function __construct(iterable $strategies, private WebspaceManagerInterface $webspaceManager)
     {
+        $this->strategies = [...$strategies];
     }
 
     public function getStrategy($name)

--- a/src/Sulu/Component/Symfony/CompilerPass/TaggedServiceCollectorCompilerPass.php
+++ b/src/Sulu/Component/Symfony/CompilerPass/TaggedServiceCollectorCompilerPass.php
@@ -17,6 +17,10 @@ use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * Collects services by tag and inject it via constructor argument.
+ *
+ * @internal
+ *
+ * @deprecated since version 2.6 use a tagged_iterator instead
  */
 class TaggedServiceCollectorCompilerPass implements CompilerPassInterface
 {

--- a/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
+++ b/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
@@ -24,11 +24,11 @@ class RequestAnalyzer implements RequestAnalyzerInterface
     public const SULU_ATTRIBUTE = '_sulu';
 
     /**
-     * @param RequestProcessorInterface[] $requestProcessors
+     * @param iterable<RequestProcessorInterface> $requestProcessors
      */
     public function __construct(
         private RequestStack $requestStack,
-        private array $requestProcessors
+        private iterable $requestProcessors
     ) {
     }
 

--- a/src/Sulu/Component/Webspace/Url/WebspaceUrlChainProvider.php
+++ b/src/Sulu/Component/Webspace/Url/WebspaceUrlChainProvider.php
@@ -19,10 +19,10 @@ use Sulu\Component\Webspace\Webspace;
 class WebspaceUrlChainProvider implements WebspaceUrlProviderInterface
 {
     /**
-     * @param WebspaceUrlProviderInterface[] $chain
+     * @param iterable<WebspaceUrlProviderInterface> $chain
      */
     public function __construct(
-        private array $chain = []
+        private iterable $chain = []
     ) {
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | refs #7402 
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Replacing the Sulu implementation of tagged iterators with the Symfony one.

#### Why?
We don't need to reinvent the wheel.

#### Example usage
Before you had to have this in the bundle configuration:
```php
         $container->addCompilerPass(
            new TaggedServiceCollectorCompilerPass(
                'sulu_markup.link_tag.provider_pool',
                'sulu.link.provider',
                0,
                'alias'
            )
        );
```

Now Sulu uses this:
```xml
<service id="sulu_markup.link_tag.provider_pool" class="..." />
    <argument type="tagged_iterator" tag="sulu.link.provider" indexed-by="alias" />
</service>
```

#### To Do

- [x] Add breaking changes to UPGRADE.md

<!--

Dear Contributors,

Thank you for contributing to the Sulu ecosystem!

We appreciate your effort to improve our project.  
If you need assistance or have questions about your pull request, our team is here to help.  
Please join our Slack channel for support: https://sulu.io/services/support#chat.

Best Regards, 
The Sulu Core Team

-->
