### PR TITLE
Fix unexpected single sign on definitions from SecurityBundle services.xml

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -388,41 +388,5 @@
 
             <tag name="sulu_admin.form_metadata_visitor" />
         </service>
-
-        <service id="sulu_security.open_id_login_subscriber" class="Sulu\Bundle\SecurityBundle\SingleSignOn\SingleSignOnLoginRequestSubscriber">
-            <argument type="service" id="sulu_security.single_sign_provider"/>
-            <argument type="service" id="router"/>
-            <argument type="service" id="sulu.repository.user"/>
-            <tag name="kernel.event_subscriber"/>
-        </service>
-
-        <service id="sulu_security.single_sign_on_adapter_factory_open_id" class="Sulu\Bundle\SecurityBundle\SingleSignOn\Adapter\OpenId\OpenIdSingleSignOnAdapterFactory">
-            <argument type="service" id="http_client"/>
-            <argument type="service" id="sulu_security.user_repository"/>
-            <argument type="service" id="doctrine.orm.entity_manager"/>
-            <argument type="service" id="sulu.repository.contact"/>
-            <argument type="service" id="sulu.repository.role"/>
-            <argument type="service" id="router"/>
-            <argument>%sulu_core.translations%</argument>
-
-            <tag name="sulu_security.single_sign_on_factory"/>
-        </service>
-
-        <service id="sulu_security.single_sign_on_adapter_factory" class="Sulu\Bundle\SecurityBundle\SingleSignOn\SingleSignOnAdapterFactory">
-            <argument type="tagged_iterator" tag="sulu_security.single_sign_on_factory"/>
-        </service>
-
-        <service id="sulu_security.single_sign_provider" class="Sulu\Bundle\SecurityBundle\SingleSignOn\SingleSignOnAdapterProvider">
-            <argument type="tagged_locator" tag="sulu_security.single_sign_on_adapter" index-by="domain" />
-        </service>
-
-        <service id="sulu_security.single_sign_on_token_extractor" class="Sulu\Bundle\SecurityBundle\SingleSignOn\SingleSignOnTokenExtractor">
-            <argument type="service" id="sulu_security.single_sign_provider"/>
-        </service>
-
-        <service id="sulu_security.single_sign_on_token_handler" class="Sulu\Bundle\SecurityBundle\SingleSignOn\SingleSignOnTokenHandler">
-            <argument type="service" id="sulu_security.single_sign_provider"/>
-            <argument type="service" id="http_client"/>
-        </service>
     </services>
 </container>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #7447
| Related issues/PRs | #
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove SSO service definitions from main services.xml

#### Why?

They are already defined in single_sign_on.xml and should be loaded conditionally (see https://github.com/sulu/sulu/blob/2.6/src/Sulu/Bundle/SecurityBundle/DependencyInjection/SuluSecurityExtension.php#L115)
