### PR TITLE
Remove deprecated parameter `sulu_media.media.max_file_size`

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -228,10 +228,6 @@ DROP INDEX IDX_13B749A0D02106C0 ON se_roles;
 ALTER TABLE se_roles DROP idSecurityTypes;
 ```
 
-And the container parameters has been removed:
-
-- `sulu_security.security_types.fixture`
-
 ### Groups and User Groups have been removed
 
 This includes the following services:
@@ -690,6 +686,11 @@ Removed JavaScript files and methods:
  - `sulu-security-bundle/stores/securityContextStore/securityContextStore.js` `loadSecurityContextGroups`
  - `sulu-security-bundle/stores/securityContextStore/securityContextStore.js` `loadAvailableActions`
  - `sulu-admin-bundle/containers/List/loadingStrategies/FullLoadingStrategy.js`
+
+Removed container parameters:
+
+- `sulu_security.security_types.fixture`
+- `sulu_media.media.max_file_size` (replaced by `sulu_media.media.max_filesize`)
 
 ### Added return type hints
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -27525,7 +27525,7 @@ parameters:
 		-
 			message: '#^Binary operation "\." between mixed and ''MB'' results in an error\.$#'
 			identifier: binaryOp.invalid
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
 
 		-
@@ -27591,7 +27591,7 @@ parameters:
 		-
 			message: '#^Cannot access offset ''max_filesize'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
+			count: 2
 			path: src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
 
 		-

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -277,12 +277,6 @@ class SuluMediaExtension extends Extension implements PrependExtensionInterface
             $config['upload']['max_filesize']
         );
 
-        /* @deprecated This parameter is duplicated and should be removed use sulu_media.upload.max_filesize instead. */
-        $container->setParameter(
-            'sulu_media.media.max_file_size',
-            $config['upload']['max_filesize'] . 'MB'
-        );
-
         // Adobe creative sdk
         $container->setParameter(
             'sulu_media.adobe_creative_key',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #7547 
| License | MIT
| Documentation PR | -

#### What's in this PR?
Removing the container `sulu_media.media.max_file_size`.

#### Why?
We don't need the parameter twice.