### PR TITLE
Remove deprecated `UtilTwigExtension::extract`

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -670,6 +670,7 @@ Removed deprecated functions and properties:
 - `Sulu\Bundle\ContactBundle\Controller\PositionController::$entityKey`
 - `Sulu\Component\Cache\Memoize::memoize()`
 - `Sulu\Component\Cache\MemoizeInterface::memoize()`
+- `Sulu\Bundle\WebsiteBundle\Twig\Core\UtilTwigExtension::extract()`
 - `Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata::setName()` (use `setKey()` instead)
 - `Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata::getName()` (use `getKey()` instead)
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -52177,24 +52177,6 @@ parameters:
 			path: src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtensionInterface.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\WebsiteBundle\\Twig\\Core\\UtilTwigExtension\:\:extract\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Twig/Core/UtilTwigExtension.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\WebsiteBundle\\Twig\\Core\\UtilTwigExtension\:\:extract\(\) has parameter \$mode with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Twig/Core/UtilTwigExtension.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\WebsiteBundle\\Twig\\Core\\UtilTwigExtension\:\:extract\(\) has parameter \$url with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Twig/Core/UtilTwigExtension.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\WebsiteBundle\\Twig\\Exception\\ParentNotFoundException\:\:__construct\(\) has parameter \$uuid with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Core/UtilTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Core/UtilTwigExtension.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\WebsiteBundle\Twig\Core;
 
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
-use Twig\TwigFunction;
 
 /**
  * Twig extension providing generally useful utilities which are available
@@ -24,40 +23,8 @@ class UtilTwigExtension extends AbstractExtension
     public function getFilters()
     {
         return [
-            new TwigFilter('sulu_util_multisort', 'Sulu\Component\Util\SortUtils::multisort'),
-            new TwigFilter('sulu_util_filter', 'Sulu\Component\Util\ArrayUtils::filter'),
-            new TwigFilter(
-                'sulu_util_domain_info',
-                [$this, 'extract'],
-                ['deprecated' => true],
-            ),
+            new TwigFilter('sulu_util_multisort', [\Sulu\Component\Util\SortUtils::class, 'multisort']),
+            new TwigFilter('sulu_util_filter', [\Sulu\Component\Util\ArrayUtils::class, 'filter']),
         ];
-    }
-
-    public function getFunctions()
-    {
-        return [
-            new TwigFunction(
-                'sulu_util_domain_info',
-                [$this, 'extract'],
-                ['deprecated' => true],
-            ),
-        ];
-    }
-
-    /**
-     * @deprecated The "sulu_util_domain_info" is deprecated and will be removed with Sulu 3.0.
-     */
-    public function extract($url, $mode = null)
-    {
-        @trigger_deprecation('sulu/sulu', '2.3', 'The "sulu_util_domain_info" is deprecated and will be removed with Sulu 3.0.');
-
-        if (\function_exists('tld_extract')) {
-            return tld_extract($url, $mode);
-        }
-
-        throw new \LogicException(
-            'The "sulu_util_domain_info" requires "layershifter/tld-extract" package to be installed.'
-        );
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #7547 
| License | MIT
| Documentation PR | -

#### What's in this PR?
Removing outdated Twig functions.

#### Why?
Removing it 'cause we don't need it.
