### PR TITLE
Add default empty schema to form metadata

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
@@ -55,6 +55,11 @@ class FormMetadata extends AbstractMetadata
     #[Exclude(if: "'admin_form_metadata_keys_only' in context.getAttribute('groups')")]
     protected $tags = [];
 
+    public function __construct()
+    {
+        $this->schema = new SchemaMetadata();
+    }
+
     public function setName(string $name)
     {
         $this->name = $name;

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/default.json
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/default.json
@@ -138,7 +138,16 @@
                             "name": "text_block",
                             "title": "Text Block",
                             "form": [],
-                            "schema": null,
+                            "schema": {
+                                "type": [
+                                    "number",
+                                    "string",
+                                    "boolean",
+                                    "object",
+                                    "array",
+                                    "null"
+                                ]
+                            },
                             "key": null,
                             "tags": [
                                 {
@@ -154,7 +163,16 @@
                             "name": "text_block2",
                             "title": "Text Block 2",
                             "form": [],
-                            "schema": null,
+                            "schema": {
+                                "type": [
+                                    "number",
+                                    "string",
+                                    "boolean",
+                                    "object",
+                                    "array",
+                                    "null"
+                                ]
+                            },
                             "key": null,
                             "tags": [
                                 {
@@ -188,7 +206,16 @@
                                     "tags": []
                                 }
                             },
-                            "schema": null,
+                            "schema": {
+                                "type": [
+                                    "number",
+                                    "string",
+                                    "boolean",
+                                    "object",
+                                    "array",
+                                    "null"
+                                ]
+                            },
                             "key": null,
                             "tags": []
                         },
@@ -235,7 +262,16 @@
                                             "name": "text_block2",
                                             "title": "Text Block 2",
                                             "form": [],
-                                            "schema": null,
+                                            "schema": {
+                                                "type": [
+                                                    "number",
+                                                    "string",
+                                                    "boolean",
+                                                    "object",
+                                                    "array",
+                                                    "null"
+                                                ]
+                                            },
                                             "key": null,
                                             "tags": [
                                                 {
@@ -251,7 +287,16 @@
                                             "name": "text_block3",
                                             "title": "Text Block 3",
                                             "form": [],
-                                            "schema": null,
+                                            "schema": {
+                                                "type": [
+                                                    "number",
+                                                    "string",
+                                                    "boolean",
+                                                    "object",
+                                                    "array",
+                                                    "null"
+                                                ]
+                                            },
                                             "key": null,
                                             "tags": [
                                                 {
@@ -273,7 +318,16 @@
                                     "tags": []
                                 }
                             },
-                            "schema": null,
+                            "schema": {
+                                "type": [
+                                    "number",
+                                    "string",
+                                    "boolean",
+                                    "object",
+                                    "array",
+                                    "null"
+                                ]
+                            },
                             "key": null,
                             "tags": []
                         }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/overview.json
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/overview.json
@@ -156,7 +156,16 @@
                             "tags": []
                         }
                     },
-                    "schema": null,
+                    "schema": {
+                        "type": [
+                            "number",
+                            "string",
+                            "boolean",
+                            "object",
+                            "array",
+                            "null"
+                        ]
+                    },
                     "key": null,
                     "tags": []
                 }
@@ -209,7 +218,16 @@
                             "tags": []
                         }
                     },
-                    "schema": null,
+                    "schema": {
+                        "type": [
+                            "number",
+                            "string",
+                            "boolean",
+                            "object",
+                            "array",
+                            "null"
+                        ]
+                    },
                     "key": null,
                     "tags": []
                 }

--- a/src/Sulu/Component/Content/Tests/Unit/Types/Metadata/GlobalBlocksTypedFormMetadataVisitorTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Types/Metadata/GlobalBlocksTypedFormMetadataVisitorTest.php
@@ -117,7 +117,6 @@ class GlobalBlocksTypedFormMetadataVisitorTest extends TestCase
 
         $formMetadata = new FormMetadata();
         $formMetadata->setKey('test');
-        $formMetadata->setSchema(new SchemaMetadata());
 
         $sectionMetadata = new SectionMetadata('test1');
         $formMetadata->addItem($sectionMetadata);
@@ -142,7 +141,6 @@ class GlobalBlocksTypedFormMetadataVisitorTest extends TestCase
         $globalBlockFormTypeMetadata = new FormMetadata();
         $globalBlockFormMetadata->addForm($globalBlockName, $globalBlockFormTypeMetadata);
 
-        $globalBlockFormTypeMetadata->setSchema(new SchemaMetadata());
         $globalBlockFormTypeMetadata->setName($globalBlockName);
         $globalBlockFormTypeMetadata->setTitle('Test Block Title');
 
@@ -177,7 +175,6 @@ class GlobalBlocksTypedFormMetadataVisitorTest extends TestCase
         $formMetadata = new TypedFormMetadata();
 
         $formTypeMetadata = new FormMetadata();
-        $formTypeMetadata->setSchema(new SchemaMetadata());
         $formMetadata->addForm('test', $formTypeMetadata);
 
         $sectionMetadata = new SectionMetadata('test1');
@@ -203,7 +200,6 @@ class GlobalBlocksTypedFormMetadataVisitorTest extends TestCase
         $globalBlockFormTypeMetadata = new FormMetadata();
         $globalBlockFormMetadata->addForm($globalBlockName, $globalBlockFormTypeMetadata);
 
-        $globalBlockFormTypeMetadata->setSchema(new SchemaMetadata());
         $globalBlockFormTypeMetadata->setName($globalBlockName);
         $globalBlockFormTypeMetadata->setTitle('Test Block Title');
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add empty schema to form metadata as default.

#### Why?

When you want to create a new Automation task you will receive following issue:

```
Uncaught PHP Exception TypeError: "Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata::getSchema(): Return value must be of type Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata, null returned" at FormMetadata.php line 116
```

This is caused of the fact that there is no schema for the form and therefor the `GlobalBlocksTypedFormMetadataVisitor` can not use it to merge with other schemas.