### PR TITLE
Migrate rest routings to default symfony routing files of TrashBundle

### DIFF
--- a/config/routes/sulu_admin.yaml
+++ b/config/routes/sulu_admin.yaml
@@ -102,8 +102,7 @@ sulu_activity_api:
     prefix: /admin/api
 
 sulu_trash_api:
-    resource: "@SuluTrashBundle/Resources/config/routing_api.yml"
-    type: rest
+    resource: "@SuluTrashBundle/Resources/config/routing_api.yaml"
     prefix: /admin/api
 
 # additional bundles

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
@@ -113,6 +113,5 @@ sulu_activity_api:
     prefix: /admin/api
 
 sulu_trash_api:
-    resource: "@SuluTrashBundle/Resources/config/routing_api.yml"
-    type: rest
+    resource: "@SuluTrashBundle/Resources/config/routing_api.yaml"
     prefix: /admin/api

--- a/src/Sulu/Bundle/TrashBundle/Resources/config/routing_api.yaml
+++ b/src/Sulu/Bundle/TrashBundle/Resources/config/routing_api.yaml
@@ -1,0 +1,31 @@
+sulu_trash.get_trash-items:
+    path: /trash-items.{_format}
+    methods: GET
+    controller: sulu_trash.trash_item_controller::cgetAction
+    format: json|csv
+    defaults:
+        _format: json
+
+sulu_trash.get_trash-item:
+    path: /trash-items/{id}.{_format}
+    methods: GET
+    controller: sulu_trash.trash_item_controller::getAction
+    format: json|csv
+    defaults:
+        _format: json
+
+sulu_trash.delete_trash-item:
+    path: /trash-items/{id}.{_format}
+    methods: DELETE
+    controller: sulu_trash.trash_item_controller::deleteAction
+    format: json|csv
+    defaults:
+        _format: json
+
+sulu_trash.post_trash-item_trigger:
+    path: /trash-items/{id}.{_format}
+    methods: POST
+    controller: sulu_trash.trash_item_controller::postTriggerAction
+    format: json|csv
+    defaults:
+        _format: json

--- a/src/Sulu/Bundle/TrashBundle/Resources/config/routing_api.yaml
+++ b/src/Sulu/Bundle/TrashBundle/Resources/config/routing_api.yaml
@@ -2,30 +2,30 @@ sulu_trash.get_trash-items:
     path: /trash-items.{_format}
     methods: GET
     controller: sulu_trash.trash_item_controller::cgetAction
-    format: json|csv
-    defaults:
-        _format: json
+    format: json
+    requirements:
+        _format: json|csv
 
 sulu_trash.get_trash-item:
     path: /trash-items/{id}.{_format}
     methods: GET
     controller: sulu_trash.trash_item_controller::getAction
-    format: json|csv
-    defaults:
-        _format: json
+    format: json
+    requirements:
+        _format: json|csv
 
 sulu_trash.delete_trash-item:
     path: /trash-items/{id}.{_format}
     methods: DELETE
     controller: sulu_trash.trash_item_controller::deleteAction
-    format: json|csv
-    defaults:
-        _format: json
+    format: json
+    requirements:
+        _format: json|csv
 
 sulu_trash.post_trash-item_trigger:
     path: /trash-items/{id}.{_format}
     methods: POST
     controller: sulu_trash.trash_item_controller::postTriggerAction
-    format: json|csv
-    defaults:
-        _format: json
+    format: json
+    requirements:
+        _format: json|csv

--- a/src/Sulu/Bundle/TrashBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/TrashBundle/Tests/Application/config/routing.yml
@@ -1,4 +1,3 @@
 sulu_trash_api:
-    type: rest
-    resource: "@SuluTrashBundle/Resources/config/routing_api.yml"
+    resource: "@SuluTrashBundle/Resources/config/routing_api.yaml"
     prefix: /api


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no 
| Fixed tickets | fixes # [7434](https://github.com/sulu/sulu/issues/7434)
| Related issues/PRs | # [7434](https://github.com/sulu/sulu/issues/7434)
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?
See ticket # [7434](https://github.com/sulu/sulu/issues/7434)

### All Routes that are needed


- [x]  sulu_trash.get_trash-items                GET      ANY      ANY    /admin/api/trash-items.{_format}
- [x]  sulu_trash.get_trash-item                  GET      ANY      ANY    /admin/api/trash-items/{id}.{_format}
- [x]  sulu_trash.delete_trash-item             DELETE   ANY      ANY    /admin/api/trash-items/{id}.{_format}
- [x]  sulu_trash.post_trash-item_trigger   POST     ANY      ANY    /admin/api/trash-items/{id}.{_format}