### PR TITLE
Fix PHP 8.4 deprecation call on SecurityVoter without a type

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26081,7 +26081,7 @@ parameters:
 			path: src/Sulu/Bundle/SecurityBundle/Controller/PermissionController.php
 
 		-
-			message: "#^Parameter \\#2 \\$identifier of method Sulu\\\\Component\\\\Security\\\\Authorization\\\\AccessControl\\\\AccessControlManagerInterface\\:\\:getPermissions\\(\\) expects string, mixed given\\.$#"
+			message: "#^Parameter \\#2 \\$identifier of method Sulu\\\\Component\\\\Security\\\\Authorization\\\\AccessControl\\\\AccessControlManagerInterface\\:\\:getPermissions\\(\\) expects string\\|null, mixed given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/Controller/PermissionController.php
 
@@ -26931,7 +26931,7 @@ parameters:
 			path: src/Sulu/Bundle/SecurityBundle/EventListener/PermissionInheritanceSubscriber.php
 
 		-
-			message: "#^Parameter \\#2 \\$identifier of method Sulu\\\\Component\\\\Security\\\\Authorization\\\\AccessControl\\\\AccessControlManagerInterface\\:\\:getPermissions\\(\\) expects string, int\\<min, \\-1\\>\\|int\\<1, max\\>\\|string given\\.$#"
+			message: "#^Parameter \\#2 \\$identifier of method Sulu\\\\Component\\\\Security\\\\Authorization\\\\AccessControl\\\\AccessControlManagerInterface\\:\\:getPermissions\\(\\) expects string\\|null, int\\<min, \\-1\\>\\|int\\<1, max\\>\\|string given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/EventListener/PermissionInheritanceSubscriber.php
 
@@ -47506,17 +47506,12 @@ parameters:
 			path: src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
 
 		-
-			message: "#^Method Sulu\\\\Component\\\\Security\\\\Authorization\\\\AccessControl\\\\AccessControlManager\\:\\:getAccessControlProvider\\(\\) should return Sulu\\\\Component\\\\Security\\\\Authorization\\\\AccessControl\\\\AccessControlProviderInterface but return statement is missing\\.$#"
-			count: 1
-			path: src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
-
-		-
 			message: "#^Method Sulu\\\\Component\\\\Security\\\\Authorization\\\\AccessControl\\\\AccessControlManager\\:\\:getPermissions\\(\\) has parameter \\$system with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
 
 		-
-			message: "#^Method Sulu\\\\Component\\\\Security\\\\Authorization\\\\AccessControl\\\\AccessControlManager\\:\\:getPermissions\\(\\) should return array but empty return statement found\\.$#"
+			message: "#^Method Sulu\\\\Component\\\\Security\\\\Authorization\\\\AccessControl\\\\AccessControlManager\\:\\:getPermissions\\(\\) should return array but returns null\\.$#"
 			count: 1
 			path: src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
 
@@ -47611,12 +47606,17 @@ parameters:
 			path: src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
 
 		-
-			message: "#^Negated boolean expression is always false\\.$#"
-			count: 2
+			message: "#^Parameter \\#1 \\$type of method Sulu\\\\Component\\\\Security\\\\Authorization\\\\AccessControl\\\\AccessControlProviderInterface\\:\\:getPermissions\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
 			path: src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
 
 		-
 			message: "#^Parameter \\#2 \\$identifier of class Sulu\\\\Component\\\\Security\\\\Event\\\\PermissionUpdateEvent constructor expects string, int\\|string given\\.$#"
+			count: 1
+			path: src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
+
+		-
+			message: "#^Parameter \\#2 \\$identifier of method Sulu\\\\Component\\\\Security\\\\Authorization\\\\AccessControl\\\\AccessControlProviderInterface\\:\\:getPermissions\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
 
@@ -47786,7 +47786,7 @@ parameters:
 			path: src/Sulu/Component/Security/Serializer/Subscriber/SecuredEntitySubscriber.php
 
 		-
-			message: "#^Parameter \\#2 \\$identifier of method Sulu\\\\Component\\\\Security\\\\Authorization\\\\AccessControl\\\\AccessControlManagerInterface\\:\\:getPermissions\\(\\) expects string, int given\\.$#"
+			message: "#^Parameter \\#2 \\$identifier of method Sulu\\\\Component\\\\Security\\\\Authorization\\\\AccessControl\\\\AccessControlManagerInterface\\:\\:getPermissions\\(\\) expects string\\|null, int given\\.$#"
 			count: 1
 			path: src/Sulu/Component/Security/Serializer/Subscriber/SecuredEntitySubscriber.php
 

--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -89,7 +89,7 @@ class CategoryController extends AbstractRestController implements ClassResource
 
         if ('true' == $request->get('flat')) {
             $rootId = ($rootKey) ? $this->categoryManager->findByKey($rootKey)->getId() : null;
-            $expandedIds = \array_filter(\explode(',', $request->get('expandedIds', $request->get('selectedIds'))));
+            $expandedIds = \array_filter(\explode(',', $request->get('expandedIds', $request->get('selectedIds', ''))));
             $defaultSort = !$request->query->has('sortBy');
             $list = $this->getListRepresentation(
                 $request,

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -404,11 +404,11 @@ class AccountController extends AbstractRestController implements ClassResourceI
      */
     protected function applyRequestParameters(Request $request, $listBuilder)
     {
-        if (\json_decode($request->get('hasNoParent', null))) {
+        if (\json_decode($request->get('hasNoParent', ''))) {
             $listBuilder->where($this->getFieldDescriptorForNoParent(), null);
         }
 
-        if (\json_decode($request->get('hasEmail', null))) {
+        if (\json_decode($request->get('hasEmail', ''))) {
             $listBuilder->whereNot($this->getFieldDescriptors()['mainEmail'], null);
         }
     }

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
@@ -148,7 +148,7 @@ class MediaController extends AbstractMediaController implements
         } else {
             /** @var UserInterface $user */
             $user = $this->getUser();
-            $types = \array_filter(\explode(',', $request->get('types')));
+            $types = \array_filter(\explode(',', $request->get('types', '')));
             $collectionId = $request->get('collection');
             $collectionId = $collectionId ? (int) $collectionId : null;
             $locale = $this->getRequestParameter($request, 'locale', true);

--- a/src/Sulu/Bundle/PageBundle/Controller/PageController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/PageController.php
@@ -399,7 +399,7 @@ class PageController extends AbstractRestController implements ClassResourceInte
 
     public function cgetAction(Request $request)
     {
-        $ids = \preg_split('/[,]/', $request->get('ids'), -1, \PREG_SPLIT_NO_EMPTY);
+        $ids = \preg_split('/[,]/', $request->get('ids', ''), -1, \PREG_SPLIT_NO_EMPTY);
         $parent = $request->get('parentId');
         $properties = \array_filter(\explode(',', $request->get('fields', 'title,published')));
         $excludeGhosts = $this->getBooleanRequestParameter($request, 'exclude-ghosts', false, false);

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
@@ -53,7 +53,7 @@ class PreviewKernel extends Kernel
     protected function getContainerClass(): string
     {
         // use parent class to normalize the generated container class.
-        return $this->generateContainerClass(\get_parent_class());
+        return $this->generateContainerClass(parent::class);
     }
 
     public function getProjectDir(): string

--- a/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
@@ -391,7 +391,7 @@ class AccessControlManager implements AccessControlManagerInterface
      */
     private function getAccessControlProvider(?string $type)
     {
-        if ($type === null) {
+        if (null === $type) {
             return null;
         }
 

--- a/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
@@ -110,7 +110,11 @@ class AccessControlManager implements AccessControlManagerInterface
         $accessControlProvider = $this->getAccessControlProvider($type);
 
         if (!$accessControlProvider) {
-            return;
+            return null;
+        }
+
+        if (!$identifier) {
+            return null;
         }
 
         return $accessControlProvider->getPermissions($type, $identifier, $system);
@@ -385,21 +389,31 @@ class AccessControlManager implements AccessControlManagerInterface
     /**
      * Returns the AccessControlProvider, which supports the given type.
      *
-     * @param string $type The type the AccessControlProvider should support
+     * @param string|null $type The type the AccessControlProvider should support
      *
-     * @return AccessControlProviderInterface
+     * @return AccessControlProviderInterface|null
      */
-    private function getAccessControlProvider($type)
+    private function getAccessControlProvider(?string $type)
     {
+        if ($type === null) {
+            return null;
+        }
+
         foreach ($this->accessControlProviders as $accessControlProvider) {
             if ($accessControlProvider->supports($type)) {
                 return $accessControlProvider;
             }
         }
+
+        return null;
     }
 
-    private function getDescendantProvider(string $type): ?DescendantProviderInterface
+    private function getDescendantProvider(?string $type): ?DescendantProviderInterface
     {
+        if (null === $type) {
+            return null;
+        }
+
         foreach ($this->descendantProviders as $descendantProvider) {
             if ($descendantProvider->supportsDescendantType($type)) {
                 return $descendantProvider;

--- a/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
@@ -113,10 +113,6 @@ class AccessControlManager implements AccessControlManagerInterface
             return null;
         }
 
-        if (!$identifier) {
-            return null;
-        }
-
         return $accessControlProvider->getPermissions($type, $identifier, $system);
     }
 

--- a/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManagerInterface.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManagerInterface.php
@@ -31,8 +31,8 @@ interface AccessControlManagerInterface
     /**
      * Returns the permissions for all security identities.
      *
-     * @param string $type The type of the protected object
-     * @param string $identifier The identifier of the protected object
+     * @param string|null $type The type of the protected object
+     * @param string|null $identifier The identifier of the protected object
      *
      * @return mixed[]
      */


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix PHP 8.4 deprecation call on SecurityVoter without a type.

#### Why?

This happens on PROD if somebody workaround the symfony error handler (not sure how?).

I did catch it up to the AccessControlManager, called via the `SecurityContextVoter` on `/admin/config` request.

![Bildschirmfoto 2025-01-30 um 15 51 49](https://github.com/user-attachments/assets/5138b868-c176-4251-bf0f-c7e519c178e8)

Stack trace:

![Bildschirmfoto 2025-01-30 um 15 56 50](https://github.com/user-attachments/assets/052f68f6-4eae-4bc9-9bbf-f635d0c5226c)


