### PR TITLE
Fix using vips without the vips php extension

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11261,11 +11261,6 @@ parameters:
 			path: src/Sulu/Bundle/DocumentManagerBundle/DataFixtures/DocumentFixtureGroupInterface.php
 
 		-
-			message: "#^Parameter \\#1 \\$object_or_class of function is_subclass_of expects object\\|string, class\\-string\\|null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Compiler/DocumentFixturePass.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\DependencyInjection\\\\Compiler\\\\ExtractingEventDispatcher\\:\\:addListener\\(\\) has parameter \\$listener with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Compiler/RegisterListenersPass.php

--- a/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Compiler/DocumentFixturePass.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Compiler/DocumentFixturePass.php
@@ -27,8 +27,9 @@ class DocumentFixturePass implements CompilerPassInterface
     {
         foreach ($container->findTaggedServiceIds(self::TAG_NAME) as $id => $tags) {
             $definition = $container->getDefinition($id);
+            $serviceClass = $definition->getClass();
 
-            if (\is_subclass_of($definition->getClass(), ContainerAwareInterface::class)) {
+            if ($serviceClass && \is_subclass_of($serviceClass, ContainerAwareInterface::class)) {
                 @trigger_deprecation(
                     'sulu/sulu',
                     '2.1',

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -327,7 +327,15 @@ class SuluMediaExtension extends Extension implements PrependExtensionInterface
         }
 
         $hasVipsAdapter = false;
-        if (\class_exists(VipsImagine::class) && \extension_loaded('vips')) {
+        if (\class_exists(VipsImagine::class)
+            && (
+                \extension_loaded('vips')
+                || (
+                    \extension_loaded('ffi')
+                    && '1' === \ini_get('ffi.enable') // preload is not yet supported by vips see https://github.com/libvips/php-vips
+                )
+            )
+        ) {
             $loader->load('services_imagine_vips.xml');
             $hasVipsAdapter = true;
         }

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -329,7 +329,7 @@ class SuluMediaExtension extends Extension implements PrependExtensionInterface
         $hasVipsAdapter = false;
         if (\class_exists(VipsImagine::class)
             && (
-                \extension_loaded('vips')
+                \extension_loaded('vips') // deprecate vips 1.0 way use ffi instead
                 || (
                     \extension_loaded('ffi')
                     && '1' === \ini_get('ffi.enable') // preload is not yet supported by vips see https://github.com/libvips/php-vips


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix using vips without the vips php extension.

#### Why?

The vips extension is not required and only requires ffi.enable now.
