### PR TITLE
Reindex moved documents so that the URL is updated

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21436,41 +21436,6 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Search/EventSubscriber/BlameTimestampSubscriber.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\PageBundle\\\\Search\\\\EventSubscriber\\\\StructureSubscriber\\:\\:deindexRemovedDocument\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Search/EventSubscriber/StructureSubscriber.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\PageBundle\\\\Search\\\\EventSubscriber\\\\StructureSubscriber\\:\\:deindexRemovedLocaleDocument\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Search/EventSubscriber/StructureSubscriber.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\PageBundle\\\\Search\\\\EventSubscriber\\\\StructureSubscriber\\:\\:deindexUnpublishedDocument\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Search/EventSubscriber/StructureSubscriber.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\PageBundle\\\\Search\\\\EventSubscriber\\\\StructureSubscriber\\:\\:indexDocument\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Search/EventSubscriber/StructureSubscriber.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\PageBundle\\\\Search\\\\EventSubscriber\\\\StructureSubscriber\\:\\:indexDocumentAfterRemoveDraft\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Search/EventSubscriber/StructureSubscriber.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\PageBundle\\\\Search\\\\EventSubscriber\\\\StructureSubscriber\\:\\:indexPersistedDocument\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Search/EventSubscriber/StructureSubscriber.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\PageBundle\\\\Search\\\\EventSubscriber\\\\StructureSubscriber\\:\\:indexPublishedDocument\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Search/EventSubscriber/StructureSubscriber.php
-
-		-
 			message: "#^Argument of an invalid type string supplied for foreach, only iterables are supported\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Search/Metadata/StructureProvider.php

--- a/src/Sulu/Bundle/PageBundle/Search/EventSubscriber/StructureSubscriber.php
+++ b/src/Sulu/Bundle/PageBundle/Search/EventSubscriber/StructureSubscriber.php
@@ -16,6 +16,7 @@ use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
 use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\Content\Document\Behavior\WorkflowStageBehavior;
 use Sulu\Component\Content\Document\WorkflowStage;
+use Sulu\Component\DocumentManager\Event\MoveEvent;
 use Sulu\Component\DocumentManager\Event\PersistEvent;
 use Sulu\Component\DocumentManager\Event\PublishEvent;
 use Sulu\Component\DocumentManager\Event\RemoveDraftEvent;
@@ -45,6 +46,7 @@ class StructureSubscriber implements EventSubscriberInterface
         return [
             Events::PERSIST => ['indexPersistedDocument', -10],
             Events::PUBLISH => ['indexPublishedDocument', -256],
+            Events::MOVE => ['indexMovedDocument', -256],
             Events::REMOVE => ['deindexRemovedDocument', 600],
             Events::UNPUBLISH => ['deindexUnpublishedDocument', -1024],
             Events::REMOVE_DRAFT => ['indexDocumentAfterRemoveDraft', -1024],
@@ -64,6 +66,14 @@ class StructureSubscriber implements EventSubscriberInterface
      * Indexes a published document.
      */
     public function indexPublishedDocument(PublishEvent $event)
+    {
+        $this->indexDocument($event->getDocument());
+    }
+
+    /**
+     * Indexes a moved document.
+     */
+    public function indexMovedDocument(MoveEvent $event)
     {
         $this->indexDocument($event->getDocument());
     }

--- a/src/Sulu/Bundle/PageBundle/Search/EventSubscriber/StructureSubscriber.php
+++ b/src/Sulu/Bundle/PageBundle/Search/EventSubscriber/StructureSubscriber.php
@@ -56,6 +56,8 @@ class StructureSubscriber implements EventSubscriberInterface
 
     /**
      * Indexes a persisted document.
+     *
+     * @return void
      */
     public function indexPersistedDocument(PersistEvent $event)
     {
@@ -64,6 +66,8 @@ class StructureSubscriber implements EventSubscriberInterface
 
     /**
      * Indexes a published document.
+     *
+     * @return void
      */
     public function indexPublishedDocument(PublishEvent $event)
     {
@@ -72,6 +76,8 @@ class StructureSubscriber implements EventSubscriberInterface
 
     /**
      * Indexes a moved document.
+     *
+     * @return void
      */
     public function indexMovedDocument(MoveEvent $event)
     {
@@ -80,6 +86,8 @@ class StructureSubscriber implements EventSubscriberInterface
 
     /**
      * Indexes a document after its draft have been removed.
+     *
+     * @return void
      */
     public function indexDocumentAfterRemoveDraft(RemoveDraftEvent $event)
     {
@@ -104,6 +112,8 @@ class StructureSubscriber implements EventSubscriberInterface
      * on the publish state.
      *
      * @param object $document
+     *
+     * @return void
      */
     private function indexDocument($document)
     {
@@ -120,6 +130,8 @@ class StructureSubscriber implements EventSubscriberInterface
 
     /**
      * Schedules a document to be deindexed.
+     *
+     * @return void
      */
     public function deindexRemovedDocument(RemoveEvent $event)
     {
@@ -145,6 +157,8 @@ class StructureSubscriber implements EventSubscriberInterface
 
     /**
      * Deindexes the document from the search index for the website.
+     *
+     * @return void
      */
     public function deindexUnpublishedDocument(UnpublishEvent $event)
     {
@@ -159,6 +173,8 @@ class StructureSubscriber implements EventSubscriberInterface
 
     /**
      * Deindexes the document from the search index for the website.
+     *
+     * @return void
      */
     public function deindexRemovedLocaleDocument(RemoveLocaleEvent $event)
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

The document indexed by MassiveSearch also contains a field for the URL (__url). This field was not updated when the document was moved. As a result, the search results pointed to the old URL until the document was published again.
