### PR TITLE
Throw exception on missing file in LocalStorage

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15371,11 +15371,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Storage\\\\LocalStorage\\:\\:load\\(\\) should return resource but returns resource\\|false\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
-
-		-
 			message: "#^Parameter \\#2 \\$fileName of method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Storage\\\\LocalStorage\\:\\:getUniqueFileName\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
@@ -59,7 +59,14 @@ class LocalStorage implements StorageInterface
 
     public function load(array $storageOptions)
     {
-        return \fopen($this->getPath($storageOptions), 'r');
+        $pathName = $this->getPath($storageOptions);
+        $fp = @\fopen($pathName, 'r');
+
+        if (false === $fp) {
+            throw new IOException(\sprintf('Failed to open file "%s"', $pathName), path: $pathName);
+        }
+
+        return $fp;
     }
 
     public function getPath(array $storageOptions): string

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/LocalStorageTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/LocalStorageTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Media\Storage;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\MediaBundle\Media\Storage\LocalStorage;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+
+class LocalStorageTest extends TestCase
+{
+    private LocalStorage $localStorage;
+
+    protected function setUp(): void
+    {
+        $fileSystem = new Filesystem();
+        $this->localStorage = new LocalStorage(__DIR__ . '/../../../uploads/media', '10', $fileSystem);
+    }
+
+    public function testLoadReturnsFileHandle(): void
+    {
+        $storageOptions = [
+            'fileName' => '023a9fe8-d5f3-4bdd-a6a3-13a935154105.jpg',
+            'segment' => '01',
+        ];
+        $pathName = $this->localStorage->getPath($storageOptions);
+        \mkdir(\dirname($pathName), 0777, true);
+        \file_put_contents($pathName, 'test');
+
+        $fp = $this->localStorage->load($storageOptions);
+
+        self::assertTrue(\is_resource($fp));
+
+        // Cleanup file and dir
+        \unlink($pathName);
+        \rmdir(\dirname($pathName));
+    }
+
+    public function testLoadThrowsExceptionOnNonExistingFile(): void
+    {
+        self::expectException(IOException::class);
+
+        $this->localStorage->load([
+            'fileName' => 'a-file-that-does-not-exist.jpg',
+            'segment' => '01',
+        ]);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | yes, a small one
| Deprecations? | no
| License | MIT

#### What's in this PR?

The `load` method of the `LocalStorage` class in the MediaBundle uses `fopen` to open a file, but there is no check if the file exists and no error handling.
This PR adds error handling by suppressing the warning and throwing an `IOException`.

#### Why?

If an image is requested whose file does not exist on the filesystem anymore, a warning is emitted and then an InvalidArgumentException is thrown in the `ImagineImageConverter` because a resource was expected and `false` was passed.

Now, an exception is thrown a the correct place.

#### Backtrace

Just for more background the backtrace of the issue looks like this:

```
{
    "class": "ErrorException",
    "message": "Warning: fopen(/srv/htdocs/mysite/var/uploads/media/09/a-bear-on-mars-52854051396.jpg): Failed to open stream: No such file or directory",
    "code": 0,
    "file": "/srv/htdocs/mysite/vendor/sulu/sulu/src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php:62",
    "trace": [
        "/srv/htdocs/mysite/vendor/sulu/sulu/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImagineImageConverter.php:93",
        "/srv/htdocs/mysite/vendor/sulu/sulu/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php:146",
        "/srv/htdocs/mysite/vendor/sulu/sulu/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php:71",
        ...
        "/srv/htdocs/mysite/public/index.php:66"
    ]
}
```

#### BC

Strictly speaking this is a bc break. But the current behaviour is incorrect and I cannot imagine that somebody depends on it.

#### Question

I am not sure if the exception should be catched in the MediaStreamController and how it should be handled. 