### PR TITLE
Add "rows" param for Textarea

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/TextArea/TextArea.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/TextArea/TextArea.js
@@ -13,6 +13,7 @@ type Props = {|
     onChange: (?string) => void,
     onFocus?: (event: Event) => void,
     placeholder?: string,
+    rows?: number,
     valid: boolean,
     value: ?string,
 |};
@@ -50,6 +51,7 @@ export default class TextArea extends React.PureComponent<Props> {
             maxCharacters,
             name,
             placeholder,
+            rows,
             value,
             valid,
         } = this.props;
@@ -73,6 +75,7 @@ export default class TextArea extends React.PureComponent<Props> {
                     onChange={this.handleChange}
                     onFocus={this.handleFocus}
                     placeholder={placeholder}
+                    rows={rows}
                     value={value || ''}
                 />
                 {maxCharacters &&

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/TextArea.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/TextArea.js
@@ -65,7 +65,7 @@ export default class TextArea extends React.Component<FieldTypeProps<?string>> {
                 onBlur={onFinish}
                 onChange={onChange}
                 onFocus={this.handleFocus}
-                rows={rows}
+                rows={rows ? parseInt(rows) : undefined}
                 valid={!error}
                 value={value}
             />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/TextArea.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/TextArea.js
@@ -29,6 +29,9 @@ export default class TextArea extends React.Component<FieldTypeProps<?string>> {
                 soft_max_length: {
                     value: softMaxLength,
                 } = {},
+                rows: {
+                    value: rows,
+                } = {},
             } = {},
             value,
         } = this.props;
@@ -48,6 +51,10 @@ export default class TextArea extends React.Component<FieldTypeProps<?string>> {
             throw new Error('The "soft_max_length" schema option must be a number!');
         }
 
+        if(rows !== undefined && isNaN(rows)) {
+            throw new Error('The "rows" schema option must be a number!');
+        }
+
         const evaluatedSoftMaxLength = softMaxLength || maxCharacters;
 
         return (
@@ -55,6 +62,7 @@ export default class TextArea extends React.Component<FieldTypeProps<?string>> {
                 disabled={!!disabled}
                 id={dataPath}
                 maxCharacters={evaluatedSoftMaxLength ? parseInt(evaluatedSoftMaxLength) : undefined}
+                rows={rows}
                 onBlur={onFinish}
                 onChange={onChange}
                 onFocus={this.handleFocus}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/TextArea.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/TextArea.js
@@ -51,7 +51,7 @@ export default class TextArea extends React.Component<FieldTypeProps<?string>> {
             throw new Error('The "soft_max_length" schema option must be a number!');
         }
 
-        if(rows !== undefined && isNaN(rows)) {
+        if (rows !== undefined && isNaN(rows)) {
             throw new Error('The "rows" schema option must be a number!');
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/TextArea.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/TextArea.js
@@ -62,10 +62,10 @@ export default class TextArea extends React.Component<FieldTypeProps<?string>> {
                 disabled={!!disabled}
                 id={dataPath}
                 maxCharacters={evaluatedSoftMaxLength ? parseInt(evaluatedSoftMaxLength) : undefined}
-                rows={rows}
                 onBlur={onFinish}
                 onChange={onChange}
                 onFocus={this.handleFocus}
+                rows={rows}
                 valid={!error}
                 value={value}
             />


### PR DESCRIPTION
Currently the Textarea does not have the Option to manually set the desired rows amount.

| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adds the function to set a manual rows amount to the Textarea Component.

#### Why?

Currently the Textarea is fixed in size. Sometimes for displaying larger Texts it would be nice to set the HTML rows property manually.