### PR TITLE
Fix default locale in SSO when no 'locale' attribute is provided

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapter.php
+++ b/src/Sulu/Bundle/SecurityBundle/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapter.php
@@ -272,7 +272,7 @@ class OpenIdSingleSignOnAdapter implements SingleSignOnAdapterInterface
         $contact = $user->getContact();
         $contact->setFirstName($attributes['given_name'] ?? '');
         $contact->setLastName($attributes['family_name'] ?? '');
-        $locale = (isset($attributes['locale']) && \in_array($attributes['locale'], $this->translations, true)) ? $attributes['locale'] : 'en';
+        $locale = (isset($attributes['locale']) && \in_array($attributes['locale'], $this->translations, true)) ? $attributes['locale'] : ($user instanceof User && $user->getLocale() ? $user->getLocale() : 'en');
         $user->setLocale($locale);
 
         $this->entityManager->flush();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #7444
| Related issues/PRs | ❌
| License | MIT
| Documentation PR | ❌

#### What's in this PR?

This PR fixes the behavior in the SSO system where the user's locale is always reset to `'en'` when no `locale` attribute is provided. Now, if the user already has a locale stored in the database, it will not be overwritten.

#### Why?

Currently, when a user logs in via SSO and the `locale` attribute is missing, their locale is reset to `'en'` even if they have a locale already set in the database. This PR ensures that the user's locale remains unchanged unless it's not set in the database and no valid locale is provided.

#### Example Usage

```php
// Example of current behavior
$locale = (isset($attributes['locale']) && \in_array($attributes['locale'], $this->translations, true)) ? $attributes['locale'] : 'en';
$user->setLocale($locale);

// The new behavior will ensure the locale is not reset if the user already has one
$locale = (isset($attributes['locale']) && \in_array($attributes['locale'], $this->translations, true)) ? $attributes['locale'] : ($user instanceof User && $user->getLocale() ? $user->getLocale() : 'en');
$user->setLocale($locale);
```