### PR TITLE
Migrate rest routings to default symfony routing files of ActivityBundle

### DIFF
--- a/config/routes/sulu_admin.yaml
+++ b/config/routes/sulu_admin.yaml
@@ -97,8 +97,7 @@ sulu_search:
     prefix: /admin/search
 
 sulu_activity_api:
-    resource: "@SuluActivityBundle/Resources/config/routing_api.yml"
-    type: rest
+    resource: "@SuluActivityBundle/Resources/config/routing_api.yaml"
     prefix: /admin/api
 
 sulu_trash_api:

--- a/src/Sulu/Bundle/ActivityBundle/Resources/config/routing_api.yaml
+++ b/src/Sulu/Bundle/ActivityBundle/Resources/config/routing_api.yaml
@@ -1,0 +1,7 @@
+sulu_activity.get_activities:
+    path: /activities.{_format}
+    controller: sulu_activity.activity_controller::cgetAction
+    methods: GET
+    format: json|csv
+    defaults:
+        _format: json

--- a/src/Sulu/Bundle/ActivityBundle/Resources/config/routing_api.yaml
+++ b/src/Sulu/Bundle/ActivityBundle/Resources/config/routing_api.yaml
@@ -2,6 +2,6 @@ sulu_activity.get_activities:
     path: /activities.{_format}
     controller: sulu_activity.activity_controller::cgetAction
     methods: GET
-    format: json|csv
-    defaults:
-        _format: json
+    format: json
+    requirements:
+        _format: json|csv

--- a/src/Sulu/Bundle/ActivityBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/ActivityBundle/Tests/Application/config/routing.yml
@@ -1,4 +1,3 @@
 sulu_activity_api:
-    type: rest
-    resource: "@SuluActivityBundle/Resources/config/routing_api.yml"
+    resource: "@SuluActivityBundle/Resources/config/routing_api.yaml"
     prefix: /api

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
@@ -108,8 +108,7 @@ sulu_audience_targeting_api:
     prefix: /admin/api
 
 sulu_activity_api:
-    resource: "@SuluActivityBundle/Resources/config/routing_api.yml"
-    type: rest
+    resource: "@SuluActivityBundle/Resources/config/routing_api.yaml"
     prefix: /admin/api
 
 sulu_trash_api:


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no 
| Fixed tickets | fixes # [7434](https://github.com/sulu/sulu/issues/7434)
| Related issues/PRs | # [7434](https://github.com/sulu/sulu/issues/7434)
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?
See ticket # [7434](https://github.com/sulu/sulu/issues/7434)

### All Routes that are needed


- [x] sulu_activity.get_activities  GET      ANY      ANY    /admin/api/activities.{_format}