### PR TITLE
Update RouteRepository.php

### DIFF
--- a/src/Sulu/Bundle/RouteBundle/Entity/RouteRepository.php
+++ b/src/Sulu/Bundle/RouteBundle/Entity/RouteRepository.php
@@ -89,10 +89,13 @@ class RouteRepository extends EntityRepository implements RouteRepositoryInterfa
     public function persist(RouteInterface $route)
     {
         $this->getEntityManager()->persist($route);
+        $this->getEntityManager()->flush();
+        
     }
 
     public function remove(RouteInterface $route)
     {
         $this->getEntityManager()->remove($route);
+        $this->getEntityManager()->flush();
     }
 }


### PR DESCRIPTION
I belive persisting route should also flush it in database

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs |  -
| License | MIT
| Documentation PR | -

#### What's in this PR?

i have added flushing entity manager in `persist` and `remove` methods in `Sulu\Bundle\RouteBundle\Entity\RouteRepository`

#### Why?

Using  `Sulu\Bundle\RouteBundle\Entity\RouteRepository:persist`  method you had to manually call `flush()` on entityManager. It means if you wanted to use `RouteManager` you had to inject not only `RouteManager` itself but `EntityManager` also to flush routes.


