### PR TITLE
Fix failing search tests with unencode url at the end

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8376,11 +8376,6 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/DataFixtures/ORM/LoadDefaultTypes.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\DataFixtures\\\\ORM\\\\LoadDefaultTypes\\:\\:load\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/DataFixtures/ORM/LoadDefaultTypes.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\ContactBundle\\\\DependencyInjection\\\\Configuration\\:\\:addObjectsSection\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/DependencyInjection/Configuration.php
@@ -13756,22 +13751,12 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadCollectionTypes.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\DataFixtures\\\\ORM\\\\LoadCollectionTypes\\:\\:load\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadCollectionTypes.php
-
-		-
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<Sulu\\\\Bundle\\\\MediaBundle\\\\Entity\\\\MediaType\\>\\:\\:setIdGenerator\\(\\)\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadMediaTypes.php
 
 		-
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<Sulu\\\\Bundle\\\\MediaBundle\\\\Entity\\\\MediaType\\>\\:\\:setIdGeneratorType\\(\\)\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadMediaTypes.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\DataFixtures\\\\ORM\\\\LoadMediaTypes\\:\\:load\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadMediaTypes.php
 
@@ -26732,11 +26717,6 @@ parameters:
 
 		-
 			message: "#^Cannot call method getParameter\\(\\) on Symfony\\\\Component\\\\DependencyInjection\\\\ContainerInterface\\|null\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/DataFixtures/ORM/LoadSecurityTypes.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\SecurityBundle\\\\DataFixtures\\\\ORM\\\\LoadSecurityTypes\\:\\:load\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/DataFixtures/ORM/LoadSecurityTypes.php
 

--- a/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/WebsiteSearchControllerTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/WebsiteSearchControllerTest.php
@@ -92,7 +92,7 @@ class WebsiteSearchControllerTest extends SuluTestCase
     public function testSearchExactTermEndingWithSpace(): void
     {
         /** @var Crawler $crawler */
-        $crawler = $this->websiteClient->request('GET', 'http://de.sulu.lo/search?q=Product ');
+        $crawler = $this->websiteClient->request('GET', 'http://de.sulu.lo/search?q=Product%20');
         $response = $this->websiteClient->getResponse();
 
         static::assertHttpStatusCode(200, $response);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |yes
| New feature? | no
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Url in test requests need encoded space instead of a raw space.

#### Why?

The new security fix by symfony early returns as bad request instead for security reasons.

> Invalid URI: A URI must not start nor end with ASCII control characters or spaces.
