### PR TITLE
Remove hardcoded order bys in metadata

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9492,12 +9492,12 @@ parameters:
 
 		-
 			message: "#^Cannot access property \\$addresses on mixed\\.$#"
-			count: 117
+			count: 92
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
 
 		-
 			message: "#^Cannot access property \\$avatar on mixed\\.$#"
-			count: 12
+			count: 6
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
 
 		-
@@ -9507,22 +9507,22 @@ parameters:
 
 		-
 			message: "#^Cannot access property \\$categories on mixed\\.$#"
-			count: 8
+			count: 4
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
 
 		-
 			message: "#^Cannot access property \\$contactDetails on mixed\\.$#"
-			count: 59
+			count: 47
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
 
 		-
 			message: "#^Cannot access property \\$firstName on mixed\\.$#"
-			count: 18
+			count: 16
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
 
 		-
 			message: "#^Cannot access property \\$formOfAddress on mixed\\.$#"
-			count: 16
+			count: 14
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
 
 		-
@@ -9532,12 +9532,12 @@ parameters:
 
 		-
 			message: "#^Cannot access property \\$id on mixed\\.$#"
-			count: 8
+			count: 7
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
 
 		-
 			message: "#^Cannot access property \\$lastName on mixed\\.$#"
-			count: 18
+			count: 16
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
 
 		-
@@ -9551,13 +9551,8 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
 
 		-
-			message: "#^Cannot access property \\$note on mixed\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
-
-		-
 			message: "#^Cannot access property \\$notes on mixed\\.$#"
-			count: 19
+			count: 15
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
 
 		-
@@ -9572,12 +9567,12 @@ parameters:
 
 		-
 			message: "#^Cannot access property \\$salutation on mixed\\.$#"
-			count: 15
+			count: 13
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
 
 		-
 			message: "#^Cannot access property \\$title on mixed\\.$#"
-			count: 15
+			count: 13
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
 
 		-
@@ -9747,12 +9742,12 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
-			count: 47
+			count: 46
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
 
 		-
 			message: "#^Parameter \\#1 \\$object_or_class of function property_exists expects object\\|string, mixed given\\.$#"
-			count: 4
+			count: 2
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
 
 		-
@@ -28157,7 +28152,7 @@ parameters:
 
 		-
 			message: "#^Cannot access property \\$key on mixed\\.$#"
-			count: 6
+			count: 4
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
 
 		-
@@ -28167,22 +28162,22 @@ parameters:
 
 		-
 			message: "#^Cannot access property \\$name on mixed\\.$#"
-			count: 7
+			count: 3
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
 
 		-
 			message: "#^Cannot access property \\$permissions on mixed\\.$#"
-			count: 145
+			count: 51
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
 
 		-
 			message: "#^Cannot access property \\$securityType on mixed\\.$#"
-			count: 5
+			count: 3
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
 
 		-
 			message: "#^Cannot access property \\$system on mixed\\.$#"
-			count: 7
+			count: 3
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
 
 		-
@@ -28191,7 +28186,7 @@ parameters:
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$object_or_class of function property_exists expects object\\|string, mixed given\\.$#"
+			message: "#^Parameter \\#2 \\$array of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayNotHasKey\\(\\) expects array\\|ArrayAccess, mixed given\\.$#"
 			count: 2
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
 

--- a/src/Sulu/Bundle/CategoryBundle/Entity/CategoryTranslation.php
+++ b/src/Sulu/Bundle/CategoryBundle/Entity/CategoryTranslation.php
@@ -113,10 +113,12 @@ class CategoryTranslation implements CategoryTranslationInterface
         $medias = [];
 
         foreach ($this->medias as $media) {
-            $medias[] = $media->getMedia();
+            $medias[$media->getPosition()] = $media->getMedia();
         }
 
-        return $medias;
+        \ksort($medias);
+
+        return \array_values($medias);
     }
 
     public function setMedias($medias)

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/CategoryTranslation.orm.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/CategoryTranslation.orm.xml
@@ -16,9 +16,6 @@
             <cascade>
                 <cascade-persist />
             </cascade>
-            <order-by>
-                <order-by-field name="position" direction="ASC"/>
-            </order-by>
         </one-to-many>
 
         <many-to-one field="category" target-entity="Sulu\Bundle\CategoryBundle\Entity\CategoryInterface" inversed-by="translations">

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/doctrine/Account.orm.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/doctrine/Account.orm.xml
@@ -86,9 +86,6 @@
                     <join-column name="idCategories" referenced-column-name="id" on-delete="CASCADE" nullable="false"/>
                 </inverse-join-columns>
             </join-table>
-            <order-by>
-                <order-by-field name="id" direction="ASC"/>
-            </order-by>
         </many-to-many>
 
         <many-to-many field="medias" target-entity="Sulu\Bundle\MediaBundle\Entity\MediaInterface">
@@ -100,9 +97,6 @@
                     <join-column name="idMedias" referenced-column-name="id" on-delete="CASCADE" nullable="false"/>
                 </inverse-join-columns>
             </join-table>
-            <order-by>
-                <order-by-field name="id" direction="ASC"/>
-            </order-by>
         </many-to-many>
 
         <many-to-many field="urls" target-entity="Sulu\Bundle\ContactBundle\Entity\Url" inversed-by="accounts">
@@ -117,9 +111,6 @@
                     <join-column name="idUrls" referenced-column-name="id" on-delete="CASCADE"/>
                 </inverse-join-columns>
             </join-table>
-            <order-by>
-                <order-by-field name="id" direction="ASC"/>
-            </order-by>
         </many-to-many>
         <many-to-many field="phones" target-entity="Sulu\Bundle\ContactBundle\Entity\Phone" inversed-by="accounts">
             <cascade>
@@ -133,9 +124,6 @@
                     <join-column name="idPhones" referenced-column-name="id" on-delete="CASCADE"/>
                 </inverse-join-columns>
             </join-table>
-            <order-by>
-                <order-by-field name="id" direction="ASC"/>
-            </order-by>
         </many-to-many>
         <many-to-many field="emails" target-entity="Sulu\Bundle\ContactBundle\Entity\Email" inversed-by="accounts">
             <cascade>
@@ -149,9 +137,6 @@
                     <join-column name="idEmails" referenced-column-name="id" on-delete="CASCADE"/>
                 </inverse-join-columns>
             </join-table>
-            <order-by>
-                <order-by-field name="id" direction="ASC"/>
-            </order-by>
         </many-to-many>
         <many-to-many field="notes" target-entity="Sulu\Bundle\ContactBundle\Entity\Note" inversed-by="accounts">
             <cascade>
@@ -165,9 +150,6 @@
                     <join-column name="idNotes" referenced-column-name="id" on-delete="CASCADE"/>
                 </inverse-join-columns>
             </join-table>
-            <order-by>
-                <order-by-field name="id" direction="ASC"/>
-            </order-by>
         </many-to-many>
         <many-to-many field="faxes" target-entity="Sulu\Bundle\ContactBundle\Entity\Fax" inversed-by="accounts">
             <cascade>
@@ -181,9 +163,6 @@
                     <join-column name="idFaxes" referenced-column-name="id" on-delete="CASCADE"/>
                 </inverse-join-columns>
             </join-table>
-            <order-by>
-                <order-by-field name="id" direction="ASC"/>
-            </order-by>
         </many-to-many>
         <many-to-many field="socialMediaProfiles"
                       target-entity="Sulu\Bundle\ContactBundle\Entity\SocialMediaProfile"
@@ -199,9 +178,6 @@
                     <join-column name="idSocialMediaProfiles" referenced-column-name="id" on-delete="CASCADE"/>
                 </inverse-join-columns>
             </join-table>
-            <order-by>
-                <order-by-field name="id" direction="ASC"/>
-            </order-by>
         </many-to-many>
         <many-to-many field="bankAccounts" target-entity="Sulu\Bundle\ContactBundle\Entity\BankAccount" inversed-by="accounts">
             <cascade>
@@ -215,9 +191,6 @@
                     <join-column name="idBankAccounts" referenced-column-name="id" on-delete="CASCADE"/>
                 </inverse-join-columns>
             </join-table>
-            <order-by>
-                <order-by-field name="id" direction="ASC"/>
-            </order-by>
         </many-to-many>
         <many-to-many field="tags" target-entity="Sulu\Bundle\TagBundle\Tag\TagInterface">
             <join-table name="co_account_tags">
@@ -228,9 +201,6 @@
                     <join-column name="idTags" referenced-column-name="id" on-delete="CASCADE"/>
                 </inverse-join-columns>
             </join-table>
-            <order-by>
-                <order-by-field name="name" direction="ASC"/>
-            </order-by>
         </many-to-many>
         <gedmo:tree type="nested"/>
     </mapped-superclass>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/doctrine/Contact.orm.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/doctrine/Contact.orm.xml
@@ -64,9 +64,6 @@
                     <join-column name="idMedias" referenced-column-name="id" on-delete="CASCADE" nullable="false"/>
                 </inverse-join-columns>
             </join-table>
-            <order-by>
-                <order-by-field name="id" direction="ASC"/>
-            </order-by>
         </many-to-many>
 
         <many-to-many field="categories" target-entity="Sulu\Bundle\CategoryBundle\Entity\CategoryInterface">
@@ -78,9 +75,6 @@
                     <join-column name="idCategories" referenced-column-name="id" on-delete="CASCADE" nullable="false"/>
                 </inverse-join-columns>
             </join-table>
-            <order-by>
-                <order-by-field name="id" direction="ASC"/>
-            </order-by>
         </many-to-many>
 
         <many-to-many field="urls" target-entity="Sulu\Bundle\ContactBundle\Entity\Url" inversed-by="contacts">
@@ -95,9 +89,6 @@
                     <join-column name="idUrls" referenced-column-name="id" on-delete="CASCADE"/>
                 </inverse-join-columns>
             </join-table>
-            <order-by>
-                <order-by-field name="id" direction="ASC"/>
-            </order-by>
         </many-to-many>
         <many-to-many field="notes" target-entity="Sulu\Bundle\ContactBundle\Entity\Note" inversed-by="contacts">
             <cascade>
@@ -111,9 +102,6 @@
                     <join-column name="idNotes" referenced-column-name="id" on-delete="CASCADE"/>
                 </inverse-join-columns>
             </join-table>
-            <order-by>
-                <order-by-field name="id" direction="ASC"/>
-            </order-by>
         </many-to-many>
         <many-to-many field="emails" target-entity="Sulu\Bundle\ContactBundle\Entity\Email" inversed-by="contacts">
             <cascade>
@@ -127,9 +115,6 @@
                     <join-column name="idEmails" referenced-column-name="id" on-delete="CASCADE"/>
                 </inverse-join-columns>
             </join-table>
-            <order-by>
-                <order-by-field name="id" direction="ASC"/>
-            </order-by>
         </many-to-many>
         <many-to-many field="phones" target-entity="Sulu\Bundle\ContactBundle\Entity\Phone" inversed-by="contacts">
             <cascade>
@@ -143,9 +128,6 @@
                     <join-column name="idPhones" referenced-column-name="id" on-delete="CASCADE"/>
                 </inverse-join-columns>
             </join-table>
-            <order-by>
-                <order-by-field name="id" direction="ASC"/>
-            </order-by>
         </many-to-many>
         <many-to-many field="faxes" target-entity="Sulu\Bundle\ContactBundle\Entity\Fax" inversed-by="contacts">
             <cascade>
@@ -159,9 +141,6 @@
                     <join-column name="idFaxes" referenced-column-name="id" on-delete="CASCADE"/>
                 </inverse-join-columns>
             </join-table>
-            <order-by>
-                <order-by-field name="id" direction="ASC"/>
-            </order-by>
         </many-to-many>
         <many-to-many field="socialMediaProfiles" target-entity="Sulu\Bundle\ContactBundle\Entity\SocialMediaProfile" inversed-by="contacts">
             <cascade>
@@ -175,9 +154,6 @@
                     <join-column name="idSocialMediaProfiles" referenced-column-name="id" on-delete="CASCADE"/>
                 </inverse-join-columns>
             </join-table>
-            <order-by>
-                <order-by-field name="id" direction="ASC"/>
-            </order-by>
         </many-to-many>
         <many-to-many field="tags" target-entity="Sulu\Bundle\TagBundle\Tag\TagInterface">
             <join-table name="co_contact_tags">
@@ -188,9 +164,6 @@
                     <join-column name="idTags" referenced-column-name="id" on-delete="CASCADE"/>
                 </inverse-join-columns>
             </join-table>
-            <order-by>
-                <order-by-field name="name" direction="ASC"/>
-            </order-by>
         </many-to-many>
         <many-to-many field="bankAccounts" target-entity="Sulu\Bundle\ContactBundle\Entity\BankAccount" inversed-by="contacts">
             <cascade>
@@ -204,9 +177,6 @@
                     <join-column name="idBankAccounts" referenced-column-name="id" on-delete="CASCADE"/>
                 </inverse-join-columns>
             </join-table>
-            <order-by>
-                <order-by-field name="id" direction="ASC"/>
-            </order-by>
         </many-to-many>
     </mapped-superclass>
 

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
@@ -995,168 +995,129 @@ class ContactControllerTest extends SuluTestCase
 
         $this->em->flush();
 
+        $putData = [
+            'firstName' => 'John',
+            'lastName' => 'Doe',
+            'note' => 'A small notice',
+            'title' => $title->getId(),
+            'position' => $position->getId(),
+            'account' => ['id' => $account->getId()],
+            'avatar' => [
+                'id' => $media->getId(),
+            ],
+            'birthday' => '1980-01-01T00:00:00',
+            'contactDetails' => [
+                'emails' => [
+                    [
+                        'id' => $email->getId(),
+                        'email' => 'john.doe@muster.at',
+                        'emailType' => $emailType->getId(),
+                    ],
+                    [
+                        'email' => 'john.doe@muster.de',
+                        'emailType' => $emailType->getId(),
+                    ],
+                ],
+                'phones' => [
+                    [
+                        'id' => $phone->getId(),
+                        'phone' => '321654987',
+                        'phoneType' => $phoneType->getId(),
+                    ],
+                    [
+                        'phone' => '789456123',
+                        'phoneType' => $phoneType->getId(),
+                    ],
+                ],
+                'faxes' => [
+                    [
+                        'id' => $fax->getId(),
+                        'fax' => '321654987-1',
+                        'faxType' => $faxType->getId(),
+                    ],
+                    [
+                        'fax' => '789456123-1',
+                        'faxType' => $faxType->getId(),
+                    ],
+                ],
+                'socialMedia' => [],
+                'websites' => [],
+            ],
+            'addresses' => [
+                [
+                    'id' => $address->getId(),
+                    'title' => 'work',
+                    'street' => 'Street',
+                    'number' => '2',
+                    'zip' => '9999',
+                    'city' => 'Springfield',
+                    'state' => 'Colorado',
+                    'countryCode' => 'ML',
+                    'addressType' => $addressType->getId(),
+                    'billingAddress' => true,
+                    'primaryAddress' => true,
+                    'deliveryAddress' => false,
+                    'postboxCity' => 'Dornbirn',
+                    'postboxPostcode' => '6850',
+                    'postboxNumber' => '4711',
+                    'note' => 'note',
+                    'addition' => 'addition',
+                    'latitude' => 20.5,
+                    'longitude' => 30.7,
+                ],
+            ],
+            'notes' => [
+                [
+                    'id' => $note->getId(),
+                    'value' => 'Note 1_1',
+                ],
+            ],
+            'salutation' => 'Sehr geehrter John',
+            'formOfAddress' => 0,
+            'categories' => [
+                $category3->getId(),
+            ],
+            'tags' => ['Tag A', 'Tag B'],
+        ];
+
         $this->client->jsonRequest(
             'PUT',
             '/api/contacts/' . $contact->getId(),
-            [
-                'firstName' => 'John',
-                'lastName' => 'Doe',
-                'note' => 'A small notice',
-                'title' => $title->getId(),
-                'position' => $position->getId(),
-                'avatar' => [
-                    'id' => $media->getId(),
-                ],
-                'contactDetails' => [
-                    'emails' => [
-                        [
-                            'id' => $email->getId(),
-                            'email' => 'john.doe@muster.at',
-                            'emailType' => $emailType->getId(),
-                        ],
-                        [
-                            'email' => 'john.doe@muster.de',
-                            'emailType' => $emailType->getId(),
-                        ],
-                    ],
-                    'phones' => [
-                        [
-                            'id' => $phone->getId(),
-                            'phone' => '321654987',
-                            'phoneType' => $phoneType->getId(),
-                        ],
-                        [
-                            'phone' => '789456123',
-                            'phoneType' => $phoneType->getId(),
-                        ],
-                    ],
-                    'faxes' => [
-                        [
-                            'id' => $fax->getId(),
-                            'fax' => '321654987-1',
-                            'faxType' => $faxType->getId(),
-                        ],
-                        [
-                            'fax' => '789456123-1',
-                            'faxType' => $faxType->getId(),
-                        ],
-                    ],
-                ],
-                'addresses' => [
-                    [
-                        'id' => $address->getId(),
-                        'title' => 'work',
-                        'street' => 'Street',
-                        'number' => '2',
-                        'zip' => '9999',
-                        'city' => 'Springfield',
-                        'state' => 'Colorado',
-                        'countryCode' => 'ML',
-                        'addressType' => $addressType->getId(),
-                        'billingAddress' => true,
-                        'primaryAddress' => true,
-                        'deliveryAddress' => false,
-                        'postboxCity' => 'Dornbirn',
-                        'postboxPostcode' => '6850',
-                        'postboxNumber' => '4711',
-                        'note' => 'note',
-                    ],
-                ],
-                'notes' => [
-                    [
-                        'id' => $note->getId(),
-                        'value' => 'Note 1_1',
-                    ],
-                ],
-                'salutation' => 'Sehr geehrter John',
-                'formOfAddress' => [
-                    'id' => 0,
-                ],
-                'categories' => [
-                    $category3->getId(),
-                ],
-            ]
+            $putData,
         );
 
-        $response = \json_decode($this->client->getResponse()->getContent());
+        $response = \json_decode($this->client->getResponse()->getContent(), true, \JSON_THROW_ON_ERROR);
+        $this->assertIsArray($response);
         $this->assertHttpStatusCode(200, $this->client->getResponse());
+        unset($response['_hash']);
+        unset($response['id']);
+        $accountId = $response['account']['id'] ?? null;
+        unset($response['account']);
+        $response['account']['id'] = $accountId;
+        unset($response['created']);
+        unset($response['changed']);
+        unset($response['locales']);
+        unset($response['middleName']);
+        unset($response['fullName']);
+        unset($response['titleName']);
+        unset($response['avatar']['url']);
+        unset($response['avatar']['thumbnails']);
+        // TODO add more data do tests:
+        unset($response['bankAccounts']);
+        unset($response['newsletter']);
+        unset($response['gender']);
+        unset($response['mainEmail']);
+        unset($response['mainPhone']);
+        unset($response['mainFax']);
+        unset($response['mainUrl']);
+        unset($response['mainAddress']);
+        unset($response['positionName']);
+        unset($response['medias']);
+        unset($response['contactDetails']['emails'][1]['id']);
+        unset($response['contactDetails']['phones'][1]['id']);
+        unset($response['contactDetails']['faxes'][1]['id']);
 
-        $this->assertEquals('John', $response->firstName);
-        $this->assertEquals('Doe', $response->lastName);
-        $this->assertEquals('A small notice', $response->note);
-        $this->assertEquals($title->getId(), $response->title);
-        $this->assertEquals('john.doe@muster.at', $response->contactDetails->emails[0]->email);
-        $this->assertEquals('john.doe@muster.de', $response->contactDetails->emails[1]->email);
-        $this->assertEquals('321654987', $response->contactDetails->phones[0]->phone);
-        $this->assertEquals('789456123', $response->contactDetails->phones[1]->phone);
-        $this->assertEquals('321654987-1', $response->contactDetails->faxes[0]->fax);
-        $this->assertEquals('789456123-1', $response->contactDetails->faxes[1]->fax);
-        $this->assertEquals('Street', $response->addresses[0]->street);
-        $this->assertEquals('2', $response->addresses[0]->number);
-        $this->assertEquals('9999', $response->addresses[0]->zip);
-        $this->assertEquals('Springfield', $response->addresses[0]->city);
-        $this->assertEquals('Colorado', $response->addresses[0]->state);
-        $this->assertEquals('ML', $response->addresses[0]->countryCode);
-        $this->assertEquals('Note 1_1', $response->notes[0]->value);
-        $this->assertEquals(1, \count($response->notes));
-        $this->assertEquals('note', $response->addresses[0]->note);
-        $this->assertEquals(true, $response->addresses[0]->billingAddress);
-        $this->assertEquals(true, $response->addresses[0]->primaryAddress);
-        $this->assertEquals(false, $response->addresses[0]->deliveryAddress);
-        $this->assertEquals('Dornbirn', $response->addresses[0]->postboxCity);
-        $this->assertEquals('6850', $response->addresses[0]->postboxPostcode);
-        $this->assertEquals('4711', $response->addresses[0]->postboxNumber);
-
-        $this->assertEquals(0, $response->formOfAddress);
-        $this->assertEquals('Sehr geehrter John', $response->salutation);
-
-        $this->assertTrue(\property_exists($response, 'avatar'));
-        $this->assertTrue(\property_exists($response->avatar, 'thumbnails'));
-        $this->assertTrue(\property_exists($response->avatar->thumbnails, 'sulu-100x100'));
-        $this->assertTrue(\is_string($response->avatar->thumbnails->{'sulu-100x100'}));
-
-        $this->assertEquals(1, \count($response->categories));
-        $this->assertEquals($category3->getId(), $response->categories[0]);
-
-        $this->client->jsonRequest('GET', '/api/contacts/' . $response->id);
-        $response = \json_decode($this->client->getResponse()->getContent());
-
-        $this->assertEquals('John', $response->firstName);
-        $this->assertEquals('Doe', $response->lastName);
-        $this->assertEquals('A small notice', $response->note);
-        $this->assertEquals($title->getId(), $response->title);
-        $this->assertEquals('john.doe@muster.at', $response->contactDetails->emails[0]->email);
-        $this->assertEquals('john.doe@muster.de', $response->contactDetails->emails[1]->email);
-        $this->assertEquals('321654987', $response->contactDetails->phones[0]->phone);
-        $this->assertEquals('789456123', $response->contactDetails->phones[1]->phone);
-        $this->assertEquals('321654987-1', $response->contactDetails->faxes[0]->fax);
-        $this->assertEquals('789456123-1', $response->contactDetails->faxes[1]->fax);
-        $this->assertEquals('Street', $response->addresses[0]->street);
-        $this->assertEquals('2', $response->addresses[0]->number);
-        $this->assertEquals('9999', $response->addresses[0]->zip);
-        $this->assertEquals('Springfield', $response->addresses[0]->city);
-        $this->assertEquals('Colorado', $response->addresses[0]->state);
-        $this->assertEquals('Note 1_1', $response->notes[0]->value);
-        $this->assertEquals(1, \count($response->notes));
-
-        $this->assertEquals('work', $response->addresses[0]->title);
-        $this->assertEquals(true, $response->addresses[0]->billingAddress);
-        $this->assertEquals(true, $response->addresses[0]->primaryAddress);
-        $this->assertEquals(false, $response->addresses[0]->deliveryAddress);
-        $this->assertEquals('Dornbirn', $response->addresses[0]->postboxCity);
-        $this->assertEquals('6850', $response->addresses[0]->postboxPostcode);
-        $this->assertEquals('4711', $response->addresses[0]->postboxNumber);
-
-        $this->assertEquals(0, $response->formOfAddress);
-        $this->assertEquals('Sehr geehrter John', $response->salutation);
-
-        $this->assertTrue(\property_exists($response, 'avatar'));
-        $this->assertTrue(\property_exists($response->avatar, 'thumbnails'));
-        $this->assertTrue(\property_exists($response->avatar->thumbnails, 'sulu-100x100'));
-        $this->assertTrue(\is_string($response->avatar->thumbnails->{'sulu-100x100'}));
-
-        $this->assertEquals(1, \count($response->categories));
-        $this->assertEquals($category3->getId(), $response->categories[0]);
+        $this->assertEquals($putData, $response);
     }
 
     public function testPutEmptyContactDetails(): void

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/Collection.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/Collection.orm.xml
@@ -40,11 +40,7 @@
             </cascade>
         </one-to-many>
         <one-to-many field="media" target-entity="Sulu\Bundle\MediaBundle\Entity\MediaInterface" mapped-by="collection"/>
-        <one-to-many field="children" target-entity="Sulu\Bundle\MediaBundle\Entity\CollectionInterface" mapped-by="parent">
-            <order-by>
-                <order-by-field name="id" direction="ASC"/>
-            </order-by>
-        </one-to-many>
+        <one-to-many field="children" target-entity="Sulu\Bundle\MediaBundle\Entity\CollectionInterface" mapped-by="parent"/>
         <many-to-one field="parent" target-entity="Sulu\Bundle\MediaBundle\Entity\Collection" inversed-by="children">
             <join-columns>
                 <join-column name="idCollectionsParent" referenced-column-name="id" on-delete="SET NULL" />

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersion.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersion.orm.xml
@@ -87,10 +87,6 @@
                     <join-column name="idCategories" referenced-column-name="id" on-delete="CASCADE" nullable="false"/>
                 </inverse-join-columns>
             </join-table>
-
-            <order-by>
-                <order-by-field name="id" direction="ASC"/>
-            </order-by>
         </many-to-many>
 
     </entity>

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/Role.orm.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/Role.orm.xml
@@ -28,9 +28,6 @@
             <cascade>
                 <cascade-persist/>
             </cascade>
-            <order-by>
-                <order-by-field name="id" direction="ASC"/>
-            </order-by>
         </one-to-many>
         <one-to-many field="userRoles" target-entity="Sulu\Bundle\SecurityBundle\Entity\UserRole" mapped-by="role"/>
         <one-to-many field="settings" target-entity="Sulu\Bundle\SecurityBundle\Entity\RoleSetting" mapped-by="role" index-by="key"/>

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/User.orm.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/User.orm.xml
@@ -44,11 +44,7 @@
             </cascade>
         </one-to-one>
 
-        <one-to-many field="userRoles" target-entity="Sulu\Bundle\SecurityBundle\Entity\UserRole" mapped-by="user">
-            <order-by>
-                <order-by-field name="id" direction="ASC"/>
-            </order-by>
-        </one-to-many>
+        <one-to-many field="userRoles" target-entity="Sulu\Bundle\SecurityBundle\Entity\UserRole" mapped-by="user"/>
         <one-to-many field="userGroups" target-entity="Sulu\Bundle\SecurityBundle\Entity\UserGroup" mapped-by="user"/>
         <one-to-many field="userSettings" target-entity="Sulu\Bundle\SecurityBundle\Entity\UserSetting" mapped-by="user"/>
 

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/doctrine/Analytics.orm.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/doctrine/Analytics.orm.xml
@@ -31,9 +31,6 @@
                     <join-column name="domain" referenced-column-name="id" on-delete="CASCADE" />
                 </inverse-join-columns>
             </join-table>
-            <order-by>
-                <order-by-field name="id" direction="ASC"/>
-            </order-by>
         </many-to-many>
     </mapped-superclass>
 </doctrine-mapping>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes 
| New feature? | no
| BC breaks? | no
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | parts of #7485
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove hardcoded order bys in metadata.

Commented on the important changes (non ID based order bys).

#### Why?

After some discussion with @friemt about #7485 we think that order bys should never be hardcoded.