### PR TITLE
Fix nested file inspection

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/FileInspector/UploadFileSubscriber.php
+++ b/src/Sulu/Bundle/MediaBundle/FileInspector/UploadFileSubscriber.php
@@ -75,7 +75,7 @@ final class UploadFileSubscriber implements EventSubscriberInterface
                 continue;
             }
 
-            $mimeType = $file->getClientMimeType();
+            $mimeType = $file->getMimeType() ?: $file->getClientMimeType();
             foreach ($this->fileInspectors as $fileInspector) {
                 if (null !== $mimeType && $fileInspector->supports($mimeType)) {
                     try {

--- a/src/Sulu/Bundle/MediaBundle/FileInspector/UploadFileSubscriber.php
+++ b/src/Sulu/Bundle/MediaBundle/FileInspector/UploadFileSubscriber.php
@@ -51,21 +51,34 @@ final class UploadFileSubscriber implements EventSubscriberInterface
     {
         $request = $event->getRequest();
 
-        /**
-         * @var string $key
-         * @var UploadedFile $file
-         */
-        foreach ($request->files as $key => $file) {
+        $request->files->replace($this->inspectFiles($request->files->all()));
+    }
+
+    /**
+     * @param array<string, mixed> $files
+     *
+     * @return array<string, mixed>
+     */
+    private function inspectFiles(array $files): array
+    {
+        foreach ($files as $key => $file) {
+            if (\is_array($file)) {
+                $files[$key] = $this->inspectFiles($file);
+                continue;
+            }
+
+            $mimeType = $file->getClientMimeType();
             foreach ($this->fileInspectors as $fileInspector) {
-                $mimeType = $file->getClientMimeType();
                 if (null !== $mimeType && $fileInspector->supports($mimeType)) {
                     try {
-                        $request->files->set($key, $fileInspector->inspect($file));
+                        $files[$key] = $fileInspector->inspect($file);
                     } catch (UnsafeFileException $exception) {
                         throw new BadRequestHttpException($exception->getMessage(), $exception);
                     }
                 }
             }
         }
+
+        return $files;
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/FileInspector/UploadFileSubscriber.php
+++ b/src/Sulu/Bundle/MediaBundle/FileInspector/UploadFileSubscriber.php
@@ -61,9 +61,17 @@ final class UploadFileSubscriber implements EventSubscriberInterface
      */
     private function inspectFiles(array $files): array
     {
+        /**
+         * @var string $key
+         * @var UploadedFile|array<string, mixed>|null $file
+         */
         foreach ($files as $key => $file) {
             if (\is_array($file)) {
                 $files[$key] = $this->inspectFiles($file);
+                continue;
+            }
+
+            if (null === $file) {
                 continue;
             }
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/FileInspector/SvgFileInspectorTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/FileInspector/SvgFileInspectorTest.php
@@ -24,6 +24,11 @@ class SvgFileInspectorTest extends TestCase
 {
     use ProphecyTrait;
 
+    public static function tearDownAfterClass(): void
+    {
+        \unlink('test.svg');
+    }
+
     public static function provideSvgs(): \Generator
     {
         // Safe SVGs

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/FileInspector/UploadFileSubscriberTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/FileInspector/UploadFileSubscriberTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Bundle\MediaBundle\Tests\Unit\FileInspector;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\MediaBundle\FileInspector\FileInspectorInterface;
@@ -104,6 +105,20 @@ class UploadFileSubscriberTest extends TestCase
 
         $this->svgInspector->supports($mimeType)->willReturn(true);
         $this->svgInspector->inspect($uploadedFile)->willReturn($uploadedFile);
+
+        $this->subscriber->onKernelRequest($event);
+
+        // If we reach here without exception, the test passes
+        $this->addToAssertionCount(1);
+    }
+
+    public function testOnKernelRequestWithNull(): void
+    {
+        $request = new Request([], [], [], [], ['Product' => ['thumbnail' => null]]);
+        $event = $this->createRequestEvent($request);
+
+        $this->svgInspector->supports(Argument::any())->shouldNotBeCalled();
+        $this->svgInspector->inspect(Argument::any())->shouldNotBeCalled();
 
         $this->subscriber->onKernelRequest($event);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #7604 
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the issue #7604 which was introduced in 2.6.5 and the SVG validation.

#### Why?

There was not encountered that the files structure in the request can be nested.

