### PR TITLE
Reset handler_id in preview, too

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
@@ -1,6 +1,7 @@
 framework:
     session:
         storage_factory_id: session.storage.factory.mock_file
+        handler_id: ~
     profiler:
         enabled: false
 


### PR DESCRIPTION
This fixes the message "Warning: ini_set(): Session ini settings cannot be changed when a session is active" in preview. The warning can come up when handler_id is set to 'session.handler.native_file' in framework.yaml for the session.

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | #7713
| Related issues/PRs | #7086, #7101
| License | MIT
| Documentation PR | 

#### What's in this PR?

Resets the handler_id for the preview.

#### Why?

See #7713 

