### PR TITLE
Fix php deprecations for string and int types given as null

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -41036,11 +41036,6 @@ parameters:
 			path: src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
 
 		-
-			message: "#^Parameter \\#2 \\$code of class Sulu\\\\Component\\\\Content\\\\Exception\\\\ResourceLocatorNotFoundException constructor expects int, null given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
-
-		-
 			message: "#^Parameter \\#2 \\$created of class Sulu\\\\Component\\\\Content\\\\Types\\\\ResourceLocator\\\\ResourceLocatorInformation constructor expects DateTime\\|null, mixed given\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
@@ -42717,16 +42712,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Component\\\\DocumentManager\\\\NodeManager\\:\\:save\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/DocumentManager/NodeManager.php
-
-		-
-			message: "#^Parameter \\#2 \\$code of class Sulu\\\\Component\\\\DocumentManager\\\\Exception\\\\DocumentNotFoundException constructor expects int, null given\\.$#"
-			count: 1
-			path: src/Sulu/Component/DocumentManager/NodeManager.php
-
-		-
-			message: "#^Parameter \\#3 \\$limit of function preg_split expects int, null given\\.$#"
 			count: 1
 			path: src/Sulu/Component/DocumentManager/NodeManager.php
 
@@ -45956,11 +45941,6 @@ parameters:
 			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
 
 		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\DoctrineListBuilder\\:\\:encodeAlias\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
-
-		-
 			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\DoctrineListBuilder\\:\\:execute\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -46076,34 +46056,9 @@ parameters:
 			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineDescriptor.php
 
 		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\FieldDescriptor\\\\DoctrineDescriptor\\:\\:encodeAlias\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineDescriptor.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\FieldDescriptor\\\\DoctrineFieldDescriptor\\:\\:encodeAlias\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineFieldDescriptor.php
-
-		-
 			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\FieldDescriptor\\\\DoctrineFieldDescriptor\\:\\:getJoins\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineFieldDescriptor.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\FieldDescriptor\\\\DoctrineIdentityFieldDescriptor\\:\\:encodeAlias\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineIdentityFieldDescriptor.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\FieldDescriptor\\\\DoctrineJoinDescriptor\\:\\:encodeAlias\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineJoinDescriptor.php
-
-		-
-			message: "#^Parameter \\#1 \\$value of method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Doctrine\\\\FieldDescriptor\\\\DoctrineJoinDescriptor\\:\\:encodeAlias\\(\\) expects array\\<string\\>\\|string, string\\|null given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineJoinDescriptor.php
 
 		-
 			message: "#^Method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\Expression\\\\BetweenExpressionInterface\\:\\:getEnd\\(\\) return type has no value type specified in iterable type array\\.$#"
@@ -47239,11 +47194,6 @@ parameters:
 			message: "#^Property Sulu\\\\Component\\\\Rest\\\\Tests\\\\Unit\\\\ListBuilder\\\\Doctrine\\\\DoctrineListBuilderTest\\:\\:\\$translationEntityNameAlias has no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Rest\\\\Tests\\\\Unit\\\\ListBuilder\\\\Doctrine\\\\EncodeAliasTraitTest\\:\\:encodeAlias\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/EncodeAliasTraitTest.php
 
 		-
 			message: "#^Method Sulu\\\\Component\\\\Rest\\\\Tests\\\\Unit\\\\ListBuilder\\\\Doctrine\\\\EncodeAliasTraitTest\\:\\:encodeAliasDataProvider\\(\\) has no return type specified\\.$#"
@@ -49187,11 +49137,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Component\\\\Util\\\\SortUtils\\:\\:multisort\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Component/Util/SortUtils.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function strtolower expects string, mixed given\\.$#"
 			count: 1
 			path: src/Sulu/Component/Util/SortUtils.php
 

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
@@ -244,7 +244,7 @@ class PhpcrMapper implements ResourceLocatorMapperInterface
                 $route = $this->getWebspaceRouteNode($webspaceKey, $languageCode, $segmentKey);
             }
         } catch (PathNotFoundException $e) {
-            throw new ResourceLocatorNotFoundException(\sprintf('Path "%s" not found', $path), null, $e);
+            throw new ResourceLocatorNotFoundException(\sprintf('Path "%s" not found', $path), 0, $e);
         }
 
         if ($route->hasProperty('sulu:content') && $route->hasProperty('sulu:history')) {

--- a/src/Sulu/Component/DocumentManager/NodeManager.php
+++ b/src/Sulu/Component/DocumentManager/NodeManager.php
@@ -47,7 +47,7 @@ class NodeManager
         } catch (RepositoryException $e) {
             throw new DocumentNotFoundException(\sprintf(
                 'Could not find document with ID or path "%s"', $identifier
-            ), null, $e);
+            ), 0, $e);
         }
     }
 
@@ -153,7 +153,7 @@ class NodeManager
     {
         $current = $this->session->getRootNode();
 
-        $segments = \preg_split('#/#', $path, null, \PREG_SPLIT_NO_EMPTY);
+        $segments = \preg_split('#/#', $path, -1, \PREG_SPLIT_NO_EMPTY);
         foreach ($segments as $segment) {
             if ($current->hasNode($segment)) {
                 $current = $current->getNode($segment);

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -462,7 +462,7 @@ class DoctrineListBuilder extends AbstractListBuilder
     /**
      * Returns all the joins required for the query.
      *
-     * @return DoctrineJoinDescriptor[]
+     * @return array<string, DoctrineJoinDescriptor>
      */
     protected function getJoins()
     {
@@ -711,7 +711,7 @@ class DoctrineListBuilder extends AbstractListBuilder
     /**
      * Adds joins to querybuilder.
      *
-     * @param DoctrineJoinDescriptor[]|null $joins
+     * @param array<string, DoctrineJoinDescriptor>|null $joins
      */
     protected function assignJoins(QueryBuilder $queryBuilder, ?array $joins = null)
     {

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/EncodeAliasTrait.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/EncodeAliasTrait.php
@@ -17,10 +17,16 @@ namespace Sulu\Component\Rest\ListBuilder\Doctrine;
 trait EncodeAliasTrait
 {
     /**
-     * @param array<string>|string $value
+     * @param array<string>|string|null $value
+     *
+     * @return array<string>|string
      */
     protected function encodeAlias($value)
     {
+        if (null === $value) {
+            return '';
+        }
+
         return \preg_replace_callback(
             '/(?:"[^"]+")|([\\\])|(?<=\S)(:)/',
             function($matches) {

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/EncodeAliasTrait.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/EncodeAliasTrait.php
@@ -17,9 +17,11 @@ namespace Sulu\Component\Rest\ListBuilder\Doctrine;
 trait EncodeAliasTrait
 {
     /**
-     * @param array<string>|string|null $value
+     * @template T of array<string>|string
      *
-     * @return array<string>|string
+     * @param T|null $value
+     *
+     * @return T
      */
     protected function encodeAlias($value)
     {
@@ -27,6 +29,7 @@ trait EncodeAliasTrait
             return '';
         }
 
+        /** @var T */
         return \preg_replace_callback(
             '/(?:"[^"]+")|([\\\])|(?<=\S)(:)/',
             function($matches) {

--- a/src/Sulu/Component/Util/SortUtils.php
+++ b/src/Sulu/Component/Util/SortUtils.php
@@ -75,6 +75,9 @@ final class SortUtils
 
                 if (\is_string($aOrder)) {
                     $aOrder = \strtolower($aOrder);
+                }
+
+                if (\is_string($bOrder)) {
                     $bOrder = \strtolower($bOrder);
                 }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix php deprecations for string and int types given as null.

#### Why?

This deprecations are thrown in different tests when deprecation output is enabled. Exception default code is 0 and preg split default limit is -1 which we need to use instead of null here.