### PR TITLE
Upgrade doctrine cache to 2

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -189,7 +189,6 @@ jobs:
                       php-extensions: 'ctype, iconv, mysql, imagick'
                       tools: 'composer:v2'
                       composer-stability: 'dev'
-                      composer-options: '--ignore-platform-reqs'
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: weak
                           DATABASE_URL: mysql://root:ChangeMe@127.0.0.1:3306/sulu_test?serverVersion=8.0

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "composer/package-versions-deprecated": "^1.8",
         "contao/imagine-svg": "^1.0",
         "doctrine/annotations": "^1.2 || ^2.0",
-        "doctrine/cache": "^1.0.1",
+        "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/collections": "^1.0 || ^2.0",
         "doctrine/data-fixtures": "^1.3.3",
         "doctrine/dbal": "^2.13 || ^3.0",

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Twig/CategoryTwigExtensionTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Twig/CategoryTwigExtensionTest.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Bundle\CategoryBundle\Tests\Unit\Twig;
 
-use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use JMS\Serializer\SerializationContext;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -26,6 +26,7 @@ use Sulu\Component\Cache\MemoizeInterface;
 use Sulu\Component\Category\Request\CategoryRequestHandler;
 use Sulu\Component\Category\Request\CategoryRequestHandlerInterface;
 use Sulu\Component\Serializer\ArraySerializerInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -41,7 +42,7 @@ class CategoryTwigExtensionTest extends TestCase
      */
     private function getMemoizeCache()
     {
-        return new Memoize(new ArrayCache(), 0);
+        return new Memoize(DoctrineProvider::wrap(new ArrayAdapter()), 0);
     }
 
     /**

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
@@ -48,7 +48,14 @@
             <argument type="service" id="sulu.repository.user" />
             <argument type="service" id="sulu_trash.trash_manager" on-invalid="null"/>
         </service>
-        <service id="sulu_contact.twig.cache" class="Doctrine\Common\Cache\ArrayCache"/>
+
+        <service id="sulu_contact.twig.cache_adapter" class="Symfony\Component\Cache\Adapter\ArrayAdapter" />
+
+        <service id="sulu_contact.twig.cache" class="Doctrine\Common\Cache\Cache">
+            <factory class="Doctrine\Common\Cache\Psr6\DoctrineProvider" method="wrap"/>
+            <argument type="service" id="sulu_contact.twig.cache_adapter" />
+        </service>
+
         <service id="sulu_contact.twig" class="Sulu\Bundle\ContactBundle\Twig\ContactTwigExtension">
             <argument type="service" id="sulu_contact.twig.cache"/>
             <argument type="service" id="sulu.repository.contact"/>

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/ContactTwigExtensionTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/ContactTwigExtensionTest.php
@@ -11,14 +11,15 @@
 
 namespace Sulu\Bundle\ContactBundle\Tests\Unit;
 
-use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\ContactBundle\Entity\Contact;
 use Sulu\Bundle\ContactBundle\Entity\ContactRepository;
 use Sulu\Bundle\ContactBundle\Twig\ContactTwigExtension;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 class ContactTwigExtensionTest extends TestCase
 {
@@ -41,7 +42,7 @@ class ContactTwigExtensionTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->cache = new ArrayCache();
+        $this->cache = DoctrineProvider::wrap(new ArrayAdapter());
         $this->contactRepository = $this->prophesize(ContactRepository::class);
 
         $this->extension = new ContactTwigExtension($this->cache, $this->contactRepository->reveal());

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/cache.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/cache.xml
@@ -3,15 +3,15 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="sulu_core.cache.memoize.cache.class">Doctrine\Common\Cache\ArrayCache</parameter>
-        <parameter key="sulu_core.cache.memoize.class">Sulu\Component\Cache\Memoize</parameter>
-    </parameters>
-
     <services>
-        <service id="sulu_core.cache.memoize.cache" class="%sulu_core.cache.memoize.cache.class%"/>
+        <service id="sulu_core.cache.memoize.cache_adapter" class="Symfony\Component\Cache\Adapter\ArrayAdapter" />
 
-        <service id="sulu_core.cache.memoize" class="%sulu_core.cache.memoize.class%">
+        <service id="sulu_core.cache.memoize.cache" class="Doctrine\Common\Cache\CacheProvider">
+            <factory class="Doctrine\Common\Cache\Psr6\DoctrineProvider" method="wrap"/>
+            <argument type="service" id="sulu_core.cache.memoize.cache_adapter" />
+        </service>
+
+        <service id="sulu_core.cache.memoize" class="Sulu\Component\Cache\Memoize">
             <argument type="service" id="sulu_core.cache.memoize.cache"/>
             <argument type="string">%sulu_core.cache.memoize.default_lifetime%</argument>
             <tag name="kernel.reset" method="reset" />

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
@@ -11,7 +11,6 @@
 
         <parameter key="sulu.content.mapper.class">Sulu\Component\Content\Mapper\ContentMapper</parameter>
         <parameter key="sulu.content.structure_manager.class">Sulu\Component\Content\Compat\StructureManager</parameter>
-        <parameter key="sulu.content.webspace_structure_provider.cache.class">Doctrine\Common\Cache\FilesystemCache</parameter>
         <parameter key="sulu.content.webspace_structure_provider.class">Sulu\Component\Webspace\StructureProvider\WebspaceStructureProvider</parameter>
 
         <parameter key="sulu.content.type_manager.class">Sulu\Component\Content\ContentTypeManager</parameter>
@@ -83,8 +82,15 @@
             <argument>%sulu.content.structure.type_map%</argument>
         </service>
 
-        <service id="sulu.content.webspace_structure_provider.cache" class="%sulu.content.webspace_structure_provider.cache.class%">
+        <service id="sulu.content.webspace_structure_provider.cache_adapter" class="Symfony\Component\Cache\Adapter\FilesystemAdapter">
+            <argument type="string"></argument>
+            <argument>0</argument>
             <argument type="string">%sulu.cache_dir%/webspace_structures</argument>
+        </service>
+
+        <service id="sulu.content.webspace_structure_provider.cache" class="Doctrine\Common\Cache\CacheProvider">
+            <factory class="Doctrine\Common\Cache\Psr6\DoctrineProvider" method="wrap"/>
+            <argument type="service" id="sulu.content.webspace_structure_provider.cache_adapter" />
         </service>
 
         <service id="sulu.content.webspace_structure_provider" class="%sulu.content.webspace_structure_provider.class%" public="true">

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/PreviewCacheTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/PreviewCacheTest.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Bundle\PreviewBundle\Tests\Unit\Preview;
 
-use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\PreviewBundle\Preview\PreviewCache;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -20,7 +20,7 @@ class PreviewCacheTest extends TestCase
 {
     public function testPreviewCache(): void
     {
-        $previewCache = new PreviewCache(new ArrayAdapter());
+        $previewCache = new PreviewCache(DoctrineProvider::wrap(new ArrayAdapter()));
 
         $this->assertFalse($previewCache->contains('id'));
         $previewCache->save('id', 'test');
@@ -32,7 +32,7 @@ class PreviewCacheTest extends TestCase
 
     public function testLegacyPreviewCache(): void
     {
-        $previewCache = new PreviewCache(new ArrayCache());
+        $previewCache = new PreviewCache(DoctrineProvider::wrap(new ArrayAdapter()));
 
         $this->assertFalse($previewCache->contains('id'));
         $previewCache->save('id', 'test');

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -285,7 +285,12 @@
             <tag name="jms_serializer.event_subscriber"/>
         </service>
 
-        <service id="sulu_security.twig_extension.user.cache" class="Doctrine\Common\Cache\ArrayCache"/>
+        <service id="sulu_security.twig_extension.user.cache_adapter" class="Symfony\Component\Cache\Adapter\ArrayAdapter" />
+        <service id="sulu_security.twig_extension.user.cache" class="Sulu\Bundle\ContactBundle\Entity\PositionRepository">
+            <factory class="Doctrine\Common\Cache\Psr6\DoctrineProvider" method="wrap"/>
+            <argument type="service" id="sulu_security.twig_extension.user.cache_adapter" />
+        </service>
+
         <service id="sulu_security.twig_extension.user" class="Sulu\Bundle\SecurityBundle\Twig\UserTwigExtension">
             <argument type="service" id="sulu_security.twig_extension.user.cache"/>
             <argument type="service" id="sulu.repository.user"/>

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Twig/UserTwigExtensionTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Twig/UserTwigExtensionTest.php
@@ -11,14 +11,15 @@
 
 namespace Sulu\Bundle\SecurityBundle\Tests\Unit\Twig;
 
-use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\SecurityBundle\Entity\UserRepository;
 use Sulu\Bundle\SecurityBundle\Twig\UserTwigExtension;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 class UserTwigExtensionTest extends TestCase
 {
@@ -41,7 +42,7 @@ class UserTwigExtensionTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->cache = new ArrayCache();
+        $this->cache = DoctrineProvider::wrap(new ArrayAdapter());
         $this->userRepository = $this->prophesize(UserRepository::class);
 
         $this->extension = new UserTwigExtension($this->cache, $this->userRepository->reveal());

--- a/src/Sulu/Bundle/TagBundle/Tests/Unit/Twig/TagTwigExtensionTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Unit/Twig/TagTwigExtensionTest.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Bundle\TagBundle\Tests\Unit\Twig;
 
-use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use JMS\Serializer\SerializationContext;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -24,6 +24,7 @@ use Sulu\Component\Cache\MemoizeInterface;
 use Sulu\Component\Serializer\ArraySerializerInterface;
 use Sulu\Component\Tag\Request\TagRequestHandler;
 use Sulu\Component\Tag\Request\TagRequestHandlerInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -39,7 +40,7 @@ class TagTwigExtensionTest extends TestCase
      */
     private function getMemoizeCache()
     {
-        return new Memoize(new ArrayCache(), 0);
+        return new Memoize(DoctrineProvider::wrap(new ArrayAdapter()), 0);
     }
 
     public static function getProvider()

--- a/src/Sulu/Component/Cache/Memoize.php
+++ b/src/Sulu/Component/Cache/Memoize.php
@@ -11,7 +11,8 @@
 
 namespace Sulu\Component\Cache;
 
-use Doctrine\Common\Cache\CacheProvider;
+use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\FlushableCache;
 use Symfony\Contracts\Service\ResetInterface;
 
 /**
@@ -20,9 +21,10 @@ use Symfony\Contracts\Service\ResetInterface;
 class Memoize implements MemoizeInterface, ResetInterface
 {
     /**
+     * @param Cache $cache should also include FlushableCache to reset in other runtimes like FrankenPHP correctly
      * @param int $defaultLifeTime
      */
-    public function __construct(protected CacheProvider $cache, protected $defaultLifeTime)
+    public function __construct(protected Cache $cache, protected $defaultLifeTime)
     {
     }
 
@@ -74,6 +76,8 @@ class Memoize implements MemoizeInterface, ResetInterface
      */
     public function reset()
     {
-        $this->cache->flushAll();
+        if ($this->cache instanceof FlushableCache) {
+            $this->cache->flushAll();
+        }
     }
 }

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -11,8 +11,8 @@
 
 namespace Sulu\Component\Content\Mapper;
 
-use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Jackalope\Query\Row;
 use PHPCR\NodeInterface;
 use PHPCR\Query\QueryInterface;
@@ -61,6 +61,7 @@ use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
 use Sulu\Component\Security\Authorization\AccessControl\AccessControlManagerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Security\Core\Security as SymfonyCoreSecurity;
@@ -909,7 +910,7 @@ class ContentMapper implements ContentMapperInterface
      */
     private function initializeExtensionCache()
     {
-        $this->extensionDataCache = new ArrayCache();
+        $this->extensionDataCache = DoctrineProvider::wrap(new ArrayAdapter());
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Tests/Unit/StructureProvider/WebspaceStructureProviderTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/StructureProvider/WebspaceStructureProviderTest.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Component\Webspace\Tests\Unit\StructureProvider;
 
-use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Component\Content\Compat\Structure\PageBridge;
@@ -19,6 +19,7 @@ use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Content\Compat\StructureManagerInterface;
 use Sulu\Component\Webspace\StructureProvider\WebspaceStructureProvider;
 use Sulu\Component\Webspace\Webspace;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
@@ -28,7 +29,7 @@ class WebspaceStructureProviderTest extends TestCase
 
     public function testGetStructures(): void
     {
-        $cache = new ArrayCache();
+        $cache = DoctrineProvider::wrap(new ArrayAdapter());
 
         $structures = [
             $this->generateStructure('t1', 'MyBundle:default:t1'),
@@ -67,7 +68,7 @@ class WebspaceStructureProviderTest extends TestCase
 
     public function testGetStructuresCached(): void
     {
-        $cache = new ArrayCache();
+        $cache = DoctrineProvider::wrap(new ArrayAdapter());
         $cache->save('sulu_io', ['t1', 't3']);
 
         $structures = [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no 
| BC breaks? | no
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Upgrade doctrine cache to 2.

#### Why?

Doctrine Cache 1 is deprecated since a longer time.