### PR TITLE
Remove Expires & Pragma HTTP headers of Media Format response

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,10 @@
 
 ## 3.0.0
 
+### Changed Media Response Header
+
+Removed Pragma & Expires headers, as the Cache-Control header is enough
+
 ### Removed deprecations for 3.0
 
 Removed classes / services:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,9 +2,11 @@
 
 ## 3.0.0
 
-### Changed Media Response Header
+### Changed Media Format HTTP Response Headers
 
-Removed Pragma & Expires headers, as the Cache-Control header is enough
+Removed `Pragma` & `Expires` HTTP headers, as the `Cache-Control` header is enough.
+
+If you still want to readd them use `sulu_media.format_manager.response_headers` configuration.
 
 ### Removed deprecations for 3.0
 

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
@@ -90,8 +90,6 @@ class Configuration implements ConfigurationInterface
                 ->children()
                     ->arrayNode('response_headers')
                         ->prototype('scalar')->end()->defaultValue([
-                            'Expires' => '+1 month',
-                            'Pragma' => 'public',
                             'Cache-Control' => 'public, immutable, max-age=31536000',
                         ])
                     ->end()

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
@@ -292,7 +292,7 @@ class FormatManager implements FormatManagerInterface
             $date = new \DateTime();
             $date->modify($this->responseHeaders['Expires']);
             $headers['Expires'] = $date->format('D, d M Y H:i:s \G\M\T');
-        } else {
+        } elseif (!$setExpireHeaders) {
             // will remove exist set expire header
             $headers['Expires'] = null;
             $headers['Cache-Control'] = 'no-cache';

--- a/src/Sulu/Bundle/MediaBundle/Tests/Application/config/config.yml
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Application/config/config.yml
@@ -4,9 +4,6 @@ massive_search:
 sulu_media:
     search:
         enabled: true
-    format_manager:
-        response_headers:
-            Expires: "+1 month"
     image_format_files:
         - "%kernel.project_dir%/config/image-formats.xml"
     ffmpeg:

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaStreamControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaStreamControllerTest.php
@@ -141,10 +141,16 @@ class MediaStreamControllerTest extends WebsiteTestCase
         $this->client->request('GET', $media->getFormats()['small-inset']);
         $this->assertHttpStatusCode(200, $this->client->getResponse());
         $this->assertSame('image/jpeg', $this->client->getResponse()->headers->get('Content-Type'));
+        $this->assertSame('immutable, max-age=31536000, public', $this->client->getResponse()->headers->get('Cache-Control'));
+        $this->assertNull($this->client->getResponse()->headers->get('Expires'));
+        $this->assertNull($this->client->getResponse()->headers->get('Pragma'));
 
         $this->client->request('GET', $media->getFormats()['small-inset.gif']);
         $this->assertHttpStatusCode(200, $this->client->getResponse());
         $this->assertSame('image/gif', $this->client->getResponse()->headers->get('Content-Type'));
+        $this->assertSame('immutable, max-age=31536000, public', $this->client->getResponse()->headers->get('Cache-Control'));
+        $this->assertNull($this->client->getResponse()->headers->get('Expires'));
+        $this->assertNull($this->client->getResponse()->headers->get('Pragma'));
     }
 
     public function testGetImageActionSvg(): void

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/DependencyInjection/SuluMediaExtensionTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/DependencyInjection/SuluMediaExtensionTest.php
@@ -56,8 +56,6 @@ class SuluMediaExtensionTest extends AbstractExtensionTestCase
 
         $this->assertContainerBuilderHasService('sulu_media.media_manager');
         $this->assertContainerBuilderHasParameter('sulu_media.format_manager.response_headers', [
-            'Expires' => '+1 month',
-            'Pragma' => 'public',
             'Cache-Control' => 'public, immutable, max-age=31536000',
         ]);
         $this->assertContainerBuilderHasParameter('sulu_media.search.default_image_format', 'sulu-100x100');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3118 
| Related issues/PRs | #3118 
| License | MIT
| Documentation PR | 

#### What's in this PR?

Removes the HTTP 1.0 Headers Expires & Pragma

#### Why?

As suggested in #3118 