### PR TITLE
Added Translation for Webspace Select Component

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Resources/js/components/WebspaceSelect/WebspaceSelect.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/components/WebspaceSelect/WebspaceSelect.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import {action, observable} from 'mobx';
 import {observer} from 'mobx-react';
+import {translate} from 'sulu-admin-bundle/utils';
 import {Icon, ArrowMenu} from 'sulu-admin-bundle/components';
 import webspaceSelectStyles from './webspaceSelect.scss';
 import type {ChildrenArray, Element} from 'react';
@@ -75,7 +76,7 @@ class WebspaceSelect extends React.Component<Props> {
                 <ArrowMenu.SingleItemSection
                     icon="su-webspace"
                     onChange={this.handleChange}
-                    title="Webspaces"
+                    title= {translate('sulu_page.webspaces')}
                     value={value}
                 >
                     {children}


### PR DESCRIPTION
The Webspace Select Component currently has the Name "Webspace" Hardcoded. For different Languages this might be different.

| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no 
| License | MIT

#### What's in this PR?

Changed the Webspace Select Component to using sulu_page.webspaces Translation.

#### Why?

Different Languages might have different names for Webspaces. 
