### PR TITLE
Fix block property call

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -33916,26 +33916,6 @@ parameters:
 			path: src/Sulu/Component/Content/Compat/Block/BlockProperty.php
 
 		-
-			message: "#^Method Sulu\\\\Component\\\\Content\\\\Compat\\\\Property\\:\\:__construct\\(\\) invoked with 12 parameters, 3\\-11 required\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Compat/Block/BlockProperty.php
-
-		-
-			message: "#^Parameter \\#10 \\$colSpan of method Sulu\\\\Component\\\\Content\\\\Compat\\\\Property\\:\\:__construct\\(\\) expects int\\|null, array\\<Sulu\\\\Component\\\\Content\\\\Compat\\\\PropertyTag\\> given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Compat/Block/BlockProperty.php
-
-		-
-			message: "#^Parameter \\#8 \\$params of method Sulu\\\\Component\\\\Content\\\\Compat\\\\Property\\:\\:__construct\\(\\) expects array, int\\|null given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Compat/Block/BlockProperty.php
-
-		-
-			message: "#^Parameter \\#9 \\$tags of method Sulu\\\\Component\\\\Content\\\\Compat\\\\Property\\:\\:__construct\\(\\) expects array\\<Sulu\\\\Component\\\\Content\\\\Compat\\\\PropertyTag\\>, array given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Compat/Block/BlockProperty.php
-
-		-
 			message: "#^Method Sulu\\\\Component\\\\Content\\\\Compat\\\\Block\\\\BlockPropertyType\\:\\:getSettings\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Compat/Block/BlockPropertyType.php

--- a/src/Sulu/Component/Content/Compat/Block/BlockProperty.php
+++ b/src/Sulu/Component/Content/Compat/Block/BlockProperty.php
@@ -45,7 +45,6 @@ class BlockProperty extends Property implements BlockPropertyInterface
             $mandatory,
             $multilingual,
             $maxOccurs,
-            $maxOccurs,
             $minOccurs,
             $params,
             $tags,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

This fix block property call which was accidently introduced when merging 2.5 -> 2.6 with https://github.com/sulu/sulu/pull/7548

#### Why?

False arguments given to constructor call.
