### PR TITLE
Fix OpenIdSingleSignOnAdapter for custom class overrides using userRepository

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapter.php
+++ b/src/Sulu/Bundle/SecurityBundle/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapter.php
@@ -19,6 +19,7 @@ use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\SecurityBundle\Entity\UserRole;
 use Sulu\Bundle\SecurityBundle\SingleSignOn\SingleSignOnAdapterInterface;
 use Sulu\Component\Security\Authentication\RoleRepositoryInterface;
+use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authentication\UserRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\HttpException;

--- a/src/Sulu/Bundle/SecurityBundle/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapter.php
+++ b/src/Sulu/Bundle/SecurityBundle/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapter.php
@@ -238,7 +238,7 @@ class OpenIdSingleSignOnAdapter implements SingleSignOnAdapterInterface
         $user = $this->userRepository->findOneBy(['email' => $email]);
 
         if (!$user instanceof User) {
-            /** @var UserInterface $user */
+            /** @var User $user */
             $user = $this->userRepository->createNew();
             $user->setEmail($email);
             $user->setUsername($email);
@@ -263,7 +263,8 @@ class OpenIdSingleSignOnAdapter implements SingleSignOnAdapterInterface
         }
 
         if (!\in_array($role->getIdentifier(), $roleNames, true)) {
-            $defaultRoleKey = new UserRole();
+            /** @var UserRole $defaultRoleKey */
+            $defaultRoleKey = $this->roleRepository->createNew();
             $defaultRoleKey->setRole($role);
             $defaultRoleKey->setUser($user);
             $defaultRoleKey->setLocale('["en", "de"]');

--- a/src/Sulu/Bundle/SecurityBundle/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapter.php
+++ b/src/Sulu/Bundle/SecurityBundle/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapter.php
@@ -237,7 +237,8 @@ class OpenIdSingleSignOnAdapter implements SingleSignOnAdapterInterface
         $user = $this->userRepository->findOneBy(['email' => $email]);
 
         if (!$user instanceof User) {
-            $user = new User();
+            /** @var UserInterface $user */
+            $user = $this->userRepository->createNew();
             $user->setEmail($email);
             $user->setUsername($email);
             $user->setPassword(Uuid::uuid4()->toString()); // create a random password as a password is required

--- a/src/Sulu/Bundle/SecurityBundle/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapter.php
+++ b/src/Sulu/Bundle/SecurityBundle/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapter.php
@@ -19,7 +19,6 @@ use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\SecurityBundle\Entity\UserRole;
 use Sulu\Bundle\SecurityBundle\SingleSignOn\SingleSignOnAdapterInterface;
 use Sulu\Component\Security\Authentication\RoleRepositoryInterface;
-use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authentication\UserRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\HttpException;

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapterTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapterTest.php
@@ -19,6 +19,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\ContactBundle\Entity\Contact;
 use Sulu\Bundle\ContactBundle\Entity\ContactRepositoryInterface;
 use Sulu\Bundle\SecurityBundle\Entity\Role;
+use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\SecurityBundle\SingleSignOn\Adapter\OpenId\OpenIdSingleSignOnAdapter;
 use Sulu\Component\Security\Authentication\RoleRepositoryInterface;
 use Sulu\Component\Security\Authentication\UserRepositoryInterface;
@@ -180,11 +181,30 @@ class OpenIdSingleSignOnAdapterTest extends TestCase
             ->willReturn('https://sulu.io/admin');
 
         $this->userRepository->findOneBy(Argument::any())->willReturn(null);
+
+        $user = $this->prophesize(User::class);
+        $user->getRoles()->willReturn([]);
+        $user->setEmail(Argument::any())->shouldBeCalled();
+        $user->setUsername(Argument::any())->shouldBeCalled();
+        $user->setPassword(Argument::any())->shouldBeCalled();
+        $user->setSalt(Argument::any())->shouldBeCalled();
+        $user->setEnabled(Argument::any())->shouldBeCalled();
+        $user->setContact(Argument::any())->shouldBeCalled();
+        $user->addUserRole(Argument::any())->shouldBeCalled();
+        $user->getLocale()->shouldBeCalled();
+        $user->setLocale(Argument::any())->shouldBeCalled();
+
+        $contact = $this->prophesize(Contact::class);
+        $user->getContact()->willReturn($contact->reveal());
+
+        $this->userRepository->createNew()->willReturn($user->reveal());
+
         $this->contactRepository->createNew()->willReturn($this->prophesize(Contact::class)->reveal());
         $this->entityManager->persist(Argument::any())->shouldBeCalled();
         $role = $this->prophesize(Role::class);
         $role->getAnonymous()->shouldBeCalled()->willReturn(false);
         $role->getIdentifier()->willReturn('hello@sulu.io');
+        $this->roleRepository->createNew()->willReturn($role->reveal());
         $this->roleRepository->findOneBy(Argument::any())
             ->shouldBeCalled()
             ->willReturn($role->reveal());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

I've changed a line in `src/Sulu/Bundle/SecurityBundle/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapter.php` so it uses the `UserRepository` to create a new Instance of a User instead of just constructing a new Sulu User object.

#### Why?

Without doing that, it'll always be the Sulu User and any custom overrides you may have done will cause an error due to the classes not matching.

#### Example Usage

When defining a custom User class like so:

```yaml
sulu_security:
    # ...
    objects:
        user:
            model: App\Entity\User
```

The old code would not create an instance of this class, but rather the Sulu User class, causing an Exception further down the line. 

Using the userRespository circumvents that by ensuring the custom class is used instead.