### PR TITLE
Add support for guzzle promises 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "friendsofsymfony/jsrouting-bundle": "^2.7 || ^3.0",
         "friendsofsymfony/rest-bundle": "^3.1",
         "gedmo/doctrine-extensions": "^3.0.4",
-        "guzzlehttp/promises": "^1.0",
+        "guzzlehttp/promises": "^1.0 || ^2.0",
         "handcraftedinthealps/goodby-csv": "^1.4",
         "handcraftedinthealps/rest-routing-bundle": "^1.0",
         "imagine/imagine": "^1.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no 
| BC breaks? | no
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add support for guzzle promises 2.0.

#### Why?

Guzzle promises is no requirment of Sulu itself but required to support FosHttpCacheBundle out of the box. So no code adjustements are required.

https://foshttpcachebundle.readthedocs.io/en/latest/overview.html#installation
