### PR TITLE
Fix debug:translation --only-missing command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -231,6 +231,7 @@
             "@lint-composer",
             "@lint-doctrine",
             "@lint-rector",
+            "@lint-translations",
             "@php-cs",
             "@phpstan"
         ],
@@ -260,6 +261,10 @@
         "lint-composer": "@composer validate --strict",
         "lint-twig": "@php bin/adminconsole lint:twig templates",
         "lint-yaml": "@php bin/adminconsole lint:yaml config",
+        "lint-translations": [
+            "@php bin/console debug:translation --all en --only-missing",
+            "@php bin/console debug:translation --all de --only-missing"
+        ],
         "lint-container": [
             "@php bin/adminconsole lint:container --env dev",
             "@php bin/websiteconsole lint:container --env dev",

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/forms/form_with_localizations.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/forms/form_with_localizations.xml
@@ -8,19 +8,19 @@
     <properties>
         <property name="formOfAddress" type="single_select" mandatory="true" colspan="3" spaceAfter="9">
             <meta>
-                <title>form_of_address</title>
+                <title>sulu_contact.form_of_address</title>
             </meta>
             <params>
                 <param name="default_value" value="0"/>
                 <param name="values" type="collection">
                     <param name="0" value="0">
                         <meta>
-                            <title>mr</title>
+                            <title>sulu_contact.male_form_of_address</title>
                         </meta>
                     </param>
                     <param name="1" value="1">
                         <meta>
-                            <title>ms</title>
+                            <title>sulu_contact.female_form_of_address</title>
                         </meta>
                     </param>
                 </param>
@@ -29,20 +29,20 @@
 
         <property name="firstName" type="text_line" mandatory="true" colspan="6">
             <meta>
-                <title>first_name</title>
+                <title>sulu_contact.first_name</title>
             </meta>d
         </property>
 
         <property name="lastName" type="text_line" mandatory="true" colspan="6">
             <meta>
-                <title>last_name</title>
+                <title>sulu_contact.last_name</title>
                 <title lang="de">Deutscher Nachname</title>
             </meta>
         </property>
 
         <property name="salutation" type="text_line">
             <meta>
-                <title>salutation</title>
+                <title>sulu_contact.salutation</title>
             </meta>
         </property>
     </properties>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Navigation/NavigationRegistryTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Navigation/NavigationRegistryTest.php
@@ -78,17 +78,19 @@ class NavigationRegistryTest extends TestCase
 
     public function testGetNavigation(): void
     {
-        $navigationItem1 = new NavigationItem('navigation_1');
+        $navigationItem1 = new NavigationItem('sulu_snippet.snippets');
         $navigationItem1->setView('view1');
+        $navigationItem1->setPosition(10);
 
         $this->admin1->configureNavigationItems(Argument::any())->will(function($arguments) use ($navigationItem1): void {
             $arguments[0]->add($navigationItem1);
         });
 
-        $navigationItem2 = new NavigationItem('navigation_2');
-        $navigationChildItem1 = new NavigationItem('navigation_2_child_1');
+        $navigationItem2 = new NavigationItem('sulu_admin.settings');
+        $navigationItem2->setPosition(20);
+        $navigationChildItem1 = new NavigationItem('sulu_category.categories');
         $navigationChildItem1->setView('view2_child1');
-        $navigationChildItem2 = new NavigationItem('navigation_2_child_2');
+        $navigationChildItem2 = new NavigationItem('sulu_tag.tags');
         $navigationChildItem2->setView('view2_child2');
         $navigationItem2->addChild($navigationChildItem1);
         $navigationItem2->addChild($navigationChildItem2);
@@ -128,20 +130,20 @@ class NavigationRegistryTest extends TestCase
         $this->viewRegistry->findViewByName('view2_child2')->shouldBeCalled()
             ->willReturn($view2Child2->reveal());
 
-        $this->translator->trans('navigation_1', [], 'admin')->willReturn('Navigation 1');
-        $this->translator->trans('navigation_2', [], 'admin')->willReturn('Navigation 2');
-        $this->translator->trans('navigation_2_child_1', [], 'admin')->willReturn('Navigation 2 - Child 1');
-        $this->translator->trans('navigation_2_child_2', [], 'admin')->willReturn('Navigation 2 - Child 2');
+        $this->translator->trans('sulu_snippet.snippets', [], 'admin')->willReturn('Snippets');
+        $this->translator->trans('sulu_admin.settings', [], 'admin')->willReturn('Settings');
+        $this->translator->trans('sulu_category.categories', [], 'admin')->willReturn('Categories');
+        $this->translator->trans('sulu_tag.tags', [], 'admin')->willReturn('Tags');
 
         $navigationItems = $this->navigationRegistry->getNavigationItems();
         $this->assertCount(2, $navigationItems);
-        $this->assertEquals('Navigation 1', $navigationItems[0]->getLabel());
-        $this->assertEquals('Navigation 2', $navigationItems[1]->getLabel());
+        $this->assertEquals('Snippets', $navigationItems[0]->getLabel());
+        $this->assertEquals('Settings', $navigationItems[1]->getLabel());
 
         // check for children of first navigation
         $this->assertCount(2, $navigationItems[1]->getChildren());
         $this->assertEquals(
-            'Navigation 2 - Child 1',
+            'Categories',
             $navigationItems[1]->getChildren()[0]->getLabel()
         );
         // check for created child views
@@ -155,7 +157,7 @@ class NavigationRegistryTest extends TestCase
         );
         // check for "Navigation 2 - Child 2"
         $this->assertEquals(
-            'Navigation 2 - Child 2',
+            'Tags',
             $navigationItems[1]->getChildren()[1]->getLabel()
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
@@ -105,35 +105,35 @@ class FormXmlLoaderTest extends TestCase
 
     public function testLoadFormWithLocalization(): void
     {
-        $this->translator->trans('mr', [], 'admin', 'en')->willReturn('en_mr');
-        $this->translator->trans('mr', [], 'admin', 'de')->willReturn('de_mr');
-        $this->translator->trans('mr', [], 'admin', 'fr')->willReturn('fr_mr');
-        $this->translator->trans('mr', [], 'admin', 'nl')->willReturn('nl_mr');
+        $this->translator->trans('sulu_contact.male_form_of_address', [], 'admin', 'en')->willReturn('en_mr');
+        $this->translator->trans('sulu_contact.male_form_of_address', [], 'admin', 'de')->willReturn('de_mr');
+        $this->translator->trans('sulu_contact.male_form_of_address', [], 'admin', 'fr')->willReturn('fr_mr');
+        $this->translator->trans('sulu_contact.male_form_of_address', [], 'admin', 'nl')->willReturn('nl_mr');
 
-        $this->translator->trans('ms', [], 'admin', 'en')->willReturn('en_ms');
-        $this->translator->trans('ms', [], 'admin', 'de')->willReturn('de_ms');
-        $this->translator->trans('ms', [], 'admin', 'fr')->willReturn('fr_ms');
-        $this->translator->trans('ms', [], 'admin', 'nl')->willReturn('nl_ms');
+        $this->translator->trans('sulu_contact.female_form_of_address', [], 'admin', 'en')->willReturn('en_ms');
+        $this->translator->trans('sulu_contact.female_form_of_address', [], 'admin', 'de')->willReturn('de_ms');
+        $this->translator->trans('sulu_contact.female_form_of_address', [], 'admin', 'fr')->willReturn('fr_ms');
+        $this->translator->trans('sulu_contact.female_form_of_address', [], 'admin', 'nl')->willReturn('nl_ms');
 
-        $this->translator->trans('form_of_address', [], 'admin', 'en')->willReturn('en_form_of_address');
-        $this->translator->trans('form_of_address', [], 'admin', 'de')->willReturn('de_form_of_address');
-        $this->translator->trans('form_of_address', [], 'admin', 'fr')->willReturn('fr_form_of_address');
-        $this->translator->trans('form_of_address', [], 'admin', 'nl')->willReturn('nl_form_of_address');
+        $this->translator->trans('sulu_contact.form_of_address', [], 'admin', 'en')->willReturn('en_form_of_address');
+        $this->translator->trans('sulu_contact.form_of_address', [], 'admin', 'de')->willReturn('de_form_of_address');
+        $this->translator->trans('sulu_contact.form_of_address', [], 'admin', 'fr')->willReturn('fr_form_of_address');
+        $this->translator->trans('sulu_contact.form_of_address', [], 'admin', 'nl')->willReturn('nl_form_of_address');
 
-        $this->translator->trans('first_name', [], 'admin', 'en')->willReturn('en_first_name');
-        $this->translator->trans('first_name', [], 'admin', 'de')->willReturn('de_first_name');
-        $this->translator->trans('first_name', [], 'admin', 'fr')->willReturn('fr_first_name');
-        $this->translator->trans('first_name', [], 'admin', 'nl')->willReturn('nl_first_name');
+        $this->translator->trans('sulu_contact.first_name', [], 'admin', 'en')->willReturn('en_first_name');
+        $this->translator->trans('sulu_contact.first_name', [], 'admin', 'de')->willReturn('de_first_name');
+        $this->translator->trans('sulu_contact.first_name', [], 'admin', 'fr')->willReturn('fr_first_name');
+        $this->translator->trans('sulu_contact.first_name', [], 'admin', 'nl')->willReturn('nl_first_name');
 
-        $this->translator->trans('last_name', [], 'admin', 'en')->willReturn('en_last_name');
-        $this->translator->trans('last_name', [], 'admin', 'de')->willReturn('de_last_name');
-        $this->translator->trans('last_name', [], 'admin', 'fr')->willReturn('fr_last_name');
-        $this->translator->trans('last_name', [], 'admin', 'nl')->willReturn('nl_last_name');
+        $this->translator->trans('sulu_contact.last_name', [], 'admin', 'en')->willReturn('en_last_name');
+        $this->translator->trans('sulu_contact.last_name', [], 'admin', 'de')->willReturn('de_last_name');
+        $this->translator->trans('sulu_contact.last_name', [], 'admin', 'fr')->willReturn('fr_last_name');
+        $this->translator->trans('sulu_contact.last_name', [], 'admin', 'nl')->willReturn('nl_last_name');
 
-        $this->translator->trans('salutation', [], 'admin', 'en')->willReturn('en_salutation');
-        $this->translator->trans('salutation', [], 'admin', 'de')->willReturn('de_salutation');
-        $this->translator->trans('salutation', [], 'admin', 'fr')->willReturn('fr_salutation');
-        $this->translator->trans('salutation', [], 'admin', 'nl')->willReturn('nl_salutation');
+        $this->translator->trans('sulu_contact.salutation', [], 'admin', 'en')->willReturn('en_salutation');
+        $this->translator->trans('sulu_contact.salutation', [], 'admin', 'de')->willReturn('de_salutation');
+        $this->translator->trans('sulu_contact.salutation', [], 'admin', 'fr')->willReturn('fr_salutation');
+        $this->translator->trans('sulu_contact.salutation', [], 'admin', 'nl')->willReturn('nl_salutation');
 
         /**
          * @var LocalizedFormMetadataCollection

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/ListMetadata/XmlListMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/ListMetadata/XmlListMetadataLoaderTest.php
@@ -52,13 +52,13 @@ class XmlListMetadataLoaderTest extends TestCase
 
     public function testGetMetadata(): void
     {
-        $this->translator->trans('sulu_contact.firstname', [], 'admin', 'de')->willReturn('First name');
-        $this->translator->trans('sulu_contact.lastname', [], 'admin', 'de')->willReturn('Last name');
+        $this->translator->trans('sulu_contact.first_name', [], 'admin', 'de')->willReturn('First name');
+        $this->translator->trans('sulu_contact.last_name', [], 'admin', 'de')->willReturn('Last name');
         $this->translator->trans('sulu_contact.name', [], 'admin', 'en')->willReturn('Name');
 
         $firstNameFieldDescriptor = new FieldDescriptor(
             'firstName',
-            'sulu_contact.firstname',
+            'sulu_contact.first_name',
             FieldDescriptorInterface::VISIBILITY_YES,
             FieldDescriptorInterface::SEARCHABILITY_NEVER,
             'string',
@@ -72,7 +72,7 @@ class XmlListMetadataLoaderTest extends TestCase
 
         $lastNameFieldDescriptor = new FieldDescriptor(
             'lastName',
-            'sulu_contact.lastname',
+            'sulu_contact.last_name',
             FieldDescriptorInterface::VISIBILITY_NO,
             FieldDescriptorInterface::SEARCHABILITY_NEVER,
             'string',

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/SymfonyExpressionTokenProviderTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/SymfonyExpressionTokenProviderTest.php
@@ -44,7 +44,9 @@ class SymfonyExpressionTokenProviderTest extends TestCase
         $translator = $this->prophesize(Translator::class);
         $translator->getLocale()->willReturn('de');
         $translator->setLocale('de')->shouldBeCalled();
-        $translator->trans('test-key', Argument::cetera())->willReturn('TEST');
+        $translator->trans(Argument::cetera())->will(function($args) {
+            return \ucfirst(\str_replace(['-', '_', '.'], [' '], $args[0]));
+        });
         $entity = $this->prophesize(RoutableInterface::class);
         $entity->getLocale()->willReturn('en');
 
@@ -52,7 +54,7 @@ class SymfonyExpressionTokenProviderTest extends TestCase
             return 'en';
         };
         $provider = new SymfonyExpressionTokenProvider($translator->reveal());
-        $this->assertEquals('TEST', $provider->provide($entity, 'translator.trans("test-key")'));
+        $this->assertEquals('Test key', $provider->provide($entity, 'translator.trans("test-key")'));
     }
 
     public function testResolveWithImplode(): void
@@ -93,7 +95,9 @@ class SymfonyExpressionTokenProviderTest extends TestCase
         $translator->getLocale()->willReturn('de');
         $translator->setLocale('de')->shouldBeCalled();
         $translator->setLocale('es')->shouldBeCalled();
-        $translator->trans('test-key', Argument::cetera())->willReturn('TEST');
+        $translator->trans(Argument::cetera())->will(function($args) {
+            return \ucfirst(\str_replace(['-', '_', '.'], [' '], $args[0]));
+        });
 
         $entity = [
             'title',
@@ -103,7 +107,7 @@ class SymfonyExpressionTokenProviderTest extends TestCase
         $provider = new SymfonyExpressionTokenProvider($translator->reveal());
 
         $this->assertEquals(
-            'TEST',
+            'Test key',
             $provider->provide($entity, 'translator.trans("test-key")', ['locale' => 'es'])
         );
     }

--- a/src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
@@ -227,6 +227,7 @@ class ResettingController
                 [
                     'user' => $user,
                     'reset_url' => $resetUrl . '#/?forgotPasswordToken=' . $token,
+                    'message' => 'sulu_security.reset_mail_message',
                     'translation_domain' => $translationDomain,
                 ]
             )

--- a/src/Sulu/Bundle/SecurityBundle/Resources/views/mail_templates/reset_password.html.twig
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/views/mail_templates/reset_password.html.twig
@@ -1,3 +1,3 @@
-{{ 'sulu_security.reset_mail_message'|trans({}, translation_domain) }}
+{{ translation_domain ? message|default('sulu_security.reset_mail_message')|trans({}, translation_domain) : message }}
 <br/>
 {{ reset_url }}

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
@@ -120,15 +120,14 @@ class StructureXmlLoaderTest extends TestCase
         $this->cacheLifetimeResolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, Argument::any())
             ->willReturn(true);
 
-        $this->translator->trans('template_title', [], 'admin', 'en')->willReturn('en_template_title');
-        $this->translator->trans('template_title', [], 'admin', 'de')->willReturn('de_template_title');
-        $this->translator->trans('template_title', [], 'admin', 'fr')->willReturn('fr_template_title');
-        $this->translator->trans('template_title', [], 'admin', 'nl')->willReturn('nl_template_title');
+        $this->translator->trans('sulu_admin.title', [], 'admin', 'en')->willReturn('en_template_title');
+        $this->translator->trans('sulu_admin.title', [], 'admin', 'fr')->willReturn('fr_template_title');
+        $this->translator->trans('sulu_admin.title', [], 'admin', 'nl')->willReturn('nl_template_title');
 
-        $this->translator->trans('property_title', [], 'admin', 'en')->willReturn('en_property_title');
-        $this->translator->trans('property_title', [], 'admin', 'de')->willReturn('de_property_title');
-        $this->translator->trans('property_title', [], 'admin', 'fr')->willReturn('fr_property_title');
-        $this->translator->trans('property_title', [], 'admin', 'nl')->willReturn('nl_property_title');
+        $this->translator->trans('sulu_admin.name', [], 'admin', 'en')->willReturn('en_property_title');
+        $this->translator->trans('sulu_admin.name', [], 'admin', 'de')->willReturn('de_property_title');
+        $this->translator->trans('sulu_admin.name', [], 'admin', 'fr')->willReturn('fr_property_title');
+        $this->translator->trans('sulu_admin.name', [], 'admin', 'nl')->willReturn('nl_property_title');
 
         $result = $this->load('template_with_localizations.xml');
 

--- a/src/Sulu/Component/Rest/Tests/Unit/FlattenExceptionNormalizerTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/FlattenExceptionNormalizerTest.php
@@ -111,7 +111,7 @@ class FlattenExceptionNormalizerTest extends TestCase
         $exception = new class('Key already exists', 56789) extends \Exception implements TranslationErrorMessageExceptionInterface {
             public function getMessageTranslationKey(): string
             {
-                return 'error_message_translation_key';
+                return 'sulu_security.key_assigned_to_other_role';
             }
 
             /**
@@ -120,8 +120,7 @@ class FlattenExceptionNormalizerTest extends TestCase
             public function getMessageTranslationParameters(): array
             {
                 return [
-                    'parameter1' => 'value1',
-                    'parameter2' => 'value2',
+                    '{key}' => 'role_key',
                 ];
             }
         };
@@ -138,10 +137,9 @@ class FlattenExceptionNormalizerTest extends TestCase
         ]);
 
         $translator->trans(
-            'error_message_translation_key',
+            'sulu_security.key_assigned_to_other_role',
             [
-                'parameter1' => 'value1',
-                'parameter2' => 'value2',
+                '{key}' => 'role_key',
             ],
             'admin'
         )->willReturn('Translated Error Message Example');
@@ -383,7 +381,7 @@ class FlattenExceptionNormalizerTest extends TestCase
         $exception = new class('Key already exists', 56789) extends \Exception implements TranslationErrorMessageExceptionInterface {
             public function getMessageTranslationKey(): string
             {
-                return 'error_message_translation_key';
+                return 'sulu_security.key_assigned_to_other_role';
             }
 
             /**
@@ -392,8 +390,7 @@ class FlattenExceptionNormalizerTest extends TestCase
             public function getMessageTranslationParameters(): array
             {
                 return [
-                    'parameter1' => 'value1',
-                    'parameter2' => 'value2',
+                    '{key}' => 'role_key',
                 ];
             }
         };
@@ -410,10 +407,9 @@ class FlattenExceptionNormalizerTest extends TestCase
         ]);
 
         $translator->trans(
-            'error_message_translation_key',
+            'sulu_security.key_assigned_to_other_role',
             [
-                'parameter1' => 'value1',
-                'parameter2' => 'value2',
+                '{key}' => 'role_key',
             ],
             'admin'
         )->willReturn('Translated Error Message Example');

--- a/tests/Resources/DataFixtures/Page/template_with_localizations.xml
+++ b/tests/Resources/DataFixtures/Page/template_with_localizations.xml
@@ -11,7 +11,7 @@
     <index name="foo_index" />
 
     <meta>
-        <title>template_title</title>
+        <title>sulu_admin.title</title>
         <title lang="de">Template Titel</title>
     </meta>
 
@@ -20,7 +20,7 @@
     <properties>
         <property name="title" type="text_line" mandatory="true">
             <meta>
-                <title>property_title</title>
+                <title>sulu_admin.name</title>
             </meta>
 
             <indexField />


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix issue with debug:translation only-missing always errors when using Sulu.

#### Why?

This should allow that projects can use:

```php
bin/console debug:translation en --only-missing
```

To get there missing translations. Keep in mind this only works for symfony translation calls not yet for translations inside sulu templates.
