### PR TITLE
Migrate rest routings to default symfony routing files of TagBundle

### DIFF
--- a/config/routes/sulu_admin.yaml
+++ b/config/routes/sulu_admin.yaml
@@ -1,7 +1,6 @@
 sulu_tag_api:
-    resource: "@SuluTagBundle/Resources/config/routing_api.yml"
-    type: rest
-    prefix:   /admin/api
+    resource: "@SuluTagBundle/Resources/config/routing_api.yaml"
+    prefix: /admin/api
 
 sulu_admin:
     resource: "@SuluAdminBundle/Resources/config/routing.yml"

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
@@ -5,9 +5,8 @@ fos_js_routing:
 
 # Sulu Routes
 sulu_tag_api:
-    type: rest
-    resource: "@SuluTagBundle/Resources/config/routing_api.yml"
-    prefix:   /admin/api
+    resource: "@SuluTagBundle/Resources/config/routing_api.yaml"
+    prefix: /admin/api
 
 sulu_admin:
     resource: "@SuluAdminBundle/Resources/config/routing.yml"

--- a/src/Sulu/Bundle/TagBundle/Resources/config/routing_api.yaml
+++ b/src/Sulu/Bundle/TagBundle/Resources/config/routing_api.yaml
@@ -1,0 +1,55 @@
+sulu_tag.get_tag:
+    path: /tags/{id}.{_format}
+    controller: sulu_tag.tag_controller::getAction
+    methods: GET
+    format: json
+    defaults:
+        _format: json
+
+sulu_tag.get_tags:
+    path: /tags.{_format}
+    controller: sulu_tag.tag_controller::cgetAction
+    methods: GET
+    format: json|csv
+    defaults:
+        _format: json
+
+sulu_tag.post_tag:
+    path: /tags.{_format}
+    controller: sulu_tag.tag_controller::postAction
+    methods: POST
+    format: json
+    defaults:
+        _format: json
+
+sulu_tag.put_tag:
+    path: /tags/{id}.{_format}
+    controller: sulu_tag.tag_controller::putAction
+    methods: PUT
+    format: json
+    defaults:
+        _format: json
+
+sulu_tag.delete_tag:
+    path: /tags/{id}.{_format}
+    controller: sulu_tag.tag_controller::deleteAction
+    methods: DELETE
+    format: json
+    defaults:
+        _format: json
+
+sulu_tag.patch_tag:
+    path: /tags.{_format}
+    controller: sulu_tag.tag_controller::patchAction
+    methods: PATCH
+    format: json
+    defaults:
+        _format: json
+
+sulu_tag.post_tag_merge:
+    path: /tags/merge.{_format}
+    controller: sulu_tag.tag_controller::postMergeAction
+    methods: POST
+    format: json
+    defaults:
+        _format: json

--- a/src/Sulu/Bundle/TagBundle/Resources/config/routing_api.yaml
+++ b/src/Sulu/Bundle/TagBundle/Resources/config/routing_api.yaml
@@ -40,7 +40,7 @@ sulu_tag.delete_tag:
 
 sulu_tag.patch_tag:
     path: /tags.{_format}
-    controller: sulu_tag.tag_controller::patchAction
+    controller: sulu_tag.tag_controller::cpatchAction
     methods: PATCH
     format: json
     defaults:

--- a/src/Sulu/Bundle/TagBundle/Resources/config/routing_api.yaml
+++ b/src/Sulu/Bundle/TagBundle/Resources/config/routing_api.yaml
@@ -3,53 +3,53 @@ sulu_tag.get_tag:
     controller: sulu_tag.tag_controller::getAction
     methods: GET
     format: json
-    defaults:
-        _format: json
+    requirements:
+       _format: json|csv
 
 sulu_tag.get_tags:
     path: /tags.{_format}
     controller: sulu_tag.tag_controller::cgetAction
     methods: GET
-    format: json|csv
-    defaults:
-        _format: json
+    format: json
+    requirements:
+        _format: json|csv
 
 sulu_tag.post_tag:
     path: /tags.{_format}
     controller: sulu_tag.tag_controller::postAction
     methods: POST
     format: json
-    defaults:
-        _format: json
+    requirements:
+        _format: json|csv
 
 sulu_tag.put_tag:
     path: /tags/{id}.{_format}
     controller: sulu_tag.tag_controller::putAction
     methods: PUT
     format: json
-    defaults:
-        _format: json
+    requirements:
+        _format: json|csv
 
 sulu_tag.delete_tag:
     path: /tags/{id}.{_format}
     controller: sulu_tag.tag_controller::deleteAction
     methods: DELETE
     format: json
-    defaults:
-        _format: json
+    requirements:
+        _format: json|csv
 
-sulu_tag.patch_tag:
+sulu_tag.patch_tags:
     path: /tags.{_format}
     controller: sulu_tag.tag_controller::cpatchAction
     methods: PATCH
     format: json
-    defaults:
-        _format: json
+    requirements:
+        _format: json|csv
 
 sulu_tag.post_tag_merge:
     path: /tags/merge.{_format}
     controller: sulu_tag.tag_controller::postMergeAction
     methods: POST
     format: json
-    defaults:
-        _format: json
+    requirements:
+        _format: json|csv

--- a/src/Sulu/Bundle/TagBundle/Resources/config/routing_api.yml
+++ b/src/Sulu/Bundle/TagBundle/Resources/config/routing_api.yml
@@ -1,55 +1,11 @@
-sulu_tag.get_tag:
-    path: /tags/{id}.{_format}
-    controller: sulu_tag.tag_controller::getAction
-    methods: GET
-    format: json
-    defaults:
-        _format: json
-
-sulu_tag.get_tags:
-    path: /tags.{_format}
-    controller: sulu_tag.tag_controller::cgetAction
-    methods: GET
-    format: json|csv
-    defaults:
-        _format: json
-
-sulu_tag.post_tag:
-    path: /tags.{_format}
-    controller: sulu_tag.tag_controller::postAction
-    methods: POST
-    format: json
-    defaults:
-        _format: json
-
-sulu_tag.put_tag:
-    path: /tags/{id}.{_format}
-    controller: sulu_tag.tag_controller::putAction
-    methods: PUT
-    format: json
-    defaults:
-        _format: json
-
-sulu_tag.delete_tag:
-    path: /tags/{id}.{_format}
-    controller: sulu_tag.tag_controller::deleteAction
-    methods: DELETE
-    format: json
-    defaults:
-        _format: json
-
-sulu_tag.patch_tag:
-    path: /tags.{_format}
-    controller: sulu_tag.tag_controller::patchAction
-    methods: PATCH
-    format: json
-    defaults:
-        _format: json
+sulu_tag.tags:
+    type: rest
+    name_prefix: sulu_tag.
+    resource: sulu_tag.tag_controller
 
 sulu_tag.post_tag_merge:
     path: /tags/merge.{_format}
-    controller: sulu_tag.tag_controller::postMergeAction
     methods: POST
-    format: json
     defaults:
+        _controller: sulu_tag.tag_controller::postMergeAction
         _format: json

--- a/src/Sulu/Bundle/TagBundle/Resources/config/routing_api.yml
+++ b/src/Sulu/Bundle/TagBundle/Resources/config/routing_api.yml
@@ -1,11 +1,55 @@
-sulu_tag.tags:
-    type: rest
-    name_prefix: sulu_tag.
-    resource: sulu_tag.tag_controller
+sulu_tag.get_tag:
+    path: /tags/{id}.{_format}
+    controller: sulu_tag.tag_controller::getAction
+    methods: GET
+    format: json
+    defaults:
+        _format: json
+
+sulu_tag.get_tags:
+    path: /tags.{_format}
+    controller: sulu_tag.tag_controller::cgetAction
+    methods: GET
+    format: json|csv
+    defaults:
+        _format: json
+
+sulu_tag.post_tag:
+    path: /tags.{_format}
+    controller: sulu_tag.tag_controller::postAction
+    methods: POST
+    format: json
+    defaults:
+        _format: json
+
+sulu_tag.put_tag:
+    path: /tags/{id}.{_format}
+    controller: sulu_tag.tag_controller::putAction
+    methods: PUT
+    format: json
+    defaults:
+        _format: json
+
+sulu_tag.delete_tag:
+    path: /tags/{id}.{_format}
+    controller: sulu_tag.tag_controller::deleteAction
+    methods: DELETE
+    format: json
+    defaults:
+        _format: json
+
+sulu_tag.patch_tag:
+    path: /tags.{_format}
+    controller: sulu_tag.tag_controller::patchAction
+    methods: PATCH
+    format: json
+    defaults:
+        _format: json
 
 sulu_tag.post_tag_merge:
     path: /tags/merge.{_format}
+    controller: sulu_tag.tag_controller::postMergeAction
     methods: POST
+    format: json
     defaults:
-        _controller: sulu_tag.tag_controller::postMergeAction
         _format: json

--- a/src/Sulu/Bundle/TagBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/TagBundle/Tests/Application/config/routing.yml
@@ -3,6 +3,5 @@ sulu_admin:
     prefix: /admin
 
 sulu_tag_api:
-    type: rest
-    resource: "@SuluTagBundle/Resources/config/routing_api.yml"
+    resource: "@SuluTagBundle/Resources/config/routing_api.yaml"
     prefix: /api


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no 
| Fixed tickets | fixes # [7434](https://github.com/sulu/sulu/issues/7434)
| Related issues/PRs | # [7434](https://github.com/sulu/sulu/issues/7434)
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?
See ticket # [7434](https://github.com/sulu/sulu/issues/7434)

### All Routes that are needed


- [x] sulu_tag.get_tag          GET      ANY      ANY    /admin/api/tags/{id}.{_format}
- [x] sulu_tag.get_tags         GET      ANY      ANY    /admin/api/tags.{_format}
- [x]  sulu_tag.post_tag         POST     ANY      ANY    /admin/api/tags.{_format}
- [x]  sulu_tag.put_tag          PUT      ANY      ANY    /admin/api/tags/{id}.{_format}
- [x]  sulu_tag.delete_tag       DELETE   ANY      ANY    /admin/api/tags/{id}.{_format}
- [x]  sulu_tag.patch_tags       PATCH    ANY      ANY    /admin/api/tags.{_format}
- [x]  sulu_tag.post_tag_merge   POST     ANY      ANY    /admin/api/tags/merge.{_format}
