### PR TITLE
Fix the lastmod sitemap property when lastModified is empty string

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Sitemap/PagesSitemapProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Sitemap/PagesSitemapProvider.php
@@ -102,7 +102,12 @@ class PagesSitemapProvider extends AbstractSitemapProvider
         string $host,
         string $scheme
     ) {
-        $changed = $contentPage['lastModified'] ?? $contentPage['changed'];
+        $changed = $contentPage['changed'];
+
+        if (!empty($contentPage['lastModified'])) {
+            $changed = $contentPage['lastModified'];
+        }
+
         if (\is_string($changed)) {
             $changed = new \DateTime($changed);
         }

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Sitemap/PagesSitemapProviderTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Sitemap/PagesSitemapProviderTest.php
@@ -152,6 +152,7 @@ class PagesSitemapProviderTest extends TestCase
             $this->createContent('/test-1'),
             $this->createContent('/test-2', false, RedirectType::NONE, [], 'de', [], (new \DateTime())->modify('+1 day')->format('c')),
             $this->createContent('/test-3', false, RedirectType::NONE, [], 'de', [], (new \DateTime())->modify('-3 day')->format('c')),
+            $this->createContent('/test-4', false, RedirectType::NONE, [], 'de', [], ''),
         ];
 
         $this->contentRepository->findAllByPortal(
@@ -165,13 +166,17 @@ class PagesSitemapProviderTest extends TestCase
         )->willReturn($pages);
 
         $this->accessControlManager->getUserPermissionByArray('de', 'sulu.webspaces.sulu_io', [], null)
-            ->shouldBeCalledTimes(3);
+            ->shouldBeCalledTimes(4);
 
         $result = $this->sitemapProvider->build(1, 'http', 'localhost');
 
-        $this->assertCount(3, $result);
-        for ($i = 0; $i < 3; ++$i) {
-            $pageLastMod = $pages[$i]->getData()['lastModified'] ?? $pages[$i]->getData()['changed'];
+        $this->assertCount(4, $result);
+        for ($i = 0; $i < 4; ++$i) {
+            $pageLastMod = $pages[$i]->getData()['changed'];
+
+            if (!empty($pages[$i]->getData()['lastModified'])) {
+                $pageLastMod = $pages[$i]->getData()['lastModified'];
+            }
 
             $this->assertEquals('http://localhost' . $pages[$i]->getUrl(), $result[$i]->getLoc());
             $this->assertEquals(new \DateTime($pageLastMod), $result[$i]->getLastMod());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no 
| Fixed tickets | fixes #7719
| Related issues/PRs | no
| License | MIT
| Documentation PR | no

#### What's in this PR?

Fixes the `lastmod` sitemap property

#### Why?

`lastmod` is always the current date if `lastModified` is empty. Because it's an empty string it doesn't fallback to `changed`

