### PR TITLE
Removing deprecated `getObjectForTrait`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -27066,21 +27066,6 @@ parameters:
 			path: src/Sulu/Bundle/SecurityBundle/Entity/UserGroup.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\SecurityBundle\\\\Entity\\\\UserRepository\\:\\:addOrderBy\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/Entity/UserRepository.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\SecurityBundle\\\\Entity\\\\UserRepository\\:\\:addOrderBy\\(\\) has parameter \\$alias with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/Entity/UserRepository.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\SecurityBundle\\\\Entity\\\\UserRepository\\:\\:addOrderBy\\(\\) has parameter \\$sortBy with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/Entity/UserRepository.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\SecurityBundle\\\\Entity\\\\UserRepository\\:\\:findUserByContact\\(\\) has parameter \\$id with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/Entity/UserRepository.php
@@ -45922,16 +45907,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Component\\\\Persistence\\\\Tests\\\\Unit\\\\EventSubscriber\\\\ORM\\\\OrderByTraitTest\\:\\:testAddOrderBy\\(\\) has parameter \\$orderBy with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/OrderByTraitTest.php
-
-		-
-			message: "#^Property Sulu\\\\Component\\\\Persistence\\\\Tests\\\\Unit\\\\EventSubscriber\\\\ORM\\\\OrderByTraitTest\\:\\:\\$orderByTrait \\(Sulu\\\\Component\\\\Persistence\\\\Repository\\\\ORM\\\\OrderByTrait\\) does not accept object\\.$#"
-			count: 1
-			path: src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/OrderByTraitTest.php
-
-		-
-			message: "#^Property Sulu\\\\Component\\\\Persistence\\\\Tests\\\\Unit\\\\EventSubscriber\\\\ORM\\\\OrderByTraitTest\\:\\:\\$orderByTrait has invalid type Sulu\\\\Component\\\\Persistence\\\\Repository\\\\ORM\\\\OrderByTrait\\.$#"
 			count: 1
 			path: src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/OrderByTraitTest.php
 

--- a/src/Sulu/Component/Persistence/Repository/ORM/OrderByTrait.php
+++ b/src/Sulu/Component/Persistence/Repository/ORM/OrderByTrait.php
@@ -20,6 +20,11 @@ trait OrderByTrait
 {
     /**
      * Function adds order-by to querybuilder based on $sortBy-data given.
+     *
+     * @param string $alias
+     * @param array<string, string> $sortBy
+     *
+     * @return void
      */
     protected function addOrderBy(QueryBuilder $queryBuilder, $alias, array $sortBy = [])
     {

--- a/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/OrderByTraitTest.php
+++ b/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/OrderByTraitTest.php
@@ -15,40 +15,12 @@ use Doctrine\ORM\QueryBuilder;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Component\Persistence\Repository\ORM\OrderByTrait;
 
 class OrderByTraitTest extends TestCase
 {
     use ProphecyTrait;
-
-    /**
-     * @var ObjectProphecy<QueryBuilder>
-     */
-    private $queryBuilder;
-
-    /**
-     * @var OrderByTrait
-     */
-    private $orderByTrait;
-
-    /**
-     * @var \ReflectionMethod
-     */
-    private $addOrderByFunction;
-
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        $this->orderByTrait = $this->getObjectForTrait(OrderByTrait::class);
-
-        $this->queryBuilder = $this->prophesize(QueryBuilder::class);
-
-        $reflectionClass = new \ReflectionClass($this->orderByTrait);
-        $this->addOrderByFunction = $reflectionClass->getMethod('addOrderBy');
-        $this->addOrderByFunction->setAccessible(true);
-    }
+    use OrderByTrait;
 
     public static function orderByProvider()
     {
@@ -65,21 +37,15 @@ class OrderByTraitTest extends TestCase
      */
     public function testAddOrderBy($alias, $orderBy, $expectedOrderBy): void
     {
+        $queryBuilder = $this->prophesize(QueryBuilder::class);
         if (0 === \count($expectedOrderBy)) {
-            $this->queryBuilder->addOrderBy(Argument::any(), Argument::any())->shouldNotBeCalled();
+            $queryBuilder->addOrderBy(Argument::any(), Argument::any())->shouldNotBeCalled();
         }
 
         foreach ($expectedOrderBy as $field => $order) {
-            $this->queryBuilder->addOrderBy($field, $order)->shouldBeCalledTimes(1);
+            $queryBuilder->addOrderBy($field, $order)->shouldBeCalledTimes(1);
         }
 
-        $this->addOrderByFunction->invokeArgs(
-            $this->orderByTrait,
-            [
-                $this->queryBuilder->reveal(),
-                $alias,
-                $orderBy,
-            ]
-        );
+        $this->addOrderBy($queryBuilder->reveal(), $alias, $orderBy);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #7507
| License | MIT
| Documentation PR | -

