### PR TITLE
Do not override existing route on copy locale subscriber

### DIFF
--- a/src/Sulu/Component/Content/Document/Subscriber/CopyLocaleSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/CopyLocaleSubscriber.php
@@ -167,7 +167,7 @@ class CopyLocaleSubscriber implements EventSubscriberInterface
             return $documentStructure;
         }
 
-        $parentPageUuid = $routePath['page']['uuid'];
+        $parentPageUuid = $routePath['page']['uuid'] ?? null;
 
         /** @var ?PageDocument $destParentDocument */
         $destParentDocument = $this->documentManager->find(

--- a/src/Sulu/Component/Content/Document/Subscriber/CopyLocaleSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/CopyLocaleSubscriber.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\Content\Document\Subscriber;
 
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Bundle\PageBundle\Document\PageDocument;
+use Sulu\Bundle\RouteBundle\Model\RouteInterface;
 use Sulu\Component\Content\Document\Behavior\ExtensionBehavior;
 use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
 use Sulu\Component\Content\Document\Behavior\StructureBehavior;
@@ -191,6 +192,12 @@ class CopyLocaleSubscriber implements EventSubscriberInterface
             'suffix' => $routePath['suffix'],
         ];
         $destDocument->setRoutePath($routePathProp);
+
+        /** @var RouteInterface|null $route */
+        $route = $destDocument->getRoute();
+        if ($route && $route->getLocale() === $destLocale) {
+            $route->setPath($routePathProp);
+        }
 
         return $documentStructure;
     }

--- a/src/Sulu/Component/Content/Document/Subscriber/CopyLocaleSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/CopyLocaleSubscriber.php
@@ -175,7 +175,7 @@ class CopyLocaleSubscriber implements EventSubscriberInterface
             $destLocale
         );
 
-        if ($destParentDocument instanceof PageDocument && WorkflowStage::PUBLISHED === $destParentDocument->getWorkflowStage()) {
+        if ($destParentDocument instanceof PageDocument) {
             $destParentUrl = $destParentDocument->getStructure()->getProperty('url')->getValue();
         } else {
             $destParentUrl = '';
@@ -192,8 +192,6 @@ class CopyLocaleSubscriber implements EventSubscriberInterface
             'suffix' => $routePath['suffix'],
         ];
         $destDocument->setRoutePath($routePathProp);
-        $destDocument->getRoute()->setPath($routePathProp);
-        $destDocument->getRoute()->setLocale($destLocale);
 
         return $documentStructure;
     }

--- a/src/Sulu/Component/Content/Document/Subscriber/CopyLocaleSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/CopyLocaleSubscriber.php
@@ -18,7 +18,6 @@ use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
 use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\Content\Document\Behavior\WebspaceBehavior;
 use Sulu\Component\Content\Document\Behavior\WorkflowStageBehavior;
-use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\Content\Metadata\PropertyMetadata;
 use Sulu\Component\Content\Types\ResourceLocator\Strategy\ResourceLocatorStrategyPoolInterface;
 use Sulu\Component\DocumentManager\Behavior\Mapping\LocaleBehavior;

--- a/src/Sulu/Component/Content/Document/Subscriber/CopyLocaleSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/CopyLocaleSubscriber.php
@@ -163,7 +163,7 @@ class CopyLocaleSubscriber implements EventSubscriberInterface
         $pageTreeRoutePropertyName = $this->getPageTreeRoutePropertyName($document);
         $routePath = $documentStructure[$pageTreeRoutePropertyName] ?? null;
 
-        if (!$routePath || !\array_key_exists('page', $routePath)) {
+        if (!$routePath || !\is_array($routePath) || !\array_key_exists('page', $routePath)) {
             return $documentStructure;
         }
 

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/CopyLocaleSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/CopyLocaleSubscriberTest.php
@@ -134,6 +134,38 @@ class CopyLocaleSubscriberTest extends SubscriberTestCase
         $this->subscriber->handleCopyLocale($event->reveal());
     }
 
+    public function testHandleCopyLocalePageTreeRouteNonArrayRoutePath(): void
+    {
+        /** @var CopyLocaleEvent|ObjectProphecy $event */
+        $event = $this->prophesize(CopyLocaleEvent::class);
+        $event->getLocale()->willReturn('en');
+        $event->getDestLocale()->willReturn('de');
+
+        $structureData = [
+            'foo' => 'bar',
+            'routePath' => 'test',
+        ];
+
+        /** @var StructureInterface|ObjectProphecy $structure */
+        $structure = $this->prophesize(StructureInterface::class);
+        $structure->toArray()->willReturn($structureData);
+
+        /** @var PageDocument|ObjectProphecy $document */
+        $document = $this->prophesize(PageDocument::class);
+        $document->getStructure()->willReturn($structure->reveal());
+
+        /** @var RoutableBehavior|ObjectProphecy $destDocument */
+        $destDocument = $this->prophesize(RoutableBehavior::class);
+
+        $structure = $this->subscriber->checkPageTreeRoute($destDocument->reveal(), $document->reveal(), 'de');
+        $expectedStructure = [
+            'foo' => 'bar',
+            'routePath' => 'test',
+        ];
+
+        $this->assertSame($expectedStructure, $structure);
+    }
+
     public function testHandleCopyLocalePageTreeRoute(): void
     {
         /** @var CopyLocaleEvent|ObjectProphecy $event */


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #7311, #7309
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fixes the copy locale subscriber to work properly for articles

#### Why?

The existing code fails in two different ways for both cases:

Original locale is already published:
copy locale runs through without an exception, but the original route is modified and changed to the new locale due to these two lines:

```php
$destDocument->getRoute()->setPath($routePathProp);
$destDocument->getRoute()->setLocale($destLocale);
```

Original locale is not published:
the copy locale request fails with an exception, because the `destDocument->getRoute()` returns null in the same two lines
```php
$destDocument->getRoute()->setPath($routePathProp);
$destDocument->getRoute()->setLocale($destLocale);
```

Additionally the parent page was lost in case that the page is not yet published, in my opinion this is not necessary, the new copied locale can still reference an unpublished page for the route.
