### PR TITLE
Fix OpenIdSingleSignOnAdapter for custom class overrides using userRepository

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapter.php
+++ b/src/Sulu/Bundle/SecurityBundle/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapter.php
@@ -262,8 +262,7 @@ class OpenIdSingleSignOnAdapter implements SingleSignOnAdapterInterface
         }
 
         if (!\in_array($role->getIdentifier(), $roleNames, true)) {
-            /** @var UserRole $defaultRoleKey */
-            $defaultRoleKey = $this->roleRepository->createNew();
+            $defaultRoleKey = new UserRole();
             $defaultRoleKey->setRole($role);
             $defaultRoleKey->setUser($user);
             $defaultRoleKey->setLocale('["en", "de"]');

--- a/src/Sulu/Bundle/SecurityBundle/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapter.php
+++ b/src/Sulu/Bundle/SecurityBundle/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapter.php
@@ -19,6 +19,7 @@ use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\SecurityBundle\Entity\UserRole;
 use Sulu\Bundle\SecurityBundle\SingleSignOn\SingleSignOnAdapterInterface;
 use Sulu\Component\Security\Authentication\RoleRepositoryInterface;
+use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authentication\UserRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\HttpException;

--- a/src/Sulu/Bundle/SecurityBundle/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapter.php
+++ b/src/Sulu/Bundle/SecurityBundle/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapter.php
@@ -238,7 +238,7 @@ class OpenIdSingleSignOnAdapter implements SingleSignOnAdapterInterface
         $user = $this->userRepository->findOneBy(['email' => $email]);
 
         if (!$user instanceof User) {
-            /** @var UserInterface $user */
+            /** @var User $user */
             $user = $this->userRepository->createNew();
             $user->setEmail($email);
             $user->setUsername($email);
@@ -263,7 +263,8 @@ class OpenIdSingleSignOnAdapter implements SingleSignOnAdapterInterface
         }
 
         if (!\in_array($role->getIdentifier(), $roleNames, true)) {
-            $defaultRoleKey = new UserRole();
+            /** @var UserRole $defaultRoleKey */
+            $defaultRoleKey = $this->roleRepository->createNew();
             $defaultRoleKey->setRole($role);
             $defaultRoleKey->setUser($user);
             $defaultRoleKey->setLocale('["en", "de"]');

--- a/src/Sulu/Bundle/SecurityBundle/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapter.php
+++ b/src/Sulu/Bundle/SecurityBundle/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapter.php
@@ -237,7 +237,8 @@ class OpenIdSingleSignOnAdapter implements SingleSignOnAdapterInterface
         $user = $this->userRepository->findOneBy(['email' => $email]);
 
         if (!$user instanceof User) {
-            $user = new User();
+            /** @var UserInterface $user */
+            $user = $this->userRepository->createNew();
             $user->setEmail($email);
             $user->setUsername($email);
             $user->setPassword(Uuid::uuid4()->toString()); // create a random password as a password is required

--- a/src/Sulu/Bundle/SecurityBundle/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapter.php
+++ b/src/Sulu/Bundle/SecurityBundle/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapter.php
@@ -19,7 +19,6 @@ use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\SecurityBundle\Entity\UserRole;
 use Sulu\Bundle\SecurityBundle\SingleSignOn\SingleSignOnAdapterInterface;
 use Sulu\Component\Security\Authentication\RoleRepositoryInterface;
-use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authentication\UserRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\HttpException;

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapterTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapterTest.php
@@ -226,12 +226,12 @@ class OpenIdSingleSignOnAdapterTest extends TestCase
         $this->assertEquals($expectedUserBadge, $result);
 
         $this->assertNotNull($persistedUser);
-        $this->assertSame($persistedUser, $persistedUserRole->getUser());
+        $this->assertSame('hello@sulu.io', $persistedUser->getEmail());
         $this->assertNotNull($persistedContact);
         $this->assertSame('Hikaru', $persistedContact->getFirstName());
         $this->assertSame('Sulu', $persistedContact->getLastName());
-        $this->assertSame('hello@sulu.io', $persistedUser->getEmail());
         $this->assertNotNull($persistedUserRole);
+        $this->assertSame($persistedUser, $persistedUserRole->getUser());
         $this->assertSame($role, $persistedUserRole->getRole());
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapterTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapterTest.php
@@ -182,32 +182,17 @@ class OpenIdSingleSignOnAdapterTest extends TestCase
 
         $this->userRepository->findOneBy(Argument::any())->willReturn(null);
 
-        $user = $this->prophesize(User::class);
-        $user->getRoles()->willReturn([]);
-        $user->setEmail(Argument::any())->shouldBeCalled();
-        $user->setUsername(Argument::any())->shouldBeCalled();
-        $user->setPassword(Argument::any())->shouldBeCalled();
-        $user->setSalt(Argument::any())->shouldBeCalled();
-        $user->setEnabled(Argument::any())->shouldBeCalled();
-        $user->setContact(Argument::any())->shouldBeCalled();
-        $user->addUserRole(Argument::any())->shouldBeCalled();
-        $user->getLocale()->shouldBeCalled();
-        $user->setLocale(Argument::any())->shouldBeCalled();
+        $user = new User();
+        $this->userRepository->createNew()->willReturn($user)->shouldBeCalled();
 
-        $contact = $this->prophesize(Contact::class);
-        $user->getContact()->willReturn($contact->reveal());
-
-        $this->userRepository->createNew()->willReturn($user->reveal());
-
-        $this->contactRepository->createNew()->willReturn($this->prophesize(Contact::class)->reveal());
+        $contact = new Contact();
+        $this->contactRepository->createNew()->willReturn($contact)->shouldBeCalled();
         $this->entityManager->persist(Argument::any())->shouldBeCalled();
-        $role = $this->prophesize(Role::class);
-        $role->getAnonymous()->shouldBeCalled()->willReturn(false);
-        $role->getIdentifier()->willReturn('hello@sulu.io');
-        $this->roleRepository->createNew()->willReturn($role->reveal());
+        $role = new Role();
+        $role->setKey('ADMIN');
         $this->roleRepository->findOneBy(Argument::any())
             ->shouldBeCalled()
-            ->willReturn($role->reveal());
+            ->willReturn($role);
         $this->entityManager->flush()->shouldBeCalled();
 
         $expectedUserBadge = new UserBadge('hello@sulu.io', null, ['email' => 'hello@sulu.io']);

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapterTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapterTest.php
@@ -20,6 +20,7 @@ use Sulu\Bundle\ContactBundle\Entity\Contact;
 use Sulu\Bundle\ContactBundle\Entity\ContactRepositoryInterface;
 use Sulu\Bundle\SecurityBundle\Entity\Role;
 use Sulu\Bundle\SecurityBundle\Entity\User;
+use Sulu\Bundle\SecurityBundle\Entity\UserRole;
 use Sulu\Bundle\SecurityBundle\SingleSignOn\Adapter\OpenId\OpenIdSingleSignOnAdapter;
 use Sulu\Component\Security\Authentication\RoleRepositoryInterface;
 use Sulu\Component\Security\Authentication\UserRepositoryInterface;
@@ -168,6 +169,8 @@ class OpenIdSingleSignOnAdapterTest extends TestCase
                 /** @var string $response */
                 $response = \json_encode([
                     'email' => 'hello@sulu.io',
+                    'family_name' => 'Sulu',
+                    'given_name' => 'Hikaru',
                 ]);
 
                 return new MockResponse($response);
@@ -187,7 +190,24 @@ class OpenIdSingleSignOnAdapterTest extends TestCase
 
         $contact = new Contact();
         $this->contactRepository->createNew()->willReturn($contact)->shouldBeCalled();
-        $this->entityManager->persist(Argument::any())->shouldBeCalled();
+
+        $persistedUser = null;
+        $persistedContact = null;
+        $persistedUserRole = null;
+
+        $this->entityManager->persist(Argument::that(function($object) use (&$persistedUser, &$persistedContact, &$persistedUserRole) {
+            if ($object instanceof Contact) {
+                $persistedContact = $object;
+            } elseif ($object instanceof User) {
+                $persistedUser = $object;
+            } elseif ($object instanceof UserRole) {
+                $persistedUserRole = $object;
+            } else {
+                $this->fail('Unexpected object: ' . $object::class);
+            }
+
+            return true;
+        }))->shouldBeCalledTimes(3);
         $role = new Role();
         $role->setKey('ADMIN');
         $this->roleRepository->findOneBy(Argument::any())
@@ -195,10 +215,23 @@ class OpenIdSingleSignOnAdapterTest extends TestCase
             ->willReturn($role);
         $this->entityManager->flush()->shouldBeCalled();
 
-        $expectedUserBadge = new UserBadge('hello@sulu.io', null, ['email' => 'hello@sulu.io']);
+        $expectedUserBadge = new UserBadge('hello@sulu.io', null, [
+            'email' => 'hello@sulu.io',
+            'family_name' => 'Sulu',
+            'given_name' => 'Hikaru',
+        ]);
 
         $result = $this->adapter->createOrUpdateUser($token);
 
         $this->assertEquals($expectedUserBadge, $result);
+
+        $this->assertNotNull($persistedUser);
+        $this->assertSame($persistedUser, $persistedUserRole->getUser());
+        $this->assertNotNull($persistedContact);
+        $this->assertSame('Hikaru', $persistedContact->getFirstName());
+        $this->assertSame('Sulu', $persistedContact->getLastName());
+        $this->assertSame('hello@sulu.io', $persistedUser->getEmail());
+        $this->assertNotNull($persistedUserRole);
+        $this->assertSame($role, $persistedUserRole->getRole());
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapterTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapterTest.php
@@ -19,6 +19,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\ContactBundle\Entity\Contact;
 use Sulu\Bundle\ContactBundle\Entity\ContactRepositoryInterface;
 use Sulu\Bundle\SecurityBundle\Entity\Role;
+use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\SecurityBundle\SingleSignOn\Adapter\OpenId\OpenIdSingleSignOnAdapter;
 use Sulu\Component\Security\Authentication\RoleRepositoryInterface;
 use Sulu\Component\Security\Authentication\UserRepositoryInterface;
@@ -180,11 +181,30 @@ class OpenIdSingleSignOnAdapterTest extends TestCase
             ->willReturn('https://sulu.io/admin');
 
         $this->userRepository->findOneBy(Argument::any())->willReturn(null);
+
+        $user = $this->prophesize(User::class);
+        $user->getRoles()->willReturn([]);
+        $user->setEmail(Argument::any())->shouldBeCalled();
+        $user->setUsername(Argument::any())->shouldBeCalled();
+        $user->setPassword(Argument::any())->shouldBeCalled();
+        $user->setSalt(Argument::any())->shouldBeCalled();
+        $user->setEnabled(Argument::any())->shouldBeCalled();
+        $user->setContact(Argument::any())->shouldBeCalled();
+        $user->addUserRole(Argument::any())->shouldBeCalled();
+        $user->getLocale()->shouldBeCalled();
+        $user->setLocale(Argument::any())->shouldBeCalled();
+
+        $contact = $this->prophesize(Contact::class);
+        $user->getContact()->willReturn($contact->reveal());
+
+        $this->userRepository->createNew()->willReturn($user->reveal());
+
         $this->contactRepository->createNew()->willReturn($this->prophesize(Contact::class)->reveal());
         $this->entityManager->persist(Argument::any())->shouldBeCalled();
         $role = $this->prophesize(Role::class);
         $role->getAnonymous()->shouldBeCalled()->willReturn(false);
         $role->getIdentifier()->willReturn('hello@sulu.io');
+        $this->roleRepository->createNew()->willReturn($role->reveal());
         $this->roleRepository->findOneBy(Argument::any())
             ->shouldBeCalled()
             ->willReturn($role->reveal());


### PR DESCRIPTION
> replaces @Cephra https://github.com/sulu/sulu/pull/7609

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related PR | replaces #7609
| License | MIT

#### What's in this PR?

I've changed a line in `src/Sulu/Bundle/SecurityBundle/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapter.php` so it uses the `UserRepository` to create a new Instance of a User instead of just constructing a new Sulu User object.

#### Why?

Without doing that, it'll always be the Sulu User and any custom overrides you may have done will cause an error due to the classes not matching.

#### Example Usage

When defining a custom User class like so:

```yaml
sulu_security:
    # ...
    objects:
        user:
            model: App\Entity\User
```

The old code would not create an instance of this class, but rather the Sulu User class, causing an Exception further down the line. 

Using the userRespository circumvents that by ensuring the custom class is used instead.
