### PR TITLE
Add PHP 8.4 to Sulu CI

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -175,7 +175,6 @@ jobs:
                       dependency-versions: 'highest'
                       php-extensions: 'ctype, iconv, mysql, gd'
                       tools: 'composer:v2'
-                      composer-stability: 'dev'
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: weak
                           DATABASE_URL: postgres://symfony:ChangeMe@127.0.0.1:5432/sulu_test?serverVersion=14.11

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -170,12 +170,25 @@ jobs:
                           DATABASE_COLLATE:
 
                     - php-version: '8.3'
+                      database: postgres-14
+                      phpcr-transport: jackrabbit
+                      dependency-versions: 'highest'
+                      php-extensions: 'ctype, iconv, mysql, gd'
+                      tools: 'composer:v2'
+                      env:
+                          SYMFONY_DEPRECATIONS_HELPER: weak
+                          DATABASE_URL: postgres://symfony:ChangeMe@127.0.0.1:5432/sulu_test?serverVersion=14.11
+                          DATABASE_CHARSET: UTF8
+                          DATABASE_COLLATE:
+
+                    - php-version: '8.4'
                       database: mysql-80
                       phpcr-transport: doctrinedbal
                       dependency-versions: 'highest'
                       php-extensions: 'ctype, iconv, mysql, gd'
                       tools: 'composer:v2'
                       composer-stability: 'dev'
+                      composer-options: '--ignore-platform-reqs'
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: weak
                           DATABASE_URL: mysql://root:ChangeMe@127.0.0.1:3306/sulu_test?serverVersion=8.0
@@ -228,6 +241,7 @@ jobs:
               uses: ramsey/composer-install@v1
               with:
                   dependency-versions: ${{matrix.dependency-versions}}
+                  composer-options: ${{ matrix.composer-options }}
 
             - name: Output versions and installed dependencies
               run: |

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -175,6 +175,7 @@ jobs:
                       dependency-versions: 'highest'
                       php-extensions: 'ctype, iconv, mysql, gd'
                       tools: 'composer:v2'
+                      composer-stability: 'dev'
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: weak
                           DATABASE_URL: postgres://symfony:ChangeMe@127.0.0.1:5432/sulu_test?serverVersion=14.11

--- a/src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTest.php
+++ b/src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTest.php
@@ -60,8 +60,11 @@ class MemoizeTest extends TestCase
             );
         };
 
-        $id12 = \md5(\sprintf('%s::%s(%s)', __CLASS__, 'Sulu\Component\Cache\Tests\Unit\{closure}', \serialize([1, 2])));
-        $id23 = \md5(\sprintf('%s::%s(%s)', __CLASS__, 'Sulu\Component\Cache\Tests\Unit\{closure}', \serialize([2, 3])));
+        $reflectionFunction = new \ReflectionFunction($closure);
+        $functionName = $reflectionFunction->getName();
+
+        $id12 = \md5(\sprintf('%s::%s(%s)', __CLASS__, $functionName, \serialize([1, 2])));
+        $id23 = \md5(\sprintf('%s::%s(%s)', __CLASS__, $functionName, \serialize([2, 3])));
 
         $this->cache->save($id12, 3, $this->defaultLifeTime)->willReturn(null);
         $this->cache->contains($id12)->willReturn(false);
@@ -93,8 +96,11 @@ class MemoizeTest extends TestCase
             );
         };
 
-        $id12 = \md5(\sprintf('%s::%s(%s)', __CLASS__, 'Sulu\Component\Cache\Tests\Unit\{closure}', \serialize([1, 2])));
-        $id23 = \md5(\sprintf('%s::%s(%s)', __CLASS__, 'Sulu\Component\Cache\Tests\Unit\{closure}', \serialize([2, 3])));
+        $reflectionFunction = new \ReflectionFunction($closure);
+        $functionName = $reflectionFunction->getName();
+
+        $id12 = \md5(\sprintf('%s::%s(%s)', __CLASS__, $functionName, \serialize([1, 2])));
+        $id23 = \md5(\sprintf('%s::%s(%s)', __CLASS__, $functionName, \serialize([2, 3])));
 
         $this->cache->save($id12, 3, 100)->willReturn(null);
         $this->cache->contains($id12)->willReturn(false);
@@ -125,8 +131,11 @@ class MemoizeTest extends TestCase
             );
         };
 
-        $id12 = \md5(\sprintf('%s::%s(%s)', __CLASS__, 'Sulu\Component\Cache\Tests\Unit\{closure}', \serialize([1, 2])));
-        $id23 = \md5(\sprintf('%s::%s(%s)', __CLASS__, 'Sulu\Component\Cache\Tests\Unit\{closure}', \serialize([2, 3])));
+        $reflectionFunction = new \ReflectionFunction($closure);
+        $functionName = $reflectionFunction->getName();
+
+        $id12 = \md5(\sprintf('%s::%s(%s)', __CLASS__, $functionName, \serialize([1, 2])));
+        $id23 = \md5(\sprintf('%s::%s(%s)', __CLASS__, $functionName, \serialize([2, 3])));
 
         $this->cache->fetch($id12)->wilLReturn(3);
         $this->cache->contains($id12)->willReturn(true);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add PHP 8.4 to Sulu CI.

#### Why?

Test Sulu also against PHP 8.4 to prepare for the new Major version of PHP getting released in November 21.

Following dependency not have official support yet `composer why-not php 8.4`:

```
scheb/2fa-backup-code          v6.12.0 requires php (~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0)
scheb/2fa-bundle               v6.12.0 requires php (~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0)
scheb/2fa-email                v6.12.0 requires php (~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0)
scheb/2fa-google-authenticator v6.12.0 requires php (~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0)
scheb/2fa-totp                 v6.12.0 requires php (~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0)
scheb/2fa-trusted-device       v6.12.0 requires php (~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0)
```

This are optional dependencies and Sulu 2.6 supports newer version where supports PHP 8.4.

#### TODO

 - [x] Closures now have more informations in the backtrace and so we need adjust a test for PHP 8.4 the behaviour change is expected see https://github.com/php/php-src/issues/16729