### PR TITLE
Improve performance with reevaluation of only changed blocks

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
@@ -47,9 +47,6 @@ exports[`Render block with schema 1`] = `
           class="header"
         >
           <div
-            class="icons"
-          />
-          <div
             class="iconButtons"
           >
             <button
@@ -174,9 +171,6 @@ exports[`Render block with schema 1`] = `
         <header
           class="header"
         >
-          <div
-            class="icons"
-          />
           <div
             class="iconButtons"
           >
@@ -335,9 +329,6 @@ exports[`Render block with schema and error on fields already being modified 1`]
           class="header"
         >
           <div
-            class="icons"
-          />
-          <div
             class="iconButtons"
           >
             <button
@@ -433,9 +424,6 @@ exports[`Render block with schema and error on fields already being modified 1`]
         <header
           class="header"
         >
-          <div
-            class="icons"
-          />
           <div
             class="iconButtons"
           >
@@ -535,9 +523,6 @@ exports[`Render block with schema and error on fields already being modified 1`]
         <header
           class="header"
         >
-          <div
-            class="icons"
-          />
           <div
             class="iconButtons"
           >
@@ -667,9 +652,6 @@ exports[`Render block with schema and error on fields already being modified 2`]
           class="header"
         >
           <div
-            class="icons"
-          />
-          <div
             class="iconButtons"
           >
             <button
@@ -765,9 +747,6 @@ exports[`Render block with schema and error on fields already being modified 2`]
         <header
           class="header"
         >
-          <div
-            class="icons"
-          />
           <div
             class="iconButtons"
           >
@@ -867,9 +846,6 @@ exports[`Render block with schema and error on fields already being modified 2`]
         <header
           class="header"
         >
-          <div
-            class="icons"
-          />
           <div
             class="iconButtons"
           >
@@ -1160,9 +1136,6 @@ exports[`Render collapsed blocks with block previews 2`] = `
           class="header"
         >
           <div
-            class="icons"
-          />
-          <div
             class="type"
           >
             Default
@@ -1223,9 +1196,6 @@ exports[`Render collapsed blocks with block previews 2`] = `
         <header
           class="header"
         >
-          <div
-            class="icons"
-          />
           <div
             class="type"
           >
@@ -1320,9 +1290,6 @@ exports[`Render collapsed blocks with block previews and sections 1`] = `
           class="header"
         >
           <div
-            class="icons"
-          />
-          <div
             class="type"
           >
             Default
@@ -1380,9 +1347,6 @@ exports[`Render collapsed blocks with block previews and sections 1`] = `
         <header
           class="header"
         >
-          <div
-            class="icons"
-          />
           <div
             class="type"
           >
@@ -1474,9 +1438,6 @@ exports[`Render collapsed blocks with block previews without tags 1`] = `
           class="header"
         >
           <div
-            class="icons"
-          />
-          <div
             class="type"
           >
             Default
@@ -1537,9 +1498,6 @@ exports[`Render collapsed blocks with block previews without tags 1`] = `
         <header
           class="header"
         >
-          <div
-            class="icons"
-          />
           <div
             class="type"
           >
@@ -1634,9 +1592,6 @@ exports[`Render collapsed blocks with block previews without tags and with secti
           class="header"
         >
           <div
-            class="icons"
-          />
-          <div
             class="type"
           >
             Default
@@ -1697,9 +1652,6 @@ exports[`Render collapsed blocks with block previews without tags and with secti
         <header
           class="header"
         >
-          <div
-            class="icons"
-          />
           <div
             class="type"
           >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/DifferenceCalculator/getDifference.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/DifferenceCalculator/getDifference.js
@@ -1,0 +1,38 @@
+// @flow
+import equals from 'fast-deep-equal';
+
+export default function getDifference(
+    target: any,
+    source: any
+): { [key: string]: any } {
+    // if target and source are not the same data structure
+    if (typeof target !== typeof source ||
+        target === null || source === null ||
+        Array.isArray(target) !== Array.isArray(source)
+    ) {
+        return target;
+    }
+
+    // get all unique keys from target and source
+    // this is necessary because the keys of the target and source can be different
+    const keys = new Set(
+        [
+            ...Object.keys(target),
+            ...Object.keys(source),
+        ]
+    );
+
+    // iterate over all keys and compare the values
+    const result = {};
+    for (const key of keys) {
+        const targetValue = target[key] || null;
+        const sourceValue = source[key] || null;
+
+        // if the values are not equal, add the value to the result
+        if (!equals(targetValue, sourceValue)) {
+            result[key] = targetValue;
+        }
+    }
+
+    return Object.keys(result).length > 0 ? result : {};
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/DifferenceCalculator/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/DifferenceCalculator/index.js
@@ -1,0 +1,5 @@
+//@flow
+
+import getDifference from './getDifference';
+
+export {getDifference};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/DifferenceCalculator/tests/getDifference.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/DifferenceCalculator/tests/getDifference.test.js
@@ -1,0 +1,83 @@
+// @flow
+import getDifference from '../getDifference';
+
+test('Should return target object if source is null', () => {
+    const target = {a: 1, b: 2};
+    const source = null;
+
+    const result = getDifference(target, source);
+
+    expect(result).toEqual(target);
+});
+
+test('Should return target object if target and source are different data structures', () => {
+    const target = {a: 1, b: 2};
+    const source = [1, 2, 3];
+
+    const result = getDifference(target, source);
+
+    expect(result).toEqual(target);
+});
+
+test('Should return empty object if target and source are equal', () => {
+    const target = {a: 1, b: 2};
+    const source = {a: 1, b: 2};
+
+    const result = getDifference(target, source);
+
+    expect(result).toEqual({});
+});
+
+test('Should return differences between target and source objects', () => {
+    const target = {a: 1, b: 2, c: {x: 3, y: 4}};
+    const source = {a: 1, b: 3, c: {x: 3, y: 5}};
+
+    const result = getDifference(target, source);
+
+    expect(result).toEqual({b: 2, c: {x: 3, y: 4}});
+});
+
+test('Should handle arrays correctly', () => {
+    const target = {a: [1, 2, 3], b: {c: [4, 5]}};
+    const source = {a: [1, 2, 4], b: {c: [4, 6]}};
+
+    const result = getDifference(target, source);
+
+    expect(result).toEqual({a: [1, 2, 3], b: {c: [4, 5]}});
+});
+
+test('Should handle null values in objects', () => {
+    const target = {a: 1, b: null, c: 3};
+    const source = {a: 1, b: 2, c: null};
+
+    const result = getDifference(target, source);
+
+    expect(result).toEqual({b: null, c: 3});
+});
+
+test('Should handle undefined values and missing properties', () => {
+    const target = {a: 1, b: undefined, d: 4};
+    const source = {a: 1, b: 2, c: 3};
+
+    const result = getDifference(target, source);
+
+    expect(result).toEqual({b: null, c: null, d: 4});
+});
+
+test('Should return empty object when comparing empty objects', () => {
+    const target = {};
+    const source = {};
+
+    const result = getDifference(target, source);
+
+    expect(result).toEqual({});
+});
+
+test('Should handle objects with different number of properties', () => {
+    const target = {a: 1, b: 2, c: 3};
+    const source = {a: 1};
+
+    const result = getDifference(target, source);
+
+    expect(result).toEqual({b: 2, c: 3});
+});


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

This PR prevents reevaluating all icon conditions of all blocks, when one block is changed. Only the condition for the changed block will be reevaluated.

#### Why?

Projects that have 50+ blocks and multiple conditions regarding icons from the blocksettings run into performance issues, due to the mass reevaluation of the conditions.