### PR TITLE
Make EnvironmentTest for Webspace more explicit

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -315,6 +315,7 @@ class PreviewRenderer implements PreviewRendererInterface
         $portal->setXDefaultLocalization($localization);
         $portal->setLocalizations([$localization]);
         $portal->setDefaultLocalization($localization);
+
         $environment = new Environment();
         $url = new Url($domain, $this->environment);
         $environment->setUrls([$url]);

--- a/src/Sulu/Component/Webspace/Tests/Unit/EnvironmentTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/EnvironmentTest.php
@@ -23,25 +23,27 @@ class EnvironmentTest extends TestCase
     public function testToArray(): void
     {
         $expected = [
-            'type' => 'foo',
+            'type' => 'test',
             'urls' => [
                 0 => [
-                    'url' => 'test',
+                    'url' => 'sulu.io',
                     'language' => null,
                     'country' => null,
                     'segment' => null,
                     'redirect' => null,
                     'main' => true,
-                    'environment' => null,
+                    'environment' => 'test',
                 ],
             ],
         ];
-        $url = new Url('test', 'test');
+
+        // Testing that the environment of the url is overridden when adding it to the environment object
+        $url = new Url('sulu.io', 'I should be overwritten');
 
         $environment = new Environment();
+        $environment->setType($expected['type']);
 
         $environment->addUrl($url);
-        $environment->setType($expected['type']);
 
         $this->assertEquals($expected, $environment->toArray());
     }

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionTest.php
@@ -39,12 +39,12 @@ class WebspaceCollectionTest extends TestCase
         $portal->setKey('portal1');
 
         $environment = new Environment();
+        $environment->setType('prod');
         $url = new Url();
         $url->setUrl('www.portal1.com');
         $url->setLanguage('en');
         $url->setCountry('us');
         $environment->addUrl($url);
-        $environment->setType('prod');
         $url = new Url();
         $url->setUrl('portal1.com');
         $url->setRedirect('www.portal1.com');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no  
| BC breaks? | no  
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #7222 #7218
| License | MIT
| Documentation PR | -

#### What's in this PR?
Making the `EnvironmentTest` more explicit on what it does.

#### Why?
When fixing the tests for the Webspace configuration migration I noticed that the second parameter of the Url wasn't used in this test. It turns out that it is overriden by the environment configuration. However, the type of the environment config is set after the url is added so the `environment` property in the expected result is empty (which should not happen). Seeing that the type is an essential property of the environment and should be configured in the constructor (see #7222 for that) We should move the setter call (that is part of the object setup) infront of the `addUrl` call. 