### PR TITLE
Add raw href value to view data of Link Content Type

### DIFF
--- a/src/Sulu/Component/Content/Tests/Unit/Types/LinkTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Types/LinkTest.php
@@ -84,6 +84,7 @@ class LinkTest extends TestCase
             'target' => 'testTarget',
             'title' => 'testTitle',
             'rel' => 'testRel',
+            'href' => '123456',
         ], $result);
     }
 
@@ -92,6 +93,7 @@ class LinkTest extends TestCase
         $this->property->getValue()
             ->shouldBeCalled()
             ->willReturn([
+                'href' => '123456',
                 'provider' => 'pages',
                 'locale' => 'de',
             ]);
@@ -101,6 +103,7 @@ class LinkTest extends TestCase
         $this->assertSame([
             'provider' => 'pages',
             'locale' => 'de',
+            'href' => '123456',
         ], $result);
     }
 

--- a/src/Sulu/Component/Content/Types/Link.php
+++ b/src/Sulu/Component/Content/Types/Link.php
@@ -124,7 +124,7 @@ class Link extends SimpleContentType
         $userId,
         $webspaceKey,
         $languageCode,
-        $segmentKey = null
+        $segmentKey = null,
     ): void {
         $property->setValue(\json_decode($value, true));
         $this->write($node, $property, $userId, $webspaceKey, $languageCode, $segmentKey);

--- a/src/Sulu/Component/Content/Types/Link.php
+++ b/src/Sulu/Component/Content/Types/Link.php
@@ -80,6 +80,13 @@ class Link extends SimpleContentType
             $result['rel'] = $value['rel'];
         }
 
+        if (null !== $value['provider'] && self::LINK_TYPE_EXTERNAL !== $value['provider'] && null !== $value['href']) {
+            $provider = $this->providerPool->getProvider($value['provider']);
+            $locale = $property->getStructure()->getLanguageCode();
+            $result['uuid'] = $value['href'];
+            $result['linkitems'] = $provider->preload([$value['href']], $locale, true);
+        }
+
         return $result;
     }
 

--- a/src/Sulu/Component/Content/Types/Link.php
+++ b/src/Sulu/Component/Content/Types/Link.php
@@ -81,6 +81,7 @@ class Link extends SimpleContentType
         }
 
         $result['href'] = $value['href'] ?? null;
+
         return $result;
     }
 
@@ -123,7 +124,7 @@ class Link extends SimpleContentType
         $userId,
         $webspaceKey,
         $languageCode,
-        $segmentKey = null
+        $segmentKey = null,
     ): void {
         $property->setValue(\json_decode($value, true));
         $this->write($node, $property, $userId, $webspaceKey, $languageCode, $segmentKey);

--- a/src/Sulu/Component/Content/Types/Link.php
+++ b/src/Sulu/Component/Content/Types/Link.php
@@ -80,13 +80,7 @@ class Link extends SimpleContentType
             $result['rel'] = $value['rel'];
         }
 
-        if (null !== $value['provider'] && self::LINK_TYPE_EXTERNAL !== $value['provider'] && null !== $value['href']) {
-            $provider = $this->providerPool->getProvider($value['provider']);
-            $locale = $property->getStructure()->getLanguageCode();
-            $result['uuid'] = $value['href'];
-            $result['linkitems'] = $provider->preload([$value['href']], $locale, true);
-        }
-
+        $result['href'] = $value['href'] ?? null;
         return $result;
     }
 

--- a/src/Sulu/Component/Content/Types/Link.php
+++ b/src/Sulu/Component/Content/Types/Link.php
@@ -124,7 +124,7 @@ class Link extends SimpleContentType
         $userId,
         $webspaceKey,
         $languageCode,
-        $segmentKey = null,
+        $segmentKey = null
     ): void {
         $property->setValue(\json_decode($value, true));
         $this->write($node, $property, $userId, $webspaceKey, $languageCode, $segmentKey);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no

#### What's in this PR?

Added uuid and linkitems to the view of link content type.

#### Why?

When using the link content type it was not possible to me to get title/contents of the page easily since only the url was provided. 