### PR TITLE
Remove deprecated `webspaceStore` and `localizationStore` functions

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -686,6 +686,9 @@ Removed JavaScript files and methods:
  - `sulu-security-bundle/stores/securityContextStore/securityContextStore.js` `loadSecurityContextGroups`
  - `sulu-security-bundle/stores/securityContextStore/securityContextStore.js` `loadAvailableActions`
  - `sulu-admin-bundle/containers/List/loadingStrategies/FullLoadingStrategy.js`
+ - `sulu-admin-bundle/stores/localizationStore/localizationStore.js` `loadLocalizations`
+ - `sulu-page-bundle/stores/webspaceStore/webspaceStore.js` `loadWebspaces`
+ - `sulu-page-bundle/stores/webspaceStore/webspaceStore.js` `loadWebspace`
 
 Removed container parameters:
 

--- a/packages/page/assets/js/stores/webspaceStore/tests/webspaceStore.test.js
+++ b/packages/page/assets/js/stores/webspaceStore/tests/webspaceStore.test.js
@@ -1,5 +1,4 @@
 // @flow
-import log from 'loglevel';
 import {defaultWebspace} from 'sulu-admin-bundle/utils/TestHelper';
 import webspaceStore from '../webspaceStore';
 
@@ -66,12 +65,7 @@ test('Load granted webspaces', () => {
 
     webspaceStore.setWebspaces(webspaces);
 
-    const webspacePromise = webspaceStore.loadWebspaces();
-
-    return webspacePromise.then((webspaces) => {
-        expect(log.warn).toBeCalled();
-        expect(webspaces).toEqual([webspace1]);
-    });
+    expect(webspaceStore.grantedWebspaces).toEqual([webspace1]);
 });
 
 test('Load webspace with given key', () => {
@@ -99,12 +93,7 @@ test('Load webspace with given key', () => {
 
     webspaceStore.setWebspaces(webspaces);
 
-    const webspacePromise = webspaceStore.loadWebspace('sulu');
-
-    return webspacePromise.then((webspace) => {
-        expect(log.warn).toBeCalled();
-        expect(webspace).toEqual(webspace1);
-    });
+    expect(webspaceStore.getWebspace('sulu')).toEqual(webspace1);
 });
 
 test('Get granted webspaces', () => {
@@ -133,7 +122,6 @@ test('Get granted webspaces', () => {
     webspaceStore.setWebspaces(webspaces);
 
     expect(webspaceStore.grantedWebspaces).toEqual([webspace1]);
-    expect(log.warn).not.toBeCalled();
 });
 
 test('Get webspace with given key', () => {
@@ -162,5 +150,4 @@ test('Get webspace with given key', () => {
     webspaceStore.setWebspaces(webspaces);
 
     expect(webspaceStore.getWebspace('sulu')).toEqual(webspace1);
-    expect(log.warn).not.toBeCalled();
 });

--- a/packages/page/assets/js/stores/webspaceStore/webspaceStore.js
+++ b/packages/page/assets/js/stores/webspaceStore/webspaceStore.js
@@ -1,6 +1,5 @@
 // @flow
 import {action, computed, observable} from 'mobx';
-import log from 'loglevel';
 import type {Webspace} from './types';
 
 class WebspaceStore {
@@ -28,26 +27,6 @@ class WebspaceStore {
         }
 
         return webspace;
-    }
-
-    // @deprecated
-    loadWebspaces(): Promise<Array<Webspace>> {
-        log.warn(
-            'The "loadWebspaces" method is deprecated since 2.1 and will be removed. ' +
-            'Use the "grantedWebspaces" property instead.'
-        );
-
-        return Promise.resolve(this.grantedWebspaces);
-    }
-
-    // @deprecated
-    loadWebspace(webspaceKey: string): Promise<Webspace> {
-        log.warn(
-            'The "loadWebspace" method is deprecated since 2.1 and will be removed. ' +
-            'Use the "getWebspace" method instead.'
-        );
-
-        return Promise.resolve(this.getWebspace(webspaceKey));
     }
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/localizationStore/localizationStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/localizationStore/localizationStore.js
@@ -1,6 +1,5 @@
 // @flow
 import {action, observable} from 'mobx';
-import log from 'loglevel';
 import type {Localization} from './types';
 
 class LocalizationStore {
@@ -8,16 +7,6 @@ class LocalizationStore {
 
     @action setLocalizations(localizations: Array<Localization>) {
         this.localizations = localizations;
-    }
-
-    // @deprecated
-    loadLocalizations(): Promise<Array<Localization>> {
-        log.warn(
-            'The "loadLocalizations" method is deprecated since 2.1 and will be removed. ' +
-            'Use the "localizations" property instead.'
-        );
-
-        return Promise.resolve(this.localizations);
     }
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/localizationStore/tests/LocalizationStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/localizationStore/tests/LocalizationStore.test.js
@@ -1,10 +1,5 @@
 // @flow
-import log from 'loglevel';
 import localizationStore from '../localizationStore';
-
-jest.mock('loglevel', () => ({
-    warn: jest.fn(),
-}));
 
 test('Load localizations', () => {
     const localizations = [
@@ -28,8 +23,5 @@ test('Load localizations', () => {
 
     localizationStore.setLocalizations(localizations);
 
-    return localizationStore.loadLocalizations().then((localizations) => {
-        expect(log.warn).toBeCalled();
-        expect(localizations).toBe(localizations);
-    });
+    expect(localizationStore.localizations).toEqual(localizations);
 });


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #7547
| License | MIT
| Documentation PR | -

#### What's in this PR?
Removing outdated js code in the webspaceStore.js