### PR TITLE
Fix password reset if SSO is enabled but not matched domain

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/SingleSignOn/SingleSignOnLoginRequestSubscriber.php
+++ b/src/Sulu/Bundle/SecurityBundle/SingleSignOn/SingleSignOnLoginRequestSubscriber.php
@@ -92,7 +92,7 @@ class SingleSignOnLoginRequestSubscriber implements EventSubscriberInterface
 
         $adapter = $this->singleSignOnAdapterProvider->getAdapterByDomain($domain);
         if (!$adapter) {
-            if ($password) {
+            if ($password || $isResetPassword) {
                 return;
             }
 

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/SingleSignOn/SingleSignOnLoginRequestSubscriberTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/SingleSignOn/SingleSignOnLoginRequestSubscriberTest.php
@@ -157,7 +157,7 @@ class SingleSignOnLoginRequestSubscriberTest extends TestCase
 
         $this->subscriber->onKernelRequest($event);
 
-        $this->assertSame('{"method":"json_login"}', $event->getResponse()?->getContent());
+        $this->assertNull($event->getResponse());
     }
 
     public function testOnKernelRequestResetPasswordExistingUser(): void
@@ -186,7 +186,7 @@ class SingleSignOnLoginRequestSubscriberTest extends TestCase
 
         $this->subscriber->onKernelRequest($event);
 
-        $this->assertSame('{"method":"json_login"}', $event->getResponse()?->getContent());
+        $this->assertNull($event->getResponse());
     }
 
     public function testOnKernelRequestExistingUserAndPassword(): void

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/SingleSignOn/SingleSignOnLoginRequestSubscriberTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/SingleSignOn/SingleSignOnLoginRequestSubscriberTest.php
@@ -148,7 +148,7 @@ class SingleSignOnLoginRequestSubscriberTest extends TestCase
         $this->assertNull($event->getResponse());
     }
 
-    public function testOnKernelRequestResetPasswordEmail(): void
+    public function testOnKernelRequestResetPasswordEmailNoAdapter(): void
     {
         $request = Request::create('/admin/login', Request::METHOD_POST);
         $request->attributes->set('_route', 'sulu_security.reset_password.email');
@@ -174,7 +174,7 @@ class SingleSignOnLoginRequestSubscriberTest extends TestCase
         $this->assertNull($event->getResponse());
     }
 
-    public function testOnKernelRequestExistingUser(): void
+    public function testOnKernelRequestExistingUserNoAdapter(): void
     {
         $request = Request::create('/admin/login', Request::METHOD_POST);
         $request->attributes->set('_route', 'sulu_security.reset_password.email');
@@ -189,7 +189,7 @@ class SingleSignOnLoginRequestSubscriberTest extends TestCase
         $this->assertNull($event->getResponse());
     }
 
-    public function testOnKernelRequestExistingUserAndPassword(): void
+    public function testOnKernelRequestExistingUserAndPasswordNoAdapter(): void
     {
         $request = Request::create('/admin/login', Request::METHOD_POST);
         $request->attributes->set('_route', 'sulu_security.reset_password.email');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Also check for reset route in the single sign on adapter.

#### Why?

Currently the password reset does not work.
