### PR TITLE
Fixing cache plugin

### DIFF
--- a/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/SuluHttpCacheExtension.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/SuluHttpCacheExtension.php
@@ -34,6 +34,9 @@ class SuluHttpCacheExtension extends Extension implements PrependExtensionInterf
             'debug' => [
                 'enabled' => $config['debug']['enabled'],
             ],
+            'cache_control' => [
+                'ttl_header' => 'X-Reverse-Proxy-TTL',
+            ]
         ];
 
         if (\array_key_exists('noop', $config['proxy_client'])) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Passing the required config to the fos-http-cache.

#### Why?
In Version 3.1.0 the friendsofsymfony/http-cache-bundle added a parameter to the `FOS\HttpCacheBundle\EventListener\CacheControlListener`. While this parameter has a default value, the bundle setting it up does not. 
See:
 https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/blob/7b737f770941bfb67e065d1be5975aa26a3ee2d7/src/DependencyInjection/FOSHttpCacheExtension.php#L51C1-L51C3

So we need to pass the value manually.

Maybe we could also update the bundle to 3.1.0 if they're doing BC breaks in minor versions now.