### PR TITLE
Add formInspector to sulu.focus event

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
@@ -100,6 +100,7 @@ class Field extends React.Component<Props> {
             setValue: this.handleChange,
             getValue: () => this.props.value,
             schemaPath,
+            formInspector: this.props.formInspector,
         };
 
         target.dispatchEvent(focusEvent);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
@@ -654,15 +654,35 @@ test('Call onFocus callback when Field gets focus', () => {
             router={undefined}
             schema={{label: 'label', type: 'text'}}
             schemaPath=""
+            value="test value"
         />
     );
 
-    const eventSpy = jest.fn();
-
     const target = new EventTarget();
-    target.addEventListener('sulu.focus', eventSpy);
+    const dispatchEventSpy = jest.spyOn(target, 'dispatchEvent');
 
     field.find('Text').props().onFocus(target);
 
-    expect(eventSpy).toBeCalled();
+    expect(dispatchEventSpy).toHaveBeenCalled();
+
+    const dispatchedEvent = dispatchEventSpy.mock.calls[0][0];
+
+    expect(dispatchedEvent.type).toBe('sulu.focus');
+    expect(dispatchedEvent.bubbles).toBe(true);
+    expect(dispatchedEvent.detail).toEqual({
+        schemaType: 'text',
+        setValue: expect.any(Function),
+        getValue: expect.any(Function),
+        schemaPath: '',
+        formInspector,
+    });
+
+    // Test the getValue function
+    expect(dispatchedEvent.detail.getValue()).toBe('test value');
+
+    // Test the setValue function
+    const onChangeMock = jest.fn();
+    field.setProps({onChange: onChangeMock});
+    dispatchedEvent.detail.setValue('new value');
+    expect(onChangeMock).toHaveBeenCalledWith('test', 'new value', undefined);
 });


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR extends to sulu.focus event with the formInspector.

#### Why?

The consumer of the event should be able to retrieve the context of the field (form data) and also the locale. Instead of adding more and more fields i think we should just give the permissions to the consumer to access the formInspector.