### PR TITLE
Add forcing direct matching for media image format urls

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,8 +4,8 @@
 
 ### Stricter Image Format Url Handling
 
-The image formats url need a direct match of filename to get the image format returned.
-Old versions will be redirected to the new version and none direct matches return 404 now.
+The image formats URL requires an exact filename match to retrieve the correct image format. 
+Old versions will be redirected to the new version and any non-matching filenames will now return a 404 error.
 
 ## 2.5.15
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,12 @@
 # Upgrade
 
+## 2.5.20
+
+### Stricter Image Format Url Handling
+
+The image formats url need a direct match of filename to get the image format returned.
+Old versions will be redirected to the new version and none direct matches return 404 now.
+
 ## 2.5.15
 
 ### Run Shadow migrations

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13766,6 +13766,11 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
 
 		-
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\FormatManager\\\\FormatManagerInterface\\:\\:returnImage\\(\\) invoked with 4 parameters, 3 required\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
+
+		-
 			message: "#^Parameter \\#1 \\$storageOptions of method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Storage\\\\StorageInterface\\:\\:getPath\\(\\) expects array\\<string, string\\|null\\>, array given\\.$#"
 			count: 2
 			path: src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
@@ -14646,11 +14651,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Media/FormatCache/LocalFormatCache.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\FormatCache\\\\LocalFormatCache\\:\\:getIdFromUrl\\(\\) should return int but returns string\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Media/FormatCache/LocalFormatCache.php
-
-		-
 			message: "#^Parameter \\#1 \\$string of function strlen expects string, int given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Media/FormatCache/LocalFormatCache.php
@@ -14884,6 +14884,11 @@ parameters:
 			message: "#^Parameter \\#1 \\$node of method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\FormatLoader\\\\BaseXmlFormatLoader\\:\\:getParametersFromNode\\(\\) expects DOMNode, DOMNode\\|null given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader11.php
+
+		-
+			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Entity\\\\MediaRepositoryInterface\\:\\:findMediaByIdForRendering\\(\\) invoked with 3 parameters, 2 required\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\FormatManager\\\\FormatManager\\:\\:__construct\\(\\) has parameter \\$formats with no value type specified in iterable type array\\.$#"

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
@@ -61,13 +61,18 @@ class MediaStreamController
             }
 
             $url = $request->getPathInfo();
+            // there are some projects which do not call this actionw ith ?v=1-0 because of they didn't wanted query strings in the image urls ( unnecessary SEO mystic reasons )
+            // to not break this projects we will fallback to 1-0 if no version is given
+            $version = (string) $request->query->get('v', '1-0');
+            $version = (int) (\explode('-', $version)[0] ?? '1');
 
             $mediaProperties = $this->formatCache->analyzedMediaUrl($url);
 
             return $this->formatManager->returnImage(
-                $mediaProperties['id'],
+                (int) $mediaProperties['id'],
                 $mediaProperties['format'],
-                $mediaProperties['fileName']
+                $mediaProperties['fileName'],
+                $version,
             );
         } catch (ImageProxyException $e) {
             throw new NotFoundHttpException('Image create error. Code: ' . $e->getCode(), $e);

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
@@ -61,7 +61,7 @@ class MediaStreamController
             }
 
             $url = $request->getPathInfo();
-            // there are some projects which do not call this actionw ith ?v=1-0 because of they didn't wanted query strings in the image urls ( unnecessary SEO mystic reasons )
+            // there are some projects which do not call this action with ?v=1-0 because of they didn't wanted query strings in the image urls ( unnecessary SEO mystic reasons )
             // to not break this projects we will fallback to 1-0 if no version is given
             $version = (string) $request->query->get('v', '1-0');
             $version = (int) (\explode('-', $version)[0] ?? '1');
@@ -69,7 +69,7 @@ class MediaStreamController
             $mediaProperties = $this->formatCache->analyzedMediaUrl($url);
 
             return $this->formatManager->returnImage(
-                (int) $mediaProperties['id'],
+                $mediaProperties['id'],
                 $mediaProperties['format'],
                 $mediaProperties['fileName'],
                 $version,

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
@@ -61,8 +61,8 @@ class MediaStreamController
             }
 
             $url = $request->getPathInfo();
-            // there are some projects which do not call this action with ?v=1-0 because of they didn't wanted query strings in the image urls ( unnecessary SEO mystic reasons )
-            // to not break this projects we will fallback to 1-0 if no version is given
+            // Some projects do not call this action with ?v=1-0 because they don't want query strings in the image urls ( unnecessary SEO mystic reasons )
+            // To maintain compatibility with these projects, we will fallback to version 1-0 if no version is specified.
             $version = (string) $request->query->get('v', '1-0');
             $version = (int) (\explode('-', $version)[0] ?? '1');
 

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatCache/LocalFormatCache.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatCache/LocalFormatCache.php
@@ -206,6 +206,13 @@ class LocalFormatCache implements FormatCacheInterface
      */
     protected function getFileNameFromUrl($url)
     {
-        return \basename($url);
+        $fileNameParts = \explode('-', \basename($url), 2); // the basename is {id}-{filename}
+        $fileName = $fileNameParts[1] ?? ull;
+
+        if (null === $fileName) {
+            throw new ImageProxyInvalidUrl('No `filename` was found in the url');
+        }
+
+        return $fileName;
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatCache/LocalFormatCache.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatCache/LocalFormatCache.php
@@ -158,7 +158,7 @@ class LocalFormatCache implements FormatCacheInterface
             throw new ImageProxyInvalidUrl('The founded `id` was not a valid integer');
         }
 
-        return $id;
+        return (int) $id;
     }
 
     /**
@@ -207,7 +207,7 @@ class LocalFormatCache implements FormatCacheInterface
     protected function getFileNameFromUrl($url)
     {
         $fileNameParts = \explode('-', \basename($url), 2); // the basename is {id}-{filename}
-        $fileName = $fileNameParts[1] ?? ull;
+        $fileName = $fileNameParts[1] ?? null;
 
         if (null === $fileName) {
             throw new ImageProxyInvalidUrl('No `filename` was found in the url');

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
@@ -96,8 +96,6 @@ class FormatManager implements FormatManagerInterface
 
             $media = $this->mediaRepository->findMediaByIdForRendering($id, $formatKey, $version);
 
-            $fileVersion = $this->getLatestFileVersion($media);
-
             if (!$media) {
                 throw new ImageProxyMediaNotFoundException('Media was not found');
             }
@@ -121,6 +119,7 @@ class FormatManager implements FormatManagerInterface
 
             if ($fileVersion->getVersion() !== $requestedFileVersion->getVersion()) {
                 $formats = $this->getFormats($id, $fileVersion->getName(), $fileVersion->getVersion(), $fileVersion->getSubVersion(), $fileVersion->getMimeType());
+
                 $formatUrl = $formats[$formatKey . '.' . $imageFormat] ?? null;
                 if (null === $formatUrl) {
                     throw new ImageProxyMediaNotFoundException('Image format "' . $formatKey . '.' . $imageFormat . '" was not found');

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
@@ -96,6 +96,8 @@ class FormatManager implements FormatManagerInterface
 
             $media = $this->mediaRepository->findMediaByIdForRendering($id, $formatKey, $version);
 
+            $fileVersion = $this->getLatestFileVersion($media);
+
             if (!$media) {
                 throw new ImageProxyMediaNotFoundException('Media was not found');
             }

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManagerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManagerInterface.php
@@ -35,7 +35,7 @@ interface FormatManagerInterface
      *
      * @return Response
      */
-    public function returnImage($id, $formatKey, $imageFormat);
+    public function returnImage($id, $formatKey, $imageFormat /*, int<1, max>|null $version = null */);
 
     /**
      * @param int $id

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatManager/FormatManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatManager/FormatManagerTest.php
@@ -124,20 +124,25 @@ class FormatManagerTest extends TestCase
         $file->addFileVersion($fileVersion);
         $media->addFile($file);
 
-        $this->mediaRepository->findMediaByIdForRendering(1, '640x480')->willReturn($media);
+        $this->mediaRepository->findMediaByIdForRendering(1, '640x480', 1)
+            ->willReturn($media)
+            ->shouldBeCalled();
 
         $this->imageConverter->getSupportedOutputImageFormats(Argument::any())->willReturn(['jpg', 'png', 'gif'])->shouldBeCalled();
-        $this->imageConverter->convert($fileVersion, '640x480', 'gif')->willReturn("\x47\x49\x46\x38image-content");
+        $this->imageConverter->convert($fileVersion, '640x480', 'gif')->willReturn("\x47\x49\x46\x38image-content")->shouldBeCalled();
 
         $this->formatCache->save(
             "\x47\x49\x46\x38image-content",
             1,
             'dummy.gif',
             '640x480'
-        )->willReturn(null);
+        )
+            ->willReturn(null)
+            ->shouldBeCalled();
 
-        $result = $this->formatManager->returnImage(1, '640x480', 'test.gif');
+        $result = $this->formatManager->returnImage(1, '640x480', 'dummy.gif', 1);
 
+        $this->assertSame(200, $result->getStatusCode());
         $this->assertEquals("\x47\x49\x46\x38image-content", $result->getContent());
         $this->assertEquals(200, $result->getStatusCode());
     }
@@ -160,19 +165,28 @@ class FormatManagerTest extends TestCase
         $file->addFileVersion($fileVersion);
         $media->addFile($file);
 
-        $this->mediaRepository->findMediaByIdForRendering(1, '640x480')->willReturn($media);
+        $this->mediaRepository->findMediaByIdForRendering(
+            1,
+            '640x480',
+            1
+        )
+            ->willReturn($media)
+            ->shouldBeCalled();
 
         $this->imageConverter->getSupportedOutputImageFormats(Argument::any())->willReturn(['jpg', 'png', 'gif'])->shouldBeCalled();
-        $this->imageConverter->convert($fileVersion, '640x480', 'jpg')->willReturn('image-content');
+        $this->imageConverter->convert($fileVersion, '640x480', 'jpg')->willReturn('image-content')->shouldBeCalled();
 
         $this->formatCache->save(
             'image-content',
             1,
             'dummy.jpg',
             '640x480'
-        )->willReturn(null);
+        )
+            ->willReturn(null)
+            ->shouldBeCalled()
+        ;
 
-        $result = $this->formatManager->returnImage(1, '640x480', 'test.jpg');
+        $result = $this->formatManager->returnImage(1, '640x480', 'dummy.jpg', 1);
 
         $this->assertEquals('image-content', $result->getContent());
         $this->assertEquals(200, $result->getStatusCode());

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatManager/FormatManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatManager/FormatManagerTest.php
@@ -188,8 +188,91 @@ class FormatManagerTest extends TestCase
 
         $result = $this->formatManager->returnImage(1, '640x480', 'dummy.jpg', 1);
 
+        $this->assertSame(200, $result->getStatusCode());
         $this->assertEquals('image-content', $result->getContent());
         $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testReturnNewFileVersion(): void
+    {
+        $media = new Media();
+        $reflection = new \ReflectionClass(\get_class($media));
+        $property = $reflection->getProperty('id');
+        $property->setAccessible(true);
+        $property->setValue($media, 1);
+
+        $file = new File();
+        $file->setVersion(2);
+        $fileVersion = new FileVersion();
+        $fileVersion->setVersion(1);
+        $fileVersion->setName('dummy.gif');
+        $fileVersion->setMimeType('image/gif');
+        $fileVersion->setStorageOptions(['a' => 'b']);
+        $file->addFileVersion($fileVersion);
+        $fileVersion2 = new FileVersion();
+        $fileVersion2->setVersion(2);
+        $fileVersion2->setName('test.gif');
+        $fileVersion2->setMimeType('image/gif');
+        $fileVersion2->setStorageOptions(['a' => 'b2']);
+        $file->addFileVersion($fileVersion2);
+        $media->addFile($file);
+
+        $this->mediaRepository->findMediaByIdForRendering(1, '640x480', 1)
+            ->willReturn($media)
+            ->shouldBeCalled();
+
+        $this->imageConverter->getSupportedOutputImageFormats(Argument::cetera())->willReturn(['jpg', 'png', 'gif'])->shouldBeCalled();
+        $this->formatCache->getMediaUrl(Argument::cetera())->will(function ($args) {
+            return '/' . $args[2] . '/' . $args[0] . '-' . $args[1] . '?v=' . $args[3] . '-' . $args[4];
+        })->shouldBeCalled();
+        $this->imageConverter->convert(Argument::cetera())->shouldNotBeCalled();
+        $this->formatCache->save(Argument::cetera())->shouldNotBeCalled();
+
+        $result = $this->formatManager->returnImage(1, '640x480', 'dummy.gif', 1);
+
+        $this->assertSame(301, $result->getStatusCode());
+        $this->assertSame('/640x480/1-test.gif?v=2-0', $result->headers->get('location'));
+    }
+
+    public function testReturnNewFileVersionWebp(): void
+    {
+        $media = new Media();
+        $reflection = new \ReflectionClass(\get_class($media));
+        $property = $reflection->getProperty('id');
+        $property->setAccessible(true);
+        $property->setValue($media, 1);
+
+        $file = new File();
+        $file->setVersion(2);
+        $fileVersion = new FileVersion();
+        $fileVersion->setVersion(1);
+        $fileVersion->setName('dummy.gif');
+        $fileVersion->setMimeType('image/gif');
+        $fileVersion->setStorageOptions(['a' => 'b']);
+        $file->addFileVersion($fileVersion);
+        $fileVersion2 = new FileVersion();
+        $fileVersion2->setVersion(2);
+        $fileVersion2->setName('test.gif');
+        $fileVersion2->setMimeType('image/gif');
+        $fileVersion2->setStorageOptions(['a' => 'b2']);
+        $file->addFileVersion($fileVersion2);
+        $media->addFile($file);
+
+        $this->mediaRepository->findMediaByIdForRendering(1, '640x480', 1)
+            ->willReturn($media)
+            ->shouldBeCalled();
+
+        $this->imageConverter->getSupportedOutputImageFormats(Argument::cetera())->willReturn(['jpg', 'png', 'gif', 'webp'])->shouldBeCalled();
+        $this->formatCache->getMediaUrl(Argument::cetera())->will(function ($args) {
+            return '/' . $args[2] . '/' . $args[0] . '-' . $args[1] . '?v=' . $args[3] . '-' . $args[4];
+        })->shouldBeCalled();
+        $this->imageConverter->convert(Argument::cetera())->shouldNotBeCalled();
+        $this->formatCache->save(Argument::cetera())->shouldNotBeCalled();
+
+        $result = $this->formatManager->returnImage(1, '640x480', 'dummy.webp', 1);
+
+        $this->assertSame(301, $result->getStatusCode());
+        $this->assertSame('/640x480/1-test.webp?v=2-0', $result->headers->get('location'));
     }
 
     public function testGetFormats(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no 
| Deprecations? | yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add direct matching for media image format urls.

#### Why?

Old Version Urls will rerendering the image format which can end up in high resources usage. So instead we are redirecting old version to new versions which should normally end in a cache hit.

As reported by one of our partners to improve traffic on their projects.

#### To Do

- [x] Test for redirect to new version
- [x] Test for redirect to new version on webp
- [x] Test for 404 for not matching file  name
