### PR TITLE
Fixing implicit array creation in FieldTypeOptionRegistry

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -751,16 +751,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/FieldType/FieldTypeOptionRegistry.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\FieldType\\\\FieldTypeOptionRegistry\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/FieldType/FieldTypeOptionRegistry.php
-
-		-
-			message: "#^Property Sulu\\\\Bundle\\\\AdminBundle\\\\FieldType\\\\FieldTypeOptionRegistry\\:\\:\\$options type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/FieldType/FieldTypeOptionRegistry.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\FieldType\\\\FieldTypeOptionRegistryInterface\\:\\:add\\(\\) has parameter \\$fieldTypeOptions with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/FieldType/FieldTypeOptionRegistryInterface.php

--- a/src/Sulu/Bundle/AdminBundle/FieldType/FieldTypeOptionRegistry.php
+++ b/src/Sulu/Bundle/AdminBundle/FieldType/FieldTypeOptionRegistry.php
@@ -14,19 +14,22 @@ namespace Sulu\Bundle\AdminBundle\FieldType;
 class FieldTypeOptionRegistry implements FieldTypeOptionRegistryInterface
 {
     /**
-     * @var array
+     * @var array<string, array<string, array<mixed>>>
      */
     private $options = [];
 
     public function add(string $name, string $baseFieldType, array $fieldTypeOptions): void
     {
         if (!\array_key_exists($baseFieldType, $this->options)) {
-            $options[$baseFieldType] = [];
+            $this->options[$baseFieldType] = [];
         }
 
         $this->options[$baseFieldType][$name] = $fieldTypeOptions;
     }
 
+    /**
+     * @return array<string, array<string, array<mixed>>>
+     */
     public function toArray(): array
     {
         return $this->options;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Removing the non-existing variable and using the correct one on of the object.

#### Why?
This works because php has a feature called implicit array creation. Which means that if you treat an undefined variable as an array, it automatically creates that array. But we don't want to rely on that behaviour. Neither for the `$options` variable (which is not used) nor for the `$this->options` property.