### PR TITLE
Backport test type changes to 2.5

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2936,11 +2936,6 @@ parameters:
 			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Tests\\\\Unit\\\\TargetGroupSubscriberTest\\:\\:provideAddTargetGroupHitScript\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Tests\\\\Unit\\\\TargetGroupSubscriberTest\\:\\:provideAddVaryHeader\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
@@ -2982,31 +2977,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Tests\\\\Unit\\\\TargetGroupSubscriberTest\\:\\:testAddSetCookieHeader\\(\\) has parameter \\$visitorSession with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Tests\\\\Unit\\\\TargetGroupSubscriberTest\\:\\:testAddTargetGroupHitScript\\(\\) has parameter \\$forwardedRefererHeader with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Tests\\\\Unit\\\\TargetGroupSubscriberTest\\:\\:testAddTargetGroupHitScript\\(\\) has parameter \\$forwardedUrlHeader with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Tests\\\\Unit\\\\TargetGroupSubscriberTest\\:\\:testAddTargetGroupHitScript\\(\\) has parameter \\$forwardedUuidHeader with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Tests\\\\Unit\\\\TargetGroupSubscriberTest\\:\\:testAddTargetGroupHitScript\\(\\) has parameter \\$targetGroupHitUrl with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Tests\\\\Unit\\\\TargetGroupSubscriberTest\\:\\:testAddTargetGroupHitScript\\(\\) has parameter \\$uuid with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
 
@@ -3261,7 +3231,7 @@ parameters:
 			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/ReferrerRuleTest.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Tests\\\\Unit\\\\Rule\\\\TargetGroupEvaluatorTest\\:\\:provideEvaluationData\\(\\) has no return type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Tests\\\\Unit\\\\Rule\\\\TargetGroupEvaluatorTest\\:\\:provideEvaluationData\\(\\) should return iterable\\<array\\{0\\: array\\<Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Entity\\\\TargetGroup\\>, 1\\: array\\<string, array\\<string\\>\\>, 2\\: string\\|null, 3\\: Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Entity\\\\TargetGroup\\|null, 4\\?\\: int, 5\\?\\: Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Entity\\\\TargetGroup\\|null\\}\\> but returns array\\{array\\{array\\{\\}, array\\{\\}, 'sulu_io', null\\}, array\\{array\\{\\}, array\\{\\}, null, null\\}, array\\{array\\{Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Entity\\\\TargetGroup\\}, array\\{\\}, 'sulu_io', null\\}, array\\{array\\{Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Entity\\\\TargetGroup\\}, array\\{rule1\\: array\\{array\\{'targetGroup2'\\}\\}\\}, 'sulu_io', Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Entity\\\\TargetGroup\\}, array\\{array\\{Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Entity\\\\TargetGroup\\}, array\\{rule1\\: array\\{array\\{'targetGroup2'\\}\\}\\}, 'test', Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Entity\\\\TargetGroup\\}, array\\{array\\{Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Entity\\\\TargetGroup\\}, array\\{rule1\\: array\\{\\}\\}, 'sulu_io', null\\}, array\\{array\\{Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Entity\\\\TargetGroup, Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Entity\\\\TargetGroup\\}, array\\{rule1\\: array\\{array\\{'targetGroup2'\\}, array\\{'targetGroup3'\\}\\}\\}, 'sulu_io', Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Entity\\\\TargetGroup\\}, array\\{array\\{Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Entity\\\\TargetGroup, Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Entity\\\\TargetGroup\\}, array\\{rule1\\: array\\{array\\{'targetGroup2'\\}, array\\{'targetGroup3'\\}\\}\\}, 'sulu_io', Sulu\\\\Bundle\\\\AudienceTargetingBundle\\\\Entity\\\\TargetGroup\\}, \\.\\.\\.\\}\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/TargetGroupEvaluatorTest.php
 
@@ -16801,11 +16771,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createAccessControl\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
 			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createAccessControl\\(\\) has parameter \\$entityClass with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
@@ -16832,11 +16797,6 @@ parameters:
 
 		-
 			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createCollection\\(\\) has parameter \\$parent with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createMedia\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
@@ -16871,11 +16831,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createRole\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
 			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createRole\\(\\) has parameter \\$name with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
@@ -16886,77 +16841,12 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createTag\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
 			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createTag\\(\\) has parameter \\$name with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createType\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
 			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:createType\\(\\) has parameter \\$name with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:findByProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:provideFindByFiltersWithAudienceTargeting\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFilters\\(\\) has parameter \\$expected with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFilters\\(\\) has parameter \\$filters with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFilters\\(\\) has parameter \\$limit with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFilters\\(\\) has parameter \\$options with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFilters\\(\\) has parameter \\$page with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFilters\\(\\) has parameter \\$pageSize with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFilters\\(\\) has parameter \\$tags with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFiltersWithAudienceTargeting\\(\\) has parameter \\$expectedIndexes with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: "#^Method Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:testFindByFiltersWithAudienceTargeting\\(\\) has parameter \\$targetGroupIndex with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
@@ -16971,32 +16861,12 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Property Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:\\$collectionData type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
 			message: "#^Property Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManager\\) does not accept Doctrine\\\\ORM\\\\EntityManagerInterface\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
 		-
-			message: "#^Property Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:\\$mediaData type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: "#^Property Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:\\$mediaTypeData type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
 			message: "#^Property Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:\\$medias is never read, only written\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: "#^Property Functional\\\\Entity\\\\MediaDataProviderRepositoryTest\\:\\:\\$tagData type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
 
@@ -17386,102 +17256,12 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Transformations/AbstractTransformationTest.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Unit\\\\Media\\\\ImageConverter\\\\Transformations\\\\CropTransformationTest\\:\\:getDataList\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Transformations/CropTransformationTest.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Unit\\\\Media\\\\ImageConverter\\\\Transformations\\\\PasteTransformationTest\\:\\:createImagine\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Transformations/PasteTransformationTest.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Manager\\\\MediaManagerTest\\:\\:createMedia\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Manager\\\\MediaManagerTest\\:\\:createMedia\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Manager\\\\MediaManagerTest\\:\\:provideGetByIds\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Manager\\\\MediaManagerTest\\:\\:provideSpecialCharacterFileName\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Manager\\\\MediaManagerTest\\:\\:provideSpecialCharacterUrl\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Manager\\\\MediaManagerTest\\:\\:testGetByIds\\(\\) has parameter \\$ids with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Manager\\\\MediaManagerTest\\:\\:testGetByIds\\(\\) has parameter \\$media with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Manager\\\\MediaManagerTest\\:\\:testGetByIds\\(\\) has parameter \\$permissions with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Manager\\\\MediaManagerTest\\:\\:testGetByIds\\(\\) has parameter \\$result with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Manager\\\\MediaManagerTest\\:\\:testGetByIds\\(\\) has parameter \\$user with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Manager\\\\MediaManagerTest\\:\\:testSpecialCharacterFileName\\(\\) has parameter \\$cleanUpArgument with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Manager\\\\MediaManagerTest\\:\\:testSpecialCharacterFileName\\(\\) has parameter \\$cleanUpResult with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Manager\\\\MediaManagerTest\\:\\:testSpecialCharacterFileName\\(\\) has parameter \\$extension with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Manager\\\\MediaManagerTest\\:\\:testSpecialCharacterFileName\\(\\) has parameter \\$fileName with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Manager\\\\MediaManagerTest\\:\\:testSpecialCharacterUrl\\(\\) has parameter \\$expected with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Manager\\\\MediaManagerTest\\:\\:testSpecialCharacterUrl\\(\\) has parameter \\$filename with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Manager\\\\MediaManagerTest\\:\\:testSpecialCharacterUrl\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Manager\\\\MediaManagerTest\\:\\:testSpecialCharacterUrl\\(\\) has parameter \\$version with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
 
@@ -33026,16 +32806,6 @@ parameters:
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Analytics/AnalyticsManagerTest.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Tests\\\\Functional\\\\BaseFunctional\\:\\:create\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Tests/Functional/BaseFunctional.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Tests\\\\Functional\\\\BaseFunctional\\:\\:findOrCreateNewDomain\\(\\) has parameter \\$domain with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Tests/Functional/BaseFunctional.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Tests\\\\Functional\\\\BaseFunctional\\:\\:getValue\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Functional/BaseFunctional.php
@@ -33047,11 +32817,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Tests\\\\Functional\\\\BaseFunctional\\:\\:getValue\\(\\) has parameter \\$default with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Tests/Functional/BaseFunctional.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Tests\\\\Functional\\\\BaseFunctional\\:\\:setData\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Functional/BaseFunctional.php
 
@@ -34581,127 +34346,7 @@ parameters:
 			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
 
 		-
-			message: "#^Method Sulu\\\\Component\\\\Contact\\\\Tests\\\\Unit\\\\SmartContent\\\\AccountDataProviderTest\\:\\:createDataItem\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Contact\\\\Tests\\\\Unit\\\\SmartContent\\\\AccountDataProviderTest\\:\\:createResourceItem\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Contact\\\\Tests\\\\Unit\\\\SmartContent\\\\AccountDataProviderTest\\:\\:dataItemsDataProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Contact\\\\Tests\\\\Unit\\\\SmartContent\\\\AccountDataProviderTest\\:\\:getRepository\\(\\) has parameter \\$filters with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Contact\\\\Tests\\\\Unit\\\\SmartContent\\\\AccountDataProviderTest\\:\\:getRepository\\(\\) has parameter \\$limit with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Contact\\\\Tests\\\\Unit\\\\SmartContent\\\\AccountDataProviderTest\\:\\:getRepository\\(\\) has parameter \\$options with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Contact\\\\Tests\\\\Unit\\\\SmartContent\\\\AccountDataProviderTest\\:\\:getRepository\\(\\) has parameter \\$page with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Contact\\\\Tests\\\\Unit\\\\SmartContent\\\\AccountDataProviderTest\\:\\:getRepository\\(\\) has parameter \\$pageSize with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Contact\\\\Tests\\\\Unit\\\\SmartContent\\\\AccountDataProviderTest\\:\\:getRepository\\(\\) has parameter \\$result with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Contact\\\\Tests\\\\Unit\\\\SmartContent\\\\AccountDataProviderTest\\:\\:resourceItemsDataProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
-
-		-
 			message: "#^Method Sulu\\\\Component\\\\Contact\\\\Tests\\\\Unit\\\\SmartContent\\\\AccountDataProviderTest\\:\\:serialize\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Contact\\\\Tests\\\\Unit\\\\SmartContent\\\\AccountDataProviderTest\\:\\:testResolveDataItems\\(\\) has parameter \\$filters with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Contact\\\\Tests\\\\Unit\\\\SmartContent\\\\AccountDataProviderTest\\:\\:testResolveDataItems\\(\\) has parameter \\$hasNextPage with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Contact\\\\Tests\\\\Unit\\\\SmartContent\\\\AccountDataProviderTest\\:\\:testResolveDataItems\\(\\) has parameter \\$items with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Contact\\\\Tests\\\\Unit\\\\SmartContent\\\\AccountDataProviderTest\\:\\:testResolveDataItems\\(\\) has parameter \\$limit with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Contact\\\\Tests\\\\Unit\\\\SmartContent\\\\AccountDataProviderTest\\:\\:testResolveDataItems\\(\\) has parameter \\$page with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Contact\\\\Tests\\\\Unit\\\\SmartContent\\\\AccountDataProviderTest\\:\\:testResolveDataItems\\(\\) has parameter \\$pageSize with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Contact\\\\Tests\\\\Unit\\\\SmartContent\\\\AccountDataProviderTest\\:\\:testResolveDataItems\\(\\) has parameter \\$repositoryResult with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Contact\\\\Tests\\\\Unit\\\\SmartContent\\\\AccountDataProviderTest\\:\\:testResolveResourceItems\\(\\) has parameter \\$filters with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Contact\\\\Tests\\\\Unit\\\\SmartContent\\\\AccountDataProviderTest\\:\\:testResolveResourceItems\\(\\) has parameter \\$hasNextPage with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Contact\\\\Tests\\\\Unit\\\\SmartContent\\\\AccountDataProviderTest\\:\\:testResolveResourceItems\\(\\) has parameter \\$items with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Contact\\\\Tests\\\\Unit\\\\SmartContent\\\\AccountDataProviderTest\\:\\:testResolveResourceItems\\(\\) has parameter \\$limit with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Contact\\\\Tests\\\\Unit\\\\SmartContent\\\\AccountDataProviderTest\\:\\:testResolveResourceItems\\(\\) has parameter \\$page with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Contact\\\\Tests\\\\Unit\\\\SmartContent\\\\AccountDataProviderTest\\:\\:testResolveResourceItems\\(\\) has parameter \\$pageSize with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Contact\\\\Tests\\\\Unit\\\\SmartContent\\\\AccountDataProviderTest\\:\\:testResolveResourceItems\\(\\) has parameter \\$repositoryResult with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
 
@@ -52809,11 +52454,6 @@ parameters:
 			message: "#^Cannot call method getLocale\\(\\) on Sulu\\\\Component\\\\Localization\\\\Localization\\|null\\.$#"
 			count: 4
 			path: src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Tests\\\\Unit\\\\WebspaceTestCase\\:\\:getResourceDirectory\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/WebspaceTestCase.php
 
 		-
 			message: "#^Method Sulu\\\\Component\\\\Webspace\\\\Url\\:\\:__construct\\(\\) has parameter \\$environment with no type specified\\.$#"

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
@@ -395,11 +395,11 @@ class TargetGroupSubscriberTest extends TestCase
      * @dataProvider provideAddTargetGroupHitScript
      */
     public function testAddTargetGroupHitScript(
-        $targetGroupHitUrl,
-        $forwardedUrlHeader,
-        $forwardedRefererHeader,
-        $forwardedUuidHeader,
-        $uuid
+        string $targetGroupHitUrl,
+        string $forwardedUrlHeader,
+        string $forwardedRefererHeader,
+        string $forwardedUuidHeader,
+        ?string $uuid
     ): void {
         $targetGroupSubscriber = new TargetGroupSubscriber(
             $this->twig->reveal(),
@@ -417,7 +417,7 @@ class TargetGroupSubscriberTest extends TestCase
             'visitor-session'
         );
         $request = new Request();
-        if ($uuid) {
+        if (null !== $uuid) {
             $structureBridge = $this->prophesize(StructureBridge::class);
             $structureBridge->getUuid()->willReturn($uuid);
             $request->attributes->set('structure', $structureBridge->reveal());
@@ -441,7 +441,16 @@ class TargetGroupSubscriberTest extends TestCase
         $this->assertEquals('<body><script></script></body>', $response->getContent());
     }
 
-    public static function provideAddTargetGroupHitScript()
+    /**
+     * @return iterable<array{
+     *     0: string,
+     *     1: string,
+     *     2: string,
+     *     3: string,
+     *     4: string|null,
+     * }>
+     */
+    public static function provideAddTargetGroupHitScript(): iterable
     {
         return [
             ['/_target_group_hit', 'X-Forwarded-URL', 'X-Fowarded-Referer', 'X-Forwarded-UUID', 'some-uuid'],

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/TargetGroupEvaluatorTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/TargetGroupEvaluatorTest.php
@@ -61,7 +61,7 @@ class TargetGroupEvaluatorTest extends TestCase
     }
 
     /**
-     * @param TargetGroup[] $targetGroups
+     * @param array<TargetGroup> $targetGroups
      * @param array<string, string[]> $ruleWhitelists
      *
      * @dataProvider provideEvaluationData
@@ -99,7 +99,17 @@ class TargetGroupEvaluatorTest extends TestCase
         $this->assertEquals($evaluatedTargetGroup, $this->targetGroupEvaluator->evaluate($frequency, $currentTargetGroup));
     }
 
-    public static function provideEvaluationData()
+    /**
+     * @return iterable<array{
+     *     0: array<TargetGroup>,
+     *     1: array<string, string[]>,
+     *     2: string|null,
+     *     3: TargetGroup|null,
+     *     4?: int,
+     *     5?: TargetGroup|null,
+     * }>
+     */
+    public static function provideEvaluationData(): iterable
     {
         $targetGroup1 = new TargetGroup();
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
@@ -47,7 +47,7 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
     private $medias = [];
 
     /**
-     * @var array
+     * @var array<string>
      */
     private $tagData = [
         'Tag-0',
@@ -57,7 +57,13 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
     ];
 
     /**
-     * @var array
+     * @var array<array{
+     *     0: string,
+     *     1: int,
+     *     2: string,
+     *     3: string,
+     *     4: array<int>,
+     * }>
      */
     private $mediaData = [
         ['Bild 1', 1, 'image/jpg', 'image', [0, 1, 2]],
@@ -71,7 +77,7 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
     ];
 
     /**
-     * @var array
+     * @var array<string>
      */
     private $mediaTypeData = ['image', 'video', 'document'];
 
@@ -81,7 +87,10 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
     private $mediaTypes = [];
 
     /**
-     * @var array
+     * @var array<array{
+     *     0: string,
+     *     1: ?int,
+     * }>
      */
     private $collectionData = [
         ['Test-2', null],
@@ -145,10 +154,8 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
 
     /**
      * @param string $name
-     *
-     * @return TargetGroup
      */
-    public function createTargetGroup($name)
+    public function createTargetGroup($name): TargetGroup
     {
         $targetGroup = new TargetGroup();
         $targetGroup->setTitle($name);
@@ -159,7 +166,7 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
         return $targetGroup;
     }
 
-    private function createType($name)
+    private function createType($name): MediaType
     {
         $type = new MediaType();
         $type->setName($name);
@@ -169,7 +176,7 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
         return $type;
     }
 
-    private function createTag($name)
+    private function createTag($name): TagInterface
     {
         $tag = $this->em->getRepository('SuluTagBundle:Tag')->createNew();
         $tag->setName($name);
@@ -179,7 +186,7 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
         return $tag;
     }
 
-    private function createMedia($title, $collection, $mimeType, $type, $tags = [], $targetGroups = [])
+    private function createMedia($title, $collection, $mimeType, $type, $tags = [], $targetGroups = []): Media
     {
         $media = new Media();
         $file = new File();
@@ -214,7 +221,7 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
         return $media;
     }
 
-    private function createRole($name, $system)
+    private function createRole($name, $system): Role
     {
         $role = new Role();
         $role->setName($name);
@@ -225,7 +232,7 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
         return $role;
     }
 
-    private function createAccessControl($entityClass, $id, $permissions, Role $role)
+    private function createAccessControl($entityClass, $id, $permissions, Role $role): AccessControl
     {
         $accessControl = new AccessControl();
         $accessControl->setPermissions($permissions);
@@ -237,7 +244,33 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
         return $accessControl;
     }
 
-    public function findByProvider()
+    /**
+     * @return iterable<array{
+     *     0: array{
+     *         dataSource?: mixed,
+     *         tags?: array<int>,
+     *         tagOperator?: string,
+     *         websiteTags?: array<int>,
+     *         websiteTagsOperator?: string,
+     *         sortBy?: string,
+     *         sortMethod?: string,
+     *         includeSubFolders?: bool|string
+     *     },
+     *     1: ?int,
+     *     2: ?int,
+     *     3: ?int,
+     *     4: array<array{
+     *         0: string,
+     *         1: int,
+     *         2: string,
+     *         3: string,
+     *         4: array<int>,
+     *     }>,
+     *     5?: array<int>,
+     *     6?: array<string, mixed>,
+     * }>
+     */
+    public function findByProvider(): iterable
     {
         // when pagination is active the result count is pageSize + 1 to determine has next page
 
@@ -573,6 +606,29 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
 
     /**
      * @dataProvider findByProvider
+     *
+     * @param array{
+     *     dataSource: mixed,
+     *     tags?: array<int>,
+     *     tagOperator?: string,
+     *     websiteTags?: array<int>,
+     *     websiteTagsOperator?: string,
+     *     sortBy?: string,
+     *     sortMethod?: string,
+     *     includeSubFolders?: bool|string
+     * } $filters
+     * @param int|null $page
+     * @param int|null $pageSize
+     * @param int|null $limit
+     * @param array<array{
+     *      0: string,
+     *      1: int,
+     *      2: string,
+     *      3: string,
+     *      4: array<int>,
+     * }> $expected
+     * @param array<int> $tags
+     * @param array<string, mixed> $options
      */
     public function testFindByFilters($filters, $page, $pageSize, $limit, $expected, $tags = [], $options = []): void
     {
@@ -642,7 +698,13 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
         }
     }
 
-    public static function provideFindByFiltersWithAudienceTargeting()
+    /**
+     * @return iterable<array{
+     *     0: int|null,
+     *     1: int[],
+     * }>
+     */
+    public static function provideFindByFiltersWithAudienceTargeting(): iterable
     {
         return [
             [null, [0, 1, 2, 3]],
@@ -653,8 +715,10 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
 
     /**
      * @dataProvider provideFindByFiltersWithAudienceTargeting
+     *
+     * @param int[] $expectedIndexes
      */
-    public function testFindByFiltersWithAudienceTargeting($targetGroupIndex, $expectedIndexes): void
+    public function testFindByFiltersWithAudienceTargeting(?int $targetGroupIndex, array $expectedIndexes): void
     {
         /** @var TargetGroupInterface[] $targetGroups */
         $targetGroups = [];

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/DependencyInjection/ImageTransformationCompilerPassTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/DependencyInjection/ImageTransformationCompilerPassTest.php
@@ -27,10 +27,7 @@ class ImageTransformationCompilerPassTest extends AbstractCompilerPassTestCase
         $container->addCompilerPass(new ImageTransformationCompilerPass());
     }
 
-    /**
-     * @test
-     */
-    public function ifCompilerPassCollectsServicesByAddingMethodCallsTheseWillExist(): void
+    public function testCollectingTaggedServices(): void
     {
         $transformationManager = new Definition();
         $this->setDefinition(ImageTransformationCompilerPass::POOL_SERVICE_ID, $transformationManager);

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Transformations/CropTransformationTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Transformations/CropTransformationTest.php
@@ -19,7 +19,19 @@ class CropTransformationTest extends AbstractTransformationTest
 {
     protected $transformationServiceName = 'sulu_media.image.transformation.crop';
 
-    protected function getDataList()
+    /**
+     * @return array<array{
+     *     options: array{
+     *         x: int,
+     *         y: int,
+     *         w: int,
+     *         h: int,
+     *     },
+     *     width: int,
+     *     height: int,
+     * }>
+     */
+    protected function getDataList(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
@@ -194,8 +194,12 @@ class MediaManagerTest extends TestCase
 
     /**
      * @dataProvider provideGetByIds
+     *
+     * @param int[] $ids
+     * @param Media[] $media
+     * @param Media[] $result
      */
-    public function testGetByIds($ids, $user, $permissions, $media, $result): void
+    public function testGetByIds(array $ids, ?SuluUserInterface $user, ?int $permissions, array $media, array $result): void
     {
         /** @var TokenInterface|ObjectProphecy $token */
         $token = $this->prophesize(TokenInterface::class);
@@ -343,7 +347,7 @@ class MediaManagerTest extends TestCase
     /**
      * @dataProvider provideSpecialCharacterFileName
      */
-    public function testSpecialCharacterFileName($fileName, $cleanUpArgument, $cleanUpResult, $extension): void
+    public function testSpecialCharacterFileName(string $fileName, string $cleanUpArgument, string $cleanUpResult, string $extension): void
     {
         /** @var UploadedFile|ObjectProphecy $uploadedFile */
         $uploadedFile = $this->prophesize(UploadedFile::class)->willBeConstructedWith([__DIR__ . \DIRECTORY_SEPARATOR . 'test.txt', 1, null, null, 1, true]);
@@ -375,7 +379,7 @@ class MediaManagerTest extends TestCase
     /**
      * @dataProvider provideSpecialCharacterUrl
      */
-    public function testSpecialCharacterUrl($id, $filename, $version, $expected): void
+    public function testSpecialCharacterUrl(int $id, string $filename, int $version, string $expected): void
     {
         $this->assertEquals($expected, $this->mediaManager->getUrl($id, $filename, $version));
     }
@@ -519,11 +523,20 @@ class MediaManagerTest extends TestCase
         $this->assertSame(['key' => 'value'], $media->getProperties());
     }
 
-    public function provideGetByIds()
+    /**
+     * @return iterable<array{
+     *     0: int[],
+     *     1: User|null,
+     *     2: int|null,
+     *     3: Media[],
+     *     4: Media[],
+     * }>
+     */
+    public static function provideGetByIds(): iterable
     {
-        $media1 = $this->createMedia(1);
-        $media2 = $this->createMedia(2);
-        $media3 = $this->createMedia(3);
+        $media1 = static::createMedia(1);
+        $media2 = static::createMedia(2);
+        $media3 = static::createMedia(3);
 
         $user = new User();
 
@@ -534,6 +547,14 @@ class MediaManagerTest extends TestCase
         ];
     }
 
+    /**
+     * @return iterable<array{
+     *     0: string,
+     *     1: string,
+     *     2: string,
+     *     3: string
+     * }>
+     */
     public static function provideSpecialCharacterFileName()
     {
         return [
@@ -542,6 +563,14 @@ class MediaManagerTest extends TestCase
         ];
     }
 
+    /**
+     * @return iterable<array{
+     *     0: int,
+     *     1: string,
+     *     2: int,
+     *     3: string
+     * }>
+     */
     public static function provideSpecialCharacterUrl()
     {
         return [
@@ -551,7 +580,7 @@ class MediaManagerTest extends TestCase
         ];
     }
 
-    protected function createMedia($id)
+    protected static function createMedia($id): Media
     {
         $media = new Media();
         self::setPrivateProperty($media, 'id', $id);

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/BaseFunctional.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/BaseFunctional.php
@@ -133,8 +133,6 @@ class BaseFunctional extends SuluTestCase
     /**
      * Returns property of data with given name.
      * If this property does not exists this function returns given default.
-     *
-     * @param string $name
      */
     protected function getValue(array $data, string $name, $default = null)
     {

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/BaseFunctional.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/BaseFunctional.php
@@ -58,16 +58,33 @@ class BaseFunctional extends SuluTestCase
         $this->domainRepository = $domainRepository;
     }
 
+    /**
+     * @param array{
+     *     title?: string,
+     *     type?: string,
+     *     content?: mixed,
+     *     allDomains?: bool,
+     * } $data
+     */
     protected function create(string $webspaceKey, array $data): AnalyticsInterface
     {
-        $entity = $this->setData($this->analyticsRepository->createNew(), $webspaceKey, $data);
+        $entity = $this->setAnalyticsData($this->analyticsRepository->createNew(), $webspaceKey, $data);
         $this->entityManager->persist($entity);
         $this->entityManager->flush();
 
         return $entity;
     }
 
-    protected function setData(AnalyticsInterface $analytics, string $webspaceKey, array $data): AnalyticsInterface
+    /**
+     * @param array{
+     *     title?: string,
+     *     type?: string,
+     *     content?: mixed,
+     *     allDomains?: bool,
+     *     domains?: array<array{}>,
+     * } $data
+     */
+    protected function setAnalyticsData(AnalyticsInterface $analytics, string $webspaceKey, array $data): AnalyticsInterface
     {
         $analytics->setTitle($this->getValue($data, 'title'));
         $analytics->setType($this->getValue($data, 'type'));
@@ -88,6 +105,11 @@ class BaseFunctional extends SuluTestCase
     /**
      * Returns domain.
      * If the domain does not exists this function creates a new one.
+     *
+     * @param array{
+     *     url: string,
+     *     environment: string,
+     * } $domain
      *
      * @return Domain
      */
@@ -114,7 +136,7 @@ class BaseFunctional extends SuluTestCase
      *
      * @param string $name
      */
-    protected function getValue(array $data, $name, $default = null)
+    protected function getValue(array $data, string $name, $default = null)
     {
         if (!\array_key_exists($name, $data)) {
             return $default;

--- a/src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
+++ b/src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
@@ -80,7 +80,20 @@ class AccountDataProviderTest extends TestCase
         $this->assertEquals([], $parameter);
     }
 
-    public static function dataItemsDataProvider()
+    /**
+     * @return iterable<array{
+     *     0: array{
+     *         tags: string[],
+     *     },
+     *     1: int|null,
+     *     2: int,
+     *     3: int,
+     *     4: Account[],
+     *     5: bool,
+     *     6: AccountDataItem[],
+     * }>
+     */
+    public static function dataItemsDataProvider(): iterable
     {
         $accounts = [
             self::createAccount(1, 'Massive Art'),
@@ -94,15 +107,25 @@ class AccountDataProviderTest extends TestCase
         }
 
         return [
-            [['tags' => [1]], null, 1, 3, $accounts, false, $dataItems],
-            [['tags' => [1]], null, 1, 2, $accounts, true, \array_slice($dataItems, 0, 2)],
-            [['tags' => [1]], 5, 1, 2, $accounts, true, \array_slice($dataItems, 0, 2)],
-            [['tags' => [1]], 1, 1, 2, \array_slice($accounts, 0, 1), false, \array_slice($dataItems, 0, 1)],
+            [['tags' => ['A']], null, 1, 3, $accounts, false, $dataItems],
+            [['tags' => ['A']], null, 1, 2, $accounts, true, \array_slice($dataItems, 0, 2)],
+            [['tags' => ['A']], 5, 1, 2, $accounts, true, \array_slice($dataItems, 0, 2)],
+            [['tags' => ['A']], 1, 1, 2, \array_slice($accounts, 0, 1), false, \array_slice($dataItems, 0, 1)],
         ];
     }
 
     /**
      * @dataProvider dataItemsDataProvider
+     *
+     * @param array{
+     *     tags: string[],
+     * } $filters
+     * @param int|null $limit
+     * @param int $page
+     * @param int $pageSize
+     * @param Account[] $repositoryResult
+     * @param bool $hasNextPage
+     * @param AccountDataItem[] $items
      */
     public function testResolveDataItems($filters, $limit, $page, $pageSize, $repositoryResult, $hasNextPage, $items): void
     {
@@ -132,7 +155,21 @@ class AccountDataProviderTest extends TestCase
         $this->assertEquals($items, $result->getItems());
     }
 
-    public static function resourceItemsDataProvider()
+
+    /**
+     * @return iterable<array{
+     *     0: array{
+     *         tags: string[],
+     *     },
+     *     1: int|null,
+     *     2: int,
+     *     3: int,
+     *     4: Account[],
+     *     5: bool,
+     *     6: ArrayAccessItem[],
+     * }>
+     */
+    public static function resourceItemsDataProvider(): iterable
     {
         $accounts = [
             self::createAccount(1, 'Massive Art'),
@@ -146,15 +183,25 @@ class AccountDataProviderTest extends TestCase
         }
 
         return [
-            [['tags' => [1]], null, 1, 3, $accounts, false, $dataItems],
-            [['tags' => [1]], null, 1, 2, $accounts, true, \array_slice($dataItems, 0, 2)],
-            [['tags' => [1]], 5, 1, 2, $accounts, true, \array_slice($dataItems, 0, 2)],
-            [['tags' => [1]], 1, 1, 2, \array_slice($accounts, 0, 1), false, \array_slice($dataItems, 0, 1)],
+            [['tags' => ['A']], null, 1, 3, $accounts, false, $dataItems],
+            [['tags' => ['A']], null, 1, 2, $accounts, true, \array_slice($dataItems, 0, 2)],
+            [['tags' => ['A']], 5, 1, 2, $accounts, true, \array_slice($dataItems, 0, 2)],
+            [['tags' => ['A']], 1, 1, 2, \array_slice($accounts, 0, 1), false, \array_slice($dataItems, 0, 1)],
         ];
     }
 
     /**
      * @dataProvider resourceItemsDataProvider
+     *
+     * @param array{
+     *      tags: string[],
+     *  } $filters
+     * @param int|null $limit
+     * @param int $page
+     * @param int $pageSize
+     * @param Account[] $repositoryResult
+     * @param bool $hasNextPage
+     * @param AccountDataItem[] $items
      */
     public function testResolveResourceItems(
         $filters,
@@ -220,6 +267,15 @@ class AccountDataProviderTest extends TestCase
     }
 
     /**
+     * @param array{
+     *     tags?: string[],
+     * } $filters
+     * @param int $page
+     * @param int $pageSize
+     * @param int|null $limit
+     * @param AccountDataItem[] $result
+     * @param array<string, mixed> $options
+     *
      * @return DataProviderRepositoryInterface
      */
     private function getRepository(
@@ -255,12 +311,12 @@ class AccountDataProviderTest extends TestCase
         return new Account($entity, 'de');
     }
 
-    private static function createDataItem(Account $account)
+    private static function createDataItem(Account $account): AccountDataItem
     {
         return new AccountDataItem($account);
     }
 
-    private static function createResourceItem(Account $account)
+    private static function createResourceItem(Account $account): ArrayAccessItem
     {
         return new ArrayAccessItem($account->getId(), self::serialize($account), $account);
     }

--- a/src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
+++ b/src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
@@ -155,7 +155,6 @@ class AccountDataProviderTest extends TestCase
         $this->assertEquals($items, $result->getItems());
     }
 
-
     /**
      * @return iterable<array{
      *     0: array{

--- a/src/Sulu/Component/Webspace/Tests/Unit/StructureProvider/WebspaceStructureProviderTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/StructureProvider/WebspaceStructureProviderTest.php
@@ -99,12 +99,9 @@ class WebspaceStructureProviderTest extends TestCase
     }
 
     /**
-     * @param string $key
-     * @param string $view
-     *
      * @return StructureInterface
      */
-    private function generateStructure($key, $view)
+    private function generateStructure(string $key, string $view)
     {
         $mock = $this->prophesize(PageBridge::class);
 

--- a/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTestCase.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTestCase.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class WebspaceTestCase extends TestCase
 {
-    protected function getResourceDirectory()
+    protected function getResourceDirectory(): string
     {
         return __DIR__ . '/../../../../../../tests/Resources';
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no 
| BC breaks? | no
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7339
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Backports type changes of https://github.com/sulu/sulu/pull/7339 to 2.5

#### Why?

Avoid merge issues from 2.5 -> 2.6. Less diff between 2.5 and 2.6 make merging things back easier.