### PR TITLE
Fix security check for snippet references tab

### DIFF
--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -223,7 +223,7 @@ class SnippetAdmin extends Admin
             );
         }
 
-        if ($this->activityViewBuilderFactory->hasActivityListPermission() || $this->referenceViewBuilderFactory->hasReferenceListPermission()) {
+        if (($this->activityViewBuilderFactory->hasActivityListPermission() || $this->referenceViewBuilderFactory->hasReferenceListPermission()) && $this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
             $insightsResourceTabViewName = SnippetAdmin::EDIT_FORM_VIEW . '.insights';
 
             $viewCollection->add(


### PR DESCRIPTION

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no 
| Fixed tickets | fixes #7519
| Related issues/PRs | #7519
| License | MIT
| Documentation PR | 

#### What's in this PR?

When adding the insights items for snippets, check for the required permissions.


#### Why?

When a user has permissions to see activities, but not the permissions to edit snippets, an error occurs on the /admin/config endpoint:

ParentViewNotFoundException
The route “sulu_snippet.edit_form” was defined as the parent of “sulu_snippet.edit_form.insights”, but the route “sulu_snippet.edit_form” does not exist


