### PR TITLE
Fix media version file not found error

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13831,12 +13831,7 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
 
 		-
-			message: "#^Cannot call method getVersion\\(\\) on Sulu\\\\Bundle\\\\MediaBundle\\\\Entity\\\\File\\|null\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
-
-		-
-			message: "#^Negated boolean expression is always false\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Entity\\\\MediaRepositoryInterface\\:\\:findMediaByIdForRendering\\(\\) invoked with 3 parameters, 2 required\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
 
@@ -13856,22 +13851,7 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
 
 		-
-			message: "#^Parameter \\#2 \\$version of method Sulu\\\\Bundle\\\\MediaBundle\\\\Controller\\\\MediaStreamController\\:\\:getFileVersion\\(\\) expects int, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
-
-		-
 			message: "#^Parameter \\#3 \\$extension of method Sulu\\\\Bundle\\\\MediaBundle\\\\Controller\\\\MediaStreamController\\:\\:cleanUpFileName\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
-
-		-
-			message: "#^Thrown exceptions in a catch block must bundle the previous exception \\(see throw statement line 124\\)\\. More info\\: http\\://bit\\.ly/bundleexception$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
-
-		-
-			message: "#^Thrown exceptions in a catch block must bundle the previous exception \\(see throw statement line 72\\)\\. More info\\: http\\://bit\\.ly/bundleexception$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
 
@@ -14587,6 +14567,11 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Entity\\\\MediaRepositoryInterface\\:\\:findMediaDisplayInfo\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/MediaBundle/Entity/MediaRepositoryInterface.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$version$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Entity/MediaRepositoryInterface.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -14571,11 +14571,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Entity/MediaRepositoryInterface.php
 
 		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$version$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaRepositoryInterface.php
-
-		-
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<object\\>\\:\\:mapManyToMany\\(\\)\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/EventListener/MediaAudienceTargetingSubscriber.php

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
@@ -214,8 +214,7 @@ class MediaStreamController
             return null;
         }
 
-        /** @var File|null $file */
-        $file = $mediaEntity->getFiles()[0];
+        $file = $mediaEntity->getFiles()[0] ?? null;
 
         if (!$file) {
             return null;

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
@@ -205,26 +205,29 @@ class MediaStreamController
      */
     protected function getFileVersion($id, $version)
     {
-        /** @var MediaInterface $mediaEntity */
-        $mediaEntity = $this->mediaRepository->findMediaByIdForRendering($id, null);
+        $version = empty($version) ? null : (int)$version;
 
-        if (!$mediaEntity) {
+        /** @var MediaInterface|null $mediaEntity */
+        $mediaEntity = $this->mediaRepository->findMediaByIdForRendering($id, null, $version);
+
+        if ($mediaEntity === null) {
             return null;
         }
 
-        $file = $mediaEntity->getFiles()[0];
+        /** @var File|null $file */
+        $file = $mediaEntity->getFiles()->get(0);
 
-        if (!$file) {
+        if ($file === null) {
             return null;
         }
 
-        if (!$version) {
-            $version = $mediaEntity->getFiles()[0]->getVersion();
+        if ($version === null) {
+            $version = $file->getVersion();
         }
 
-        $fileVersion = $file->getFileVersion((int) $version);
+        $fileVersion = $file->getFileVersion($version);
 
-        if (!$fileVersion) {
+        if ($fileVersion === null) {
             throw new FileVersionNotFoundException($id, $version);
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\MediaBundle\Controller;
 
 use Sulu\Bundle\MediaBundle\Admin\MediaAdmin;
 use Sulu\Bundle\MediaBundle\Entity\Collection;
+use Sulu\Bundle\MediaBundle\Entity\File;
 use Sulu\Bundle\MediaBundle\Entity\FileVersion;
 use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
 use Sulu\Bundle\MediaBundle\Entity\MediaRepositoryInterface;
@@ -86,6 +87,7 @@ class MediaStreamController
             }
 
             $version = $request->get('v', null);
+            $version = \is_numeric($version) ? ((int) $version) : null;
             $noCount = $request->get('no-count', false);
 
             $fileVersion = $this->getFileVersion($id, $version);
@@ -197,7 +199,7 @@ class MediaStreamController
 
     /**
      * @param int $id
-     * @param int $version
+     * @param int|null $version
      *
      * @return FileVersion|null
      *
@@ -205,29 +207,27 @@ class MediaStreamController
      */
     protected function getFileVersion($id, $version)
     {
-        $version = empty($version) ? null : (int)$version;
-
         /** @var MediaInterface|null $mediaEntity */
         $mediaEntity = $this->mediaRepository->findMediaByIdForRendering($id, null, $version);
 
-        if ($mediaEntity === null) {
+        if (!$mediaEntity) {
             return null;
         }
 
         /** @var File|null $file */
-        $file = $mediaEntity->getFiles()->get(0);
+        $file = $mediaEntity->getFiles()[0];
 
-        if ($file === null) {
+        if (!$file) {
             return null;
         }
 
-        if ($version === null) {
+        if (!$version) {
             $version = $file->getVersion();
         }
 
         $fileVersion = $file->getFileVersion($version);
 
-        if ($fileVersion === null) {
+        if (!$fileVersion) {
             throw new FileVersionNotFoundException($id, $version);
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
@@ -70,7 +70,7 @@ class MediaStreamController
                 $mediaProperties['fileName']
             );
         } catch (ImageProxyException $e) {
-            throw new NotFoundHttpException('Image create error. Code: ' . $e->getCode());
+            throw new NotFoundHttpException('Image create error. Code: ' . $e->getCode(), $e);
         }
     }
 
@@ -123,7 +123,7 @@ class MediaStreamController
 
             return $response;
         } catch (MediaException $e) {
-            throw new NotFoundHttpException('File not found: ' . $e->getCode() . ' ' . $e->getMessage());
+            throw new NotFoundHttpException('File not found: ' . $e->getCode() . ' ' . $e->getMessage(), $e);
         }
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
@@ -116,7 +116,7 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
 
             $fileVersionJoinCondition = 'file.version = fileVersion.version';
             if (null !== $version) {
-                $fileVersionJoinCondition = 'fileVersion.version = :version';
+                $fileVersionJoinCondition = 'fileVersion.version IN (:version, fileVersion.version)'; // for the x-robots canonical we require latest version and old version
                 $queryBuilder->setParameter('version', $version);
             }
 

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
@@ -102,6 +102,16 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
                 ->where('media.id = :mediaId')
                 ->setParameter('mediaId', $id);
 
+            $fileVersionJoinCondition = 'file.version = fileVersion.version';
+            if (null !== $version) {
+                $fileVersionJoinCondition = 'fileVersion.version IN (:version, fileVersion.version)'; // for the x-robots canonical we require latest version and old version
+                $queryBuilder->setParameter('version', $version);
+            }
+
+            $queryBuilder
+                ->addSelect('fileVersion')
+                ->leftJoin('file.fileVersions', 'fileVersion', Join::WITH, $fileVersionJoinCondition);
+
             if (null !== $formatKey) {
                 $queryBuilder
                     ->addSelect('formatOptions')
@@ -113,16 +123,6 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
                     )
                     ->setParameter('formatKey', $formatKey);
             }
-
-            $fileVersionJoinCondition = 'file.version = fileVersion.version';
-            if (null !== $version) {
-                $fileVersionJoinCondition = 'fileVersion.version IN (:version, fileVersion.version)'; // for the x-robots canonical we require latest version and old version
-                $queryBuilder->setParameter('version', $version);
-            }
-
-            $queryBuilder
-                ->addSelect('fileVersion')
-                ->leftJoin('file.fileVersions', 'fileVersion', Join::WITH, $fileVersionJoinCondition);
 
             /** @var MediaInterface */
             return $queryBuilder->getQuery()->getSingleResult();

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepositoryInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepositoryInterface.php
@@ -38,10 +38,11 @@ interface MediaRepositoryInterface extends RepositoryInterface
      *
      * @param int $id
      * @param string|null $formatKey
+     * @param int|null $specificFileVersion
      *
      * @return MediaInterface|null
      */
-    public function findMediaByIdForRendering($id, $formatKey);
+    public function findMediaByIdForRendering($id, $formatKey, $specificFileVersion = null);
 
     /**
      * Finds all media, can be filtered with parent.

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepositoryInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepositoryInterface.php
@@ -38,11 +38,11 @@ interface MediaRepositoryInterface extends RepositoryInterface
      *
      * @param int $id
      * @param string|null $formatKey
-     * @param int|null $specificFileVersion
+     * @param int<1, max>|null $version
      *
      * @return MediaInterface|null
      */
-    public function findMediaByIdForRendering($id, $formatKey, $specificFileVersion = null);
+    public function findMediaByIdForRendering($id, $formatKey /*, $version = null */);
 
     /**
      * Finds all media, can be filtered with parent.

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepositoryInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepositoryInterface.php
@@ -38,11 +38,10 @@ interface MediaRepositoryInterface extends RepositoryInterface
      *
      * @param int $id
      * @param string|null $formatKey
-     * @param int<1, max>|null $version
      *
      * @return MediaInterface|null
      */
-    public function findMediaByIdForRendering($id, $formatKey /*, $version = null */);
+    public function findMediaByIdForRendering($id, $formatKey /*, int<1, max>|null $version = null */);
 
     /**
      * Finds all media, can be filtered with parent.

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaStreamControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaStreamControllerTest.php
@@ -60,11 +60,12 @@ class MediaStreamControllerTest extends WebsiteTestCase
 
     public function testOldExistVersionDownloadAction(): void
     {
-        $filePath = $this->createMediaFile('test.jpg');
-        $oldMedia = $this->createMedia($filePath, 'file-without-extension');
-        $newMedia = $this->createMediaVersion($oldMedia->getId(), $filePath, 'new-file-without-extension');
+        $filePath1 = $this->createMediaFile('test-1.jpg');
+        $filePath2 = $this->createMediaFile('test-2.jpg');
+        $oldMedia = $this->createMedia($filePath1, 'file-without-extension');
+        $newMedia = $this->createMediaVersion($oldMedia->getId(), $filePath2, 'new-file-without-extension');
 
-        $this->client->jsonRequest('GET', $oldMedia->getUrl());
+        $this->client->request('GET', $oldMedia->getUrl());
         $response = $this->client->getResponse();
         $this->assertHttpStatusCode(200, $response);
         $this->assertEquals(
@@ -78,6 +79,12 @@ class MediaStreamControllerTest extends WebsiteTestCase
             'noindex, follow',
             $response->headers->get('X-Robots-Tag')
         );
+        $this->assertSame('attachment; filename=test-1.jpg', $response->headers->get('Content-Disposition'));
+
+        $this->client->request('GET', $newMedia->getUrl());
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $this->assertSame('attachment; filename=test-2.jpg', $response->headers->get('Content-Disposition'));
     }
 
     public function testDownloadWithoutExtensionAction(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? |yes
| Deprecations? | no
| Fixed tickets | fixes #7480 and #7319
| Related issues/PRs | #7480 and #7319
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Adds new parameter to add specific version into Media.fileVersions results in addition to the current version

#### Why?

As explained here (https://github.com/sulu/sulu/issues/7480) and here (https://github.com/sulu/sulu/issues/7319), trying to view old versions of a media file results in a 404 not found error.
This is because the query that retrieves the media item only fetches the current version of the file. Therefore, when attempting to find a specific version that is not the current one, the file version cannot be found.

#### Example Usage

Optional: Create a new media file from the Admin menu Media.
Changing the file in the media menu creates a new version of the file that you can see in the History tab. Click on the eye icon in any previous version and the file should show without any problem.

#### To Do

- [ ] Integration Tests
- [ ] Unit Tests
