### PR TITLE
Replace ubuntu-latest with ubuntu-22.04 to fix the testcases

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
     js-css:
         name: "Node ${{ matrix.node-version }}"
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 30
 
         strategy:
@@ -81,7 +81,7 @@ jobs:
 
     js-lint:
         name: "Node Lint"
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 30
 
         env:
@@ -118,7 +118,7 @@ jobs:
 
     php:
         name: "PHP ${{ matrix.php-version }} (${{ matrix.database }}, ${{ matrix.phpcr-transport }}, ${{ matrix.dependency-versions }})"
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 30
 
         env:
@@ -245,7 +245,7 @@ jobs:
 
     php-lint:
         name: "PHP Lint"
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 30
 
         env:

--- a/.github/workflows/trigger-styleguide-build.yaml
+++ b/.github/workflows/trigger-styleguide-build.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
     trigger-styleguide-build:
         name: Trigger styleguide build
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 30
 
         steps:


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

Fix the run image for the workflows

#### Why?

Pipeline breaks because of the ubuntu update in github actions see: https://github.blog/changelog/2024-09-25-actions-new-images-and-ubuntu-latest-changes/
