### PR TITLE
Fix npx symlink command correctly for Windows CMD shell

### DIFF
--- a/symlink-vendor-directory.js
+++ b/symlink-vendor-directory.js
@@ -33,7 +33,7 @@ if (
         && path.basename(path.dirname(process.cwd())) === 'assets'
     )
 ) {
-    exec('npx "symlink-dir@<6.0" ' + from + ' ' + to, (error) => {
+    exec('npx "symlink-dir@<6.0" "' + from + '" "' + to + '"', (error) => {
         if (error) {
             throw new Error('Error occured while creating symlink: ' + error);
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes https://github.com/sulu/sulu/issues/7429
| Related issues/PRs | https://github.com/sulu/skeleton/pull/247
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Escape npx command correctly for windows CMD.

#### Why?

Currently failing see https://github.com/sulu/skeleton/pull/247.