### PR TITLE
Introduce sulu.focus event on text_area, text_line and text_editor

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
@@ -46,6 +46,14 @@ export default class Input<T: ?string | ?number> extends React.PureComponent<Inp
         this.props.onChange(event.currentTarget.value || undefined, event);
     };
 
+    handleFocus = (event: Event) => {
+        const {onFocus} = this.props;
+
+        if (onFocus) {
+            onFocus(event);
+        }
+    };
+
     handleKeyPress = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {
         const {onKeyPress} = this.props;
 
@@ -74,7 +82,6 @@ export default class Input<T: ?string | ?number> extends React.PureComponent<Inp
             onBlur,
             onIconClick,
             onClearClick,
-            onFocus,
             onKeyPress,
             segmentDelimiter,
             type,
@@ -156,7 +163,7 @@ export default class Input<T: ?string | ?number> extends React.PureComponent<Inp
                         name={name}
                         onBlur={onBlur}
                         onChange={this.handleChange}
-                        onFocus={onFocus}
+                        onFocus={this.handleFocus}
                         onKeyPress={onKeyPress ? this.handleKeyPress : undefined}
                         placeholder={placeholder}
                         ref={inputRef ? this.setInputRef : undefined}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/Input.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/Input.test.js
@@ -187,3 +187,13 @@ test('Input should render with type number with attributes', () => {
         render(<Input max={50} min={10} onBlur={jest.fn()} onChange={jest.fn()} step={5} type="number" value={25} />);
     expect(container).toMatchSnapshot();
 });
+
+test('Input should call onFocus when the Input gets focus', async() => {
+    const focusSpy = jest.fn();
+    render(bindValueToOnChange(<Input onChange={jest.fn()} onFocus={focusSpy} value="My value" />));
+
+    const input = screen.queryByDisplayValue('My value');
+    input.focus();
+
+    expect(focusSpy).toHaveBeenCalled();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/types.js
@@ -25,7 +25,7 @@ export type InputProps<T: ?string | ?number> = {|
     onBlur?: () => void,
     onChange: (value: ?string, event: SyntheticEvent<HTMLInputElement>) => void,
     onClearClick?: () => void,
-    onFocus?: () => void,
+    onFocus?: (event: Event) => void,
     onIconClick?: () => void,
     onKeyPress?: (key: ?string, event: SyntheticKeyboardEvent<HTMLInputElement>) => void,
     placeholder?: string,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/TextArea/TextArea.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/TextArea/TextArea.js
@@ -11,6 +11,7 @@ type Props = {|
     name?: string,
     onBlur?: () => void,
     onChange: (?string) => void,
+    onFocus?: (event: Event) => void,
     placeholder?: string,
     valid: boolean,
     value: ?string,
@@ -31,6 +32,14 @@ export default class TextArea extends React.PureComponent<Props> {
 
         if (onBlur) {
             onBlur();
+        }
+    };
+
+    handleFocus = (event: Event) => {
+        const {onFocus} = this.props;
+
+        if (onFocus) {
+            onFocus(event);
         }
     };
 
@@ -62,6 +71,7 @@ export default class TextArea extends React.PureComponent<Props> {
                     name={name}
                     onBlur={this.handleBlur}
                     onChange={this.handleChange}
+                    onFocus={this.handleFocus}
                     placeholder={placeholder}
                     value={value || ''}
                 />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/TextArea/tests/TextArea.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/TextArea/tests/TextArea.test.js
@@ -76,3 +76,13 @@ test('TextArea should call onChange with undefined when the TextArea changes to 
 
     expect(changeSpy).toHaveBeenCalledWith(undefined);
 });
+
+test('TextArea should call onFocus when the TextArea gets focus', async() => {
+    const focusSpy = jest.fn();
+    render(bindValueToOnChange(<TextArea onChange={jest.fn()} onFocus={focusSpy} value="My value" />));
+
+    const textarea = screen.queryByDisplayValue('My value');
+    textarea.focus();
+
+    expect(focusSpy).toHaveBeenCalled();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/CKEditor5.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/CKEditor5.js
@@ -31,6 +31,7 @@ type Props = {|
     locale?: ?IObservableValue<string>,
     onBlur?: () => void,
     onChange: (value: ?string) => void,
+    onFocus?: (event: { target: EventTarget }) => void,
     value: ?string,
 |};
 
@@ -195,7 +196,7 @@ export default class CKEditor5 extends React.Component<Props> {
 
                 this.editorInstance.setData(this.props.value);
 
-                const {disabled, onBlur, onChange} = this.props;
+                const {disabled, onBlur, onChange, onFocus} = this.props;
                 const {
                     model: {
                         document: modelDocument,
@@ -215,6 +216,14 @@ export default class CKEditor5 extends React.Component<Props> {
                 if (onBlur) {
                     viewDocument.on('blur', () => {
                         onBlur();
+                    });
+                }
+
+                if (onFocus) {
+                    viewDocument.on('focus', () => {
+                        onFocus({
+                            target: this.editorInstance.ui.element.querySelector('div[contenteditable="true"]'),
+                        });
                     });
                 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/tests/CKEditor5.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/tests/CKEditor5.test.js
@@ -355,3 +355,37 @@ test('Call onBlur prop when CKEditor5 fires its blur event', () => {
         expect(blurSpy).toBeCalled();
     });
 });
+
+test('Call onFocus prop when CKEditor5 fires its focus event', () => {
+    const focusSpy = jest.fn();
+    const target = new EventTarget();
+    const querySelectorSpy = jest.fn().mockReturnValue(target);
+    const editor = {
+        ...defaultEditor,
+        getData: jest.fn().mockReturnValue('test'),
+        model: {
+            document: {
+                on: jest.fn(),
+                differ: {
+                    getChanges: jest.fn().mockReturnValue([]),
+                },
+            },
+        },
+        ui: {
+            element: {
+                querySelector: querySelectorSpy,
+            },
+        },
+    };
+
+    const editorPromise = Promise.resolve(editor);
+    ClassicEditor.create.mockReturnValue(editorPromise);
+
+    mount(<CKEditor5 onChange={jest.fn()} onFocus={focusSpy} value={undefined} />);
+
+    return editorPromise.then(() => {
+        editor.editing.view.document.on.mock.calls[0][1]();
+        expect(focusSpy).toBeCalledWith({target});
+        expect(querySelectorSpy).toBeCalledWith('div[contenteditable="true"]');
+    });
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
@@ -87,6 +87,24 @@ class Field extends React.Component<Props> {
         onFinish(dataPath, schemaPath);
     };
 
+    handleFocus = (target: EventTarget) => {
+        const {
+            schemaPath,
+            schema: schemaEntry,
+        } = this.props;
+
+        const focusEvent = new Event('sulu.focus', {bubbles: true});
+        // $FlowFixMe
+        focusEvent.detail = {
+            schemaType: schemaEntry?.type,
+            setValue: this.handleChange,
+            getValue: () => this.props.value,
+            schemaPath,
+        };
+
+        target.dispatchEvent(focusEvent);
+    };
+
     findErrorKeyword(error: ?Error | ErrorCollection): ?string {
         if (!error) {
             return;
@@ -212,6 +230,7 @@ class Field extends React.Component<Props> {
                             minOccurs={minOccurs}
                             onChange={this.handleChange}
                             onFinish={this.handleFinish}
+                            onFocus={this.handleFocus}
                             onSuccess={onSuccess}
                             router={router}
                             schemaOptions={schemaOptions}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Input.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Input.js
@@ -9,6 +9,16 @@ export default class Input extends React.Component<FieldTypeProps<?string>> {
         this.props.onFinish();
     };
 
+    handleFocus = (event: Event) => {
+        const {
+            onFocus,
+        } = this.props;
+
+        if (onFocus) {
+            onFocus(event.target);
+        }
+    };
+
     render() {
         const {
             dataPath,
@@ -77,6 +87,7 @@ export default class Input extends React.Component<FieldTypeProps<?string>> {
                 maxSegments={maxSegments ? parseInt(maxSegments) : undefined}
                 onBlur={this.handleBlur}
                 onChange={onChange}
+                onFocus={this.handleFocus}
                 segmentDelimiter={segmentDelimiter}
                 valid={!error}
                 value={value}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/TextArea.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/TextArea.js
@@ -2,9 +2,19 @@
 import React from 'react';
 import log from 'loglevel';
 import TextAreaComponent from '../../../components/TextArea';
-import type {FieldTypeProps} from '../../../types';
+import type {FieldTypeProps} from '../types';
 
 export default class TextArea extends React.Component<FieldTypeProps<?string>> {
+    handleFocus = (event: Event) => {
+        const {
+            onFocus,
+        } = this.props;
+
+        if (onFocus) {
+            onFocus(event.target);
+        }
+    };
+
     render() {
         const {
             dataPath,
@@ -47,6 +57,7 @@ export default class TextArea extends React.Component<FieldTypeProps<?string>> {
                 maxCharacters={evaluatedSoftMaxLength ? parseInt(evaluatedSoftMaxLength) : undefined}
                 onBlur={onFinish}
                 onChange={onChange}
+                onFocus={this.handleFocus}
                 valid={!error}
                 value={value}
             />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/TextEditor.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/TextEditor.js
@@ -3,9 +3,19 @@ import React from 'react';
 import {observable} from 'mobx';
 import TextEditorContainer from '../../../containers/TextEditor';
 import userStore from '../../../stores/userStore';
-import type {FieldTypeProps} from '../../../types';
+import type {FieldTypeProps} from '../types';
 
 export default class TextEditor extends React.Component<FieldTypeProps<?string>> {
+    handleFocus = (event: { target: EventTarget }) => {
+        const {
+            onFocus,
+        } = this.props;
+
+        if (onFocus) {
+            onFocus(event.target);
+        }
+    };
+
     render() {
         const {disabled, formInspector, onChange, onFinish, schemaOptions, value} = this.props;
 
@@ -18,6 +28,7 @@ export default class TextEditor extends React.Component<FieldTypeProps<?string>>
                 locale={locale}
                 onBlur={onFinish}
                 onChange={onChange}
+                onFocus={this.handleFocus}
                 options={schemaOptions}
                 value={value}
             />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
@@ -634,3 +634,35 @@ test('Do not render anything if field does not exist and onInvalid is set to ign
 
     expect(field.isEmptyRender()).toEqual(true);
 });
+
+test('Call onFocus callback when Field gets focus', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('snippets'), 'snippets'));
+
+    fieldRegistry.get.mockReturnValue(function Text() {
+        return <input type="text" />;
+    });
+
+    const field = shallow(
+        <Field
+            data={{}}
+            dataPath=""
+            formInspector={formInspector}
+            name="test"
+            onChange={jest.fn()}
+            onFinish={jest.fn()}
+            onSuccess={undefined}
+            router={undefined}
+            schema={{label: 'label', type: 'text'}}
+            schemaPath=""
+        />
+    );
+
+    const eventSpy = jest.fn();
+
+    const target = new EventTarget();
+    target.addEventListener('sulu.focus', eventSpy);
+
+    field.find('Text').props().onFocus(target);
+
+    expect(eventSpy).toBeCalled();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Input.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Input.test.js
@@ -161,3 +161,22 @@ test('Should not pass any arguments to onFinish callback', () => {
 
     expect(finishSpy).toBeCalledWith();
 });
+
+test('TextArea should call onFocus when the TextArea gets focus', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'snippets'));
+    const focusSpy = jest.fn();
+    const inputValid = shallow(
+        <Input
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            onFocus={focusSpy}
+        />
+    );
+
+    const target = new EventTarget();
+    inputValid.find(InputComponent).prop('onFocus')({
+        target,
+    });
+
+    expect(focusSpy).toBeCalledWith(target);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/TextArea.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/TextArea.test.js
@@ -118,3 +118,22 @@ test('Pass props correctly including soft_max_length to TextArea component', () 
     expect(inputValid.find(TextAreaComponent).prop('maxCharacters')).toBe(70);
     expect(inputValid.find(TextAreaComponent).prop('valid')).toBe(true);
 });
+
+test('TextArea should call onFocus when the TextArea gets focus', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+    const focusSpy = jest.fn();
+    const inputValid = shallow(
+        <TextArea
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            onFocus={focusSpy}
+        />
+    );
+
+    const target = new EventTarget();
+    inputValid.find(TextAreaComponent).prop('onFocus')({
+        target,
+    });
+
+    expect(focusSpy).toBeCalledWith(target);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/TextEditor.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/TextEditor.test.js
@@ -71,3 +71,22 @@ test('Pass content locale from user to TextEditor if form has no locale', () => 
     expect(textEditor.find('TextEditor').props().locale).toBeDefined();
     expect(textEditor.find('TextEditor').props().locale.get()).toEqual('de');
 });
+
+test('Call onFocus when editor get focus', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+    const focusSpy = jest.fn();
+
+    const textEditor = shallow(
+        <TextEditor
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            onFocus={focusSpy}
+        />
+    );
+
+    const target = new EventTarget();
+
+    textEditor.find('TextEditor').props().onFocus({target});
+
+    expect(focusSpy).toBeCalledWith(target);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -127,6 +127,7 @@ export type FieldTypeProps<T> = {|
     minOccurs: ?number,
     onChange: (value: T, context?: ChangeContext) => void,
     onFinish: (subDataPath: ?string, subSchemaPath: ?string) => void,
+    onFocus?: (target: EventTarget) => void,
     onSuccess: ?() => void,
     router: ?Router,
     schemaOptions: SchemaOptions,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/TextEditor/adapters/CKEditor5.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/TextEditor/adapters/CKEditor5.js
@@ -12,6 +12,7 @@ export default class CKEditor5 extends React.Component<TextEditorProps> {
             locale,
             onBlur,
             onChange,
+            onFocus,
             options,
             value,
         } = this.props;
@@ -40,6 +41,7 @@ export default class CKEditor5 extends React.Component<TextEditorProps> {
                 locale={locale}
                 onBlur={onBlur}
                 onChange={onChange}
+                onFocus={onFocus}
                 value={value}
             />
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/TextEditor/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/TextEditor/types.js
@@ -7,6 +7,7 @@ export type TextEditorProps = {|
     locale: ?IObservableValue<string>,
     onBlur?: () => void,
     onChange: (value: ?string) => void,
+    onFocus?: (event: {target: EventTarget}) => void,
     options?: ?SchemaOptions,
     value: ?string,
 |};


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR introduces `sulu.focus` events for text_editor, text_area and text_line.

#### Why?

Can be used to hook into the form.

#### To Do

- [x] Introduce tests
- [x] Implement event for text_editor