### PR TITLE
Fix cachelifetime configuration for sitemap

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Configuration.php
@@ -86,7 +86,7 @@ class Configuration implements ConfigurationInterface
                     ->arrayNode('sitemap')
                         ->addDefaultsIfNotSet()
                         ->children()
-                            ->scalarNode('cache_lifetime')->defaultValue(43200)->end()
+                            ->scalarNode('cache_lifetime')->defaultValue(3600)->end()
                         ->end()
                     ->end()
                 ->end()

--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/SuluWebsiteExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/SuluWebsiteExtension.php
@@ -98,7 +98,7 @@ class SuluWebsiteExtension extends Extension implements PrependExtensionInterfac
         );
         $container->setParameter(
             'sulu_website.sitemap.cache.lifetime',
-            $config['twig']['content']['cache_lifetime']
+            $config['twig']['sitemap']['cache_lifetime']
         );
         $container->setParameter(
             'sulu_website.sitemap.dump_dir',

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/SitemapControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/SitemapControllerTest.php
@@ -67,7 +67,6 @@ class SitemapControllerTest extends WebsiteTestCase
         $this->assertCount(1, $crawler->filterXPath('//x:urlset/x:url/x:lastmod'));
         $this->assertCount(0, $crawler->filterXPath('//x:urlset/x:url/xhtml:link'));
         $this->assertEquals('http://sulu.lo/', $crawler->filterXPath('//x:urlset/x:url[1]/x:loc[1]')->text());
-
     }
 
     public function testIndexMultipleLanguage(): void

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/SitemapControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/SitemapControllerTest.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\WebsiteBundle\Tests\Functional\Controller;
 
+use Sulu\Bundle\HttpCacheBundle\Cache\SuluHttpCache;
 use Sulu\Bundle\SecurityBundle\Entity\Permission;
 use Sulu\Bundle\TestBundle\Testing\WebsiteTestCase;
 use Sulu\Component\Security\Authentication\RoleInterface;
@@ -57,20 +58,25 @@ class SitemapControllerTest extends WebsiteTestCase
     {
         $crawler = $this->client->request('GET', 'http://sulu.lo/sitemap.xml');
         $crawler->registerNamespace('x', 'http://www.sitemaps.org/schemas/sitemap/0.9');
-        $this->assertHttpStatusCode(200, $this->client->getResponse());
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $this->assertSame('3600', $response->headers->get(SuluHttpCache::HEADER_REVERSE_PROXY_TTL));
 
         $this->assertCount(1, $crawler->filterXPath('//x:urlset/x:url'));
         $this->assertCount(1, $crawler->filterXPath('//x:urlset/x:url/x:loc'));
         $this->assertCount(1, $crawler->filterXPath('//x:urlset/x:url/x:lastmod'));
         $this->assertCount(0, $crawler->filterXPath('//x:urlset/x:url/xhtml:link'));
         $this->assertEquals('http://sulu.lo/', $crawler->filterXPath('//x:urlset/x:url[1]/x:loc[1]')->text());
+
     }
 
     public function testIndexMultipleLanguage(): void
     {
         $crawler = $this->client->request('GET', 'http://test.lo/sitemap.xml');
         $crawler->registerNamespace('x', 'http://www.sitemaps.org/schemas/sitemap/0.9');
-        $this->assertHttpStatusCode(200, $this->client->getResponse());
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $this->assertSame('3600', $response->headers->get(SuluHttpCache::HEADER_REVERSE_PROXY_TTL));
 
         $this->assertCount(2, $crawler->filterXPath('//x:urlset/x:url'));
 
@@ -132,7 +138,9 @@ class SitemapControllerTest extends WebsiteTestCase
     {
         $crawler = $this->client->request('GET', 'http://sulu.lo/sitemaps/pages-1.xml');
         $crawler->registerNamespace('x', 'http://www.sitemaps.org/schemas/sitemap/0.9');
-        $this->assertHttpStatusCode(200, $this->client->getResponse());
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $this->assertSame('3600', $response->headers->get(SuluHttpCache::HEADER_REVERSE_PROXY_TTL));
 
         $this->assertCount(1, $crawler->filterXPath('//x:urlset/x:url'));
         $this->assertCount(1, $crawler->filterXPath('//x:urlset/x:url/x:loc'));


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix cachelifetime configuration for sitemap.

#### Why?

The default value of `43200` ( 12h ) was never used and cachelifetime was so only 1 second.

https://github.com/sulu/sulu/blob/61dcef5e79705b6a87c45eb57d6de3acd543f7ef/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Configuration.php#L89
