### PR TITLE
Add Rector with PHPUnit DataProviders update

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -207,7 +207,7 @@ jobs:
             - name: Remove Lint Tools
               # These tools are not required to run tests, so we are removing them to improve dependency resolving and
               # testing lowest versions.
-              run: composer remove "*php-cs-fixer*" "*phpstan*" --dev --no-update
+              run: composer remove "*php-cs-fixer*" "*phpstan*" "*rector*" --dev --no-update
 
             - name: Require jackrabbit dependencies
               if: ${{ matrix.phpcr-transport == 'jackrabbit' }}

--- a/composer.json
+++ b/composer.json
@@ -133,6 +133,7 @@
         "phpstan/phpstan-webmozart-assert": "^1.0",
         "phpunit/phpunit": "^9.5.20",
         "psr/event-dispatcher": "^1.0",
+        "rector/rector": "^1.1",
         "scheb/2fa-backup-code": "^6.0",
         "scheb/2fa-bundle": "^6.0",
         "scheb/2fa-email": "^6.0",
@@ -230,6 +231,7 @@
             "@lint-container",
             "@lint-composer",
             "@lint-doctrine",
+            "@lint-rector",
             "@php-cs",
             "@phpstan"
         ],
@@ -241,8 +243,21 @@
             "@php bin/adminconsole cache:warmup --env=dev",
             "@php vendor/bin/phpstan analyse"
         ],
+        "fix": [
+            "@rector",
+            "@php-cs-fix"
+        ],
         "php-cs": "@php vendor/bin/php-cs-fixer fix --verbose --diff --dry-run",
         "php-cs-fix": "@php vendor/bin/php-cs-fixer fix",
+        "lint-rector": [
+            "Composer\\Config::disableProcessTimeout",
+            "@php bin/websiteconsole cache:warmup --env=dev",
+            "@php vendor/bin/rector process --dry-run"
+        ],
+        "rector": [
+            "Composer\\Config::disableProcessTimeout",
+            "@php vendor/bin/rector process"
+        ],
         "lint-composer": "@composer validate --strict",
         "lint-twig": "@php bin/adminconsole lint:twig templates",
         "lint-yaml": "@php bin/adminconsole lint:yaml config",

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+
+return RectorConfig::configure()
+    ->withRootFiles()
+    ->withPaths([
+        __DIR__ . '/bin',
+        __DIR__ . '/config',
+        __DIR__ . '/public',
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->withSkipPath('*/var/cache')
+    ->withSkipPath('*/tests/Resources/cache')
+    ->withSkipPath('*/node_modules')
+    // ->withImportNames(importShortClasses: false)
+    ->withSets([
+        // SetList::CODE_QUALITY,
+        // LevelSetList::UP_TO_PHP_80,
+    ])
+    ->withRules([
+        StaticDataProviderClassMethodRector::class, // prepare for PHPUnit >= 10
+    ]);

--- a/rector.php
+++ b/rector.php
@@ -12,9 +12,11 @@ declare(strict_types=1);
  */
 
 use Rector\Config\RectorConfig;
+use Rector\Doctrine\Set\DoctrineSetList;
 use Rector\PHPUnit\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
+use Rector\Symfony\Set\SymfonySetList;
 
 return RectorConfig::configure()
     ->withRootFiles()
@@ -28,9 +30,16 @@ return RectorConfig::configure()
     ->withSkipPath('*/var/cache')
     ->withSkipPath('*/tests/Resources/cache')
     ->withSkipPath('*/node_modules')
+    ->withPHPStanConfigs([
+        __DIR__ . '/phpstan.neon',
+    ])
+    ->withSymfonyContainerXml(__DIR__ . '/var/cache/admin/dev/App_KernelDevDebugContainer.xml')
     // ->withImportNames(importShortClasses: false)
     ->withSets([
+        // Currently disabled as code is not typed enough:
         // SetList::CODE_QUALITY,
+        // SymfonySetList::SYMFONY_CODE_QUALITY,
+        // DoctrineSetList::DOCTRINE_CODE_QUALITY,
         // LevelSetList::UP_TO_PHP_80,
     ])
     ->withRules([

--- a/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
+++ b/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
@@ -346,7 +346,7 @@ class MediaDataProviderTest extends TestCase
         $this->assertEquals($dataItems, $result->getItems());
     }
 
-    public function resourceItemsDataProvider()
+    public static function resourceItemsDataProvider()
     {
         $medias = [
             self::createMedia(1, 'Test-1'),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no 
| BC breaks? | no
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add Rector with PHPUnit DataProviders update.

#### Why?

This avoids regression and reintroducing of dataproviders without the part of static method.
