### PR TITLE
Fix purge search index on build

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10026,26 +10026,6 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Util/IndexComparatorInterface.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\CoreBundle\\\\Build\\\\DatabaseBuilder\\:\\:getDependencies\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/CoreBundle/Build/DatabaseBuilder.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\CoreBundle\\\\Build\\\\FixturesBuilder\\:\\:getDependencies\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/CoreBundle/Build/FixturesBuilder.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\CoreBundle\\\\Build\\\\PhpcrBuilder\\:\\:getDependencies\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/CoreBundle/Build/PhpcrBuilder.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\CoreBundle\\\\Build\\\\PhpcrMigrationsBuilder\\:\\:getDependencies\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/CoreBundle/Build/PhpcrMigrationsBuilder.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\CoreBundle\\\\Build\\\\SuluBuilder\\:\\:execCommand\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/CoreBundle/Build/SuluBuilder.php
@@ -17424,11 +17404,6 @@ parameters:
 			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Admin\\\\PageAdmin\\:\\:\\$sessionManager is never read, only written\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\PageBundle\\\\Build\\\\NodeOrderBuilder\\:\\:getDependencies\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Build/NodeOrderBuilder.php
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\PageBundle\\\\Build\\\\NodeOrderBuilder\\:\\:setContext\\(\\) has no return type specified\\.$#"
@@ -25849,16 +25824,6 @@ parameters:
 			message: "#^Property Sulu\\\\Bundle\\\\SecurityBundle\\\\Admin\\\\SecurityAdmin\\:\\:\\$translator is never read, only written\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\SecurityBundle\\\\Build\\\\SecurityBuilder\\:\\:getDependencies\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/Build/SecurityBuilder.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\SecurityBundle\\\\Build\\\\UserBuilder\\:\\:getDependencies\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/Build/UserBuilder.php
 
 		-
 			message: "#^Call to an undefined method Sulu\\\\Component\\\\Security\\\\Authentication\\\\RoleRepositoryInterface\\:\\:findOneByName\\(\\)\\.$#"
@@ -44334,11 +44299,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$locale of method Sulu\\\\Bundle\\\\MediaBundle\\\\Collection\\\\Manager\\\\CollectionManagerInterface\\:\\:getById\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
-
-		-
-			message: "#^Method Sulu\\\\Component\\\\Media\\\\SystemCollections\\\\SystemCollectionBuilder\\:\\:getDependencies\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Component/Media/SystemCollections/SystemCollectionBuilder.php
 
 		-
 			message: "#^Method Sulu\\\\Component\\\\Media\\\\SystemCollections\\\\SystemCollectionBuilder\\:\\:setContext\\(\\) has no return type specified\\.$#"

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -230,6 +230,7 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
                                 'phpcr_migrations' => [],
                                 'system_collections' => [],
                                 'security' => [],
+                                'search_init' => [],
                             ],
                         ],
                         'maintain' => [

--- a/src/Sulu/Bundle/SearchBundle/Build/InitBuilder.php
+++ b/src/Sulu/Bundle/SearchBundle/Build/InitBuilder.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SearchBundle\Build;
+
+use Sulu\Bundle\CoreBundle\Build\SuluBuilder;
+
+/**
+ * Builder for index.
+ */
+class InitBuilder extends SuluBuilder
+{
+    /**
+     * Return the name for this builder.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'search_init';
+    }
+
+    /**
+     * Return the dependencies for this builder.
+     *
+     * @return array
+     */
+    public function getDependencies(): array
+    {
+        return [];
+    }
+
+    /**
+     * Execute the build logic.
+     */
+    public function build(): void
+    {
+        if ($this->input->getOption('destroy')) {
+            $this->execCommand('Purging search indexes', 'massive:search:purge', ['--all'=>true, '--force'=>true]);
+        }
+        $this->execCommand('Create search indexes', 'massive:search:init');
+    }
+}

--- a/src/Sulu/Bundle/SearchBundle/Build/InitBuilder.php
+++ b/src/Sulu/Bundle/SearchBundle/Build/InitBuilder.php
@@ -16,7 +16,7 @@ use Sulu\Bundle\CoreBundle\Build\SuluBuilder;
 /**
  * Builder for index.
  *
- * @internal No backwards compatibility promise is given for this class it can be removed or changed at any time.
+ * @internal no backwards compatibility promise is given for this class it can be removed or changed at any time
  */
 class InitBuilder extends SuluBuilder
 {

--- a/src/Sulu/Bundle/SearchBundle/Build/InitBuilder.php
+++ b/src/Sulu/Bundle/SearchBundle/Build/InitBuilder.php
@@ -15,6 +15,8 @@ use Sulu\Bundle\CoreBundle\Build\SuluBuilder;
 
 /**
  * Builder for index.
+ *
+ * @internal No backwards compatibility promise is given for this class it can be removed or changed at any time.
  */
 class InitBuilder extends SuluBuilder
 {
@@ -28,8 +30,6 @@ class InitBuilder extends SuluBuilder
 
     /**
      * Return the dependencies for this builder.
-     *
-     * @return array{}
      */
     public function getDependencies(): array
     {

--- a/src/Sulu/Bundle/SearchBundle/Build/InitBuilder.php
+++ b/src/Sulu/Bundle/SearchBundle/Build/InitBuilder.php
@@ -20,8 +20,6 @@ class InitBuilder extends SuluBuilder
 {
     /**
      * Return the name for this builder.
-     *
-     * @return string
      */
     public function getName(): string
     {
@@ -31,7 +29,7 @@ class InitBuilder extends SuluBuilder
     /**
      * Return the dependencies for this builder.
      *
-     * @return array
+     * @return array{}
      */
     public function getDependencies(): array
     {
@@ -44,7 +42,7 @@ class InitBuilder extends SuluBuilder
     public function build(): void
     {
         if ($this->input->getOption('destroy')) {
-            $this->execCommand('Purging search indexes', 'massive:search:purge', ['--all'=>true, '--force'=>true]);
+            $this->execCommand('Purging search indexes', 'massive:search:purge', ['--all' => true, '--force' => true]);
         }
         $this->execCommand('Create search indexes', 'massive:search:init');
     }

--- a/src/Sulu/Bundle/SearchBundle/Resources/config/build.xml
+++ b/src/Sulu/Bundle/SearchBundle/Resources/config/build.xml
@@ -5,11 +5,15 @@
 
     <parameters>
         <parameter key="sulu_search.build.index.class">Sulu\Bundle\SearchBundle\Build\IndexBuilder</parameter>
+        <parameter key="sulu_search.build.init.class">Sulu\Bundle\SearchBundle\Build\InitBuilder</parameter>
     </parameters>
 
     <services>
         <!-- build command -->
         <service id="sulu_search.build.index" class="%sulu_search.build.index.class%">
+            <tag name="massive_build.builder"/>
+        </service>
+        <service id="sulu_search.build.init" class="%sulu_search.build.init.class%">
             <tag name="massive_build.builder"/>
         </service>
     </services>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4068
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Adds an `InitBuilder` that purges the search indexes, if `sulu:build dev` is called with the `--destroy` flag

#### Why?

because of #4068 

#### Example Usage

```sh
bin/adminconsole sulu:build dev --destroy
```

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md