### PR TITLE
Fix compatibility to Node 14 and 16 and NPM 6

### DIFF
--- a/symlink-vendor-directory.js
+++ b/symlink-vendor-directory.js
@@ -33,7 +33,7 @@ if (
         && path.basename(path.dirname(process.cwd())) === 'assets'
     )
 ) {
-    exec('npx "symlink-dir@<6.0" ' + from + ' ' + to, (error) => {
+    exec('npx "symlink-dir@5.1.1" ' + from + ' ' + to, (error) => {
         if (error) {
             throw new Error('Error occured while creating symlink: ' + error);
         }

--- a/symlink-vendor-directory.js
+++ b/symlink-vendor-directory.js
@@ -33,7 +33,7 @@ if (
         && path.basename(path.dirname(process.cwd())) === 'assets'
     )
 ) {
-    exec('npx "symlink-dir@5.1.1" ' + from + ' ' + to, (error) => {
+    exec('npx "symlink-dir@5.2.0" ' + from + ' ' + to, (error) => {
         if (error) {
             throw new Error('Error occured while creating symlink: ' + error);
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | similar to https://github.com/sulu/sulu/issues/7365
| Related issues/PRs | https://github.com/zkochan/packages/issues/194
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix compatibility to Node 14 and 16 and NPM 6.

#### Why?

<details>
<summary>Error: Error occured while creating symlink: Error: Command failed: npx "symlink-dir@<6.0" ../../vendor node_modules/@sulu/vendor</summary>

```
Users/alexanderschranz/Documents/Projects/sulu-develop.localhost/vendor/sulu/sulu/symlink-vendor-directory.js:38
            throw new Error('Error occured while creating symlink: ' + error);
            ^

Error: Error occured while creating symlink: Error: Command failed: npx "symlink-dir@<6.0" ../../vendor node_modules/@sulu/vendor
npm ERR! code ENOTSUP
npm ERR! notsup Unsupported engine for rename-overwrite@5.0.1: wanted: {"node":">=18"} (current: {"node":"14.21.3","npm":"6.14.18"})
npm ERR! notsup Not compatible with your version of node/npm: rename-overwrite@5.0.1
npm ERR! notsup Not compatible with your version of node/npm: rename-overwrite@5.0.1
npm ERR! notsup Required: {"node":">=18"}
npm ERR! notsup Actual:   {"npm":"6.14.18","node":"14.21.3"}

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/alexanderschranz/.npm/_logs/2024-07-04T12_51_25_341Z-debug.log
Die Installation von [ 'symlink-dir@<6.0' ] ist mit dem Code 1 fehlgeschlagen

    at /Users/alexanderschranz/Documents/Projects/sulu-develop.localhost/vendor/sulu/sulu/symlink-vendor-directory.js:38:19
    at ChildProcess.exithandler (child_process.js:390:5)
    at ChildProcess.emit (events.js:400:28)
    at maybeClose (internal/child_process.js:1088:16)
    at Socket.<anonymous> (internal/child_process.js:446:11)
    at Socket.emit (events.js:400:28)
    at Pipe.<anonymous> (net.js:686:12)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! sulu-skeleton@ preinstall: `node ../../vendor/sulu/sulu/preinstall.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the sulu-skeleton@ preinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/alexanderschranz/.npm/_logs/2024-07-04T12_51_25_426Z-debug.log


 [ERROR] Unexpected error while installing npm dependencies.
```

</details>

This is caused as a new version `rename-overwrite` was released which causes now issues on node 14:

> Unsupported engine for rename-overwrite@5.0.1: wanted: {"node":">=18"} (current: {"node":"14.21.3","npm":"6.14.18"}) 

Downgrading to a legacy version may not required if the change is reverted. See https://github.com/zkochan/packages/issues/194 for issue on the rename-overwrite package.