### PR TITLE
Remove segments from `PortalInformation`

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -907,6 +907,8 @@ Removed deprecated functions and properties:
 - `Sulu\Bundle\WebsiteBundle\Controller\RedirectController::redirectWebspaceAction` (use Symfony RedirectController instead)
 - `Sulu\Component\Cache\Memoize::memoize()`
 - `Sulu\Component\Cache\MemoizeInterface::memoize()`
+- `Sulu\Component\Webspace\PortalInformation::getSegment()`
+- `Sulu\Component\Webspace\PortalInformation::setSegment()`
 - `Sulu\Bundle\WebsiteBundle\Twig\Core\UtilTwigExtension::extract()`
 - `Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata::setName()` (use `setKey()` instead)
 - `Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata::getName()` (use `getKey()` instead)
@@ -954,6 +956,7 @@ Removed unused arguments:
 - `Sulu\Bundle\ContactBundle\Controller\ContactController::__construct` `$contactRepository` (7rd argument) removed
 - `Sulu\Bundle\ContactBundle\Controller\ContactController::__construct` `$userRepository` (9rd argument) removed
 - `Sulu\Bundle\ContactBundle\Controller\ContactController::__construct` `$suluSecuritySystem` (12rd argument) removed
+- `Sulu\Component\Webspace\PortalInformation::__construct` `$segment` (6th argument) removed
 
 Removed kernel parameters:
 

--- a/packages/page/config/serializer/PortalInformation.xml
+++ b/packages/page/config/serializer/PortalInformation.xml
@@ -4,7 +4,6 @@
         <virtual-property method="getWebspaceKey" name="webspaceKey" type="string" expose="true"/>
         <virtual-property method="getPortalKey" name="portalKey" type="string" expose="true"/>
         <virtual-property method="getLocale" name="locale" type="string" expose="true"/>
-        <virtual-property method="getSegmentKey" name="segmentKey" type="string" expose="true"/>
 
         <property name="url" type="string" expose="true"/>
         <property name="type" type="integer" expose="true"/>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -43665,13 +43665,7 @@ parameters:
 		-
 			message: '#^If condition is always true\.$#'
 			identifier: if.alwaysTrue
-			count: 3
-			path: src/Sulu/Component/Webspace/PortalInformation.php
-
-		-
-			message: '#^Method Sulu\\Component\\Webspace\\PortalInformation\:\:__construct\(\) has parameter \$main with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
+			count: 2
 			path: src/Sulu/Component/Webspace/PortalInformation.php
 
 		-
@@ -43723,12 +43717,6 @@ parameters:
 			path: src/Sulu/Component/Webspace/PortalInformation.php
 
 		-
-			message: '#^Method Sulu\\Component\\Webspace\\PortalInformation\:\:getSegmentKey\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Component/Webspace/PortalInformation.php
-
-		-
 			message: '#^Method Sulu\\Component\\Webspace\\PortalInformation\:\:getWebspaceKey\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -43765,12 +43753,6 @@ parameters:
 			path: src/Sulu/Component/Webspace/PortalInformation.php
 
 		-
-			message: '#^Method Sulu\\Component\\Webspace\\PortalInformation\:\:setSegment\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Component/Webspace/PortalInformation.php
-
-		-
 			message: '#^Method Sulu\\Component\\Webspace\\PortalInformation\:\:setType\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -43796,12 +43778,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$localization of method Sulu\\Component\\Webspace\\PortalInformation\:\:setLocalization\(\) expects Sulu\\Component\\Localization\\Localization, Sulu\\Component\\Localization\\Localization\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Webspace/PortalInformation.php
-
-		-
-			message: '#^Parameter \#1 \$main of method Sulu\\Component\\Webspace\\PortalInformation\:\:setMain\(\) expects bool, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Component/Webspace/PortalInformation.php
@@ -43845,12 +43821,6 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$webspace of method Sulu\\Component\\Webspace\\PortalInformation\:\:setWebspace\(\) expects Sulu\\Component\\Webspace\\Webspace, Sulu\\Component\\Webspace\\Webspace\|null given\.$#'
 			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Webspace/PortalInformation.php
-
-		-
-			message: '#^Ternary operator condition is always true\.$#'
-			identifier: ternary.alwaysTrue
 			count: 1
 			path: src/Sulu/Component/Webspace/PortalInformation.php
 
@@ -43911,7 +43881,7 @@ parameters:
 		-
 			message: '#^Cannot access offset ''match_type'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
+			count: 1
 			path: src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
 
 		-
@@ -43923,13 +43893,13 @@ parameters:
 		-
 			message: '#^Cannot access offset ''portal_url'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 6
+			count: 4
 			path: src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
 
 		-
 			message: '#^Cannot access offset ''redirect'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 6
+			count: 4
 			path: src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
 
 		-
@@ -43951,7 +43921,7 @@ parameters:
 			path: src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Webspace\\Tests\\Functional\\Analyzer\\RequestAnalyzerTest\:\:prepareWebspaceManager\(\) has parameter \$portalInformation with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\Webspace\\Tests\\Functional\\Analyzer\\RequestAnalyzerTest\:\:prepareWebspaceManager\(\) has parameter \$config with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
@@ -44661,7 +44631,7 @@ parameters:
 		-
 			message: '#^Cannot access offset ''environments'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 8
+			count: 7
 			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionTest.php
 
 		-
@@ -44743,12 +44713,6 @@ parameters:
 			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionTest.php
 
 		-
-			message: '#^Cannot access offset ''segment'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionTest.php
-
-		-
 			message: '#^Cannot access offset ''segments'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 8
@@ -44787,7 +44751,7 @@ parameters:
 		-
 			message: '#^Cannot access offset ''urls'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 7
+			count: 6
 			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionTest.php
 
 		-
@@ -44805,7 +44769,7 @@ parameters:
 		-
 			message: '#^Cannot access offset 0 on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 33
+			count: 31
 			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionTest.php
 
 		-

--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
@@ -163,7 +163,6 @@ class WebspaceCollectionBuilder
                 null,
                 $urlAddress,
                 null,
-                null,
                 false,
                 $urlAddress,
                 1
@@ -189,7 +188,6 @@ class WebspaceCollectionBuilder
             $portal,
             null,
             $urlAddress,
-            null,
             $urlRedirect,
             $url->isMain(),
             $url->getUrl(),
@@ -216,7 +214,6 @@ class WebspaceCollectionBuilder
             $portal,
             $localization,
             $urlResult,
-            null,
             null,
             $url->isMain(),
             $url->getUrl(),
@@ -253,7 +250,6 @@ class WebspaceCollectionBuilder
                 $portal,
                 null,
                 $urlResult,
-                null,
                 $urlRedirect,
                 false, // partial matches cannot be main
                 $url->getUrl(),

--- a/src/Sulu/Component/Webspace/PortalInformation.php
+++ b/src/Sulu/Component/Webspace/PortalInformation.php
@@ -48,15 +48,6 @@ class PortalInformation implements ArrayableInterface
     private $localization;
 
     /**
-     * The segment for this portal information.
-     *
-     * @deprecated Is not set anymore since https://github.com/sulu/sulu/pull/5277
-     *
-     * @var Segment
-     */
-    private $segment;
-
-    /**
      * The url for this portal information.
      *
      * @var string
@@ -89,9 +80,8 @@ class PortalInformation implements ArrayableInterface
         ?Portal $portal = null,
         ?Localization $localization = null,
         $url = null,
-        ?Segment $segment = null,
         $redirect = null,
-        $main = false,
+        bool $main = false,
         $urlExpression = null,
         $priority = 0
     ) {
@@ -104,10 +94,6 @@ class PortalInformation implements ArrayableInterface
         $this->setMain($main);
         $this->setUrlExpression($urlExpression);
         $this->setPriority($priority);
-
-        if ($segment) {
-            $this->setSegment($segment);
-        }
     }
 
     /**
@@ -194,55 +180,6 @@ class PortalInformation implements ArrayableInterface
     public function getRedirect()
     {
         return $this->redirect;
-    }
-
-    /**
-     * Sets the segment for the PortalInformation.
-     *
-     * @deprecated Is not set anymore since https://github.com/sulu/sulu/pull/5277
-     *
-     * @param Segment $segment
-     */
-    public function setSegment($segment)
-    {
-        @trigger_deprecation(
-            'sulu/sulu',
-            '2.2',
-            'Segment on the PortalInformation will be removed and should not be used anymore.'
-        );
-        $this->segment = $segment;
-    }
-
-    /**
-     * Returns the segment for the PortalInformation.
-     *
-     * @deprecated Is not set anymore since https://github.com/sulu/sulu/pull/5277
-     *
-     * @return Segment
-     */
-    public function getSegment()
-    {
-        @trigger_deprecation(
-            'sulu/sulu',
-            '2.2',
-            'Segment on the PortalInformation will be removed and should not be used anymore.'
-        );
-
-        return $this->segment;
-    }
-
-    /**
-     * @deprecated Is not set anymore since https://github.com/sulu/sulu/pull/5277
-     */
-    public function getSegmentKey()
-    {
-        @trigger_deprecation(
-            'sulu/sulu',
-            '2.2',
-            'Segment on the PortalInformation will be removed and should not be used anymore.'
-        );
-
-        return $this->segment ? $this->segment->getKey() : null;
     }
 
     /**
@@ -428,11 +365,6 @@ class PortalInformation implements ArrayableInterface
         }
 
         $result['redirect'] = $this->getRedirect();
-
-        $segment = $this->getSegment();
-        if ($segment) {
-            $result['segment'] = $segment->getKey();
-        }
 
         $urlExpression = $this->getUrlExpression();
         if ($urlExpression) {

--- a/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
+++ b/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
@@ -129,40 +129,25 @@ class {{ cache_class }} extends {{ base_class }}
 {% for environmentKey, environment in collection.portalInformations %}
 {% for portalInformation in environment %}
         $portalInformationRefs['{{ environmentKey }}']['{{ portalInformation.url }}'] = new PortalInformation(
-            {{ portalInformation.type }},
-            $webspaceRefs['{{ portalInformation.webspace }}'],
+            type: {{ portalInformation.type }},
+            webspace: $webspaceRefs['{{ portalInformation.webspace }}'],
 {% if portalInformation.portal %}
-            $portalRefs['{{ portalInformation.portal }}'],
-{% else %}
-            null,
+            portal: $portalRefs['{{ portalInformation.portal }}'],
 {% endif %}
 {% if portalInformation.localization %}
-            $localizationRefs['{{ portalInformation.webspace }}_{{ portalInformation.localization.localization }}'],
-{% else %}
-            null,
+            localization: $localizationRefs['{{ portalInformation.webspace }}_{{ portalInformation.localization.localization }}'],
 {% endif %}
-            '{{ portalInformation.url }}',
-{% if portalInformation.segment %}
-            $segmentRefs['{{ portalInformation.webspace }}_{{ portalInformation.segment }}'],
-{% else %}
-            null,
-{% endif %}
+            url: '{{ portalInformation.url }}',
 {% if portalInformation.redirect %}
-            '{{ portalInformation.redirect }}',
-{% else %}
-            null,
+            redirect: '{{ portalInformation.redirect }}',
 {% endif %}
 {% if portalInformation.main %}
-            true,
-{% else %}
-            false,
+            main: true,
 {% endif %}
 {% if portalInformation.urlExpression %}
-            '{{ portalInformation.urlExpression }}',
-{% else %}
-            null,
+            urlExpression: '{{ portalInformation.urlExpression }}',
 {% endif %}
-            {{ portalInformation.priority }}
+            priority: {{ portalInformation.priority }}
         );
 
 {% endfor %}

--- a/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
@@ -35,10 +35,9 @@ class RequestAnalyzerTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var RequestAnalyzer
-     */
-    private $requestAnalyzer;
+    private Webspace $webspace;
+    private Portal $portal;
+    private RequestAnalyzer $requestAnalyzer;
 
     /**
      * @var ObjectProphecy<WebspaceManagerInterface>
@@ -52,6 +51,12 @@ class RequestAnalyzerTest extends TestCase
 
     public function setUp(): void
     {
+        $this->webspace = new Webspace();
+        $this->webspace->setKey('sulu');
+
+        $this->portal = new Portal();
+        $this->portal->setKey('sulu');
+
         $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
         $this->requestStack = $this->prophesize(RequestStack::class);
 
@@ -67,8 +72,17 @@ class RequestAnalyzerTest extends TestCase
         );
     }
 
-    protected function prepareWebspaceManager($portalInformation)
+    protected function prepareWebspaceManager($config)
     {
+        $portalInformation = new PortalInformation(
+            type: $config['match_type'],
+            webspace: $this->webspace,
+            portal: $this->portal,
+            localization: new Localization('de', 'at'),
+            url: $config['portal_url'],
+            redirect: $config['redirect']
+        );
+
         $this->webspaceManager->findPortalInformationsByUrl(Argument::any(), Argument::any())
             ->willReturn([$portalInformation]);
         $this->webspaceManager->getPortalInformations(Argument::any())->willReturn([]);
@@ -177,23 +191,7 @@ class RequestAnalyzerTest extends TestCase
     #[\PHPUnit\Framework\Attributes\DataProvider('provideAnalyze')]
     public function testAnalyze($config, $expected = []): void
     {
-        $webspace = new Webspace();
-        $webspace->setKey('sulu');
-
-        $portal = new Portal();
-        $portal->setKey('sulu');
-
-        $portalInformation = new PortalInformation(
-            $config['match_type'],
-            $webspace,
-            $portal,
-            new Localization('de', 'at'),
-            $config['portal_url'],
-            null,
-            $config['redirect']
-        );
-
-        $this->prepareWebspaceManager($portalInformation);
+        $this->prepareWebspaceManager($config);
 
         $request = new Request(['get' => 1], ['post' => 1], [], [], [], ['REQUEST_URI' => $config['path_info']]);
         $request->headers->set('HOST', 'sulu.lo');
@@ -216,23 +214,7 @@ class RequestAnalyzerTest extends TestCase
     #[\PHPUnit\Framework\Attributes\DataProvider('provideAnalyzeWithFormat')]
     public function testAnalyzeWithFormat($config, $expected = []): void
     {
-        $webspace = new Webspace();
-        $webspace->setKey('sulu');
-
-        $portal = new Portal();
-        $portal->setKey('sulu');
-
-        $portalInformation = new PortalInformation(
-            $config['match_type'],
-            $webspace,
-            $portal,
-            new Localization('de', 'at'),
-            $config['portal_url'],
-            null,
-            $config['redirect']
-        );
-
-        $this->prepareWebspaceManager($portalInformation);
+        $this->prepareWebspaceManager($config);
 
         $request = new Request(['get' => 1], ['post' => 1], [], [], [], ['REQUEST_URI' => $config['path_info']]);
         $request->headers->set('HOST', 'sulu.lo');
@@ -274,23 +256,7 @@ class RequestAnalyzerTest extends TestCase
     #[\PHPUnit\Framework\Attributes\DataProvider('provideAnalyze')]
     public function testAnalyzeCurrentRequest($config, $expected = []): void
     {
-        $webspace = new Webspace();
-        $webspace->setKey('sulu');
-
-        $portal = new Portal();
-        $portal->setKey('sulu');
-
-        $portalInformation = new PortalInformation(
-            $config['match_type'],
-            $webspace,
-            $portal,
-            new Localization('de', 'at'),
-            $config['portal_url'],
-            null,
-            $config['redirect']
-        );
-
-        $this->prepareWebspaceManager($portalInformation);
+        $this->prepareWebspaceManager($config);
 
         $request = new Request(['get' => 1], ['post' => 1], [], [], [], ['REQUEST_URI' => $config['path_info']]);
         $request->headers->set('HOST', 'sulu.lo');

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
@@ -50,7 +50,6 @@ class PortalInformationRequestProcessorTest extends TestCase
             $portal,
             $localization,
             $config['portal_url'],
-            null,
             $config['redirect'],
             false,
             $config['url_expression']
@@ -99,7 +98,6 @@ class PortalInformationRequestProcessorTest extends TestCase
             $portal,
             null,
             $config['portal_url'],
-            null,
             $config['redirect'],
             false,
             $config['url_expression']
@@ -149,7 +147,6 @@ class PortalInformationRequestProcessorTest extends TestCase
             $portal,
             $localization,
             $config['portal_url'],
-            null,
             $config['redirect']
         );
 

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/WebsiteRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/WebsiteRequestProcessorTest.php
@@ -63,7 +63,6 @@ class WebsiteRequestProcessorTest extends TestCase
             $portal,
             $localization,
             'sulu.lo',
-            null,
             'sulu.lo/de'
         );
 
@@ -114,7 +113,6 @@ class WebsiteRequestProcessorTest extends TestCase
             $portal,
             $localization,
             'sulu.lo',
-            null,
             'sulu.lo',
             false,
             'sulu.lo',
@@ -127,7 +125,6 @@ class WebsiteRequestProcessorTest extends TestCase
             $portal,
             $localization,
             'sulu.lo',
-            null,
             null,
             false,
             'sulu.lo',
@@ -165,7 +162,6 @@ class WebsiteRequestProcessorTest extends TestCase
             $localization,
             'sulu.lo/de',
             null,
-            null,
             false,
             'sulu.lo/de',
             5
@@ -177,7 +173,6 @@ class WebsiteRequestProcessorTest extends TestCase
             $portal,
             $localization,
             'sulu.lo',
-            null,
             null,
             false,
             'sulu.lo',
@@ -228,7 +223,6 @@ class WebsiteRequestProcessorTest extends TestCase
                         $portal,
                         $localization,
                         'sulu.lo',
-                        null,
                         null,
                         false,
                         'sulu.lo',

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionTest.php
@@ -93,7 +93,6 @@ class WebspaceCollectionTest extends TestCase
             $portal,
             $localizationEnUs,
             'www.portal1.com',
-            $segmentSummer
         );
 
         $portalInformations['dev']['portal1.lo'] = new PortalInformation(
@@ -102,7 +101,6 @@ class WebspaceCollectionTest extends TestCase
             $portal,
             $localizationEnUs,
             'portal1.lo',
-            $segmentSummer
         );
 
         $this->webspaceCollection = new WebspaceCollection(['default' => $webspace]);
@@ -164,7 +162,6 @@ class WebspaceCollectionTest extends TestCase
         $this->assertEquals('www.portal1.com', $portal['environments'][0]['urls'][0]['url']);
         $this->assertEquals('en', $portal['environments'][0]['urls'][0]['language']);
         $this->assertEquals('us', $portal['environments'][0]['urls'][0]['country']);
-        $this->assertEquals(null, $portal['environments'][0]['urls'][0]['segment']);
         $this->assertEquals(null, $portal['environments'][0]['urls'][0]['redirect']);
         $this->assertEquals('portal1.com', $portal['environments'][0]['urls'][1]['url']);
         $this->assertEquals('www.portal1.com', $portal['environments'][0]['urls'][1]['redirect']);
@@ -184,7 +181,6 @@ class WebspaceCollectionTest extends TestCase
         $this->assertEquals('default', $portalInformation['webspace']);
         $this->assertEquals('portal1', $portalInformation['portal']);
         $this->assertEquals('en_us', $portalInformation['localization']['localization']);
-        $this->assertEquals('s', $portalInformation['segment']);
         $this->assertEquals('www.portal1.com', $portalInformation['url']);
 
         $portalInformation = $collectionArray['portalInformations']['dev']['portal1.lo'];
@@ -193,7 +189,6 @@ class WebspaceCollectionTest extends TestCase
         $this->assertEquals('default', $portalInformation['webspace']);
         $this->assertEquals('portal1', $portalInformation['portal']);
         $this->assertEquals('en_us', $portalInformation['localization']['localization']);
-        $this->assertEquals('s', $portalInformation['segment']);
         $this->assertEquals('portal1.lo', $portalInformation['url']);
     }
 

--- a/src/Sulu/Component/Webspace/Tests/Unit/PortalInformationTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/PortalInformationTest.php
@@ -45,7 +45,13 @@ class PortalInformationTest extends TestCase
 
     public function setUp(): void
     {
-        $this->portalInformation = new PortalInformation(null, null, null, null, null);
+        $this->portalInformation = new PortalInformation(
+            type: null,
+            webspace: null,
+            portal: null,
+            localization: null,
+            url: null,
+        );
         $this->webspace = $this->prophesize(Webspace::class);
         $this->portal = $this->prophesize(Portal::class);
         $this->localization = $this->prophesize(Localization::class);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no 
| BC breaks? |  yes
| Deprecations? | no 
| Fixed tickets |-
| Related issues/PRs | #7547
| License | MIT
| Documentation PR |-

#### What's in this PR?
Removing the segment of the portal information.
- Using named arguments for the `PortalInformation` constructor in the cache.

#### Why?
It's not being used anywhere.