### PR TITLE
Make `Environment` type part of the constructor

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -10,6 +10,17 @@ We refactored the Migrations the abstract class is now under the Infrastructure 
 
  - `Sulu\Content\Migrations\AbstractTagNameToIdMigration` -> `Sulu\Content\Infrastructure\Doctrine\Migrations\AbstractTagNameToIdMigration`
 
+### Cleaning up the environment use in the webspaces
+
+The function `Sulu\Component\Webspace\Environment::setType()` is now deprecated and should be replaced with a call to the constructor with the correct environment:
+```diff
+- $environment = new Environment();
+- $environment->setType('prod');
++ $environment = new Environment('prod');
+```
+
+Using the `Url::getEnvironment()` and `Url::setEnvironment()` functions is deprecated. Use the environment of the `Portal::getEnvironment` instead.
+
 ## 3.0.7
 
 ### Smart content tag and category resolving is opt-in

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -10,7 +10,7 @@ We refactored the Migrations the abstract class is now under the Infrastructure 
 
  - `Sulu\Content\Migrations\AbstractTagNameToIdMigration` -> `Sulu\Content\Infrastructure\Doctrine\Migrations\AbstractTagNameToIdMigration`
 
-### Cleaning up the environment use in the webspaces
+### Cleaning up environment usage in webspaces
 
 The function `Sulu\Component\Webspace\Environment::setType()` is now deprecated and should be replaced with a call to the constructor with the correct environment:
 ```diff

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -19,7 +19,7 @@ The function `Sulu\Component\Webspace\Environment::setType()` is now deprecated 
 + $environment = new Environment('prod');
 ```
 
-Using the `Url::getEnvironment()` and `Url::setEnvironment()` functions is deprecated. Use the environment of the `Portal::getEnvironment` instead.
+Using the `Url::getEnvironment()` and `Url::setEnvironment()` functions is deprecated. Retrieve the environment from the portal instead via `Portal::getEnvironment($type)`, and use the returned `Environment` object for reading or updating the environment configuration.
 
 ## 3.0.7
 

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -21,6 +21,8 @@ The function `Sulu\Component\Webspace\Environment::setType()` is now deprecated 
 
 Using the `Url::getEnvironment()` and `Url::setEnvironment()` functions is deprecated. Retrieve the environment from the portal instead via `Portal::getEnvironment($type)`, and use the returned `Environment` object for reading or updating the environment configuration.
 
+The `Sulu\Component\Webspace\Url::setUrl` is now deprecated as it should only be set through the constructor.
+
 ## 3.0.7
 
 ### Smart content tag and category resolving is opt-in

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -37723,12 +37723,6 @@ parameters:
 			path: src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
 
 		-
-			message: '#^Parameter \#1 \$type of method Sulu\\Component\\Webspace\\Environment\:\:setType\(\) expects string, string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
-
-		-
 			message: '#^Parameter \#1 \$type of method Sulu\\Component\\Webspace\\Webspace\:\:addDefaultTemplate\(\) expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -255,10 +255,10 @@ class PreviewRenderer implements PreviewRendererInterface
         $portal->setLocalizations([$localization]);
         $portal->setDefaultLocalization($localization);
 
-        $environment = new Environment();
-        $url = new Url($domain, $this->environment);
-        $environment->setUrls([$url]);
-        $portal->setEnvironments([$environment]);
+        $environment = new Environment($this->environment);
+        $environment->addUrl(new Url($domain));
+
+        $portal->addEnvironment($environment);
         $webspace->setPortals([$portal]);
 
         return new PortalInformation(RequestAnalyzer::MATCH_TYPE_FULL, $webspace, $portal, $localization, $domain);

--- a/src/Sulu/Component/Webspace/Environment.php
+++ b/src/Sulu/Component/Webspace/Environment.php
@@ -45,7 +45,7 @@ class Environment
     public function __construct(?string $type = null)
     {
         if (null === $type) {
-            @trigger_deprecation('sulu/sulu', '2.5', 'Not passing the type of the environment is deprecated.');
+            @trigger_deprecation('sulu/sulu', '3.0', 'Not passing the type of the environment is deprecated.');
         } else {
             $this->type = $type;
         }
@@ -60,7 +60,7 @@ class Environment
      */
     public function setType($type)
     {
-        @trigger_deprecation('sulu/sulu', '2.5', 'Using the setter to set the type of the environment is deprecated. Use the constructor instead.');
+        @trigger_deprecation('sulu/sulu', '3.0', 'Environment::setType is deprecated. Use the constructor instead.');
         $this->type = $type;
     }
 

--- a/src/Sulu/Component/Webspace/Environment.php
+++ b/src/Sulu/Component/Webspace/Environment.php
@@ -42,13 +42,25 @@ class Environment
      */
     private $mainUrl;
 
+    public function __construct(?string $type = null)
+    {
+        if (null === $type) {
+            @trigger_deprecation('sulu/sulu', '2.5', 'Not passing the type of the environment is deprecated.');
+        } else {
+            $this->type = $type;
+        }
+    }
+
     /**
-     * Sets the tye of this environment.
+     * Sets the type of the environment.
      *
      * @param string $type
+     *
+     * @deprecated
      */
     public function setType($type)
     {
+        @trigger_deprecation('sulu/sulu', '2.5', 'Using the setter to set the type of the environment is deprecated. Use the constructor instead.');
         $this->type = $type;
     }
 

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
@@ -481,8 +481,7 @@ class XmlFileLoader10 extends BaseXmlFileLoader
     {
         foreach ($this->xpath->query('x:environments/x:environment', $portalNode) as $environmentNode) {
             /** @var \DOMNode $environmentNode */
-            $environment = new Environment();
-            $environment->setType($environmentNode->attributes->getNamedItem('type')->nodeValue);
+            $environment = new Environment($environmentNode->attributes->getNamedItem('type')->nodeValue);
 
             $this->generateUrls($environmentNode, $environment);
             $this->generateCustomUrls($environmentNode, $environment);

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
@@ -504,9 +504,7 @@ class XmlFileLoader10 extends BaseXmlFileLoader
             }
 
             /** @var \DOMNode $urlNode */
-            $url = new Url();
-
-            $url->setUrl(\rtrim($urlNode->nodeValue, '/'));
+            $url = new Url(\rtrim($urlNode->nodeValue, '/'));
 
             // set optional nodes
             $url->setLanguage($this->getOptionalNodeAttribute($urlNode, 'language'));

--- a/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
+++ b/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
@@ -97,8 +97,7 @@ class {{ cache_class }} extends {{ base_class }}
 {% for environment in portal.environments %}
 
         // add environment
-        $environment = new Environment();
-        $environment->setType('{{ environment.type }}');
+        $environment = new Environment('{{ environment.type }}');
 {% for url in environment.urls %}
 
         // add environment url

--- a/src/Sulu/Component/Webspace/Tests/Unit/EnvironmentTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/EnvironmentTest.php
@@ -37,11 +37,9 @@ class EnvironmentTest extends TestCase
             ],
         ];
 
-        // Testing that the environment of the url is overridden when adding it to the environment object
-        $url = new Url('sulu.io', 'I should be overwritten');
+        $url = new Url('sulu.io');
 
-        $environment = new Environment();
-        $environment->setType($expected['type']);
+        $environment = new Environment($expected['type']);
 
         $environment->addUrl($url);
 
@@ -79,7 +77,7 @@ class EnvironmentTest extends TestCase
     #[\PHPUnit\Framework\Attributes\DataProvider('addUrlProvider')]
     public function testAddUrl(array $urls, Url $expectedMainUrl): void
     {
-        $environment = new Environment();
+        $environment = new Environment('prod');
         foreach ($urls as $url) {
             $environment->addUrl($url);
         }
@@ -101,7 +99,7 @@ class EnvironmentTest extends TestCase
      */
     private static function getUrl($isMain = false)
     {
-        $url = new Url('test', 'test');
+        $url = new Url('test');
         $url->setMain($isMain);
 
         return $url;

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionTest.php
@@ -38,8 +38,7 @@ class WebspaceCollectionTest extends TestCase
         $portal->setName('Portal1');
         $portal->setKey('portal1');
 
-        $environment = new Environment();
-        $environment->setType('prod');
+        $environment = new Environment('prod');
         $url = new Url();
         $url->setUrl('www.portal1.com');
         $url->setLanguage('en');

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionTest.php
@@ -39,13 +39,13 @@ class WebspaceCollectionTest extends TestCase
         $portal->setKey('portal1');
 
         $environment = new Environment('prod');
-        $url = new Url();
-        $url->setUrl('www.portal1.com');
+
+        $url = new Url('www.portal1.com');
         $url->setLanguage('en');
         $url->setCountry('us');
         $environment->addUrl($url);
-        $url = new Url();
-        $url->setUrl('portal1.com');
+
+        $url = new Url('portal1.com');
         $url->setRedirect('www.portal1.com');
         $environment->addUrl($url);
         $portal->addEnvironment($environment);

--- a/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
@@ -146,8 +146,7 @@ class WebspaceTest extends TestCase
         $portal = new Portal();
         $webspace->addPortal($portal);
 
-        $environment = new Environment();
-        $environment->setType('prod');
+        $environment = new Environment('prod');
         $portal->addEnvironment($environment);
 
         $url = new Url('sulu.lo');
@@ -164,8 +163,7 @@ class WebspaceTest extends TestCase
         $portal = new Portal();
         $webspace->addPortal($portal);
 
-        $environment = new Environment();
-        $environment->setType('prod');
+        $environment = new Environment('prod');
         $portal->addEnvironment($environment);
 
         $url = new Url('{host}');
@@ -182,11 +180,10 @@ class WebspaceTest extends TestCase
         $portal = new Portal();
         $webspace->addPortal($portal);
 
-        $environment = new Environment();
-        $environment->setType('prod');
+        $environment = new Environment('prod');
         $portal->addEnvironment($environment);
 
-        $url = new Url('sulu.lo', 'prod');
+        $url = new Url('sulu.lo');
         $url->setLanguage('de');
         $url->setCountry('');
         $environment->addUrl($url);
@@ -203,11 +200,10 @@ class WebspaceTest extends TestCase
         $portal = new Portal();
         $webspace->addPortal($portal);
 
-        $environment = new Environment();
-        $environment->setType('prod');
+        $environment = new Environment('prod');
         $portal->addEnvironment($environment);
 
-        $url = new Url('sulu.lo', 'prod');
+        $url = new Url('sulu.lo');
         $url->setLanguage('de');
         $url->setCountry('at');
         $environment->addUrl($url);
@@ -224,16 +220,15 @@ class WebspaceTest extends TestCase
         $portal = new Portal();
         $webspace->addPortal($portal);
 
-        $environment = new Environment();
-        $environment->setType('prod');
+        $environment = new Environment('prod');
         $portal->addEnvironment($environment);
 
-        $urlDe = new Url('sulu.de', 'prod');
+        $urlDe = new Url('sulu.de');
         $urlDe->setLanguage('de');
         $urlDe->setCountry('');
         $environment->addUrl($urlDe);
 
-        $urlAt = new Url('sulu.at', 'prod');
+        $urlAt = new Url('sulu.at');
         $urlAt->setLanguage('de');
         $urlAt->setCountry('at');
         $environment->addUrl($urlAt);

--- a/src/Sulu/Component/Webspace/Url.php
+++ b/src/Sulu/Component/Webspace/Url.php
@@ -51,8 +51,8 @@ class Url implements ArrayableInterface
     private $main;
 
     /**
-     * @param string $url
-     * @param string $environment
+     * @param ?string $url
+     * @param ?string $environment
      */
     public function __construct(
         private $url = null,
@@ -192,7 +192,7 @@ class Url implements ArrayableInterface
      */
     public function getEnvironment()
     {
-        @trigger_deprecation('sulu/sulu', '3.0', 'getting and setting the environment on the url is deprecated use the portals environment.');
+        @trigger_deprecation('sulu/sulu', '3.0', 'Url::getEnvironment is deprecated use the Environment::getType.');
 
         return $this->environment;
     }
@@ -206,7 +206,7 @@ class Url implements ArrayableInterface
      */
     public function setEnvironment($environment)
     {
-        @trigger_deprecation('sulu/sulu', '3.0', 'getting and setting the environment on the url is deprecated use the portals environment.');
+        @trigger_deprecation('sulu/sulu', '3.0', 'Url::setEnvironment is deprecated. Move the url to a differnt Environment object.');
         $this->environment = $environment;
     }
 
@@ -233,6 +233,8 @@ class Url implements ArrayableInterface
         $res['segment'] = $this->getSegment();
         $res['redirect'] = $this->getRedirect();
         $res['main'] = $this->isMain();
+
+        // @deprecated: We should not rely on this anymore
         $res['environment'] = $this->getEnvironment();
 
         return $res;

--- a/src/Sulu/Component/Webspace/Url.php
+++ b/src/Sulu/Component/Webspace/Url.php
@@ -58,6 +58,9 @@ class Url implements ArrayableInterface
         private $url = null,
         private $environment = null
     ) {
+        if (null !== $environment) {
+            @trigger_deprecation('sulu/sulu', '3.0', 'Passing an environment to the URL is deprecated.');
+        }
     }
 
     /**
@@ -184,9 +187,13 @@ class Url implements ArrayableInterface
      * Returns the environment.
      *
      * @return string
+     *
+     * @deprecated use Portal::getEnvironment() instead
      */
     public function getEnvironment()
     {
+        @trigger_deprecation('sulu/sulu', '3.0', 'getting and setting the environment on the url is deprecated use the portals environment.');
+
         return $this->environment;
     }
 
@@ -194,9 +201,12 @@ class Url implements ArrayableInterface
      * Sets the environment.
      *
      * @param string $environment
+     *
+     * @deprecated
      */
     public function setEnvironment($environment)
     {
+        @trigger_deprecation('sulu/sulu', '3.0', 'getting and setting the environment on the url is deprecated use the portals environment.');
         $this->environment = $environment;
     }
 

--- a/src/Sulu/Component/Webspace/Url.php
+++ b/src/Sulu/Component/Webspace/Url.php
@@ -51,13 +51,16 @@ class Url implements ArrayableInterface
     private $main;
 
     /**
-     * @param ?string $url
+     * @param string $url
      * @param ?string $environment
      */
     public function __construct(
         private $url = null,
         private $environment = null
     ) {
+        if (null === $url) {
+            @trigger_deprecation('sulu/sulu', '3.0', 'Not passing a URL is deprecated.');
+        }
         if (null !== $environment) {
             @trigger_deprecation('sulu/sulu', '3.0', 'Passing an environment to the URL is deprecated.');
         }
@@ -67,6 +70,8 @@ class Url implements ArrayableInterface
      * Sets the url.
      *
      * @param string $url
+     *
+     * @deprecated use the constructor for that
      */
     public function setUrl($url)
     {
@@ -186,7 +191,7 @@ class Url implements ArrayableInterface
     /**
      * Returns the environment.
      *
-     * @return string
+     * @return string|null
      *
      * @deprecated use Portal::getEnvironment() instead
      */


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
* Adding a constructor to the `Environment` class (an environment without a type doesn't make sense)
* Deprecating the `$environment` property on the `Url` class (Use the portal's environment)

#### Why?
Instantiating an object of that class without setting the property makes it useless. Because when adding this to a portal (the main use of this class) the `getType` function is getting called and in 8.0 and higher causes an uninitialized property exception.

#### Example Usage
Old: 
```php
$env = new Environment();
$env->setType('prod');
```

New:
```php
$env = new Environment('prod');
```

#### To Do

- [x] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md
