### PR TITLE
Fix issue with backmerge 2.5 in 2.6 duplicated __construct method

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
@@ -60,11 +60,6 @@ class FormMetadata extends AbstractMetadata
         $this->schema = new SchemaMetadata();
     }
 
-    public function __construct()
-    {
-        $this->schema = new SchemaMetadata();
-    }
-
     public function setName(string $name)
     {
         $this->name = $name;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix issue with backmerge 2.5 in 2.6 duplicated __construct method.

#### Why?

Looks like it happened on backmerge without any conflict. #7647 #7648