### PR TITLE
Fix deprecation message on HitListener rtrim function call

### DIFF
--- a/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
+++ b/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
@@ -153,7 +153,7 @@ class RequestAnalyzer implements RequestAnalyzerInterface
 
     public function getResourceLocatorPrefix()
     {
-        return $this->getAttribute('resourceLocatorPrefix');
+        return $this->getAttribute('resourceLocatorPrefix', '');
     }
 
     public function getPortalInformation()

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/RequestAnalyzerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/RequestAnalyzerTest.php
@@ -207,7 +207,7 @@ class RequestAnalyzerTest extends TestCase
             [['resourceLocator' => 1], 'getResourceLocator', 1],
             [[], 'getResourceLocator', false],
             [['resourceLocatorPrefix' => 1], 'getResourceLocatorPrefix', 1],
-            [[], 'getResourceLocatorPrefix', null],
+            [[], 'getResourceLocatorPrefix', ''],
             [['portalInformation' => 1], 'getPortalInformation', 1],
             [[], 'getPortalInformation', null],
         ];


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no 
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Always return a getResourceLocatorPrefix even if not defined as empty string.

#### Why?

> deprecation.INFO: Deprecated: rtrim(): Passing null to parameter #1 ($string) of type string is deprecated {"exception":"[object] (ErrorException(code: 0): Deprecated: rtrim(): Passing null to parameter #1 ($string) of type string is deprecated at /Users/alexanderschranz/Documents/Projects/sulu-develop.localhost/vendor/sulu/sulu/src/Sulu/Bundle/PageBundle/Search/EventListener/HitListener.php:53)"} []

https://github.com/sulu/sulu/blob/00bbda89fc57626237ee144ff6c2dc5c5287cd86/src/Sulu/Bundle/PageBundle/Search/EventListener/HitListener.php#L53