### PR TITLE
Replacing `will` method with more specific methods

### DIFF
--- a/src/Sulu/Bundle/LocationBundle/Tests/Unit/Content/Types/LocationContentTypeTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Unit/Content/Types/LocationContentTypeTest.php
@@ -66,11 +66,11 @@ class LocationContentTypeTest extends TestCase
         $this->phpcrNode->expects($this->once())
             ->method('getPropertyValueWithDefault')
             ->with('foobar', null)
-            ->will($this->returnValue(\json_encode($data)));
+            ->willReturn(\json_encode($data));
 
         $this->suluProperty->expects($this->once())
             ->method('getName')
-            ->will($this->returnValue('foobar'));
+            ->willReturn('foobar');
 
         $this->locationContent->read(
             $this->phpcrNode,

--- a/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/GeolocatorResponseTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/GeolocatorResponseTest.php
@@ -42,7 +42,7 @@ class GeolocatorResponseTest extends TestCase
 
         $this->location->expects($this->once())
             ->method('toArray')
-            ->will($this->returnValue($expected));
+            ->willReturn($expected);
 
         $this->response->addLocation($this->location);
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Content/Types/MediaSelectionContentTypeTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Content/Types/MediaSelectionContentTypeTest.php
@@ -95,24 +95,17 @@ class MediaSelectionContentTypeTest extends TestCase
             ['getValue', 'getParams']
         );
 
-        $property->expects($this->any())->method('getName')->will($this->returnValue('property'));
+        $property->expects($this->any())->method('getName')->willReturn('property');
 
-        $property->expects($this->any())->method('getValue')->will(
-            $this->returnValue(
-                [
-                    'ids' => [1, 2, 3, 4],
-                    'displayOption' => 'right',
-                    'config' => ['conf1' => 1, 'conf2' => 2],
-                ]
-            )
+        $property->expects($this->any())->method('getValue')->willReturn(
+            [
+                'ids' => [1, 2, 3, 4],
+                'displayOption' => 'right',
+                'config' => ['conf1' => 1, 'conf2' => 2],
+            ]
         );
 
-        $property->expects($this->any())->method('getParams')->will(
-            $this->returnValue(
-                [
-                ]
-            )
-        );
+        $property->expects($this->any())->method('getParams')->willReturn([]);
 
         $node->expects($this->once())->method('setProperty')->with(
             'property',
@@ -150,25 +143,18 @@ class MediaSelectionContentTypeTest extends TestCase
             ['getValue', 'getParams']
         );
 
-        $property->expects($this->any())->method('getName')->will($this->returnValue('property'));
+        $property->expects($this->any())->method('getName')->willReturn('property');
 
-        $property->expects($this->any())->method('getValue')->will(
-            $this->returnValue(
-                [
-                    'ids' => [1, 2, 3, 4],
-                    'displayOption' => 'right',
-                    'config' => ['conf1' => 1, 'conf2' => 2],
-                    'data' => ['data1', 'data2'],
-                ]
-            )
+        $property->expects($this->any())->method('getValue')->willReturn(
+            [
+                'ids' => [1, 2, 3, 4],
+                'displayOption' => 'right',
+                'config' => ['conf1' => 1, 'conf2' => 2],
+                'data' => ['data1', 'data2'],
+            ]
         );
 
-        $property->expects($this->any())->method('getParams')->will(
-            $this->returnValue(
-                [
-                ]
-            )
-        );
+        $property->expects($this->any())->method('getParams')->willReturn([]);
 
         $node->expects($this->once())->method('setProperty')->with(
             'property',
@@ -208,30 +194,19 @@ class MediaSelectionContentTypeTest extends TestCase
             ['setValue', 'getParams']
         );
 
-        $node->expects($this->any())->method('getPropertyValueWithDefault')->will(
-            $this->returnValueMap(
+        $node->expects($this->any())->method('getPropertyValueWithDefault')->willReturnMap(
+            [
                 [
-                    [
-                        'property',
-                        '{"ids": []}',
-                        $config,
-                    ],
-                ]
-            )
+                    'property',
+                    '{"ids": []}',
+                    $config,
+                ],
+            ]
         );
 
-        $property->expects($this->any())->method('getName')->will($this->returnValue('property'));
-
-        $property->expects($this->once())->method('setValue')->with(\json_decode($config, true))->will(
-            $this->returnValue(null)
-        );
-
-        $property->expects($this->any())->method('getParams')->will(
-            $this->returnValue(
-                [
-                ]
-            )
-        );
+        $property->expects($this->any())->method('getName')->willReturn('property');
+        $property->expects($this->once())->method('setValue')->with(\json_decode($config, true))->willReturn(null);
+        $property->expects($this->any())->method('getParams')->willReturn([]);
 
         $this->mediaSelection->read($node, $property, 'test', 'en', 's');
     }
@@ -260,30 +235,19 @@ class MediaSelectionContentTypeTest extends TestCase
             ['setValue', 'getParams']
         );
 
-        $node->expects($this->any())->method('getPropertyValueWithDefault')->will(
-            $this->returnValueMap(
+        $node->expects($this->any())->method('getPropertyValueWithDefault')->willReturnMap(
+            [
                 [
-                    [
-                        'property',
-                        '{"ids": []}',
-                        $config,
-                    ],
-                ]
-            )
+                    'property',
+                    '{"ids": []}',
+                    $config,
+                ],
+            ]
         );
 
-        $property->expects($this->any())->method('getName')->will($this->returnValue('property'));
-
-        $property->expects($this->once())->method('setValue')->with(null)->will(
-            $this->returnValue(null)
-        );
-
-        $property->expects($this->any())->method('getParams')->will(
-            $this->returnValue(
-                [
-                ]
-            )
-        );
+        $property->expects($this->any())->method('getName')->willReturn('property');
+        $property->expects($this->once())->method('setValue')->with(null)->willReturn(null);
+        $property->expects($this->any())->method('getParams')->willReturn([]);
 
         $this->mediaSelection->read($node, $property, 'test', 'en', 's');
     }
@@ -312,31 +276,19 @@ class MediaSelectionContentTypeTest extends TestCase
             ['setValue', 'getParams']
         );
 
-        $node->expects($this->any())->method('getPropertyValueWithDefault')->will(
-            $this->returnValueMap(
+        $node->expects($this->any())->method('getPropertyValueWithDefault')->willReturnMap(
+            [
                 [
-                    [
-                        'property',
-                        '{"ids": []}',
-                        $config,
-                    ],
-                ]
-            )
+                    'property',
+                    '{"ids": []}',
+                    $config,
+                ],
+            ]
         );
 
-        $property->expects($this->any())->method('getName')->will($this->returnValue('property'));
-
-        $property->expects($this->once())->method('setValue')->with(\json_decode($config, true))->will(
-            $this->returnValue(null)
-        );
-
-        $property->expects($this->any())->method('getParams')->will(
-            $this->returnValue(
-                [
-                    'types' => 'document',
-                ]
-            )
-        );
+        $property->expects($this->any())->method('getName')->willReturn('property');
+        $property->expects($this->once())->method('setValue')->with(\json_decode($config, true))->willReturn(null);
+        $property->expects($this->any())->method('getParams')->willReturn(['types' => 'document']);
 
         $this->mediaSelection->read($node, $property, 'test', 'en', 's');
     }
@@ -365,31 +317,19 @@ class MediaSelectionContentTypeTest extends TestCase
             ['setValue', 'getParams']
         );
 
-        $node->expects($this->any())->method('getPropertyValueWithDefault')->will(
-            $this->returnValueMap(
+        $node->expects($this->any())->method('getPropertyValueWithDefault')->willReturnMap(
+            [
                 [
-                    [
-                        'property',
-                        '{"ids": []}',
-                        $config,
-                    ],
-                ]
-            )
+                    'property',
+                    '{"ids": []}',
+                    $config,
+                ],
+            ]
         );
 
-        $property->expects($this->any())->method('getName')->will($this->returnValue('property'));
-
-        $property->expects($this->once())->method('setValue')->with(\json_decode($config, true))->will(
-            $this->returnValue(null)
-        );
-
-        $property->expects($this->any())->method('getParams')->will(
-            $this->returnValue(
-                [
-                    'types' => 'document,image',
-                ]
-            )
-        );
+        $property->expects($this->any())->method('getName')->willReturn('property');
+        $property->expects($this->once())->method('setValue')->with(\json_decode($config, true))->willReturn(null);
+        $property->expects($this->any())->method('getParams')->willReturn(['types' => 'document,image']);
 
         $this->mediaSelection->read($node, $property, 'test', 'en', 's');
     }

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/SnippetContentTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/SnippetContentTest.php
@@ -94,14 +94,14 @@ class SnippetContentTest extends BaseFunctionalTestCase
     public function testPropertyRead(): void
     {
         $this->property->expects($this->exactly(2))
-            ->method('getName')->will($this->returnValue('i18n:de-hotels'));
+            ->method('getName')->willReturn('i18n:de-hotels');
         $this->property->expects($this->once())
             ->method('setValue')
-            ->will($this->returnCallback(function($snippets): void {
+            ->willReturnCallback(function($snippets): void {
                 foreach ($snippets as $snippet) {
                     $this->assertTrue(UUIDHelper::isUUID($snippet));
                 }
-            }));
+            });
 
         $pageNode = $this->session->getNode('/cmf/sulu_io/contents/hotels');
         $this->contentType->read($pageNode, $this->property, 'sulu_io', 'de', null);
@@ -127,7 +127,7 @@ class SnippetContentTest extends BaseFunctionalTestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->property->expects($this->once())
             ->method('getValue')
-            ->will($this->returnValue(['ids' => 'this-aint-nuffin']));
+            ->willReturn(['ids' => 'this-aint-nuffin']);
 
         $pageNode = $this->session->getNode('/cmf/sulu_io/contents/hotels');
         $this->contentType->write($pageNode, $this->property, 0, 'sulu_io', 'de', null);
@@ -213,7 +213,7 @@ class SnippetContentTest extends BaseFunctionalTestCase
     public function testRemove(): void
     {
         $this->property->expects($this->any())
-            ->method('getName')->will($this->returnValue('i18n:de-hotels'));
+            ->method('getName')->willReturn('i18n:de-hotels');
 
         $pageNode = $this->session->getNode('/cmf/sulu_io/contents/hotels');
         $this->contentType->remove($pageNode, $this->property, 'sulu_io', 'de', null);

--- a/src/Sulu/Bundle/TagBundle/Tests/Unit/Tag/TagManagerTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Unit/Tag/TagManagerTest.php
@@ -112,22 +112,18 @@ class TagManagerTest extends TestCase
             false
         );
 
-        $this->tagRepository->expects($this->any())->method('findTagByName')->will($this->returnValueMap(
-            [
-                ['Tag1', (new Tag())->setId(1)],
-                ['Tag2', (new Tag())->setId(2)],
-                ['Tag3', (new Tag())->setId(3)],
-            ]
-        )
+        $this->tagRepository->expects($this->any())->method('findTagByName')->willReturnMap([
+            ['Tag1', (new Tag())->setId(1)],
+            ['Tag2', (new Tag())->setId(2)],
+            ['Tag3', (new Tag())->setId(3)],
+        ]
         );
 
-        $this->tagRepository->expects($this->any())->method('findTagById')->will($this->returnValueMap(
-            [
-                [1, (new Tag())->setName('Tag1')],
-                [2, (new Tag())->setName('Tag2')],
-                [3, (new Tag())->setName('Tag3')],
-            ]
-        )
+        $this->tagRepository->expects($this->any())->method('findTagById')->willReturnMap([
+            [1, (new Tag())->setName('Tag1')],
+            [2, (new Tag())->setName('Tag2')],
+            [3, (new Tag())->setName('Tag3')],
+        ]
         );
 
         $this->tagManager = new TagManager(

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapGeneratorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapGeneratorTest.php
@@ -167,7 +167,7 @@ class SitemapGeneratorTest extends SuluTestCase
         $this->webspaceManager
             ->expects($this->any())
             ->method('findWebspaceByKey')
-            ->will($this->returnValue($this->webspace));
+            ->willReturn($this->webspace);
     }
 
     public function getExtensionCallback()

--- a/src/Sulu/Component/Rest/Tests/Unit/RestHelperTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/RestHelperTest.php
@@ -234,7 +234,7 @@ class RestHelperTest extends TestCase
     public function testprocessSubEntitiesWithDelete(): void
     {
         $mockedObject = $this->getMockBuilder('Mock')->setMethods(['getId'])->getMock();
-        $mockedObject->expects($this->any())->method('getId')->will($this->returnValue(1));
+        $mockedObject->expects($this->any())->method('getId')->willReturn(1);
 
         $mock = $this->getMockBuilder('Mock')->setMethods(['delete', 'update', 'add', 'get'])->getMock();
         $mock->expects($this->once())->method('delete');
@@ -273,7 +273,7 @@ class RestHelperTest extends TestCase
     public function testprocessSubEntitiesWithUpdate(): void
     {
         $mockedObject = $this->getMockBuilder('Mock')->setMethods(['getId'])->getMock();
-        $mockedObject->expects($this->any())->method('getId')->will($this->returnValue(1));
+        $mockedObject->expects($this->any())->method('getId')->willReturn(1);
 
         $mock = $this->getMockBuilder('Mock')->setMethods(['delete', 'update', 'add', 'get'])->getMock();
         $mock->expects($this->never())->method('delete');
@@ -354,8 +354,8 @@ class RestHelperTest extends TestCase
     public function testCompareEntitiesWithData(): void
     {
         $mockedObject = $this->getMockBuilder('Mock')->setMethods(['getId', 'getValue'])->getMock();
-        $mockedObject->expects($this->any())->method('getId')->will($this->returnValue(1));
-        $mockedObject->expects($this->any())->method('getValue')->will($this->returnValue(2));
+        $mockedObject->expects($this->any())->method('getId')->willReturn(1);
+        $mockedObject->expects($this->any())->method('getValue')->willReturn(2);
 
         $mockedObject2 = clone $mockedObject;
         $mockedObject3 = clone $mockedObject;

--- a/src/Sulu/Component/SmartContent/Tests/Unit/ContentTypeTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/ContentTypeTest.php
@@ -117,8 +117,8 @@ class ContentTypeTest extends TestCase
         $this->requestStack = $this->getMockBuilder(RequestStack::class)->getMock();
         $this->request = $this->getMockBuilder(Request::class)->getMock();
 
-        $this->requestStack->expects($this->any())->method('getCurrentRequest')->will(
-            $this->returnValue($this->request)
+        $this->requestStack->expects($this->any())->method('getCurrentRequest')->willReturn(
+            $this->request
         );
 
         $this->tagRequestHandler = $this->prophesize(TagRequestHandlerInterface::class);
@@ -127,22 +127,18 @@ class ContentTypeTest extends TestCase
         $this->categoryRequestHandler = $this->prophesize(CategoryRequestHandlerInterface::class);
         $this->categoryRequestHandler->getCategories('categories')->willReturn([]);
 
-        $this->tagManager->expects($this->any())->method('resolveTagIds')->will(
-            $this->returnValueMap(
-                [
-                    [[1, 2], ['Tag1', 'Tag2']],
-                ]
-            )
+        $this->tagManager->expects($this->any())->method('resolveTagIds')->willReturnMap(
+            [
+                [[1, 2], ['Tag1', 'Tag2']],
+            ]
         );
 
-        $this->tagManager->expects($this->any())->method('resolveTagNames')->will(
-            $this->returnValueMap(
-                [
-                    [['Tag1', 'Tag2'], [1, 2]],
-                    [['Tag1'], [1]],
-                    [['Tag2'], [2]],
-                ]
-            )
+        $this->tagManager->expects($this->any())->method('resolveTagNames')->willReturnMap(
+            [
+                [['Tag1', 'Tag2'], [1, 2]],
+                [['Tag1'], [1]],
+                [['Tag2'], [2]],
+            ]
         );
 
         $this->targetGroupStore = $this->prophesize(TargetGroupStoreInterface::class);
@@ -199,19 +195,17 @@ class ContentTypeTest extends TestCase
             ['getValue']
         );
 
-        $property->expects($this->any())->method('getName')->will($this->returnValue('property'));
+        $property->expects($this->any())->method('getName')->willReturn('property');
 
-        $property->expects($this->any())->method('getValue')->will(
-            $this->returnValue(
-                [
-                    'dataSource' => [
-                        'home/products',
-                    ],
-                    'sortBy' => [
-                        'published',
-                    ],
-                ]
-            )
+        $property->expects($this->any())->method('getValue')->willReturn(
+            [
+                'dataSource' => [
+                    'home/products',
+                ],
+                'sortBy' => [
+                    'published',
+                ],
+            ]
         );
 
         $node->expects($this->once())->method('setProperty')->with(
@@ -270,17 +264,15 @@ class ContentTypeTest extends TestCase
             ['setValue']
         );
 
-        $node->expects($this->any())->method('getPropertyValueWithDefault')->will(
-            $this->returnValueMap(
-                [
-                    ['property', '{}', '{"tags":[1,2],"limitResult":"2"}'],
-                ]
-            )
+        $node->expects($this->any())->method('getPropertyValueWithDefault')->willReturnMap(
+            [
+                ['property', '{}', '{"tags":[1,2],"limitResult":"2"}'],
+            ]
         );
 
-        $property->expects($this->any())->method('getName')->will($this->returnValue('property'));
-        $property->expects($this->any())->method('getParams')->will(
-            $this->returnValue(['properties' => ['my_title' => 'title']])
+        $property->expects($this->any())->method('getName')->willReturn('property');
+        $property->expects($this->any())->method('getParams')->willReturn(
+            ['properties' => ['my_title' => 'title']]
         );
 
         $property->expects($this->exactly(1))->method('setValue')->with($config);
@@ -320,9 +312,9 @@ class ContentTypeTest extends TestCase
             ->willReturn(\array_merge($config, ['page' => 1, 'hasNextPage' => true]));
 
         $property->expects($this->any())->method('getParams')
-            ->will($this->returnValue($parameter));
+            ->willReturn($parameter);
         $property->expects($this->exactly(2))->method('getStructure')
-            ->will($this->returnValue($structure->reveal()));
+            ->willReturn($structure->reveal());
 
         $this->pageDataProvider->resolveResourceItems(
             [
@@ -520,12 +512,12 @@ class ContentTypeTest extends TestCase
             ->willReturn(1);
 
         $property->expects($this->exactly(1))->method('getValue')
-            ->will($this->returnValue(['dataSource' => '123-123-123']));
+            ->willReturn(['dataSource' => '123-123-123']);
 
         $property->expects($this->any())->method('getParams')
-            ->will($this->returnValue(['max_per_page' => new PropertyParameter('max_per_page', '5')]));
+            ->willReturn(['max_per_page' => new PropertyParameter('max_per_page', '5')]);
         $property->expects($this->exactly(2))->method('getStructure')
-            ->will($this->returnValue($structure->reveal()));
+            ->willReturn($structure->reveal());
 
         $this->pageDataProvider->resolveResourceItems(
             [
@@ -715,11 +707,11 @@ class ContentTypeTest extends TestCase
         )->willReturn(new DataProviderResult($expectedData, $hasNextPage));
 
         $property->expects($this->exactly(1))->method('getValue')
-            ->will($this->returnValue($config));
+            ->willReturn($config);
         $property->expects($this->any())->method('getParams')
-            ->will($this->returnValue(['max_per_page' => new PropertyParameter('max_per_page', $pageSize)]));
+            ->willReturn(['max_per_page' => new PropertyParameter('max_per_page', $pageSize)]);
         $property->expects($this->exactly(2))->method('getStructure')
-            ->will($this->returnValue($structure->reveal()));
+            ->willReturn($structure->reveal());
 
         $webspace = new Webspace();
         $webspace->setKey('sulu_io');
@@ -838,9 +830,9 @@ class ContentTypeTest extends TestCase
             ->willReturn(\array_merge($config, ['page' => $page, 'hasNextPage' => $hasNextPage]));
 
         $property->expects($this->any())->method('getParams')
-            ->will($this->returnValue(['max_per_page' => new PropertyParameter('max_per_page', $pageSize)]));
+            ->willReturn(['max_per_page' => new PropertyParameter('max_per_page', $pageSize)]);
         $property->expects($this->exactly(2))->method('getStructure')
-            ->will($this->returnValue($structure->reveal()));
+            ->willReturn($structure->reveal());
 
         $webspace = new Webspace();
         $webspace->setKey('sulu_io');
@@ -891,13 +883,13 @@ class ContentTypeTest extends TestCase
         $structure = $this->prophesize(StructureInterface::class);
 
         $property->expects($this->exactly(1))->method('getValue')
-            ->will($this->returnValue($value));
+            ->willReturn($value);
 
         $property->expects($this->any())->method('getParams')
-            ->will($this->returnValue([]));
+            ->willReturn([]);
 
         $property->expects($this->any())->method('getStructure')
-            ->will($this->returnValue($structure->reveal()));
+            ->willReturn($structure->reveal());
 
         $this->pageDataProvider->resolveResourceItems(
             [

--- a/src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
+++ b/src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
@@ -103,16 +103,16 @@ class SuluNodeHelperTest extends TestCase
         ] as $propertyName => $propertyValue) {
             $this->{'property' . $propertyIndex}->expects($this->any())
                 ->method('getName')
-                ->will($this->returnValue($propertyName));
+                ->willReturn($propertyName);
             $this->{'property' . $propertyIndex}->expects($this->any())
                 ->method('getValue')
-                ->will($this->returnValue($propertyValue));
+                ->willReturn($propertyValue);
             ++$propertyIndex;
         }
 
         $this->node->expects($this->any())
             ->method('getProperties')
-            ->will($this->returnValue([
+            ->willReturn([
                 $this->property1,
                 $this->property2,
                 $this->property3,
@@ -120,7 +120,7 @@ class SuluNodeHelperTest extends TestCase
                 $this->property5,
                 $this->property6,
                 $this->property7,
-            ]));
+            ]);
 
         $this->helper = new SuluNodeHelper(
             $this->session,
@@ -218,7 +218,7 @@ class SuluNodeHelperTest extends TestCase
         $this->node->expects($this->any())
             ->method('getPropertyValueWithDefault')
             ->with('jcr:mixinTypes', [])
-            ->will($this->returnValue([$nodeType]));
+            ->willReturn([$nodeType]);
 
         $this->assertEquals($expected, $this->helper->getStructureTypeForNode($this->node));
     }
@@ -242,7 +242,7 @@ class SuluNodeHelperTest extends TestCase
         $this->node->expects($this->any())
             ->method('getPropertyValueWithDefault')
             ->with('jcr:mixinTypes', [])
-            ->will($this->returnValue(['sulu:snippet']));
+            ->willReturn(['sulu:snippet']);
 
         $this->assertEquals($expected, $this->helper->hasSuluNodeType($this->node, $nodeTypes));
     }
@@ -253,17 +253,17 @@ class SuluNodeHelperTest extends TestCase
             ${'node' . $i} = $this->getMockBuilder(Node::class)->disableOriginalConstructor()->getMock();
             ${'node' . $i}->expects($this->any())
                 ->method('getPath')
-                ->will($this->returnValue('/foobar/foobar-' . $i));
+                ->willReturn('/foobar/foobar-' . $i);
         }
 
         $node2->expects($this->any())
             ->method('getParent')
-            ->will($this->returnValue($this->node));
+            ->willReturn($this->node);
         $this->node->expects($this->any())
             ->method('getNodes')
-            ->will($this->returnValue([
+            ->willReturn([
                 $node1, $node2, $node3,
-            ]));
+            ]);
 
         $res = $this->helper->getNextNode($node2);
         $this->assertSame($node3->getPath(), $res->getPath());
@@ -277,12 +277,12 @@ class SuluNodeHelperTest extends TestCase
         $baseSnippetNode = $this->getMockBuilder(Node::class)->disableOriginalConstructor()->getMock();
         $baseSnippetNode->expects($this->any())
             ->method('getIdentifier')
-            ->will($this->returnValue('some-uuid'));
+            ->willReturn('some-uuid');
 
         $this->session->expects($this->any())
             ->method('getNode')
             ->with('/cmf/snippets/snippet')
-            ->will($this->returnValue($baseSnippetNode));
+            ->willReturn($baseSnippetNode);
 
         $this->assertEquals('some-uuid', $this->helper->getBaseSnippetUuid('snippet'));
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #7507 
| License | MIT
| Documentation PR | -

#### What's in this PR?
Replacing outdated phpunit methods with the specific methods. Thanks to Rector for https://github.com/rectorphp/rector-phpunit/blob/main/rules/CodeQuality/Rector/MethodCall/UseSpecificWillMethodRector.php

#### Why?
PHPUnit 11
