### PR TITLE
Fix DateTimeImmutable in CSV Export be formatted correctly

### DIFF
--- a/src/Sulu/Component/Rest/Csv/CsvHandler.php
+++ b/src/Sulu/Component/Rest/Csv/CsvHandler.php
@@ -118,7 +118,7 @@ class CsvHandler
         }
 
         foreach ($row as $key => $value) {
-            if ($value instanceof \DateTime) {
+            if ($value instanceof \DateTimeInterface) {
                 $row[$key] = $value->format(\DateTime::RFC3339);
             } elseif (\is_bool($value)) {
                 $row[$key] = true === $value ? 1 : 0;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Check for instance of `\DateTimeInterface` instead of `\DateTime` in the CsvHandler.

#### Why?

So that for example `DateTimeImmutable` values will also be formatted correctly on csv export.

