### PR TITLE
Fix block response for minOccurs=1 / maxOccurs=1

### DIFF
--- a/packages/content/src/Application/ContentResolver/ContentResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolver.php
@@ -151,7 +151,7 @@ class ContentResolver implements ContentResolverInterface
                 }
 
                 $result['content'][$name][$key] = $entry;
-                $result['view'][$name][$key] = [];
+                $result['view'][$name][$key] = $view;
             }
 
             $result['resolvableResources'] = $resolvableResources;

--- a/packages/content/src/Application/PropertyResolver/Resolver/BlockPropertyResolver.php
+++ b/packages/content/src/Application/PropertyResolver/Resolver/BlockPropertyResolver.php
@@ -94,6 +94,13 @@ class BlockPropertyResolver implements PropertyResolverInterface
             );
         }
 
+        $minOccurs = $metadata->getMinOccurs();
+        $maxOccurs = $metadata->getMaxOccurs();
+
+        if (1 === $minOccurs && 1 === $maxOccurs && \count($contentViews) > 0) {
+            $contentViews = $contentViews[0]->getContent();
+        }
+
         return ContentView::create($contentViews, [...$returnedParams]);
     }
 

--- a/packages/content/src/Application/PropertyResolver/Resolver/BlockPropertyResolver.php
+++ b/packages/content/src/Application/PropertyResolver/Resolver/BlockPropertyResolver.php
@@ -98,7 +98,7 @@ class BlockPropertyResolver implements PropertyResolverInterface
         $maxOccurs = $metadata->getMaxOccurs();
 
         if (1 === $minOccurs && 1 === $maxOccurs && \count($contentViews) > 0) {
-            $contentViews = $contentViews[0]->getContent();
+            return $contentViews[0];
         }
 
         return ContentView::create($contentViews, [...$returnedParams]);

--- a/packages/content/tests/Unit/Content/Application/PropertyResolver/Resolver/BlockPropertyResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/PropertyResolver/Resolver/BlockPropertyResolverTest.php
@@ -135,6 +135,54 @@ class BlockPropertyResolverTest extends TestCase
         $this->assertSame([], $content->getView());
     }
 
+    public function testResolveMinMaxOccursOne(): void
+    {
+        $data = [
+            [
+                'type' => 'text_block',
+                'title' => 'Sulu',
+                'description' => 'Sulu is awesome',
+            ],
+        ];
+        $locale = 'en';
+
+        $formMetadata = new FormMetadata();
+        $formMetadata->setName('text_block');
+        $formMetadata->setKey('text_block');
+        $blockFieldMetadata = new FieldMetadata('text_block');
+        $blockFieldMetadata->addType($formMetadata);
+        $blockFieldMetadata->setMinOccurs(1);
+        $blockFieldMetadata->setMaxOccurs(1);
+
+        $tileFieldMetadata = new FieldMetadata('title');
+        $tileFieldMetadata->setType('text_line');
+
+        $descriptionFieldMetadata = new FieldMetadata('description');
+        $descriptionFieldMetadata->setType('text_area');
+
+        $formMetadata->addItem($tileFieldMetadata);
+        $formMetadata->addItem($descriptionFieldMetadata);
+
+        $params = [
+            'metadata' => $blockFieldMetadata,
+        ];
+
+        $content = $this->resolver->resolve($data, $locale, $params);
+        $this->assertInstanceOf(ContentView::class, $content);
+        /** @var ContentView[] $innerContent */
+        $innerContent = $content->getContent();
+        // title / description / type
+        $this->assertCount(3, $innerContent);
+        $this->assertSame('text_block', $innerContent['type']);
+        $this->assertInstanceOf(ContentView::class, $innerContent['title']);
+        $this->assertSame('Sulu', $innerContent['title']->getContent());
+        $this->assertSame([], $innerContent['title']->getView());
+        $this->assertSame('Sulu is awesome', $innerContent['description']->getContent());
+        $this->assertSame([], $innerContent['description']->getView());
+
+        $this->assertSame([], $content->getView());
+    }
+
     public function testGetType(): void
     {
         $this->assertSame('block', BlockPropertyResolver::getType());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | part of https://github.com/sulu/sulu/issues/7672
| License | MIT

#### What's in this PR?

Adjusts the response of the `BlockPropertyResolver` to return the single block instead of a list when `minOccurs` and `maxOccurs` are `1`.

#### Why?

The behaviour should not be changed between Sulu 2.6 and 3.0.