### PR TITLE
Add better detection for Symfony Security Bundle Version

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31837,7 +31837,7 @@ parameters:
 
 		-
 			message: "#^If condition is always true\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/TestBundle/Resources/app/config/config.php
 
 		-

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/config.php
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/config.php
@@ -30,10 +30,10 @@ return static function(PhpFileLoader $loader, ContainerBuilder $container) {
     }
 
     if ('admin' === $context) {
-        if (\version_compare(Kernel::VERSION, '6.0.0', '>=')) {
-            $loader->import('security-6.yml');
-        } else {
+        if (\class_exists(Symfony\Bundle\SecurityBundle\Command\UserPasswordEncoderCommand::class)) { // detect Symfony <= 5.4
             $loader->import('security-5-4.yml');
+        } else {
+            $loader->import('security-6.yml');
         }
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | compatibility for https://github.com/sulu/SuluCommentBundle/pull/55 on PHP 8.0
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add better detection for Symfony Security Bundle Version.

#### Why?

Sometimes our own bundles install a mixed of Symfony versions like FrameworkBundle on 5.4 and SecurityBundle on 6.0. Currently we did not detect the bundle verson correctly and so the config was not there and errored with:

>  Unrecognized option "encoders" under "security". Available options are "access_control", "access_decision_manager", "access_denied_url", "enable_authenticator_manager", "erase_credentials", "firewalls", "hide_user_not_found",  "password_hashers", "providers", "role_hierarchy", "session_fixation_strategy".     