### PR TITLE
Add animate support for webp

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImagineImageConverter.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImagineImageConverter.php
@@ -378,6 +378,9 @@ class ImagineImageConverter implements ImageConverterInterface
     private function getOptionsFromImage(ImageInterface $image, $imageExtension, $imagineOptions)
     {
         $options = [];
+        // TODO avif support requires first support in imagemagick and then in imagine php library
+        //     https://github.com/ImageMagick/ImageMagick/issues/6380
+        //     https://github.com/php-imagine/Imagine/pull/812 (same changes for avif required)
         if (\in_array($imageExtension, ['gif', 'webp']) && \count($image->layers()) > 1) {
             $options['animated'] = true;
             $options['optimize'] = true;

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImagineImageConverter.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImagineImageConverter.php
@@ -378,7 +378,7 @@ class ImagineImageConverter implements ImageConverterInterface
     private function getOptionsFromImage(ImageInterface $image, $imageExtension, $imagineOptions)
     {
         $options = [];
-        if ('gif' == $imageExtension && \count($image->layers()) > 1) {
+        if (\in_array($imageExtension, ['gif', 'webp']) && \count($image->layers()) > 1) {
             $options['animated'] = true;
             $options['optimize'] = true;
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no yes
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/php-imagine/Imagine/pull/812
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add animate support for webp.

#### Why?

Support for webp animation was added in https://github.com/php-imagine/Imagine/pull/812