### PR TITLE
Only allow sorting references by existing fields

### DIFF
--- a/src/Sulu/Bundle/ReferenceBundle/Tests/Functional/UserInterface/Controller/Admin/ReferenceControllerTest.php
+++ b/src/Sulu/Bundle/ReferenceBundle/Tests/Functional/UserInterface/Controller/Admin/ReferenceControllerTest.php
@@ -45,7 +45,10 @@ class ReferenceControllerTest extends SuluTestCase
         );
     }
 
-    public function testCgetActionFiltersAndFields(): void
+    /**
+     * @dataProvider dataCgetActionFiltersAndFields
+     */
+    public function testCgetActionFiltersAndFields(string $url): void
     {
         $client = $this->createAuthenticatedClient();
 
@@ -61,7 +64,7 @@ class ReferenceControllerTest extends SuluTestCase
         self::getEntityManager()->flush();
 
         // represents a real request of the admin list UI
-        $client->request('GET', '/admin/api/references?resourceKey=media&resourceId=1&fields=referenceTitle,referenceLocale,referenceResourceKey,referenceContext,referenceProperty,id');
+        $client->request('GET', $url);
         $response = $client->getResponse();
 
         $this->assertHttpStatusCode(200, $response);
@@ -100,6 +103,17 @@ class ReferenceControllerTest extends SuluTestCase
             ],
             $json,
         );
+    }
+
+    public static function dataCgetActionFiltersAndFields(): \Generator
+    {
+        yield 'no sorting' => [
+            '/admin/api/references?resourceKey=media&resourceId=1&fields=referenceTitle,referenceLocale,referenceResourceKey,referenceContext,referenceProperty,id',
+        ];
+
+        yield 'non existing sorting' => [
+            '/admin/api/references?resourceKey=media&resourceId=1&fields=referenceTitle,referenceLocale,referenceResourceKey,referenceContext,referenceProperty,id&sortBy=does_not_exist&sortOrder=asc',
+        ];
     }
 
     public function testCgetActionChild(): void

--- a/src/Sulu/Bundle/ReferenceBundle/UserInterface/Controller/Admin/ReferenceController.php
+++ b/src/Sulu/Bundle/ReferenceBundle/UserInterface/Controller/Admin/ReferenceController.php
@@ -85,14 +85,6 @@ class ReferenceController extends AbstractRestController implements ClassResourc
             'offset' => $offset,
         ]);
 
-        /** @var string|null $sortBy */
-        $sortBy = $request->query->get('sortBy');
-        /** @var 'asc'|'desc' $sortOrder */
-        $sortOrder = $request->query->get('sortOrder', 'asc');
-        $sortBys = $sortBy ? [
-            $sortBy => $sortOrder,
-        ] : [];
-
         $fields = \explode(',', $request->query->get('fields', ''));
         $removeFields = ['id']; // the frontend always add the id field, but we don't need it in this case as we group by other fields
         $fields = [
@@ -102,6 +94,15 @@ class ReferenceController extends AbstractRestController implements ClassResourc
             'referenceLocale',
             'referenceRouterAttributes',
         ];
+
+        $sortBys = [];
+        /** @var string|null $sortBy */
+        $sortBy = $request->query->get('sortBy');
+        if (\in_array($sortBy, $fields, true)) {
+            /** @var 'asc'|'desc' $sortOrder */
+            $sortOrder = $request->query->get('sortOrder', 'asc');
+            $sortBys = [$sortBy => $sortOrder];
+        }
 
         if ($rootLevel) {
             $removeFields[] = 'referenceContext';


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #7207
| License | MIT
| Documentation PR | -

#### What's in this PR?
Only allow sorting by columns that the user can see (because we don't use the `DoctrineListBuilder` here).

#### Why?
If the user gets a `sortBy` inserted into the query parameter and can't get rid of it (since it's saved in the user settings) the controller returns a 500 and the user sees nothing.

The downside is that now you can't sort by fields that you can't see. But I don't think that this is such a downside.