### PR TITLE
Wrong cut icon in block toolbar

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -527,7 +527,7 @@ class BlockCollection<T: string, U: {type: T}> extends React.Component<Props<T, 
                     },
                     {
                         label: translate('sulu_admin.cut'),
-                        icon: 'su-cut',
+                        icon: 'su-scissors',
                         handleClick: this.handleCutSelectedBlocks,
                     },
                     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #7707
| License | MIT

Sorry for the noise with the other PR, I targeted the wrong branch...

#### Before

![Capture d’écran du 2024-12-19 22-51-37](https://github.com/user-attachments/assets/9d40b4e9-d01c-4dfa-952e-7421c5e0a374)

#### After

![Capture d’écran du 2024-12-21 01-02-57](https://github.com/user-attachments/assets/fff91983-25e1-4a1b-9285-9e4b39c1f925)

Fixes #7707