### PR TITLE
Fix type deprecation for list properties

### DIFF
--- a/src/Sulu/Bundle/ActivityBundle/Resources/config/lists/activities.xml
+++ b/src/Sulu/Bundle/ActivityBundle/Resources/config/lists/activities.xml
@@ -96,7 +96,8 @@
             visibility="always"
             searchability="never"
             sortable="false"
-            type="html"
-        />
+        >
+            <transformer type="html"/>
+        </property>
     </properties>
 </list>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/lists/contacts.xml
@@ -400,7 +400,7 @@
             </joins>
         </property>
 
-        <property name="userLocked" visibility="no" translation="sulu_security.user_locked" type="bool">
+        <property name="userLocked" visibility="no" translation="sulu_security.user_locked">
             <field-name>locked</field-name>
             <entity-name>%sulu.model.user.class%</entity-name>
 
@@ -411,6 +411,8 @@
                     <condition>%sulu.model.user.class%.contact = %sulu.model.contact.class%.id</condition>
                 </join>
             </joins>
+
+            <transformer type="bool"/>
         </property>
     </properties>
 </list>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Related issues/PRs | https://github.com/sulu/SuluFormBundle/pull/392
| License | MIT

#### What's in this PR?

Fix deprecation `Since sulu/sulu 2.2: Attribute "type" of list property should not be used anymore! Use "<transformer type="..."/>" inside of property instead.`
