### PR TITLE
Fix ArticleTeaserProvider

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Content/ArticleTeaserProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/ArticleTeaserProvider.php
@@ -70,4 +70,9 @@ class ArticleTeaserProvider extends ContentTeaserProvider
 
         return $article ?: parent::getDescription($dimensionContent, $data);
     }
+
+    protected function getEntityIdField(): string
+    {
+        return 'uuid';
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| License | MIT

#### What's in this PR?

Fix for the ArticleTeaserProvider

#### Why?

Because it did expect an `id` field.