### PR TITLE
Fix loading of website bundle config in admin context

### DIFF
--- a/src/Sulu/Component/HttpKernel/SuluKernel.php
+++ b/src/Sulu/Component/HttpKernel/SuluKernel.php
@@ -99,6 +99,10 @@ abstract class SuluKernel extends Kernel
             $this->load($loader, $confDir, '/{packages}/sulu_admin');
             $this->load($loader, $confDir, '/{packages}/' . $this->environment . '/sulu_admin');
         }
+        if (isset($bundles['SuluWebsiteBundle'])) {
+            $this->load($loader, $confDir, '/{packages}/sulu_website');
+            $this->load($loader, $confDir, '/{packages}/' . $this->environment . '/sulu_website');
+        }
 
         $this->load($loader, $confDir, '/{packages}/*');
         $this->load($loader, $confDir, '/{packages}/' . $this->environment . '/*');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #7552
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Make sure the sulu_website.yaml config is also loaded in the admin context. We already doing similar mechanism to load the admin bundle in website context. This is also a step forward to get rid of the `sulu.context`.

#### Why?

Currently the following deprecation is called https://github.com/sulu/sulu/blob/463fafce1f7cd9171e565e27ba01c06305924b86/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationMapper.php#L80 even when the bundle is correctly configured.
