### PR TITLE
Fix file inspector tests namespace

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/FileInspector/SvgFileInspectorTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/FileInspector/SvgFileInspectorTest.php
@@ -20,7 +20,7 @@ use Sulu\Bundle\MediaBundle\FileInspector\SvgSanitizerFactory;
 use Sulu\Bundle\MediaBundle\FileInspector\UnsafeFileException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
-class SvgFileInspecaorTest extends TestCase
+class SvgFileInspectorTest extends TestCase
 {
     use ProphecyTrait;
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/FileInspector/SvgFileInspectorTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/FileInspector/SvgFileInspectorTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\MediaBundle\Tests\Unit\SvgInspector;
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\FileInspector;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -20,7 +20,7 @@ use Sulu\Bundle\MediaBundle\FileInspector\SvgSanitizerFactory;
 use Sulu\Bundle\MediaBundle\FileInspector\UnsafeFileException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
-class SvgFileInspectorTest extends TestCase
+class SvgFileInspecaorTest extends TestCase
 {
     use ProphecyTrait;
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/FileInspector/UploadFileSubscriberTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/FileInspector/UploadFileSubscriberTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\MediaBundle\Tests\Unit\SvgInspector;
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\FileInspector;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Move tests of file inspector to correct namespace.

#### Why?

Should make the backmerge of 2.5 easier.
