### PR TITLE
Add a conflict to the doctrine bundle 2.13.1 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -157,6 +157,7 @@
     "conflict": {
         "behat/transliterator": "< 1.3.0",
         "doctrine/lexer": ">= 3.0.0",
+        "doctrine/doctrine-bundle": "2.13.1 || 2.13.x-dev || 2.14.x-dev",
         "doctrine/orm": "2.10.0 || 2.14.2 || 2.16.0 - 2.17.2",
         "friendsofphp/php-cs-fixer": "3.9.1",
         "gedmo/doctrine-extensions" : "3.7.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7231,7 +7231,7 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
 
 		-
-			message: "#^Offset 'id' does not exist on non\\-falsy\\-string\\.$#"
+			message: "#^Offset 'id' does not exist on non\\-empty\\-string\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add a conflict to the doctrine bundle 2.13.1 version.

#### Why?

> "Declaration of Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor::getProperties(string $class, array $context = []) must be compatible with Symfony\Component\PropertyInfo\PropertyListExtractorInterface::getProperties(string $class, array $context = []): ?array

See https://github.com/doctrine/DoctrineBundle/pull/1841 hopefully this get merged and so we do not need to conflict `>2.13.0` completely.