### PR TITLE
Migrate rest routings to default symfony routing files of ReferenceBundle

### DIFF
--- a/src/Sulu/Bundle/ReferenceBundle/Resources/config/routing_api.yaml
+++ b/src/Sulu/Bundle/ReferenceBundle/Resources/config/routing_api.yaml
@@ -1,7 +1,7 @@
 sulu_reference.references:
     path: /references.{_format}
     methods: GET
-    controller: sulu_reference.reference_controller:cgetAction
+    controller: sulu_reference.reference_controller::cgetAction
     format: json|csv
     defaults:
         _format: json

--- a/src/Sulu/Bundle/ReferenceBundle/Resources/config/routing_api.yaml
+++ b/src/Sulu/Bundle/ReferenceBundle/Resources/config/routing_api.yaml
@@ -1,0 +1,7 @@
+sulu_reference.references:
+    path: /admin/api/references.{_format}
+    methods: GET
+    controller: sulu_reference.reference_controller:cgetAction
+    format: json|csv
+    defaults:
+        _format: json

--- a/src/Sulu/Bundle/ReferenceBundle/Resources/config/routing_api.yaml
+++ b/src/Sulu/Bundle/ReferenceBundle/Resources/config/routing_api.yaml
@@ -1,5 +1,5 @@
 sulu_reference.references:
-    path: /admin/api/references.{_format}
+    path: /references.{_format}
     methods: GET
     controller: sulu_reference.reference_controller:cgetAction
     format: json|csv

--- a/src/Sulu/Bundle/ReferenceBundle/Resources/config/routing_api.yaml
+++ b/src/Sulu/Bundle/ReferenceBundle/Resources/config/routing_api.yaml
@@ -1,7 +1,7 @@
-sulu_reference.references:
+sulu_reference.get_references:
     path: /references.{_format}
     methods: GET
     controller: sulu_reference.reference_controller::cgetAction
-    format: json|csv
-    defaults:
-        _format: json
+    format: json
+    requirements:
+        _format: json|csv

--- a/src/Sulu/Bundle/ReferenceBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/ReferenceBundle/Tests/Application/config/routing.yml
@@ -1,4 +1,4 @@
 sulu_reference_api:
     type: rest
-    resource: "@SuluReferenceBundle/Resources/config/routing_api.yml"
+    resource: "@SuluReferenceBundle/Resources/config/routing_api.yaml"
     prefix: /admin/api


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no 
| Fixed tickets | fixes # [7434](https://github.com/sulu/sulu/issues/7434)
| Related issues/PRs | # [7434](https://github.com/sulu/sulu/issues/7434)
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?
See ticket # [7434](https://github.com/sulu/sulu/issues/7434)

### All Routes that are needed


- [x] sulu_reference.get_references      GET      ANY      ANY    /admin/api/references.{_format}
