### PR TITLE
Marking twig function as deprecated

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -45,6 +45,7 @@ $config->setRiskyAllowed(true)
         'nullable_type_declaration_for_default_null_value' => true,
         'no_null_property_initialization' => false,
         'fully_qualified_strict_types' => false,
+        'new_with_parentheses' => true
     ])
     ->setFinder($finder);
 

--- a/src/Sulu/Bundle/SnippetBundle/Twig/DefaultSnippetTwigExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/Twig/DefaultSnippetTwigExtension.php
@@ -37,7 +37,7 @@ class DefaultSnippetTwigExtension extends AbstractExtension
     public function getFunctions()
     {
         return [
-            new TwigFunction('sulu_snippet_load_default', [$this, 'getDefault']),
+            new TwigFunction('sulu_snippet_load_default', [$this, 'getDefault'], ['deprecated' => true]),
         ];
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes (but they aren't new)
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Marking the twig function as deprecated.

#### Why?
Some Editors (PHPStorm) then show it in the twig files as strikethrough.
