### PR TITLE
Fix ENOENT: no such file or directory, open 'node:stream' by downgrad cheerio to 1.0.0-rc.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "clean-webpack-plugin": "^4.0.0",
         "core-js": "^3.18.0",
         "css-loader": "^5.2.4",
+        "cheerio": "1.0.0-rc.12",
         "dependency-cruiser": "^11.12.0",
         "empty": "^0.10.1",
         "enzyme": "^3.3.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/cheeriojs/cheerio/issues?q=is%3Aissue+node%3Astream https://github.com/cheeriojs/cheerio/issues/4044 https://github.com/cheeriojs/cheerio/issues/4032 https://github.com/cheeriojs/cheerio/issues/4012 https://github.com/cheeriojs/cheerio/issues/4005 https://github.com/cheeriojs/cheerio/issues/3987
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix ENOENT: no such file or directory, open 'node:stream'.

#### Why?

Enzym uses cherrio which is not compatible with Jest as the current used Jest version does not include node:stream package / node standard library.