### PR TITLE
Improve error message on not found data-config attribute

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -404,7 +404,7 @@ function startAdmin() {
     }
 
     if (!('config' in applicationElement.dataset)) {
-        throw new Error('Configuration not found');
+        throw new Error(`Attribute "data-config" not found on element with ID "${id}"!`);
     }
 
     Object.assign(Config, JSON.parse(applicationElement.dataset.config));


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Improve error message on not found data-config attribute.

#### Why?

Better error message if the `data-config` attribute is missing.
