### PR TITLE
Fix translations locale issue

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/initializer/initializer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/initializer/initializer.js
@@ -78,15 +78,18 @@ class Initializer {
         });
     }
 
-    initializeTranslations() {
+    initializeTranslations(userIsLoggedIn: boolean) {
         const locale = userStore.user ? userStore.user.locale : getDefaultLocale();
 
         return this.initializedTranslationsLocale === locale
             ? Promise.resolve()
-            : Requester.get(Config.endpoints.translations + '?locale=' + locale).then((translations) => {
-                setTranslations(translations, locale);
-                this.setInitializedTranslationsLocale(locale);
-            });
+            : Requester.get(
+                Config.endpoints.translations + (!userIsLoggedIn ? '?locale=' + locale : ''))
+                .then((translations) => {
+                    setTranslations(translations, locale);
+                    this.setInitializedTranslationsLocale(locale);
+                }
+                );
     }
 
     initialize(userIsLoggedIn: boolean) {
@@ -96,13 +99,13 @@ class Initializer {
         // if no user is logged in, we do not want to fetch this data to prevent unnecessary 401 responses
         // a 401 response will reset cached basic auth credentials and lead to a second authentication prompt
         if (!userIsLoggedIn) {
-            return this.initializeTranslations()
+            return this.initializeTranslations(userIsLoggedIn)
                 .then(() => {
                     this.setLoading(false);
                 });
         }
 
-        const translationsPromise = this.initializeTranslations();
+        const translationsPromise = this.initializeTranslations(userIsLoggedIn);
         const configPromise = Requester.get(Config.endpoints.config);
         const routePromise = this.initializeSymfonyRouting();
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/initializer/initializer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/initializer/initializer.js
@@ -1,7 +1,6 @@
 // @flow
 import {action, computed, observable} from 'mobx';
 import moment from 'moment';
-import userStore from '../../stores/userStore';
 import Config from '../Config';
 import {setTranslations} from '../../utils/Translator';
 import Requester from '../Requester';
@@ -78,18 +77,13 @@ class Initializer {
         });
     }
 
-    initializeTranslations(userIsLoggedIn: boolean) {
-        const locale = userStore.user ? userStore.user.locale : getDefaultLocale();
-
+    initializeTranslations(locale: string) {
         return this.initializedTranslationsLocale === locale
             ? Promise.resolve()
-            : Requester.get(
-                Config.endpoints.translations + (!userIsLoggedIn ? '?locale=' + locale : ''))
-                .then((translations) => {
-                    setTranslations(translations, locale);
-                    this.setInitializedTranslationsLocale(locale);
-                }
-                );
+            : Requester.get(Config.endpoints.translations + '?locale=' + locale).then((translations) => {
+                setTranslations(translations, locale);
+                this.setInitializedTranslationsLocale(locale);
+            });
     }
 
     initialize(userIsLoggedIn: boolean) {
@@ -99,18 +93,26 @@ class Initializer {
         // if no user is logged in, we do not want to fetch this data to prevent unnecessary 401 responses
         // a 401 response will reset cached basic auth credentials and lead to a second authentication prompt
         if (!userIsLoggedIn) {
-            return this.initializeTranslations(userIsLoggedIn)
+            return this.initializeTranslations(getDefaultLocale())
                 .then(() => {
                     this.setLoading(false);
                 });
         }
 
-        const translationsPromise = this.initializeTranslations(userIsLoggedIn);
         const configPromise = Requester.get(Config.endpoints.config);
         const routePromise = this.initializeSymfonyRouting();
 
-        return Promise.all([configPromise, routePromise, translationsPromise])
+        return Promise.all([configPromise, routePromise])
             .then(action(([config]) => {
+                const locale = config?.sulu_admin?.user?.locale || getDefaultLocale();
+
+                return this.initializeTranslations(locale).then(
+                    () => {
+                        return config;
+                    }
+                );
+            }))
+            .then(action((config) => {
                 this.config = config;
 
                 if (!this.initialized) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

As we did load the translation in parallel to the config request, in some cases it happened that the UI was translated in two different languages, the default client language and the default backend language.

This MR fixes it, as it does not send translation/config request in parallel but in sequence to directly use the user locale from the config request.
