### PR TITLE
Fix resetting of PasswordResetTokenEmailsSent Value after Expiring

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26467,7 +26467,7 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\:\\:setPasswordResetTokenEmailsSent\\(\\)\\.$#"
-			count: 2
+			count: 3
 			path: src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
 
 		-
@@ -27667,7 +27667,7 @@ parameters:
 
 		-
 			message: "#^Cannot call method getCollector\\(\\) on Symfony\\\\Component\\\\HttpKernel\\\\Profiler\\\\Profile\\|false\\|null\\.$#"
-			count: 9
+			count: 11
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ResettingControllerTest.php
 
 		-
@@ -27697,7 +27697,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
-			count: 13
+			count: 15
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ResettingControllerTest.php
 
 		-

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/LegacyResettingControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/LegacyResettingControllerTest.php
@@ -239,6 +239,53 @@ class LegacyResettingControllerTest extends SuluTestCase
         $this->assertEquals($counter, $user->getPasswordResetTokenEmailsSent());
     }
 
+    public function testResetCounterAfterTokenExpiration(): void
+    {
+        $this->client->enableProfiler();
+
+        // starting counter at 1 - because user3 already has one sent email
+        $counter = 1;
+        $maxNumberEmails = $this->getContainer()->getParameter('sulu_security.reset_password.mail.token_send_limit');
+        for (; $counter < $maxNumberEmails; ++$counter) {
+            $this->client->jsonRequest('GET', '/security/reset/email', [
+                'user' => $this->users[2]->getEmail(),
+            ]);
+
+            $mailCollector = $this->client->getProfile()->getCollector('swiftmailer');
+            $response = \json_decode($this->client->getResponse()->getContent());
+
+            $this->assertHttpStatusCode(204, $this->client->getResponse());
+            $this->assertEquals(null, $response);
+            $this->assertEquals(1, $mailCollector->getMessageCount());
+        }
+
+        $user = $this->em->find(
+            User::class,
+            $this->users[2]->getId(),
+        );
+
+        $user->setPasswordResetTokenExpiresAt(new \DateTime('-1 day'));
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->client->jsonRequest('GET', '/security/reset/email', [
+            'user' => $user->getEmail(),
+        ]);
+
+        $mailCollector = $this->client->getProfile()->getCollector('swiftmailer');
+        $response = \json_decode($this->client->getResponse()->getContent());
+        $user = $this->client->getContainer()->get('doctrine')->getManager()->find(
+            'SuluSecurityBundle:User',
+            $user->getId()
+        );
+
+        $this->assertHttpStatusCode(204, $this->client->getResponse());
+        $this->assertEquals(null, $response);
+        $this->assertEquals(1, $mailCollector->getMessageCount());
+        $this->assertEquals(1, $user->getPasswordResetTokenEmailsSent());
+        $this->assertGreaterThanOrEqual(new \DateTime(), $user->getPasswordResetTokenExpiresAt());
+    }
+
     public function testSendEmailActionWithMissingUser(): void
     {
         $this->client->enableProfiler();

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/LegacyResettingControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/LegacyResettingControllerTest.php
@@ -259,6 +259,9 @@ class LegacyResettingControllerTest extends SuluTestCase
             $this->assertEquals(1, $mailCollector->getMessageCount());
         }
 
+        static::ensureKernelShutdown(); // shutdown to fix lowest test with: `Error: Cannot use object of type Doctrine\ORM\EntityNotFoundException as array` when try to flush the entity manager next
+        $this->client = $this->createAuthenticatedClient();
+
         $user = $this->em->find(
             User::class,
             $this->users[2]->getId(),

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ResettingControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ResettingControllerTest.php
@@ -266,6 +266,57 @@ class ResettingControllerTest extends SuluTestCase
         $this->assertEquals($counter, $user->getPasswordResetTokenEmailsSent());
     }
 
+    public function testResetCounterAfterTokenExpiration(): void
+    {
+        $this->client->enableProfiler();
+
+        // starting counter at 1 - because user3 already has one sent email
+        $counter = 1;
+        $maxNumberEmails = $this->getContainer()->getParameter('sulu_security.reset_password.mail.token_send_limit');
+        for (; $counter < $maxNumberEmails; ++$counter) {
+            $this->client->jsonRequest('GET', '/security/reset/email', [
+                'user' => $this->users[2]->getEmail(),
+            ]);
+
+            /** @var MessageDataCollector $mailCollector */
+            $mailCollector = $this->client->getProfile()->getCollector('mailer');
+            $response = \json_decode($this->client->getResponse()->getContent());
+
+            $this->assertHttpStatusCode(204, $this->client->getResponse());
+            $this->assertEquals(null, $response);
+            $this->assertCount(1, $mailCollector->getEvents()->getMessages());
+        }
+
+        /** @var User $user */
+        $user = $this->em->find(
+            User::class,
+            $this->users[2]->getId(),
+        );
+
+        $user->setPasswordResetTokenExpiresAt(new \DateTime('-1 day'));
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->client->jsonRequest('GET', '/security/reset/email', [
+            'user' => $user->getEmail(),
+        ]);
+
+        /** @var MessageDataCollector $mailCollector */
+        $mailCollector = $this->client->getProfile()->getCollector('mailer');
+        $response = \json_decode($this->client->getResponse()->getContent());
+        /** @var User $user */
+        $user = $this->client->getContainer()->get('doctrine')->getManager()->find(
+            User::class,
+            $user->getId()
+        );
+
+        $this->assertHttpStatusCode(204, $this->client->getResponse());
+        $this->assertEquals(null, $response);
+        $this->assertCount(1, $mailCollector->getEvents()->getMessages());
+        $this->assertEquals(1, $user->getPasswordResetTokenEmailsSent());
+        $this->assertGreaterThanOrEqual(new \DateTime(), $user->getPasswordResetTokenExpiresAt());
+    }
+
     public function testSendEmailActionWithMissingUser(): void
     {
         $this->client->enableProfiler();

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ResettingControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ResettingControllerTest.php
@@ -287,6 +287,9 @@ class ResettingControllerTest extends SuluTestCase
             $this->assertCount(1, $mailCollector->getEvents()->getMessages());
         }
 
+        static::ensureKernelShutdown(); // shutdown to fix lowest test with: `Error: Cannot use object of type Doctrine\ORM\EntityNotFoundException as array` when try to flush the entity manager next
+        $this->client = $this->createAuthenticatedClient();
+
         /** @var User $user */
         $user = $this->em->find(
             User::class,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #7037
| License | MIT

#### What's in this PR?

Fix check of `passwordResetTokenExpiresAt` by moving it to the calling function and dividing it into two checks. So that if the token is expired the `passwordResetTokenEmailsSent` is reset to 0. Otherwise it's going to be checked whether the `maxNumberEmails` was reached or not, and acted upon that accordingly.

#### Why?

"Reset password does not work properly.
If someone makes a reset password request, request works and "passwordResetTokenEmailsSent" goes up to 3.
Even 48h after, passwordResetTokenEmailsSent stays at 3, so reset emails are not sent.
BUT, this number is never reset to 0, even if time interval (24h) is done."
- https://github.com/sulu/sulu/issues/7037

#### To Do

- [x] Gather feedback for my changes
- [x] Change target branch to 2.5
- [x] Fix lint
- [x] Add test case