### PR TITLE
Use a shared session cookie between admin and website

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/DependencyInjection/SuluSecurityExtension.php
+++ b/src/Sulu/Bundle/SecurityBundle/DependencyInjection/SuluSecurityExtension.php
@@ -178,9 +178,6 @@ class SuluSecurityExtension extends Extension implements PrependExtensionInterfa
                 'framework',
                 [
                     'csrf_protection' => true,
-                    'session' => [
-                        'cookie_path' => '/admin',
-                    ],
                     'fragments' => [
                         'path' => '/admin/_fragments',
                     ],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/skeleton/pull/256
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Use a shared session cookie between admin and website.

#### Why?

See https://github.com/sulu/skeleton/pull/256.

This will make this default with Sulu 3.0. For bc reasons we can not yet merge this into 2.6 to not break existing applications.
