### PR TITLE
Add dataPath property to sulu.focus event

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
@@ -89,6 +89,7 @@ class Field extends React.Component<Props> {
 
     handleFocus = (target: EventTarget) => {
         const {
+            dataPath,
             schemaPath,
             schema: schemaEntry,
         } = this.props;
@@ -99,6 +100,7 @@ class Field extends React.Component<Props> {
             schemaType: schemaEntry?.type,
             setValue: this.handleChange,
             getValue: () => this.props.value,
+            dataPath,
             schemaPath,
             formInspector: this.props.formInspector,
         };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
@@ -645,7 +645,7 @@ test('Call onFocus callback when Field gets focus', () => {
     const field = shallow(
         <Field
             data={{}}
-            dataPath=""
+            dataPath="/title"
             formInspector={formInspector}
             name="test"
             onChange={jest.fn()}
@@ -653,7 +653,7 @@ test('Call onFocus callback when Field gets focus', () => {
             onSuccess={undefined}
             router={undefined}
             schema={{label: 'label', type: 'text'}}
-            schemaPath=""
+            schemaPath="/schema/title"
             value="test value"
         />
     );
@@ -673,7 +673,8 @@ test('Call onFocus callback when Field gets focus', () => {
         schemaType: 'text',
         setValue: expect.any(Function),
         getValue: expect.any(Function),
-        schemaPath: '',
+        schemaPath: '/schema/title',
+        dataPath: '/title',
         formInspector,
     });
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add the dataPath to the event.detail

#### Why?

This can be used to find the context of the page content.