### PR TITLE
Remove deprecated `$entityKeys` on controllers

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -30,7 +30,18 @@ Removed deprecated functions and properties:
 - `Sulu\Component\Webspace\Portal::getXDefaultLocalization`
 - `Sulu\Component\Webspace\Portal::setXDefaultLocalization`
 - `Sulu\Component\Localization\Localization::isXDefault`
+- `Sulu\Bundle\ContactBundle\Controller\AccountController::$contactEntityKey`
+- `Sulu\Bundle\ContactBundle\Controller\AccountController::$entityKey`
+- `Sulu\Bundle\WebsiteBundle\Controller\AnalyticsController::$entityKey`
+- `Sulu\Bundle\CategoryBundle\Controller\CategoryController::$entityKey`
+- `Sulu\Bundle\MediaBundle\Controller\CollectionController::$entityKey`
 - `Sulu\Bundle\MediaBundle\Controller\MediaController::$entityKey`
+- `Sulu\Bundle\PageBundle\Controller\PageController::$entityKey`
+- `Sulu\Bundle\TagBundle\Controller\TagController::$entityKey`
+- `Sulu\Bundle\SecurityBundle\Controller\UserController::$entityKey`
+- `Sulu\Bundle\ContactBundle\Controller\ContactTitleController::$entityKey`
+- `Sulu\Bundle\ContactBundle\Controller\ContactController::$entityKey`
+- `Sulu\Bundle\ContactBundle\Controller\PositionController::$entityKey`
 
 Removed unused arguments:
 

--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -41,11 +41,6 @@ class CategoryController extends AbstractRestController implements ClassResource
     use RequestParametersTrait;
 
     /**
-     * @deprecated Use the CategoryInterface::RESOURCE_KEY constant instead
-     */
-    protected static $entityKey = 'categories';
-
-    /**
      * @param class-string $categoryClass
      */
     public function __construct(

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -55,17 +55,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  */
 class AccountController extends AbstractRestController implements ClassResourceInterface, SecuredControllerInterface
 {
-    /**
-     * @deprecated Use the AccountInterface::RESOURCE_KEY constant instead
-     */
-    protected static $entityKey = 'accounts';
-
     protected static $positionEntityName = \Sulu\Bundle\ContactBundle\Entity\Position::class;
-
-    /**
-     * @deprecated Use the ContactInterface::RESOURCE_KEY constant instead
-     */
-    protected static $contactEntityKey = 'contacts';
 
     protected static $accountContactEntityName = AccountContactEntity::class;
 

--- a/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
@@ -45,15 +45,6 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  */
 class ContactController extends AbstractRestController implements ClassResourceInterface, SecuredControllerInterface
 {
-    /**
-     * @deprecated
-     *
-     * @see ContactInterface::RESOURCE_KEY
-     *
-     * @var string
-     */
-    protected static $entityKey = ContactInterface::RESOURCE_KEY;
-
     protected static $accountContactEntityName = \Sulu\Bundle\ContactBundle\Entity\AccountContact::class;
 
     protected static $positionEntityName = \Sulu\Bundle\ContactBundle\Entity\Position::class;

--- a/src/Sulu/Bundle/ContactBundle/Controller/ContactTitleController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/ContactTitleController.php
@@ -35,15 +35,6 @@ class ContactTitleController extends AbstractRestController implements ClassReso
 {
     protected static $entityName = ContactTitle::class;
 
-    /**
-     * @var string
-     *
-     * @deprecated
-     *
-     * @see ContactTitle::RESOURCE_KEY
-     */
-    protected static $entityKey = ContactTitle::RESOURCE_KEY;
-
     public function __construct(
         ViewHandlerInterface $viewHandler,
         private ContactTitleRepository $contactTitleRepository,

--- a/src/Sulu/Bundle/ContactBundle/Controller/PositionController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/PositionController.php
@@ -35,15 +35,6 @@ class PositionController extends AbstractRestController implements ClassResource
 {
     protected static $entityName = Position::class;
 
-    /**
-     * @var string
-     *
-     * @deprecated
-     *
-     * @see Position::RESOURCE_KEY
-     */
-    protected static $entityKey = Position::RESOURCE_KEY;
-
     public function __construct(
         ViewHandlerInterface $viewHandler,
         private PositionRepository $positionRepository,

--- a/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
@@ -49,13 +49,6 @@ class CollectionController extends AbstractRestController implements ClassResour
      */
     protected static $entityName = \Sulu\Bundle\MediaBundle\Entity\Collection::class;
 
-    /**
-     * @var string
-     *
-     * @deprecated Use CollectionInterface::RESOURCE_KEY instead
-     */
-    protected static $entityKey = CollectionInterface::RESOURCE_KEY;
-
     public function __construct(
         ViewHandlerInterface $viewHandler,
         TokenStorageInterface $tokenStorage,

--- a/src/Sulu/Bundle/PageBundle/Controller/PageController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/PageController.php
@@ -59,13 +59,6 @@ class PageController extends AbstractRestController implements ClassResourceInte
 
     public const WEBSPACE_NODES_ALL = 'all';
 
-    /**
-     * @deprecated Use the BasePageDocument::RESOURCE_KEY constant instead
-     *
-     * @var string
-     */
-    protected static $relationName = BasePageDocument::RESOURCE_KEY;
-
     public function __construct(
         ViewHandlerInterface $viewHandler,
         TokenStorageInterface $tokenStorage,

--- a/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
@@ -44,11 +44,6 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class RoleController extends AbstractRestController implements ClassResourceInterface, SecuredControllerInterface
 {
-    /**
-     * @deprecated Use the RoleInterface::RESOURCE_KEY constant instead
-     */
-    protected static $entityKey = 'roles';
-
     public const ENTITY_NAME_PERMISSION = Permission::class;
 
     protected $bundlePrefix = 'security.roles.';

--- a/src/Sulu/Bundle/SecurityBundle/Controller/UserController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/UserController.php
@@ -39,11 +39,6 @@ class UserController extends AbstractRestController implements ClassResourceInte
 {
     use RequestParametersTrait;
 
-    /**
-     * @deprecated Use the UserInterface::RESOURCE_KEY constant instead
-     */
-    protected static $entityKey = 'users';
-
     public function __construct(
         ViewHandlerInterface $viewHandler,
         private RestHelperInterface $restHelper,

--- a/src/Sulu/Bundle/TagBundle/Controller/TagController.php
+++ b/src/Sulu/Bundle/TagBundle/Controller/TagController.php
@@ -42,11 +42,6 @@ class TagController extends AbstractRestController implements ClassResourceInter
 {
     protected static $entityName = \Sulu\Bundle\TagBundle\Entity\Tag::class;
 
-    /**
-     * @deprecated Use the TagInterface::RESOURCE_KEY constant instead
-     */
-    protected static $entityKey = 'tags';
-
     protected $unsortable = [];
 
     protected $bundlePrefix = 'tags.';

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/AnalyticsController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/AnalyticsController.php
@@ -32,11 +32,6 @@ use Symfony\Component\HttpFoundation\Response;
 class AnalyticsController extends AbstractRestController implements ClassResourceInterface, SecuredControllerInterface
 {
     /**
-     * @deprecated Use the AnalyticsInterface::RESOURCE_KEY constant instead
-     */
-    public const RESULT_KEY = 'analytics';
-
-    /**
      * @var AnalyticsManagerInterface
      */
     private $analyticsManager;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #7547
| License | MIT
| Documentation PR | -

#### What's in this PR?
Replacing the `$entityKey` properties with the `RESOURCE_KEY` property of the entities.

#### Why?
Less code to maintain