### PR TITLE
Remove deprecated `getMockForAbstractClass` in phpunit tests

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -41256,11 +41256,6 @@ parameters:
 			path: src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/TreeLeafEditStrategyTest.php
 
 		-
-			message: "#^Call to an undefined method Sulu\\\\Component\\\\SmartContent\\\\Orm\\\\BaseDataProvider\\:\\:expects\\(\\)\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Tests/Unit/SmartContent/Orm/BaseDataProviderTest.php
-
-		-
 			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNull\\(\\) with Sulu\\\\Component\\\\SmartContent\\\\DatasourceItemInterface will always evaluate to false\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Tests/Unit/SmartContent/Orm/BaseDataProviderTest.php
@@ -46901,11 +46896,6 @@ parameters:
 			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
 
 		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\DoctrineListBuilder\\:\\:encodeAlias\\(\\) has parameter \\$value with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
-
-		-
 			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\DoctrineListBuilder\\:\\:execute\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -47051,22 +47041,12 @@ parameters:
 			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineDescriptor.php
 
 		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\FieldDescriptor\\\\DoctrineDescriptor\\:\\:encodeAlias\\(\\) has parameter \\$value with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineDescriptor.php
-
-		-
 			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\FieldDescriptor\\\\DoctrineFieldDescriptor\\:\\:__construct\\(\\) has parameter \\$joins with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineFieldDescriptor.php
 
 		-
 			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\FieldDescriptor\\\\DoctrineFieldDescriptor\\:\\:encodeAlias\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineFieldDescriptor.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\FieldDescriptor\\\\DoctrineFieldDescriptor\\:\\:encodeAlias\\(\\) has parameter \\$value with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineFieldDescriptor.php
 
@@ -47086,17 +47066,7 @@ parameters:
 			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineIdentityFieldDescriptor.php
 
 		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\FieldDescriptor\\\\DoctrineIdentityFieldDescriptor\\:\\:encodeAlias\\(\\) has parameter \\$value with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineIdentityFieldDescriptor.php
-
-		-
 			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\FieldDescriptor\\\\DoctrineJoinDescriptor\\:\\:encodeAlias\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineJoinDescriptor.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\FieldDescriptor\\\\DoctrineJoinDescriptor\\:\\:encodeAlias\\(\\) has parameter \\$value with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineJoinDescriptor.php
 
@@ -48326,27 +48296,12 @@ parameters:
 			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
 
 		-
+			message: "#^Method Sulu\\\\Component\\\\Rest\\\\Tests\\\\Unit\\\\ListBuilder\\\\Doctrine\\\\EncodeAliasTraitTest\\:\\:encodeAlias\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/EncodeAliasTraitTest.php
+
+		-
 			message: "#^Method Sulu\\\\Component\\\\Rest\\\\Tests\\\\Unit\\\\ListBuilder\\\\Doctrine\\\\EncodeAliasTraitTest\\:\\:encodeAliasDataProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/EncodeAliasTraitTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\Tests\\\\Unit\\\\ListBuilder\\\\Doctrine\\\\EncodeAliasTraitTest\\:\\:testEncodeAlias\\(\\) has parameter \\$expected with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/EncodeAliasTraitTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\Tests\\\\Unit\\\\ListBuilder\\\\Doctrine\\\\EncodeAliasTraitTest\\:\\:testEncodeAlias\\(\\) has parameter \\$value with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/EncodeAliasTraitTest.php
-
-		-
-			message: "#^Property Sulu\\\\Component\\\\Rest\\\\Tests\\\\Unit\\\\ListBuilder\\\\Doctrine\\\\EncodeAliasTraitTest\\:\\:\\$encodeAlias \\(Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\EncodeAliasTrait\\) does not accept PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/EncodeAliasTraitTest.php
-
-		-
-			message: "#^Property Sulu\\\\Component\\\\Rest\\\\Tests\\\\Unit\\\\ListBuilder\\\\Doctrine\\\\EncodeAliasTraitTest\\:\\:\\$encodeAlias has invalid type Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\EncodeAliasTrait\\.$#"
 			count: 1
 			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/EncodeAliasTraitTest.php
 
@@ -49927,11 +49882,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Component\\\\SmartContent\\\\Orm\\\\BaseDataProvider\\:\\:resolveFilters\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Component/SmartContent/Orm/BaseDataProvider.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\SmartContent\\\\Orm\\\\BaseDataProvider\\:\\:resolveFilters\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Component/SmartContent/Orm/BaseDataProvider.php
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Content/Types/MediaSelectionContentTypeTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Content/Types/MediaSelectionContentTypeTest.php
@@ -75,39 +75,18 @@ class MediaSelectionContentTypeTest extends TestCase
 
     public function testWrite(): void
     {
-        $node = $this->getMockForAbstractClass(
-            NodeInterface::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['setProperty']
-        );
-
-        $property = $this->getMockForAbstractClass(
-            PropertyInterface::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['getValue', 'getParams']
-        );
-
-        $property->expects($this->any())->method('getName')->willReturn('property');
-
-        $property->expects($this->any())->method('getValue')->willReturn(
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getName()->willReturn('property')->shouldBeCalled();
+        $property->getValue()->willReturn(
             [
                 'ids' => [1, 2, 3, 4],
                 'displayOption' => 'right',
                 'config' => ['conf1' => 1, 'conf2' => 2],
             ]
-        );
+        )->shouldBeCalled();
 
-        $property->expects($this->any())->method('getParams')->willReturn([]);
-
-        $node->expects($this->once())->method('setProperty')->with(
+        $node = $this->prophesize(NodeInterface::class);
+        $node->setProperty(
             'property',
             \json_encode(
                 [
@@ -116,47 +95,27 @@ class MediaSelectionContentTypeTest extends TestCase
                     'config' => ['conf1' => 1, 'conf2' => 2],
                 ]
             )
-        );
+        )->shouldBeCalled();
 
-        $this->mediaSelection->write($node, $property, 0, 'test', 'en', 's');
+        $this->mediaSelection->write($node->reveal(), $property->reveal(), 0, 'test', 'en', 's');
     }
 
     public function testWriteWithPassedContainer(): void
     {
-        $node = $this->getMockForAbstractClass(
-            NodeInterface::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['setProperty']
-        );
+        $property = $this->prophesize(PropertyInterface::class);
 
-        $property = $this->getMockForAbstractClass(
-            PropertyInterface::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['getValue', 'getParams']
-        );
-
-        $property->expects($this->any())->method('getName')->willReturn('property');
-
-        $property->expects($this->any())->method('getValue')->willReturn(
+        $property->getName()->willReturn('property')->shouldBeCalled();
+        $property->getValue()->willReturn(
             [
                 'ids' => [1, 2, 3, 4],
                 'displayOption' => 'right',
                 'config' => ['conf1' => 1, 'conf2' => 2],
                 'data' => ['data1', 'data2'],
             ]
-        );
+        )->shouldBeCalled();
 
-        $property->expects($this->any())->method('getParams')->willReturn([]);
-
-        $node->expects($this->once())->method('setProperty')->with(
+        $node = $this->prophesize(NodeInterface::class);
+        $node->setProperty(
             'property',
             \json_encode(
                 [
@@ -165,173 +124,66 @@ class MediaSelectionContentTypeTest extends TestCase
                     'config' => ['conf1' => 1, 'conf2' => 2],
                 ]
             )
-        );
+        )->shouldBeCalled();
 
-        $this->mediaSelection->write($node, $property, 0, 'test', 'en', 's');
+        $this->mediaSelection->write($node->reveal(), $property->reveal(), 0, 'test', 'en', 's');
     }
 
     public function testRead(): void
     {
         $config = '{"config":{"conf1": 1, "conf2": 2}, "displayOption": "right", "ids": [1,2,3,4]}';
 
-        $node = $this->getMockForAbstractClass(
-            NodeInterface::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['getPropertyValueWithDefault']
-        );
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getPropertyValueWithDefault('property', '{"ids": []}')->willReturn($config)->shouldBeCalled();
 
-        $property = $this->getMockForAbstractClass(
-            PropertyInterface::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['setValue', 'getParams']
-        );
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getName()->willReturn('property')->shouldBeCalled();
+        $property->setValue(\json_decode($config, true))->willReturn(null)->shouldBeCalled();
 
-        $node->expects($this->any())->method('getPropertyValueWithDefault')->willReturnMap(
-            [
-                [
-                    'property',
-                    '{"ids": []}',
-                    $config,
-                ],
-            ]
-        );
-
-        $property->expects($this->any())->method('getName')->willReturn('property');
-        $property->expects($this->once())->method('setValue')->with(\json_decode($config, true))->willReturn(null);
-        $property->expects($this->any())->method('getParams')->willReturn([]);
-
-        $this->mediaSelection->read($node, $property, 'test', 'en', 's');
+        $this->mediaSelection->read($node->reveal(), $property->reveal(), 'test', 'en', 's');
     }
 
     public function testReadWithInvalidValue(): void
     {
         $config = '[]';
 
-        $node = $this->getMockForAbstractClass(
-            NodeInterface::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['getPropertyValueWithDefault']
-        );
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getPropertyValueWithDefault('property', '{"ids": []}')->willReturn($config)->shouldBeCalled();
 
-        $property = $this->getMockForAbstractClass(
-            PropertyInterface::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['setValue', 'getParams']
-        );
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getName()->willReturn('property')->shouldBeCalled();
+        $property->setValue(null)->willReturn(null)->shouldBeCalled();
 
-        $node->expects($this->any())->method('getPropertyValueWithDefault')->willReturnMap(
-            [
-                [
-                    'property',
-                    '{"ids": []}',
-                    $config,
-                ],
-            ]
-        );
-
-        $property->expects($this->any())->method('getName')->willReturn('property');
-        $property->expects($this->once())->method('setValue')->with(null)->willReturn(null);
-        $property->expects($this->any())->method('getParams')->willReturn([]);
-
-        $this->mediaSelection->read($node, $property, 'test', 'en', 's');
+        $this->mediaSelection->read($node->reveal(), $property->reveal(), 'test', 'en', 's');
     }
 
     public function testReadWithType(): void
     {
         $config = '{"config":{"conf1": 1, "conf2": 2}, "displayOption": "right", "ids": [1,2,3,4]}';
 
-        $node = $this->getMockForAbstractClass(
-            NodeInterface::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['getPropertyValueWithDefault']
-        );
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getPropertyValueWithDefault('property', '{"ids": []}')->willReturn($config)->shouldBeCalled();
 
-        $property = $this->getMockForAbstractClass(
-            PropertyInterface::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['setValue', 'getParams']
-        );
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getName()->willReturn('property')->shouldBeCalled();
+        $property->setValue(\json_decode($config, true))->willReturn(null)->shouldBeCalled();
+        $property->getParams()->willReturn(['types' => 'document']);
 
-        $node->expects($this->any())->method('getPropertyValueWithDefault')->willReturnMap(
-            [
-                [
-                    'property',
-                    '{"ids": []}',
-                    $config,
-                ],
-            ]
-        );
-
-        $property->expects($this->any())->method('getName')->willReturn('property');
-        $property->expects($this->once())->method('setValue')->with(\json_decode($config, true))->willReturn(null);
-        $property->expects($this->any())->method('getParams')->willReturn(['types' => 'document']);
-
-        $this->mediaSelection->read($node, $property, 'test', 'en', 's');
+        $this->mediaSelection->read($node->reveal(), $property->reveal(), 'test', 'en', 's');
     }
 
     public function testReadWithMultipleTypes(): void
     {
         $config = '{"config":{"conf1": 1, "conf2": 2}, "displayOption": "right", "ids": [1,2,3,4]}';
 
-        $node = $this->getMockForAbstractClass(
-            NodeInterface::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['getPropertyValueWithDefault']
-        );
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getPropertyValueWithDefault('property', '{"ids": []}')->willReturn($config);
 
-        $property = $this->getMockForAbstractClass(
-            PropertyInterface::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['setValue', 'getParams']
-        );
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getName()->willReturn('property')->shouldBeCalled();
+        $property->setValue(\json_decode($config, true))->willReturn(null)->shouldBeCalled();
 
-        $node->expects($this->any())->method('getPropertyValueWithDefault')->willReturnMap(
-            [
-                [
-                    'property',
-                    '{"ids": []}',
-                    $config,
-                ],
-            ]
-        );
-
-        $property->expects($this->any())->method('getName')->willReturn('property');
-        $property->expects($this->once())->method('setValue')->with(\json_decode($config, true))->willReturn(null);
-        $property->expects($this->any())->method('getParams')->willReturn(['types' => 'document,image']);
-
-        $this->mediaSelection->read($node, $property, 'test', 'en', 's');
+        $this->mediaSelection->read($node->reveal(), $property->reveal(), 'test', 'en', 's');
     }
 
     public function testGetContentData(): void

--- a/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/ResourceLocatorStrategyTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/ResourceLocatorStrategyTest.php
@@ -86,19 +86,33 @@ class ResourceLocatorStrategyTest extends TestCase
         $this->documentManager = $this->prophesize(DocumentManagerInterface::class);
         $this->resourceLocatorGenerator = $this->prophesize(ResourceLocatorGeneratorInterface::class);
 
-        $this->resourceLocatorStrategy = $this->getMockForAbstractClass(
-            ResourceLocatorStrategy::class,
-            [
-                $this->mapper->reveal(),
-                $this->cleaner->reveal(),
-                $this->structureManager->reveal(),
-                $this->contentTypeManager->reveal(),
-                $this->nodeHelper->reveal(),
-                $this->documentInspector->reveal(),
-                $this->documentManager->reveal(),
-                $this->resourceLocatorGenerator->reveal(),
-            ]
-        );
+        $this->resourceLocatorStrategy = new class(
+            $this->mapper->reveal(),
+            $this->cleaner->reveal(),
+            $this->structureManager->reveal(),
+            $this->contentTypeManager->reveal(),
+            $this->nodeHelper->reveal(),
+            $this->documentInspector->reveal(),
+            $this->documentManager->reveal(),
+            $this->resourceLocatorGenerator->reveal(),
+        ) extends ResourceLocatorStrategy {
+            /**
+             * Returns the child part from the given resource segment.
+             *
+             * @param string $resourceSegment
+             *
+             * @return string
+             */
+            public function getChildPart($resourceSegment)
+            {
+                return '';
+            }
+
+            public function getInputType(): string
+            {
+                return '';
+            }
+        };
     }
 
     public function testGenerate(): void

--- a/src/Sulu/Component/Content/Tests/Unit/SmartContent/Orm/TestBaseDataProvier.php
+++ b/src/Sulu/Component/Content/Tests/Unit/SmartContent/Orm/TestBaseDataProvier.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Tests\Unit\SmartContent\Orm;
+
+use Sulu\Component\SmartContent\ItemInterface;
+use Sulu\Component\SmartContent\Orm\BaseDataProvider;
+
+class TestBaseDataProvier extends BaseDataProvider
+{
+    /** @var array<ItemInterface> */
+    public array $returnValue = [];
+
+    /**
+     * Decorates result as data item.
+     *
+     * @param object[] $data
+     *
+     * @return ItemInterface[]
+     */
+    protected function decorateDataItems(array $data): array
+    {
+        return $this->returnValue;
+    }
+}

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/EncodeAliasTrait.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/EncodeAliasTrait.php
@@ -16,6 +16,9 @@ namespace Sulu\Component\Rest\ListBuilder\Doctrine;
  */
 trait EncodeAliasTrait
 {
+    /**
+     * @param array<string>|string $value
+     */
     protected function encodeAlias($value)
     {
         return \preg_replace_callback(

--- a/src/Sulu/Component/Rest/Tests/Unit/AbstractRestControllerTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/AbstractRestControllerTest.php
@@ -32,7 +32,8 @@ class AbstractRestControllerTest extends TestCase
     public function setUp(): void
     {
         $viewHandler = $this->prophesize(ViewHandlerInterface::class);
-        $this->controller = $this->getMockForAbstractClass(AbstractRestController::class, [$viewHandler->reveal()]);
+        $this->controller = new class($viewHandler->reveal()) extends AbstractRestController {
+        };
     }
 
     public function testResponseGetById(): void

--- a/src/Sulu/Component/Rest/Tests/Unit/DoctrineRestHelperTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/DoctrineRestHelperTest.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Component\Rest\Tests\Unit;
 
-use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
 use Sulu\Component\Rest\DoctrineRestHelper;
 use Sulu\Component\Rest\ListBuilder\ListRestHelper;
@@ -39,15 +39,11 @@ class DoctrineRestHelperTest extends TestCase
 
     public function testProcessSubEntities(): void
     {
-        $entities = $this->getMockBuilder(Collection::class)->getMockForAbstractClass();
+        /** @var ArrayCollection<array-key, mixed> $entities */
+        $entities = new ArrayCollection(['test' => true, 'hello' => null, 'foo' => false]);
 
-        $entities->expects($this->once())->method('count')->willReturn(2);
-        $entities->expects($this->once())->method('getValues')->willReturn([null, null]);
-        $entities->expects($this->once())->method('clear');
-        $entities->expects($this->once())->method('getIterator')->willReturn(new \ArrayIterator([null, null]));
-        $entities->expects($this->exactly(2))->method('add');
+        $this->restHelper->processSubEntities($entities, [], function() {});
 
-        $this->restHelper->processSubEntities($entities, [], function() {
-        });
+        $this->assertSame($entities->toArray(), [true, null, false]);
     }
 }

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/EncodeAliasTraitTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/EncodeAliasTraitTest.php
@@ -16,15 +16,7 @@ use Sulu\Component\Rest\ListBuilder\Doctrine\EncodeAliasTrait;
 
 class EncodeAliasTraitTest extends TestCase
 {
-    /**
-     * @var EncodeAliasTrait
-     */
-    private $encodeAlias;
-
-    public function setup(): void
-    {
-        $this->encodeAlias = $this->getMockForTrait(EncodeAliasTrait::class);
-    }
+    use EncodeAliasTrait;
 
     public static function encodeAliasDataProvider()
     {
@@ -47,11 +39,8 @@ class EncodeAliasTraitTest extends TestCase
     /**
      * @dataProvider encodeAliasDataProvider
      */
-    public function testEncodeAlias($value, $expected): void
+    public function testEncodeAlias(string $value, string $expected): void
     {
-        $method = new \ReflectionMethod(\get_class($this->encodeAlias), 'encodeAlias');
-        $method->setAccessible(true);
-
-        $this->assertEquals($expected, $method->invoke($this->encodeAlias, $value));
+        $this->assertEquals($expected, $this->encodeAlias($value));
     }
 }

--- a/src/Sulu/Component/SmartContent/Orm/BaseDataProvider.php
+++ b/src/Sulu/Component/SmartContent/Orm/BaseDataProvider.php
@@ -160,7 +160,7 @@ abstract class BaseDataProvider implements DataProviderInterface
      * @param int|null $pageSize
      * @param array $options
      *
-     * @return array
+     * @return array{array<mixed>, bool}
      */
     private function resolveFilters(
         array $filters,

--- a/src/Sulu/Component/SmartContent/Tests/Unit/ContentTypeTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/ContentTypeTest.php
@@ -41,7 +41,7 @@ class ContentTypeTest extends TestCase
     use ProphecyTrait;
 
     /**
-     * @var TagManagerInterface
+     * @var ObjectProphecy<TagManagerInterface>
      */
     private $tagManager;
 
@@ -95,6 +95,11 @@ class ContentTypeTest extends TestCase
      */
     private $requestAnalyzer;
 
+    /**
+     * @var SmartContent
+     */
+    private $smartContent;
+
     public function setUp(): void
     {
         $this->pageDataProvider = $this->prophesize(DataProviderInterface::class);
@@ -104,15 +109,12 @@ class ContentTypeTest extends TestCase
         $this->dataProviderPool = new DataProviderPool(true);
         $this->dataProviderPool->add('pages', $this->pageDataProvider->reveal());
 
-        $this->tagManager = $this->getMockForAbstractClass(
-            TagManagerInterface::class,
-            [],
-            '',
-            false,
-            true,
-            true,
-            ['resolveTagIds', 'resolveTagName']
-        );
+        $this->tagManager = $this->prophesize(TagManagerInterface::class);
+        $this->tagManager->resolveTagIds([1, 2])->willReturn(['Tag1', 'Tag2']);
+
+        $this->tagManager->resolveTagNames(['Tag1', 'Tag2'])->willReturn([1, 2]);
+        $this->tagManager->resolveTagNames(['Tag1'])->willReturn([1]);
+        $this->tagManager->resolveTagNames(['Tag2'])->willReturn([2]);
 
         $this->requestStack = $this->getMockBuilder(RequestStack::class)->getMock();
         $this->request = $this->getMockBuilder(Request::class)->getMock();
@@ -127,26 +129,24 @@ class ContentTypeTest extends TestCase
         $this->categoryRequestHandler = $this->prophesize(CategoryRequestHandlerInterface::class);
         $this->categoryRequestHandler->getCategories('categories')->willReturn([]);
 
-        $this->tagManager->expects($this->any())->method('resolveTagIds')->willReturnMap(
-            [
-                [[1, 2], ['Tag1', 'Tag2']],
-            ]
-        );
-
-        $this->tagManager->expects($this->any())->method('resolveTagNames')->willReturnMap(
-            [
-                [['Tag1', 'Tag2'], [1, 2]],
-                [['Tag1'], [1]],
-                [['Tag2'], [2]],
-            ]
-        );
-
         $this->targetGroupStore = $this->prophesize(TargetGroupStoreInterface::class);
 
         $this->categoryReferenceStore = $this->prophesize(ReferenceStoreInterface::class);
         $this->tagReferenceStore = $this->prophesize(ReferenceStoreInterface::class);
 
         $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+
+        $this->smartContent = new SmartContent(
+            $this->dataProviderPool,
+            $this->tagManager->reveal(),
+            $this->requestStack,
+            $this->tagRequestHandler->reveal(),
+            $this->categoryRequestHandler->reveal(),
+            $this->categoryReferenceStore->reveal(),
+            $this->tagReferenceStore->reveal(),
+            null,
+            $this->requestAnalyzer->reveal()
+        );
     }
 
     private function getProviderConfiguration()
@@ -163,41 +163,9 @@ class ContentTypeTest extends TestCase
 
     public function testWrite(): void
     {
-        $smartContent = new SmartContent(
-            $this->dataProviderPool,
-            $this->tagManager,
-            $this->requestStack,
-            $this->tagRequestHandler->reveal(),
-            $this->categoryRequestHandler->reveal(),
-            $this->categoryReferenceStore->reveal(),
-            $this->tagReferenceStore->reveal(),
-            null,
-            $this->requestAnalyzer->reveal()
-        );
-
-        $node = $this->getMockForAbstractClass(
-            NodeInterface::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['setProperty']
-        );
-
-        $property = $this->getMockForAbstractClass(
-            PropertyInterface::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['getValue']
-        );
-
-        $property->expects($this->any())->method('getName')->willReturn('property');
-
-        $property->expects($this->any())->method('getValue')->willReturn(
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getName()->willReturn('property');
+        $property->getValue()->willReturn(
             [
                 'dataSource' => [
                     'home/products',
@@ -208,7 +176,8 @@ class ContentTypeTest extends TestCase
             ]
         );
 
-        $node->expects($this->once())->method('setProperty')->with(
+        $node = $this->prophesize(NodeInterface::class);
+        $node->setProperty(
             'property',
             \json_encode(
                 [
@@ -220,101 +189,42 @@ class ContentTypeTest extends TestCase
                     ],
                 ]
             )
-        );
+        )->shouldBeCalled();
 
-        $smartContent->write($node, $property, 0, 'test', 'en', 's');
+        $this->smartContent->write($node->reveal(), $property->reveal(), 0, 'test', 'en', 's');
     }
 
     public function testRead(): void
     {
-        $smartContent = new SmartContent(
-            $this->dataProviderPool,
-            $this->tagManager,
-            $this->requestStack,
-            $this->tagRequestHandler->reveal(),
-            $this->categoryRequestHandler->reveal(),
-            $this->categoryReferenceStore->reveal(),
-            $this->tagReferenceStore->reveal(),
-            null,
-            $this->requestAnalyzer->reveal()
-        );
-
         $config = [
             'tags' => ['Tag1', 'Tag2'],
             'limitResult' => '2',
         ];
 
-        $node = $this->getMockForAbstractClass(
-            NodeInterface::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['getPropertyValueWithDefault']
-        );
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getPropertyValueWithDefault('property', '{}')->willReturn('{"tags":[1,2],"limitResult":"2"}');
 
-        $property = $this->getMockForAbstractClass(
-            PropertyInterface::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['setValue']
-        );
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getName()->willReturn('property');
+        $property->getParams()->willReturn(['properties' => ['my_title' => 'title']]);
 
-        $node->expects($this->any())->method('getPropertyValueWithDefault')->willReturnMap(
-            [
-                ['property', '{}', '{"tags":[1,2],"limitResult":"2"}'],
-            ]
-        );
+        $property->setValue($config)->shouldBeCalledTimes(1);
 
-        $property->expects($this->any())->method('getName')->willReturn('property');
-        $property->expects($this->any())->method('getParams')->willReturn(
-            ['properties' => ['my_title' => 'title']]
-        );
-
-        $property->expects($this->exactly(1))->method('setValue')->with($config);
-
-        $smartContent->read($node, $property, 'test', 'en', 's');
+        $this->smartContent->read($node->reveal(), $property->reveal(), 'test', 'en', 's');
     }
 
     public function testGetViewData(): void
     {
-        $smartContent = new SmartContent(
-            $this->dataProviderPool,
-            $this->tagManager,
-            $this->requestStack,
-            $this->tagRequestHandler->reveal(),
-            $this->categoryRequestHandler->reveal(),
-            $this->categoryReferenceStore->reveal(),
-            $this->tagReferenceStore->reveal(),
-            null,
-            $this->requestAnalyzer->reveal()
-        );
-
-        $property = $this->getMockForAbstractClass(
-            PropertyInterface::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['getValue', 'getParams']
-        );
         $structure = $this->prophesize(StructureInterface::class);
 
         $config = ['dataSource' => 'some-uuid'];
         $parameter = ['max_per_page' => new PropertyParameter('max_per_page', '5')];
 
-        $property->expects($this->any())->method('getValue')
-            ->willReturn(\array_merge($config, ['page' => 1, 'hasNextPage' => true]));
-
-        $property->expects($this->any())->method('getParams')
-            ->willReturn($parameter);
-        $property->expects($this->exactly(2))->method('getStructure')
-            ->willReturn($structure->reveal());
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getValue()->shouldBeCalled()->willReturn(\array_merge($config, ['page' => 1, 'hasNextPage' => true]));
+        $property->getParams()->shouldBeCalled()->willReturn($parameter);
+        $property->getStructure()->shouldBeCalledTimes(2)->willReturn($structure->reveal());
+        $property->setValue(Argument::any())->willReturn(null);
 
         $this->pageDataProvider->resolveResourceItems(
             [
@@ -388,7 +298,7 @@ class ContentTypeTest extends TestCase
             ->with($this->equalTo('p'))
             ->willReturn(1);
 
-        $viewData = $smartContent->getViewData($property);
+        $viewData = $this->smartContent->getViewData($property->reveal());
 
         $expectedViewData = \array_merge($config, ['page' => 1, 'hasNextPage' => true]);
 
@@ -400,18 +310,6 @@ class ContentTypeTest extends TestCase
 
     public function testGetContentData(): void
     {
-        $smartContent = new SmartContent(
-            $this->dataProviderPool,
-            $this->tagManager,
-            $this->requestStack,
-            $this->tagRequestHandler->reveal(),
-            $this->categoryRequestHandler->reveal(),
-            $this->categoryReferenceStore->reveal(),
-            $this->tagReferenceStore->reveal(),
-            null,
-            $this->requestAnalyzer->reveal()
-        );
-
         $property = $this->getContentDataProperty(
             [
                 'dataSource' => '123-123-123',
@@ -430,7 +328,7 @@ class ContentTypeTest extends TestCase
         $this->tagReferenceStore->add(1)->shouldBeCalled();
         $this->tagReferenceStore->add(2)->shouldBeCalled();
 
-        $pageData = $smartContent->getContentData($property);
+        $pageData = $this->smartContent->getContentData($property);
 
         $this->assertEquals(
             [
@@ -447,18 +345,6 @@ class ContentTypeTest extends TestCase
 
     public function testGetContentDataNullTagsCategories(): void
     {
-        $smartContent = new SmartContent(
-            $this->dataProviderPool,
-            $this->tagManager,
-            $this->requestStack,
-            $this->tagRequestHandler->reveal(),
-            $this->categoryRequestHandler->reveal(),
-            $this->categoryReferenceStore->reveal(),
-            $this->tagReferenceStore->reveal(),
-            null,
-            $this->requestAnalyzer->reveal()
-        );
-
         $property = $this->getContentDataProperty(
             [
                 'dataSource' => '123-123-123',
@@ -467,7 +353,7 @@ class ContentTypeTest extends TestCase
             ]
         );
 
-        $pageData = $smartContent->getContentData($property);
+        $pageData = $this->smartContent->getContentData($property);
 
         $this->assertEquals(
             [
@@ -484,40 +370,20 @@ class ContentTypeTest extends TestCase
 
     public function testGetContentDataPaged(): void
     {
-        $smartContent = new SmartContent(
-            $this->dataProviderPool,
-            $this->tagManager,
-            $this->requestStack,
-            $this->tagRequestHandler->reveal(),
-            $this->categoryRequestHandler->reveal(),
-            $this->categoryReferenceStore->reveal(),
-            $this->tagReferenceStore->reveal(),
-            null,
-            $this->requestAnalyzer->reveal()
-        );
-
-        $property = $this->getMockForAbstractClass(
-            PropertyInterface::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['getValue', 'getParams']
-        );
         $structure = $this->prophesize(StructureInterface::class);
 
         $this->request->expects($this->any())->method('get')
             ->with($this->equalTo('p'))
             ->willReturn(1);
 
-        $property->expects($this->exactly(1))->method('getValue')
-            ->willReturn(['dataSource' => '123-123-123']);
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getValue()->willReturn(['dataSource' => '123-123-123']);
 
-        $property->expects($this->any())->method('getParams')
-            ->willReturn(['max_per_page' => new PropertyParameter('max_per_page', '5')]);
-        $property->expects($this->exactly(2))->method('getStructure')
-            ->willReturn($structure->reveal());
+        $property->getParams()
+            ->willReturn(['max_per_page' => new PropertyParameter('max_per_page', '5')])
+            ->shouldBeCalledTimes(3);
+        $property->getStructure()->willReturn($structure->reveal())->shouldBeCalledTimes(2);
+        $property->setValue(Argument::any())->shouldBeCalled();
 
         $this->pageDataProvider->resolveResourceItems(
             [
@@ -585,7 +451,7 @@ class ContentTypeTest extends TestCase
         $structure->getUuid()->willReturn('123-123-123');
         $structure->getLanguageCode()->willReturn('de');
 
-        $pageData = $smartContent->getContentData($property);
+        $pageData = $this->smartContent->getContentData($property->reveal());
 
         $this->assertEquals([1, 2, 3, 4, 5], $pageData);
     }
@@ -619,27 +485,7 @@ class ContentTypeTest extends TestCase
         $expectedData,
         $hasNextPage
     ): void {
-        $smartContent = new SmartContent(
-            $this->dataProviderPool,
-            $this->tagManager,
-            $this->requestStack,
-            $this->tagRequestHandler->reveal(),
-            $this->categoryRequestHandler->reveal(),
-            $this->categoryReferenceStore->reveal(),
-            $this->tagReferenceStore->reveal(),
-            null,
-            $this->requestAnalyzer->reveal()
-        );
-
-        $property = $this->getMockForAbstractClass(
-            PropertyInterface::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['getValue', 'getParams']
-        );
+        $property = $this->prophesize(PropertyInterface::class);
         $structure = $this->prophesize(StructureInterface::class);
 
         $this->request->expects($this->any())->method('get')
@@ -706,12 +552,10 @@ class ContentTypeTest extends TestCase
             null
         )->willReturn(new DataProviderResult($expectedData, $hasNextPage));
 
-        $property->expects($this->exactly(1))->method('getValue')
-            ->willReturn($config);
-        $property->expects($this->any())->method('getParams')
-            ->willReturn(['max_per_page' => new PropertyParameter('max_per_page', $pageSize)]);
-        $property->expects($this->exactly(2))->method('getStructure')
-            ->willReturn($structure->reveal());
+        $property->getValue()->willReturn($config)->shouldBeCalled();
+        $property->getParams()->willReturn(['max_per_page' => new PropertyParameter('max_per_page', $pageSize)]);
+        $property->getStructure()->willReturn($structure->reveal())->shouldBeCalledTimes(2);
+        $property->setValue(Argument::any())->shouldBeCalled();
 
         $webspace = new Webspace();
         $webspace->setKey('sulu_io');
@@ -722,7 +566,7 @@ class ContentTypeTest extends TestCase
         $structure->getUuid()->willReturn($uuid);
         $structure->getLanguageCode()->willReturn('de');
 
-        $pageData = $smartContent->getContentData($property);
+        $pageData = $this->smartContent->getContentData($property->reveal());
         $this->assertEquals($expectedData, $pageData);
     }
 
@@ -737,27 +581,6 @@ class ContentTypeTest extends TestCase
         $expectedData,
         $hasNextPage
     ): void {
-        $smartContent = new SmartContent(
-            $this->dataProviderPool,
-            $this->tagManager,
-            $this->requestStack,
-            $this->tagRequestHandler->reveal(),
-            $this->categoryRequestHandler->reveal(),
-            $this->categoryReferenceStore->reveal(),
-            $this->tagReferenceStore->reveal(),
-            null,
-            $this->requestAnalyzer->reveal()
-        );
-
-        $property = $this->getMockForAbstractClass(
-            PropertyInterface::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['getValue', 'getParams']
-        );
         $structure = $this->prophesize(StructureInterface::class);
 
         $this->request->expects($this->any())->method('get')
@@ -826,13 +649,11 @@ class ContentTypeTest extends TestCase
             null
         )->willReturn(new DataProviderResult($expectedData, $hasNextPage));
 
-        $property->expects($this->any())->method('getValue')
-            ->willReturn(\array_merge($config, ['page' => $page, 'hasNextPage' => $hasNextPage]));
-
-        $property->expects($this->any())->method('getParams')
-            ->willReturn(['max_per_page' => new PropertyParameter('max_per_page', $pageSize)]);
-        $property->expects($this->exactly(2))->method('getStructure')
-            ->willReturn($structure->reveal());
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getValue()->willReturn(\array_merge($config, ['page' => $page, 'hasNextPage' => $hasNextPage]));
+        $property->getParams()->willReturn(['max_per_page' => new PropertyParameter('max_per_page', $pageSize)]);
+        $property->getStructure()->willReturn($structure->reveal())->shouldBeCalled();
+        $property->setValue(Argument::any())->shouldBeCalled();
 
         $webspace = new Webspace();
         $webspace->setKey('sulu_io');
@@ -843,7 +664,7 @@ class ContentTypeTest extends TestCase
         $structure->getUuid()->willReturn($uuid);
         $structure->getLanguageCode()->willReturn('de');
 
-        $viewData = $smartContent->getViewData($property);
+        $viewData = $this->smartContent->getViewData($property->reveal());
         $this->assertEquals(
             \array_merge(
                 [
@@ -871,25 +692,13 @@ class ContentTypeTest extends TestCase
 
     private function getContentDataProperty($value = ['dataSource' => '123-123-123'])
     {
-        $property = $this->getMockForAbstractClass(
-            PropertyInterface::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['getValue', 'getParams']
-        );
         $structure = $this->prophesize(StructureInterface::class);
 
-        $property->expects($this->exactly(1))->method('getValue')
-            ->willReturn($value);
-
-        $property->expects($this->any())->method('getParams')
-            ->willReturn([]);
-
-        $property->expects($this->any())->method('getStructure')
-            ->willReturn($structure->reveal());
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getValue()->shouldBeCalled()->willReturn($value);
+        $property->getParams()->shouldBeCalled()->willReturn([]);
+        $property->getStructure()->shouldBeCalled()->willReturn($structure->reveal());
+        $property->setValue(Argument::any())->willReturn(null);
 
         $this->pageDataProvider->resolveResourceItems(
             [
@@ -968,29 +777,18 @@ class ContentTypeTest extends TestCase
         $structure->getUuid()->willReturn('123-123-123');
         $structure->getLanguageCode()->willReturn('de');
 
-        return $property;
+        return $property->reveal();
     }
 
     public function testGetContentDataWithActivatedAudienceTargeting(): void
     {
-        $smartContent = new SmartContent(
-            $this->dataProviderPool,
-            $this->tagManager,
-            $this->requestStack,
-            $this->tagRequestHandler->reveal(),
-            $this->categoryRequestHandler->reveal(),
-            $this->categoryReferenceStore->reveal(),
-            $this->tagReferenceStore->reveal(),
-            $this->targetGroupStore->reveal(),
-            $this->requestAnalyzer->reveal()
-        );
-
         $property = $this->prophesize(PropertyInterface::class);
         $property->getParams()->willReturn([
             'provider' => new PropertyParameter('provider', 'pages'),
         ]);
         $property->getValue()->willReturn([
             'audienceTargeting' => true,
+            'targetGroupId' => 1,
         ]);
 
         $structure = $this->prophesize(StructureInterface::class);
@@ -1004,7 +802,7 @@ class ContentTypeTest extends TestCase
 
         $this->targetGroupStore->getTargetGroupId()->willReturn(1);
         $this->pageDataProvider->resolveResourceItems(
-            Argument::that(function($value) {
+            Argument::that(function(array $value) {
                 return 1 === $value['targetGroupId'];
             }),
             Argument::cetera(),
@@ -1015,23 +813,11 @@ class ContentTypeTest extends TestCase
             return 1 === $value['targetGroupId'];
         }))->shouldBeCalled();
 
-        $smartContent->getContentData($property->reveal());
+        $this->smartContent->getContentData($property->reveal());
     }
 
     public function testGetContentDataWithDeactivatedAudienceTargeting(): void
     {
-        $smartContent = new SmartContent(
-            $this->dataProviderPool,
-            $this->tagManager,
-            $this->requestStack,
-            $this->tagRequestHandler->reveal(),
-            $this->categoryRequestHandler->reveal(),
-            $this->categoryReferenceStore->reveal(),
-            $this->tagReferenceStore->reveal(),
-            $this->targetGroupStore->reveal(),
-            $this->requestAnalyzer->reveal()
-        );
-
         $property = $this->prophesize(PropertyInterface::class);
         $property->getParams()->willReturn([
             'provider' => new PropertyParameter('provider', 'pages'),
@@ -1062,23 +848,11 @@ class ContentTypeTest extends TestCase
             return !\array_key_exists('targetGroupId', $value);
         }))->shouldBeCalled();
 
-        $smartContent->getContentData($property->reveal());
+        $this->smartContent->getContentData($property->reveal());
     }
 
     public function testGetContentDataWithSegmentKey(): void
     {
-        $smartContent = new SmartContent(
-            $this->dataProviderPool,
-            $this->tagManager,
-            $this->requestStack,
-            $this->tagRequestHandler->reveal(),
-            $this->categoryRequestHandler->reveal(),
-            $this->categoryReferenceStore->reveal(),
-            $this->tagReferenceStore->reveal(),
-            $this->targetGroupStore->reveal(),
-            $this->requestAnalyzer->reveal()
-        );
-
         $webspace = new Webspace();
         $webspace->setKey('sulu_io');
         $this->requestAnalyzer->getWebspace()->willReturn($webspace);
@@ -1108,6 +882,6 @@ class ContentTypeTest extends TestCase
             return 's' === $value['segmentKey'];
         }))->shouldBeCalled();
 
-        $smartContent->getContentData($property->reveal());
+        $this->smartContent->getContentData($property->reveal());
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes (in the tests)
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #7507 
 | License | MIT
| Documentation PR | -

#### What's in this PR?
Replacing calls to `getMockForAbstractClass` with implementation or prophecy.

#### Why?
PHPUnit 11 suport
