### PR TITLE
Use php-cs-fixer shim to avoid conflicts

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -205,8 +205,8 @@ jobs:
                   coverage: none
 
             - name: Remove Lint Tools
-              # This tools are not required for running tests and are so removed to improve dependency resolving and
-              # testing lowest versions
+              # These tools are not required to run tests, so we are removing them to improve dependency resolving and
+              # testing lowest versions.
               run: composer remove "*php-cs-fixer*" "*phpstan*" --dev --no-update
 
             - name: Require jackrabbit dependencies

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -204,6 +204,11 @@ jobs:
                   ini-values: memory_limit=-1
                   coverage: none
 
+            - name: Remove Lint Tools
+              # This tools are not required for running tests and are so removed to improve dependency resolving and
+              # testing lowest versions
+              run: composer remove "*php-cs-fixer*" "*phpstan*" --dev --no-update
+
             - name: Require jackrabbit dependencies
               if: ${{ matrix.phpcr-transport == 'jackrabbit' }}
               run: |

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,6 +15,7 @@ $finder = PhpCsFixer\Finder::create()
 
 $config = new PhpCsFixer\Config();
 $config->setRiskyAllowed(true)
+    ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
     ->setRules([
         '@Symfony' => true,
         'array_syntax' => ['syntax' => 'short'],

--- a/composer.json
+++ b/composer.json
@@ -109,7 +109,6 @@
         "webmozart/assert": "^1.9"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.14",
         "google/cloud-storage": "^1.0",
         "handcraftedinthealps/zendsearch": "^2.0",
         "jackalope/jackalope": "^1.4.5",
@@ -122,6 +121,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "microsoft/azure-storage-blob": "^1.2",
         "monolog/monolog": "^1.26.1 || ^2.3",
+        "php-cs-fixer/shim": "^3.14",
         "php-ffmpeg/php-ffmpeg": "^0.17 || ^1.0",
         "phpcr/phpcr-shell": "^1.4.0",
         "phpspec/prophecy": "^1.14",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Use php-cs-fixer shim to avoid conflicts.

#### Why?

The php cs fixer added some more dependency for parallel runs to avoid future dependeny conflicts we should use the `shim` verson instead.

 - https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/composer.json
 - https://github.com/PHP-CS-Fixer/shim/blob/master/composer.json