### PR TITLE
Fix local test running with max connection error

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
 ###> doctrine/doctrine-bundle ###
   database:
+    command: '--max_connections=1000'
     ports:
       - "3306:3306"
 ###< doctrine/doctrine-bundle ###


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix local test running with max connection error.

#### Why?

It crashes locally on my notebook als with too many connections when run test against the basic docker setup.