### PR TITLE
Add default empty schema to form metadata

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
@@ -61,6 +61,11 @@ class FormMetadata extends AbstractMetadata
      */
     protected $tags;
 
+    public function __construct()
+    {
+        $this->schema = new SchemaMetadata();
+    }
+
     public function setName(string $name)
     {
         $this->name = $name;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes none
| Related issues/PRs | #7647 
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add empty schema to form metadata as default.

#### Why?

When you want to create a new Automation task you will receive following issue:

```
Uncaught PHP Exception TypeError: "Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata::getSchema(): Return value must be of type Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata, null returned" at FormMetadata.php line 116
```

This is caused of the fact that there is no schema for the form and therefor the `GlobalBlocksTypedFormMetadataVisitor` can not use it to merge with other schemas.