### PR TITLE
Fix portalInformaton handling in RequestListener when UserBasedContext is active

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -32196,11 +32196,6 @@ parameters:
 			path: src/Sulu/Bundle/WebsiteBundle/Routing/RequestListener.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Routing\\\\RequestListener\\:\\:onRequest\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Routing/RequestListener.php
-
-		-
 			message: "#^Property Sulu\\\\Bundle\\\\WebsiteBundle\\\\Sitemap\\\\Sitemap\\:\\:\\$lastmod \\(DateTime\\) does not accept DateTime\\|null\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Sitemap/Sitemap.php

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/RequestListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/RequestListener.php
@@ -52,7 +52,6 @@ class RequestListener implements EventSubscriberInterface
         $context = $this->router->getContext();
         $portalInformation = $this->requestAnalyzer->getPortalInformation();
 
-
         if (!$event->isMainRequest()) {
             // sub requests like /_fos_user_context_hash ends in false prefix and should not set anything here
             // else it can happen that the main request get the false prefix and generate urls incorrect.

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/RequestListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/RequestListener.php
@@ -52,12 +52,6 @@ class RequestListener implements EventSubscriberInterface
         $context = $this->router->getContext();
         $portalInformation = $this->requestAnalyzer->getPortalInformation();
 
-        if (!$event->isMainRequest()) {
-            // sub requests like /_fos_user_context_hash ends in false prefix and should not set anything here
-            // else it can happen that the main request get the false prefix and generate urls incorrect.
-            return;
-        }
-
         $request = $event->getRequest();
 
         if ($request->attributes->get('internalRequest', false)) {

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/RequestListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/RequestListener.php
@@ -52,9 +52,16 @@ class RequestListener implements EventSubscriberInterface
         $context = $this->router->getContext();
         $portalInformation = $this->requestAnalyzer->getPortalInformation();
 
+
         if (!$event->isMainRequest()) {
             // sub requests like /_fos_user_context_hash ends in false prefix and should not set anything here
             // else it can happen that the main request get the false prefix and generate urls incorrect.
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if ($request->attributes->get('internalRequest', false)) {
             return;
         }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RequestListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RequestListenerTest.php
@@ -83,13 +83,15 @@ class RequestListenerTest extends TestCase
         $this->portalInformation->getHost()->willReturn('sulu.io');
         $this->requestAnalyzer->getPortalInformation()->willReturn($this->portalInformation);
 
-        $event = $this->createRequestEvent(Request::create('/_fragment'), HttpKernelInterface::SUB_REQUEST);
+        // if a route was not found the request listener is called as sub request
+        // to render to 404 page correctly we still need to set the prefix and host
+        $event = $this->createRequestEvent(Request::create('/error-404'), HttpKernelInterface::SUB_REQUEST);
 
         $requestListener = new RequestListener($this->router->reveal(), $this->requestAnalyzer->reveal());
         $requestListener->onRequest($event);
 
-        $this->assertFalse($this->requestContext->hasParameter('prefix'));
-        $this->assertFalse($this->requestContext->hasParameter('host'));
+        $this->assertSame('test/', $this->requestContext->getParameter('prefix'));
+        $this->assertSame('sulu.io', $this->requestContext->getParameter('host'));
     }
 
     public function testRequestAnalyzerInternalRequest(): void

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RequestListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RequestListenerTest.php
@@ -22,7 +22,6 @@ use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RequestContextAwareInterface;
-use Symfony\Component\Routing\RouterInterface;
 
 class RequestListenerTest extends TestCase
 {

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RequestListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RequestListenerTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\RequestContextAwareInterface;
 use Symfony\Component\Routing\RouterInterface;
 
 class RequestListenerTest extends TestCase
@@ -33,7 +34,7 @@ class RequestListenerTest extends TestCase
     private $requestAnalyzer;
 
     /**
-     * @var ObjectProphecy<RouterInterface>
+     * @var ObjectProphecy<RequestContextAwareInterface>
      */
     private $router;
 
@@ -56,7 +57,7 @@ class RequestListenerTest extends TestCase
     {
         $this->kernel = $this->prophesize(HttpKernelInterface::class);
         $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
-        $this->router = $this->prophesize(RouterInterface::class);
+        $this->router = $this->prophesize(RequestContextAwareInterface::class);
         $this->portalInformation = $this->prophesize(PortalInformation::class);
         $this->requestContext = new RequestContext();
         $this->router->getContext()->willReturn($this->requestContext);

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RequestListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RequestListenerTest.php
@@ -112,21 +112,6 @@ class RequestListenerTest extends TestCase
         $this->assertFalse($this->requestContext->hasParameter('host'));
     }
 
-    public function testRequestUserContextListener(): void
-    {
-        $this->portalInformation->getPrefix()->willReturn('test/');
-        $this->portalInformation->getHost()->willReturn('sulu.io');
-        $this->requestAnalyzer->getPortalInformation()->willReturn($this->portalInformation);
-
-        $event = $this->createRequestEvent(Request::create('/_fragment'), HttpKernelInterface::MAIN_REQUEST); // see https://github.com/FriendsOfSymfony/FOSHttpCache/blob/a582deb3f55f8a7efdae8ac916ef4adc285543a0/src/SymfonyCache/UserContextListener.php#L170 which is a main request
-
-        $requestListener = new RequestListener($this->router->reveal(), $this->requestAnalyzer->reveal());
-        $requestListener->onRequest($event);
-
-        $this->assertFalse($this->requestContext->hasParameter('prefix'));
-        $this->assertFalse($this->requestContext->hasParameter('host'));
-    }
-
     private function createRequestEvent(Request $request, int $requestType = HttpKernelInterface::MAIN_REQUEST): RequestEvent
     {
         return new RequestEvent(

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RequestListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RequestListenerTest.php
@@ -83,7 +83,7 @@ class RequestListenerTest extends TestCase
         $this->portalInformation->getHost()->willReturn('sulu.io');
         $this->requestAnalyzer->getPortalInformation()->willReturn($this->portalInformation);
 
-        $event = $this->createRequestEvent(new Request(), HttpKernelInterface::SUB_REQUEST);
+        $event = $this->createRequestEvent(Request::create('/_fos_user_context_hash'), HttpKernelInterface::SUB_REQUEST);
 
         $requestListener = new RequestListener($this->router->reveal(), $this->requestAnalyzer->reveal());
         $requestListener->onRequest($event);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #7551 <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Only set the portal information if its a main request and avoid for sub requests like `/_fos_user_context_hash`.

#### Why?

The `/_fos_user_context_hash` does not contain a locale prefix or portal prefix and as previously set prefix and host currently wins the `/_fos_user_context_hash` sets the default locale and the main request will not overwrite it correctly. By check for `isMainRequest` we can avoid this.

This bug so only appeared when a SubRequest was called before the MainRequest. In most cases MainRequest is the first and set the prefix and host correctly. But in case of HttpCache it wasn't.