### PR TITLE
Add support for the doctrine fixtures 2 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "doctrine/annotations": "^1.2 || ^2.0",
         "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/collections": "^1.0 || ^2.0",
-        "doctrine/data-fixtures": "^1.3.3",
+        "doctrine/data-fixtures": "^1.3.3 || ^2.0",
         "doctrine/dbal": "^2.13 || ^3.0",
         "doctrine/doctrine-bundle": "^2.4",
         "doctrine/doctrine-fixtures-bundle": "^3.3 || ^4.0",

--- a/src/Sulu/Bundle/ContactBundle/DataFixtures/ORM/LoadDefaultTypes.php
+++ b/src/Sulu/Bundle/ContactBundle/DataFixtures/ORM/LoadDefaultTypes.php
@@ -23,9 +23,13 @@ use Sulu\Bundle\ContactBundle\Entity\PhoneType;
 use Sulu\Bundle\ContactBundle\Entity\SocialMediaProfileType;
 use Sulu\Bundle\ContactBundle\Entity\UrlType;
 
+/**
+ * @internal This is an internal class which should not be used by a project.
+ *           Instead Create your own fixtures file instead.
+ */
 class LoadDefaultTypes extends AbstractFixture implements OrderedFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         // Phone types.
         $metadata = $manager->getClassMetaData(PhoneType::class);

--- a/src/Sulu/Bundle/ContactBundle/DataFixtures/ORM/LoadDefaultTypes.php
+++ b/src/Sulu/Bundle/ContactBundle/DataFixtures/ORM/LoadDefaultTypes.php
@@ -24,6 +24,8 @@ use Sulu\Bundle\ContactBundle\Entity\SocialMediaProfileType;
 use Sulu\Bundle\ContactBundle\Entity\UrlType;
 
 /**
+ * @final
+ *
  * @internal This is an internal class which should not be used by a project.
  *           Instead Create your own fixtures file instead.
  */

--- a/src/Sulu/Bundle/ContactBundle/DataFixtures/ORM/LoadDefaultTypes.php
+++ b/src/Sulu/Bundle/ContactBundle/DataFixtures/ORM/LoadDefaultTypes.php
@@ -182,7 +182,7 @@ class LoadDefaultTypes extends AbstractFixture implements OrderedFixtureInterfac
         $manager->flush();
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 2;
     }

--- a/src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadCollectionTypes.php
+++ b/src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadCollectionTypes.php
@@ -19,9 +19,13 @@ use Doctrine\Persistence\ObjectManager;
 use Sulu\Bundle\MediaBundle\Entity\CollectionType;
 use Sulu\Component\Media\SystemCollections\SystemCollectionManagerInterface;
 
+/**
+ * @internal This is an internal class which should not be used by a project.
+ *           Instead Create your own fixtures file instead.
+ */
 class LoadCollectionTypes extends AbstractFixture implements OrderedFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         // set id manually
         $metadata = $manager->getClassMetaData(CollectionType::class);

--- a/src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadCollectionTypes.php
+++ b/src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadCollectionTypes.php
@@ -57,7 +57,7 @@ class LoadCollectionTypes extends AbstractFixture implements OrderedFixtureInter
         $manager->flush();
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 3;
     }

--- a/src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadCollectionTypes.php
+++ b/src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadCollectionTypes.php
@@ -20,6 +20,8 @@ use Sulu\Bundle\MediaBundle\Entity\CollectionType;
 use Sulu\Component\Media\SystemCollections\SystemCollectionManagerInterface;
 
 /**
+ * @final
+ *
  * @internal This is an internal class which should not be used by a project.
  *           Instead Create your own fixtures file instead.
  */

--- a/src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadMediaTypes.php
+++ b/src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadMediaTypes.php
@@ -18,9 +18,13 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 use Sulu\Bundle\MediaBundle\Entity\MediaType;
 
+/**
+ * @internal This is an internal class which should not be used by a project.
+ *           Instead Create your own fixtures file instead.
+ */
 class LoadMediaTypes extends AbstractFixture implements OrderedFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         // set id manually
         $metadata = $manager->getClassMetaData(MediaType::class);

--- a/src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadMediaTypes.php
+++ b/src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadMediaTypes.php
@@ -68,7 +68,7 @@ class LoadMediaTypes extends AbstractFixture implements OrderedFixtureInterface
         $manager->flush();
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 4;
     }

--- a/src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadMediaTypes.php
+++ b/src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadMediaTypes.php
@@ -19,6 +19,8 @@ use Doctrine\Persistence\ObjectManager;
 use Sulu\Bundle\MediaBundle\Entity\MediaType;
 
 /**
+ * @final
+ *
  * @internal This is an internal class which should not be used by a project.
  *           Instead Create your own fixtures file instead.
  */

--- a/src/Sulu/Bundle/SecurityBundle/DataFixtures/ORM/LoadSecurityTypes.php
+++ b/src/Sulu/Bundle/SecurityBundle/DataFixtures/ORM/LoadSecurityTypes.php
@@ -20,6 +20,11 @@ use Sulu\Bundle\SecurityBundle\Entity\SecurityType;
  * Load security-types from xml to database.
  *
  * @deprecated
+ *
+ * @final
+ *
+ * @internal This is an internal class which should not be used by a project.
+ *            Instead Create your own fixtures file instead.
  */
 class LoadSecurityTypes implements FixtureInterface, OrderedFixtureInterface
 {
@@ -28,7 +33,7 @@ class LoadSecurityTypes implements FixtureInterface, OrderedFixtureInterface
     ) {
     }
 
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         // get already present
         $qb = $manager->createQueryBuilder();
@@ -79,7 +84,7 @@ class LoadSecurityTypes implements FixtureInterface, OrderedFixtureInterface
         $manager->flush();
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 5;
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | technical yes but the fixtures classes should have been internal and not public
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add support for the doctrine fixtures 2 version.

#### Why?

Update things to latest version to get read of outdated dependencies in `composer outdated`.