### PR TITLE
Add Global blocks definitions for the FormMetadata

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
@@ -211,6 +211,7 @@
             <argument type="service" id="sulu_admin.metadata_provider_registry" />
 
             <tag name="sulu_admin.typed_form_metadata_visitor"/>
+            <tag name="sulu_admin.form_metadata_visitor" />
         </service>
 
         <!-- content query -->

--- a/src/Sulu/Component/Content/Types/Metadata/GlobalBlocksTypedFormMetadataVisitor.php
+++ b/src/Sulu/Component/Content/Types/Metadata/GlobalBlocksTypedFormMetadataVisitor.php
@@ -15,6 +15,7 @@ namespace Sulu\Component\Content\Types\Metadata;
 
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataVisitorInterface;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\ItemMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SectionMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
@@ -22,7 +23,7 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadataVisitorInterf
 use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
 
-class GlobalBlocksTypedFormMetadataVisitor implements TypedFormMetadataVisitorInterface
+class GlobalBlocksTypedFormMetadataVisitor implements TypedFormMetadataVisitorInterface, FormMetadataVisitorInterface
 {
     public function __construct(
         private MetadataProviderRegistry $metadataProviderRegistry,
@@ -96,5 +97,14 @@ class GlobalBlocksTypedFormMetadataVisitor implements TypedFormMetadataVisitorIn
         }
 
         return $this->globalBlocksMetadata->getForms()[$name] ?? null;
+    }
+
+    public function visitFormMetadata(FormMetadata $formMetadata, string $locale, array $metadataOptions = []): void
+    {
+        if ($metadataOptions['ignore_global_blocks'] ?? false) {
+            return;
+        }
+
+        $this->enhanceGlobalBlockTypes($formMetadata->getItems(), $locale, $formMetadata->getSchema());
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #7229 #7423
| License | MIT
| Documentation PR | -

#### What's in this PR?

Add missing definitions of used global blocks in the FormData in custom entities.

more info: https://sulu-io.slack.com/archives/C0430GGCV/p1718908503052599

#### Why?

Actually when using global blocks in the form in custom entities will throw error `Error: can't resolve reference #/definitions/[global_block] from id #` because GlobalBlockVisitor has missing interface for parsing `FormMetadata`.

