### PR TITLE
Migrate rest routings to default symfony routing files of SearchBundle

### DIFF
--- a/config/routes/sulu_admin.yaml
+++ b/config/routes/sulu_admin.yaml
@@ -93,7 +93,7 @@ sulu_preview_public:
     prefix: /admin/p
 
 sulu_search:
-    resource: "@SuluSearchBundle/Resources/config/routing.yml"
+    resource: "@SuluSearchBundle/Resources/config/routing.yaml"
     prefix: /admin/search
 
 sulu_activity_api:

--- a/config/routes/sulu_website.yaml
+++ b/config/routes/sulu_website.yaml
@@ -3,7 +3,7 @@ sulu_media:
 
 sulu_search:
     type: portal
-    resource: "@SuluSearchBundle/Resources/config/routing_website.yml"
+    resource: "@SuluSearchBundle/Resources/config/routing_website.yaml"
 
 sulu_website:
     resource: "@SuluWebsiteBundle/Resources/config/routing_website.yml"

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
@@ -99,7 +99,7 @@ sulu_preview_public:
     prefix: /admin/p
 
 sulu_search:
-    resource: "@SuluSearchBundle/Resources/config/routing.yml"
+    resource: "@SuluSearchBundle/Resources/config/routing.yaml"
     prefix: /admin/search
 
 sulu_audience_targeting_api:

--- a/src/Sulu/Bundle/MediaBundle/Tests/Application/config/routing_admin.yml
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Application/config/routing_admin.yml
@@ -18,7 +18,7 @@ sulu_media_website:
 # Including a portal route to test if media download is still working
 sulu_search:
     type: portal
-    resource: "@SuluSearchBundle/Resources/config/routing_website.yml"
+    resource: "@SuluSearchBundle/Resources/config/routing_website.yaml"
 
 sulu_pages_api:
     type: rest

--- a/src/Sulu/Bundle/MediaBundle/Tests/Application/config/routing_website.yml
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Application/config/routing_website.yml
@@ -4,4 +4,4 @@ sulu_media_website:
 # Including a portal route to test if media download is still working
 sulu_search:
     type: portal
-    resource: "@SuluSearchBundle/Resources/config/routing_website.yml"
+    resource: "@SuluSearchBundle/Resources/config/routing_website.yaml"

--- a/src/Sulu/Bundle/SearchBundle/Resources/config/routing.yaml
+++ b/src/Sulu/Bundle/SearchBundle/Resources/config/routing.yaml
@@ -1,0 +1,10 @@
+sulu_search_indexes:
+    path: /indexes
+    controller: sulu_search.controller.search::indexesAction
+    format: json
+
+sulu_search_search:
+    path: /query
+    controller: sulu_search.controller.search::searchAction
+    format: json
+

--- a/src/Sulu/Bundle/SearchBundle/Resources/config/routing_website.yaml
+++ b/src/Sulu/Bundle/SearchBundle/Resources/config/routing_website.yaml
@@ -1,0 +1,4 @@
+sulu_search.website_search:
+    path: /search.{_format}
+    controller: sulu_search.controller.website_search::queryAction
+    format: html

--- a/src/Sulu/Bundle/SearchBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Application/config/routing.yml
@@ -2,8 +2,8 @@ sulu_media_website:
     resource: "@SuluMediaBundle/Resources/config/routing_website.yml"
 
 sulu_search_website:
-    resource: "@SuluSearchBundle/Resources/config/routing_website.yml"
+    resource: "@SuluSearchBundle/Resources/config/routing_website.yaml"
 
 sulu_search_api:
-    resource: "@SuluSearchBundle/Resources/config/routing.yml"
+    resource: "@SuluSearchBundle/Resources/config/routing.yaml"
     prefix: /search


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no 
| Fixed tickets | fixes # [7434](https://github.com/sulu/sulu/issues/7434)
| Related issues/PRs | # [7434](https://github.com/sulu/sulu/issues/7434)
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?
See ticket # [7434](https://github.com/sulu/sulu/issues/7434)

### All Routes that are needed


- [x]  sulu_search_indexes                                  ANY      ANY      ANY    /admin/search/indexes
- [x]  sulu_search_search                                   ANY      ANY      ANY    /admin/search/query