### PR TITLE
New parameter "form_options_to_request" for the Selection form field

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -56,6 +56,9 @@ class Selection extends React.Component<Props> {
                 resource_store_properties_to_request: {
                     value: unvalidatedResourceStorePropertiesToRequest = [],
                 } = {},
+                form_options_to_request: {
+                    value: unvalidatedFormOptionsToRequest = [],
+                } = {},
             },
         } = this.props;
 
@@ -75,9 +78,16 @@ class Selection extends React.Component<Props> {
         // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
         const resourceStorePropertiesToRequest: Array | IObservableArray = unvalidatedResourceStorePropertiesToRequest;
 
+        if (!isArrayLike(unvalidatedFormOptionsToRequest)) {
+            throw new Error('The "form_options_to_request" schemaOption must be an array!');
+        }
+        // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
+        const formOptionsToRequest: Array | IObservableArray = unvalidatedFormOptionsToRequest;
+
         this.requestOptions = this.buildRequestOptions(
             requestParameters,
             resourceStorePropertiesToRequest,
+            formOptionsToRequest,
             formInspector
         );
 
@@ -91,6 +101,7 @@ class Selection extends React.Component<Props> {
                 const newRequestOptions = this.buildRequestOptions(
                     requestParameters,
                     resourceStorePropertiesToRequest,
+                    formOptionsToRequest,
                     formInspector
                 );
 
@@ -279,6 +290,7 @@ class Selection extends React.Component<Props> {
     buildRequestOptions(
         requestParameters: Array<SchemaOption>,
         resourceStorePropertiesToRequest: Array<SchemaOption>,
+        formOptionsToRequest: Array<SchemaOption>,
         formInspector: FormInspector
     ) {
         const requestOptions = {};
@@ -291,6 +303,14 @@ class Selection extends React.Component<Props> {
             const {name: parameterName, value: propertyName} = propertyToRequest;
             const propertyPath = typeof propertyName === 'string' ? propertyName : parameterName;
             requestOptions[parameterName] = toJS(formInspector.getValueByPath('/' + propertyPath));
+        });
+
+        formOptionsToRequest.forEach((optionToRequest) => {
+            const {name: parameterName, value: optionName} = optionToRequest;
+            const optionKey = typeof optionName === 'string' ? optionName : parameterName;
+            if (formInspector.options && optionKey in formInspector.options) {
+                requestOptions[parameterName] = toJS(formInspector.options[optionKey]);
+            }
         });
 
         return requestOptions;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
@@ -49,6 +49,9 @@ class SingleSelection extends React.Component<Props>
                 resource_store_properties_to_request: {
                     value: unvalidatedResourceStorePropertiesToRequest = [],
                 } = {},
+                form_options_to_request: {
+                    value: unvalidatedFormOptionsToRequest = [],
+                } = {},
             },
         } = this.props;
 
@@ -68,9 +71,16 @@ class SingleSelection extends React.Component<Props>
         // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
         const resourceStorePropertiesToRequest: Array | IObservableArray = unvalidatedResourceStorePropertiesToRequest;
 
+        if (!isArrayLike(unvalidatedFormOptionsToRequest)) {
+            throw new Error('The "form_options_to_request" schemaOption must be an array!');
+        }
+        // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
+        const formOptionsToRequest: Array | IObservableArray = unvalidatedFormOptionsToRequest;
+
         this.requestOptions = this.buildRequestOptions(
             requestParameters,
             resourceStorePropertiesToRequest,
+            formOptionsToRequest,
             formInspector
         );
 
@@ -84,6 +94,7 @@ class SingleSelection extends React.Component<Props>
                 const newRequestOptions = this.buildRequestOptions(
                     requestParameters,
                     resourceStorePropertiesToRequest,
+                    formOptionsToRequest,
                     formInspector
                 );
 
@@ -116,6 +127,7 @@ class SingleSelection extends React.Component<Props>
     buildRequestOptions(
         requestParameters: Array<SchemaOption>,
         resourceStorePropertiesToRequest: Array<SchemaOption>,
+        formOptionsToRequest: Array<SchemaOption>,
         formInspector: FormInspector
     ) {
         const requestOptions = {};
@@ -128,6 +140,14 @@ class SingleSelection extends React.Component<Props>
             const {name: parameterName, value: propertyName} = propertyToRequest;
             const propertyPath = typeof propertyName === 'string' ? propertyName : parameterName;
             requestOptions[parameterName] = toJS(formInspector.getValueByPath('/' + propertyPath));
+        });
+
+        formOptionsToRequest.forEach((optionToRequest) => {
+            const {name: parameterName, value: optionName} = optionToRequest;
+            const optionKey = typeof optionName === 'string' ? optionName : parameterName;
+            if (formInspector.options && optionKey in formInspector.options) {
+                requestOptions[parameterName] = toJS(formInspector.options[optionKey]);
+            }
         });
 
         return requestOptions;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adds a new parameter "form_options_to_request" to the Selection form field. This parameter allows a form option to be passed to the resource controller like the "resource_store_properties_to_request" does.

#### Why?

Our use case is to pass the current webspace to the resource controller for filtering. At the moment we're using the "resource_store_properties_to_request" parameter, but this only works in an "edit form". The "form_options_to_request" parameter can also be used in an "add form".

The SingleSelection form field already has the "form_options_to_list_options" parameter, which does something similar.

#### Example Usage

```xml
<property name="related" type="custom_selection">
  <params>
    <param name="form_options_to_request" type="collection">
      <param name="webspace" value="webspace"/>
    </param>
  </params>
</property>
```

