### PR TITLE
Fix build of admin js by exclude fos/jsrouting-bundle from babel loader in the webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -86,7 +86,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                     test: /\.js$/,
                     // eslint-disable-next-line max-len
                     exclude: [/node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5|array-move|htmlparser2|lodash-es|@react-leaflet|react-leaflet)[/\\])/,
-                        /friendsofsymfony\/jsrouting-bundle/
+                        /friendsofsymfony\/jsrouting-bundle/,
                     ],
                     use: {
                         loader: 'babel-loader',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -87,7 +87,6 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                     // eslint-disable-next-line max-len
                     exclude: [
                         /node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5|array-move|htmlparser2|lodash-es|@react-leaflet|react-leaflet)[/\\])/,
-                        /node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5|array-move|htmlparser2|lodash-es|@react-leaflet|react-leaflet)[/\\])/,
                         /friendsofsymfony\/jsrouting-bundle/,
                     ],
                     use: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,7 +85,9 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                 {
                     test: /\.js$/,
                     // eslint-disable-next-line max-len
-                    exclude: /node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5|array-move|htmlparser2|lodash-es|@react-leaflet|react-leaflet)[/\\])/,
+                    exclude: [/node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5|array-move|htmlparser2|lodash-es|@react-leaflet|react-leaflet)[/\\])/,
+                        /friendsofsymfony\/jsrouting-bundle/
+                    ],
                     use: {
                         loader: 'babel-loader',
                         options: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -87,6 +87,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                     // eslint-disable-next-line max-len
                     exclude: [
                         /node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5|array-move|htmlparser2|lodash-es|@react-leaflet|react-leaflet)[/\\])/,
+                        /node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5|array-move|htmlparser2|lodash-es|@react-leaflet|react-leaflet)[/\\])/,
                         /friendsofsymfony\/jsrouting-bundle/,
                     ],
                     use: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,7 +85,8 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                 {
                     test: /\.js$/,
                     // eslint-disable-next-line max-len
-                    exclude: [/node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5|array-move|htmlparser2|lodash-es|@react-leaflet|react-leaflet)[/\\])/,
+                    exclude: [
+                        /node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5|array-move|htmlparser2|lodash-es|@react-leaflet|react-leaflet)[/\\])/,
                         /friendsofsymfony\/jsrouting-bundle/,
                     ],
                     use: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -83,9 +83,11 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
         module: {
             rules: [
                 {
-                    test: /\.js$/,
-                    // eslint-disable-next-line max-len
-                    exclude: [/node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5|array-move|htmlparser2|lodash-es|@react-leaflet|react-leaflet)[/\\])/,
+                    test: /\.js$/,                    
+                    exclude: [
+                        // eslint-disable-next-line max-len
+                        /node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5|array-move|htmlparser2|lodash-es|@react-leaflet|react-leaflet)[/\\])/,
+                        // eslint-disable-next-line max-len
                         /friendsofsymfony\/jsrouting-bundle/,
                     ],
                     use: {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #7636 
| Related issues/PRs | #7636
| License | MIT

#### What's in this PR?

Adds /friendsofsymfony\/jsrouting-bundle/ to webpack.config.js excludes under js rules

#### Why?

jsrouting-bundle is causing console error on admin, which resulted admin frontend not loading
It fixes #7636 https://github.com/sulu/sulu/issues/7636

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md