### PR TITLE
Use `tagged_iterator` instead of deprecated `tagged`

### DIFF
--- a/packages/content/config/resource-loader.xml
+++ b/packages/content/config/resource-loader.xml
@@ -7,7 +7,7 @@
         <service id="sulu_content.resource_loader_provider"
                  class="Sulu\Content\Application\ResourceLoader\ResourceLoaderProvider">
             <argument
-                type="tagged"
+                type="tagged_iterator"
                 tag="sulu_content.resource_loader"
                 default-index-method="getKey"
                 index-by="key"

--- a/packages/content/config/services.xml
+++ b/packages/content/config/services.xml
@@ -31,7 +31,7 @@
 
         <!-- ContentMerger -->
         <service id="sulu_content.content_merger" class="Sulu\Content\Application\ContentMerger\ContentMerger">
-            <argument type="tagged" tag="sulu_content.merger"/>
+            <argument type="tagged_iterator" tag="sulu_content.merger"/>
             <argument type="service" id="property_accessor"/>
         </service>
 
@@ -64,7 +64,7 @@
 
         <!-- Content Data Mapper -->
         <service id="sulu_content.content_data_mapper" class="Sulu\Content\Application\ContentDataMapper\ContentDataMapper">
-            <argument type="tagged" tag="sulu_content.data_mapper"/>
+            <argument type="tagged_iterator" tag="sulu_content.data_mapper"/>
         </service>
 
         <service id="Sulu\Content\Application\ContentDataMapper\ContentDataMapperInterface" alias="sulu_content.content_data_mapper"/>
@@ -119,7 +119,7 @@
 
         <!-- ContentNormalizer -->
         <service id="sulu_content.content_normalizer" class="Sulu\Content\Application\ContentNormalizer\ContentNormalizer">
-            <argument type="tagged" tag="sulu_content.normalizer"/>
+            <argument type="tagged_iterator" tag="sulu_content.normalizer"/>
         </service>
 
         <service id="Sulu\Content\Application\ContentNormalizer\ContentNormalizerInterface" alias="sulu_content.content_normalizer"/>

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -55,9 +55,9 @@
             id="sulu_admin.form_metadata_provider"
             class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataProvider"
         >
-            <argument type="tagged" tag="sulu_admin.form_metadata_loader"/>
-            <argument type="tagged" tag="sulu_admin.form_metadata_visitor"/>
-            <argument type="tagged" tag="sulu_admin.typed_form_metadata_visitor"/>
+            <argument type="tagged_iterator" tag="sulu_admin.form_metadata_loader"/>
+            <argument type="tagged_iterator" tag="sulu_admin.form_metadata_visitor"/>
+            <argument type="tagged_iterator" tag="sulu_admin.typed_form_metadata_visitor"/>
             <argument>%sulu_core.fallback_locale%</argument>
 
             <tag name="sulu_admin.metadata_provider" type="form" />
@@ -168,8 +168,8 @@
             id="sulu_admin.list_metadata_provider"
             class="Sulu\Bundle\AdminBundle\Metadata\ListMetadata\ListMetadataProvider"
         >
-            <argument type="tagged" tag="sulu_admin.list_metadata_loader"/>
-            <argument type="tagged" tag="sulu_admin.list_metadata_visitor"/>
+            <argument type="tagged_iterator" tag="sulu_admin.list_metadata_loader"/>
+            <argument type="tagged_iterator" tag="sulu_admin.list_metadata_visitor"/>
 
             <tag name="sulu_admin.metadata_provider" type="list" />
         </service>
@@ -387,7 +387,7 @@
 
         <service id="sulu_admin.field_metadata_validator.chain"
                  class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Validation\ChainFieldMetadataValidator">
-            <argument type="tagged" tag="sulu_admin.field_metadata_validator"/>
+            <argument type="tagged_iterator" tag="sulu_admin.field_metadata_validator"/>
         </service>
 
         <service id="sulu_admin.field_metadata_validator.types_property"

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/rest.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/rest.xml
@@ -36,7 +36,7 @@
             class="Sulu\Component\Rest\ListBuilder\Filter\FilterTypeRegistry"
         >
             <argument
-                type="tagged"
+                type="tagged_iterator"
                 tag="sulu_core.list_builder_filter_type"
                 index-by="alias"
                 default-index-method="getDefaultIndexName"

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -459,7 +459,7 @@
             id="sulu_media.file_inspector.subscriber"
             class="Sulu\Bundle\MediaBundle\FileInspector\UploadFileSubscriber"
         >
-            <argument type="tagged" tag="sulu_media.file_inspector"/>
+            <argument type="tagged_iterator" tag="sulu_media.file_inspector"/>
 
             <tag name="kernel.event_subscriber"/>
         </service>

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/sitemap.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/sitemap.xml
@@ -4,7 +4,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sulu_website.sitemap.pool" class="Sulu\Bundle\WebsiteBundle\Sitemap\SitemapProviderPool">
-            <argument type="tagged" tag="sulu.sitemap.provider"/>
+            <argument type="tagged_iterator" tag="sulu.sitemap.provider"/>
 
             <tag name="kernel.reset" method="reset"/>
         </service>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no (Only applications below Symfony 4.4)
| Deprecations? | Removing ones
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Replacing the service type `tagged` with the `tagged_iterator`.

#### Why?
Less deprecations from Symfony:
```
Since symfony/dependency-injection 7.2: Type "tagged" is deprecated for tag <argument>, use "tagged_iterator" instead in "/home/mamazu/packages/sulu/sulu/packages/content/config/services.xml".
```

In Symfony the `tagged` type was introduced in 4.4 and Symfony converted to the new type in 5.0.
