### PR TITLE
Add forcing direct matching for media download urls

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
@@ -81,10 +81,11 @@ class MediaStreamController
 
     /**
      * @param int $id
+     * @param string $slug
      *
      * @return Response
      */
-    public function downloadAction(Request $request, $id)
+    public function downloadAction(Request $request, $id, $slug)
     {
         try {
             if (\ob_get_length()) {
@@ -98,7 +99,11 @@ class MediaStreamController
             $fileVersion = $this->getFileVersion($id, $version);
 
             if (!$fileVersion) {
-                return new Response(null, 404);
+                return new Response('Invalid version "' . $version . '" for media with ID "' . $id . '".', 404);
+            }
+
+            if ($fileVersion->getName() !== $slug) {
+                return new Response('Invalid file name "' . $slug . '" for media with ID "' . $id . '".', 404);
             }
 
             if ($this->securityChecker) {

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
@@ -381,7 +381,7 @@ class MediaControllerTest extends SuluTestCase
      */
     public function test404ResponseHeader(): void
     {
-        $this->client->jsonRequest(
+        $this->client->request(
             'GET',
             '/uploads/media/50x50/1/0-photo.jpg'
         );
@@ -399,9 +399,9 @@ class MediaControllerTest extends SuluTestCase
         $media = $this->createMedia('photo');
 
         \ob_start();
-        $this->client->jsonRequest(
+        $this->client->request(
             'GET',
-            '/media/' . $media->getId() . '/download/photo.jpg'
+            '/media/' . $media->getId() . '/download/photo.jpeg'
         );
         \ob_end_clean();
         $this->assertEquals(
@@ -418,9 +418,9 @@ class MediaControllerTest extends SuluTestCase
         $media = $this->createMedia('photo');
 
         \ob_start();
-        $this->client->jsonRequest(
+        $this->client->request(
             'GET',
-            '/media/' . $media->getId() . '/download/photo.jpg?inline=1'
+            '/media/' . $media->getId() . '/download/photo.jpeg?inline=1'
         );
         \ob_end_clean();
         $this->assertEquals(
@@ -437,7 +437,7 @@ class MediaControllerTest extends SuluTestCase
         $media = $this->createMedia('wöchentlich');
 
         \ob_start();
-        $this->client->jsonRequest(
+        $this->client->request(
             'GET',
             '/media/' . $media->getId() . '/download/wöchentlich.jpeg?inline=1'
         );

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaStreamControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaStreamControllerTest.php
@@ -43,9 +43,19 @@ class MediaStreamControllerTest extends WebsiteTestCase
         $filePath = $this->createMediaFile('test.jpg');
         $media = $this->createMedia($filePath, 'file-without-extension');
 
-        $this->client->jsonRequest('GET', $media->getUrl());
+        $this->client->request('GET', $media->getUrl());
         $response = $this->client->getResponse();
         $this->assertHttpStatusCode(200, $response);
+    }
+
+    public function testDownloadActionNotMatchingFileName(): void
+    {
+        $filePath = $this->createMediaFile('test.jpg');
+        $media = $this->createMedia($filePath, 'test.jpg');
+
+        $this->client->request('GET', \str_replace('test.jpg', 'other.jpg', $media->getUrl()));
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(404, $response);
     }
 
     public function testNotExistVersionDownloadAction(): void
@@ -53,7 +63,7 @@ class MediaStreamControllerTest extends WebsiteTestCase
         $filePath = $this->createMediaFile('test.jpg');
         $media = $this->createMedia($filePath, 'file-without-extension');
 
-        $this->client->jsonRequest('GET', \str_replace('v=1', 'v=99', $media->getUrl()));
+        $this->client->request('GET', \str_replace('v=1', 'v=99', $media->getUrl()));
         $response = $this->client->getResponse();
         $this->assertHttpStatusCode(404, $response);
     }
@@ -92,7 +102,7 @@ class MediaStreamControllerTest extends WebsiteTestCase
         $filePath = $this->createMediaFile('file-without-extension');
         $media = $this->createMedia($filePath, 'File without Extension');
 
-        $this->client->jsonRequest('GET', $media->getUrl());
+        $this->client->request('GET', $media->getUrl());
         $response = $this->client->getResponse();
         $this->assertHttpStatusCode(200, $response);
     }
@@ -102,7 +112,7 @@ class MediaStreamControllerTest extends WebsiteTestCase
         $filePath = $this->createMediaFile('fitness-seasons.agency--C-&-C--Rodach,-Johannes');
         $media = $this->createMedia($filePath, 'fitness-seasons.agency--C-&-C--Rodach,-Johannes');
 
-        $this->client->jsonRequest('GET', $media->getUrl());
+        $this->client->request('GET', $media->getUrl());
         $response = $this->client->getResponse();
         $this->assertHttpStatusCode(200, $response);
 
@@ -118,7 +128,7 @@ class MediaStreamControllerTest extends WebsiteTestCase
 
     public function testGetImageActionForNonExistingMedia(): void
     {
-        $this->client->jsonRequest('GET', '/uploads/media/sulu-400x400/01/test.jpg?v=1');
+        $this->client->request('GET', '/uploads/media/sulu-400x400/01/test.jpg?v=1');
 
         $this->assertHttpStatusCode(404, $this->client->getResponse());
     }
@@ -128,11 +138,11 @@ class MediaStreamControllerTest extends WebsiteTestCase
         $filePath = $this->createMediaFile('test.jpg');
         $media = $this->createMedia($filePath, 'Test jpg');
 
-        $this->client->jsonRequest('GET', $media->getFormats()['small-inset']);
+        $this->client->request('GET', $media->getFormats()['small-inset']);
         $this->assertHttpStatusCode(200, $this->client->getResponse());
         $this->assertSame('image/jpeg', $this->client->getResponse()->headers->get('Content-Type'));
 
-        $this->client->jsonRequest('GET', $media->getFormats()['small-inset.gif']);
+        $this->client->request('GET', $media->getFormats()['small-inset.gif']);
         $this->assertHttpStatusCode(200, $this->client->getResponse());
         $this->assertSame('image/gif', $this->client->getResponse()->headers->get('Content-Type'));
     }
@@ -142,11 +152,11 @@ class MediaStreamControllerTest extends WebsiteTestCase
         $filePath = $this->createMediaFile('test.svg', 'sulu.svg');
         $media = $this->createMedia($filePath, 'Test svg');
 
-        $this->client->jsonRequest('GET', $media->getFormats()['small-inset']);
+        $this->client->request('GET', $media->getFormats()['small-inset']);
         $this->assertHttpStatusCode(200, $this->client->getResponse());
         $this->assertSame('image/svg+xml', $this->client->getResponse()->headers->get('Content-Type'));
 
-        $this->client->jsonRequest('GET', $media->getFormats()['small-inset.svg']);
+        $this->client->request('GET', $media->getFormats()['small-inset.svg']);
         $this->assertHttpStatusCode(200, $this->client->getResponse());
         $this->assertSame('image/svg+xml', $this->client->getResponse()->headers->get('Content-Type'));
     }
@@ -162,14 +172,14 @@ class MediaStreamControllerTest extends WebsiteTestCase
         $filePath = $this->createMediaFile('test.svg', 'sulu.svg');
         $media = $this->createMedia($filePath, 'Test svg');
 
-        $this->client->jsonRequest('GET', $media->getFormats()['small-inset.jpg']);
+        $this->client->request('GET', $media->getFormats()['small-inset.jpg']);
         $this->assertHttpStatusCode(200, $this->client->getResponse());
         $this->assertSame('image/jpeg', $this->client->getResponse()->headers->get('Content-Type'));
     }
 
     public function testDownloadActionForNonExistingMedia(): void
     {
-        $this->client->jsonRequest('GET', '/media/999/download/test.jpg?v=1');
+        $this->client->request('GET', '/media/999/download/test.jpg?v=1');
 
         $this->assertHttpStatusCode(404, $this->client->getResponse());
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7534
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The filename / slug need to match also for the download url else it can reduce lot of high traffic on the servers.

#### Why?

Same as for https://github.com/sulu/sulu/pull/7534

As reported by one of our partners to improve traffic on their projects.