### PR TITLE
Use `tagged_iterator` for Initalizer services

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -183,6 +183,14 @@ This will only create the service `sulu_media.storage` as the alias to `sulu_med
 The image formats URL requires an exact filename match to retrieve the correct image format. 
 Old versions will be redirected to the new version and any non-matching filenames will now return a 404 error.
 
+### Replacing compiler passes with `tagged_iterator`s
+
+We have replaced the manual logic of getting a list of tagged services to the Symfony `tagged_iterator` argument. This
+means that the following classes have been deprecated:
+- `Sulu\\Bundle\\DocumentManagerBundle\\DependencyInjection\\Compiler\\InitializerPass`
+
+This now also means that all services tagged with the `sulu_document_manger.initializer` are now private by default.
+
 ## 2.6.3
 
 ### Change locale length

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11311,16 +11311,6 @@ parameters:
 			path: src/Sulu/Bundle/DocumentManagerBundle/Document/Subscriber/SecuritySubscriber.php
 
 		-
-			message: "#^Cannot call method initialize\\(\\) on object\\|null\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/DocumentManagerBundle/Initializer/Initializer.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\Initializer\\\\Initializer\\:\\:initialize\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/DocumentManagerBundle/Initializer/Initializer.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\Initializer\\\\InitializerInterface\\:\\:initialize\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/DocumentManagerBundle/Initializer/InitializerInterface.php

--- a/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Compiler/InitializerPass.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Compiler/InitializerPass.php
@@ -14,6 +14,11 @@ namespace Sulu\Bundle\DocumentManagerBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+/**
+ * @internal
+ *
+ * @deprecated Since 2.6 use tagged_iterator instead
+ */
 class InitializerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)

--- a/src/Sulu/Bundle/DocumentManagerBundle/Initializer/Initializer.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Initializer/Initializer.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\DocumentManagerBundle\Initializer;
 
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Content repository initializer.
@@ -28,11 +27,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class Initializer
 {
     /**
-     * @param array<string, int> $initializerMap
+     * @param iterable<string, InitializerInterface> $initializerMap
      */
     public function __construct(
-        private ContainerInterface $container,
-        private array $initializerMap = []
+        private iterable $initializerMap = []
     ) {
     }
 
@@ -40,16 +38,15 @@ class Initializer
      * Initialize the content repository, optionally purging it before-hand.
      *
      * @param bool $purge
+     *
+     * @return void
      */
     public function initialize(?OutputInterface $output = null, $purge = false)
     {
         $output = $output ?: new NullOutput();
 
-        \arsort($this->initializerMap);
-
-        foreach (\array_keys($this->initializerMap) as $initializerId) {
-            $output->writeln(\sprintf('<comment>%s</>', $initializerId));
-            $initializer = $this->container->get($initializerId);
+        foreach ($this->initializerMap as $serviceId => $initializer) {
+            $output->writeln(\sprintf('<comment>%s</>', $serviceId));
             $initializer->initialize($output, $purge);
         }
         $output->write(\PHP_EOL);

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/core.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/core.xml
@@ -117,8 +117,7 @@
         </service>
 
         <service id="sulu_document_manager.initializer" class="Sulu\Bundle\DocumentManagerBundle\Initializer\Initializer" public="true">
-            <argument type="service" id="service_container" />
-            <argument type="collection" />
+            <argument type="tagged_iterator" tag="sulu_document_manager.initializer" index-by="id" />
         </service>
 
         <service id="sulu_document_manager.initializer.workspace" class="Sulu\Bundle\DocumentManagerBundle\Initializer\WorkspaceInitializer">

--- a/src/Sulu/Bundle/DocumentManagerBundle/SuluDocumentManagerBundle.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/SuluDocumentManagerBundle.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\DocumentManagerBundle;
 
 use Sulu\Bundle\DocumentManagerBundle\DependencyInjection\Compiler\DocumentFixturePass;
-use Sulu\Bundle\DocumentManagerBundle\DependencyInjection\Compiler\InitializerPass;
 use Sulu\Bundle\DocumentManagerBundle\DependencyInjection\Compiler\RegisterListenersPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -29,7 +28,7 @@ class SuluDocumentManagerBundle extends Bundle
     public function build(ContainerBuilder $container): void
     {
         parent::build($container);
-        $container->addCompilerPass(new InitializerPass());
+
         $container->addCompilerPass(new RegisterListenersPass(
             'sulu_document_manager.event_dispatcher',
             'sulu_document_manager.event_listener',

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Initialalizer/InitializerTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Initialalizer/InitializerTest.php
@@ -17,16 +17,10 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\DocumentManagerBundle\Initializer\Initializer;
 use Sulu\Bundle\DocumentManagerBundle\Initializer\InitializerInterface;
 use Symfony\Component\Console\Output\NullOutput;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class InitializerTest extends TestCase
 {
     use ProphecyTrait;
-
-    /**
-     * @var ObjectProphecy<ContainerInterface>
-     */
-    private $container;
 
     /**
      * @var ObjectProphecy<InitializerInterface>
@@ -50,23 +44,15 @@ class InitializerTest extends TestCase
 
     public function setUp(): void
     {
-        $this->container = $this->prophesize(ContainerInterface::class);
         $this->initializer1 = $this->prophesize(InitializerInterface::class);
         $this->initializer2 = $this->prophesize(InitializerInterface::class);
         $this->initializer3 = $this->prophesize(InitializerInterface::class);
 
-        $this->initializer = new Initializer(
-            $this->container->reveal(),
-            [
-                'service1' => 50,
-                'service2' => 10,
-                'service3' => 29,
-            ]
-        );
-
-        $this->container->get('service1')->willReturn($this->initializer1->reveal());
-        $this->container->get('service2')->willReturn($this->initializer2->reveal());
-        $this->container->get('service3')->willReturn($this->initializer3->reveal());
+        $this->initializer = new Initializer([
+            'service1' => $this->initializer1->reveal(),
+            'service3' => $this->initializer3->reveal(),
+            'service2' => $this->initializer2->reveal(),
+        ]);
     }
 
     public function testInitialize(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? |  yes
| Deprecations? |  yes
| Fixed tickets | -
| Related issues/PRs | #7402 
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?
Replacing the `InitializerPass` with a tagged iterator.

BC Breaks:
- The signiture of the Initializer has changed.
- All Initializers are now private by default because we don't need the container anymore.

#### Why?
All of what the `InitializerPass` can do the tagged iterator can do as well.