### PR TITLE
Fix matchMedia compatibility to jest

### DIFF
--- a/tests/js/testSetup.config.js
+++ b/tests/js/testSetup.config.js
@@ -20,3 +20,17 @@ jest.mock('sulu-admin-bundle/services/Config', () => ({
     translations: ['en', 'de'],
     fallbackLocale: 'en',
 }));
+
+Object.defineProperty(window, 'matchMedia', { // see https://github.com/ckeditor/ckeditor5/issues/16368
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(), // deprecated
+        removeListener: jest.fn(), // deprecated
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+    })),
+});


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/ckeditor/ckeditor5/issues/16368 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix matchMedia compatibility to jest.

#### Why?

Avoid Ci failing currenltly beasue of the issue mention [here in ckeditor](https://github.com/ckeditor/ckeditor5/issues/16368?issue=1).