### PR TITLE
Fix debug:translation --only-missing command for 2.6

### DIFF
--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/DependencyInjection/Compiler/SnippetAreaCompilerPassTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/DependencyInjection/Compiler/SnippetAreaCompilerPassTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\SnippetBundle\Tests\Unit\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\SnippetBundle\DependencyInjection\Compiler\SnippetAreaCompilerPass;
@@ -186,7 +187,7 @@ class SnippetAreaCompilerPassTest extends TestCase
                     'key' => 'article',
                     'cache-invalidation' => 'false',
                     'title' => [
-                        'sulu_snippet.areas.article.title',
+                        'sulu_snippet.snippet_area',
                     ],
                 ],
             ]
@@ -196,8 +197,8 @@ class SnippetAreaCompilerPassTest extends TestCase
         $this->structureFactory->getStructures('snippet')->willReturn([$structureMetaData->reveal()]);
 
         $translator = $this->prophesize(TranslatorInterface::class);
-        $translator->trans('sulu_snippet.areas.article.title', [], 'admin', 'en')->willReturn('Article Test');
-        $translator->trans('sulu_snippet.areas.article.title', [], 'admin', 'de')->willReturn('Artikel Test');
+        $translator->trans('sulu_snippet.snippet_area', [], 'admin', 'en')->willReturn('Article Test');
+        $translator->trans('sulu_snippet.snippet_area', [], 'admin', 'de')->willReturn('Artikel Test');
         $this->container = $this->prophesize(ContainerBuilder::class);
         $this->container->get('sulu_page.structure.factory')->willReturn($this->structureFactory->reveal());
         $this->container->get('translator')->willReturn($translator->reveal());
@@ -242,8 +243,7 @@ class SnippetAreaCompilerPassTest extends TestCase
         $this->structureFactory->getStructures('snippet')->willReturn([$structureMetaData->reveal()]);
 
         $translator = $this->prophesize(TranslatorInterface::class);
-        $translator->trans('sulu_snippet.areas.article.title', [], 'admin', 'en')->willReturn('sulu_snippet.areas.article.title');
-        $translator->trans('sulu_snippet.areas.article.title', [], 'admin', 'de')->willReturn('sulu_snippet.areas.article.title');
+        $translator->trans(Argument::any(), [], 'admin', Argument::any())->willReturnArgument(0);
         $this->container = $this->prophesize(ContainerBuilder::class);
         $this->container->get('sulu_page.structure.factory')->willReturn($this->structureFactory->reveal());
         $this->container->get('translator')->willReturn($translator->reveal());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | same as for https://github.com/sulu/sulu/pull/7577
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

See same as for https://github.com/sulu/sulu/pull/7577

#### Why?

Same as for https://github.com/sulu/sulu/pull/7577 but for 2.6

#### TODO

 - [x] Rebase when backmerge https://github.com/sulu/sulu/pull/7577