### PR TITLE
Fix issue with trailing slash in Matomo analytics templates

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Analytics/matomo/body-open.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Analytics/matomo/body-open.html.twig
@@ -1,1 +1,1 @@
-<noscript><p><img referrerpolicy="no-referrer-when-downgrade" src="{{ analytics.content.url }}/matomo.php?idsite={{ analytics.content.siteId }}&amp;rec=1" style="border:0;" alt="" /></p></noscript>
+<noscript><p><img referrerpolicy="no-referrer-when-downgrade" src="{{ analytics.content.url|trim('/', 'right') }}/matomo.php?idsite={{ analytics.content.siteId }}&amp;rec=1" style="border:0;" alt="" /></p></noscript>

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Analytics/matomo/head-close.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Analytics/matomo/head-close.html.twig
@@ -3,10 +3,10 @@
     _paq.push(['trackPageView']);
     _paq.push(['enableLinkTracking']);
     (function() {
-        var u="{{ analytics.content.url|trim('/') }}";
-        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        var u="{{ analytics.content.url|trim('/', 'right') }}";
+        _paq.push(['setTrackerUrl', u+'/matomo.php']);
         _paq.push(['setSiteId', '{{ analytics.content.siteId }}']);
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+        g.async=true; g.src=u+'/matomo.js'; s.parentNode.insertBefore(g,s);
     })();
 </script>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #7732
| Related issues/PRs | #7692 #7693
| License | MIT

#### What's in this PR?

Fixed for missing trailing slashes.

#### Why?

In order to fix Matomo URLs.

#### Context

Follow-up to 84a6d7bf61e3e642064e91eb8fd9eaa50488ef67