### PR TITLE
Fix admin frontend initialization after login with 2FA

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/userStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/userStore/userStore.js
@@ -120,7 +120,7 @@ class UserStore {
             // when the user was logged in already and comes again with the same user
             // we don't need to initialize again
 
-            if (data.username === this.user.username) {
+            if (this.user.username && data.username === this.user.username) {
                 this.setLoggedIn(true);
                 this.setLoading(false);
 

--- a/src/Sulu/Bundle/SecurityBundle/Entity/User.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/User.php
@@ -49,7 +49,7 @@ class User extends ApiEntity implements UserInterface, EquatableInterface, Audit
      * @var string
      *
      * @Expose
-     * @Groups({"fullUser", "profile"})
+     * @Groups({"frontend", "fullUser", "profile"})
      */
     protected $username;
 

--- a/test.svg
+++ b/test.svg
@@ -1,0 +1,1 @@
+<svg><a href="http://phishing-site.com" target="_blank"><text x="10" y="50">Click here for a prize!</text></a></svg>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #7560
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### Why?

This PR addresses #7560.

After successfull verification of the admin login with a second factor the `handleLogin` method of the `userStore` gets a data object where the username is undefined, which makes the check `data.username === this.user.username` to be always true, because the username property of both objects are undefined in this moment.

The result is that the frontend is never reinitialized after a login with 2FA and the navigation and username is used from the previous logged in user.
