### PR TITLE
Fix null deprecations for rtrim and json_decode

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -40751,11 +40751,6 @@ parameters:
 			path: src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function usort expects callable\\(Sulu\\\\Component\\\\Content\\\\Types\\\\ResourceLocator\\\\ResourceLocatorInformation, Sulu\\\\Component\\\\Content\\\\Types\\\\ResourceLocator\\\\ResourceLocatorInformation\\)\\: int, Closure\\(Sulu\\\\Component\\\\Content\\\\Types\\\\ResourceLocator\\\\ResourceLocatorInformation, Sulu\\\\Component\\\\Content\\\\Types\\\\ResourceLocator\\\\ResourceLocatorInformation\\)\\: bool given\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
-
-		-
 			message: "#^Parameter \\#2 \\$created of class Sulu\\\\Component\\\\Content\\\\Types\\\\ResourceLocator\\\\ResourceLocatorInformation constructor expects DateTime\\|null, mixed given\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
@@ -49917,11 +49912,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$domain of method Sulu\\\\Component\\\\Webspace\\\\Manager\\\\WebspaceManager\\:\\:isFromDomain\\(\\) expects string, string\\|null given\\.$#"
-			count: 2
-			path: src/Sulu/Component/Webspace/Manager/WebspaceManager.php
-
-		-
-			message: "#^Parameter \\#2 \\$resourceLocator of method Sulu\\\\Component\\\\Webspace\\\\Manager\\\\WebspaceManager\\:\\:createResourceLocatorUrl\\(\\) expects string, string\\|null given\\.$#"
 			count: 2
 			path: src/Sulu/Component/Webspace/Manager/WebspaceManager.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4281,11 +4281,6 @@ parameters:
 			path: src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function usort expects callable\\(mixed, mixed\\)\\: int, Closure\\(mixed, mixed\\)\\: bool given\\.$#"
-			count: 13
-			path: src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
-
-		-
 			message: "#^Cannot access offset 'code' on mixed\\.$#"
 			count: 2
 			path: src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/KeywordControllerTest.php
@@ -4493,11 +4488,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
 			count: 15
-			path: src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/KeywordControllerTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$callback of function usort expects callable\\(mixed, mixed\\)\\: int, Closure\\(mixed, mixed\\)\\: bool given\\.$#"
-			count: 1
 			path: src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/KeywordControllerTest.php
 
 		-
@@ -11126,11 +11116,6 @@ parameters:
 			path: src/Sulu/Bundle/DocumentManagerBundle/Command/SubscriberDebugCommand.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function usort expects callable\\(array\\{string, mixed, mixed\\}, array\\{string, mixed, mixed\\}\\)\\: int, Closure\\(mixed, mixed\\)\\: bool given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/DocumentManagerBundle/Command/SubscriberDebugCommand.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\DataFixtures\\\\DocumentExecutor\\:\\:execute\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/DocumentManagerBundle/DataFixtures/DocumentExecutor.php
@@ -11147,11 +11132,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\DataFixtures\\\\DocumentExecutor\\:\\:execute\\(\\) has parameter \\$purge with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/DocumentManagerBundle/DataFixtures/DocumentExecutor.php
-
-		-
-			message: "#^Parameter \\#2 \\$callback of function usort expects callable\\(mixed, mixed\\)\\: int, Closure\\(Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\DataFixtures\\\\DocumentFixtureInterface, Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\DataFixtures\\\\DocumentFixtureInterface\\)\\: bool given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/DocumentManagerBundle/DataFixtures/DocumentExecutor.php
 

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
@@ -199,7 +199,7 @@ class CategoryControllerTest extends SuluTestCase
         \usort(
             $categories,
             function($cat1, $cat2) {
-                return $cat1->id > $cat2->id;
+                return $cat1->id <=> $cat2->id;
             }
         );
 
@@ -309,7 +309,7 @@ class CategoryControllerTest extends SuluTestCase
         \usort(
             $categories,
             function($cat1, $cat2) {
-                return $cat1->id > $cat2->id;
+                return $cat1->id <=> $cat2->id;
             }
         );
 
@@ -362,7 +362,7 @@ class CategoryControllerTest extends SuluTestCase
         \usort(
             $categories,
             function($cat1, $cat2) {
-                return $cat1->id > $cat2->id;
+                return $cat1->id <=> $cat2->id;
             }
         );
 
@@ -415,7 +415,7 @@ class CategoryControllerTest extends SuluTestCase
         \usort(
             $categories,
             function($cat1, $cat2) {
-                return $cat1->id > $cat2->id;
+                return $cat1->id <=> $cat2->id;
             }
         );
 
@@ -471,7 +471,7 @@ class CategoryControllerTest extends SuluTestCase
         \usort(
             $categories,
             function($cat1, $cat2) {
-                return $cat1->id > $cat2->id;
+                return $cat1->id <=> $cat2->id;
             }
         );
 
@@ -565,7 +565,7 @@ class CategoryControllerTest extends SuluTestCase
         \usort(
             $categories,
             function($cat1, $cat2) {
-                return $cat1->id > $cat2->id;
+                return $cat1->id <=> $cat2->id;
             }
         );
 
@@ -601,7 +601,7 @@ class CategoryControllerTest extends SuluTestCase
         \usort(
             $categories,
             function($cat1, $cat2) {
-                return $cat1->id > $cat2->id;
+                return $cat1->id <=> $cat2->id;
             }
         );
 
@@ -640,7 +640,7 @@ class CategoryControllerTest extends SuluTestCase
         \usort(
             $categories,
             function($cat1, $cat2) {
-                return $cat1->id > $cat2->id;
+                return $cat1->id <=> $cat2->id;
             }
         );
 
@@ -709,7 +709,7 @@ class CategoryControllerTest extends SuluTestCase
         \usort(
             $categories,
             function($cat1, $cat2) {
-                return $cat1->id > $cat2->id;
+                return $cat1->id <=> $cat2->id;
             }
         );
 
@@ -750,7 +750,7 @@ class CategoryControllerTest extends SuluTestCase
         \usort(
             $categories,
             function($cat1, $cat2) {
-                return $cat1->id > $cat2->id;
+                return $cat1->id <=> $cat2->id;
             }
         );
 
@@ -804,7 +804,7 @@ class CategoryControllerTest extends SuluTestCase
         \usort(
             $categories,
             function($cat1, $cat2) {
-                return $cat1->id > $cat2->id;
+                return $cat1->id <=> $cat2->id;
             }
         );
 
@@ -893,7 +893,7 @@ class CategoryControllerTest extends SuluTestCase
         \usort(
             $categories,
             function($cat1, $cat2) {
-                return $cat1->id > $cat2->id;
+                return $cat1->id <=> $cat2->id;
             }
         );
 
@@ -945,7 +945,7 @@ class CategoryControllerTest extends SuluTestCase
         \usort(
             $categories,
             function($cat1, $cat2) {
-                return $cat1->id > $cat2->id;
+                return $cat1->id <=> $cat2->id;
             }
         );
 

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/KeywordControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/KeywordControllerTest.php
@@ -93,7 +93,7 @@ class KeywordControllerTest extends SuluTestCase
         $this->assertEquals(2, $response->total);
 
         \usort($response->_embedded->category_keywords, function($key1, $key2) {
-            return $key1->id > $key2->id;
+            return $key1->id <=> $key2->id;
         });
 
         $this->assertEquals('keyword1', $response->_embedded->category_keywords[0]->keyword);

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/SubscriberDebugCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/SubscriberDebugCommand.php
@@ -66,7 +66,7 @@ class SubscriberDebugCommand extends Command
         }
 
         \usort($rows, function($a, $b) {
-            return $a[2] < $b[2];
+            return $b[2] <=> $a[2];
         });
 
         $table = new Table($output);

--- a/src/Sulu/Bundle/DocumentManagerBundle/DataFixtures/DocumentExecutor.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/DataFixtures/DocumentExecutor.php
@@ -38,7 +38,7 @@ class DocumentExecutor
     public function execute(array $fixtures, $purge = true, $initialize = true, ?OutputInterface $output = null)
     {
         \usort($fixtures, function(DocumentFixtureInterface $fixture1, DocumentFixtureInterface $fixture2) {
-            return $fixture1->getOrder() > $fixture2->getOrder();
+            return $fixture1->getOrder() <=> $fixture2->getOrder();
         });
 
         $output = $output ?: new NullOutput();

--- a/src/Sulu/Bundle/PageBundle/Teaser/TeaserContentType.php
+++ b/src/Sulu/Bundle/PageBundle/Teaser/TeaserContentType.php
@@ -56,7 +56,7 @@ class TeaserContentType extends SimpleContentType implements PreResolvableConten
 
     protected function decodeValue($value)
     {
-        return \json_decode($value, true);
+        return $value !== null ? json_decode($value, true) : null;
     }
 
     protected function encodeValue($value)

--- a/src/Sulu/Bundle/PageBundle/Teaser/TeaserContentType.php
+++ b/src/Sulu/Bundle/PageBundle/Teaser/TeaserContentType.php
@@ -56,7 +56,7 @@ class TeaserContentType extends SimpleContentType implements PreResolvableConten
 
     protected function decodeValue($value)
     {
-        return $value !== null ? json_decode($value, true) : null;
+        return null !== $value ? \json_decode($value, true) : null;
     }
 
     protected function encodeValue($value)

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
@@ -214,7 +214,7 @@ class PhpcrMapper implements ResourceLocatorMapperInterface
         \usort(
             $result,
             function(ResourceLocatorInformation $item1, ResourceLocatorInformation $item2) {
-                return $item1->getCreated() < $item2->getCreated();
+                return $item2->getCreated() <=> $item1->getCreated();
             }
         );
 

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -291,7 +291,7 @@ class WebspaceManager implements WebspaceManagerInterface
 
         $this->portalUrlCache[$webspaceKey][$domain][$environment][$languageCode] = $portalUrl;
 
-        if (!$portalUrl || $resourceLocator === null) {
+        if (!$portalUrl) {
             return null;
         }
 

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -209,6 +209,9 @@ class WebspaceManager implements WebspaceManagerInterface
             $currentWebspace = $this->getCurrentWebspace();
             $webspaceKey = $currentWebspace ? $currentWebspace->getKey() : $webspaceKey;
         }
+        if (null === $resourceLocator) {
+            $resourceLocator = '/';
+        }
 
         if (isset($this->portalUrlCache[$webspaceKey][$domain][$environment][$languageCode])) {
             $portalUrl = $this->portalUrlCache[$webspaceKey][$domain][$environment][$languageCode];
@@ -288,7 +291,7 @@ class WebspaceManager implements WebspaceManagerInterface
 
         $this->portalUrlCache[$webspaceKey][$domain][$environment][$languageCode] = $portalUrl;
 
-        if (!$portalUrl) {
+        if (!$portalUrl || $resourceLocator === null) {
             return null;
         }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Adds some checks to prevent deprecations:
`Deprecated: rtrim(): Passing null to parameter #1 ($string) of type string is deprecated`
`Deprecated: json_decode(): Passing null to parameter #1 ($json) of type string is deprecated`
`Deprecated: usort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero`

