### PR TITLE
Remove not longer required symlink node scripts

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -1,3 +1,1 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
-
-require('./symlink-vendor-directory.js');

--- a/preinstall.js
+++ b/preinstall.js
@@ -6,5 +6,3 @@ if (process.env.npm_execpath.indexOf('npm') === -1
 ) {
     throw new Error('\x1b[31mYou must use "npm install", yarn is not supported\x1b[0m');
 }
-
-require('./symlink-vendor-directory.js');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no
| BC breaks? | no 
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove not longer required symlink node scripts.

#### Why?

The Sulu 2.6 not longer requires this symlink script.
