### PR TITLE
Use form-renderer to render forms for copy-locale and ghost dialog

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
@@ -113,6 +113,11 @@ class SuluAdminExtension extends Extension implements PrependExtensionInterface
         $container->prependExtensionConfig(
             'sulu_admin',
             [
+                'forms' => [
+                    'directories' => [
+                        __DIR__ . '/../Resources/config/forms',
+                    ],
+                ],
                 'resources' => [
                     'collaborations' => [
                         'routes' => [

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Visitor/LocalesOptionFormMetadataVisitor.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Visitor/LocalesOptionFormMetadataVisitor.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Visitor;
+
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataVisitorInterface;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
+
+class LocalesOptionFormMetadataVisitor implements FormMetadataVisitorInterface
+{
+    public function visitFormMetadata(FormMetadata $formMetadata, string $locale, array $metadataOptions = []): void
+    {
+        if ('ghost_copy_locale' !== $formMetadata->getKey() && 'copy_locale' !== $formMetadata->getKey()) {
+            return;
+        }
+
+        $locales = $metadataOptions['locales'] ?? []; // TODO get all locales
+        $defaultValue = $locales[0] ?? null;
+
+        $defaultValueOption = new OptionMetadata();
+        $defaultValueOption->setName('default_value');
+        $defaultValueOption->setValue($defaultValue);
+
+        $valuesOption = new OptionMetadata();
+        $valuesOption->setName('values');
+        $valuesOption->setType('collection');
+        $valuesOption->setValue(\array_map(function ($locale) {
+            $option = new OptionMetadata();
+            $option->setName($locale);
+            $option->setValue($locale);
+            $option->setTitle($locale);
+
+            return $option;
+        }, $locales));
+
+        /** @var FieldMetadata $localeProperty */
+        $localeProperty = $formMetadata->getItems()['locale'] ?? $formMetadata->getItems()['locales'];
+        $localeProperty->addOption($defaultValueOption);
+        $localeProperty->addOption($valuesOption);
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Visitor/LocalesOptionFormMetadataVisitor.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Visitor/LocalesOptionFormMetadataVisitor.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Visitor;
 
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
@@ -9,6 +18,9 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataVisitorInterface;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 
+/**
+ * @internal
+ */
 class LocalesOptionFormMetadataVisitor implements FormMetadataVisitorInterface
 {
     public function visitFormMetadata(FormMetadata $formMetadata, string $locale, array $metadataOptions = []): void
@@ -17,17 +29,20 @@ class LocalesOptionFormMetadataVisitor implements FormMetadataVisitorInterface
             return;
         }
 
-        $locales = $metadataOptions['locales'] ?? []; // TODO get all locales
-        $defaultValue = $locales[0] ?? null;
+        /** @var string[] $locales */
+        $locales = $metadataOptions['locales'] ?? [];
+        if (0 === \count($locales)) {
+            return;
+        }
 
         $defaultValueOption = new OptionMetadata();
         $defaultValueOption->setName('default_value');
-        $defaultValueOption->setValue($defaultValue);
+        $defaultValueOption->setValue($locales[0]);
 
         $valuesOption = new OptionMetadata();
         $valuesOption->setName('values');
         $valuesOption->setType('collection');
-        $valuesOption->setValue(\array_map(function ($locale) {
+        $valuesOption->setValue(\array_map(function($locale) {
             $option = new OptionMetadata();
             $option->setName($locale);
             $option->setValue($locale);

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/forms/copy_locale.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/forms/copy_locale.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<form xmlns="http://schemas.sulu.io/template/template"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd"
+>
+    <key>copy_locale</key>
+
+    <properties>
+        <property name="locales" type="select" mandatory="true" colspan="6">
+            <meta>
+                <title>sulu_admin.choose_target_locale</title>
+                <info_text>sulu_admin.copy_locale_dialog_description</info_text>
+            </meta>
+            <params>
+                <param name="values" type="collection"/>
+            </params>
+        </property>
+    </properties>
+</form>

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/forms/ghost_copy_locale.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/forms/ghost_copy_locale.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<form xmlns="http://schemas.sulu.io/template/template"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd"
+>
+    <key>ghost_copy_locale</key>
+
+    <properties>
+        <property name="locale" type="single_select" mandatory="true" colspan="6">
+            <meta>
+                <title>sulu_admin.choose_language</title>
+            </meta>
+            <params>
+                <param name="default_value" value=""/>
+                <param name="values" type="collection"/>
+            </params>
+        </property>
+    </properties>
+</form>

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -287,7 +287,7 @@
             <tag name="sulu_admin.field_metadata_validator"/>
         </service>
 
-        <service id="sulu_admin.form_metadata_validator.ghost_copy_locale"
+        <service id="sulu_admin.form_metadata_validator.locale_options"
                  class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Visitor\LocalesOptionFormMetadataVisitor">
             <tag name="sulu_admin.form_metadata_visitor"/>
         </service>

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -286,5 +286,10 @@
                  class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Validation\BlockFieldMetadataValidator">
             <tag name="sulu_admin.field_metadata_validator"/>
         </service>
+
+        <service id="sulu_admin.form_metadata_validator.ghost_copy_locale"
+                 class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Visitor\LocalesOptionFormMetadataVisitor">
+            <tag name="sulu_admin.form_metadata_visitor"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
@@ -106,14 +106,14 @@ class Form extends React.Component<Props> {
         this.hideGhostDialog();
     };
 
-    @action handleGhostDialogConfirm = (locale: string) => {
+    @action handleGhostDialogConfirm = (locale: string, options: Object) => {
         const {store} = this.props;
 
         if (!store.copyFromLocale) {
             return;
         }
 
-        store.copyFromLocale(locale);
+        store.copyFromLocale(locale, options);
         this.hideGhostDialog();
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
@@ -146,8 +146,8 @@ class Form extends React.Component<Props> {
         const {onSuccess, router, store} = this.props;
         const {
             data: {
-                availableLocales,
-            },
+                availableLocales = null,
+            } = {availableLocales: null},
         } = store;
 
         if (store.forbidden) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/GhostDialog.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/GhostDialog.js
@@ -1,17 +1,17 @@
 // @flow
 import React from 'react';
-import {action, observable} from 'mobx';
+import {observable} from 'mobx';
 import {observer} from 'mobx-react';
 import Dialog from '../../components/Dialog';
+import {translate} from '../../utils';
 import FormContainer from './Form';
 import memoryFormStoreFactory from './stores/memoryFormStoreFactory';
-import type {FormStoreInterface} from '../../../containers/Form';
-import {translate} from '../../utils';
+import type {FormStoreInterface} from './../Form';
 
 type Props = {
     locales: Array<string>,
     onCancel: () => void,
-    onConfirm: (locale: string) => void,
+    onConfirm: (locale: string, options: Object) => void,
     open: boolean,
 };
 
@@ -24,9 +24,15 @@ class GhostDialog extends React.Component<Props> {
         super(props);
 
         this.selectedLocale = this.props.locales[0];
-        this.formStore = memoryFormStoreFactory.createFromFormKey('ghost_copy_locale', undefined, undefined, undefined, {
-            locales: this.props.locales,
-        });
+        this.formStore = memoryFormStoreFactory.createFromFormKey(
+            'ghost_copy_locale',
+            undefined,
+            undefined,
+            undefined,
+            {
+                locales: this.props.locales,
+            }
+        );
     }
 
     handleCancel = () => {
@@ -63,8 +69,8 @@ class GhostDialog extends React.Component<Props> {
             >
                 <p>{translate('sulu_admin.ghost_dialog_description')}</p>
                 <FormContainer
-                    store={this.formStore}
                     onSubmit={this.handleConfirm}
+                    store={this.formStore}
                 />
             </Dialog>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
@@ -240,8 +240,11 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
         return this.resourceStore.delete({...this.options, ...options});
     }
 
-    copyFromLocale(sourceLocale: string) {
-        return this.resourceStore.copyFromLocale(sourceLocale, this.options);
+    copyFromLocale(sourceLocale: string, options: Object) {
+        return this.resourceStore.copyFromLocale(sourceLocale, {
+            ...options,
+            ...this.options,
+        });
     }
 
     /**

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/GhostDialog.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/GhostDialog.test.js
@@ -1,10 +1,76 @@
 // @flow
 import React from 'react';
 import {mount} from 'enzyme';
+import metadataStore from '../stores/metadataStore';
 import GhostDialog from '../GhostDialog';
+import SingleSelect from '../fields/SingleSelect';
+import Input from '../fields/Input';
+import fieldRegistry from '../registries/fieldRegistry';
+
+fieldRegistry.add('single_select', SingleSelect);
+fieldRegistry.add('text_line', Input);
+
+const FORM = {
+    locale: {
+        label: 'Sprache wählen',
+        disabledCondition: null,
+        visibleCondition: null,
+        description: '',
+        type: 'single_select',
+        colSpan: 6,
+        options: {
+            default_value: {
+                name: 'default_value',
+                type: null,
+                value: 'de',
+                title: null,
+                placeholder: null,
+                infoText: null,
+            },
+            values: {
+                name: 'values',
+                type: 'collection',
+                value: [
+                    {
+                        name: 'de',
+                        type: null,
+                        value: 'de',
+                        title: 'de',
+                        placeholder: null,
+                        infoText: null,
+                    },
+                    {
+                        name: 'en',
+                        type: null,
+                        value: 'en',
+                        title: 'en',
+                        placeholder: null,
+                        infoText: null,
+                    },
+                ],
+                title: null,
+                placeholder: null,
+                infoText: null,
+            },
+        },
+        types: [],
+        defaultType: null,
+        required: true,
+        spaceAfter: null,
+        minOccurs: null,
+        maxOccurs: null,
+        onInvalid: null,
+        tags: [],
+    },
+};
 
 jest.mock('../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
+}));
+
+jest.mock('../stores/metadataStore', () => ({
+    getSchema: jest.fn().mockReturnValue(Promise.resolve(FORM)),
+    getJsonSchema: jest.fn().mockReturnValue(Promise.resolve({})),
 }));
 
 afterEach(() => {
@@ -13,12 +79,15 @@ afterEach(() => {
     }
 });
 
-test('Should render a Dialog', () => {
+test('Should render a Dialog', (resolve) => {
     const ghostDialog = mount(
         <GhostDialog locales={['en', 'de']} onCancel={jest.fn()} onConfirm={jest.fn()} open={true} />
     );
+    setTimeout(() => {
+        expect(ghostDialog.render()).toMatchSnapshot();
 
-    expect(ghostDialog.render()).toMatchSnapshot();
+        resolve();
+    }, 1);
 });
 
 test('Should call onCancel callback if user chooses not to copy content', () => {
@@ -32,14 +101,54 @@ test('Should call onCancel callback if user chooses not to copy content', () => 
     expect(cancelSpy).toBeCalledWith();
 });
 
-test('Should call onConfirm callback with chosen locale if user chooses to copy content', () => {
+test('Should call onConfirm callback with chosen locale if user chooses to copy content', (resolve) => {
     const confirmSpy = jest.fn();
     const ghostDialog = mount(
         <GhostDialog locales={['en', 'de']} onCancel={jest.fn()} onConfirm={confirmSpy} open={true} />
     );
 
-    ghostDialog.find('SingleSelect').prop('onChange')('de');
-    ghostDialog.find('Button[skin="primary"]').simulate('click');
+    setTimeout(() => {
+        ghostDialog.update();
 
-    expect(confirmSpy).toBeCalledWith('de');
+        ghostDialog.find('SingleSelect').at(0).prop('onChange')('de');
+        ghostDialog.find('Button[skin="primary"]').at(0).simulate('click');
+
+        expect(confirmSpy).toBeCalledWith('de', {});
+
+        resolve();
+    }, 1);
+});
+
+test('Should call onConfirm callback with chosen locale if user chooses to copy content (with additional fields)', (resolve) => { // eslint-disable-line max-len
+    const formMetadata = {
+        ...FORM,
+        title: {
+            label: 'Test',
+            disabledCondition: null,
+            visibleCondition: null,
+            description: '',
+            type: 'text_line',
+            colSpan: 6,
+        },
+    };
+    metadataStore.getSchema.mockReturnValue(Promise.resolve(formMetadata));
+
+    const confirmSpy = jest.fn();
+    const ghostDialog = mount(
+        <GhostDialog locales={['en', 'de']} onCancel={jest.fn()} onConfirm={confirmSpy} open={true} />
+    );
+
+    setTimeout(() => {
+        ghostDialog.update();
+
+        ghostDialog.find('Input').at(0).prop('onChange')('Test 123');
+        ghostDialog.find('SingleSelect').at(0).prop('onChange')('de');
+        ghostDialog.find('Button[skin="primary"]').at(0).simulate('click');
+
+        expect(confirmSpy).toBeCalledWith('de', {
+            title: 'Test 123',
+        });
+
+        resolve();
+    }, 1);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/GhostDialog.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/GhostDialog.test.js.snap
@@ -56,54 +56,63 @@ Array [
             class="grid grid"
           >
             <div
-              class="item gridItem colSpan colSpan-6 space-before-0 space-after-0"
+              class="item gridItem colSpan colSpan-6 space-before-0 space-after-null"
             >
               <div
                 class="field"
               >
                 <label
                   class="label"
+                  for="/locale"
                 >
-                  sulu_admin.choose_language
+                  Sprache wählen *
                 </label>
                 <div
-                  class="select"
-                  role="none"
+                  class="fieldContainer"
                 >
-                  <button
-                    class="displayValue default"
-                    type="button"
+                  <div
+                    class="field"
                   >
                     <div
-                      aria-label="en"
-                      class="croppedText"
-                      title="en"
+                      class="select"
+                      role="none"
                     >
-                      <div
-                        aria-hidden="true"
-                        class="front"
+                      <button
+                        class="displayValue default"
+                        type="button"
                       >
-                        e
-                      </div>
-                      <div
-                        aria-hidden="true"
-                        class="back"
-                      >
-                        <span>
-                          n
-                        </span>
-                      </div>
-                      <div
-                        class="whole"
-                      >
-                        en
-                      </div>
+                        <div
+                          aria-label="de"
+                          class="croppedText"
+                          title="de"
+                        >
+                          <div
+                            aria-hidden="true"
+                            class="front"
+                          >
+                            d
+                          </div>
+                          <div
+                            aria-hidden="true"
+                            class="back"
+                          >
+                            <span>
+                              e
+                            </span>
+                          </div>
+                          <div
+                            class="whole"
+                          >
+                            de
+                          </div>
+                        </div>
+                        <span
+                          aria-label="su-angle-down"
+                          class="su-angle-down toggle"
+                        />
+                      </button>
                     </div>
-                    <span
-                      aria-label="su-angle-down"
-                      class="su-angle-down toggle"
-                    />
-                  </button>
+                  </div>
                 </div>
                 <div
                   class="errorLabel"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -87,7 +87,7 @@ export interface FormStoreInterface {
     +changeMultiple: (values: {[dataPath: string]: mixed}, context?: ChangeContext) => void,
     +changeType: (type: string, context?: ChangeContext) => void,
     // Only exists in one implementation, therefore optional. Maybe we can remove that definition one day...
-    +copyFromLocale?: (string) => Promise<*>,
+    +copyFromLocale?: (string, Object) => Promise<*>,
     +data: {[string]: any},
     +destroy: () => void,
     dirty: boolean,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/CopyLocaleToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/CopyLocaleToolbarAction.test.js
@@ -7,6 +7,67 @@ import ResourceStore from '../../../../stores/ResourceStore';
 import Router from '../../../../services/Router';
 import Form from '../../../../views/Form';
 import CopyLocaleToolbarAction from '../../toolbarActions/CopyLocaleToolbarAction';
+import fieldRegistry from '../../../../containers/Form/registries/fieldRegistry';
+import metadataStore from '../../../../containers/Form/stores/metadataStore';
+import Select from './../../../../containers/Form/fields/Select';
+import Input from './../../../../containers/Form/fields/Input';
+
+fieldRegistry.add('select', Select);
+fieldRegistry.add('text_line', Input);
+
+const FORM = {
+    locales: {
+        label: 'Wähle Zielsprachen',
+        disabledCondition: null,
+        visibleCondition: null,
+        description: '* Neue Sprachvariante wird erstellt',
+        type: 'select',
+        colSpan: 6,
+        options: {
+            values: {
+                name: 'values',
+                type: 'collection',
+                value: [
+                    {
+                        name: 'de',
+                        type: null,
+                        value: 'de',
+                        title: 'de',
+                        placeholder: null,
+                        infoText: null,
+                    },
+                    {
+                        name: 'en',
+                        type: null,
+                        value: 'en',
+                        title: 'en',
+                        placeholder: null,
+                        infoText: null,
+                    },
+                ],
+                title: null,
+                placeholder: null,
+                infoText: null,
+            },
+            default_value: {
+                name: 'default_value',
+                type: null,
+                value: 'de',
+                title: null,
+                placeholder: null,
+                infoText: null,
+            },
+        },
+        types: [],
+        defaultType: null,
+        required: true,
+        spaceAfter: null,
+        minOccurs: null,
+        maxOccurs: null,
+        onInvalid: null,
+        tags: [],
+    },
+};
 
 jest.mock('loglevel', () => ({
     warn: jest.fn(),
@@ -64,6 +125,11 @@ jest.mock('../../../../services/Router', () => jest.fn(function() {
 jest.mock('../../../../views/Form', () => jest.fn(function() {
     this.submit = jest.fn();
     this.showSuccessSnackbar = jest.fn();
+}));
+
+jest.mock('../../../../containers/Form/stores/metadataStore', () => ({
+    getSchema: jest.fn().mockReturnValue(Promise.resolve(FORM)),
+    getJsonSchema: jest.fn().mockReturnValue(Promise.resolve({})),
 }));
 
 function createCopyLocaleToolbarAction(locales, options = {}) {
@@ -202,7 +268,7 @@ test('Close dialog when cancel button of dialog is clicked', () => {
     }));
 });
 
-test('Close dialog and show success message when onClose from CopyLocaleDialog is called with true', () => {
+test('Close dialog and show success message when onClose from CopyLocaleDialog is called with true', (resolve) => {
     const postPromise = Promise.resolve();
     ResourceRequester.post.mockReturnValue(postPromise);
 
@@ -225,31 +291,103 @@ test('Close dialog and show success message when onClose from CopyLocaleDialog i
         throw new Error('A onClick callback should be registered on the copy locale option');
     }
 
-    let element = mount(copyLocaleToolbarAction.getNode()).at(0);
-    expect(element.instance().props).toEqual(expect.objectContaining({
+    const elementBefore = mount(copyLocaleToolbarAction.getNode());
+    expect(elementBefore.instance().props).toEqual(expect.objectContaining({
         open: false,
     }));
 
     clickHandler();
-    element = mount(copyLocaleToolbarAction.getNode()).at(0);
-    expect(element.instance().props).toEqual(expect.objectContaining({
-        open: true,
+
+    setTimeout(() => {
+        let element = mount(copyLocaleToolbarAction.getNode());
+        expect(element.instance().props).toEqual(expect.objectContaining({
+            open: true,
+        }));
+
+        element.find('Select').at(0).prop('onChange')(['de', 'fr']);
+        element.prop('onConfirm')();
+        expect(ResourceRequester.post).toBeCalledWith(
+            'snippets',
+            undefined,
+            {action: 'copy-locale', dest: ['de', 'fr'], id: 3, locale, webspace: 'sulu_io'}
+        );
+
+        postPromise.then(() => {
+            expect(copyLocaleToolbarAction.form.showSuccessSnackbar).toBeCalledWith();
+            element = mount(copyLocaleToolbarAction.getNode()).at(0);
+            expect(element.instance().props).toEqual(expect.objectContaining({
+                open: false,
+            }));
+            resolve();
+        });
+    }, 1);
+});
+
+test('Close dialog and show success message when onClose from CopyLocaleDialog is called with true (with additional fields)', (resolve) => { // eslint-disable-line max-len
+    const formMetadata = {
+        ...FORM,
+        title: {
+            label: 'Test',
+            disabledCondition: null,
+            visibleCondition: null,
+            description: '',
+            type: 'text_line',
+            colSpan: 6,
+        },
+    };
+    metadataStore.getSchema.mockReturnValue(Promise.resolve(formMetadata));
+
+    const postPromise = Promise.resolve();
+    ResourceRequester.post.mockReturnValue(postPromise);
+
+    const copyLocaleToolbarAction = createCopyLocaleToolbarAction(['en', 'de', 'fr']);
+    copyLocaleToolbarAction.resourceFormStore.resourceStore.id = 3;
+    // $FlowFixMe
+    copyLocaleToolbarAction.resourceFormStore.resourceKey = 'snippets';
+    const locale = copyLocaleToolbarAction.resourceFormStore.resourceStore.locale;
+    // $FlowFixMe
+    locale.get.mockReturnValue('en');
+    copyLocaleToolbarAction.resourceFormStore.options.webspace = 'sulu_io';
+
+    const toolbarItemConfig = copyLocaleToolbarAction.getToolbarItemConfig();
+    if (!toolbarItemConfig) {
+        throw new Error('The toolbarItemConfig should be a value!');
+    }
+
+    const clickHandler = toolbarItemConfig.onClick;
+    if (!clickHandler) {
+        throw new Error('A onClick callback should be registered on the copy locale option');
+    }
+
+    const elementBefore = mount(copyLocaleToolbarAction.getNode());
+    expect(elementBefore.instance().props).toEqual(expect.objectContaining({
+        open: false,
     }));
 
-    element.find('Checkbox[value="de"]').prop('onChange')(true, 'de');
-    element.find('Checkbox[value="fr"]').prop('onChange')(true, 'fr');
-    element.prop('onConfirm')();
-    expect(ResourceRequester.post).toBeCalledWith(
-        'snippets',
-        undefined,
-        {action: 'copy-locale', dest: ['de', 'fr'], id: 3, locale, webspace: 'sulu_io'}
-    );
+    clickHandler();
 
-    return postPromise.then(() => {
-        expect(copyLocaleToolbarAction.form.showSuccessSnackbar).toBeCalledWith();
-        element = mount(copyLocaleToolbarAction.getNode()).at(0);
+    setTimeout(() => {
+        let element = mount(copyLocaleToolbarAction.getNode());
         expect(element.instance().props).toEqual(expect.objectContaining({
-            open: false,
+            open: true,
         }));
-    });
+
+        element.find('Input').at(0).prop('onChange')('Test 123');
+        element.find('Select').at(0).prop('onChange')(['de', 'fr']);
+        element.prop('onConfirm')();
+        expect(ResourceRequester.post).toBeCalledWith(
+            'snippets',
+            undefined,
+            {action: 'copy-locale', dest: ['de', 'fr'], id: 3, locale, webspace: 'sulu_io', title: 'Test 123'}
+        );
+
+        postPromise.then(() => {
+            expect(copyLocaleToolbarAction.form.showSuccessSnackbar).toBeCalledWith();
+            element = mount(copyLocaleToolbarAction.getNode()).at(0);
+            expect(element.instance().props).toEqual(expect.objectContaining({
+                open: false,
+            }));
+            resolve();
+        });
+    }, 1);
 });

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -186,7 +186,106 @@ class AdminControllerTest extends SuluTestCase
 
         $defaultMetadata = $metaData['types']['default'];
         $overviewMetadata = $metaData['types']['overview'];
-        $this->assertSame(\json_decode((string) \file_get_contents(__DIR__ . '/fixtures/default.json'), true), $defaultMetadata);
-        $this->assertSame(\json_decode((string) \file_get_contents(__DIR__ . '/fixtures/overview.json'), true), $overviewMetadata);
+        $this->assertSame(
+            \json_decode((string) \file_get_contents(__DIR__ . '/fixtures/default.json'), true),
+            $defaultMetadata);
+        $this->assertSame(
+            \json_decode((string) \file_get_contents(__DIR__ . '/fixtures/overview.json'), true),
+            $overviewMetadata);
+    }
+
+    public function testGetMetaDataGhostLocale(): void
+    {
+        $this->initPhpcr();
+        $collectionType = new LoadCollectionTypes();
+        $collectionType->load($this->getEntityManager());
+
+        $this->client->request('GET', '/admin/metadata/form/ghost_copy_locale?locales[]=de&locales[]=en');
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $json = $response->getContent();
+        $this->assertIsString($json);
+
+        /**
+         * @var array{
+         *     form: array{
+         *         locale: array{
+         *             options: array{
+         *                 default_value: array{
+         *                     value: string,
+         *                 },
+         *                 values: array{
+         *                     value: array<array{
+         *                         name: string,
+         *                         value: string,
+         *                         title: string,
+         *                     }>,
+         *                 },
+         *             },
+         *         },
+         *     }
+         * } $metaData
+         */
+        $metaData = \json_decode($json, true, 512, \JSON_THROW_ON_ERROR);
+
+        $form = $metaData['form'];
+
+        $this->assertArrayHasKey('locale', $form);
+        $this->assertSame('de', $form['locale']['options']['default_value']['value']);
+        $this->assertCount(2, $form['locale']['options']['values']['value']);
+        $this->assertSame('de', $form['locale']['options']['values']['value'][0]['name']);
+        $this->assertSame('de', $form['locale']['options']['values']['value'][0]['value']);
+        $this->assertSame('de', $form['locale']['options']['values']['value'][0]['title']);
+        $this->assertSame('en', $form['locale']['options']['values']['value'][1]['name']);
+        $this->assertSame('en', $form['locale']['options']['values']['value'][1]['value']);
+        $this->assertSame('en', $form['locale']['options']['values']['value'][1]['title']);
+    }
+
+    public function testGetMetaDataCopyLocale(): void
+    {
+        $this->initPhpcr();
+        $collectionType = new LoadCollectionTypes();
+        $collectionType->load($this->getEntityManager());
+
+        $this->client->request('GET', '/admin/metadata/form/copy_locale?locales[]=de&locales[]=en&locales[]=fr');
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $json = $response->getContent();
+        $this->assertIsString($json);
+
+        /**
+         * @var array{
+         *     form: array{
+         *         locales: array{
+         *             options: array{
+         *                 values: array{
+         *                     value: array<array{
+         *                         name: string,
+         *                         value: string,
+         *                         title: string,
+         *                     }>,
+         *                 },
+         *             },
+         *         },
+         *     },
+         * } $metaData
+         */
+        $metaData = \json_decode($json, true, 512, \JSON_THROW_ON_ERROR);
+
+        $form = $metaData['form'];
+
+        $this->assertArrayHasKey('locales', $form);
+        $this->assertCount(3, $form['locales']['options']['values']['value']);
+        $this->assertSame('de', $form['locales']['options']['values']['value'][0]['name']);
+        $this->assertSame('de', $form['locales']['options']['values']['value'][0]['value']);
+        $this->assertSame('de', $form['locales']['options']['values']['value'][0]['title']);
+        $this->assertSame('en', $form['locales']['options']['values']['value'][1]['name']);
+        $this->assertSame('en', $form['locales']['options']['values']['value'][1]['value']);
+        $this->assertSame('en', $form['locales']['options']['values']['value'][1]['title']);
+        $this->assertSame('fr', $form['locales']['options']['values']['value'][2]['name']);
+        $this->assertSame('fr', $form['locales']['options']['values']['value'][2]['value']);
+        $this->assertSame('fr', $form['locales']['options']['values']['value'][2]['title']);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Visitor/LocalesOptionFormMetadataVisitorTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Visitor/LocalesOptionFormMetadataVisitorTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\FormMetadata\Visitor;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Visitor\LocalesOptionFormMetadataVisitor;
+
+class LocalesOptionFormMetadataVisitorTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private LocalesOptionFormMetadataVisitor $localesOptionFormMetadataVisitor;
+
+    protected function setUp(): void
+    {
+        $this->localesOptionFormMetadataVisitor = new LocalesOptionFormMetadataVisitor();
+    }
+
+    public function testVisitFormMetadata(): void
+    {
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('ghost_copy_locale');
+
+        $localeProperty = new FieldMetadata('locale');
+        $formMetadata->addItem($localeProperty);
+
+        $this->localesOptionFormMetadataVisitor->visitFormMetadata($formMetadata, 'en', ['locales' => ['en', 'de']]);
+
+        $this->assertSame('en', $localeProperty->getOptions()['default_value']->getValue());
+        $this->assertSame('collection', $localeProperty->getOptions()['values']->getType());
+        $this->assertCount(2, $localeProperty->getOptions()['values']->getValue());
+        $this->assertSame('en', $localeProperty->getOptions()['values']->getValue()[0]->getValue());
+        $this->assertSame('de', $localeProperty->getOptions()['values']->getValue()[1]->getValue());
+    }
+
+    public function testVisitFormMetadataWithCopyLocale(): void
+    {
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('copy_locale');
+
+        $localeProperty = new FieldMetadata('locales');
+        $formMetadata->addItem($localeProperty);
+
+        $this->localesOptionFormMetadataVisitor->visitFormMetadata($formMetadata, 'en', ['locales' => ['en', 'de']]);
+
+        $this->assertSame('collection', $localeProperty->getOptions()['values']->getType());
+        $this->assertCount(2, $localeProperty->getOptions()['values']->getValue());
+        $this->assertSame('en', $localeProperty->getOptions()['values']->getValue()[0]->getValue());
+        $this->assertSame('de', $localeProperty->getOptions()['values']->getValue()[1]->getValue());
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add the form-renderer to the copy locale and ghost locale copy overlay.

#### Why?

This allow to add additionalal fields to the forms.