### PR TITLE
Improve error messages for regenerate-format

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13226,11 +13226,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$dirs of method Symfony\\\\Component\\\\Finder\\\\Finder\\:\\:in\\(\\) expects array\\<string\\>\\|string, string\\|false given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateCommand.php
-
-		-
 			message: "#^Property Sulu\\\\Bundle\\\\MediaBundle\\\\Command\\\\FormatCacheRegenerateCommand\\:\\:\\$filesystem is never read, only written\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateCommand.php

--- a/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateCommand.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateCommand.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
@@ -41,8 +42,13 @@ class FormatCacheRegenerateCommand extends Command
     {
         $ui = new SymfonyStyle($input, $output);
 
+        $imageCachePath = \realpath($this->localFormatCachePath);
+        if (false === $imageCachePath) {
+            throw new FileNotFoundException(\sprintf('Unable to resolve path "%s".', $this->localFormatCachePath));
+        }
+
         $finder = new Finder();
-        $finder->in(\realpath($this->localFormatCachePath));
+        $finder->in($imageCachePath);
         $files = $finder->files();
 
         if (!\count($files)) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Adding a better error message.

#### Why?
I was trying to run this command on a fresh instance where the public upload directory does not exist, so the `realpath` call returned false which due to lax typing became an empty string and produced this error message:
![image](https://github.com/user-attachments/assets/b34bb356-6a8b-42b7-9c0d-5f1c2edba4c4)

Now the error message is a little better:
![image](https://github.com/user-attachments/assets/c7644cdc-a6e3-48c0-97c3-e8b6f4204c6f)