### PR TITLE
Fix empty phone/email/url/fax error on contact and accounts

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
@@ -577,7 +577,7 @@ abstract class AbstractContactManager implements ContactManagerInterface
         $urls = $this->getProperty($contactDetailsData, 'websites');
         if (!empty($urls)) {
             foreach ($urls as $urlData) {
-                if(!empty($urlData['website'])) {
+                if (!empty($urlData['website'])) {
                     $this->addUrl($contact, $urlData);
                 }
             }
@@ -588,7 +588,7 @@ abstract class AbstractContactManager implements ContactManagerInterface
         $faxes = $this->getProperty($contactDetailsData, 'faxes');
         if (!empty($faxes)) {
             foreach ($faxes as $faxData) {
-                if(!empty($faxData['fax'])) {
+                if (!empty($faxData['fax'])) {
                     $this->addFax($contact, $faxData);
                 }
             }
@@ -607,7 +607,7 @@ abstract class AbstractContactManager implements ContactManagerInterface
         $emails = $this->getProperty($contactDetailsData, 'emails');
         if (!empty($emails)) {
             foreach ($emails as $emailData) {
-                if(!empty($emailData['email'])) {
+                if (!empty($emailData['email'])) {
                     $this->addEmail($contact, $emailData);
                 }
             }
@@ -618,7 +618,7 @@ abstract class AbstractContactManager implements ContactManagerInterface
         $phones = $this->getProperty($contactDetailsData, 'phones');
         if (!empty($phones)) {
             foreach ($phones as $phoneData) {
-                if(!empty($phoneData['phone'])) {
+                if (!empty($phoneData['phone'])) {
                     $this->addPhone($contact, $phoneData);
                 }
             }

--- a/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
@@ -577,7 +577,7 @@ abstract class AbstractContactManager implements ContactManagerInterface
         $urls = $this->getProperty($contactDetailsData, 'websites');
         if (!empty($urls)) {
             foreach ($urls as $urlData) {
-                if(!empty($urlData['url'])) {
+                if(!empty($urlData['website'])) {
                     $this->addUrl($contact, $urlData);
                 }
             }

--- a/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
@@ -577,7 +577,9 @@ abstract class AbstractContactManager implements ContactManagerInterface
         $urls = $this->getProperty($contactDetailsData, 'websites');
         if (!empty($urls)) {
             foreach ($urls as $urlData) {
-                $this->addUrl($contact, $urlData);
+                if(!empty($urlData['url'])) {
+                    $this->addUrl($contact, $urlData);
+                }
             }
             $this->setMainUrl($contact);
         }
@@ -586,7 +588,9 @@ abstract class AbstractContactManager implements ContactManagerInterface
         $faxes = $this->getProperty($contactDetailsData, 'faxes');
         if (!empty($faxes)) {
             foreach ($faxes as $faxData) {
-                $this->addFax($contact, $faxData);
+                if(!empty($faxData['fax'])) {
+                    $this->addFax($contact, $faxData);
+                }
             }
             $this->setMainFax($contact);
         }
@@ -603,7 +607,9 @@ abstract class AbstractContactManager implements ContactManagerInterface
         $emails = $this->getProperty($contactDetailsData, 'emails');
         if (!empty($emails)) {
             foreach ($emails as $emailData) {
-                $this->addEmail($contact, $emailData);
+                if(!empty($emailData['email'])) {
+                    $this->addEmail($contact, $emailData);
+                }
             }
             $this->setMainEmail($contact);
         }
@@ -612,7 +618,9 @@ abstract class AbstractContactManager implements ContactManagerInterface
         $phones = $this->getProperty($contactDetailsData, 'phones');
         if (!empty($phones)) {
             foreach ($phones as $phoneData) {
-                $this->addPhone($contact, $phoneData);
+                if(!empty($phoneData['phone'])) {
+                    $this->addPhone($contact, $phoneData);
+                }
             }
             $this->setMainPhone($contact);
         }

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
@@ -356,6 +356,10 @@ class ContactControllerTest extends SuluTestCase
                             'email' => 'erika.mustermann@muster.de',
                             'emailType' => $emailType->getId(),
                         ],
+                        [
+                            'email' => null,
+                            'emailType' => $emailType->getId(),
+                        ],
                     ],
                     'phones' => [
                         [
@@ -366,6 +370,10 @@ class ContactControllerTest extends SuluTestCase
                             'phone' => '987654321',
                             'phoneType' => $phoneType->getId(),
                         ],
+                        [
+                            'phone' => null,
+                            'phoneType' => $phoneType->getId(),
+                        ],
                     ],
                     'faxes' => [
                         [
@@ -374,6 +382,10 @@ class ContactControllerTest extends SuluTestCase
                         ],
                         [
                             'fax' => '987654321-1',
+                            'faxType' => $faxType->getId(),
+                        ],
+                        [
+                            'fax' => null,
                             'faxType' => $faxType->getId(),
                         ],
                     ],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no

#### What's in this PR?

Fixes the error when creating a new contact.

#### Why?

When you try to create a new contact, fill something in a field (e.g. phone), and then delete it, you cannot save the contact because of the following error:
`An exception occurred while executing a query: SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'phone' cannot be null`
