### PR TITLE
Fix deprecation message of PHPUnit 9

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1406,7 +1406,7 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/AdminControllerTest.php
 
 		-
-			message: "#^Parameter \\#2 \\$object of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertObjectHasAttribute\\(\\) expects object, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$object_or_class of function property_exists expects object\\|string, mixed given\\.$#"
 			count: 4
 			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/AdminControllerTest.php
 
@@ -2621,7 +2621,7 @@ parameters:
 			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Functional/Controller/AdminControllerTest.php
 
 		-
-			message: "#^Parameter \\#2 \\$object of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertObjectHasAttribute\\(\\) expects object, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$object_or_class of function property_exists expects object\\|string, mixed given\\.$#"
 			count: 2
 			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Functional/Controller/AdminControllerTest.php
 
@@ -9336,6 +9336,11 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
 
 		-
+			message: "#^Parameter \\#1 \\$object_or_class of function property_exists expects object\\|string, mixed given\\.$#"
+			count: 3
+			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
+
+		-
 			message: "#^Parameter \\#1 \\$primaryAddress of method Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\Address\\:\\:setPrimaryAddress\\(\\) expects bool, bool\\|null given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
@@ -9353,11 +9358,6 @@ parameters:
 		-
 			message: "#^Parameter \\#2 \\$haystack of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertCount\\(\\) expects Countable\\|iterable, mixed given\\.$#"
 			count: 2
-			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$object of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertObjectHasAttribute\\(\\) expects object, mixed given\\.$#"
-			count: 3
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
 
 		-
@@ -9421,13 +9421,13 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AdminControllerTest.php
 
 		-
-			message: "#^Parameter \\#2 \\$array of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) expects array\\|ArrayAccess, mixed given\\.$#"
-			count: 1
+			message: "#^Parameter \\#1 \\$object_or_class of function property_exists expects object\\|string, mixed given\\.$#"
+			count: 4
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AdminControllerTest.php
 
 		-
-			message: "#^Parameter \\#2 \\$object of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertObjectHasAttribute\\(\\) expects object, mixed given\\.$#"
-			count: 4
+			message: "#^Parameter \\#2 \\$array of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) expects array\\|ArrayAccess, mixed given\\.$#"
+			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AdminControllerTest.php
 
 		-
@@ -9751,6 +9751,11 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
 
 		-
+			message: "#^Parameter \\#1 \\$object_or_class of function property_exists expects object\\|string, mixed given\\.$#"
+			count: 4
+			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
+
+		-
 			message: "#^Parameter \\#1 \\$primaryAddress of method Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\Address\\:\\:setPrimaryAddress\\(\\) expects bool, bool\\|null given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
@@ -9763,11 +9768,6 @@ parameters:
 		-
 			message: "#^Parameter \\#2 \\$array of function array_map expects array, mixed given\\.$#"
 			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$object of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertObjectHasAttribute\\(\\) expects object, mixed given\\.$#"
-			count: 4
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
 
 		-
@@ -16406,7 +16406,7 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaFormatControllerTest.php
 
 		-
-			message: "#^Parameter \\#2 \\$object of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertObjectNotHasAttribute\\(\\) expects object, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$object_or_class of function property_exists expects object\\|string, mixed given\\.$#"
 			count: 7
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaFormatControllerTest.php
 
@@ -21896,7 +21896,7 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/AdminControllerTest.php
 
 		-
-			message: "#^Parameter \\#2 \\$object of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertObjectHasAttribute\\(\\) expects object, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$object_or_class of function property_exists expects object\\|string, mixed given\\.$#"
 			count: 3
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/AdminControllerTest.php
 
@@ -28301,7 +28301,7 @@ parameters:
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
 
 		-
-			message: "#^Parameter \\#2 \\$object of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertObjectNotHasAttribute\\(\\) expects object, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$object_or_class of function property_exists expects object\\|string, mixed given\\.$#"
 			count: 2
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
 
@@ -28426,7 +28426,7 @@ parameters:
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/UserControllerTest.php
 
 		-
-			message: "#^Parameter \\#2 \\$object of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertObjectNotHasAttribute\\(\\) expects object, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$object_or_class of function property_exists expects object\\|string, mixed given\\.$#"
 			count: 4
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/UserControllerTest.php
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -40,15 +40,15 @@ class AdminControllerTest extends SuluTestCase
 
         $response = \json_decode($this->client->getResponse()->getContent() ?: '');
 
-        $this->assertObjectHasAttribute('sulu_admin', $response);
-        $this->assertObjectHasAttribute('navigation', $response->sulu_admin);
-        $this->assertObjectHasAttribute('resources', $response->sulu_admin);
-        $this->assertObjectHasAttribute('routes', $response->sulu_admin);
-        $this->assertObjectHasAttribute('fieldTypeOptions', $response->sulu_admin);
+        $this->assertTrue(\property_exists($response, 'sulu_admin'));
+        $this->assertTrue(\property_exists($response->sulu_admin, 'navigation'));
+        $this->assertTrue(\property_exists($response->sulu_admin, 'resources'));
+        $this->assertTrue(\property_exists($response->sulu_admin, 'routes'));
+        $this->assertTrue(\property_exists($response->sulu_admin, 'fieldTypeOptions'));
         $this->assertIsArray($response->sulu_admin->navigation);
         $this->assertIsArray($response->sulu_admin->routes);
         $this->assertIsObject($response->sulu_admin->resources);
-        $this->assertObjectHasAttribute('sulu_preview', $response);
+        $this->assertTrue(\property_exists($response, 'sulu_preview'));
 
         $this->assertEquals('en', $response->sulu_admin->localizations[0]->localization);
         $this->assertEquals('en_us', $response->sulu_admin->localizations[1]->localization);
@@ -71,15 +71,15 @@ class AdminControllerTest extends SuluTestCase
 
         $response = \json_decode($this->client->getResponse()->getContent() ?: '');
 
-        $this->assertObjectHasAttribute('sulu_admin', $response);
-        $this->assertObjectHasAttribute('navigation', $response->sulu_admin);
-        $this->assertObjectHasAttribute('resources', $response->sulu_admin);
-        $this->assertObjectHasAttribute('routes', $response->sulu_admin);
-        $this->assertObjectHasAttribute('fieldTypeOptions', $response->sulu_admin);
+        $this->assertTrue(\property_exists($response, 'sulu_admin'));
+        $this->assertTrue(\property_exists($response->sulu_admin, 'navigation'));
+        $this->assertTrue(\property_exists($response->sulu_admin, 'resources'));
+        $this->assertTrue(\property_exists($response->sulu_admin, 'routes'));
+        $this->assertTrue(\property_exists($response->sulu_admin, 'fieldTypeOptions'));
         $this->assertIsArray($response->sulu_admin->navigation);
         $this->assertIsArray($response->sulu_admin->routes);
         $this->assertIsObject($response->sulu_admin->resources);
-        $this->assertObjectHasAttribute('sulu_preview', $response);
+        $this->assertTrue(\property_exists($response, 'sulu_preview'));
 
         $this->assertEquals('en', $response->sulu_admin->localizations[0]->localization);
         $this->assertEquals('en_us', $response->sulu_admin->localizations[1]->localization);

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/CollaborationControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/CollaborationControllerTest.php
@@ -84,15 +84,15 @@ class CollaborationControllerTest extends SuluTestCase
         $this->assertEquals('page', $collaborations[0]->resourceKey);
         $this->assertEquals(4, $collaborations[0]->id);
         $this->assertEquals('Max Mustermann', $collaborations[0]->fullName);
-        $this->assertObjectHasAttribute('connectionId', $collaborations[0]);
-        $this->assertObjectHasAttribute('started', $collaborations[0]);
-        $this->assertObjectHasAttribute('changed', $collaborations[0]);
+        $this->assertTrue(\property_exists($collaborations[0], 'connectionId'));
+        $this->assertTrue(\property_exists($collaborations[0], 'started'));
+        $this->assertTrue(\property_exists($collaborations[0], 'changed'));
         $this->assertEquals('page', $collaborations[1]->resourceKey);
         $this->assertEquals(4, $collaborations[1]->id);
         $this->assertEquals('Erika Mustermann', $collaborations[1]->fullName);
-        $this->assertObjectHasAttribute('connectionId', $collaborations[1]);
-        $this->assertObjectHasAttribute('started', $collaborations[1]);
-        $this->assertObjectHasAttribute('changed', $collaborations[1]);
+        $this->assertTrue(\property_exists($collaborations[1], 'connectionId'));
+        $this->assertTrue(\property_exists($collaborations[1], 'started'));
+        $this->assertTrue(\property_exists($collaborations[1], 'changed'));
     }
 
     public function testDelete(): void

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/PropertyMetadataMinMaxValueResolverTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/PropertyMetadataMinMaxValueResolverTest.php
@@ -38,9 +38,9 @@ class PropertyMetadataMinMaxValueResolverTest extends TestCase
 
         $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($propertyMetadata);
 
-        $this->assertObjectHasAttribute('min', $minMaxValue);
+        $this->assertTrue(\property_exists($minMaxValue, 'min'));
         $this->assertSame(2, $minMaxValue->min);
-        $this->assertObjectHasAttribute('max', $minMaxValue);
+        $this->assertTrue(\property_exists($minMaxValue, 'max'));
         $this->assertSame(3, $minMaxValue->max);
     }
 
@@ -54,9 +54,9 @@ class PropertyMetadataMinMaxValueResolverTest extends TestCase
 
         $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($propertyMetadata);
 
-        $this->assertObjectHasAttribute('min', $minMaxValue);
+        $this->assertTrue(\property_exists($minMaxValue, 'min'));
         $this->assertSame(2, $minMaxValue->min);
-        $this->assertObjectHasAttribute('max', $minMaxValue);
+        $this->assertTrue(\property_exists($minMaxValue, 'max'));
         $this->assertNull($minMaxValue->max);
     }
 
@@ -70,9 +70,9 @@ class PropertyMetadataMinMaxValueResolverTest extends TestCase
 
         $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($propertyMetadata);
 
-        $this->assertObjectHasAttribute('min', $minMaxValue);
+        $this->assertTrue(\property_exists($minMaxValue, 'min'));
         $this->assertNull($minMaxValue->min);
-        $this->assertObjectHasAttribute('max', $minMaxValue);
+        $this->assertTrue(\property_exists($minMaxValue, 'max'));
         $this->assertSame(2, $minMaxValue->max);
     }
 
@@ -83,9 +83,9 @@ class PropertyMetadataMinMaxValueResolverTest extends TestCase
 
         $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($propertyMetadata);
 
-        $this->assertObjectHasAttribute('min', $minMaxValue);
+        $this->assertTrue(\property_exists($minMaxValue, 'min'));
         $this->assertNull($minMaxValue->min);
-        $this->assertObjectHasAttribute('max', $minMaxValue);
+        $this->assertTrue(\property_exists($minMaxValue, 'max'));
         $this->assertNull($minMaxValue->max);
     }
 
@@ -97,9 +97,9 @@ class PropertyMetadataMinMaxValueResolverTest extends TestCase
 
         $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($propertyMetadata);
 
-        $this->assertObjectHasAttribute('min', $minMaxValue);
+        $this->assertTrue(\property_exists($minMaxValue, 'min'));
         $this->assertSame(1, $minMaxValue->min);
-        $this->assertObjectHasAttribute('max', $minMaxValue);
+        $this->assertTrue(\property_exists($minMaxValue, 'max'));
         $this->assertNull($minMaxValue->max);
     }
 
@@ -114,9 +114,9 @@ class PropertyMetadataMinMaxValueResolverTest extends TestCase
 
         $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($propertyMetadata);
 
-        $this->assertObjectHasAttribute('min', $minMaxValue);
+        $this->assertTrue(\property_exists($minMaxValue, 'min'));
         $this->assertSame(2, $minMaxValue->min);
-        $this->assertObjectHasAttribute('max', $minMaxValue);
+        $this->assertTrue(\property_exists($minMaxValue, 'max'));
         $this->assertSame(3, $minMaxValue->max);
     }
 
@@ -135,9 +135,9 @@ class PropertyMetadataMinMaxValueResolverTest extends TestCase
             'maxItems'
         );
 
-        $this->assertObjectHasAttribute('min', $minMaxValue);
+        $this->assertTrue(\property_exists($minMaxValue, 'min'));
         $this->assertSame(2, $minMaxValue->min);
-        $this->assertObjectHasAttribute('max', $minMaxValue);
+        $this->assertTrue(\property_exists($minMaxValue, 'max'));
         $this->assertSame(3, $minMaxValue->max);
     }
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -51,8 +51,8 @@ class AdminControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $this->client->getResponse());
         $response = \json_decode($this->client->getResponse()->getContent());
 
-        $this->assertObjectHasAttribute('id', $response);
-        $this->assertObjectHasAttribute('title', $response);
+        $this->assertTrue(\property_exists($response, 'id'));
+        $this->assertTrue(\property_exists($response, 'title'));
 
         $this->assertEquals('ID', $response->id->label);
         $this->assertEquals('string', $response->id->type);

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -26,10 +26,10 @@ class AdminControllerTest extends SuluTestCase
 
         $form = $response->form;
 
-        $this->assertObjectHasAttribute('name', $form);
-        $this->assertObjectHasAttribute('key', $form);
-        $this->assertObjectHasAttribute('description', $form);
-        $this->assertObjectHasAttribute('medias', $form);
+        $this->assertTrue(\property_exists($form, 'name'));
+        $this->assertTrue(\property_exists($form, 'key'));
+        $this->assertTrue(\property_exists($form, 'description'));
+        $this->assertTrue(\property_exists($form, 'medias'));
 
         $schema = $response->schema;
 

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
@@ -383,7 +383,7 @@ class CategoryControllerTest extends SuluTestCase
         $category3 = $category1->_embedded->categories[0];
         $this->assertEquals('Third Category', $category3->name);
         $this->assertTrue($category3->hasChildren);
-        $this->assertObjectNotHasAttribute('_embedded', $category3);
+        $this->assertFalse(\property_exists($category3, '_embedded'));
     }
 
     public function testCGetFlatWithExpandedIds(): void

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
@@ -251,10 +251,10 @@ class AccountControllerTest extends SuluTestCase
         $this->assertEquals('6850', $response->addresses[0]->postboxPostcode);
         $this->assertEquals('4711', $response->addresses[0]->postboxNumber);
 
-        $this->assertObjectHasAttribute('logo', $response);
+        $this->assertTrue(\property_exists($response, 'logo'));
         $this->assertEquals($logo->getId(), $response->logo->id);
-        $this->assertObjectHasAttribute('thumbnails', $response->logo);
-        $this->assertObjectHasAttribute('sulu-100x100', $response->logo->thumbnails);
+        $this->assertTrue(\property_exists($response->logo, 'thumbnails'));
+        $this->assertTrue(\property_exists($response->logo->thumbnails, 'sulu-100x100'));
         $this->assertTrue(\is_string($response->logo->thumbnails->{'sulu-100x100'}));
     }
 
@@ -532,10 +532,10 @@ class AccountControllerTest extends SuluTestCase
         $this->assertEquals(47.4049309, $response->addresses[0]->latitude);
         $this->assertEquals(9.7593077, $response->addresses[0]->longitude);
 
-        $this->assertObjectHasAttribute('logo', $response);
+        $this->assertTrue(\property_exists($response, 'logo'));
         $this->assertEquals($logo->getId(), $response->logo->id);
-        $this->assertObjectHasAttribute('thumbnails', $response->logo);
-        $this->assertObjectHasAttribute('sulu-100x100', $response->logo->thumbnails);
+        $this->assertTrue(\property_exists($response->logo, 'thumbnails'));
+        $this->assertTrue(\property_exists($response->logo->thumbnails, 'sulu-100x100'));
         $this->assertTrue(\is_string($response->logo->thumbnails->{'sulu-100x100'}));
 
         $this->assertEquals(2, \count($response->categories));
@@ -1064,10 +1064,10 @@ class AccountControllerTest extends SuluTestCase
         $this->assertEquals('Note1', $response->notes[0]->value);
         $this->assertEquals('Note2', $response->notes[1]->value);
 
-        $this->assertObjectHasAttribute('logo', $response);
+        $this->assertTrue(\property_exists($response, 'logo'));
         $this->assertEquals($logo->getId(), $response->logo->id);
-        $this->assertObjectHasAttribute('thumbnails', $response->logo);
-        $this->assertObjectHasAttribute('sulu-100x100', $response->logo->thumbnails);
+        $this->assertTrue(\property_exists($response->logo, 'thumbnails'));
+        $this->assertTrue(\property_exists($response->logo->thumbnails, 'sulu-100x100'));
         $this->assertTrue(\is_string($response->logo->thumbnails->{'sulu-100x100'}));
 
         $this->assertEquals(1, \count($response->categories));

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountMediaControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountMediaControllerTest.php
@@ -105,8 +105,8 @@ class AccountMediaControllerTest extends SuluTestCase
 
         $this->assertEquals(1, $response->total);
         $this->assertEquals($media1->getId(), $response->_embedded->account_media[0]->id);
-        $this->assertObjectHasAttribute('thumbnails', $response->_embedded->account_media[0]);
-        $this->assertObjectHasAttribute('sulu-100x100', $response->_embedded->account_media[0]->thumbnails);
+        $this->assertTrue(\property_exists($response->_embedded->account_media[0], 'thumbnails'));
+        $this->assertTrue(\property_exists($response->_embedded->account_media[0]->thumbnails, 'sulu-100x100'));
         $this->assertTrue(\is_string($response->_embedded->account_media[0]->thumbnails->{'sulu-100x100'}));
     }
 

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -149,10 +149,10 @@ class AdminControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $this->client->getResponse());
         $response = \json_decode($this->client->getResponse()->getContent());
 
-        $this->assertObjectHasAttribute('id', $response);
-        $this->assertObjectHasAttribute('name', $response);
-        $this->assertObjectHasAttribute('zip', $response);
-        $this->assertObjectHasAttribute('city', $response);
+        $this->assertTrue(\property_exists($response, 'id'));
+        $this->assertTrue(\property_exists($response, 'name'));
+        $this->assertTrue(\property_exists($response, 'zip'));
+        $this->assertTrue(\property_exists($response, 'city'));
     }
 
     public function testContactFormMetadataAction(): void
@@ -166,8 +166,8 @@ class AdminControllerTest extends SuluTestCase
 
         $form = $response->form;
 
-        $this->assertObjectHasAttribute('avatar', $form);
-        $this->assertObjectHasAttribute('contact', $form);
+        $this->assertTrue(\property_exists($form, 'avatar'));
+        $this->assertTrue(\property_exists($form, 'contact'));
 
         $schema = $response->schema;
 
@@ -185,8 +185,8 @@ class AdminControllerTest extends SuluTestCase
 
         $form = $response->form;
 
-        $this->assertObjectHasAttribute('logo', $form);
-        $this->assertObjectHasAttribute('account', $form);
+        $this->assertTrue(\property_exists($form, 'logo'));
+        $this->assertTrue(\property_exists($form, 'account'));
 
         $schema = $response->schema;
 

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
@@ -152,9 +152,9 @@ class ContactControllerTest extends SuluTestCase
         $this->assertEquals('4711', $response->addresses[0]->postboxNumber);
         $this->assertEquals($addressType->getId(), $response->addresses[0]->addressType);
 
-        $this->assertObjectHasAttribute('avatar', $response);
-        $this->assertObjectHasAttribute('thumbnails', $response->avatar);
-        $this->assertObjectHasAttribute('sulu-100x100', $response->avatar->thumbnails);
+        $this->assertTrue(\property_exists($response, 'avatar'));
+        $this->assertTrue(\property_exists($response->avatar, 'thumbnails'));
+        $this->assertTrue(\property_exists($response->avatar->thumbnails, 'sulu-100x100'));
         $this->assertTrue(\is_string($response->avatar->thumbnails->{'sulu-100x100'}));
 
         $this->assertEquals(1, $response->formOfAddress);
@@ -458,9 +458,9 @@ class ContactControllerTest extends SuluTestCase
         $this->assertEquals('6850', $response->addresses[0]->postboxPostcode);
         $this->assertEquals('4711', $response->addresses[0]->postboxNumber);
 
-        $this->assertObjectHasAttribute('avatar', $response);
-        $this->assertObjectHasAttribute('thumbnails', $response->avatar);
-        $this->assertObjectHasAttribute('sulu-100x100', $response->avatar->thumbnails);
+        $this->assertTrue(\property_exists($response, 'avatar'));
+        $this->assertTrue(\property_exists($response->avatar, 'thumbnails'));
+        $this->assertTrue(\property_exists($response->avatar->thumbnails, 'sulu-100x100'));
         $this->assertTrue(\is_string($response->avatar->thumbnails->{'sulu-100x100'}));
 
         $this->assertEquals(0, $response->formOfAddress);
@@ -1110,9 +1110,9 @@ class ContactControllerTest extends SuluTestCase
         $this->assertEquals(0, $response->formOfAddress);
         $this->assertEquals('Sehr geehrter John', $response->salutation);
 
-        $this->assertObjectHasAttribute('avatar', $response);
-        $this->assertObjectHasAttribute('thumbnails', $response->avatar);
-        $this->assertObjectHasAttribute('sulu-100x100', $response->avatar->thumbnails);
+        $this->assertTrue(\property_exists($response, 'avatar'));
+        $this->assertTrue(\property_exists($response->avatar, 'thumbnails'));
+        $this->assertTrue(\property_exists($response->avatar->thumbnails, 'sulu-100x100'));
         $this->assertTrue(\is_string($response->avatar->thumbnails->{'sulu-100x100'}));
 
         $this->assertEquals(1, \count($response->categories));
@@ -1150,9 +1150,9 @@ class ContactControllerTest extends SuluTestCase
         $this->assertEquals(0, $response->formOfAddress);
         $this->assertEquals('Sehr geehrter John', $response->salutation);
 
-        $this->assertObjectHasAttribute('avatar', $response);
-        $this->assertObjectHasAttribute('thumbnails', $response->avatar);
-        $this->assertObjectHasAttribute('sulu-100x100', $response->avatar->thumbnails);
+        $this->assertTrue(\property_exists($response, 'avatar'));
+        $this->assertTrue(\property_exists($response->avatar, 'thumbnails'));
+        $this->assertTrue(\property_exists($response->avatar->thumbnails, 'sulu-100x100'));
         $this->assertTrue(\is_string($response->avatar->thumbnails->{'sulu-100x100'}));
 
         $this->assertEquals(1, \count($response->categories));

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactMediaControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactMediaControllerTest.php
@@ -92,8 +92,8 @@ class ContactMediaControllerTest extends SuluTestCase
 
         $this->assertEquals(1, $response->total);
         $this->assertEquals($media1->getId(), $response->_embedded->contact_media[0]->id);
-        $this->assertObjectHasAttribute('thumbnails', $response->_embedded->contact_media[0]);
-        $this->assertObjectHasAttribute('sulu-100x100', $response->_embedded->contact_media[0]->thumbnails);
+        $this->assertTrue(\property_exists($response->_embedded->contact_media[0], 'thumbnails'));
+        $this->assertTrue(\property_exists($response->_embedded->contact_media[0]->thumbnails, 'sulu-100x100'));
         $this->assertTrue(\is_string($response->_embedded->contact_media[0]->thumbnails->{'sulu-100x100'}));
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -39,8 +39,8 @@ class AdminControllerTest extends SuluTestCase
 
         $form = $response->form;
 
-        $this->assertObjectHasAttribute('title', $form);
-        $this->assertObjectHasAttribute('description', $form);
+        $this->assertTrue(\property_exists($form, 'title'));
+        $this->assertTrue(\property_exists($form, 'description'));
 
         $schema = $response->schema;
 
@@ -57,14 +57,14 @@ class AdminControllerTest extends SuluTestCase
         $response = \json_decode($client->getResponse()->getContent());
 
         $form = $response->form;
-        $this->assertObjectHasAttribute('media_upload', $form);
-        $this->assertObjectHasAttribute('media_details', $form);
+        $this->assertTrue(\property_exists($form, 'media_upload'));
+        $this->assertTrue(\property_exists($form, 'media_details'));
 
         $items = $form->media_details->items;
-        $this->assertObjectHasAttribute('title', $items);
-        $this->assertObjectHasAttribute('description', $items);
-        $this->assertObjectHasAttribute('license', $items);
-        $this->assertObjectHasAttribute('taxonomies', $items);
+        $this->assertTrue(\property_exists($items, 'title'));
+        $this->assertTrue(\property_exists($items, 'description'));
+        $this->assertTrue(\property_exists($items, 'license'));
+        $this->assertTrue(\property_exists($items, 'taxonomies'));
 
         $schema = $response->schema;
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaFormatControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaFormatControllerTest.php
@@ -131,8 +131,8 @@ class MediaFormatControllerTest extends SuluTestCase
         $this->assertEquals(32, $response->{'big-squared'}->cropHeight);
         $this->assertEquals(33, $response->{'big-squared'}->cropWidth);
 
-        $this->assertObjectNotHasAttribute('small-inset', $response);
-        $this->assertObjectNotHasAttribute('one-side', $response);
+        $this->assertFalse(\property_exists($response, 'small-inset'));
+        $this->assertFalse(\property_exists($response, 'one-side'));
     }
 
     public function testPatch(): void
@@ -151,8 +151,8 @@ class MediaFormatControllerTest extends SuluTestCase
         $this->assertEquals(32, $response->{'big-squared'}->cropHeight);
         $this->assertEquals(33, $response->{'big-squared'}->cropWidth);
 
-        $this->assertObjectNotHasAttribute('small-inset', $response);
-        $this->assertObjectNotHasAttribute('one-side', $response);
+        $this->assertFalse(\property_exists($response, 'small-inset'));
+        $this->assertFalse(\property_exists($response, 'one-side'));
 
         $this->client->jsonRequest(
             'PATCH',
@@ -176,7 +176,7 @@ class MediaFormatControllerTest extends SuluTestCase
         $response = \json_decode($this->client->getResponse()->getContent());
         $this->assertHttpStatusCode(200, $this->client->getResponse());
 
-        $this->assertObjectNotHasAttribute('big-squared', $response);
+        $this->assertFalse(\property_exists($response, 'big-squared'));
 
         $this->assertNotNull($response->{'small-inset'});
         $this->assertEquals(50, $response->{'small-inset'}->cropX);
@@ -184,7 +184,7 @@ class MediaFormatControllerTest extends SuluTestCase
         $this->assertEquals(52, $response->{'small-inset'}->cropHeight);
         $this->assertEquals(53, $response->{'small-inset'}->cropWidth);
 
-        $this->assertObjectNotHasAttribute('one-side', $response);
+        $this->assertFalse(\property_exists($response, 'one-side'));
     }
 
     public function testPutWithFormatOptions(): void
@@ -249,7 +249,7 @@ class MediaFormatControllerTest extends SuluTestCase
         $response = \json_decode($this->client->getResponse()->getContent());
         $this->assertHttpStatusCode(200, $this->client->getResponse());
 
-        $this->assertObjectNotHasAttribute('big-squared', $response);
+        $this->assertFalse(\property_exists($response, 'big-squared'));
     }
 
     public function testPutNotExistingFormat(): void

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -61,7 +61,7 @@ class AdminControllerTest extends SuluTestCase
 
         $adminConfig = $response->sulu_admin;
 
-        $this->assertObjectHasAttribute('pages', $adminConfig->smartContent);
+        $this->assertTrue(\property_exists($adminConfig->smartContent, 'pages'));
         $this->assertEquals('sulu_page.page_edit_form', $adminConfig->smartContent->pages->view);
         $this->assertEquals(
             ['id' => 'id', 'webspace' => 'webspace'],
@@ -116,9 +116,9 @@ class AdminControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = \json_decode($client->getResponse()->getContent());
 
-        $this->assertObjectHasAttribute('id', $response);
-        $this->assertObjectHasAttribute('title', $response);
-        $this->assertObjectHasAttribute('published', $response);
+        $this->assertTrue(\property_exists($response, 'id'));
+        $this->assertTrue(\property_exists($response, 'title'));
+        $this->assertTrue(\property_exists($response, 'published'));
 
         $this->assertEquals('ID', $response->id->label);
         $this->assertEquals('string', $response->id->type);
@@ -135,34 +135,34 @@ class AdminControllerTest extends SuluTestCase
 
         $types = $response->types;
 
-        $this->assertObjectHasAttribute('default', $types);
-        $this->assertObjectHasAttribute('overview', $types);
-        $this->assertObjectHasAttribute('blocks', $types);
+        $this->assertTrue(\property_exists($types, 'default'));
+        $this->assertTrue(\property_exists($types, 'overview'));
+        $this->assertTrue(\property_exists($types, 'blocks'));
 
         $defaultType = $types->default;
-        $this->assertObjectHasAttribute('name', $defaultType);
+        $this->assertTrue(\property_exists($defaultType, 'name'));
         $this->assertEquals('default', $defaultType->name);
-        $this->assertObjectHasAttribute('title', $defaultType);
+        $this->assertTrue(\property_exists($defaultType, 'title'));
         $this->assertEquals('Standard page', $defaultType->title);
-        $this->assertObjectHasAttribute('form', $defaultType);
-        $this->assertObjectHasAttribute('title', $defaultType->form);
-        $this->assertObjectHasAttribute('url', $defaultType->form);
+        $this->assertTrue(\property_exists($defaultType, 'form'));
+        $this->assertTrue(\property_exists($defaultType->form, 'title'));
+        $this->assertTrue(\property_exists($defaultType->form, 'url'));
         $this->assertEquals('sulu.rlp.part', $defaultType->form->title->tags[0]->name);
         $this->assertEquals(1, $defaultType->form->title->tags[0]->priority);
-        $this->assertObjectHasAttribute('schema', $defaultType);
+        $this->assertTrue(\property_exists($defaultType, 'schema'));
         $this->assertEquals(['title'], $defaultType->schema->required);
 
         $overviewType = $types->overview;
-        $this->assertObjectHasAttribute('name', $overviewType);
+        $this->assertTrue(\property_exists($overviewType, 'name'));
         $this->assertEquals('overview', $overviewType->name);
-        $this->assertObjectHasAttribute('title', $overviewType);
+        $this->assertTrue(\property_exists($overviewType, 'title'));
         $this->assertEquals('Overview', $overviewType->title);
-        $this->assertObjectHasAttribute('form', $overviewType);
-        $this->assertObjectHasAttribute('title', $overviewType->form);
-        $this->assertObjectHasAttribute('tags', $overviewType->form);
-        $this->assertObjectHasAttribute('url', $overviewType->form);
-        $this->assertObjectHasAttribute('article', $overviewType->form);
-        $this->assertObjectHasAttribute('schema', $overviewType);
+        $this->assertTrue(\property_exists($overviewType, 'form'));
+        $this->assertTrue(\property_exists($overviewType->form, 'title'));
+        $this->assertTrue(\property_exists($overviewType->form, 'tags'));
+        $this->assertTrue(\property_exists($overviewType->form, 'url'));
+        $this->assertTrue(\property_exists($overviewType->form, 'article'));
+        $this->assertTrue(\property_exists($overviewType, 'schema'));
         $this->assertCount(5, (array) $overviewType->schema->properties);
         $this->assertEquals('array', $overviewType->schema->properties->block->type);
 
@@ -210,11 +210,11 @@ class AdminControllerTest extends SuluTestCase
 
         $form = $response->form;
 
-        $this->assertObjectHasAttribute('search_result', $form);
-        $this->assertObjectHasAttribute('ext/seo/title', $form);
-        $this->assertObjectHasAttribute('ext/seo/description', $form);
+        $this->assertTrue(\property_exists($form, 'search_result'));
+        $this->assertTrue(\property_exists($form, 'ext/seo/title'));
+        $this->assertTrue(\property_exists($form, 'ext/seo/description'));
 
-        $this->assertObjectHasAttribute('properties', $response->schema);
+        $this->assertTrue(\property_exists($response->schema, 'properties'));
     }
 
     public function testPageExcerptFormMetadataAction(): void
@@ -228,12 +228,12 @@ class AdminControllerTest extends SuluTestCase
 
         $form = $response->form;
 
-        $this->assertObjectHasAttribute('ext/excerpt/title', $form);
-        $this->assertObjectHasAttribute('ext/excerpt/more', $form);
-        $this->assertObjectHasAttribute('ext/excerpt/description', $form);
-        $this->assertObjectHasAttribute('ext/excerpt/segments', $form);
+        $this->assertTrue(\property_exists($form, 'ext/excerpt/title'));
+        $this->assertTrue(\property_exists($form, 'ext/excerpt/more'));
+        $this->assertTrue(\property_exists($form, 'ext/excerpt/description'));
+        $this->assertTrue(\property_exists($form, 'ext/excerpt/segments'));
 
-        $this->assertObjectHasAttribute('properties', $response->schema);
+        $this->assertTrue(\property_exists($response->schema, 'properties'));
     }
 
     public function testPageSettingFormMetadataAction(): void
@@ -247,9 +247,9 @@ class AdminControllerTest extends SuluTestCase
 
         $form = $response->form;
 
-        $this->assertObjectHasAttribute('navContexts', $form);
-        $this->assertObjectHasAttribute('pageType', $form);
-        $this->assertObjectHasAttribute('shadowPage', $form);
+        $this->assertTrue(\property_exists($form, 'navContexts'));
+        $this->assertTrue(\property_exists($form, 'pageType'));
+        $this->assertTrue(\property_exists($form, 'shadowPage'));
 
         $schema = $response->schema;
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
@@ -133,10 +133,10 @@ class PageControllerTest extends SuluTestCase
         $page2 = $response->_embedded->pages[1];
         $this->assertEquals('Homepage', $page1->title);
         $this->assertEquals('test_io', $page1->webspaceKey);
-        $this->assertObjectHasAttribute('id', $page1);
+        $this->assertTrue(\property_exists($page1, 'id'));
         $this->assertEquals('Homepage', $page2->title);
         $this->assertEquals('sulu_io', $page2->webspaceKey);
-        $this->assertObjectHasAttribute('id', $page2);
+        $this->assertTrue(\property_exists($page2, 'id'));
     }
 
     public function testGetFlatResponseWithGhostIds(): void
@@ -259,7 +259,7 @@ class PageControllerTest extends SuluTestCase
         $this->assertEquals('de', $childPages[0]->locale);
         $this->assertEquals('en', $childPages[0]->ghostLocale);
         $this->assertEquals('sulu_io', $childPages[0]->webspaceKey);
-        $this->assertObjectNotHasAttribute('shadowLocale', $childPages[0]);
+        $this->assertFalse(\property_exists($childPages[0], 'shadowLocale'));
         $this->assertEquals('ghost', $childPages[0]->type->name);
         $this->assertEquals('en', $childPages[0]->type->value);
 
@@ -267,7 +267,7 @@ class PageControllerTest extends SuluTestCase
         $this->assertEquals('de', $childPages[1]->locale);
         $this->assertEquals('en', $childPages[1]->shadowLocale);
         $this->assertEquals('sulu_io', $childPages[1]->webspaceKey);
-        $this->assertObjectNotHasAttribute('ghostLocale', $childPages[1]);
+        $this->assertFalse(\property_exists($childPages[1], 'ghostLocale'));
         $this->assertEquals('shadow', $childPages[1]->type->name);
         $this->assertEquals('en', $childPages[1]->type->value);
     }

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/AdminControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/AdminControllerTest.php
@@ -54,8 +54,8 @@ class AdminControllerTest extends SuluTestCase
 
         $form = $response->form;
 
-        $this->assertObjectHasAttribute('username', $form);
-        $this->assertObjectHasAttribute('password', $form);
+        $this->assertTrue(\property_exists($form, 'username'));
+        $this->assertTrue(\property_exists($form, 'password'));
 
         $schema = $response->schema;
 
@@ -75,8 +75,8 @@ class AdminControllerTest extends SuluTestCase
 
         $form = $response->form;
 
-        $this->assertObjectHasAttribute('name', $form);
-        $this->assertObjectHasAttribute('system', $form);
+        $this->assertTrue(\property_exists($form, 'name'));
+        $this->assertTrue(\property_exists($form, 'system'));
 
         $schema = $response->schema;
 

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
@@ -489,7 +489,7 @@ class RoleControllerTest extends SuluTestCase
         $this->assertEquals(true, $response->permissions[2]->permissions->archive);
         $this->assertEquals(true, $response->permissions[2]->permissions->live);
         $this->assertEquals(true, $response->permissions[2]->permissions->security);
-        $this->assertObjectNotHasAttribute('securityType', $response);
+        $this->assertFalse(\property_exists($response, 'securityType'));
 
         $this->client->jsonRequest(
             'GET',
@@ -523,7 +523,7 @@ class RoleControllerTest extends SuluTestCase
         $this->assertEquals(true, $response->permissions[2]->permissions->archive);
         $this->assertEquals(true, $response->permissions[2]->permissions->live);
         $this->assertEquals(true, $response->permissions[2]->permissions->security);
-        $this->assertObjectNotHasAttribute('securityType', $response);
+        $this->assertFalse(\property_exists($response, 'securityType'));
     }
 
     public function testPutNotExisting(): void

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/UserControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/UserControllerTest.php
@@ -253,7 +253,7 @@ class UserControllerTest extends SuluTestCase
         $this->assertEquals(4, \count($response->_embedded->users));
         $this->assertEquals('admin', $response->_embedded->users[0]->username);
         $this->assertEquals('admin@test.com', $response->_embedded->users[0]->email);
-        $this->assertObjectNotHasAttribute('password', $response->_embedded->users[0]);
+        $this->assertFalse(\property_exists($response->_embedded->users[0], 'password'));
         $this->assertEquals('de', $response->_embedded->users[0]->locale);
     }
 
@@ -265,7 +265,7 @@ class UserControllerTest extends SuluTestCase
 
         $this->assertEquals('admin', $response->username);
         $this->assertEquals('admin@test.com', $response->email);
-        $this->assertObjectNotHasAttribute('password', $response);
+        $this->assertFalse(\property_exists($response, 'password'));
         $this->assertEquals('de', $response->locale);
         $this->assertEquals('Role1', $response->userRoles[0]->role->name);
         $this->assertEquals('Role2', $response->userRoles[1]->role->name);
@@ -860,7 +860,7 @@ class UserControllerTest extends SuluTestCase
 
         $this->assertEquals($this->user1->getId(), $response->id);
         $this->assertEquals('admin', $response->username);
-        $this->assertObjectNotHasAttribute('password', $response);
+        $this->assertFalse(\property_exists($response, 'password'));
 
         $this->assertEquals('Role1', $response->userRoles[0]->role->name);
         $this->assertEquals('Sulu', $response->userRoles[0]->role->system);
@@ -902,7 +902,7 @@ class UserControllerTest extends SuluTestCase
 
         $this->assertNotNull($adminUser);
         $this->assertEquals('admin', $adminUser->username);
-        $this->assertObjectNotHasAttribute('password', $adminUser);
+        $this->assertFalse(\property_exists($adminUser, 'password'));
         $this->assertEquals('de', $adminUser->locale);
     }
 
@@ -919,17 +919,17 @@ class UserControllerTest extends SuluTestCase
         $user = $users[0];
         $contact = $user->contact;
 
-        $this->assertObjectNotHasAttribute('account', $contact);
-        $this->assertObjectNotHasAttribute('phones', $contact);
-        $this->assertObjectNotHasAttribute('faxes', $contact);
-        $this->assertObjectNotHasAttribute('position', $contact);
-        $this->assertObjectNotHasAttribute('addresses', $contact);
-        $this->assertObjectNotHasAttribute('notes', $contact);
-        $this->assertObjectNotHasAttribute('tags', $contact);
-        $this->assertObjectNotHasAttribute('medias', $contact);
-        $this->assertObjectNotHasAttribute('categories', $contact);
-        $this->assertObjectNotHasAttribute('urls', $contact);
-        $this->assertObjectNotHasAttribute('bankAccounts', $contact);
+        $this->assertFalse(\property_exists($contact, 'account'));
+        $this->assertFalse(\property_exists($contact, 'phones'));
+        $this->assertFalse(\property_exists($contact, 'faxes'));
+        $this->assertFalse(\property_exists($contact, 'position'));
+        $this->assertFalse(\property_exists($contact, 'addresses'));
+        $this->assertFalse(\property_exists($contact, 'notes'));
+        $this->assertFalse(\property_exists($contact, 'tags'));
+        $this->assertFalse(\property_exists($contact, 'medias'));
+        $this->assertFalse(\property_exists($contact, 'categories'));
+        $this->assertFalse(\property_exists($contact, 'urls'));
+        $this->assertFalse(\property_exists($contact, 'bankAccounts'));
     }
 
     public function testPutWithRemovedRoles(): void
@@ -1062,7 +1062,7 @@ class UserControllerTest extends SuluTestCase
         $response = \json_decode($this->client->getResponse()->getContent());
 
         $this->assertEquals('manager', $response->username);
-        $this->assertObjectNotHasAttribute('password', $response);
+        $this->assertFalse(\property_exists($response, 'password'));
     }
 
     public function testPutWithEmptyPassword(): void
@@ -1099,7 +1099,7 @@ class UserControllerTest extends SuluTestCase
         $response = \json_decode($this->client->getResponse()->getContent());
 
         $this->assertEquals('manager', $response->username);
-        $this->assertObjectNotHasAttribute('password', $response);
+        $this->assertFalse(\property_exists($response, 'password'));
         $this->assertEquals($this->contact1->getId(), $response->contact->id);
         $this->assertEquals('en', $response->locale);
         $this->assertEquals('Role1', $response->userRoles[0]->role->name);

--- a/src/Sulu/Bundle/TagBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -26,7 +26,7 @@ class AdminControllerTest extends SuluTestCase
 
         $form = $response->form;
 
-        $this->assertObjectHasAttribute('name', $form);
+        $this->assertTrue(\property_exists($form, 'name'));
 
         $schema = $response->schema;
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

This was already tackled by @mamazu on 2.6 branch, sadly rector has no rule for this / don't add a rule for it because a replacement function is only added later (10.1) and they directly migrate to that method.

#### Why?

Prepare PHPUnit 10.

#### Example Usage

**assertObjectNotHasAttribute**:

```regex
assertObjectNotHasAttribute\((.*), (.*)\)
```

```
assertFalse(property_exists($2, $1))
```

**assertObjectHasAttribute**

```regex
assertObjectHasAttribute\((.*), (.*)\)
```

```
assertTrue(property_exists($2, $1))
```

