### PR TITLE
Add hint about doctrine incompatibility

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,31 @@
 
 ## 2.5.23
 
+### Doctrine incompatibility with Symfony 6.3
+
+Latest releases of different Doctrine packages have issues with Symfony 6.3.* Doctrine bridge.
+
+For all projects which still run on Symfony 6.0 - 6.3, we recommend to update to Symfony 6.4.
+Else an update of Doctrine packages alone will end in errors like:
+
+> No mapping file found named 'TrashItem.orm.xml' for class 'Sulu\Bundle\TrashBundle\Domain\Model\TrashItem'
+> No mapping file found named 'Collection.orm.xml' for class 'Sulu\Bundle\MediaBundle\Entity\Collection'.
+
+To upgrade Symfony go into your `composer.json` and adopt the required Symfony version:
+
+```diff
+     "extra": {
+         "symfony": {
+             "allow-contrib": true,
+-            "require": "6.3.*"
++            "require": "6.4.*"
+         }
+     }
+```
+
+And run `composer update` to update all your dependencies. Keep in mind to check the different packages `UPGRADE.md`
+files for further changes.
+
 ### User getSalt method return types changed
 
 To support the upgrade of `Legacy` password hashes from Sulu 1.6, the `User::getSalt` method requires the following changes if you have overwritten it:
@@ -11,7 +36,7 @@ To support the upgrade of `Legacy` password hashes from Sulu 1.6, the `User::get
 +public function getSalt(): ?string;
 ```
 
-If migrating from an old Sulu 1.6 project, you can configure a legacy hasher to seamlessly upgrade the user's password:
+If migrating from an old Sulu 1.6 project, you can configure a legacy password hasher to seamlessly upgrade the user's password:
 
 <details>
 <summary>Example Password Upgrade configuration:</summary>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no 
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add hint about doctrine incompatibility.

#### Why?

Latest releases of different Doctrine packages have issues with Symfony 6.3.* Doctrine bridge.

With Support of doctrine/persistence 2 now in Symfony 6.4.18 via https://github.com/symfony/symfony/pull/59185 we not longer run into this issues. 