### PR TITLE
Add possibility for legacy password upgrade

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,14 +2,40 @@
 
 ## 2.5.23
 
-### User entity method return types changed
+### User getSalt method return types changed
 
-The sulu `User` entity requires the following changes:
+To support upgrade of `Legacy` passwords hashes from Sulu 1.6, the Sulu `User::getSalt` method requires the following changes if you have overwritten it:
 
 ```diff
 -public function getSalt();
 +public function getSalt(): ?string;
 ```
+
+If migrating from an old Sulu 1.6 project you can configure a legacy hasher to seamlessly upgrade the Users password:
+
+<details>
+<summary>Example Password Upgrade configuration:</summary>
+
+```yaml
+# config/packages/security.yaml
+security:
+    # ...
+    password_hashers:
+        legacy:
+            algorithm: sha512
+            iterations: 5000
+            encode_as_base64: false
+
+        Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface:
+            algorithm: bcrypt
+            migrate_from:
+                - legacy
+    # ...
+```
+
+See also the Symfony Password Upgrade Documentation [here](https://symfony.com/doc/6.4/security/passwords.html#upgrade-the-password).
+
+</details>
 
 ## 2.5.20
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,16 @@
 # Upgrade
 
+## 2.5.23
+
+### User entity method return types changed
+
+The sulu `User` entity requires the following changes:
+
+```diff
+-public function getSalt();
++public function getSalt(): ?string;
+```
+
 ## 2.5.20
 
 ### Stricter Image Format Url Handling

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,14 +4,14 @@
 
 ### User getSalt method return types changed
 
-To support upgrade of `Legacy` passwords hashes from Sulu 1.6, the Sulu `User::getSalt` method requires the following changes if you have overwritten it:
+To support the upgrade of `Legacy` password hashes from Sulu 1.6, the `User::getSalt` method requires the following changes if you have overwritten it:
 
 ```diff
 -public function getSalt();
 +public function getSalt(): ?string;
 ```
 
-If migrating from an old Sulu 1.6 project you can configure a legacy hasher to seamlessly upgrade the Users password:
+If migrating from an old Sulu 1.6 project, you can configure a legacy hasher to seamlessly upgrade the user's password:
 
 <details>
 <summary>Example Password Upgrade configuration:</summary>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -27776,6 +27776,11 @@ parameters:
 			path: src/Sulu/Bundle/SecurityBundle/Twig/UserTwigExtension.php
 
 		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\PasswordAuthenticatedUserInterface\\:\\:setPassword\\(\\)\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/SecurityBundle/User/UserProvider.php
+
+		-
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\:\\:getId\\(\\)\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/User/UserProvider.php

--- a/src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
@@ -363,7 +363,7 @@ class ResettingController
         if ('' === $password) {
             throw new MissingPasswordException();
         }
-        $user->setPassword($this->encodePassword($user, $password, $user->getSalt()));
+        $user->setPassword($this->encodePassword($user, $password, $user->getSalt() ?? ''));
         $this->entityManager->persist($user);
 
         $this->domainEventCollector->collect(new UserPasswordResettedEvent($user));

--- a/src/Sulu/Bundle/SecurityBundle/Entity/User.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/User.php
@@ -28,11 +28,6 @@ use Symfony\Component\Security\Core\User\EquatableInterface;
 use Symfony\Component\Security\Core\User\LegacyPasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface as SymfonyUserInterface;
 
-/**
- * User.
- *
- * @ExclusionPolicy("all")
- */
 #[ExclusionPolicy('all')]
 class User extends ApiEntity implements UserInterface, EquatableInterface, AuditableInterface, PasswordAuthenticatedUserInterface, LegacyPasswordAuthenticatedUserInterface
 {
@@ -280,8 +275,6 @@ class User extends ApiEntity implements UserInterface, EquatableInterface, Audit
      *
      * @deprecated The salt functionality was deprecated in Sulu 2.5 and will be removed in Sulu 3.0
      *             Modern password algorithm do not longer require a salt.
-     *
-     * @return string
      */
     public function getSalt(): ?string
     {

--- a/src/Sulu/Bundle/SecurityBundle/Entity/User.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/User.php
@@ -28,7 +28,9 @@ use Symfony\Component\Security\Core\User\EquatableInterface;
 use Symfony\Component\Security\Core\User\LegacyPasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface as SymfonyUserInterface;
 
-#[ExclusionPolicy('all')]
+/**
+ * @ExclusionPolicy("all")
+ */
 class User extends ApiEntity implements UserInterface, EquatableInterface, AuditableInterface, PasswordAuthenticatedUserInterface, LegacyPasswordAuthenticatedUserInterface
 {
     use AuditableTrait;

--- a/src/Sulu/Bundle/SecurityBundle/Entity/User.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/User.php
@@ -25,6 +25,7 @@ use Sulu\Component\Persistence\Model\AuditableInterface;
 use Sulu\Component\Persistence\Model\AuditableTrait;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Symfony\Component\Security\Core\User\EquatableInterface;
+use Symfony\Component\Security\Core\User\LegacyPasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface as SymfonyUserInterface;
 
 /**
@@ -32,7 +33,8 @@ use Symfony\Component\Security\Core\User\UserInterface as SymfonyUserInterface;
  *
  * @ExclusionPolicy("all")
  */
-class User extends ApiEntity implements UserInterface, EquatableInterface, AuditableInterface, PasswordAuthenticatedUserInterface
+#[ExclusionPolicy('all')]
+class User extends ApiEntity implements UserInterface, EquatableInterface, AuditableInterface, PasswordAuthenticatedUserInterface, LegacyPasswordAuthenticatedUserInterface
 {
     use AuditableTrait;
     use TwoFactorTrait;
@@ -281,7 +283,7 @@ class User extends ApiEntity implements UserInterface, EquatableInterface, Audit
      *
      * @return string
      */
-    public function getSalt()
+    public function getSalt(): ?string
     {
         return $this->salt;
     }

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -258,6 +258,7 @@
         <service id="sulu_security.user_provider" class="Sulu\Bundle\SecurityBundle\User\UserProvider">
             <argument type="service" id="sulu_security.user_repository"/>
             <argument type="service" id="sulu_security.system_store"/>
+            <argument type="service" id="doctrine"/>
         </service>
 
         <service id="sulu_security.build.user" class="%sulu_security.build.user.class%">

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -258,7 +258,7 @@
         <service id="sulu_security.user_provider" class="Sulu\Bundle\SecurityBundle\User\UserProvider">
             <argument type="service" id="sulu_security.user_repository"/>
             <argument type="service" id="sulu_security.system_store"/>
-            <argument type="service" id="doctrine"/>
+            <argument type="service" id="doctrine.orm.entity_manager"/>
         </service>
 
         <service id="sulu_security.build.user" class="%sulu_security.build.user.class%">

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/User/UserProviderTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/User/UserProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\SecurityBundle\Tests\Unit\User;
 
+use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -38,6 +39,11 @@ class UserProviderTest extends TestCase
     private $systemStore;
 
     /**
+     * @var ObjectProphecy<EntityManagerInterface>
+     */
+    private $entityManager;
+
+    /**
      * @var UserProvider
      */
     private $userProvider;
@@ -51,7 +57,8 @@ class UserProviderTest extends TestCase
     {
         $this->userRepository = $this->prophesize(UserRepositoryInterface::class);
         $this->systemStore = $this->prophesize(SystemStoreInterface::class);
-        $this->userProvider = new UserProvider($this->userRepository->reveal(), $this->systemStore->reveal());
+        $this->entityManager = $this->prophesize(EntityManagerInterface::class);
+        $this->userProvider = new UserProvider($this->userRepository->reveal(), $this->systemStore->reveal(), $this->entityManager->reveal());
 
         $this->user = new User();
         $this->user->setUsername('sulu');
@@ -107,5 +114,11 @@ class UserProviderTest extends TestCase
         $this->expectException(DisabledException::class);
         $this->user->setEnabled(false);
         $this->userProvider->refreshUser($this->user);
+    }
+
+    public function testUpgradePassword(): void
+    {
+        $this->userProvider->upgradePassword($this->user, 'hashedPass');
+        $this->assertEquals('hashedPass', $this->user->getPassword());
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/User/UserProviderTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/User/UserProviderTest.php
@@ -119,6 +119,6 @@ class UserProviderTest extends TestCase
     public function testUpgradePassword(): void
     {
         $this->userProvider->upgradePassword($this->user, 'hashedPass');
-        $this->assertEquals('hashedPass', $this->user->getPassword());
+        $this->assertSame('hashedPass', $this->user->getPassword());
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/User/UserProvider.php
+++ b/src/Sulu/Bundle/SecurityBundle/User/UserProvider.php
@@ -121,6 +121,10 @@ class UserProvider implements UserProviderInterface, PasswordUpgraderInterface
 
     public function upgradePassword(PasswordAuthenticatedUserInterface $user, string $newHashedPassword): void
     {
+        if (!$user instanceof UserInterface) {
+            return;
+        }
+
         $user->setPassword($newHashedPassword);
 
         Assert::notNull($this->entityManager, 'Entity manager is required for upgradePassword method.');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | yes
| Fixed tickets | fixes #6986 
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

add the ability to upgrade user passwords to a new algorithm

#### Why?

because of #6986

#### Example Usage

Update the `security.yaml` of the project using the core with:

```yaml
    password_hashers:
        legacy:
            # id: '<id or path to legacy hasher>' # either define the service with id
            # or define it directly here:
            algorithm: sha512
            iterations: 5000
            encode_as_base64: false

        Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface:
            algorithm: bcrypt
            migrate_from:
                - legacy # uses the "legacy" hasher configured above

```