### PR TITLE
Fix locale length for languages like zh-Hans

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,24 @@
 # Upgrade
 
+## 2.6.3
+
+### Change locale length
+
+Change length of the locale fields to support longer locales.
+
+```sql
+ALTER TABLE re_references CHANGE referenceLocale referenceLocale VARCHAR(15) DEFAULT NULL;
+ALTER TABLE me_collection_meta CHANGE locale locale VARCHAR(15) NOT NULL;
+ALTER TABLE me_file_version_publish_languages CHANGE locale locale VARCHAR(15) NOT NULL;
+ALTER TABLE me_file_version_meta CHANGE locale locale VARCHAR(15) NOT NULL;
+ALTER TABLE me_file_version_content_languages CHANGE locale locale VARCHAR(15) NOT NULL;
+ALTER TABLE ca_category_meta CHANGE locale locale VARCHAR(15) DEFAULT NULL;
+ALTER TABLE ca_category_translations CHANGE locale locale VARCHAR(15) NOT NULL;
+ALTER TABLE ca_categories CHANGE default_locale default_locale VARCHAR(15) NOT NULL;
+ALTER TABLE ca_keywords CHANGE locale locale VARCHAR(15) NOT NULL;
+ALTER TABLE ro_routes CHANGE locale locale VARCHAR(15) NOT NULL;
+```
+
 ## 2.6.0
 
 ### PHP 8.2 upgrade

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/Category.orm.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/Category.orm.xml
@@ -10,7 +10,7 @@
         </id>
 
         <field name="key" column="category_key" type="string" length="191" nullable="true" unique="true"/>
-        <field name="defaultLocale" column="default_locale" type="string" length="5" nullable="false"/>
+        <field name="defaultLocale" column="default_locale" type="string" length="15" nullable="false"/>
         <field name="lft" type="integer" column="lft">
             <gedmo:tree-left/>
         </field>

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/CategoryMeta.orm.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/CategoryMeta.orm.xml
@@ -10,7 +10,7 @@
 
         <field name="key" column="meta_key" type="string" length="45"/>
         <field name="value" column="value" type="string" length="255"/>
-        <field name="locale" column="locale" type="string" length="5" nullable="true"/>
+        <field name="locale" column="locale" type="string" length="15" nullable="true"/>
 
         <many-to-one field="category" target-entity="Sulu\Bundle\CategoryBundle\Entity\CategoryInterface" inversed-by="meta">
             <join-columns>

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/CategoryTranslation.orm.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/CategoryTranslation.orm.xml
@@ -9,7 +9,7 @@
         </id>
 
         <field name="translation" column="translation" type="string" length="255"/>
-        <field name="locale" column="locale" type="string" length="5"/>
+        <field name="locale" column="locale" type="string" length="15"/>
         <field name="description" type="text" column="description" nullable="true"/>
 
         <one-to-many field="medias" target-entity="Sulu\Bundle\CategoryBundle\Entity\CategoryTranslationMedia" mapped-by="categoryTranslation" orphan-removal="true">

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/Keyword.orm.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/Keyword.orm.xml
@@ -16,7 +16,7 @@
             <generator strategy="AUTO"/>
         </id>
 
-        <field name="locale" column="locale" type="string" length="5" nullable="false"/>
+        <field name="locale" column="locale" type="string" length="15" nullable="false"/>
         <field name="keyword" column="keyword" type="string" length="191" nullable="false"/>
 
         <many-to-many target-entity="Sulu\Bundle\CategoryBundle\Entity\CategoryTranslationInterface" field="categoryTranslations"

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/CollectionMeta.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/CollectionMeta.orm.xml
@@ -13,7 +13,7 @@
         </id>
         <field name="title" type="string" column="title" length="191"/>
         <field name="description" type="text" column="description" nullable="true"/>
-        <field name="locale" type="string" column="locale" length="5"/>
+        <field name="locale" type="string" column="locale" length="15"/>
         <many-to-one field="collection" target-entity="Sulu\Bundle\MediaBundle\Entity\CollectionInterface" inversed-by="meta">
             <join-columns>
                 <join-column name="idCollections" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersionContentLanguage.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersionContentLanguage.orm.xml
@@ -8,7 +8,7 @@
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>
-        <field name="locale" type="string" column="locale" length="5" />
+        <field name="locale" type="string" column="locale" length="15" />
         <many-to-one field="fileVersion" target-entity="Sulu\Bundle\MediaBundle\Entity\FileVersion" inversed-by="contentLanguages">
             <join-columns>
                 <join-column name="idFileVersions" referenced-column-name="id" on-delete="CASCADE" />

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersionMeta.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersionMeta.orm.xml
@@ -17,7 +17,7 @@
         <field name="description" type="text" column="description" nullable="true"/>
         <field name="copyright" type="text" column="copyright" nullable="true"/>
         <field name="credits" type="text" column="credits" nullable="true"/>
-        <field name="locale" type="string" column="locale" length="5"/>
+        <field name="locale" type="string" column="locale" length="15"/>
 
         <many-to-one field="fileVersion" target-entity="Sulu\Bundle\MediaBundle\Entity\FileVersion" inversed-by="meta">
             <join-columns>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersionPublishLanguage.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersionPublishLanguage.orm.xml
@@ -8,7 +8,7 @@
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>
-        <field name="locale" type="string" column="locale" length="5" />
+        <field name="locale" type="string" column="locale" length="15" />
         <many-to-one field="fileVersion" target-entity="Sulu\Bundle\MediaBundle\Entity\FileVersion" inversed-by="publishLanguages">
             <join-columns>
                 <join-column name="idFileVersions" referenced-column-name="id" on-delete="CASCADE" />

--- a/src/Sulu/Bundle/ReferenceBundle/Resources/config/doctrine/Reference.orm.xml
+++ b/src/Sulu/Bundle/ReferenceBundle/Resources/config/doctrine/Reference.orm.xml
@@ -15,7 +15,7 @@
         <field name="resourceId" column="resourceId" type="string" nullable="false" length="191"/>
         <field name="referenceResourceKey" column="referenceResourceKey" type="string" nullable="false" length="191"/>
         <field name="referenceResourceId" column="referenceResourceId" type="string" nullable="false" length="191"/>
-        <field name="referenceLocale" column="referenceLocale" type="string" nullable="true" length="5"/>
+        <field name="referenceLocale" column="referenceLocale" type="string" nullable="true" length="15"/>
         <field name="referenceRouterAttributes" column="referenceRouterAttributes" type="json">
             <options>
                 <option name="jsonb">true</option>

--- a/src/Sulu/Bundle/RouteBundle/Resources/config/doctrine/Route.orm.xml
+++ b/src/Sulu/Bundle/RouteBundle/Resources/config/doctrine/Route.orm.xml
@@ -22,7 +22,7 @@
         </unique-constraints>
 
         <field name="path" type="string" length="191"/>
-        <field name="locale" type="string" length="8"/>
+        <field name="locale" type="string" length="15"/>
         <field name="entityClass" type="string" length="191"/>
         <field name="entityId" type="string" length="191"/>
         <field name="history" type="boolean"/>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Increase the length of the "locale" fields.

#### Why?

To allow locales like "zh-Hans".

So the biggest official locale is `zh-Hans_CN` which 10 chars.
