### PR TITLE
Allow to debug SuluHttpCache without Kernel Debug enabled

### DIFF
--- a/src/Sulu/Bundle/HttpCacheBundle/Cache/SuluHttpCache.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Cache/SuluHttpCache.php
@@ -45,7 +45,7 @@ class SuluHttpCache extends HttpCache implements CacheInvalidation
      * @param string $cacheDir
      * @param bool|null $debug given null will fallback to kernel debug
      */
-    public function __construct(HttpKernelInterface $kernel, $cacheDir = null, bool $debug = null)
+    public function __construct(HttpKernelInterface $kernel, $cacheDir = null, ?bool $debug = null)
     {
         if (!$cacheDir && $kernel instanceof SuluKernel) {
             $cacheDir = $kernel->getCommonCacheDir() . \DIRECTORY_SEPARATOR . 'http_cache';

--- a/src/Sulu/Bundle/HttpCacheBundle/Cache/SuluHttpCache.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Cache/SuluHttpCache.php
@@ -39,16 +39,21 @@ class SuluHttpCache extends HttpCache implements CacheInvalidation
 
     public const HEADER_REVERSE_PROXY_TTL = 'X-Reverse-Proxy-TTL';
 
+    private bool $debug;
+
     /**
      * @param string $cacheDir
+     * @param bool|null $debug given null will fallback to kernel debug
      */
-    public function __construct(HttpKernelInterface $kernel, $cacheDir = null)
+    public function __construct(HttpKernelInterface $kernel, $cacheDir = null, bool $debug = null)
     {
         if (!$cacheDir && $kernel instanceof SuluKernel) {
             $cacheDir = $kernel->getCommonCacheDir() . \DIRECTORY_SEPARATOR . 'http_cache';
         }
 
         parent::__construct($kernel, $cacheDir);
+
+        $this->debug = $debug ?? $this->kernel->isDebug();
 
         foreach ($this->getSubscribers() as $subscriber) {
             $this->addSubscriber($subscriber);
@@ -61,13 +66,13 @@ class SuluHttpCache extends HttpCache implements CacheInvalidation
     protected function getSubscribers(): array
     {
         $subscribers = [
-            CustomTtlListener::class => new CustomTtlListener(static::HEADER_REVERSE_PROXY_TTL, $this->kernel->isDebug()),
+            CustomTtlListener::class => new CustomTtlListener(static::HEADER_REVERSE_PROXY_TTL, $this->debug),
             PurgeListener::class => new PurgeListener(),
             PurgeTagsListener::class => new PurgeTagsListener(),
             SegmentCacheListener::class => new SegmentCacheListener(),
         ];
 
-        if ($this->kernel->isDebug()) {
+        if ($this->debug) {
             $subscribers[DebugListener::class] = new DebugListener();
         } else {
             $subscribers[CleanupCacheTagsListener::class] = new CleanupCacheTagsListener();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Allow to debug SuluHttpCache without Kernel Debug enabled.

#### Why?

HttpCache is only enabled in stage and prod env. But APP_DEBUG=1 does not work there as it has strange side effects. To still allow to debug the cache headers additional debug flag on the SuluHttpCache can be enabled to make debugging easier.
