### PR TITLE
Fix custom admin build on windows machines

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -87,7 +87,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                     exclude: [
                         // eslint-disable-next-line max-len
                         /node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5|array-move|htmlparser2|lodash-es|@react-leaflet|react-leaflet)[/\\])/,
-                        /friendsofsymfony\/jsrouting-bundle/,
+                        /friendsofsymfony[/\\]jsrouting-bundle/,
                     ],
                     use: {
                         loader: 'babel-loader',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/issues/7662, https://github.com/sulu/sulu/issues/7661, https://github.com/sulu/sulu/issues/7636, https://github.com/sulu/sulu/pull/7639
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix custom admin build on windows machines.

#### Why?

Windows using a different path seperator.
