### PR TITLE
Remove deprecated `securityContextStore` methods

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -685,6 +685,11 @@ Removed kernel parameters:
 - All `sulu_*.class` parameters for services where removed (use compilerpasses to replace class of a service definition)
 - Parameter `%permissions%` was replaced in favor of `%sulu_security.permissions%`
 
+Removed JavaScript functions:
+
+ - `sulu-security-bundle/stores/securityContextStore/securityContextStore.js` `loadSecurityContextGroups`
+ - `sulu-security-bundle/stores/securityContextStore/securityContextStore.js` `loadAvailableActions`
+
 ### Added return type hints
 
 The following methods have been updated with a return type hint:

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/stores/securityContextStore/securityContextStore.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/stores/securityContextStore/securityContextStore.js
@@ -1,5 +1,4 @@
 // @flow
-import log from 'loglevel';
 import type {Actions, SecurityContextGroups, Systems} from './types';
 
 class SecurityContextStore {
@@ -42,26 +41,6 @@ class SecurityContextStore {
         }
 
         return [];
-    }
-
-    // @deprecated
-    loadSecurityContextGroups(system: string): Promise<SecurityContextGroups> {
-        log.warn(
-            'The "loadSecurityContextGroups" method is deprecated since 2.2 and will be removed. ' +
-            'Use the "getSecurityContextGroups" method instead.'
-        );
-
-        return Promise.resolve(this.getSecurityContextGroups(system));
-    }
-
-    // @deprecated
-    loadAvailableActions(resourceKey: string) {
-        log.warn(
-            'The "loadAvailableActions" method is deprecated since 2.2 and will be removed. ' +
-            'Use the "getAvailableActions" method instead.'
-        );
-
-        return Promise.resolve(this.getAvailableActions(resourceKey));
     }
 }
 

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/stores/securityContextStore/tests/securityContextStore.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/stores/securityContextStore/tests/securityContextStore.test.js
@@ -1,10 +1,5 @@
 // @flow
-import log from 'loglevel';
 import securityContextStore from '../securityContextStore';
-
-jest.mock('loglevel', () => ({
-    warn: jest.fn(),
-}));
 
 jest.mock('sulu-admin-bundle/services/Requester', () => ({
     get: jest.fn(),
@@ -13,50 +8,6 @@ jest.mock('sulu-admin-bundle/services/Requester', () => ({
 beforeEach(() => {
     securityContextStore.suluSecuritySystem = 'Sulu';
     securityContextStore.setSecurityContexts({});
-});
-
-test('Load available actions for permissions with given keys', () => {
-    securityContextStore.resourceKeyMapping = {
-        'test': 'sulu.test',
-    };
-
-    securityContextStore.setSecurityContexts({
-        'Sulu': {
-            'Global': {
-                'sulu.snippets': ['view', 'add'],
-            },
-            'Test': {
-                'sulu.test': ['view', 'add', 'edit'],
-            },
-        },
-    });
-
-    return securityContextStore.loadAvailableActions('test').then((actions) => {
-        expect(log.warn).toBeCalled();
-        expect(actions).toEqual(['view', 'add', 'edit']);
-    });
-});
-
-test('Load security contexts for entire system', () => {
-    securityContextStore.resourceKeyMapping = {
-        'test': 'sulu.test',
-    };
-
-    const suluSecurityContexts = {
-        'Global': {
-            'sulu.snippets': ['view', 'add'],
-        },
-        'Test': {
-            'sulu.test': ['view', 'add', 'edit'],
-        },
-    };
-
-    securityContextStore.setSecurityContexts({Sulu: suluSecurityContexts});
-
-    return securityContextStore.loadSecurityContextGroups('Sulu').then((securityContexts) => {
-        expect(log.warn).toBeCalled();
-        expect(securityContexts).toEqual(suluSecurityContexts);
-    });
 });
 
 test('Get available actions for permissions with given keys', () => {
@@ -76,7 +27,6 @@ test('Get available actions for permissions with given keys', () => {
     });
 
     expect(securityContextStore.getAvailableActions('test')).toEqual(['view', 'add', 'edit']);
-    expect(log.warn).not.toBeCalled();
 });
 
 test('Get available actions for permissions with given keys and system', () => {
@@ -106,7 +56,6 @@ test('Get available actions for permissions with given keys and system', () => {
     expect(securityContextStore.getAvailableActions('test')).toEqual(['view', 'add', 'edit']);
     expect(securityContextStore.getAvailableActions('test', 'Sulu')).toEqual(['view', 'add', 'edit']);
     expect(securityContextStore.getAvailableActions('test', 'Website')).toEqual(['view']);
-    expect(log.warn).not.toBeCalled();
 });
 
 test('Get security contexts for entire system', () => {
@@ -126,7 +75,6 @@ test('Get security contexts for entire system', () => {
     securityContextStore.setSecurityContexts({Sulu: suluSecurityContexts});
 
     expect(securityContextStore.getSecurityContextGroups('Sulu')).toEqual(suluSecurityContexts);
-    expect(log.warn).not.toBeCalled();
 });
 
 test('Get systems from entire system', () => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #7547
| License | MIT
| Documentation PR | -

#### What's in this PR?
Removing deprecated javascript functions.

#### Why?
Clean code is good code.