### PR TITLE
Add Sulu 3.0 var directories to gitignore for better DX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ phpunit.stdout
 # test cache folders
 /src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/cache/
 /tests/Resources/cache/
+/packages/*/tests/Application/var/
 /src/Sulu/Bundle/*/Tests/var/
 /src/Sulu/Bundle/*/Tests/Application/var/
 /src/Sulu/Bundle/*/Tests/Application/public/uploads
@@ -22,6 +23,7 @@ phpunit.stdout
 /composer.phar
 composer.lock
 /vendor
+/packages/*/vendor
 
 # npm
 package-lock.json


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no 
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add Sulu 3.0 var directories to gitignore for better DX-

#### Why?

Working in Sulu requires switching between 2.5, 2.6 and 3.0. To avoid accidently commit the `/packages/*/tests/Application/var/` directories we also add them to the gitignore.