### PR TITLE
Migrate rest routings to default symfony routing files of PreviewBundle

### DIFF
--- a/config/routes/sulu_admin.yaml
+++ b/config/routes/sulu_admin.yaml
@@ -80,16 +80,15 @@ sulu_route_api:
     prefix: /admin/api
 
 sulu_preview:
-    resource: "@SuluPreviewBundle/Resources/config/routing.yml"
+    resource: "@SuluPreviewBundle/Resources/config/routing.yaml"
     prefix: /admin/preview
 
 sulu_preview_api:
-    type: rest
-    resource: "@SuluPreviewBundle/Resources/config/routing_api.yml"
+    resource: "@SuluPreviewBundle/Resources/config/routing_api.yaml"
     prefix: /admin/api
 
 sulu_preview_public:
-    resource: "@SuluPreviewBundle/Resources/config/routing_public.yml"
+    resource: "@SuluPreviewBundle/Resources/config/routing_public.yaml"
     prefix: /admin/p
 
 sulu_search:

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
@@ -86,16 +86,15 @@ sulu_route_api:
     prefix: /admin/api
 
 sulu_preview:
-    resource: "@SuluPreviewBundle/Resources/config/routing.yml"
+    resource: "@SuluPreviewBundle/Resources/config/routing.yaml"
     prefix: /admin/preview
 
 sulu_preview_api:
-    type: rest
-    resource: "@SuluPreviewBundle/Resources/config/routing_api.yml"
+    resource: "@SuluPreviewBundle/Resources/config/routing_api.yaml"
     prefix: /admin/api
 
 sulu_preview_public:
-    resource: "@SuluPreviewBundle/Resources/config/routing_public.yml"
+    resource: "@SuluPreviewBundle/Resources/config/routing_public.yaml"
     prefix: /admin/p
 
 sulu_search:

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Application/config/routing_admin.yml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Application/config/routing_admin.yml
@@ -14,8 +14,7 @@ sulu_media:
     prefix: /admin/media
 
 sulu_preview:
-    type: rest
-    resource: "@SuluPreviewBundle/Resources/config/routing.yml"
+    resource: "@SuluPreviewBundle/Resources/config/routing.yaml"
     prefix: /admin
 
 sulu_security:
@@ -29,15 +28,13 @@ sulu_security_api:
     prefix: /admin/api
 
 sulu_website:
-    type: rest
     resource: "@SuluWebsiteBundle/Resources/config/routing.yml"
     prefix: /admin
 
 sulu_preview_api:
-    type: rest
-    resource: "@SuluPreviewBundle/Resources/config/routing_api.yml"
+    resource: "@SuluPreviewBundle/Resources/config/routing_api.yaml"
     prefix: /admin/api
 
 sulu_preview_public:
-    resource: "@SuluPreviewBundle/Resources/config/routing_public.yml"
+    resource: "@SuluPreviewBundle/Resources/config/routing_public.yaml"
     prefix: /admin/p

--- a/src/Sulu/Bundle/ContactBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Application/config/routing.yml
@@ -21,15 +21,13 @@ sulu_website:
     prefix: /admin
 
 sulu_preview:
-    type: rest
-    resource: "@SuluPreviewBundle/Resources/config/routing.yml"
+    resource: "@SuluPreviewBundle/Resources/config/routing.yaml"
     prefix: /admin
 
 sulu_preview_api:
-    type: rest
-    resource: "@SuluPreviewBundle/Resources/config/routing_api.yml"
+    resource: "@SuluPreviewBundle/Resources/config/routing_api.yaml"
     prefix: /admin/api
 
 sulu_preview_public:
-    resource: "@SuluPreviewBundle/Resources/config/routing_public.yml"
+    resource: "@SuluPreviewBundle/Resources/config/routing_public.yaml"
     prefix: /admin/p

--- a/src/Sulu/Bundle/MediaBundle/Tests/Application/config/routing_admin.yml
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Application/config/routing_admin.yml
@@ -36,15 +36,13 @@ sulu_website:
     prefix: /admin
 
 sulu_preview:
-    type: rest
-    resource: "@SuluPreviewBundle/Resources/config/routing.yml"
+    resource: "@SuluPreviewBundle/Resources/config/routing.yaml"
     prefix: /admin
 
 sulu_preview_api:
-    type: rest
-    resource: "@SuluPreviewBundle/Resources/config/routing_api.yml"
+    resource: "@SuluPreviewBundle/Resources/config/routing_api.yaml"
     prefix: /admin/api
 
 sulu_preview_public:
-    resource: "@SuluPreviewBundle/Resources/config/routing_public.yml"
+    resource: "@SuluPreviewBundle/Resources/config/routing_public.yaml"
     prefix: /admin/p

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/routing.yml
@@ -25,17 +25,15 @@ sulu_security_api:
     prefix: /api
 
 sulu_preview:
-    type: rest
     resource: "@SuluPreviewBundle/Resources/config/routing.yml"
     prefix: /admin
 
 sulu_preview_api:
-    type: rest
-    resource: "@SuluPreviewBundle/Resources/config/routing_api.yml"
+    resource: "@SuluPreviewBundle/Resources/config/routing_api.yaml"
     prefix: /admin/api
 
 sulu_preview_public:
-    resource: "@SuluPreviewBundle/Resources/config/routing_public.yml"
+    resource: "@SuluPreviewBundle/Resources/config/routing_public.yaml"
     prefix: /admin/p
 
 sulu_website:

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/routing.yaml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/routing.yaml
@@ -1,0 +1,20 @@
+sulu_preview.start:
+    path: /start
+    controller: sulu_preview.preview_controller::startAction
+
+sulu_preview.render:
+    path: /render
+    controller: sulu_preview.preview_controller::renderAction
+
+sulu_preview.update:
+    path: /update
+    methods: [POST]
+    controller: sulu_preview.preview_controller::updateAction
+
+sulu_preview.update-context:
+    path: /update-context
+    controller: sulu_preview.preview_controller::updateContextAction
+    
+sulu_preview.stop:
+    path: /stop
+    controller: sulu_preview.preview_controller::stopAction

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/routing_api.yaml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/routing_api.yaml
@@ -1,0 +1,13 @@
+sulu_preview.get_preview-link:
+    path: /admin/api/preview-links/{resourceId}.{_format}
+    methods: GET
+    controller: sulu_preview.preview_link_controller::getAction
+    format: json|csv
+    defaults:
+        _format: json
+
+sulu_preview.post_preview_link_trigger:
+    path: /preview-links/{resourceId}.{_format}
+    controller: sulu_preview.preview_link_controller::postTriggerAction
+    methods: POST
+    format: json

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/routing_api.yaml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/routing_api.yaml
@@ -1,13 +1,15 @@
 sulu_preview.get_preview-link:
-    path: /admin/api/preview-links/{resourceId}.{_format}
+    path: /preview-links/{resourceId}.{_format}
     methods: GET
     controller: sulu_preview.preview_link_controller::getAction
-    format: json|csv
-    defaults:
-        _format: json
+    format: json
+    requirements:
+        _format: json|csv
 
 sulu_preview.post_preview_link_trigger:
     path: /preview-links/{resourceId}.{_format}
     controller: sulu_preview.preview_link_controller::postTriggerAction
     methods: POST
     format: json
+    requirements:
+        _format: json|csv

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/routing_public.yaml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/routing_public.yaml
@@ -1,0 +1,7 @@
+sulu_preview.public_preview:
+    path: "/{token}"
+    controller: sulu_preview.public_preview_controller::renderAction
+
+sulu_preview.public_render:
+    path: "/{token}/render"
+    controller: sulu_preview.public_preview_controller::renderAction

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/routing_public.yaml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/routing_public.yaml
@@ -1,6 +1,6 @@
 sulu_preview.public_preview:
     path: "/{token}"
-    controller: sulu_preview.public_preview_controller::renderAction
+    controller: sulu_preview.public_preview_controller::previewAction
 
 sulu_preview.public_render:
     path: "/{token}/render"

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Application/config/routing.yml
@@ -1,12 +1,11 @@
 sulu_preview:
-    resource: "@SuluPreviewBundle/Resources/config/routing.yml"
+    resource: "@SuluPreviewBundle/Resources/config/routing.yaml"
     prefix: /
 
 sulu_preview_api:
-    type: rest
-    resource: "@SuluPreviewBundle/Resources/config/routing_api.yml"
+    resource: "@SuluPreviewBundle/Resources/config/routing_api.yaml"
     prefix: /api
 
 sulu_preview_public:
-    resource: "@SuluPreviewBundle/Resources/config/routing_public.yml"
+    resource: "@SuluPreviewBundle/Resources/config/routing_public.yaml"
     prefix: /p

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Application/config/routing.yml
@@ -13,17 +13,15 @@ sulu_admin:
     prefix: /admin
 
 sulu_preview:
-    type: rest
-    resource: "@SuluPreviewBundle/Resources/config/routing.yml"
+    resource: "@SuluPreviewBundle/Resources/config/routing.yaml"
     prefix: /admin
 
 sulu_preview_api:
-    type: rest
-    resource: "@SuluPreviewBundle/Resources/config/routing_api.yml"
+    resource: "@SuluPreviewBundle/Resources/config/routing_api.yaml"
     prefix: /admin/api
 
 sulu_preview_public:
-    resource: "@SuluPreviewBundle/Resources/config/routing_public.yml"
+    resource: "@SuluPreviewBundle/Resources/config/routing_public.yaml"
     prefix: /admin/p
 
 sulu_website:


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no 
| Fixed tickets | fixes # [7434](https://github.com/sulu/sulu/issues/7434)
| Related issues/PRs | # [7434](https://github.com/sulu/sulu/issues/7434)
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?
See ticket # [7434](https://github.com/sulu/sulu/issues/7434)

### All Routes that are needed


- [x]   sulu_preview.start                                           ANY      ANY      ANY    /admin/preview/start
- [x]   sulu_preview.render                                        ANY      ANY      ANY    /admin/preview/render
- [x]   sulu_preview.update                                       POST     ANY      ANY    /admin/preview/update
- [x]   sulu_preview.update-context                         ANY      ANY      ANY    /admin/preview/update-context
- [x]   sulu_preview.stop                                            ANY      ANY      ANY    /admin/preview/stop
- [x]   sulu_preview.get_preview-link                       GET      ANY      ANY    /admin/api/preview-links/{resourceId}.{_format}
- [x]   sulu_preview.post_preview-link_trigger        POST     ANY      ANY    /admin/api/preview-links/{resourceId}/triggers.{_format}
- [x]   sulu_preview.post_preview_link_trigger               POST     ANY      ANY    /admin/api/preview-links/{resourceId}.{_format}
- [x]   sulu_preview.public_preview                          ANY      ANY      ANY    /admin/p/{token}
- [x]   sulu_preview.public_render                           ANY      ANY      ANY    /admin/p/{token}/render