### PR TITLE
Replace Uuid->__toString() with more descriptive Uuid->toRfc4122

### DIFF
--- a/packages/article/src/Domain/Model/Article.php
+++ b/packages/article/src/Domain/Model/Article.php
@@ -35,7 +35,7 @@ class Article implements ArticleInterface
     public function __construct(
         ?string $uuid = null
     ) {
-        $this->uuid = $uuid ?: Uuid::v7()->__toString();
+        $this->uuid = $uuid ?: Uuid::v7()->toRfc4122();
     }
 
     public function getId(): string // TODO should be replaced by uuid

--- a/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/EventSubscriber/TagsSubscriberTest.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/EventSubscriber/TagsSubscriberTest.php
@@ -80,9 +80,9 @@ class TagsSubscriberTest extends TestCase
 
     public function setUp(): void
     {
-        $this->uuid1 = Uuid::v7()->__toString();
-        $this->uuid2 = Uuid::v7()->__toString();
-        $this->currentStructureUuid = Uuid::v7()->__toString();
+        $this->uuid1 = Uuid::v7()->toRfc4122();
+        $this->uuid2 = Uuid::v7()->toRfc4122();
+        $this->currentStructureUuid = Uuid::v7()->toRfc4122();
 
         $testReferenceStore = $this->prophesize(ReferenceStoreInterface::class);
         $testReferenceStore->getAll()->willReturn(['1', '2']);

--- a/src/Sulu/Bundle/PreviewBundle/Infrastructure/Doctrine/Repository/PreviewLinkRepository.php
+++ b/src/Sulu/Bundle/PreviewBundle/Infrastructure/Doctrine/Repository/PreviewLinkRepository.php
@@ -73,7 +73,7 @@ class PreviewLinkRepository implements PreviewLinkRepositoryInterface
 
     protected function generateToken(): string
     {
-        $token = \substr(\md5(Uuid::v7()->__toString()), 0, 12);
+        $token = \substr(\md5(Uuid::v7()->toRfc4122()), 0, 12);
         if ($this->findByToken($token)) {
             return $this->generateToken();
         }

--- a/src/Sulu/Bundle/ReferenceBundle/Tests/Functional/Infrastructure/Doctrine/Repository/ReferenceRepositoryTest.php
+++ b/src/Sulu/Bundle/ReferenceBundle/Tests/Functional/Infrastructure/Doctrine/Repository/ReferenceRepositoryTest.php
@@ -200,7 +200,7 @@ class ReferenceRepositoryTest extends SuluTestCase
         static::purgeDatabase();
 
         $referenceResourceKey = 'pages';
-        $referenceResourceId = Uuid::v7()->__toString();
+        $referenceResourceId = Uuid::v7()->toRfc4122();
         $referenceLocale = 'en';
 
         $reference1 = $this->createReference();
@@ -244,7 +244,7 @@ class ReferenceRepositoryTest extends SuluTestCase
         static::purgeDatabase();
 
         $referenceResourceKey = 'article';
-        $referenceResourceId = Uuid::v7()->__toString();
+        $referenceResourceId = Uuid::v7()->toRfc4122();
         $referenceLocale = 'de';
 
         $reference1 = $this->createReference();
@@ -284,7 +284,7 @@ class ReferenceRepositoryTest extends SuluTestCase
         static::purgeDatabase();
 
         $referenceResourceKey = 'article';
-        $referenceResourceId = Uuid::v7()->__toString();
+        $referenceResourceId = Uuid::v7()->toRfc4122();
         $referenceLocale = 'de';
 
         $reference1 = $this->createReference();
@@ -316,7 +316,7 @@ class ReferenceRepositoryTest extends SuluTestCase
             'media',
             '1',
             'pages',
-            Uuid::v7()->__toString(),
+            Uuid::v7()->toRfc4122(),
             'en',
             'Page Title',
             'default',

--- a/src/Sulu/Bundle/ReferenceBundle/Tests/Unit/Domain/Model/ReferenceTest.php
+++ b/src/Sulu/Bundle/ReferenceBundle/Tests/Unit/Domain/Model/ReferenceTest.php
@@ -93,7 +93,7 @@ class ReferenceTest extends TestCase
 
     public function testEqualsTrue(): void
     {
-        $uuid = Uuid::v7()->__toString();
+        $uuid = Uuid::v7()->toRfc4122();
         $reference1 = $this->createReference();
         $reference1->setResourceKey('media');
         $reference1->setResourceId('1');
@@ -118,8 +118,8 @@ class ReferenceTest extends TestCase
 
     public function testEqualsFalse(): void
     {
-        $uuid = Uuid::v7()->__toString();
-        $uuid2 = Uuid::v7()->__toString();
+        $uuid = Uuid::v7()->toRfc4122();
+        $uuid2 = Uuid::v7()->toRfc4122();
         $reference1 = $this->createReference();
         $reference1->setReferenceResourceId($uuid);
         $reference2 = $this->createReference();

--- a/src/Sulu/Bundle/SecurityBundle/EventListener/AuhenticationFailureListener.php
+++ b/src/Sulu/Bundle/SecurityBundle/EventListener/AuhenticationFailureListener.php
@@ -46,10 +46,10 @@ class AuhenticationFailureListener implements EventSubscriberInterface
 
             if ($this->passwordHasherFactory instanceof PasswordHasherFactoryInterface) {
                 $hasher = $this->passwordHasherFactory->getPasswordHasher($user);
-                $hasher->hash(Uuid::v7()->__toString());
+                $hasher->hash(Uuid::v7()->toRfc4122());
             } else {
                 $encoder = $this->passwordHasherFactory->getEncoder($user);
-                $encoder->encodePassword(Uuid::v7()->__toString(), 'dummy-salt');
+                $encoder->encodePassword(Uuid::v7()->toRfc4122(), 'dummy-salt');
             }
         }
     }

--- a/src/Sulu/Bundle/SecurityBundle/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapter.php
+++ b/src/Sulu/Bundle/SecurityBundle/SingleSignOn/Adapter/OpenId/OpenIdSingleSignOnAdapter.php
@@ -87,9 +87,9 @@ class OpenIdSingleSignOnAdapter implements SingleSignOnAdapterInterface
         ?string $codeVerifier = null,
         ?string $codeChallengeMethod = null,
     ): array {
-        $state ??= Uuid::v7()->__toString();
+        $state ??= Uuid::v7()->toRfc4122();
         $attributes['state'] = $state;
-        $nonce ??= Uuid::v7()->__toString();
+        $nonce ??= Uuid::v7()->toRfc4122();
 
         $query = [
             'response_type' => 'code',
@@ -241,7 +241,7 @@ class OpenIdSingleSignOnAdapter implements SingleSignOnAdapterInterface
             $user = $this->userRepository->createNew();
             $user->setEmail($email);
             $user->setUsername($email);
-            $user->setPassword(Uuid::v7()->__toString()); // create a random password as a password is required
+            $user->setPassword(Uuid::v7()->toRfc4122()); // create a random password as a password is required
             $user->setSalt(\base64_encode(\random_bytes(32))); // copied from sulu SaltGenerator
             $user->setEnabled(true);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

<!-- Explain the contents of the PR. -->
Use `Uuid::v7()->toRfc4122()` instead of `Uuid::v7()->__toString()`.

#### Why?

Both methods output the `$this->uid` property, but `toRfc4122` also describes the returned format (e.g. `f81d4fae-7dec-11d0-a765-00a0c91e6bf6`)