### PR TITLE
Avoid __toString() return null error on Doctrine Exceptions

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Entity/Permission.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/Permission.php
@@ -161,6 +161,6 @@ class Permission
 
     public function __toString()
     {
-        return $this->context;
+        return (string) $this->context;
     }
 }

--- a/src/Sulu/Bundle/TagBundle/Entity/Tag.php
+++ b/src/Sulu/Bundle/TagBundle/Entity/Tag.php
@@ -146,6 +146,6 @@ class Tag implements TagInterface
 
     public function __toString()
     {
-        return $this->getName();
+        return (string) $this->getName();
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Avoid __toString() on doctrine Exceptions.

#### Why?

If a `Doctrine` Exception happen doctrine tries to call `$entity->__toString()` method for generating the error message. But as in some cases the Tag Name is may not set it ends up in the error:

> Sulu\Bundle\TagBundle\Entity\Tag::__toString(): Return value must be of type string, null returned

Most devs confused that and not looking at the `Stack Trace` of the error to get the real error message. To avoid this error we should always return a string if possible.

For 3.0 I would recommend to remove the magic methods so doctrine returns always the object hash, but that is a bc break at current state, so need to discussed first.