### PR TITLE
Add content resolver for the new ContentBundle architecture

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "ext-simplexml": "*",
         "composer-runtime-api": "^2.0",
         "composer/package-versions-deprecated": "^1.8",
+        "composer/semver": "^3.4",
         "contao/imagine-svg": "^1.0",
         "doctrine/annotations": "^1.14 || ^2.0",
         "doctrine/cache": "^1.12.1",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7281,7 +7281,7 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
 
 		-
-			message: "#^Offset 'id' does not exist on non\\-falsy\\-string\\.$#"
+			message: "#^Offset 'id' does not exist on non\\-empty\\-string\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
 

--- a/src/Sulu/Bundle/CategoryBundle/DependencyInjection/SuluCategoryExtension.php
+++ b/src/Sulu/Bundle/CategoryBundle/DependencyInjection/SuluCategoryExtension.php
@@ -50,9 +50,9 @@ class SuluCategoryExtension extends Extension implements PrependExtensionInterfa
         }
 
         if (
-            InstalledVersions::isInstalled('sulu/sulu-content-bundle')
-            && \version_compare(InstalledVersions::getVersion('sulu/sulu-content-bundle') ?? '0.0.0', '0.9', '>=')
-            && \version_compare(InstalledVersions::getVersion('sulu/sulu-content-bundle') ?? '0.0.0', '0.10', '<')
+            InstalledVersions::isInstalled('sulu/content-bundle')
+            && \version_compare(InstalledVersions::getVersion('sulu/content-bundle') ?? '0.0.0', '0.9', '>=')
+            && \version_compare(InstalledVersions::getVersion('sulu/content-bundle') ?? '0.0.0', '0.10', '<')
         ) {
             $loader->load('services_content.xml');
         }

--- a/src/Sulu/Bundle/CategoryBundle/DependencyInjection/SuluCategoryExtension.php
+++ b/src/Sulu/Bundle/CategoryBundle/DependencyInjection/SuluCategoryExtension.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\CategoryBundle\DependencyInjection;
 
+use Composer\InstalledVersions;
 use Sulu\Bundle\CategoryBundle\Admin\CategoryAdmin;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryMetaRepositoryInterface;
@@ -46,6 +47,14 @@ class SuluCategoryExtension extends Extension implements PrependExtensionInterfa
         $bundles = $container->getParameter('kernel.bundles');
         if (\array_key_exists('SuluTrashBundle', $bundles)) {
             $loader->load('services_trash.xml');
+        }
+
+        if (
+            InstalledVersions::isInstalled('sulu/sulu-content-bundle')
+            && \version_compare(InstalledVersions::getVersion('sulu/sulu-content-bundle') ?? '0.0.0', '0.9', '>=')
+            && \version_compare(InstalledVersions::getVersion('sulu/sulu-content-bundle') ?? '0.0.0', '0.10', '<')
+        ) {
+            $loader->load('services_content.xml');
         }
 
         $this->configurePersistence($config['objects'], $container);

--- a/src/Sulu/Bundle/CategoryBundle/DependencyInjection/SuluCategoryExtension.php
+++ b/src/Sulu/Bundle/CategoryBundle/DependencyInjection/SuluCategoryExtension.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\CategoryBundle\DependencyInjection;
 
 use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
 use Sulu\Bundle\CategoryBundle\Admin\CategoryAdmin;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryMetaRepositoryInterface;
@@ -51,8 +52,7 @@ class SuluCategoryExtension extends Extension implements PrependExtensionInterfa
 
         if (
             InstalledVersions::isInstalled('sulu/content-bundle')
-            && \version_compare(InstalledVersions::getVersion('sulu/content-bundle') ?? '0.0.0', '0.9', '>=')
-            && \version_compare(InstalledVersions::getVersion('sulu/content-bundle') ?? '0.0.0', '0.10', '<')
+            && InstalledVersions::satisfies(new VersionParser(), 'sulu/content-bundle', '^0.9')
         ) {
             $loader->load('services_content.xml');
         }

--- a/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Content/PropertyResolver/CategorySelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Content/PropertyResolver/CategorySelectionPropertyResolver.php
@@ -15,7 +15,7 @@ namespace Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\PropertyResolve
 
 use Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\ResourceLoader\CategoryResourceLoader;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
-use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 
 /**
  * @internal if you need to override this service, create a new service with based on PropertyResolverInterface instead of extending this class

--- a/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Content/PropertyResolver/CategorySelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Content/PropertyResolver/CategorySelectionPropertyResolver.php
@@ -11,27 +11,35 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\CategoryBundle\Infrastructure\Content\PropertyResolver\Resolver;
+namespace Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\PropertyResolver;
 
-use Sulu\Bundle\CategoryBundle\Infrastructure\Content\ResourceLoader\CategoryResourceLoader;
+use Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\ResourceLoader\CategoryResourceLoader;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
 
+/**
+ * @internal if you need to override this service, create a new service with based on PropertyResolverInterface instead of extending this class
+ *
+ * @final
+ */
 class CategorySelectionPropertyResolver implements PropertyResolverInterface
 {
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
     {
-        if (empty($data) || !\is_array($data) || !isset($data['ids'])) {
-            return ContentView::create([], ['ids' => []]);
+        if (!\is_array($data)
+            || 0 === \count($data)
+            || !\array_is_list($data)
+        ) {
+            return ContentView::create([], ['ids' => [], ...$params]);
         }
 
         /** @var string $resourceLoaderKey */
         $resourceLoaderKey = $params['resourceLoader'] ?? CategoryResourceLoader::getKey();
 
         return ContentView::createResolvables(
-            $data['ids'],
+            $data,
             $resourceLoaderKey,
-            ['ids' => $data['ids']],
+            ['ids' => $data, ...$params],
         );
     }
 

--- a/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Content/PropertyResolver/Resolver/CategorySelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Content/PropertyResolver/Resolver/CategorySelectionPropertyResolver.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\CategoryBundle\Infrastructure\Content\PropertyResolver\Resolver;
 
+use Sulu\Bundle\CategoryBundle\Infrastructure\Content\ResourceLoader\CategoryResourceLoader;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
 

--- a/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Content/PropertyResolver/Resolver/CategorySelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Content/PropertyResolver/Resolver/CategorySelectionPropertyResolver.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CategoryBundle\Infrastructure\Content\PropertyResolver\Resolver;
+
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+
+class CategorySelectionPropertyResolver implements PropertyResolverInterface
+{
+    public function resolve(mixed $data, string $locale, array $params = []): ContentView
+    {
+        if (empty($data) || !\is_array($data) || !isset($data['ids'])) {
+            return ContentView::create([], ['ids' => []]);
+        }
+
+        /** @var string $resourceLoaderKey */
+        $resourceLoaderKey = $params['resourceLoader'] ?? CategoryResourceLoader::getKey();
+
+        return ContentView::createResolvables(
+            $data['ids'],
+            $resourceLoaderKey,
+            ['ids' => $data['ids']],
+        );
+    }
+
+    public static function getType(): string
+    {
+        return 'category_selection';
+    }
+}

--- a/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleCategorySelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleCategorySelectionPropertyResolver.php
@@ -15,7 +15,7 @@ namespace Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\PropertyResolve
 
 use Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\ResourceLoader\CategoryResourceLoader;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
-use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 
 /**
  * @internal if you need to override this service, create a new service with based on PropertyResolverInterface instead of extending this class

--- a/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleCategorySelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleCategorySelectionPropertyResolver.php
@@ -33,7 +33,7 @@ class SingleCategorySelectionPropertyResolver implements PropertyResolverInterfa
         /** @var string $resourceLoaderKey */
         $resourceLoaderKey = $params['resourceLoader'] ?? CategoryResourceLoader::getKey();
 
-        return ContentView::createResolvables(
+        return ContentView::createResolvable(
             $data,
             $resourceLoaderKey,
             $params,

--- a/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleCategorySelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleCategorySelectionPropertyResolver.php
@@ -26,7 +26,7 @@ class SingleCategorySelectionPropertyResolver implements PropertyResolverInterfa
 {
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
     {
-        if (!\is_string($data) || '' === $data) {
+        if (!\is_int($data)) {
             return ContentView::create([], $params);
         }
 

--- a/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleCategorySelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleCategorySelectionPropertyResolver.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\PropertyResolver;
+
+use Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\ResourceLoader\CategoryResourceLoader;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+
+/**
+ * @internal if you need to override this service, create a new service with based on PropertyResolverInterface instead of extending this class
+ *
+ * @final
+ */
+class SingleCategorySelectionPropertyResolver implements PropertyResolverInterface
+{
+    public function resolve(mixed $data, string $locale, array $params = []): ContentView
+    {
+        if (!\is_string($data) || '' === $data) {
+            return ContentView::create([], $params);
+        }
+
+        /** @var string $resourceLoaderKey */
+        $resourceLoaderKey = $params['resourceLoader'] ?? CategoryResourceLoader::getKey();
+
+        return ContentView::createResolvables(
+            $data,
+            $resourceLoaderKey,
+            $params,
+        );
+    }
+
+    public static function getType(): string
+    {
+        return 'single_category_selection';
+    }
+}

--- a/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Content/ResourceLoader/CategoryResourceLoader.php
+++ b/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Content/ResourceLoader/CategoryResourceLoader.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CategoryBundle\Infrastructure\Content\ResourceLoader;
+
+use Sulu\Bundle\CategoryBundle\Category\CategoryManagerInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\ResourceLoader\ResourceLoaderInterface;
+
+class CategoryResourceLoader implements ResourceLoaderInterface
+{
+    public const RESOURCE_LOADER_KEY = 'category';
+
+    public function __construct(
+        private CategoryManagerInterface $categoryManager
+    ) {
+    }
+
+    public function load(array $ids, ?string $locale, array $params = []): array
+    {
+        $result = $this->categoryManager->findByIds($ids);
+
+        $mappedResult = [];
+        foreach ($result as $category) {
+            $mappedResult[$category->getId()] = $category;
+        }
+
+        return $mappedResult;
+    }
+
+    public static function getKey(): string
+    {
+        return self::RESOURCE_LOADER_KEY;
+    }
+}

--- a/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Content/ResourceLoader/CategoryResourceLoader.php
+++ b/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Content/ResourceLoader/CategoryResourceLoader.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\ResourceLoader;
 
 use Sulu\Bundle\CategoryBundle\Category\CategoryManagerInterface;
-use Sulu\Bundle\ContentBundle\Content\Application\ResourceLoader\ResourceLoaderInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
 
 /**
  * @internal if you need to override this service, create a new service with based on ResourceLoaderInterface instead of extending this class

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/services_content.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/services_content.xml
@@ -4,14 +4,20 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <!-- Property Resolver -->
-        <service id="sulu_category.property_resolver.category_selection"
-                 class="Sulu\Bundle\CategoryBundle\Infrastructure\Content\PropertyResolver\Resolver\CategorySelectionPropertyResolver">
+        <service id="sulu_category.category_selection_property_resolver"
+                 class="Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\PropertyResolver\CategorySelectionPropertyResolver">
+            <tag name="sulu_content.property_resolver"/>
+        </service>
+
+        <service id="sulu_category.single_category_selection_property_resolver"
+                 class="Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\PropertyResolver\CategorySelectionPropertyResolver">
+
             <tag name="sulu_content.property_resolver"/>
         </service>
 
         <!-- Resource Loader -->
-        <service id="sulu_category.resource_loader.category"
-                 class="Sulu\Bundle\CategoryBundle\Infrastructure\Content\ResourceLoader\CategoryResourceLoader">
+        <service id="sulu_category.category_resource_loader"
+                 class="Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\ResourceLoader\CategoryResourceLoader">
             <argument type="service" id="sulu_category.category_manager"/>
 
             <tag name="sulu_content.resource_loader" type="media"/>

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/services_content.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/services_content.xml
@@ -10,7 +10,7 @@
         </service>
 
         <service id="sulu_category.single_category_selection_property_resolver"
-                 class="Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\PropertyResolver\CategorySelectionPropertyResolver">
+                 class="Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\PropertyResolver\SingleCategorySelectionPropertyResolver">
 
             <tag name="sulu_content.property_resolver"/>
         </service>

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/services_content.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/services_content.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <!-- Property Resolver -->
+        <service id="sulu_category.property_resolver.category_selection"
+                 class="Sulu\Bundle\CategoryBundle\Infrastructure\Content\PropertyResolver\Resolver\CategorySelectionPropertyResolver">
+            <tag name="sulu_content.property_resolver"/>
+        </service>
+
+        <!-- Resource Loader -->
+        <service id="sulu_category.resource_loader.category"
+                 class="Sulu\Bundle\CategoryBundle\Infrastructure\Content\ResourceLoader\CategoryResourceLoader">
+            <argument type="service" id="sulu_category.category_manager"/>
+
+            <tag name="sulu_content.resource_loader" type="media"/>
+        </service>
+    </services>
+</container>

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/services_content.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/services_content.xml
@@ -20,7 +20,7 @@
                  class="Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\ResourceLoader\CategoryResourceLoader">
             <argument type="service" id="sulu_category.category_manager"/>
 
-            <tag name="sulu_content.resource_loader" type="media"/>
+            <tag name="sulu_content.resource_loader" type="category"/>
         </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/CategorySelectionPropertyResolverTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/CategorySelectionPropertyResolverTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CategoryBundle\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ResolvableResource;
+use Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\PropertyResolver\CategorySelectionPropertyResolver;
+
+#[CoversClass(CategorySelectionPropertyResolver::class)]
+class CategorySelectionPropertyResolverTest extends TestCase
+{
+    private CategorySelectionPropertyResolver $resolver;
+
+    public function setUp(): void
+    {
+        $this->resolver = new CategorySelectionPropertyResolver();
+    }
+
+    public function testResolveEmpty(): void
+    {
+        $contentView = $this->resolver->resolve([], 'en');
+
+        $this->assertSame([], $contentView->getContent());
+        $this->assertSame(['ids' => []], $contentView->getView());
+    }
+
+    public function testResolveParams(): void
+    {
+        $contentView = $this->resolver->resolve([], 'en', ['custom' => 'params']);
+
+        $this->assertSame([], $contentView->getContent());
+        $this->assertSame([
+            'ids' => [],
+            'custom' => 'params',
+        ], $contentView->getView());
+    }
+
+    #[DataProvider('provideUnresolvableData')]
+    public function testResolveUnresolvableData(mixed $data): void
+    {
+        $contentView = $this->resolver->resolve($data, 'en');
+
+        $this->assertSame([], $contentView->getContent());
+        $this->assertSame(['ids' => []], $contentView->getView());
+    }
+
+    /**
+     * @return iterable<array{
+     *     0: mixed,
+     * }>
+     */
+    public static function provideUnresolvableData(): iterable
+    {
+        yield 'null' => [null];
+        yield 'smart_content' => [['source' => '123']];
+        yield 'single_value' => [1];
+        yield 'object' => [(object) [1, 2]];
+    }
+
+    /**
+     * @param array<string|int> $data
+     */
+    #[DataProvider('provideResolvableData')]
+    public function testResolveResolvableData(array $data): void
+    {
+        $contentView = $this->resolver->resolve($data, 'en');
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        foreach ($data as $key => $value) {
+            $resolvable = $content[$key] ?? null;
+            $this->assertInstanceOf(ResolvableResource::class, $resolvable);
+            $this->assertSame($value, $resolvable->getId());
+            $this->assertSame('category', $resolvable->getResourceLoaderKey());
+        }
+
+        $this->assertSame(['ids' => $data], $contentView->getView());
+    }
+
+    /**
+     * @return iterable<array{
+     *     0: array<string|int>,
+     * }>
+     */
+    public static function provideResolvableData(): iterable
+    {
+        yield 'empty' => [[]];
+        yield 'int_list' => [[1, 2]];
+        yield 'string_list' => [['1', '2']];
+    }
+
+    public function testCustomResourceLoader(): void
+    {
+        $contentView = $this->resolver->resolve([1], 'en', ['resourceLoader' => 'custom_category']);
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        $resolvable = $content[0] ?? null;
+        $this->assertInstanceOf(ResolvableResource::class, $resolvable);
+        $this->assertSame(1, $resolvable->getId());
+        $this->assertSame('custom_category', $resolvable->getResourceLoaderKey());
+    }
+}

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/CategoryResourceLoaderTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/CategoryResourceLoaderTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CategoryBundle\Tests\Unit\Infrastructure\Sulu\Content\ResourceLoader;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\CategoryBundle\Category\CategoryManagerInterface;
+use Sulu\Bundle\CategoryBundle\Entity\Category;
+use Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\ResourceLoader\CategoryResourceLoader;
+use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
+
+class CategoryResourceLoaderTest extends TestCase
+{
+    use ProphecyTrait;
+    use SetGetPrivatePropertyTrait;
+
+    /**
+     * @var ObjectProphecy<CategoryManagerInterface>
+     */
+    private ObjectProphecy $categoryManager;
+
+    private CategoryResourceLoader $loader;
+
+    public function setUp(): void
+    {
+        $this->categoryManager = $this->prophesize(CategoryManagerInterface::class);
+        $this->loader = new CategoryResourceLoader($this->categoryManager->reveal());
+    }
+
+    public function testGetKey(): void
+    {
+        $this->assertSame('category', $this->loader::getKey());
+    }
+
+    public function testLoad(): void
+    {
+        $category1 = $this->createCategory(1);
+        $category2 = $this->createCategory(3);
+
+        $this->categoryManager->findByIds([1, 3])->willReturn([
+            $category1,
+            $category2,
+        ])
+            ->shouldBeCalled();
+
+        $result = $this->loader->load([1, 3], 'en', []);
+
+        $this->assertSame([
+            1 => $category1,
+            3 => $category2,
+        ], $result);
+    }
+
+    private static function createCategory(int $id): Category
+    {
+        $category = new Category();
+        static::setPrivateProperty($category, 'id', $id);
+        $category->setKey('category-' . $id);
+
+        return $category;
+    }
+}

--- a/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
+++ b/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\ContactBundle\DependencyInjection;
 
 use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
 use Sulu\Bundle\ContactBundle\Admin\ContactAdmin;
 use Sulu\Bundle\ContactBundle\Entity\AccountRepositoryInterface;
 use Sulu\Bundle\ContactBundle\Entity\ContactRepositoryInterface;
@@ -280,8 +281,7 @@ class SuluContactExtension extends Extension implements PrependExtensionInterfac
 
         if (
             InstalledVersions::isInstalled('sulu/content-bundle')
-            && \version_compare(InstalledVersions::getVersion('sulu/content-bundle') ?? '0.0.0', '0.9', '>=')
-            && \version_compare(InstalledVersions::getVersion('sulu/content-bundle') ?? '0.0.0', '0.10', '<')
+            && InstalledVersions::satisfies(new VersionParser(), 'sulu/content-bundle', '^0.9')
         ) {
             $loader->load('services_content.xml');
         }

--- a/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
+++ b/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
@@ -279,9 +279,9 @@ class SuluContactExtension extends Extension implements PrependExtensionInterfac
         $loader->load('command.xml');
 
         if (
-            InstalledVersions::isInstalled('sulu/sulu-content-bundle')
-            && \version_compare(InstalledVersions::getVersion('sulu/sulu-content-bundle') ?? '0.0.0', '0.9', '>=')
-            && \version_compare(InstalledVersions::getVersion('sulu/sulu-content-bundle') ?? '0.0.0', '0.10', '<')
+            InstalledVersions::isInstalled('sulu/content-bundle')
+            && \version_compare(InstalledVersions::getVersion('sulu/content-bundle') ?? '0.0.0', '0.9', '>=')
+            && \version_compare(InstalledVersions::getVersion('sulu/content-bundle') ?? '0.0.0', '0.10', '<')
         ) {
             $loader->load('services_content.xml');
         }

--- a/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
+++ b/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\ContactBundle\DependencyInjection;
 
+use Composer\InstalledVersions;
 use Sulu\Bundle\ContactBundle\Admin\ContactAdmin;
 use Sulu\Bundle\ContactBundle\Entity\AccountRepositoryInterface;
 use Sulu\Bundle\ContactBundle\Entity\ContactRepositoryInterface;
@@ -276,6 +277,14 @@ class SuluContactExtension extends Extension implements PrependExtensionInterfac
         $loader->load('services.xml');
         $loader->load('content.xml');
         $loader->load('command.xml');
+
+        if (
+            InstalledVersions::isInstalled('sulu/sulu-content-bundle')
+            && \version_compare(InstalledVersions::getVersion('sulu/sulu-content-bundle') ?? '0.0.0', '0.9', '>=')
+            && \version_compare(InstalledVersions::getVersion('sulu/sulu-content-bundle') ?? '0.0.0', '0.10', '<')
+        ) {
+            $loader->load('services_content.xml');
+        }
 
         if (\array_key_exists('SuluTrashBundle', $bundles)) {
             $loader->load('services_trash.xml');

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/AccountSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/AccountSelectionPropertyResolver.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\PropertyResolver;
+
+use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader\AccountResourceLoader;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+
+class AccountSelectionPropertyResolver implements PropertyResolverInterface
+{
+    public function resolve(mixed $data, string $locale, array $params = []): ContentView
+    {
+        if (!\is_array($data)
+            || 0 === \count($data)
+        ) {
+            return ContentView::create([], ['ids' => [], ...$params]);
+        }
+
+        /** @var string $resourceLoaderKey */
+        $resourceLoaderKey = $params['resourceLoader'] ?? AccountResourceLoader::getKey();
+
+        return ContentView::createResolvables(
+            $data,
+            $resourceLoaderKey,
+            [
+                'ids' => $data,
+                ...$params,
+            ],
+        );
+    }
+
+    public static function getType(): string
+    {
+        return 'account_selection';
+    }
+}

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/AccountSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/AccountSelectionPropertyResolver.php
@@ -23,6 +23,7 @@ class AccountSelectionPropertyResolver implements PropertyResolverInterface
     {
         if (!\is_array($data)
             || 0 === \count($data)
+            || !\array_is_list($data)
         ) {
             return ContentView::create([], ['ids' => [], ...$params]);
         }

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/AccountSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/AccountSelectionPropertyResolver.php
@@ -17,6 +17,11 @@ use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader\Account
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
 
+/**
+ * @internal if you need to override this service, create a new service with based on PropertyResolverInterface instead of extending this class
+ *
+ * @final
+ */
 class AccountSelectionPropertyResolver implements PropertyResolverInterface
 {
     public function resolve(mixed $data, string $locale, array $params = []): ContentView

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/AccountSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/AccountSelectionPropertyResolver.php
@@ -15,7 +15,7 @@ namespace Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\PropertyResolver
 
 use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader\AccountResourceLoader;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
-use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 
 /**
  * @internal if you need to override this service, create a new service with based on PropertyResolverInterface instead of extending this class

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/ContactAccountSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/ContactAccountSelectionPropertyResolver.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\PropertyResolver;
+
+use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader\AccountResourceLoader;
+use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader\ContactResourceLoader;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ResolvableResource;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+
+class ContactAccountSelectionPropertyResolver implements PropertyResolverInterface
+{
+    public const PREFIX_CONTACT = 'c';
+
+    public const PREFIX_ACCOUNT = 'a';
+
+    public function resolve(mixed $data, string $locale, array $params = []): ContentView
+    {
+        if (!\is_array($data)
+            || 0 === \count($data)
+        ) {
+            return ContentView::create([], ['ids' => [], ...$params]);
+        }
+
+        /** @var string $contactResourceLoaderKey */
+        $contactResourceLoaderKey = $params['contactResourceLoader'] ?? ContactResourceLoader::getKey();
+        /** @var string $contactResourceLoaderKey */
+        $accountResourceLoaderKey = $params['accountResourceLoader'] ?? AccountResourceLoader::getKey();
+
+        $resolvableResources = [];
+        foreach ($data as $id) {
+            $key = \substr($id, 0, 1);
+            $id = \substr($id, 1);
+            $id = \is_numeric($id) ? \intval($id) : null; // ignore invalid ids, invalid value can happen when template or block type was changed
+
+            // this is a very edge case normally the `ResolvableResource` class should not be used by property resolvers
+            // but in this case we need to use it to load resources depending on the key correctly
+            // the ResolvableResource is kept internal to the content bundle and should not be used by other bundles
+            match ($key) {
+                self::PREFIX_CONTACT => $resolvableResources[] = new ResolvableResource($id, $contactResourceLoaderKey),
+                self::PREFIX_ACCOUNT => $resolvableResources[] = new ResolvableResource($id, $accountResourceLoaderKey),
+                default => null,
+            };
+        }
+
+        return ContentView::create(
+            $resolvableResources,
+            [
+                'ids' => $data,
+                ...$params,
+            ],
+        );
+    }
+
+    public static function getType(): string
+    {
+        return 'contact_account_selection';
+    }
+}

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/ContactAccountSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/ContactAccountSelectionPropertyResolver.php
@@ -29,6 +29,7 @@ class ContactAccountSelectionPropertyResolver implements PropertyResolverInterfa
     {
         if (!\is_array($data)
             || 0 === \count($data)
+            || !\array_is_list($data)
         ) {
             return ContentView::create([], ['ids' => [], ...$params]);
         }
@@ -40,6 +41,10 @@ class ContactAccountSelectionPropertyResolver implements PropertyResolverInterfa
 
         $resolvableResources = [];
         foreach ($data as $id) {
+            if (!\is_string($id)) {
+                continue;
+            }
+
             $key = \substr($id, 0, 1);
             $id = \substr($id, 1);
             $id = \is_numeric($id) ? \intval($id) : null;
@@ -61,7 +66,7 @@ class ContactAccountSelectionPropertyResolver implements PropertyResolverInterfa
         return ContentView::create(
             $resolvableResources,
             [
-                'ids' => $data,
+                'ids' => 0 === \count($resolvableResources) ? [] : $data,
                 ...$params,
             ],
         );

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/ContactAccountSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/ContactAccountSelectionPropertyResolver.php
@@ -17,7 +17,7 @@ use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader\Account
 use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader\ContactResourceLoader;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ResolvableResource;
-use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 
 /**
  * @internal if you need to override this service, create a new service with based on PropertyResolverInterface instead of extending this class

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/ContactAccountSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/ContactAccountSelectionPropertyResolver.php
@@ -42,7 +42,11 @@ class ContactAccountSelectionPropertyResolver implements PropertyResolverInterfa
         foreach ($data as $id) {
             $key = \substr($id, 0, 1);
             $id = \substr($id, 1);
-            $id = \is_numeric($id) ? \intval($id) : null; // ignore invalid ids, invalid value can happen when template or block type was changed
+            $id = \is_numeric($id) ? \intval($id) : null;
+
+            if (null === $id) { // ignore invalid ids, invalid value can happen when template or block type was changed
+                continue;
+            }
 
             // this is a very edge case normally the `ResolvableResource` class should not be used by property resolvers
             // but in this case we need to use it to load resources depending on the key correctly

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/ContactAccountSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/ContactAccountSelectionPropertyResolver.php
@@ -19,6 +19,11 @@ use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentV
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ResolvableResource;
 use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
 
+/**
+ * @internal if you need to override this service, create a new service with based on PropertyResolverInterface instead of extending this class
+ *
+ * @final
+ */
 class ContactAccountSelectionPropertyResolver implements PropertyResolverInterface
 {
     public const PREFIX_CONTACT = 'c';

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/ContactSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/ContactSelectionPropertyResolver.php
@@ -23,6 +23,7 @@ class ContactSelectionPropertyResolver implements PropertyResolverInterface
     {
         if (!\is_array($data)
             || 0 === \count($data)
+            || !\array_is_list($data)
         ) {
             return ContentView::create([], ['ids' => [], ...$params]);
         }

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/ContactSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/ContactSelectionPropertyResolver.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\PropertyResolver;
+
+use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader\ContactResourceLoader;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+
+class ContactSelectionPropertyResolver implements PropertyResolverInterface
+{
+    public function resolve(mixed $data, string $locale, array $params = []): ContentView
+    {
+        if (!\is_array($data)
+            || 0 === \count($data)
+        ) {
+            return ContentView::create([], ['ids' => [], ...$params]);
+        }
+
+        /** @var string $resourceLoaderKey */
+        $resourceLoaderKey = $params['resourceLoader'] ?? ContactResourceLoader::getKey();
+
+        return ContentView::createResolvables(
+            $data,
+            $resourceLoaderKey,
+            [
+                'ids' => $data,
+                ...$params,
+            ],
+        );
+    }
+
+    public static function getType(): string
+    {
+        return 'contact_selection';
+    }
+}

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/ContactSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/ContactSelectionPropertyResolver.php
@@ -15,7 +15,7 @@ namespace Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\PropertyResolver
 
 use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader\ContactResourceLoader;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
-use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 
 /**
  * @internal if you need to override this service, create a new service with based on PropertyResolverInterface instead of extending this class

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleAccountSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleAccountSelectionPropertyResolver.php
@@ -15,7 +15,7 @@ namespace Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\PropertyResolver
 
 use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader\AccountResourceLoader;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
-use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 
 /**
  * @internal if you need to override this service, create a new service with based on PropertyResolverInterface instead of extending this class

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleAccountSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleAccountSelectionPropertyResolver.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\PropertyResolver;
+
+use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader\AccountResourceLoader;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+
+class SingleAccountSelectionPropertyResolver implements PropertyResolverInterface
+{
+    public function resolve(mixed $data, string $locale, array $params = []): ContentView
+    {
+        if (!\is_int($data)) {
+            return ContentView::create([], ['id' => null, ...$params]);
+        }
+
+        /** @var string $resourceLoaderKey */
+        $resourceLoaderKey = $params['resourceLoader'] ?? AccountResourceLoader::getKey();
+
+        return ContentView::createResolvable(
+            $data,
+            $resourceLoaderKey,
+            [
+                'ids' => $data,
+                ...$params,
+            ],
+        );
+    }
+
+    public static function getType(): string
+    {
+        return 'single_account_selection';
+    }
+}

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleAccountSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleAccountSelectionPropertyResolver.php
@@ -21,18 +21,18 @@ class SingleAccountSelectionPropertyResolver implements PropertyResolverInterfac
 {
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
     {
-        if (!\is_int($data)) {
-            return ContentView::create([], ['id' => null, ...$params]);
+        if (!\is_numeric($data)) {
+            return ContentView::create(null, ['id' => null, ...$params]);
         }
 
         /** @var string $resourceLoaderKey */
         $resourceLoaderKey = $params['resourceLoader'] ?? AccountResourceLoader::getKey();
 
         return ContentView::createResolvable(
-            $data,
+            (int) $data,
             $resourceLoaderKey,
             [
-                'ids' => $data,
+                'id' => $data,
                 ...$params,
             ],
         );

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleAccountSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleAccountSelectionPropertyResolver.php
@@ -17,6 +17,11 @@ use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader\Account
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
 
+/**
+ * @internal if you need to override this service, create a new service with based on PropertyResolverInterface instead of extending this class
+ *
+ * @final
+ */
 class SingleAccountSelectionPropertyResolver implements PropertyResolverInterface
 {
     public function resolve(mixed $data, string $locale, array $params = []): ContentView

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleContactSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleContactSelectionPropertyResolver.php
@@ -21,15 +21,15 @@ class SingleContactSelectionPropertyResolver implements PropertyResolverInterfac
 {
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
     {
-        if (!\is_int($data)) {
-            return ContentView::create([], ['id' => null, ...$params]);
+        if (!\is_numeric($data)) {
+            return ContentView::create(null, ['id' => null, ...$params]);
         }
 
         /** @var string $resourceLoaderKey */
         $resourceLoaderKey = $params['resourceLoader'] ?? ContactResourceLoader::getKey();
 
         return ContentView::createResolvable(
-            $data,
+            (int) $data,
             $resourceLoaderKey,
             [
                 'id' => $data,

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleContactSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleContactSelectionPropertyResolver.php
@@ -17,6 +17,11 @@ use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader\Contact
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
 
+/**
+ * @internal if you need to override this service, create a new service with based on PropertyResolverInterface instead of extending this class
+ *
+ * @final
+ */
 class SingleContactSelectionPropertyResolver implements PropertyResolverInterface
 {
     public function resolve(mixed $data, string $locale, array $params = []): ContentView

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleContactSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleContactSelectionPropertyResolver.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\PropertyResolver;
+
+use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader\ContactResourceLoader;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+
+class SingleContactSelectionPropertyResolver implements PropertyResolverInterface
+{
+    public function resolve(mixed $data, string $locale, array $params = []): ContentView
+    {
+        if (!\is_int($data)) {
+            return ContentView::create([], ['id' => null, ...$params]);
+        }
+
+        /** @var string $resourceLoaderKey */
+        $resourceLoaderKey = $params['resourceLoader'] ?? ContactResourceLoader::getKey();
+
+        return ContentView::createResolvable(
+            $data,
+            $resourceLoaderKey,
+            [
+                'id' => $data,
+                ...$params,
+            ],
+        );
+    }
+
+    public static function getType(): string
+    {
+        return 'single_contact_selection';
+    }
+}

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleContactSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleContactSelectionPropertyResolver.php
@@ -15,7 +15,7 @@ namespace Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\PropertyResolver
 
 use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader\ContactResourceLoader;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
-use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 
 /**
  * @internal if you need to override this service, create a new service with based on PropertyResolverInterface instead of extending this class

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/ResourceLoader/AccountResourceLoader.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/ResourceLoader/AccountResourceLoader.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader;
+
+use Sulu\Bundle\ContactBundle\Contact\ContactManagerInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\ResourceLoader\ResourceLoaderInterface;
+
+class AccountResourceLoader implements ResourceLoaderInterface
+{
+    public const RESOURCE_LOADER_KEY = 'account';
+
+    public function __construct(
+        private ContactManagerInterface $accountManager,
+    ) {
+    }
+
+    public function load(array $ids, ?string $locale, array $params = []): array
+    {
+        $result = $this->accountManager->getByIds($ids, (string) $locale);
+
+        $mappedResult = [];
+        foreach ($result as $media) {
+            $mappedResult[$media->getId()] = $media;
+        }
+
+        return $mappedResult;
+    }
+
+    public static function getKey(): string
+    {
+        return self::RESOURCE_LOADER_KEY;
+    }
+}

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/ResourceLoader/AccountResourceLoader.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/ResourceLoader/AccountResourceLoader.php
@@ -13,13 +13,19 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader;
 
+use Sulu\Bundle\ContactBundle\Api\Account as AccountApi;
 use Sulu\Bundle\ContactBundle\Contact\ContactManagerInterface;
+use Sulu\Bundle\ContactBundle\Entity\AccountAddress as AccountAddressEntity;
+use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
 use Sulu\Bundle\ContentBundle\Content\Application\ResourceLoader\ResourceLoaderInterface;
 
 class AccountResourceLoader implements ResourceLoaderInterface
 {
     public const RESOURCE_LOADER_KEY = 'account';
 
+    /**
+     * @param ContactManagerInterface<AccountInterface, AccountApi, AccountAddressEntity> $accountManager
+     */
     public function __construct(
         private ContactManagerInterface $accountManager,
     ) {
@@ -30,8 +36,8 @@ class AccountResourceLoader implements ResourceLoaderInterface
         $result = $this->accountManager->getByIds($ids, (string) $locale);
 
         $mappedResult = [];
-        foreach ($result as $media) {
-            $mappedResult[$media->getId()] = $media;
+        foreach ($result as $object) {
+            $mappedResult[$object->getId()] = $object;
         }
 
         return $mappedResult;

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/ResourceLoader/AccountResourceLoader.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/ResourceLoader/AccountResourceLoader.php
@@ -17,7 +17,7 @@ use Sulu\Bundle\ContactBundle\Api\Account as AccountApi;
 use Sulu\Bundle\ContactBundle\Contact\ContactManagerInterface;
 use Sulu\Bundle\ContactBundle\Entity\AccountAddress as AccountAddressEntity;
 use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
-use Sulu\Bundle\ContentBundle\Content\Application\ResourceLoader\ResourceLoaderInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
 
 /**
  * @internal if you need to override this service, create a new service with based on ResourceLoaderInterface instead of extending this class

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/ResourceLoader/AccountResourceLoader.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/ResourceLoader/AccountResourceLoader.php
@@ -19,6 +19,11 @@ use Sulu\Bundle\ContactBundle\Entity\AccountAddress as AccountAddressEntity;
 use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
 use Sulu\Bundle\ContentBundle\Content\Application\ResourceLoader\ResourceLoaderInterface;
 
+/**
+ * @internal if you need to override this service, create a new service with based on ResourceLoaderInterface instead of extending this class
+ *
+ * @final
+ */
 class AccountResourceLoader implements ResourceLoaderInterface
 {
     public const RESOURCE_LOADER_KEY = 'account';

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/ResourceLoader/ContactResourceLoader.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/ResourceLoader/ContactResourceLoader.php
@@ -17,7 +17,7 @@ use Sulu\Bundle\ContactBundle\Api\Contact as ContactApi;
 use Sulu\Bundle\ContactBundle\Contact\ContactManagerInterface;
 use Sulu\Bundle\ContactBundle\Entity\ContactAddress;
 use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
-use Sulu\Bundle\ContentBundle\Content\Application\ResourceLoader\ResourceLoaderInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
 
 /**
  * @internal if you need to override this service, create a new service with based on ResourceLoaderInterface instead of extending this class

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/ResourceLoader/ContactResourceLoader.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/ResourceLoader/ContactResourceLoader.php
@@ -19,6 +19,11 @@ use Sulu\Bundle\ContactBundle\Entity\ContactAddress;
 use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
 use Sulu\Bundle\ContentBundle\Content\Application\ResourceLoader\ResourceLoaderInterface;
 
+/**
+ * @internal if you need to override this service, create a new service with based on ResourceLoaderInterface instead of extending this class
+ *
+ * @final
+ */
 class ContactResourceLoader implements ResourceLoaderInterface
 {
     public const RESOURCE_LOADER_KEY = 'contact';

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/ResourceLoader/ContactResourceLoader.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/ResourceLoader/ContactResourceLoader.php
@@ -13,13 +13,19 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader;
 
+use Sulu\Bundle\ContactBundle\Api\Contact as ContactApi;
 use Sulu\Bundle\ContactBundle\Contact\ContactManagerInterface;
+use Sulu\Bundle\ContactBundle\Entity\ContactAddress;
+use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
 use Sulu\Bundle\ContentBundle\Content\Application\ResourceLoader\ResourceLoaderInterface;
 
 class ContactResourceLoader implements ResourceLoaderInterface
 {
     public const RESOURCE_LOADER_KEY = 'contact';
 
+    /**
+     * @param ContactManagerInterface<ContactInterface, ContactApi, ContactAddress> $contactManager
+     */
     public function __construct(
         private ContactManagerInterface $contactManager,
     ) {
@@ -30,8 +36,8 @@ class ContactResourceLoader implements ResourceLoaderInterface
         $result = $this->contactManager->getByIds($ids, (string) $locale);
 
         $mappedResult = [];
-        foreach ($result as $media) {
-            $mappedResult[$media->getId()] = $media;
+        foreach ($result as $object) {
+            $mappedResult[$object->getId()] = $object;
         }
 
         return $mappedResult;

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/ResourceLoader/ContactResourceLoader.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/ResourceLoader/ContactResourceLoader.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader;
+
+use Sulu\Bundle\ContactBundle\Contact\ContactManagerInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\ResourceLoader\ResourceLoaderInterface;
+
+class ContactResourceLoader implements ResourceLoaderInterface
+{
+    public const RESOURCE_LOADER_KEY = 'contact';
+
+    public function __construct(
+        private ContactManagerInterface $contactManager,
+    ) {
+    }
+
+    public function load(array $ids, ?string $locale, array $params = []): array
+    {
+        $result = $this->contactManager->getByIds($ids, (string) $locale);
+
+        $mappedResult = [];
+        foreach ($result as $media) {
+            $mappedResult[$media->getId()] = $media;
+        }
+
+        return $mappedResult;
+    }
+
+    public static function getKey(): string
+    {
+        return self::RESOURCE_LOADER_KEY;
+    }
+}

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/services_content.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/services_content.xml
@@ -27,13 +27,13 @@
         <service id="sulu_contact.contact_resource_loader" class="Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader\ContactResourceLoader">
             <argument type="service" id="sulu_contact.contact_manager"/>
 
-            <tag name="sulu_content.resource_loader"/>
+            <tag name="sulu_content.resource_loader" type="contact"/>
         </service>
 
         <service id="sulu_contact.account_resource_loader" class="Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader\AccountResourceLoader">
             <argument type="service" id="sulu_contact.account_manager"/>
 
-            <tag name="sulu_content.resource_loader"/>
+            <tag name="sulu_content.resource_loader" type="account"/>
         </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/services_content.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/services_content.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <!-- Content Property Resolvers -->
+        <service id="sulu_contact.account_selection_property_resolver" class="Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\PropertyResolver\AccountSelectionPropertyResolver">
+            <tag name="sulu_content.property_resolver"/>
+        </service>
+
+        <service id="sulu_contact.single_account_selection_property_resolver" class="Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\PropertyResolver\SingleAccountSelectionPropertyResolver">
+            <tag name="sulu_content.property_resolver"/>
+        </service>
+
+        <service id="sulu_contact.contact_selection_property_resolver" class="Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\PropertyResolver\ContactSelectionPropertyResolver">
+            <tag name="sulu_content.property_resolver"/>
+        </service>
+
+        <service id="sulu_contact.single_contact_selection_property_resolver" class="Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\PropertyResolver\SingleContactSelectionPropertyResolver">
+            <tag name="sulu_content.property_resolver"/>
+        </service>
+
+        <service id="sulu_contact.account_contact_selection_property_resolver" class="Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\PropertyResolver\ContactAccountSelectionPropertyResolver">
+            <tag name="sulu_content.property_resolver"/>
+        </service>
+
+        <!-- Content Resource Loaders -->
+        <service id="sulu_contact.contact_resource_loader" class="Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader\ContactResourceLoader">
+            <argument type="service" id="sulu_contact.contact_manager"/>
+
+            <tag name="sulu_content.resource_loader"/>
+        </service>
+
+        <service id="sulu_contact.account_resource_loader" class="Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader\AccountResourceLoader">
+            <argument type="service" id="sulu_contact.account_manager"/>
+
+            <tag name="sulu_content.resource_loader"/>
+        </service>
+    </services>
+</container>

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/AccountSelectionPropertyResolverTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/AccountSelectionPropertyResolverTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\PropertyResolver\AccountSelectionPropertyResolver;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ResolvableResource;
+
+#[CoversClass(AccountSelectionPropertyResolver::class)]
+class AccountSelectionPropertyResolverTest extends TestCase
+{
+    private AccountSelectionPropertyResolver $resolver;
+
+    public function setUp(): void
+    {
+        $this->resolver = new AccountSelectionPropertyResolver();
+    }
+
+    public function testResolveEmpty(): void
+    {
+        $contentView = $this->resolver->resolve([], 'en');
+
+        $this->assertSame([], $contentView->getContent());
+        $this->assertSame(['ids' => []], $contentView->getView());
+    }
+
+    public function testResolveParams(): void
+    {
+        $contentView = $this->resolver->resolve([], 'en', ['custom' => 'params']);
+
+        $this->assertSame([], $contentView->getContent());
+        $this->assertSame([
+            'ids' => [],
+            'custom' => 'params',
+        ], $contentView->getView());
+    }
+
+    #[DataProvider('provideUnresolvableData')]
+    public function testResolveUnresolvableData(mixed $data): void
+    {
+        $contentView = $this->resolver->resolve($data, 'en');
+
+        $this->assertSame([], $contentView->getContent());
+        $this->assertSame(['ids' => []], $contentView->getView());
+    }
+
+    /**
+     * @return iterable<array{
+     *     0: mixed,
+     * }>
+     */
+    public static function provideUnresolvableData(): iterable
+    {
+        yield 'null' => [null];
+        yield 'smart_content' => [['source' => '123']];
+        yield 'single_value' => [1];
+        yield 'object' => [(object) [1, 2]];
+    }
+
+    /**
+     * @param array<string|int> $data
+     */
+    #[DataProvider('provideResolvableData')]
+    public function testResolveResolvableData(array $data): void
+    {
+        $contentView = $this->resolver->resolve($data, 'en');
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        foreach ($data as $key => $value) {
+            $resolvable = $content[$key] ?? null;
+            $this->assertInstanceOf(ResolvableResource::class, $resolvable);
+            $this->assertSame($value, $resolvable->getId());
+            $this->assertSame('account', $resolvable->getResourceLoaderKey());
+        }
+
+        $this->assertSame(['ids' => $data], $contentView->getView());
+    }
+
+    /**
+     * @return iterable<array{
+     *     0: array<string|int>,
+     * }>
+     */
+    public static function provideResolvableData(): iterable
+    {
+        yield 'empty' => [[]];
+        yield 'int_list' => [[1, 2]];
+        yield 'string_list' => [['1', '2']];
+    }
+
+    public function testCustomResourceLoader(): void
+    {
+        $contentView = $this->resolver->resolve([1], 'en', ['resourceLoader' => 'custom_account']);
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        $resolvable = $content[0] ?? null;
+        $this->assertInstanceOf(ResolvableResource::class, $resolvable);
+        $this->assertSame(1, $resolvable->getId());
+        $this->assertSame('custom_account', $resolvable->getResourceLoaderKey());
+    }
+}

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ContactAccountSelectionPropertyResolverTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ContactAccountSelectionPropertyResolverTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\PropertyResolver\ContactAccountSelectionPropertyResolver;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ResolvableResource;
+
+#[CoversClass(ContactAccountSelectionPropertyResolver::class)]
+class ContactAccountSelectionPropertyResolverTest extends TestCase
+{
+    private ContactAccountSelectionPropertyResolver $resolver;
+
+    public function setUp(): void
+    {
+        $this->resolver = new ContactAccountSelectionPropertyResolver();
+    }
+
+    public function testResolveEmpty(): void
+    {
+        $contentView = $this->resolver->resolve([], 'en');
+
+        $this->assertSame([], $contentView->getContent());
+        $this->assertSame(['ids' => []], $contentView->getView());
+    }
+
+    public function testResolveParams(): void
+    {
+        $contentView = $this->resolver->resolve([], 'en', ['custom' => 'params']);
+
+        $this->assertSame([], $contentView->getContent());
+        $this->assertSame([
+            'ids' => [],
+            'custom' => 'params',
+        ], $contentView->getView());
+    }
+
+    #[DataProvider('provideUnresolvableData')]
+    public function testResolveUnresolvableData(mixed $data): void
+    {
+        $contentView = $this->resolver->resolve($data, 'en');
+
+        $this->assertSame([], $contentView->getContent());
+        $this->assertSame(['ids' => []], $contentView->getView());
+    }
+
+    /**
+     * @return iterable<array{
+     *     0: mixed,
+     * }>
+     */
+    public static function provideUnresolvableData(): iterable
+    {
+        yield 'null' => [null];
+        yield 'smart_content' => [['source' => '123']];
+        yield 'single_value' => [1];
+        yield 'object' => [(object) [1, 2]];
+        yield 'unknown_prefix' => [['e1', 'b2']];
+    }
+
+    /**
+     * @param string[] $data
+     * @param string[] $expectedResourceLoaderKeys
+     */
+    #[DataProvider('provideResolvableData')]
+    public function testResolveResolvableData(array $data, array $expectedResourceLoaderKeys): void
+    {
+        $contentView = $this->resolver->resolve($data, 'en');
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        foreach ($data as $key => $value) {
+            $resolvable = $content[$key] ?? null;
+            $this->assertInstanceOf(ResolvableResource::class, $resolvable);
+            $this->assertSame((int) \substr($value, 1), $resolvable->getId());
+            $expectedResourceLoaderKey = $expectedResourceLoaderKeys[$key] ?? null;
+            $this->assertSame($expectedResourceLoaderKey, $resolvable->getResourceLoaderKey());
+        }
+
+        $this->assertSame(['ids' => $data], $contentView->getView());
+    }
+
+    /**
+     * @return iterable<array{
+     *     0: string[],
+     *     1: string[],
+     * }>
+     */
+    public static function provideResolvableData(): iterable
+    {
+        yield 'empty' => [[], []];
+        yield 'contact_list' => [['c1', 'a2'], ['contact', 'account']];
+    }
+
+    public function testCustomResourceLoader(): void
+    {
+        $contentView = $this->resolver->resolve(['c1', 'a2'], 'en', [
+            'contactResourceLoader' => 'custom_contact',
+            'accountResourceLoader' => 'custom_account',
+        ]);
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+
+        $resolvable = $content[0] ?? null;
+        $this->assertInstanceOf(ResolvableResource::class, $resolvable);
+        $this->assertSame(1, $resolvable->getId());
+        $this->assertSame('custom_contact', $resolvable->getResourceLoaderKey());
+
+        $resolvable = $content[1] ?? null;
+        $this->assertInstanceOf(ResolvableResource::class, $resolvable);
+        $this->assertSame(2, $resolvable->getId());
+        $this->assertSame('custom_account', $resolvable->getResourceLoaderKey());
+    }
+}

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ContactSelectionPropertyResolverTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ContactSelectionPropertyResolverTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\PropertyResolver\ContactSelectionPropertyResolver;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ResolvableResource;
+
+#[CoversClass(ContactSelectionPropertyResolver::class)]
+class ContactSelectionPropertyResolverTest extends TestCase
+{
+    private ContactSelectionPropertyResolver $resolver;
+
+    public function setUp(): void
+    {
+        $this->resolver = new ContactSelectionPropertyResolver();
+    }
+
+    public function testResolveEmpty(): void
+    {
+        $contentView = $this->resolver->resolve([], 'en');
+
+        $this->assertSame([], $contentView->getContent());
+        $this->assertSame(['ids' => []], $contentView->getView());
+    }
+
+    public function testResolveParams(): void
+    {
+        $contentView = $this->resolver->resolve([], 'en', ['custom' => 'params']);
+
+        $this->assertSame([], $contentView->getContent());
+        $this->assertSame([
+            'ids' => [],
+            'custom' => 'params',
+        ], $contentView->getView());
+    }
+
+    #[DataProvider('provideUnresolvableData')]
+    public function testResolveUnresolvableData(mixed $data): void
+    {
+        $contentView = $this->resolver->resolve($data, 'en');
+
+        $this->assertSame([], $contentView->getContent());
+        $this->assertSame(['ids' => []], $contentView->getView());
+    }
+
+    /**
+     * @return iterable<array{
+     *     0: mixed,
+     * }>
+     */
+    public static function provideUnresolvableData(): iterable
+    {
+        yield 'null' => [null];
+        yield 'smart_content' => [['source' => '123']];
+        yield 'single_value' => [1];
+        yield 'object' => [(object) [1, 2]];
+    }
+
+    /**
+     * @param array<string|int> $data
+     */
+    #[DataProvider('provideResolvableData')]
+    public function testResolveResolvableData(array $data): void
+    {
+        $contentView = $this->resolver->resolve($data, 'en');
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        foreach ($data as $key => $value) {
+            $resolvable = $content[$key] ?? null;
+            $this->assertInstanceOf(ResolvableResource::class, $resolvable);
+            $this->assertSame($value, $resolvable->getId());
+            $this->assertSame('contact', $resolvable->getResourceLoaderKey());
+        }
+
+        $this->assertSame(['ids' => $data], $contentView->getView());
+    }
+
+    /**
+     * @return iterable<array{
+     *     0: array<string|int>,
+     * }>
+     */
+    public static function provideResolvableData(): iterable
+    {
+        yield 'empty' => [[]];
+        yield 'int_list' => [[1, 2]];
+        yield 'string_list' => [['1', '2']];
+    }
+
+    public function testCustomResourceLoader(): void
+    {
+        $contentView = $this->resolver->resolve([1], 'en', ['resourceLoader' => 'custom_contact']);
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        $resolvable = $content[0] ?? null;
+        $this->assertInstanceOf(ResolvableResource::class, $resolvable);
+        $this->assertSame(1, $resolvable->getId());
+        $this->assertSame('custom_contact', $resolvable->getResourceLoaderKey());
+    }
+}

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleAccountSelectionPropertyResolverTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleAccountSelectionPropertyResolverTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\PropertyResolver\SingleAccountSelectionPropertyResolver;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ResolvableResource;
+
+#[CoversClass(SingleAccountSelectionPropertyResolver::class)]
+class SingleAccountSelectionPropertyResolverTest extends TestCase
+{
+    private SingleAccountSelectionPropertyResolver $resolver;
+
+    public function setUp(): void
+    {
+        $this->resolver = new SingleAccountSelectionPropertyResolver();
+    }
+
+    public function testResolveEmpty(): void
+    {
+        $contentView = $this->resolver->resolve(null, 'en');
+
+        $this->assertNull($contentView->getContent());
+        $this->assertSame(['id' => null], $contentView->getView());
+    }
+
+    public function testResolveParams(): void
+    {
+        $contentView = $this->resolver->resolve(null, 'en', ['custom' => 'params']);
+
+        $this->assertNull($contentView->getContent());
+        $this->assertSame([
+            'id' => null,
+            'custom' => 'params',
+        ], $contentView->getView());
+    }
+
+    #[DataProvider('provideUnresolvableData')]
+    public function testResolveUnresolvableData(mixed $data): void
+    {
+        $contentView = $this->resolver->resolve($data, 'en');
+
+        $this->assertNull($contentView->getContent());
+        $this->assertSame(['id' => null], $contentView->getView());
+    }
+
+    /**
+     * @return iterable<array{
+     *     0: mixed,
+     * }>
+     */
+    public static function provideUnresolvableData(): iterable
+    {
+        yield 'null' => [null];
+        yield 'smart_content' => [['source' => '123']];
+        yield 'multi_value' => [[1]];
+        yield 'object' => [(object) [1]];
+    }
+
+    #[DataProvider('provideResolvableData')]
+    public function testResolveResolvableData(int|string $data): void
+    {
+        $contentView = $this->resolver->resolve($data, 'en');
+
+        $content = $contentView->getContent();
+        $this->assertInstanceOf(ResolvableResource::class, $content);
+        $this->assertSame((int) $data, $content->getId());
+        $this->assertSame('account', $content->getResourceLoaderKey());
+
+        $this->assertSame(['id' => $data], $contentView->getView());
+    }
+
+    /**
+     * @return iterable<array{
+     *     0: int|string,
+     * }>
+     */
+    public static function provideResolvableData(): iterable
+    {
+        yield 'int' => [1];
+        yield 'string' => ['2'];
+    }
+
+    public function testCustomResourceLoader(): void
+    {
+        $contentView = $this->resolver->resolve(1, 'en', ['resourceLoader' => 'custom_account']);
+
+        $content = $contentView->getContent();
+
+        $this->assertInstanceOf(ResolvableResource::class, $content);
+        $this->assertSame(1, $content->getId());
+        $this->assertSame('custom_account', $content->getResourceLoaderKey());
+    }
+}

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleContactSelectionPropertyResolverTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleContactSelectionPropertyResolverTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\PropertyResolver\SingleContactSelectionPropertyResolver;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ResolvableResource;
+
+#[CoversClass(SingleContactSelectionPropertyResolver::class)]
+class SingleContactSelectionPropertyResolverTest extends TestCase
+{
+    private SingleContactSelectionPropertyResolver $resolver;
+
+    public function setUp(): void
+    {
+        $this->resolver = new SingleContactSelectionPropertyResolver();
+    }
+
+    public function testResolveEmpty(): void
+    {
+        $contentView = $this->resolver->resolve(null, 'en');
+
+        $this->assertNull($contentView->getContent());
+        $this->assertSame(['id' => null], $contentView->getView());
+    }
+
+    public function testResolveParams(): void
+    {
+        $contentView = $this->resolver->resolve(null, 'en', ['custom' => 'params']);
+
+        $this->assertNull($contentView->getContent());
+        $this->assertSame([
+            'id' => null,
+            'custom' => 'params',
+        ], $contentView->getView());
+    }
+
+    #[DataProvider('provideUnresolvableData')]
+    public function testResolveUnresolvableData(mixed $data): void
+    {
+        $contentView = $this->resolver->resolve($data, 'en');
+
+        $this->assertNull($contentView->getContent());
+        $this->assertSame(['id' => null], $contentView->getView());
+    }
+
+    /**
+     * @return iterable<array{
+     *     0: mixed,
+     * }>
+     */
+    public static function provideUnresolvableData(): iterable
+    {
+        yield 'null' => [null];
+        yield 'smart_content' => [['source' => '123']];
+        yield 'multi_value' => [[1]];
+        yield 'object' => [(object) [1]];
+    }
+
+    #[DataProvider('provideResolvableData')]
+    public function testResolveResolvableData(int|string $data): void
+    {
+        $contentView = $this->resolver->resolve($data, 'en');
+
+        $content = $contentView->getContent();
+        $this->assertInstanceOf(ResolvableResource::class, $content);
+        $this->assertSame((int) $data, $content->getId());
+        $this->assertSame('contact', $content->getResourceLoaderKey());
+
+        $this->assertSame(['id' => $data], $contentView->getView());
+    }
+
+    /**
+     * @return iterable<array{
+     *     0: int|string,
+     * }>
+     */
+    public static function provideResolvableData(): iterable
+    {
+        yield 'int' => [1];
+        yield 'string' => ['2'];
+    }
+
+    public function testCustomResourceLoader(): void
+    {
+        $contentView = $this->resolver->resolve(1, 'en', ['resourceLoader' => 'custom_contact']);
+
+        $content = $contentView->getContent();
+
+        $this->assertInstanceOf(ResolvableResource::class, $content);
+        $this->assertSame(1, $content->getId());
+        $this->assertSame('custom_contact', $content->getResourceLoaderKey());
+    }
+}

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/AccountResourceLoaderTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/AccountResourceLoaderTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Tests\Unit\Infrastructure\Sulu\Content\ResourceLoader;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\ContactBundle\Api\Account as AccountApi;
+use Sulu\Bundle\ContactBundle\Contact\AccountManager;
+use Sulu\Bundle\ContactBundle\Entity\Account;
+use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader\AccountResourceLoader;
+
+class AccountResourceLoaderTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<AccountManager>
+     */
+    private ObjectProphecy $accountManager;
+
+    private AccountResourceLoader $loader;
+
+    public function setUp(): void
+    {
+        $this->accountManager = $this->prophesize(AccountManager::class);
+        $this->loader = new AccountResourceLoader($this->accountManager->reveal());
+    }
+
+    public function testGetKey(): void
+    {
+        $this->assertSame('account', $this->loader::getKey());
+    }
+
+    public function testLoad(): void
+    {
+        $account1 = $this->createAccount(1);
+        $account2 = $this->createAccount(3);
+
+        $this->accountManager->getByIds([1, 3], 'en')->willReturn([
+            $account1,
+            $account2,
+        ])
+            ->shouldBeCalled();
+
+        $result = $this->loader->load([1, 3], 'en', []);
+
+        $this->assertSame([
+            1 => $account1,
+            3 => $account2,
+        ], $result);
+    }
+
+    private static function createAccount(int $id): AccountApi
+    {
+        $account = new Account();
+        $account->setId($id);
+
+        return new AccountApi($account, 'en');
+    }
+}

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/ContactResourceLoaderTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/ContactResourceLoaderTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Tests\Unit\Infrastructure\Sulu\Content\ResourceLoader;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\ContactBundle\Api\Contact as ContactApi;
+use Sulu\Bundle\ContactBundle\Contact\ContactManager;
+use Sulu\Bundle\ContactBundle\Entity\Contact;
+use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader\ContactResourceLoader;
+use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
+
+class ContactResourceLoaderTest extends TestCase
+{
+    use ProphecyTrait;
+    use SetGetPrivatePropertyTrait;
+
+    /**
+     * @var ObjectProphecy<ContactManager>
+     */
+    private ObjectProphecy $contactManager;
+
+    private ContactResourceLoader $loader;
+
+    public function setUp(): void
+    {
+        $this->contactManager = $this->prophesize(ContactManager::class);
+        $this->loader = new ContactResourceLoader($this->contactManager->reveal());
+    }
+
+    public function testGetKey(): void
+    {
+        $this->assertSame('contact', $this->loader::getKey());
+    }
+
+    public function testLoad(): void
+    {
+        $contact1 = $this->createContact(1);
+        $contact2 = $this->createContact(3);
+
+        $this->contactManager->getByIds([1, 3], 'en')->willReturn([
+            $contact1,
+            $contact2,
+        ])
+            ->shouldBeCalled();
+
+        $result = $this->loader->load([1, 3], 'en', []);
+
+        $this->assertSame([
+            1 => $contact1,
+            3 => $contact2,
+        ], $result);
+    }
+
+    private static function createContact(int $id): ContactApi
+    {
+        $contact = new Contact();
+        static::setPrivateProperty($contact, 'id', $id);
+
+        return new ContactApi($contact, 'en');
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\MediaBundle\DependencyInjection;
 
 use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
 use Contao\ImagineSvg\Imagine as SvgImagine;
 use FFMpeg\FFMpeg;
 use Imagine\Vips\Imagine as VipsImagine;
@@ -375,8 +376,7 @@ class SuluMediaExtension extends Extension implements PrependExtensionInterface
 
         if (
             InstalledVersions::isInstalled('sulu/content-bundle')
-            && \version_compare(InstalledVersions::getVersion('sulu/content-bundle') ?? '0.0.0', '0.9', '>=')
-            && \version_compare(InstalledVersions::getVersion('sulu/content-bundle') ?? '0.0.0', '0.10', '<')
+            && InstalledVersions::satisfies(new VersionParser(), 'sulu/content-bundle', '^0.9')
         ) {
             $loader->load('services_content.xml');
         }

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -374,9 +374,9 @@ class SuluMediaExtension extends Extension implements PrependExtensionInterface
         }
 
         if (
-            InstalledVersions::isInstalled('sulu/sulu-content-bundle')
-            && \version_compare(InstalledVersions::getVersion('sulu/sulu-content-bundle') ?? '0.0.0', '0.9', '>=')
-            && \version_compare(InstalledVersions::getVersion('sulu/sulu-content-bundle') ?? '0.0.0', '0.10', '<')
+            InstalledVersions::isInstalled('sulu/content-bundle')
+            && \version_compare(InstalledVersions::getVersion('sulu/content-bundle') ?? '0.0.0', '0.9', '>=')
+            && \version_compare(InstalledVersions::getVersion('sulu/content-bundle') ?? '0.0.0', '0.10', '<')
         ) {
             $loader->load('services_content.xml');
         }

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\MediaBundle\DependencyInjection;
 
+use Composer\InstalledVersions;
 use Contao\ImagineSvg\Imagine as SvgImagine;
 use FFMpeg\FFMpeg;
 use Imagine\Vips\Imagine as VipsImagine;
@@ -370,6 +371,14 @@ class SuluMediaExtension extends Extension implements PrependExtensionInterface
 
         if (\array_key_exists('SuluTrashBundle', $bundles)) {
             $loader->load('services_trash.xml');
+        }
+
+        if (
+            InstalledVersions::isInstalled('sulu/sulu-content-bundle')
+            && \version_compare(InstalledVersions::getVersion('sulu/sulu-content-bundle') ?? '0.0.0', '0.9', '>=')
+            && \version_compare(InstalledVersions::getVersion('sulu/sulu-content-bundle') ?? '0.0.0', '0.10', '<')
+        ) {
+            $loader->load('services_content.xml');
         }
 
         $ffmpegBinary = $container->resolveEnvPlaceholders($config['ffmpeg']['ffmpeg_binary'] ?? null, true);

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/CollectionSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/CollectionSelectionPropertyResolver.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver;
 
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
-use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\CollectionResourceLoader;
 
 /**

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/CollectionSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/CollectionSelectionPropertyResolver.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver;
+
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\CollectionResourceLoader;
+
+/**
+ * @internal if you need to override this service, create a new service with based on PropertyResolverInterface instead of extending this class
+ *
+ * @final
+ */
+class CollectionSelectionPropertyResolver implements PropertyResolverInterface
+{
+    public function resolve(mixed $data, string $locale, array $params = []): ContentView
+    {
+        if (!\is_array($data)
+            || 0 === \count($data)
+            || !\array_is_list($data)
+        ) {
+            return ContentView::create([], ['ids' => [], ...$params]);
+        }
+
+        /** @var string $resourceLoaderKey */
+        $resourceLoaderKey = $params['resourceLoader'] ?? CollectionResourceLoader::getKey();
+
+        return ContentView::createResolvables(
+            $data,
+            $resourceLoaderKey,
+            ['ids' => $data, ...$params],
+        );
+    }
+
+    public static function getType(): string
+    {
+        return 'collection_selection';
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolver.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolver.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver;
+
+use Psr\Log\LoggerInterface;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ResolvableResource;
+use Sulu\Bundle\ContentBundle\Content\Application\MetadataResolver\MetadataResolver;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\MediaResourceLoader;
+
+/**
+ * @internal if you need to override this service, create a new service with based on ResourceLoaderInterface instead of extending this class
+ *
+ * @final
+ */
+class ImageMapPropertyResolver implements PropertyResolverInterface // TODO we may should implement a PropertyResolverAwareMetadataInterface
+{
+    private MetadataResolver $metadataResolver;
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly bool $debug = false,
+    ) {
+    }
+
+    /**
+     * @internal
+     *
+     * Prevent circular dependency by injecting the MetadataResolver after instantiation
+     */
+    public function setMetadataResolver(MetadataResolver $metadataResolver): void
+    {
+        $this->metadataResolver = $metadataResolver;
+    }
+
+    public function resolve(mixed $data, string $locale, array $params = []): ContentView
+    {
+        $hotspots = (\is_array($data) && isset($data['hotspots']) && \is_array($data['hotspots'])) && \array_is_list($data['hotspots'])
+            ? $data['hotspots']
+            : [];
+
+        $hotspots = [] !== $hotspots ? $this->resolveHotspots($hotspots, $locale, $params) : ContentView::create([], []);
+
+        $returnedParams = $params;
+        unset($returnedParams['metadata']); // TODO we may should implement a PropertyResolverAwareMetadataInterface
+
+        if (!\is_array($data)
+            || !isset($data['imageId'])
+            || !\is_numeric($data['imageId'])
+        ) {
+            return ContentView::create([
+                'image' => null,
+                'hotspots' => $hotspots->getContent(),
+            ], [
+                'imageId' => null,
+                'hotspots' => $hotspots->getView(),
+                ...$returnedParams,
+            ]);
+        }
+
+        /** @var string $resourceLoaderKey */
+        $resourceLoaderKey = $params['resourceLoader'] ?? MediaResourceLoader::getKey();
+        $imageId = (int) $data['imageId'];
+
+        return ContentView::create(
+            [
+                'image' => new ResolvableResource($imageId, $resourceLoaderKey),
+                'hotspots' => $hotspots->getContent(),
+            ],
+            [
+                'imageId' => $imageId,
+                'hotspots' => $hotspots->getView(),
+                ...$returnedParams,
+            ],
+        );
+    }
+
+    /**
+     * @param non-empty-array<array<mixed>> $hotspots
+     * @param array<string, mixed> $params
+     */
+    private function resolveHotspots(array $hotspots, string $locale, array $params): ContentView
+    {
+        $metadata = $params['metadata'] ?? null;
+        \assert($metadata instanceof FieldMetadata, 'Metadata must be set to resolve hotspots.');
+        $metadataTypes = $metadata->getTypes();
+        $content = [];
+        $view = [];
+        foreach ($hotspots as $key => $block) {
+            if (!\is_array($block) || !isset($block['type']) || !\is_string($block['type'])) {
+                continue;
+            }
+            if (!isset($block['hotspot']) || !\is_array($block['hotspot'])) {
+                continue;
+            }
+
+            $type = $block['type'];
+            $formMetadata = $metadataTypes[$type] ?? null;
+
+            if (!$formMetadata instanceof FormMetadata) {
+                $errorMessage = \sprintf(
+                    'Metadata type "%s" in "%s" not found, founded types are: "%s"',
+                    $type,
+                    $metadata->getName(),
+                    \implode('", "', \array_keys($metadataTypes)),
+                );
+
+                $this->logger->error($errorMessage);
+
+                if ($this->debug) {
+                    throw new \UnexpectedValueException($errorMessage);
+                }
+
+                $type = $metadata->getDefaultType();
+                $formMetadata = $metadataTypes[$type] ?? null;
+                if (!$formMetadata instanceof FormMetadata) {
+                    continue;
+                }
+            }
+
+            $content[$key] = [
+                'type' => $type,
+                'hotspot' => $block['hotspot'],
+            ];
+
+            $view[$key] = [];
+
+            foreach ($this->metadataResolver->resolveItems($formMetadata->getItems(), $block, $locale) as $field => $resolvedItem) {
+                $content[$key][$field] = $resolvedItem->getContent();
+                $view[$key][$field] = $resolvedItem->getView();
+            }
+        }
+
+        return ContentView::create(\array_values($content), \array_values($view));
+    }
+
+    public static function getType(): string
+    {
+        return 'image_map';
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolver.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolver.php
@@ -19,7 +19,7 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ResolvableResource;
 use Sulu\Bundle\ContentBundle\Content\Application\MetadataResolver\MetadataResolver;
-use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\MediaResourceLoader;
 
 /**

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/MediaSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/MediaSelectionPropertyResolver.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver;
 
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
-use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\MediaResourceLoader;
 
 /**

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/MediaSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/MediaSelectionPropertyResolver.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver\Resolver;
+namespace Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver;
 
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
@@ -26,8 +26,15 @@ class MediaSelectionPropertyResolver implements PropertyResolverInterface
 {
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
     {
-        if (empty($data) || !\is_array($data) || !isset($data['ids'])) {
-            return ContentView::create([], ['ids' => []]);
+        $displayOption = (\is_array($data) && isset($data['displayOption']) && \is_string($data['displayOption']))
+            ? $data['displayOption']
+            : null;
+
+        if (!\is_array($data)
+            || !isset($data['ids'])
+            || !\array_is_list($data['ids'])
+        ) {
+            return ContentView::create([], ['ids' => [], 'displayOption' => $displayOption, ...$params]);
         }
 
         /** @var string $resourceLoaderKey */
@@ -36,7 +43,11 @@ class MediaSelectionPropertyResolver implements PropertyResolverInterface
         return ContentView::createResolvables(
             $data['ids'],
             $resourceLoaderKey,
-            ['ids' => $data['ids']],
+            [
+                'ids' => $data['ids'],
+                'displayOption' => $displayOption,
+                ...$params,
+            ],
         );
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/Resolver/MediaSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/Resolver/MediaSelectionPropertyResolver.php
@@ -17,6 +17,11 @@ use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentV
 use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
 use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\MediaResourceLoader;
 
+/**
+ * @internal if you need to override this service, create a new service with based on PropertyResolverInterface instead of extending this class
+ *
+ * @final
+ */
 class MediaSelectionPropertyResolver implements PropertyResolverInterface
 {
     public function resolve(mixed $data, string $locale, array $params = []): ContentView

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/Resolver/MediaSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/Resolver/MediaSelectionPropertyResolver.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver\Resolver;
+
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\MediaResourceLoader;
+
+class MediaSelectionPropertyResolver implements PropertyResolverInterface
+{
+    public function resolve(mixed $data, string $locale, array $params = []): ContentView
+    {
+        if (empty($data) || !\is_array($data) || !isset($data['ids'])) {
+            return ContentView::create([], ['ids' => []]);
+        }
+
+        /** @var string $resourceLoaderKey */
+        $resourceLoaderKey = $params['resourceLoader'] ?? MediaResourceLoader::getKey();
+
+        return ContentView::createResolvables(
+            $data['ids'],
+            $resourceLoaderKey,
+            ['ids' => $data['ids']],
+        );
+    }
+
+    public static function getType(): string
+    {
+        return 'media_selection';
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleCollectionSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleCollectionSelectionPropertyResolver.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver;
+
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\CollectionResourceLoader;
+
+/**
+ * @internal if you need to override this service, create a new service with based on PropertyResolverInterface instead of extending this class
+ *
+ * @final
+ */
+class SingleCollectionSelectionPropertyResolver implements PropertyResolverInterface
+{
+    public function resolve(mixed $data, string $locale, array $params = []): ContentView
+    {
+        if (!\is_numeric($data)) {
+            return ContentView::create(null, ['id' => null, ...$params]);
+        }
+
+        /** @var string $resourceLoaderKey */
+        $resourceLoaderKey = $params['resourceLoader'] ?? CollectionResourceLoader::getKey();
+
+        return ContentView::createResolvable(
+            (int) $data,
+            $resourceLoaderKey,
+            [
+                'id' => $data,
+                ...$params,
+            ],
+        );
+    }
+
+    public static function getType(): string
+    {
+        return 'single_collection_selection';
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleCollectionSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleCollectionSelectionPropertyResolver.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver;
 
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
-use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\CollectionResourceLoader;
 
 /**

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleMediaSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleMediaSelectionPropertyResolver.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver;
 
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
-use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\MediaResourceLoader;
 
 /**

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleMediaSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleMediaSelectionPropertyResolver.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver;
+
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\MediaResourceLoader;
+
+/**
+ * @internal if you need to override this service, create a new service with based on ResourceLoaderInterface instead of extending this class
+ *
+ * @final
+ */
+class SingleMediaSelectionPropertyResolver implements PropertyResolverInterface
+{
+    public function resolve(mixed $data, string $locale, array $params = []): ContentView
+    {
+        $displayOption = (\is_array($data) && isset($data['displayOption']) && \is_string($data['displayOption']))
+            ? $data['displayOption']
+            : null;
+
+        if (!\is_array($data)
+            || !isset($data['id'])
+            || !\is_numeric($data['id'])
+        ) {
+            return ContentView::create(null, ['id' => null, 'displayOption' => $displayOption, ...$params]);
+        }
+
+        /** @var string $resourceLoaderKey */
+        $resourceLoaderKey = $params['resourceLoader'] ?? MediaResourceLoader::getKey();
+        $id = (int) $data['id'];
+
+        return ContentView::createResolvable(
+            $id,
+            $resourceLoaderKey,
+            [
+                'id' => $id,
+                'displayOption' => $displayOption,
+                ...$params,
+            ],
+        );
+    }
+
+    public static function getType(): string
+    {
+        return 'single_media_selection';
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/ResourceLoader/CollectionResourceLoader.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/ResourceLoader/CollectionResourceLoader.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader;
 
-use Sulu\Bundle\ContentBundle\Content\Application\ResourceLoader\ResourceLoaderInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
 use Sulu\Bundle\MediaBundle\Collection\Manager\CollectionManagerInterface;
 use Sulu\Bundle\MediaBundle\Media\Exception\CollectionNotFoundException;
 

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/ResourceLoader/CollectionResourceLoader.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/ResourceLoader/CollectionResourceLoader.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader;
+
+use Sulu\Bundle\ContentBundle\Content\Application\ResourceLoader\ResourceLoaderInterface;
+use Sulu\Bundle\MediaBundle\Collection\Manager\CollectionManagerInterface;
+use Sulu\Bundle\MediaBundle\Media\Exception\CollectionNotFoundException;
+
+/**
+ * @internal if you need to override this service, create a new service with based on ResourceLoaderInterface instead of extending this class
+ *
+ * @final
+ */
+class CollectionResourceLoader implements ResourceLoaderInterface
+{
+    public const RESOURCE_LOADER_KEY = 'collection';
+
+    public function __construct(
+        private CollectionManagerInterface $collectionManager,
+    ) {
+    }
+
+    public function load(array $ids, ?string $locale, array $params = []): array
+    {
+        $mappedResult = [];
+        foreach ($ids as $id) {
+            try {
+                $collection = $this->collectionManager->getById($id, $locale); // TODO load all over one query
+                $mappedResult[$collection->getId()] = $collection;
+            } catch (CollectionNotFoundException $e) {
+                // @ignoreException: do not crash page if selected collection is deleted
+            }
+        }
+
+        return $mappedResult;
+    }
+
+    public static function getKey(): string
+    {
+        return self::RESOURCE_LOADER_KEY;
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/ResourceLoader/CollectionResourceLoader.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/ResourceLoader/CollectionResourceLoader.php
@@ -33,8 +33,16 @@ class CollectionResourceLoader implements ResourceLoaderInterface
 
     public function load(array $ids, ?string $locale, array $params = []): array
     {
+        if (null === $locale) {
+            throw new \RuntimeException('Locale is required for loading collections');
+        }
+
         $mappedResult = [];
         foreach ($ids as $id) {
+            if (!\is_integer($id)) {
+                continue;
+            }
+
             try {
                 $collection = $this->collectionManager->getById($id, $locale); // TODO load all over one query
                 $mappedResult[$collection->getId()] = $collection;

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/ResourceLoader/MediaResourceLoader.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/ResourceLoader/MediaResourceLoader.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader;
 
-use Sulu\Bundle\ContentBundle\Content\Application\ResourceLoader\ResourceLoaderInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
 
 /**

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/ResourceLoader/MediaResourceLoader.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/ResourceLoader/MediaResourceLoader.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader;
+
+use Sulu\Bundle\ContentBundle\Content\Application\ResourceLoader\ResourceLoaderInterface;
+use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
+
+class MediaResourceLoader implements ResourceLoaderInterface
+{
+    public const RESOURCE_LOADER_KEY = 'media';
+
+    public function __construct(
+        private MediaManagerInterface $mediaManager
+    ) {
+    }
+
+    public function load(array $ids, ?string $locale, array $params = []): array
+    {
+        $result = $this->mediaManager->getByIds($ids, (string) $locale);
+
+        $mappedResult = [];
+        foreach ($result as $media) {
+            $mappedResult[$media->getId()] = $media;
+        }
+
+        return $mappedResult;
+    }
+
+    public static function getKey(): string
+    {
+        return self::RESOURCE_LOADER_KEY;
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/ResourceLoader/MediaResourceLoader.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/ResourceLoader/MediaResourceLoader.php
@@ -16,6 +16,11 @@ namespace Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader;
 use Sulu\Bundle\ContentBundle\Content\Application\ResourceLoader\ResourceLoaderInterface;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
 
+/**
+ * @internal if you need to override this service, create a new service with based on ResourceLoaderInterface instead of extending this class
+ *
+ * @final
+ */
 class MediaResourceLoader implements ResourceLoaderInterface
 {
     public const RESOURCE_LOADER_KEY = 'media';

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services_content.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services_content.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <!-- Property Resolver -->
+        <service id="sulu_media.property_resolver.media_selection"
+                 class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver\Resolver\MediaSelectionPropertyResolver">
+            <tag name="sulu_content.property_resolver"/>
+        </service>
+
+        <!-- Resource Loader -->
+        <service id="sulu_media.resource_loader.media"
+                 class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\MediaResourceLoader">
+            <argument type="service" id="sulu_media.media_manager"/>
+
+            <tag name="sulu_content.resource_loader" type="media"/>
+        </service>
+    </services>
+</container>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services_content.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services_content.xml
@@ -4,13 +4,13 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <!-- Property Resolver -->
-        <service id="sulu_media.property_resolver.media_selection"
-                 class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver\Resolver\MediaSelectionPropertyResolver">
+        <service id="sulu_media.media_selection_property_resolver"
+                 class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver\MediaSelectionPropertyResolver">
             <tag name="sulu_content.property_resolver"/>
         </service>
 
         <!-- Resource Loader -->
-        <service id="sulu_media.resource_loader.media"
+        <service id="sulu_media.media_resource_loader"
                  class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\MediaResourceLoader">
             <argument type="service" id="sulu_media.media_manager"/>
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services_content.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services_content.xml
@@ -9,6 +9,19 @@
             <tag name="sulu_content.property_resolver"/>
         </service>
 
+        <service id="sulu_media.single_media_selection_property_resolver"
+                 class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver\SingleMediaSelectionPropertyResolver">
+            <tag name="sulu_content.property_resolver"/>
+        </service>
+
+        <service id="sulu_media.image_map_property_resolver"
+                 class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver\ImageMapPropertyResolver">
+            <argument type="service" id="logger"/>
+            <argument>%kernel.debug%</argument>
+
+            <tag name="sulu_content.property_resolver"/>
+        </service>
+
         <!-- Resource Loader -->
         <service id="sulu_media.media_resource_loader"
                  class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\MediaResourceLoader">

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services_content.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services_content.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <container xmlns="http://symfony.com/schema/dic/services"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <!-- Property Resolver -->
         <service id="sulu_media.media_selection_property_resolver"
@@ -22,12 +22,29 @@
             <tag name="sulu_content.property_resolver"/>
         </service>
 
+        <service id="sulu_media.collection_selection_property_resolver"
+                 class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver\CollectionSelectionPropertyResolver">
+            <tag name="sulu_content.property_resolver"/>
+        </service>
+
+        <service id="sulu_media.single_collection_selection_property_resolver"
+                 class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver\SingleCollectionSelectionPropertyResolver">
+            <tag name="sulu_content.property_resolver"/>
+        </service>
+
         <!-- Resource Loader -->
         <service id="sulu_media.media_resource_loader"
                  class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\MediaResourceLoader">
             <argument type="service" id="sulu_media.media_manager"/>
 
             <tag name="sulu_content.resource_loader" type="media"/>
+        </service>
+
+        <service id="sulu_media.collection_resource_loader"
+                 class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\CollectionResourceLoader">
+            <argument type="service" id="sulu_media.collection_manager"/>
+
+            <tag name="sulu_content.resource_loader" type="collection"/>
         </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/CollectionSelectionPropertyResolverTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/CollectionSelectionPropertyResolverTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ResolvableResource;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver\CollectionSelectionPropertyResolver;
+
+#[CoversClass(CollectionSelectionPropertyResolver::class)]
+class CollectionSelectionPropertyResolverTest extends TestCase
+{
+    private CollectionSelectionPropertyResolver $resolver;
+
+    public function setUp(): void
+    {
+        $this->resolver = new CollectionSelectionPropertyResolver();
+    }
+
+    public function testResolveEmpty(): void
+    {
+        $contentView = $this->resolver->resolve([], 'en');
+
+        $this->assertSame([], $contentView->getContent());
+        $this->assertSame(['ids' => []], $contentView->getView());
+    }
+
+    public function testResolveParams(): void
+    {
+        $contentView = $this->resolver->resolve([], 'en', ['custom' => 'params']);
+
+        $this->assertSame([], $contentView->getContent());
+        $this->assertSame([
+            'ids' => [],
+            'custom' => 'params',
+        ], $contentView->getView());
+    }
+
+    #[DataProvider('provideUnresolvableData')]
+    public function testResolveUnresolvableData(mixed $data): void
+    {
+        $contentView = $this->resolver->resolve($data, 'en');
+
+        $this->assertSame([], $contentView->getContent());
+        $this->assertSame(['ids' => []], $contentView->getView());
+    }
+
+    /**
+     * @return iterable<array{
+     *     0: mixed,
+     * }>
+     */
+    public static function provideUnresolvableData(): iterable
+    {
+        yield 'null' => [null];
+        yield 'smart_content' => [['source' => '123']];
+        yield 'single_value' => [1];
+        yield 'object' => [(object) [1, 2]];
+    }
+
+    /**
+     * @param array<string|int> $data
+     */
+    #[DataProvider('provideResolvableData')]
+    public function testResolveResolvableData(array $data): void
+    {
+        $contentView = $this->resolver->resolve($data, 'en');
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        foreach ($data as $key => $value) {
+            $resolvable = $content[$key] ?? null;
+            $this->assertInstanceOf(ResolvableResource::class, $resolvable);
+            $this->assertSame($value, $resolvable->getId());
+            $this->assertSame('collection', $resolvable->getResourceLoaderKey());
+        }
+
+        $this->assertSame(['ids' => $data], $contentView->getView());
+    }
+
+    /**
+     * @return iterable<array{
+     *     0: array<string|int>,
+     * }>
+     */
+    public static function provideResolvableData(): iterable
+    {
+        yield 'empty' => [[]];
+        yield 'int_list' => [[1, 2]];
+        yield 'string_list' => [['1', '2']];
+    }
+
+    public function testCustomResourceLoader(): void
+    {
+        $contentView = $this->resolver->resolve([1], 'en', ['resourceLoader' => 'custom_collection']);
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        $resolvable = $content[0] ?? null;
+        $this->assertInstanceOf(ResolvableResource::class, $resolvable);
+        $this->assertSame(1, $resolvable->getId());
+        $this->assertSame('custom_collection', $resolvable->getResourceLoaderKey());
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolverTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolverTest.php
@@ -141,7 +141,7 @@ class ImageMapPropertyResolverTest extends TestCase
     /**
      * @return iterable<array{
      *     0: array{
-     *         id: string|int,
+     *         id?: string|int,
      *         displayOption?: string|null,
      *     },
      * }>

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolverTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolverTest.php
@@ -1,0 +1,261 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ResolvableResource;
+use Sulu\Bundle\ContentBundle\Content\Application\MetadataResolver\MetadataResolver;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverProvider;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\Resolver\DefaultPropertyResolver;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver\ImageMapPropertyResolver;
+use Symfony\Component\ErrorHandler\BufferingLogger;
+
+#[CoversClass(ImageMapPropertyResolver::class)]
+class ImageMapPropertyResolverTest extends TestCase
+{
+    private ImageMapPropertyResolver $resolver;
+
+    private BufferingLogger $logger;
+
+    public function setUp(): void
+    {
+        $this->logger = new BufferingLogger();
+        $this->resolver = new ImageMapPropertyResolver(
+            $this->logger,
+            debug: false,
+        );
+        $metadataResolverProperty = new PropertyResolverProvider([
+            'default' => new DefaultPropertyResolver(),
+        ]);
+        $metadataResolver = new MetadataResolver($metadataResolverProperty);
+        $this->resolver->setMetadataResolver($metadataResolver);
+    }
+
+    public function testResolveEmpty(): void
+    {
+        $contentView = $this->resolver->resolve(null, 'en');
+
+        $this->assertSame(['image' => null, 'hotspots' => []], $contentView->getContent());
+        $this->assertSame(['imageId' => null, 'hotspots' => []], $contentView->getView());
+        $this->assertCount(0, $this->logger->cleanLogs());
+    }
+
+    public function testResolveParams(): void
+    {
+        $contentView = $this->resolver->resolve(null, 'en', ['custom' => 'params']);
+
+        $this->assertSame(['image' => null, 'hotspots' => []], $contentView->getContent());
+        $this->assertSame([
+            'imageId' => null,
+            'hotspots' => [],
+            'custom' => 'params',
+        ], $contentView->getView());
+        $this->assertCount(0, $this->logger->cleanLogs());
+    }
+
+    #[DataProvider('provideUnresolvableData')]
+    public function testResolveUnresolvableData(mixed $data): void
+    {
+        $contentView = $this->resolver->resolve($data, 'en');
+
+        $this->assertSame(['image' => null, 'hotspots' => []], $contentView->getContent());
+        $this->assertSame(['imageId' => null, 'hotspots' => []], $contentView->getView());
+        $this->assertCount(0, $this->logger->cleanLogs());
+    }
+
+    /**
+     * @return iterable<array{
+     *     0: mixed,
+     * }>
+     */
+    public static function provideUnresolvableData(): iterable
+    {
+        yield 'null' => [null];
+        yield 'smart_content' => [['source' => '123']];
+        yield 'single_value' => [1];
+        yield 'object' => [(object) [1, 2]];
+        yield 'int_list_not_in_ids' => [[1, 2]];
+        yield 'ids_null' => [['ids' => null]];
+        yield 'ids_list' => [['ids' => [1, 2]]];
+        yield 'id_list' => [['id' => [1, 2]]];
+        yield 'non_numeric_image_id' => [['imageId' => 'a']];
+    }
+
+    /**
+     * @param array{
+     *     imageId?: string|int,
+     *     hotspots?: array<array{
+     *         type: string,
+     *         hotspot: array{type: string},
+     *         ...
+     *     }>,
+     * } $data
+     */
+    #[DataProvider('provideResolvableData')]
+    public function testResolveResolvableData(array $data): void
+    {
+        $contentView = $this->resolver->resolve($data, 'en', ['metadata' => $this->createMetadata()]);
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        $imageId = $data['imageId'] ?? null;
+        if (null !== $imageId) {
+            $imageId = (int) $imageId;
+            $image = $content['image'] ?? null;
+            $this->assertInstanceOf(ResolvableResource::class, $image);
+            $this->assertSame($imageId, $image->getId());
+            $this->assertSame('media', $image->getResourceLoaderKey());
+        }
+
+        $hotspots = $content['hotspots'] ?? [];
+        $this->assertIsArray($hotspots);
+        $expectedView = [];
+        foreach (($data['hotspots'] ?? []) as $key => $hotspot) {
+            $hotspot = $hotspots[$key] ?? null;
+            $this->assertIsArray($hotspot);
+            $this->assertSame($data['hotspots'][$key], $hotspot);
+            $expectedView[] = ['title' => []];
+        }
+
+        $this->assertSame([
+            'imageId' => $imageId,
+            'hotspots' => $expectedView,
+        ], $contentView->getView());
+
+        $this->assertCount(0, $this->logger->cleanLogs());
+    }
+
+    /**
+     * @return iterable<array{
+     *     0: array{
+     *         id: string|int,
+     *         displayOption?: string|null,
+     *     },
+     * }>
+     */
+    public static function provideResolvableData(): iterable
+    {
+        yield 'empty' => [[]];
+        yield 'int_id' => [['imageId' => 1]];
+        yield 'int_id_with_hotspots' => [
+            ['imageId' => 1, 'hotspots' => [['type' => 'text', 'hotspot' => ['type' => 'circle'], 'title' => 'Title 1'], ['type' => 'text', 'hotspot' => ['type' => 'circle'], 'title' => 'Title 2']]],
+        ];
+        yield 'string_id' => [['imageId' => '1']];
+        yield 'string_id_with_hotspots' => [['imageId' => '1', 'hotspots' => [['type' => 'text', 'hotspot' => ['type' => 'circle'], 'title' => 'Title 1'], ['type' => 'text', 'hotspot' => ['type' => 'circle'], 'title' => 'Title 2']]]];
+    }
+
+    public function testCustomResourceLoader(): void
+    {
+        $contentView = $this->resolver->resolve(
+            ['imageId' => 1, 'hotspots' => [['type' => 'text', 'title' => 'Title'], ['type' => 'text', 'title' => 'Title']]],
+            'en',
+            [
+                'metadata' => $this->createMetadata(),
+                'resourceLoader' => 'custom_media',
+            ]
+        );
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        $image = $content['image'] ?? null;
+        $this->assertInstanceOf(ResolvableResource::class, $image);
+        $this->assertSame(1, $image->getId());
+        $this->assertSame('custom_media', $image->getResourceLoaderKey());
+
+        $this->assertSame([
+            'imageId' => 1,
+            'hotspots' => [],
+            'resourceLoader' => 'custom_media',
+        ], $contentView->getView());
+        $this->assertCount(0, $this->logger->cleanLogs());
+    }
+
+    /**
+     * @param array{
+     *     imageId: int,
+     *     hotspots?: array<array{
+     *         type?: string,
+     *         hotspot?: array{type: string},
+     *         ...
+     *     }>,
+     * } $data
+     */
+    #[DataProvider('provideUnresolvableHotspotData')]
+    public function testResolveUnresolvableHotspotData(mixed $data): void
+    {
+        $contentView = $this->resolver->resolve($data, 'en', ['metadata' => $this->createMetadata()]);
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        $image = $content['image'] ?? null;
+        $this->assertInstanceOf(ResolvableResource::class, $image);
+        $this->assertSame(1, $image->getId());
+        $this->assertSame('media', $image->getResourceLoaderKey());
+        $hotspots = $content['hotspots'] ?? null;
+        $this->assertIsArray($hotspots);
+
+        $expectedView = [];
+        $expectedCount = \count($data['hotspots'] ?? []);
+        $expectedErrorLogs = 0;
+        foreach ($data['hotspots'] ?? [] as $hotspot) {
+            if (!isset($hotspot['type'])) {
+                --$expectedCount;
+                continue;
+            }
+            if (!isset($hotspot['hotspot'])) {
+                --$expectedCount;
+                continue;
+            }
+            ++$expectedErrorLogs;
+            $expectedView[] = ['title' => []];
+        }
+
+        $this->assertCount($expectedCount, $hotspots);
+
+        $this->assertSame(['imageId' => 1, 'hotspots' => $expectedView], $contentView->getView());
+        $logs = $this->logger->cleanLogs();
+        $this->assertCount($expectedErrorLogs, $logs);
+    }
+
+    /**
+     * @return iterable<array{
+     *     0: mixed,
+     * }>
+     */
+    public static function provideUnresolvableHotspotData(): iterable
+    {
+        yield 'hotspot_with_not_exist_type' => [['imageId' => 1, 'hotspots' => [['type' => 'not_exist', 'hotspot' => ['type' => 'circle'], 'title' => 'Title']]]];
+        yield 'hotspot_with_no_type' => [['imageId' => 1, 'hotspots' => [['hotspot' => ['type' => 'circle'], 'title' => 'Title']]]];
+        yield 'hotspot_with_no_hotspot' => [['imageId' => 1, 'hotspots' => [['type' => 'not_exist', 'title' => 'Title']]]];
+    }
+
+    private function createMetadata(): FieldMetadata
+    {
+        $fieldMetadata = new FieldMetadata('image');
+        $fieldMetadata->setType('image_map');
+        $fieldMetadata->setDefaultType('text');
+
+        $textFormMetadata = new FormMetadata();
+        $textFormMetadata->setName('text');
+        $itemMetadata = new FieldMetadata('title');
+        $itemMetadata->setType('text_line');
+        $textFormMetadata->addItem($itemMetadata);
+
+        $fieldMetadata->addType($textFormMetadata);
+
+        return $fieldMetadata;
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/MediaSelectionPropertyResolverTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/MediaSelectionPropertyResolverTest.php
@@ -102,7 +102,7 @@ class MediaSelectionPropertyResolverTest extends TestCase
     /**
      * @return iterable<array{
      *     0: array{
-     *         ids: array<string|int>,
+     *         ids?: array<string|int>,
      *         displayOption?: string|null,
      *     },
      * }>

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/MediaSelectionPropertyResolverTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/MediaSelectionPropertyResolverTest.php
@@ -9,22 +9,22 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\CategoryBundle\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\PropertyResolver\CategorySelectionPropertyResolver;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ResolvableResource;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver\MediaSelectionPropertyResolver;
 
-#[CoversClass(CategorySelectionPropertyResolver::class)]
-class CategorySelectionPropertyResolverTest extends TestCase
+#[CoversClass(MediaSelectionPropertyResolver::class)]
+class MediaSelectionPropertyResolverTest extends TestCase
 {
-    private CategorySelectionPropertyResolver $resolver;
+    private MediaSelectionPropertyResolver $resolver;
 
     public function setUp(): void
     {
-        $this->resolver = new CategorySelectionPropertyResolver();
+        $this->resolver = new MediaSelectionPropertyResolver();
     }
 
     public function testResolveEmpty(): void
@@ -32,7 +32,7 @@ class CategorySelectionPropertyResolverTest extends TestCase
         $contentView = $this->resolver->resolve([], 'en');
 
         $this->assertSame([], $contentView->getContent());
-        $this->assertSame(['ids' => []], $contentView->getView());
+        $this->assertSame(['ids' => [], 'displayOption' => null], $contentView->getView());
     }
 
     public function testResolveParams(): void
@@ -42,17 +42,18 @@ class CategorySelectionPropertyResolverTest extends TestCase
         $this->assertSame([], $contentView->getContent());
         $this->assertSame([
             'ids' => [],
+            'displayOption' => null,
             'custom' => 'params',
         ], $contentView->getView());
     }
 
     #[DataProvider('provideUnresolvableData')]
-    public function testResolveUnresolvableData(mixed $data): void
+    public function testResolveUnresolvableData(mixed $data, ?string $expectedDisplayOption = null): void
     {
         $contentView = $this->resolver->resolve($data, 'en');
 
         $this->assertSame([], $contentView->getContent());
-        $this->assertSame(['ids' => []], $contentView->getView());
+        $this->assertSame(['ids' => [], 'displayOption' => $expectedDisplayOption], $contentView->getView());
     }
 
     /**
@@ -66,49 +67,64 @@ class CategorySelectionPropertyResolverTest extends TestCase
         yield 'smart_content' => [['source' => '123']];
         yield 'single_value' => [1];
         yield 'object' => [(object) [1, 2]];
+        yield 'int_list_not_in_ids' => [[1, 2]];
+        yield 'ids_null' => [['ids' => null]];
+        yield 'display_option_only' => [['displayOption' => 'left'], 'left'];
     }
 
     /**
-     * @param array<string|int> $data
+     * @param array{
+     *     ids?: array<string|int>,
+     *     displayOption?: string|null,
+     * } $data
      */
     #[DataProvider('provideResolvableData')]
-    public function testResolveResolvableData(array $data): void
+    public function testResolveResolvableData(array $data, ?string $expectedDisplayOption = null): void
     {
         $contentView = $this->resolver->resolve($data, 'en');
 
         $content = $contentView->getContent();
         $this->assertIsArray($content);
-        foreach ($data as $key => $value) {
+
+        foreach (($data['ids'] ?? []) as $key => $value) {
             $resolvable = $content[$key] ?? null;
             $this->assertInstanceOf(ResolvableResource::class, $resolvable);
             $this->assertSame($value, $resolvable->getId());
-            $this->assertSame('category', $resolvable->getResourceLoaderKey());
+            $this->assertSame('media', $resolvable->getResourceLoaderKey());
         }
 
-        $this->assertSame(['ids' => $data], $contentView->getView());
+        $this->assertSame([
+            'ids' => ($data['ids'] ?? []),
+            'displayOption' => $expectedDisplayOption,
+        ], $contentView->getView());
     }
 
     /**
      * @return iterable<array{
-     *     0: array<string|int>,
+     *     0: array{
+     *         ids: array<string|int>,
+     *         displayOption?: string|null,
+     *     },
      * }>
      */
     public static function provideResolvableData(): iterable
     {
         yield 'empty' => [[]];
-        yield 'int_list' => [[1, 2]];
-        yield 'string_list' => [['1', '2']];
+        yield 'int_list' => [['ids' => [1, 2]]];
+        yield 'int_list_with_display_option' => [['ids' => [1, 2], 'displayOption' => 'left'], 'left'];
+        yield 'string_list' => [['ids' => ['1', '2']]];
+        yield 'string_list_with_display_option' => [['ids' => ['1', '2'], 'displayOption' => 'left'], 'left'];
     }
 
     public function testCustomResourceLoader(): void
     {
-        $contentView = $this->resolver->resolve([1], 'en', ['resourceLoader' => 'custom_category']);
+        $contentView = $this->resolver->resolve(['ids' => [1]], 'en', ['resourceLoader' => 'custom_media']);
 
         $content = $contentView->getContent();
         $this->assertIsArray($content);
         $resolvable = $content[0] ?? null;
         $this->assertInstanceOf(ResolvableResource::class, $resolvable);
         $this->assertSame(1, $resolvable->getId());
-        $this->assertSame('custom_category', $resolvable->getResourceLoaderKey());
+        $this->assertSame('custom_media', $resolvable->getResourceLoaderKey());
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleCollectionSelectionPropertyResolverTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleCollectionSelectionPropertyResolverTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ResolvableResource;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver\SingleCollectionSelectionPropertyResolver;
+
+#[CoversClass(SingleCollectionSelectionPropertyResolver::class)]
+class SingleCollectionSelectionPropertyResolverTest extends TestCase
+{
+    private SingleCollectionSelectionPropertyResolver $resolver;
+
+    public function setUp(): void
+    {
+        $this->resolver = new SingleCollectionSelectionPropertyResolver();
+    }
+
+    public function testResolveEmpty(): void
+    {
+        $contentView = $this->resolver->resolve(null, 'en');
+
+        $this->assertNull($contentView->getContent());
+        $this->assertSame(['id' => null], $contentView->getView());
+    }
+
+    public function testResolveParams(): void
+    {
+        $contentView = $this->resolver->resolve(null, 'en', ['custom' => 'params']);
+
+        $this->assertNull($contentView->getContent());
+        $this->assertSame([
+            'id' => null,
+            'custom' => 'params',
+        ], $contentView->getView());
+    }
+
+    #[DataProvider('provideUnresolvableData')]
+    public function testResolveUnresolvableData(mixed $data): void
+    {
+        $contentView = $this->resolver->resolve($data, 'en');
+
+        $this->assertNull($contentView->getContent());
+        $this->assertSame(['id' => null], $contentView->getView());
+    }
+
+    /**
+     * @return iterable<array{
+     *     0: mixed,
+     * }>
+     */
+    public static function provideUnresolvableData(): iterable
+    {
+        yield 'null' => [null];
+        yield 'smart_content' => [['source' => '123']];
+        yield 'multi_value' => [[1]];
+        yield 'object' => [(object) [1]];
+    }
+
+    #[DataProvider('provideResolvableData')]
+    public function testResolveResolvableData(int|string $data): void
+    {
+        $contentView = $this->resolver->resolve($data, 'en');
+
+        $content = $contentView->getContent();
+        $this->assertInstanceOf(ResolvableResource::class, $content);
+        $this->assertSame((int) $data, $content->getId());
+        $this->assertSame('collection', $content->getResourceLoaderKey());
+
+        $this->assertSame(['id' => $data], $contentView->getView());
+    }
+
+    /**
+     * @return iterable<array{
+     *     0: int|string,
+     * }>
+     */
+    public static function provideResolvableData(): iterable
+    {
+        yield 'int' => [1];
+        yield 'string' => ['2'];
+    }
+
+    public function testCustomResourceLoader(): void
+    {
+        $contentView = $this->resolver->resolve(1, 'en', ['resourceLoader' => 'custom_collection']);
+
+        $content = $contentView->getContent();
+
+        $this->assertInstanceOf(ResolvableResource::class, $content);
+        $this->assertSame(1, $content->getId());
+        $this->assertSame('custom_collection', $content->getResourceLoaderKey());
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleMediaSelectionPropertyResolverTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleMediaSelectionPropertyResolverTest.php
@@ -31,7 +31,7 @@ class SingleMediaSelectionPropertyResolverTest extends TestCase
     {
         $contentView = $this->resolver->resolve(null, 'en');
 
-        $this->assertSame(null, $contentView->getContent());
+        $this->assertNull($contentView->getContent());
         $this->assertSame(['id' => null, 'displayOption' => null], $contentView->getView());
     }
 
@@ -39,7 +39,7 @@ class SingleMediaSelectionPropertyResolverTest extends TestCase
     {
         $contentView = $this->resolver->resolve(null, 'en', ['custom' => 'params']);
 
-        $this->assertSame(null, $contentView->getContent());
+        $this->assertNull($contentView->getContent());
         $this->assertSame([
             'id' => null,
             'displayOption' => null,
@@ -52,7 +52,7 @@ class SingleMediaSelectionPropertyResolverTest extends TestCase
     {
         $contentView = $this->resolver->resolve($data, 'en');
 
-        $this->assertSame(null, $contentView->getContent());
+        $this->assertNull($contentView->getContent());
         $this->assertSame(['id' => null, 'displayOption' => $expectedDisplayOption], $contentView->getView());
     }
 
@@ -103,7 +103,7 @@ class SingleMediaSelectionPropertyResolverTest extends TestCase
     /**
      * @return iterable<array{
      *     0: array{
-     *         id: string|int,
+     *         id?: string|int,
      *         displayOption?: string|null,
      *     },
      * }>

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleMediaSelectionPropertyResolverTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleMediaSelectionPropertyResolverTest.php
@@ -119,13 +119,11 @@ class SingleMediaSelectionPropertyResolverTest extends TestCase
 
     public function testCustomResourceLoader(): void
     {
-        $contentView = $this->resolver->resolve(['ids' => [1]], 'en', ['resourceLoader' => 'custom_media']);
+        $contentView = $this->resolver->resolve(['id' => 1], 'en', ['resourceLoader' => 'custom_media']);
 
         $content = $contentView->getContent();
-        $this->assertIsArray($content);
-        $resolvable = $content[0] ?? null;
-        $this->assertInstanceOf(ResolvableResource::class, $resolvable);
-        $this->assertSame(1, $resolvable->getId());
-        $this->assertSame('custom_media', $resolvable->getResourceLoaderKey());
+        $this->assertInstanceOf(ResolvableResource::class, $content);
+        $this->assertSame(1, $content->getId());
+        $this->assertSame('custom_media', $content->getResourceLoaderKey());
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleMediaSelectionPropertyResolverTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleMediaSelectionPropertyResolverTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ResolvableResource;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver\SingleMediaSelectionPropertyResolver;
+
+#[CoversClass(SingleMediaSelectionPropertyResolver::class)]
+class SingleMediaSelectionPropertyResolverTest extends TestCase
+{
+    private SingleMediaSelectionPropertyResolver $resolver;
+
+    public function setUp(): void
+    {
+        $this->resolver = new SingleMediaSelectionPropertyResolver();
+    }
+
+    public function testResolveEmpty(): void
+    {
+        $contentView = $this->resolver->resolve(null, 'en');
+
+        $this->assertSame(null, $contentView->getContent());
+        $this->assertSame(['id' => null, 'displayOption' => null], $contentView->getView());
+    }
+
+    public function testResolveParams(): void
+    {
+        $contentView = $this->resolver->resolve(null, 'en', ['custom' => 'params']);
+
+        $this->assertSame(null, $contentView->getContent());
+        $this->assertSame([
+            'id' => null,
+            'displayOption' => null,
+            'custom' => 'params',
+        ], $contentView->getView());
+    }
+
+    #[DataProvider('provideUnresolvableData')]
+    public function testResolveUnresolvableData(mixed $data, ?string $expectedDisplayOption = null): void
+    {
+        $contentView = $this->resolver->resolve($data, 'en');
+
+        $this->assertSame(null, $contentView->getContent());
+        $this->assertSame(['id' => null, 'displayOption' => $expectedDisplayOption], $contentView->getView());
+    }
+
+    /**
+     * @return iterable<array{
+     *     0: mixed,
+     * }>
+     */
+    public static function provideUnresolvableData(): iterable
+    {
+        yield 'null' => [null];
+        yield 'smart_content' => [['source' => '123']];
+        yield 'single_value' => [1];
+        yield 'object' => [(object) [1, 2]];
+        yield 'int_list_not_in_ids' => [[1, 2]];
+        yield 'ids_null' => [['ids' => null]];
+        yield 'ids_list' => [['ids' => [1, 2]]];
+        yield 'id_list' => [['id' => [1, 2]]];
+        yield 'display_option_only' => [['displayOption' => 'left'], 'left'];
+    }
+
+    /**
+     * @param array{
+     *     id?: string|int,
+     *     displayOption?: string|null,
+     * } $data
+     */
+    #[DataProvider('provideResolvableData')]
+    public function testResolveResolvableData(array $data, ?string $expectedDisplayOption = null): void
+    {
+        $contentView = $this->resolver->resolve($data, 'en');
+
+        $content = $contentView->getContent();
+        $id = $data['id'] ?? null;
+        if (null !== $id) {
+            $id = (int) $id;
+            $this->assertInstanceOf(ResolvableResource::class, $content);
+            $this->assertSame($id, $content->getId());
+            $this->assertSame('media', $content->getResourceLoaderKey());
+        }
+
+        $this->assertSame([
+            'id' => $id,
+            'displayOption' => $expectedDisplayOption,
+        ], $contentView->getView());
+    }
+
+    /**
+     * @return iterable<array{
+     *     0: array{
+     *         id: string|int,
+     *         displayOption?: string|null,
+     *     },
+     * }>
+     */
+    public static function provideResolvableData(): iterable
+    {
+        yield 'empty' => [[]];
+        yield 'int_id' => [['id' => 1]];
+        yield 'int_id_with_display_option' => [['id' => 1, 'displayOption' => 'left'], 'left'];
+        yield 'string_id' => [['id' => '1']];
+        yield 'string_id_with_display_option' => [['id' => '1', 'displayOption' => 'left'], 'left'];
+    }
+
+    public function testCustomResourceLoader(): void
+    {
+        $contentView = $this->resolver->resolve(['ids' => [1]], 'en', ['resourceLoader' => 'custom_media']);
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        $resolvable = $content[0] ?? null;
+        $this->assertInstanceOf(ResolvableResource::class, $resolvable);
+        $this->assertSame(1, $resolvable->getId());
+        $this->assertSame('custom_media', $resolvable->getResourceLoaderKey());
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/CollectionResourceLoaderTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/CollectionResourceLoaderTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Infrastructure\Sulu\Content\ResourceLoader;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\MediaBundle\Api\Collection as ApiCollection;
+use Sulu\Bundle\MediaBundle\Collection\Manager\CollectionManagerInterface;
+use Sulu\Bundle\MediaBundle\Entity\Collection;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\CollectionResourceLoader;
+use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
+
+class CollectionResourceLoaderTest extends TestCase
+{
+    use ProphecyTrait;
+    use SetGetPrivatePropertyTrait;
+
+    /**
+     * @var ObjectProphecy<CollectionManagerInterface>
+     */
+    private ObjectProphecy $collectionManager;
+
+    private CollectionResourceLoader $loader;
+
+    public function setUp(): void
+    {
+        $this->collectionManager = $this->prophesize(CollectionManagerInterface::class);
+        $this->loader = new CollectionResourceLoader($this->collectionManager->reveal());
+    }
+
+    public function testGetKey(): void
+    {
+        $this->assertSame('collection', $this->loader::getKey());
+    }
+
+    public function testLoad(): void
+    {
+        $collection1 = $this->createCollection(1);
+        $collection3 = $this->createCollection(3);
+
+        $this->collectionManager->getById(1, 'en')->willReturn($collection1)
+            ->shouldBeCalled();
+
+        $this->collectionManager->getById(3, 'en')->willReturn($collection3)
+            ->shouldBeCalled();
+
+        $result = $this->loader->load([1, 3], 'en', []);
+
+        $this->assertSame([
+            1 => $collection1,
+            3 => $collection3,
+        ], $result);
+    }
+
+    private static function createCollection(int $id): ApiCollection
+    {
+        $collection = new Collection();
+        static::setPrivateProperty($collection, 'id', $id);
+
+        return new ApiCollection($collection, 'en');
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/MediaResourceLoaderTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/MediaResourceLoaderTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Infrastructure\Sulu\Content\ResourceLoader;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\MediaBundle\Api\Media as ApiMedia;
+use Sulu\Bundle\MediaBundle\Entity\Media;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\MediaResourceLoader;
+use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
+use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
+
+class MediaResourceLoaderTest extends TestCase
+{
+    use ProphecyTrait;
+    use SetGetPrivatePropertyTrait;
+
+    /**
+     * @var ObjectProphecy<MediaManagerInterface>
+     */
+    private ObjectProphecy $mediaManager;
+
+    private MediaResourceLoader $loader;
+
+    public function setUp(): void
+    {
+        $this->mediaManager = $this->prophesize(MediaManagerInterface::class);
+        $this->loader = new MediaResourceLoader($this->mediaManager->reveal());
+    }
+
+    public function testGetKey(): void
+    {
+        $this->assertSame('media', $this->loader::getKey());
+    }
+
+    public function testLoad(): void
+    {
+        $media1 = $this->createMedia(1);
+        $media2 = $this->createMedia(3);
+
+        $this->mediaManager->getByIds([1, 3], 'en')->willReturn([
+            $media1,
+            $media2,
+        ])
+            ->shouldBeCalled();
+
+        $result = $this->loader->load([1, 3], 'en', []);
+
+        $this->assertSame([
+            1 => $media1,
+            3 => $media2,
+        ], $result);
+    }
+
+    private static function createMedia(int $id): ApiMedia
+    {
+        $media = new Media();
+        static::setPrivateProperty($media, 'id', $id);
+
+        return new ApiMedia($media, 'en');
+    }
+}

--- a/src/Sulu/Bundle/TagBundle/DependencyInjection/SuluTagExtension.php
+++ b/src/Sulu/Bundle/TagBundle/DependencyInjection/SuluTagExtension.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\TagBundle\DependencyInjection;
 
+use Composer\InstalledVersions;
 use Sulu\Bundle\PersistenceBundle\DependencyInjection\PersistenceExtensionTrait;
 use Sulu\Bundle\TagBundle\Tag\TagInterface;
 use Sulu\Bundle\TagBundle\Tag\TagRepositoryInterface;
@@ -92,6 +93,14 @@ class SuluTagExtension extends Extension implements PrependExtensionInterface
 
         if (\array_key_exists('SuluTrashBundle', $bundles)) {
             $loader->load('services_trash.xml');
+        }
+
+        if (
+            InstalledVersions::isInstalled('sulu/content-bundle')
+            && \version_compare(InstalledVersions::getVersion('sulu/content-bundle') ?? '0.0.0', '0.9', '>=')
+            && \version_compare(InstalledVersions::getVersion('sulu/content-bundle') ?? '0.0.0', '0.10', '<')
+        ) {
+            $loader->load('services_content.xml');
         }
     }
 }

--- a/src/Sulu/Bundle/TagBundle/DependencyInjection/SuluTagExtension.php
+++ b/src/Sulu/Bundle/TagBundle/DependencyInjection/SuluTagExtension.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\TagBundle\DependencyInjection;
 
 use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
 use Sulu\Bundle\PersistenceBundle\DependencyInjection\PersistenceExtensionTrait;
 use Sulu\Bundle\TagBundle\Tag\TagInterface;
 use Sulu\Bundle\TagBundle\Tag\TagRepositoryInterface;
@@ -97,8 +98,7 @@ class SuluTagExtension extends Extension implements PrependExtensionInterface
 
         if (
             InstalledVersions::isInstalled('sulu/content-bundle')
-            && \version_compare(InstalledVersions::getVersion('sulu/content-bundle') ?? '0.0.0', '0.9', '>=')
-            && \version_compare(InstalledVersions::getVersion('sulu/content-bundle') ?? '0.0.0', '0.10', '<')
+            && InstalledVersions::satisfies(new VersionParser(), 'sulu/content-bundle', '^0.9')
         ) {
             $loader->load('services_content.xml');
         }

--- a/src/Sulu/Bundle/TagBundle/Infrastructure/Sulu/Content/PropertyResolver/TagSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/TagBundle/Infrastructure/Sulu/Content/PropertyResolver/TagSelectionPropertyResolver.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Bundle\TagBundle\Infrastructure\Sulu\Content\PropertyResolver;
 
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
-use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 use Sulu\Bundle\TagBundle\Infrastructure\Sulu\Content\ResourceLoader\TagResourceLoader;
 
 /**

--- a/src/Sulu/Bundle/TagBundle/Infrastructure/Sulu/Content/PropertyResolver/TagSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/TagBundle/Infrastructure/Sulu/Content/PropertyResolver/TagSelectionPropertyResolver.php
@@ -11,18 +11,18 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\PropertyResolver;
+namespace Sulu\Bundle\TagBundle\Infrastructure\Sulu\Content\PropertyResolver;
 
-use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Content\ResourceLoader\ContactResourceLoader;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+use Sulu\Bundle\TagBundle\Infrastructure\Sulu\Content\ResourceLoader\TagResourceLoader;
 
 /**
  * @internal if you need to override this service, create a new service with based on PropertyResolverInterface instead of extending this class
  *
  * @final
  */
-class ContactSelectionPropertyResolver implements PropertyResolverInterface
+class TagSelectionPropertyResolver implements PropertyResolverInterface
 {
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
     {
@@ -34,20 +34,17 @@ class ContactSelectionPropertyResolver implements PropertyResolverInterface
         }
 
         /** @var string $resourceLoaderKey */
-        $resourceLoaderKey = $params['resourceLoader'] ?? ContactResourceLoader::getKey();
+        $resourceLoaderKey = $params['resourceLoader'] ?? TagResourceLoader::getKey();
 
         return ContentView::createResolvables(
             $data,
             $resourceLoaderKey,
-            [
-                'ids' => $data,
-                ...$params,
-            ],
+            ['ids' => $data, ...$params],
         );
     }
 
     public static function getType(): string
     {
-        return 'contact_selection';
+        return 'tag_selection';
     }
 }

--- a/src/Sulu/Bundle/TagBundle/Infrastructure/Sulu/Content/ResourceLoader/TagResourceLoader.php
+++ b/src/Sulu/Bundle/TagBundle/Infrastructure/Sulu/Content/ResourceLoader/TagResourceLoader.php
@@ -11,32 +11,32 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\ResourceLoader;
+namespace Sulu\Bundle\TagBundle\Infrastructure\Sulu\Content\ResourceLoader;
 
-use Sulu\Bundle\CategoryBundle\Category\CategoryManagerInterface;
 use Sulu\Bundle\ContentBundle\Content\Application\ResourceLoader\ResourceLoaderInterface;
+use Sulu\Bundle\TagBundle\Tag\TagRepositoryInterface;
 
 /**
  * @internal if you need to override this service, create a new service with based on ResourceLoaderInterface instead of extending this class
  *
  * @final
  */
-class CategoryResourceLoader implements ResourceLoaderInterface
+class TagResourceLoader implements ResourceLoaderInterface
 {
-    public const RESOURCE_LOADER_KEY = 'category';
+    public const RESOURCE_LOADER_KEY = 'tag';
 
     public function __construct(
-        private CategoryManagerInterface $categoryManager
+        private TagRepositoryInterface $tagRepository
     ) {
     }
 
     public function load(array $ids, ?string $locale, array $params = []): array
     {
-        $result = $this->categoryManager->findByIds($ids);
+        $result = $this->tagRepository->findBy(['id' => $ids]);
 
         $mappedResult = [];
-        foreach ($result as $category) {
-            $mappedResult[$category->getId()] = $category;
+        foreach ($result as $tag) {
+            $mappedResult[$tag->getId()] = $tag->getName();
         }
 
         return $mappedResult;

--- a/src/Sulu/Bundle/TagBundle/Infrastructure/Sulu/Content/ResourceLoader/TagResourceLoader.php
+++ b/src/Sulu/Bundle/TagBundle/Infrastructure/Sulu/Content/ResourceLoader/TagResourceLoader.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\TagBundle\Infrastructure\Sulu\Content\ResourceLoader;
 
-use Sulu\Bundle\ContentBundle\Content\Application\ResourceLoader\ResourceLoaderInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
 use Sulu\Bundle\TagBundle\Tag\TagRepositoryInterface;
 
 /**

--- a/src/Sulu/Bundle/TagBundle/Infrastructure/Sulu/Content/ResourceLoader/TagResourceLoader.php
+++ b/src/Sulu/Bundle/TagBundle/Infrastructure/Sulu/Content/ResourceLoader/TagResourceLoader.php
@@ -32,11 +32,11 @@ class TagResourceLoader implements ResourceLoaderInterface
 
     public function load(array $ids, ?string $locale, array $params = []): array
     {
-        $result = $this->tagRepository->findBy(['id' => $ids]);
+        $result = $this->tagRepository->findBy(['name' => $ids]);
 
         $mappedResult = [];
         foreach ($result as $tag) {
-            $mappedResult[$tag->getId()] = $tag->getName();
+            $mappedResult[$tag->getName()] = $tag->getName();
         }
 
         return $mappedResult;

--- a/src/Sulu/Bundle/TagBundle/Resources/config/services_content.xml
+++ b/src/Sulu/Bundle/TagBundle/Resources/config/services_content.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <!-- Content Property Resolvers -->
+        <service id="sulu_tag.tag_selection_property_resolver" class="Sulu\Bundle\TagBundle\Infrastructure\Sulu\Content\PropertyResolver\TagSelectionPropertyResolver">
+            <tag name="sulu_content.property_resolver"/>
+        </service>
+
+        <!-- Content Resource Loaders -->
+        <service id="sulu_tag.tag_resource_loader" class="Sulu\Bundle\TagBundle\Infrastructure\Sulu\Content\ResourceLoader\TagResourceLoader">
+            <argument type="service" id="sulu.repository.tag"/>
+
+            <tag name="sulu_content.resource_loader"/>
+        </service>
+    </services>
+</container>

--- a/src/Sulu/Bundle/TagBundle/Resources/config/services_content.xml
+++ b/src/Sulu/Bundle/TagBundle/Resources/config/services_content.xml
@@ -12,7 +12,7 @@
         <service id="sulu_tag.tag_resource_loader" class="Sulu\Bundle\TagBundle\Infrastructure\Sulu\Content\ResourceLoader\TagResourceLoader">
             <argument type="service" id="sulu.repository.tag"/>
 
-            <tag name="sulu_content.resource_loader"/>
+            <tag name="sulu_content.resource_loader" type="tag"/>
         </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/TagBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/TagSelectionPropertyResolverTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/TagSelectionPropertyResolverTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\TagBundle\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ResolvableResource;
+use Sulu\Bundle\TagBundle\Infrastructure\Sulu\Content\PropertyResolver\TagSelectionPropertyResolver;
+
+#[CoversClass(TagSelectionPropertyResolver::class)]
+class TagSelectionPropertyResolverTest extends TestCase
+{
+    private TagSelectionPropertyResolver $resolver;
+
+    public function setUp(): void
+    {
+        $this->resolver = new TagSelectionPropertyResolver();
+    }
+
+    public function testResolveEmpty(): void
+    {
+        $contentView = $this->resolver->resolve([], 'en');
+
+        $this->assertSame([], $contentView->getContent());
+        $this->assertSame(['ids' => []], $contentView->getView());
+    }
+
+    public function testResolveParams(): void
+    {
+        $contentView = $this->resolver->resolve([], 'en', ['custom' => 'params']);
+
+        $this->assertSame([], $contentView->getContent());
+        $this->assertSame([
+            'ids' => [],
+            'custom' => 'params',
+        ], $contentView->getView());
+    }
+
+    #[DataProvider('provideUnresolvableData')]
+    public function testResolveUnresolvableData(mixed $data): void
+    {
+        $contentView = $this->resolver->resolve($data, 'en');
+
+        $this->assertSame([], $contentView->getContent());
+        $this->assertSame(['ids' => []], $contentView->getView());
+    }
+
+    /**
+     * @return iterable<array{
+     *     0: mixed,
+     * }>
+     */
+    public static function provideUnresolvableData(): iterable
+    {
+        yield 'null' => [null];
+        yield 'smart_content' => [['source' => '123']];
+        yield 'single_value' => [1];
+        yield 'object' => [(object) [1, 2]];
+    }
+
+    /**
+     * @param array<string|int> $data
+     */
+    #[DataProvider('provideResolvableData')]
+    public function testResolveResolvableData(array $data): void
+    {
+        $contentView = $this->resolver->resolve($data, 'en');
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        foreach ($data as $key => $value) {
+            $resolvable = $content[$key] ?? null;
+            $this->assertInstanceOf(ResolvableResource::class, $resolvable);
+            $this->assertSame($value, $resolvable->getId());
+            $this->assertSame('tag', $resolvable->getResourceLoaderKey());
+        }
+
+        $this->assertSame(['ids' => $data], $contentView->getView());
+    }
+
+    /**
+     * @return iterable<array{
+     *     0: array<string|int>,
+     * }>
+     */
+    public static function provideResolvableData(): iterable
+    {
+        yield 'empty' => [[]];
+        yield 'int_list' => [[1, 2]];
+        yield 'string_list' => [['1', '2']];
+    }
+
+    public function testCustomResourceLoader(): void
+    {
+        $contentView = $this->resolver->resolve([1], 'en', ['resourceLoader' => 'custom_tag']);
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        $resolvable = $content[0] ?? null;
+        $this->assertInstanceOf(ResolvableResource::class, $resolvable);
+        $this->assertSame(1, $resolvable->getId());
+        $this->assertSame('custom_tag', $resolvable->getResourceLoaderKey());
+    }
+}

--- a/src/Sulu/Bundle/TagBundle/Tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/TagResourceLoaderTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/TagResourceLoaderTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\TagBundle\Tests\Unit\Infrastructure\Sulu\Content\ResourceLoader;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\TagBundle\Entity\Tag;
+use Sulu\Bundle\TagBundle\Infrastructure\Sulu\Content\ResourceLoader\TagResourceLoader;
+use Sulu\Bundle\TagBundle\Tag\TagRepositoryInterface;
+use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
+
+class TagResourceLoaderTest extends TestCase
+{
+    use ProphecyTrait;
+    use SetGetPrivatePropertyTrait;
+
+    /**
+     * @var ObjectProphecy<TagRepositoryInterface>
+     */
+    private ObjectProphecy $tagRepository;
+
+    private TagResourceLoader $loader;
+
+    public function setUp(): void
+    {
+        $this->tagRepository = $this->prophesize(TagRepositoryInterface::class);
+        $this->loader = new TagResourceLoader($this->tagRepository->reveal());
+    }
+
+    public function testGetKey(): void
+    {
+        $this->assertSame('tag', $this->loader::getKey());
+    }
+
+    public function testLoad(): void
+    {
+        $tag1 = $this->createTag(1);
+        $tag2 = $this->createTag(3);
+
+        $this->tagRepository->findBy(['id' => [1, 3]])->willReturn([
+            $tag1,
+            $tag2,
+        ])
+            ->shouldBeCalled();
+
+        $result = $this->loader->load([1, 3], 'en', []);
+
+        $this->assertSame([
+            1 => $tag1->getName(),
+            3 => $tag2->getName(),
+        ], $result);
+    }
+
+    private static function createTag(int $id): Tag
+    {
+        $tag = new Tag();
+        static::setPrivateProperty($tag, 'id', $id);
+        $tag->setName('Tag ' . $id);
+
+        return $tag;
+    }
+}

--- a/src/Sulu/Bundle/TagBundle/Tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/TagResourceLoaderTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/TagResourceLoaderTest.php
@@ -47,17 +47,17 @@ class TagResourceLoaderTest extends TestCase
         $tag1 = $this->createTag(1);
         $tag2 = $this->createTag(3);
 
-        $this->tagRepository->findBy(['id' => [1, 3]])->willReturn([
+        $this->tagRepository->findBy(['name' => ['Tag 1', 'Tag 3']])->willReturn([
             $tag1,
             $tag2,
         ])
             ->shouldBeCalled();
 
-        $result = $this->loader->load([1, 3], 'en', []);
+        $result = $this->loader->load(['Tag 1', 'Tag 3'], 'en', []);
 
         $this->assertSame([
-            1 => $tag1->getName(),
-            3 => $tag2->getName(),
+            'Tag 1' => $tag1->getName(),
+            'Tag 3' => $tag2->getName(),
         ], $result);
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Adds new `PropertyResolver` and `ResourceLoader` to use for the `ContentBundle`

#### Why?

ContentBundle will introduce a new architecture to more efficiently resolve content.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
