### PR TITLE
Remove SymfonyTestsListener configuration

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,7 +31,4 @@
         <ini name="date.timezone" value="UTC"/>
     </php>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/ActivityBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/ActivityBundle/phpunit.xml.dist
@@ -27,7 +27,4 @@
         <ini name="date.timezone" value="UTC"/>
     </php>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/AdminBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/AdminBundle/phpunit.xml.dist
@@ -25,22 +25,4 @@
         <ini name="date.timezone" value="UTC"/>
     </php>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener">
-            <arguments>
-                <array>
-                    <element key="time-sensitive">
-                        <array>
-                            <element key="0">
-                                <string>Sulu\Bundle\AdminBundle\Entity</string>
-                            </element>
-                            <element key="1">
-                                <string>Sulu\Bundle\AdminBundle\Tests\Unit\Entity</string>
-                            </element>
-                        </array>
-                    </element>
-                </array>
-            </arguments>
-        </listener>
-    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/phpunit.xml.dist
@@ -27,7 +27,4 @@
         <ini name="date.timezone" value="UTC"/>
     </php>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/CategoryBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/CategoryBundle/phpunit.xml.dist
@@ -27,7 +27,4 @@
         <ini name="date.timezone" value="UTC"/>
     </php>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/ContactBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/ContactBundle/phpunit.xml.dist
@@ -27,7 +27,4 @@
         <ini name="date.timezone" value="UTC"/>
     </php>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/CoreBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/CoreBundle/phpunit.xml.dist
@@ -27,7 +27,4 @@
         <ini name="date.timezone" value="UTC"/>
     </php>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/CustomUrlBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/CustomUrlBundle/phpunit.xml.dist
@@ -27,7 +27,4 @@
         <ini name="date.timezone" value="UTC"/>
     </php>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/DocumentManagerBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/DocumentManagerBundle/phpunit.xml.dist
@@ -29,7 +29,4 @@
         <ini name="date.timezone" value="UTC"/>
     </php>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/HttpCacheBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/HttpCacheBundle/phpunit.xml.dist
@@ -25,7 +25,4 @@
         <ini name="date.timezone" value="UTC"/>
     </php>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/LocationBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/LocationBundle/phpunit.xml.dist
@@ -26,7 +26,4 @@
         <ini name="date.timezone" value="UTC"/>
     </php>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/MarkupBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/MarkupBundle/phpunit.xml.dist
@@ -26,7 +26,4 @@
         <ini name="date.timezone" value="UTC"/>
     </php>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaStreamControllerWebsiteSecuredTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaStreamControllerWebsiteSecuredTest.php
@@ -58,6 +58,8 @@ class MediaStreamControllerWebsiteSecuredTest extends WebsiteTestCase
 
     /**
      * @runInSeparateProcess
+     *
+     * @preserveGlobalState disabled
      */
     public function testDownloadWithCollectionPermissions(): void
     {

--- a/src/Sulu/Bundle/MediaBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/MediaBundle/phpunit.xml.dist
@@ -27,7 +27,4 @@
         <ini name="date.timezone" value="UTC"/>
     </php>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/PageBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/PageBundle/phpunit.xml.dist
@@ -27,7 +27,4 @@
         <ini name="date.timezone" value="UTC"/>
     </php>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/PersistenceBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/PersistenceBundle/phpunit.xml.dist
@@ -27,7 +27,4 @@
         <ini name="date.timezone" value="UTC"/>
     </php>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/PreviewBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/PreviewBundle/phpunit.xml.dist
@@ -27,7 +27,4 @@
         <ini name="date.timezone" value="UTC"/>
     </php>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/RouteBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/RouteBundle/phpunit.xml.dist
@@ -27,7 +27,4 @@
         <ini name="date.timezone" value="UTC"/>
     </php>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/SearchBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/SearchBundle/phpunit.xml.dist
@@ -29,7 +29,4 @@
         <ini name="date.timezone" value="UTC"/>
     </php>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/SecurityBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/SecurityBundle/phpunit.xml.dist
@@ -27,7 +27,4 @@
         <ini name="date.timezone" value="UTC"/>
     </php>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/SnippetBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/SnippetBundle/phpunit.xml.dist
@@ -28,7 +28,4 @@
         <ini name="date.timezone" value="UTC"/>
     </php>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/TagBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/TagBundle/phpunit.xml.dist
@@ -27,7 +27,4 @@
         <ini name="date.timezone" value="UTC"/>
     </php>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/TrashBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/TrashBundle/phpunit.xml.dist
@@ -24,7 +24,4 @@
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
         <ini name="date.timezone" value="UTC"/>
     </php>
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/EventListener/SecurityListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/EventListener/SecurityListenerTest.php
@@ -43,6 +43,9 @@ class SecurityListenerTest extends SuluTestCase
         $this->initPhpcr();
     }
 
+    /**
+     * @preserveGlobalState disabled
+     */
     public function testNoPermissions(): void
     {
         $pageDocument = $this->createSecuredPage();
@@ -54,6 +57,9 @@ class SecurityListenerTest extends SuluTestCase
         $this->assertNull($response->headers->get('Location'));
     }
 
+    /**
+     * @preserveGlobalState disabled
+     */
     public function testRedirectToLoginWhenNoAccess(): void
     {
         $pageDocument = $this->createSecuredPage();

--- a/src/Sulu/Bundle/WebsiteBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/WebsiteBundle/phpunit.xml.dist
@@ -27,7 +27,4 @@
         <ini name="date.timezone" value="UTC"/>
     </php>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no
| Fixed tickets | fixes 
| Related issues/PRs | related #7339 
| License | MIT
| Documentation PR | 

#### What's in this PR?
Removing SymfonyTestsLister since it's being removed in PhpUnit 10 anyways.

#### Why?
see above

